### PR TITLE
Improved constraint handling, part 3

### DIFF
--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -239,7 +239,13 @@ class QgsVectorDataProvider : QgsDataProvider
 
     /**
      * Returns any literal default values which are present at the provider for a specified
-     * field index.
+     * field index. Important - this should ONLY be called when creating an attribute to insert
+     * directly into the database. Do not call this method for non-feature creation or modification,
+     * eg when validating an attribute or to compare it against an existing value, as calling it
+     * can cause changes to the underlying data source (eg Postgres provider where the default value
+     * is calculated as a result of a sequence). It is recommended that you instead use the methods
+     * in QgsVectorLayerUtils such as QgsVectorLayerUtils::createFeature()
+     * so that default value handling and validation is automatically carried out.
      * @see defaultValueClause()
      */
     virtual QVariant defaultValue( int fieldIndex ) const;
@@ -257,8 +263,18 @@ class QgsVectorDataProvider : QgsDataProvider
      * Returns any constraints which are present at the provider for a specified
      * field index.
      * @note added in QGIS 3.0
+     * @see skipConstraintCheck()
      */
     QgsFieldConstraints::Constraints fieldConstraints( int fieldIndex ) const;
+
+    /**
+     * Returns true if a constraint check should be skipped for a specified field (eg if
+     * the value returned by defaultValue() is trusted implicitly. An optional attribute value can be
+     * passed which can help refine the skip constraint check.
+     * @note added in QGIS 3.0
+     * @see fieldConstraints()
+     */
+    virtual bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant& value = QVariant() ) const;
 
     /**
      * Changes geometries of existing features

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -148,6 +148,18 @@ class QgsVectorDataProvider : QgsDataProvider
      */
     virtual void uniqueValues( int index, QList<QVariant> &uniqueValues /Out/, int limit = -1 ) const;
 
+    /**
+     * Returns unique string values of an attribute which contain a specified subset string. Subset
+     * matching is done in a case-insensitive manner.
+     * @param index the index of the attribute
+     * @param substring substring to match (case insensitive)
+     * @param limit maxmum number of the values to return, or -1 to return all unique values
+     * @param feedback optional feedback object for cancelling request
+     * @returns list of unique strings containg substring
+     */
+    virtual QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
+                                               QgsFeedback* feedback = nullptr ) const;
+
     /** Calculates an aggregated value from the layer's features. The base implementation does nothing,
      * but subclasses can override this method to handoff calculation of aggregates to the provider.
      * @param aggregate aggregate to calculate

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1326,6 +1326,22 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
      */
     void uniqueValues( int index, QList<QVariant> &uniqueValues /Out/, int limit = -1 ) const;
 
+    /**
+     * Returns unique string values of an attribute which contain a specified subset string. Subset
+     * matching is done in a case-insensitive manner. Note that
+     * in some circumstances when unsaved changes are present for the layer then the returned list
+     * may contain outdated values (for instance when the attribute value in a saved feature has
+     * been changed inside the edit buffer then the previous saved value will be included in the
+     * returned list).
+     * @param index column index for attribute
+     * @param substring substring to match (case insensitive)
+     * @param limit maxmum number of the values to return, or -1 to return all unique values
+     * @param feedback optional feedback object for cancelling request
+     * @returns list of unique strings containing substring
+     */
+    QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
+                                       QgsFeedback* feedback = nullptr ) const;
+
     /** Returns the minimum value for an attribute column or an invalid variant in case of error.
      * Note that in some circumstances when unsaved changes are present for the layer then the
      * returned value may be outdated (for instance when the attribute value in a saved feature has

--- a/python/core/qgsvectorlayerutils.sip
+++ b/python/core/qgsvectorlayerutils.sip
@@ -36,4 +36,16 @@ class QgsVectorLayerUtils
                                    QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
                                    QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
 
+    /**
+     * Creates a new feature ready for insertion into a layer. Default values and constraints
+     * (eg unique constraints) will automatically be handled. An optional attribute map can be
+     * passed for the new feature to copy as many attribute values as possible from the map,
+     * assuming that they respect the layer's constraints. Note that the created feature is not
+     * automatically inserted into the layer.
+     */
+    static QgsFeature createFeature( QgsVectorLayer* layer,
+                                     const QgsGeometry& geometry = QgsGeometry(),
+                                     const QgsAttributeMap& attributes = QgsAttributeMap(),
+                                     QgsExpressionContext* context = nullptr );
+
 };

--- a/python/core/qgsvectorlayerutils.sip
+++ b/python/core/qgsvectorlayerutils.sip
@@ -16,8 +16,16 @@ class QgsVectorLayerUtils
      * Returns true if the specified value already exists within a field. This method can be used to test for uniqueness
      * of values inside a layer's attributes. An optional list of ignored feature IDs can be provided, if so, any features
      * with IDs within this list are ignored when testing for existance of the value.
+     * @see createUniqueValue()
      */
     static bool valueExists( const QgsVectorLayer* layer, int fieldIndex, const QVariant& value, const QgsFeatureIds& ignoreIds = QgsFeatureIds() );
+
+    /**
+     * Returns a new attribute value for the specified field index which is guaranteed to be unique. The optional seed
+     * value can be used as a basis for generated values.
+     * @see valueExists()
+     */
+    static QVariant createUniqueValue( const QgsVectorLayer* layer, int fieldIndex, const QVariant& seed = QVariant() );
 
     /**
      * Tests an attribute value to check whether it passes all constraints which are present on the corresponding field.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -241,6 +241,7 @@
 #include "qgsvirtuallayerdefinitionutils.h"
 #include "qgstransaction.h"
 #include "qgstransactiongroup.h"
+#include "qgsvectorlayerutils.h"
 
 #include "qgssublayersdialog.h"
 #include "ogr/qgsopenvectorlayerdialog.h"
@@ -7454,7 +7455,6 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
 
   QHash<int, int> remap;
   QgsFields fields = clipboard()->fields();
-  QgsAttributeList pkAttrList = pasteVectorLayer->pkAttributeList();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     int dst = pasteVectorLayer->fields().lookupField( fields.at( idx ).name() );
@@ -7465,33 +7465,14 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
   }
 
   QgsExpressionContext context = pasteVectorLayer->createExpressionContext();
-  int dstAttrCount = pasteVectorLayer->fields().count();
 
-  QgsFeatureList::iterator featureIt = features.begin();
-  while ( featureIt != features.end() )
+  QgsFeatureIds newIds;
+
+  QgsFeatureList::const_iterator featureIt = features.constBegin();
+  while ( featureIt != features.constEnd() )
   {
     QgsAttributes srcAttr = featureIt->attributes();
-    QgsAttributes dstAttr( dstAttrCount );
-
-    // pre-initialized with default values
-    for ( int dst = 0; dst < dstAttr.count(); ++dst )
-    {
-      QVariant defVal;
-      if ( !pasteVectorLayer->defaultValueExpression( dst ).isEmpty() )
-      {
-        // client side default expression set - use this in preference to provider default
-        defVal = pasteVectorLayer->defaultValue( dst, *featureIt, &context );
-      }
-      else
-      {
-        defVal = pasteVectorLayer->dataProvider()->defaultValueClause( dst );
-      }
-
-      if ( defVal.isValid() && !defVal.isNull() )
-      {
-        dstAttr[ dst ] = defVal;
-      }
-    }
+    QgsAttributeMap dstAttr;
 
     for ( int src = 0; src < srcAttr.count(); ++src )
     {
@@ -7499,21 +7480,10 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
       if ( dst < 0 )
         continue;
 
-      // don't overwrite default value for primary key fields if it's NOT NULL
-      // or for spatialite layers
-      if ( pkAttrList.contains( dst ) )
-      {
-        if ( !dstAttr.at( dst ).isNull() )
-          continue;
-        else if ( pasteVectorLayer->providerType() == QLatin1String( "spatialite" ) )
-          continue;
-      }
-
       dstAttr[ dst ] = srcAttr.at( src );
     }
 
-    featureIt->setAttributes( dstAttr );
-
+    QgsGeometry geom = featureIt->geometry();
     if ( featureIt->hasGeometry() )
     {
       // convert geometry to match destination layer
@@ -7528,25 +7498,29 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
 
       if ( destType != QgsWkbTypes::UnknownGeometry )
       {
-        QgsGeometry newGeometry = featureIt->geometry().convertToType( destType, destIsMulti );
+        QgsGeometry newGeometry = geom.convertToType( destType, destIsMulti );
         if ( newGeometry.isEmpty() )
         {
-          featureIt = features.erase( featureIt );
           continue;
         }
-        featureIt->setGeometry( newGeometry );
+        geom = newGeometry;
       }
       // avoid intersection if enabled in digitize settings
-      QgsGeometry g = featureIt->geometry();
-      g.avoidIntersections();
-      featureIt->setGeometry( g );
+      geom.avoidIntersections();
     }
+
+    // now create new feature using pasted feature as a template. This automatically handles default
+    // values and field constraints
+    QgsFeature newFeature = QgsVectorLayerUtils::createFeature( pasteVectorLayer, geom, dstAttr, &context );
+    pasteVectorLayer->addFeature( newFeature, false );
+    newIds << newFeature.id();
 
     ++featureIt;
   }
 
-  pasteVectorLayer->addFeatures( features );
+  pasteVectorLayer->selectByIds( newIds );
   pasteVectorLayer->endEditCommand();
+  pasteVectorLayer->updateExtents();
 
   int nCopiedFeatures = features.count();
   if ( nCopiedFeatures == 0 )

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -1001,13 +1001,25 @@ void QgsFieldsProperties::apply()
     {
       mLayer->setFieldConstraint( i, QgsFieldConstraints::ConstraintNotNull, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard ) );
     }
+    else
+    {
+      mLayer->removeFieldConstraint( i, QgsFieldConstraints::ConstraintNotNull );
+    }
     if ( cfg.mConstraints & QgsFieldConstraints::ConstraintUnique )
     {
       mLayer->setFieldConstraint( i, QgsFieldConstraints::ConstraintUnique, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintStrengthHard ) );
     }
+    else
+    {
+      mLayer->removeFieldConstraint( i, QgsFieldConstraints::ConstraintUnique );
+    }
     if ( cfg.mConstraints & QgsFieldConstraints::ConstraintExpression )
     {
       mLayer->setFieldConstraint( i, QgsFieldConstraints::ConstraintExpression, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthHard ) );
+    }
+    else
+    {
+      mLayer->removeFieldConstraint( i, QgsFieldConstraints::ConstraintExpression );
     }
 
     if ( mFieldsList->item( i, attrWMSCol )->checkState() == Qt::Unchecked )

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -114,6 +114,11 @@ QgsFieldConstraints::Constraints QgsVectorDataProvider::fieldConstraints( int fi
   return f.at( fieldIndex ).constraints().constraints();
 }
 
+bool QgsVectorDataProvider::skipConstraintCheck( int, QgsFieldConstraints::Constraint, const QVariant& ) const
+{
+  return false;
+}
+
 bool QgsVectorDataProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
 {
   Q_UNUSED( geometry_map );

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -209,7 +209,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * @param substring substring to match (case insensitive)
      * @param limit maxmum number of the values to return, or -1 to return all unique values
      * @param feedback optional feedback object for cancelling request
-     * @returns list of unique strings containg substring
+     * @returns list of unique strings containing substring
      */
     virtual QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
         QgsFeedback* feedback = nullptr ) const;

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -293,7 +293,13 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
 
     /**
      * Returns any literal default values which are present at the provider for a specified
-     * field index.
+     * field index. Important - this should ONLY be called when creating an attribute to insert
+     * directly into the database. Do not call this method for non-feature creation or modification,
+     * eg when validating an attribute or to compare it against an existing value, as calling it
+     * can cause changes to the underlying data source (eg Postgres provider where the default value
+     * is calculated as a result of a sequence). It is recommended that you instead use the methods
+     * in QgsVectorLayerUtils such as QgsVectorLayerUtils::createFeature()
+     * so that default value handling and validation is automatically carried out.
      * @see defaultValueClause()
      */
     virtual QVariant defaultValue( int fieldIndex ) const;
@@ -311,8 +317,18 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * Returns any constraints which are present at the provider for a specified
      * field index.
      * @note added in QGIS 3.0
+     * @see skipConstraintCheck()
      */
     QgsFieldConstraints::Constraints fieldConstraints( int fieldIndex ) const;
+
+    /**
+     * Returns true if a constraint check should be skipped for a specified field (eg if
+     * the value returned by defaultValue() is trusted implicitly. An optional attribute value can be
+     * passed which can help refine the skip constraint check.
+     * @note added in QGIS 3.0
+     * @see fieldConstraints()
+     */
+    virtual bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant& value = QVariant() ) const;
 
     /**
      * Changes geometries of existing features

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -36,6 +36,7 @@ typedef QHash<int, QString> QgsAttrPalIndexNameHash;
 
 class QgsFeatureIterator;
 class QgsTransaction;
+class QgsFeedback;
 
 #include "qgsfeaturerequest.h"
 
@@ -200,6 +201,18 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * Default implementation simply iterates the features
      */
     virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const;
+
+    /**
+     * Returns unique string values of an attribute which contain a specified subset string. Subset
+     * matching is done in a case-insensitive manner.
+     * @param index the index of the attribute
+     * @param substring substring to match (case insensitive)
+     * @param limit maxmum number of the values to return, or -1 to return all unique values
+     * @param feedback optional feedback object for cancelling request
+     * @returns list of unique strings containg substring
+     */
+    virtual QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
+        QgsFeedback* feedback = nullptr ) const;
 
     /** Calculates an aggregated value from the layer's features. The base implementation does nothing,
      * but subclasses can override this method to handoff calculation of aggregates to the provider.

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -82,6 +82,7 @@
 #include "qgspallabeling.h"
 #include "qgssimplifymethod.h"
 #include "qgsexpressioncontext.h"
+#include "qgsfeedback.h"
 
 #include "diagram/qgsdiagram.h"
 
@@ -3222,6 +3223,107 @@ void QgsVectorLayer::uniqueValues( int index, QList<QVariant> &uniqueValues, int
   }
 
   Q_ASSERT_X( false, "QgsVectorLayer::uniqueValues()", "Unknown source of the field!" );
+}
+
+QStringList QgsVectorLayer::uniqueStringsMatching( int index, const QString& substring, int limit, QgsFeedback* feedback ) const
+{
+  QStringList results;
+  if ( !mDataProvider )
+  {
+    return results;
+  }
+
+  QgsFields::FieldOrigin origin = mFields.fieldOrigin( index );
+  switch ( origin )
+  {
+    case QgsFields::OriginUnknown:
+      return results;
+
+    case QgsFields::OriginProvider: //a provider field
+    {
+      results = mDataProvider->uniqueStringsMatching( index, substring, limit, feedback );
+
+      if ( mEditBuffer )
+      {
+        QgsFeatureMap added = mEditBuffer->addedFeatures();
+        QMapIterator< QgsFeatureId, QgsFeature > addedIt( added );
+        while ( addedIt.hasNext() && ( limit < 0 || results.count() < limit ) && ( !feedback || !feedback->isCancelled() ) )
+        {
+          addedIt.next();
+          QVariant v = addedIt.value().attribute( index );
+          if ( v.isValid() )
+          {
+            QString vs = v.toString();
+            if ( vs.contains( substring, Qt::CaseInsensitive ) && !results.contains( vs ) )
+            {
+              results << vs;
+            }
+          }
+        }
+
+        QMapIterator< QgsFeatureId, QgsAttributeMap > it( mEditBuffer->changedAttributeValues() );
+        while ( it.hasNext() && ( limit < 0 || results.count() < limit ) && ( !feedback || !feedback->isCancelled() ) )
+        {
+          it.next();
+          QVariant v = it.value().value( index );
+          if ( v.isValid() )
+          {
+            QString vs = v.toString();
+            if ( vs.contains( substring, Qt::CaseInsensitive ) && !results.contains( vs ) )
+            {
+              results << vs;
+            }
+          }
+        }
+      }
+
+      return results;
+    }
+
+    case QgsFields::OriginEdit:
+      // the layer is editable, but in certain cases it can still be avoided going through all features
+      if ( mEditBuffer->mDeletedFeatureIds.isEmpty() &&
+           mEditBuffer->mAddedFeatures.isEmpty() &&
+           !mEditBuffer->mDeletedAttributeIds.contains( index ) &&
+           mEditBuffer->mChangedAttributeValues.isEmpty() )
+      {
+        return mDataProvider->uniqueStringsMatching( index, substring, limit, feedback );
+      }
+      FALLTHROUGH;
+      //we need to go through each feature
+    case QgsFields::OriginJoin:
+    case QgsFields::OriginExpression:
+    {
+      QgsAttributeList attList;
+      attList << index;
+
+      QgsFeatureRequest request;
+      request.setSubsetOfAttributes( attList );
+      request.setFlags( QgsFeatureRequest::NoGeometry );
+      QString fieldName = mFields.at( index ).name();
+      request.setFilterExpression( QStringLiteral( "\"%1\" ILIKE '%%2%'" ).arg( fieldName, substring ) );
+      QgsFeatureIterator fit = getFeatures( request );
+
+      QgsFeature f;
+      QString currentValue;
+      while ( fit.nextFeature( f ) )
+      {
+        currentValue = f.attribute( index ).toString();
+        if ( !results.contains( currentValue ) )
+          results << currentValue;
+
+        if (( limit >= 0 && results.size() >= limit ) || ( feedback && feedback->isCancelled() ) )
+        {
+          break;
+        }
+      }
+
+      return results;
+    }
+  }
+
+  Q_ASSERT_X( false, "QgsVectorLayer::uniqueStringsMatching()", "Unknown source of the field!" );
+  return results;
 }
 
 QVariant QgsVectorLayer::minimumValue( int index ) const

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -68,6 +68,7 @@ class QgsVectorLayerEditBuffer;
 class QgsVectorLayerJoinBuffer;
 class QgsAbstractVectorLayerLabeling;
 class QgsPointV2;
+class QgsFeedback;
 
 typedef QList<int> QgsAttributeList;
 typedef QSet<int> QgsAttributeIds;
@@ -1467,6 +1468,22 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * @see maximumValue()
      */
     void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const;
+
+    /**
+     * Returns unique string values of an attribute which contain a specified subset string. Subset
+     * matching is done in a case-insensitive manner. Note that
+     * in some circumstances when unsaved changes are present for the layer then the returned list
+     * may contain outdated values (for instance when the attribute value in a saved feature has
+     * been changed inside the edit buffer then the previous saved value will be included in the
+     * returned list).
+     * @param index column index for attribute
+     * @param substring substring to match (case insensitive)
+     * @param limit maxmum number of the values to return, or -1 to return all unique values
+     * @param feedback optional feedback object for cancelling request
+     * @returns list of unique strings containing substring
+     */
+    QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
+                                       QgsFeedback* feedback = nullptr ) const;
 
     /** Returns the minimum value for an attribute column or an invalid variant in case of error.
      * Note that in some circumstances when unsaved changes are present for the layer then the

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -19,6 +19,7 @@
 #include "qgsfeature.h"
 
 #include "qgsvectorlayer.h"
+#include "qgsgeometry.h"
 
 class QgsGeometryCache;
 class QgsCurve;

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -33,8 +33,16 @@ class CORE_EXPORT QgsVectorLayerUtils
      * Returns true if the specified value already exists within a field. This method can be used to test for uniqueness
      * of values inside a layer's attributes. An optional list of ignored feature IDs can be provided, if so, any features
      * with IDs within this list are ignored when testing for existance of the value.
+     * @see createUniqueValue()
      */
     static bool valueExists( const QgsVectorLayer* layer, int fieldIndex, const QVariant& value, const QgsFeatureIds& ignoreIds = QgsFeatureIds() );
+
+    /**
+     * Returns a new attribute value for the specified field index which is guaranteed to be unique. The optional seed
+     * value can be used as a basis for generated values.
+     * @see valueExists()
+     */
+    static QVariant createUniqueValue( const QgsVectorLayer* layer, int fieldIndex, const QVariant& seed = QVariant() );
 
     /**
      * Tests an attribute value to check whether it passes all constraints which are present on the corresponding field.
@@ -44,6 +52,7 @@ class CORE_EXPORT QgsVectorLayerUtils
     static bool validateAttribute( const QgsVectorLayer* layer, const QgsFeature& feature, int attributeIndex, QStringList& errors,
                                    QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
                                    QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
+
 
 };
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -17,6 +17,7 @@
 #define QGSVECTORLAYERUTILS_H
 
 #include "qgsvectorlayer.h"
+#include "qgsgeometry.h"
 
 /** \ingroup core
  * \class QgsVectorLayerUtils
@@ -53,6 +54,17 @@ class CORE_EXPORT QgsVectorLayerUtils
                                    QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
                                    QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
 
+    /**
+     * Creates a new feature ready for insertion into a layer. Default values and constraints
+     * (eg unique constraints) will automatically be handled. An optional attribute map can be
+     * passed for the new feature to copy as many attribute values as possible from the map,
+     * assuming that they respect the layer's constraints. Note that the created feature is not
+     * automatically inserted into the layer.
+     */
+    static QgsFeature createFeature( QgsVectorLayer* layer,
+                                     const QgsGeometry& geometry = QgsGeometry(),
+                                     const QgsAttributeMap& attributes = QgsAttributeMap(),
+                                     QgsExpressionContext* context = nullptr );
 
 };
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -132,6 +132,13 @@ QgsAfsProvider::QgsAfsProvider( const QString& uri )
     if ( mFields.at( idx ).name() == mObjectIdFieldName )
     {
       mObjectIdFieldIdx = idx;
+
+      // primary key is not null, unique
+      QgsFieldConstraints constraints = mFields.at( idx ).constraints();
+      constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
+      constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
+      mFields[ idx ].setConstraints( constraints );
+
       break;
     }
   }

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -54,16 +54,8 @@ class QgsDb2Provider : public QgsVectorDataProvider
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const override;
 
-    /**
-     * Get feature type.
-     * @return int representing the feature type
-     */
     virtual QgsWkbTypes::Type wkbType() const override;
 
-    /**
-     * Number of features in the layer
-     * @return long containing number of features
-     */
     virtual long featureCount() const override;
 
     /**
@@ -79,45 +71,24 @@ class QgsDb2Provider : public QgsVectorDataProvider
     virtual bool isValid() const override;
     QString subsetString() const override;
 
-    /**
-     * Mutator for SQL WHERE clause used to limit dataset size.
-     */
     bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
     virtual bool supportsSubsetString() const override { return true; }
 
-    /** Return a provider name
-
-        Essentially just returns the provider key.  Should be used to build file
-        dialogs so that providers can be shown with their supported types. Thus
-        if more than one provider supports a given format, the user is able to
-        select a specific provider to open that file.
-     */
     virtual QString name() const override;
 
-    /** Return description
-
-        Return a terse string describing what the provider is.
-     */
     virtual QString description() const override;
 
-    /** Returns a bitmask containing the supported capabilities
-        Note, some capabilities may change depending on whether
-        a spatial filter is active on this provider, so it may
-        be prudent to check this value per intended operation.
-     */
+    QgsAttributeList pkAttributeIndexes() const override;
+
     virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
-    //! Writes a list of features to the database
     virtual bool addFeatures( QgsFeatureList & flist ) override;
 
-    //! Deletes a feature
     virtual bool deleteFeatures( const QgsFeatureIds & id ) override;
 
-    //! Changes attribute values of existing features
     virtual bool changeAttributeValues( const QgsChangedAttributesMap &attr_map ) override;
 
-    //! Changes existing geometries
     virtual bool changeGeometryValues( const QgsGeometryMap &geometry_map ) override;
 
     //! Import a vector layer into the database
@@ -155,6 +126,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
     bool mUseEstimatedMetadata;
     bool mSkipFailures;
     long mNumberFeatures;
+    int mFidColIdx;
     QString mFidColName;
     QString mExtents;
     mutable long mSRId;

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -62,33 +62,15 @@ class QgsMssqlProvider : public QgsVectorDataProvider
 
     /* Implementation of functions from QgsVectorDataProvider */
 
-    /**
-     * Returns the permanent storage type for this layer as a friendly name.
-     */
     virtual QString storageType() const override;
-
-    /**
-     * Sub-layers handled by this provider, in order from bottom to top
-     *
-     * Sub-layers are used when the provider's source can combine layers
-     * it knows about in some way before it hands them off to the provider.
-     */
     virtual QStringList subLayers() const override;
     virtual QVariant minimumValue( int index ) const override;
     virtual QVariant maximumValue( int index ) const override;
     virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const override;
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
-    /**
-     * Get feature type.
-     * @return int representing the feature type
-     */
     virtual QgsWkbTypes::Type wkbType() const override;
 
-    /**
-     * Number of features in the layer
-     * @return long containing number of features
-     */
     virtual long featureCount() const override;
 
     //! Update the extent, feature count, wkb type and srid for this layer
@@ -98,47 +80,20 @@ class QgsMssqlProvider : public QgsVectorDataProvider
 
     QString subsetString() const override;
 
-    //! Mutator for sql where clause used to limit dataset size
     bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
     virtual bool supportsSubsetString() const override { return true; }
 
-    /** Returns a bitmask containing the supported capabilities
-        Note, some capabilities may change depending on whether
-        a spatial filter is active on this provider, so it may
-        be prudent to check this value per intended operation.
-     */
     virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
 
     /* Implementation of functions from QgsDataProvider */
 
-    /** Return a provider name
-
-        Essentially just returns the provider key.  Should be used to build file
-        dialogs so that providers can be shown with their supported types. Thus
-        if more than one provider supports a given format, the user is able to
-        select a specific provider to open that file.
-
-        @note
-
-        Instead of being pure virtual, might be better to generalize this
-        behavior and presume that none of the sub-classes are going to do
-        anything strange with regards to their name or description?
-     */
     QString name() const override;
 
-    /** Return description
-
-        Return a terse string describing what the provider is.
-
-        @note
-
-        Instead of being pure virtual, might be better to generalize this
-        behavior and presume that none of the sub-classes are going to do
-        anything strange with regards to their name or description?
-     */
     QString description() const override;
+
+    QgsAttributeList pkAttributeIndexes() const override;
 
     virtual QgsRectangle extent() const override;
 
@@ -146,38 +101,20 @@ class QgsMssqlProvider : public QgsVectorDataProvider
 
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
 
-    //! Writes a list of features to the database
     virtual bool addFeatures( QgsFeatureList & flist ) override;
 
-    //! Deletes a feature
     virtual bool deleteFeatures( const QgsFeatureIds & id ) override;
 
-    /**
-     * Adds new attributes
-     * @param attributes list of new attributes
-     * @return true in case of success and false in case of failure
-     */
     virtual bool addAttributes( const QList<QgsField> &attributes ) override;
 
-    /**
-     * Deletes existing attributes
-     * @param attributes a set containing names of attributes
-     * @return true in case of success and false in case of failure
-     */
     virtual bool deleteAttributes( const QgsAttributeIds &attributes ) override;
 
-    //! Changes attribute values of existing features
     virtual bool changeAttributeValues( const QgsChangedAttributesMap &attr_map ) override;
 
-    //! Changes existing geometries
     virtual bool changeGeometryValues( const QgsGeometryMap &geometry_map ) override;
 
-    /**
-     * Create a spatial index for the current layer
-     */
     virtual bool createSpatialIndex() override;
 
-    //! Create an attribute index on the datasource
     virtual bool createAttributeIndex( int field ) override;
 
     //! Convert a QgsField to work with MSSQL
@@ -227,6 +164,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
 
     long mNumberFeatures;
     QString mFidColName;
+    int mFidColIdx;
     mutable long mSRId;
     QString mGeometryColName;
     QString mGeometryColType;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -20,6 +20,7 @@ email                : sherman at mrcc.com
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
 #include "qgslocalec.h"
+#include "qgsfeedback.h"
 
 #define CPL_SUPRESS_CPLUSPLUS
 #include <gdal.h>         // to collect version information
@@ -2920,6 +2921,59 @@ void QgsOgrProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int
   }
 
   OGR_DS_ReleaseResultSet( ogrDataSource, l );
+#endif
+}
+
+QStringList QgsOgrProvider::uniqueStringsMatching( int index, const QString& substring, int limit, QgsFeedback* feedback ) const
+{
+  QStringList results;
+
+  if ( !mValid || index < 0 || index >= mAttributeFields.count() )
+    return results;
+
+  QgsField fld = mAttributeFields.at( index );
+  if ( fld.name().isNull() )
+  {
+    return results; //not a provider field
+  }
+
+#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM < 1910
+  // avoid GDAL #4509
+  return QgsVectorDataProvider::uniqueStringsMatching( index, substring, limit, feedback );
+#else
+  QByteArray sql = "SELECT DISTINCT " + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) );
+  sql += " FROM " + quotedIdentifier( OGR_FD_GetName( OGR_L_GetLayerDefn( ogrLayer ) ) );
+
+  sql += " WHERE " + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) ) + " LIKE '%" +  textEncoding()->fromUnicode( substring ) + "%'";
+
+  if ( !mSubsetString.isEmpty() )
+  {
+    sql += " AND (" + textEncoding()->fromUnicode( mSubsetString ) + ')';
+  }
+
+  sql += " ORDER BY " + textEncoding()->fromUnicode( fld.name() ) + " ASC";  // quoting of fieldname produces a syntax error
+
+  QgsDebugMsg( QString( "SQL: %1" ).arg( textEncoding()->toUnicode( sql ) ) );
+  OGRLayerH l = OGR_DS_ExecuteSQL( ogrDataSource, sql.constData(), nullptr, nullptr );
+  if ( !l )
+  {
+    QgsDebugMsg( "Failed to execute SQL" );
+    return QgsVectorDataProvider::uniqueStringsMatching( index, substring, limit, feedback );
+  }
+
+  OGRFeatureH f;
+  while (( f = OGR_L_GetNextFeature( l ) ) )
+  {
+    if ( OGR_F_IsFieldSet( f, 0 ) )
+      results << textEncoding()->toUnicode( OGR_F_GetFieldAsString( f, 0 ) );
+    OGR_F_Destroy( f );
+
+    if (( limit >= 0 && results.size() >= limit ) || ( feedback && feedback->isCancelled() ) )
+      break;
+  }
+
+  OGR_DS_ReleaseResultSet( ogrDataSource, l );
+  return results;
 #endif
 }
 

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -207,6 +207,9 @@ class QgsOgrProvider : public QgsVectorDataProvider
      */
     virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const override;
 
+    virtual QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
+        QgsFeedback* feedback = nullptr ) const override;
+
     /** Return a provider name
      *
      * Essentially just returns the provider key.  Should be used to build file

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1002,9 +1002,9 @@ bool QgsPostgresProvider::loadFields()
     QgsField newField = QgsField( fieldName, fieldType, fieldTypeName, fieldSize, fieldPrec, fieldComment, fieldSubType );
 
     QgsFieldConstraints constraints;
-    if ( notNullMap[tableoid][attnum] )
+    if ( notNullMap[tableoid][attnum] || mPrimaryKeyAttrs.contains( i ) )
       constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
-    if ( uniqueMap[tableoid][attnum] )
+    if ( uniqueMap[tableoid][attnum] || mPrimaryKeyAttrs.contains( i ) )
       constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
     newField.setConstraints( constraints );
 
@@ -1373,6 +1373,15 @@ bool QgsPostgresProvider::determinePrimaryKey()
   else
   {
     determinePrimaryKeyFromUriKeyColumn();
+  }
+
+  Q_FOREACH ( int fieldIdx, mPrimaryKeyAttrs )
+  {
+    //primary keys are unique, not null
+    QgsFieldConstraints constraints = mAttributeFields.at( fieldIdx ).constraints();
+    constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
+    constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
+    mAttributeFields[ fieldIdx ].setConstraints( constraints );
   }
 
   mValid = mPrimaryKeyType != pktUnknown;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1806,6 +1806,20 @@ QVariant QgsPostgresProvider::defaultValue( int fieldId ) const
   return QVariant();
 }
 
+bool QgsPostgresProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint, const QVariant& value ) const
+{
+  if ( providerProperty( EvaluateDefaultValues, false ).toBool() )
+  {
+    return mDefaultValues.contains( fieldIndex );
+  }
+  else
+  {
+    // stricter check - if we are evaluating default values only on commit then we can only bypass the check
+    // if the attribute values matches the original default clause
+    return mDefaultValues.contains( fieldIndex ) && mDefaultValues.value( fieldIndex ) == value.toString();
+  }
+}
+
 QString QgsPostgresProvider::paramValue( const QString& fieldValue, const QString &defaultValue ) const
 {
   if ( fieldValue.isNull() )

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -155,6 +155,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QVariant minimumValue( int index ) const override;
     QVariant maximumValue( int index ) const override;
     virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const override;
+    virtual QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
+        QgsFeedback* feedback = nullptr ) const override;
     virtual void enumValues( int index, QStringList& enumList ) const override;
     bool isValid() const override;
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -164,6 +164,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QString defaultValueClause( int fieldId ) const override;
     QVariant defaultValue( int fieldId ) const override;
+    bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant& value = QVariant() ) const override;
 
     /** Adds a list of features
       @return true in case of success and false in case of failure*/

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -762,6 +762,9 @@ void QgsSpatiaLiteProvider::loadFieldsAbstractInterface( gaiaVectorLayerPtr lyr 
     }
   }
 
+  // check for constraints
+  fetchConstraints();
+
   // for views try to get the primary key from the meta table
   if ( mViewBased && mPrimaryKey.isEmpty() )
   {
@@ -861,6 +864,15 @@ void QgsSpatiaLiteProvider::fetchConstraints()
 
   }
   sqlite3_free_table( results );
+
+  Q_FOREACH ( int fieldIdx, mPrimaryKeyAttrs )
+  {
+    //primary keys are unique, not null
+    QgsFieldConstraints constraints = mAttributeFields.at( fieldIdx ).constraints();
+    constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
+    constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
+    mAttributeFields[ fieldIdx ].setConstraints( constraints );
+  }
 
   return;
 

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -131,6 +131,9 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     QVariant maximumValue( int index ) const override;
     virtual void uniqueValues( int index, QList < QVariant > &uniqueValues, int limit = -1 ) const override;
 
+    virtual QStringList uniqueStringsMatching( int index, const QString& substring, int limit = -1,
+        QgsFeedback* feedback = nullptr ) const override;
+
     bool isValid() const override;
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
 

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -566,6 +566,25 @@ class ProviderTestCase(object):
         self.provider.setSubsetString(None)
         self.assertEqual(set(values), set([200, 300]))
 
+    def testUniqueStringsMatching(self):
+        self.assertEqual(set(self.provider.uniqueStringsMatching(2, 'a')), set(['Pear', 'Orange', 'Apple']))
+        # test case insensitive
+        self.assertEqual(set(self.provider.uniqueStringsMatching(2, 'A')), set(['Pear', 'Orange', 'Apple']))
+        # test string ending in substring
+        self.assertEqual(set(self.provider.uniqueStringsMatching(2, 'ney')), set(['Honey']))
+        # test limit
+        result = set(self.provider.uniqueStringsMatching(2, 'a', 2))
+        self.assertEqual(len(result), 2)
+        self.assertTrue(result.issubset(set(['Pear', 'Orange', 'Apple'])))
+
+        assert set([u'Apple', u'Honey', u'Orange', u'Pear', NULL]) == set(self.provider.uniqueValues(2)), 'Got {}'.format(set(self.provider.uniqueValues(2)))
+
+        subset = self.getSubsetString2()
+        self.provider.setSubsetString(subset)
+        values = self.provider.uniqueStringsMatching(2, 'a')
+        self.provider.setSubsetString(None)
+        self.assertEqual(set(values), set(['Pear', 'Apple']))
+
     def testFeatureCount(self):
         assert self.provider.featureCount() == 5, 'Got {}'.format(self.provider.featureCount())
 

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -474,14 +474,14 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         f = QgsVectorLayerUtils.createFeature(vl)
         self.assertEqual(f.attributes(), [None, "qgis 'is good", 5, 5.7, None])
 
-        # check that provider passed attribute values take precedence over default literals
+        # check that provider default literals take precedence over passed attribute values
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 'qgis is great', 0: 3})
-        self.assertEqual(f.attributes(), [3, "qgis is great", 5, 5.7, None])
+        self.assertEqual(f.attributes(), [3, "qgis 'is good", 5, 5.7, None])
 
-        # test take vector layer default value expression overrides postgres provider default clause
+        # test that vector layer default value expression overrides provider default literal
         vl.setDefaultValueExpression(3, "4*3")
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 'qgis is great', 0: 3})
-        self.assertEqual(f.attributes(), [3, "qgis is great", 5, 12, None])
+        self.assertEqual(f.attributes(), [3, "qgis 'is good", 5, 12, None])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -178,6 +178,38 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         self.assertEqual(len(errors), 2)
         print(errors)
 
+    def testCreateUniqueValue(self):
+        """ test creating a unique value """
+        layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer&field=flddbl:double",
+                               "addfeat", "memory")
+        # add a bunch of features
+        f = QgsFeature()
+        f.setAttributes(["test", 123, 1.0])
+        f1 = QgsFeature(2)
+        f1.setAttributes(["test_1", 124, 1.1])
+        f2 = QgsFeature(3)
+        f2.setAttributes(["test_2", 125, 2.4])
+        f3 = QgsFeature(4)
+        f3.setAttributes(["test_3", 126, 1.7])
+        f4 = QgsFeature(5)
+        f4.setAttributes(["superpig", 127, 0.8])
+        self.assertTrue(layer.dataProvider().addFeatures([f, f1, f2, f3, f4]))
+
+        # bad field indices
+        self.assertFalse(QgsVectorLayerUtils.createUniqueValue(layer, -10))
+        self.assertFalse(QgsVectorLayerUtils.createUniqueValue(layer, 10))
+
+        # integer field
+        self.assertEqual(QgsVectorLayerUtils.createUniqueValue(layer, 1), 128)
+
+        # double field
+        self.assertEqual(QgsVectorLayerUtils.createUniqueValue(layer, 2), 3.0)
+
+        # string field
+        self.assertEqual(QgsVectorLayerUtils.createUniqueValue(layer, 0), 'test_4')
+        self.assertEqual(QgsVectorLayerUtils.createUniqueValue(layer, 0, 'test_1'), 'test_4')
+        self.assertEqual(QgsVectorLayerUtils.createUniqueValue(layer, 0, 'seed'), 'seed')
+        self.assertEqual(QgsVectorLayerUtils.createUniqueValue(layer, 0, 'superpig'), 'superpig_1')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Improves handling of defaults (inc provider default clauses, literal defaults, and qgis expression defaults) and automatically handling unique value constraints on layers.

This adds a new method QgsVectorLayerUtils::createFeature which returns a new feature which includes all relevant defaults. Any fields with unique value constraints will be guaranteed to have a value
which is unique for the field. It's heavily unit tested and designed to replace all the duplicate, inconsistent code for handling provider default clauses currently scattered around the code base.

All (identified) map tools which create new features have been updated to use this to gain automatic handling of provider defaults, qgis default expressions, and provider/qgis side unique field constraints.

Sponsored by Canton of Zug and the QGEP project