### PR TITLE
[spatialite] Don't skip default values

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3764,9 +3764,6 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList & flist )
 
     for ( int i = 0; i < attributevec.count(); ++i )
     {
-      if ( !attributevec.at( i ).isValid() )
-        continue;
-
       if ( i >= mAttributeFields.count() )
         continue;
 
@@ -3822,8 +3819,6 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList & flist )
         for ( int i = 0; i < attributevec.count(); ++i )
         {
           QVariant v = attributevec.at( i );
-          if ( !v.isValid() )
-            continue;
 
           // binding values for each attribute
           if ( i >= mAttributeFields.count() )
@@ -3835,7 +3830,11 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList & flist )
 
           QVariant::Type type = mAttributeFields.at( i ).type();
 
-          if ( v.isNull() )
+          if ( !v.isValid() )
+          {
+            ++ia;
+          }
+          else if ( v.isNull() )
           {
             // binding a NULL value
             sqlite3_bind_null( stmt, ++ia );


### PR DESCRIPTION
When inserting multiple features in a single prepared statement, the spatialite
provider would skip any default for individual features, even though they have
been specified in the field list, resulting in missing fields.