### PR TITLE
[processing] use algorithm description in modeler dependencies dialog

### DIFF
--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -247,7 +247,7 @@ class ModelerParametersDialog(QDialog):
         return opts
 
     def getDependenciesPanel(self):
-        return MultipleInputPanel([alg.algorithm.name for alg in self.getAvailableDependencies()])
+        return MultipleInputPanel([alg.description for alg in self.getAvailableDependencies()])
 
     def showAdvancedParametersClicked(self):
         self.showAdvanced = not self.showAdvanced


### PR DESCRIPTION
This PR improves the modeler algorithm dependencies UI by using the algorithm's description (attached to the modeler algorithm item) instead of its default name. The reasoning behind this is to avoid duplicates when a given algorithm (for e.g. PostGIS execute SQL) is used more than once in a model.

A picture if worth a thousand words:
![untitled](https://cloud.githubusercontent.com/assets/1728657/20163514/bb48f272-a72f-11e6-99e7-aba9e1db08a3.png)
_left: current sub-optimal UI, right: proposed improvement_

I discovered this while building a complex model. Using the algorithm's default name had me check and uncheck every single duplicate name to try and find the right algorithm in the chain. 