### PR TITLE
Remove WKB and GEOS caching from QgsGeometry

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -844,6 +844,7 @@ value instead of a pointer. The biggest impact with this change is that PyQGIS c
 result to None, but instead either use a boolean test (`if g.buffer(10):`) or explicitly use the isEmpty()
 method to determine if a geometry is valid.
 - wkbSize() and asWkb() has been replaced by exportToWkb(). WKB representation is no longer cached within QgsGeometry
+- asGeos() has been replaced by exportToGeos(). GEOS representation is no longer cached within QgsGeometry
 - int addPart( const QList<QgsPoint> &points, QgsWkbTypes::GeometryType geomType ) has been renamed to addPoints
 - int addPart( const QList<QgsPointV2> &points, QgsWkbTypes::GeometryType geomType ) has been renamed to addPointsV2
 - static bool compare( const QgsPolyline& p1, const QgsPolyline& p2, double epsilon ) has been renamed to comparePolylines

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -318,6 +318,13 @@ QgsAnnotation        {#qgis_api_break_3_0_QgsAnnotation}
 -  mapPositionFixed() has been renamed to hasFixedMapPosition()
 
 
+QgsAbstractGeometry        {#qgis_api_break_3_0_QgsAbstractGeometry}
+-------------------
+
+- asWkb() returns QByteArray instead of new raw pointer
+- wkbSize() has been removed, use asWkb() to get length of returned QByteArray
+- fromWkb() gets the WKB pointer passed by reference instead of value, so that caller may to find out where the parsing ended
+
 
 QgsActionManager        {#qgis_api_break_3_0_QgsActionManager}
 ----------------
@@ -836,6 +843,7 @@ QgsGeometry        {#qgis_api_break_3_0_QgsGeometry}
 value instead of a pointer. The biggest impact with this change is that PyQGIS code should not compare a geometry
 result to None, but instead either use a boolean test (`if g.buffer(10):`) or explicitly use the isEmpty()
 method to determine if a geometry is valid.
+- wkbSize() and asWkb() has been replaced by exportToWkb(). WKB representation is no longer cached within QgsGeometry
 - int addPart( const QList<QgsPoint> &points, QgsWkbTypes::GeometryType geomType ) has been renamed to addPoints
 - int addPart( const QList<QgsPointV2> &points, QgsWkbTypes::GeometryType geomType ) has been renamed to addPointsV2
 - static bool compare( const QgsPolyline& p1, const QgsPolyline& p2, double epsilon ) has been renamed to comparePolylines

--- a/python/core/geometry/qgsabstractgeometry.sip
+++ b/python/core/geometry/qgsabstractgeometry.sip
@@ -140,9 +140,10 @@ class QgsAbstractGeometry
     //import
 
     /** Sets the geometry from a WKB string.
+     * After successful read the wkb argument will be at the position where the reading has stopped.
      * @see fromWkt
      */
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) = 0;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) = 0;
 
     /** Sets the geometry from a WKT string.
      * @see fromWkb
@@ -151,20 +152,14 @@ class QgsAbstractGeometry
 
     //export
 
-    /** Returns the size of the WKB representation of the geometry.
-     * @see asWkb
-     */
-    virtual int wkbSize() const = 0;
-
     /** Returns a WKB representation of the geometry.
-     * @param binarySize will be set to the size of the returned WKB string
-     * @see wkbSize
      * @see asWkt
      * @see asGML2
      * @see asGML3
      * @see asJSON
+     * @note added in 3.0
      */
-    virtual unsigned char* asWkb( int& binarySize ) const = 0;
+    virtual QByteArray asWkb() const = 0;
 
     /** Returns a WKT representation of the geometry.
      * @param precision number of decimal places for coordinates

--- a/python/core/geometry/qgscircularstring.sip
+++ b/python/core/geometry/qgscircularstring.sip
@@ -16,11 +16,10 @@ class QgsCircularString: public QgsCurve
     virtual QgsCircularString* clone() const /Factory/;
     virtual void clear();
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb );
+    virtual bool fromWkb( QgsConstWkbPtr& wkb );
     virtual bool fromWkt( const QString& wkt );
 
-    int wkbSize() const;
-    unsigned char* asWkb( int& binarySize ) const;
+    QByteArray asWkb() const;
     QString asWkt( int precision = 17 ) const;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/python/core/geometry/qgscompoundcurve.sip
+++ b/python/core/geometry/qgscompoundcurve.sip
@@ -18,11 +18,10 @@ class QgsCompoundCurve: public QgsCurve
     virtual QgsCompoundCurve* clone() const /Factory/;
     virtual void clear();
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb );
+    virtual bool fromWkb( QgsConstWkbPtr& wkb );
     virtual bool fromWkt( const QString& wkt );
 
-    int wkbSize() const;
-    unsigned char* asWkb( int& binarySize ) const;
+    QByteArray asWkb() const;
     QString asWkt( int precision = 17 ) const;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/python/core/geometry/qgscurvepolygon.sip
+++ b/python/core/geometry/qgscurvepolygon.sip
@@ -15,11 +15,10 @@ class QgsCurvePolygon: public QgsSurface
     virtual QgsCurvePolygon* clone() const /Factory/;
     void clear();
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb );
+    virtual bool fromWkb( QgsConstWkbPtr& wkb );
     virtual bool fromWkt( const QString& wkt );
 
-    int wkbSize() const;
-    unsigned char* asWkb( int& binarySize ) const;
+    QByteArray asWkb() const;
     QString asWkt( int precision = 17 ) const;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -103,12 +103,12 @@ class QgsGeometry
      */
     void fromWkb( const QByteArray& wkb );
 
-    /** Returns a geos geometry. QgsGeometry retains ownership of the geometry, so the returned object should not be deleted.
+    /** Returns a geos geometry - caller takes ownership of the object (should be deleted with GEOSGeom_destroy_r)
      *  @param precision The precision of the grid to which to snap the geometry vertices. If 0, no snapping is performed.
-     *  @note this method was added in version 1.1
+     *  @note added in version 3.0
      *  @note not available in python bindings
      */
-    // const GEOSGeometry* asGeos( double precision = 0 ) const;
+    // GEOSGeometry* exportToGeos( double precision = 0 ) const;
 
     /** Returns type of the geometry as a WKB type (point / linestring / polygon etc.)
      * @see type

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -93,30 +93,15 @@ class QgsGeometry
     /**
       Set the geometry, feeding in the buffer containing OGC Well-Known Binary and the buffer's length.
       This class will take ownership of the buffer.
+      @note not available in python bindings
      */
-    void fromWkb( unsigned char * wkb /Array/, int length /ArraySize/ );
-%MethodCode
-  // create copy of Python's string and pass it to fromWkb()
-  unsigned char * copy = new unsigned char[a1];
-  memcpy(copy, a0, a1);
-  sipCpp->fromWkb(copy, a1);
-%End
+    // void fromWkb( unsigned char *wkb, int length );
 
     /**
-       Returns the buffer containing this geometry in WKB format.
-       You may wish to use in conjunction with wkbSize().
-       @see wkbSize
+     * Set the geometry, feeding in the buffer containing OGC Well-Known Binary
+     * @note added in 3.0
      */
-    SIP_PYOBJECT asWkb();
-%MethodCode
-  sipRes = PyBytes_FromStringAndSize((const char *)sipCpp->asWkb(), sipCpp->wkbSize());
-%End
-
-    /**
-     * Returns the size of the WKB in asWkb().
-     * @see asWkb
-     */
-    int wkbSize() const;
+    void fromWkb( const QByteArray& wkb );
 
     /** Returns a geos geometry. QgsGeometry retains ownership of the geometry, so the returned object should not be deleted.
      *  @param precision The precision of the grid to which to snap the geometry vertices. If 0, no snapping is performed.
@@ -592,6 +577,11 @@ class QgsGeometry
 
     /** Returns an extruded version of this geometry. */
     QgsGeometry extrude( double x, double y );
+
+    /** Export the geometry to WKB
+     * @note added in 3.0
+     */
+    QByteArray exportToWkb() const;
 
     /** Exports the geometry to WKT
      *  @note precision parameter added in 2.4

--- a/python/core/geometry/qgsgeometrycollection.sip
+++ b/python/core/geometry/qgsgeometrycollection.sip
@@ -55,10 +55,9 @@ class QgsGeometryCollection: public QgsAbstractGeometry
 
     virtual void draw( QPainter& p ) const;
 
-    bool fromWkb( QgsConstWkbPtr wkb );
+    bool fromWkb( QgsConstWkbPtr& wkb );
     virtual bool fromWkt( const QString& wkt );
-    int wkbSize() const;
-    unsigned char* asWkb( int& binarySize ) const;
+    QByteArray asWkb() const;
     QString asWkt( int precision = 17 ) const;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/python/core/geometry/qgslinestring.sip
+++ b/python/core/geometry/qgslinestring.sip
@@ -107,11 +107,10 @@ class QgsLineString: public QgsCurve
     virtual QgsLineString* clone() const /Factory/;
     virtual void clear();
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb );
+    virtual bool fromWkb( QgsConstWkbPtr& wkb );
     virtual bool fromWkt( const QString& wkt );
 
-    int wkbSize() const;
-    unsigned char* asWkb( int& binarySize ) const;
+    QByteArray asWkb() const;
     QString asWkt( int precision = 17 ) const;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/python/core/geometry/qgspointv2.sip
+++ b/python/core/geometry/qgspointv2.sip
@@ -185,10 +185,9 @@ class QgsPointV2: public QgsAbstractGeometry
     virtual int dimension() const;
     virtual QgsPointV2* clone() const /Factory/;
     void clear();
-    virtual bool fromWkb( QgsConstWkbPtr wkb );
+    virtual bool fromWkb( QgsConstWkbPtr& wkb );
     virtual bool fromWkt( const QString& wkt );
-    int wkbSize() const;
-    unsigned char* asWkb( int& binarySize ) const;
+    QByteArray asWkb() const;
     QString asWkt( int precision = 17 ) const;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/python/core/geometry/qgspolygon.sip
+++ b/python/core/geometry/qgspolygon.sip
@@ -14,12 +14,11 @@ class QgsPolygonV2: public QgsCurvePolygon
     virtual QgsPolygonV2* clone() const /Factory/;
     void clear();
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb );
+    virtual bool fromWkb( QgsConstWkbPtr& wkb );
 
     // inherited: bool fromWkt( const QString &wkt );
 
-    int wkbSize() const;
-    unsigned char* asWkb( int& binarySize ) const;
+    QByteArray asWkb() const;
     // inherited: QString asWkt( int precision = 17 ) const;
     // inherited: QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     // inherited: QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/python/plugins/processing/algs/qgis/scripts/Fill_holes.py
+++ b/python/plugins/processing/algs/qgis/scripts/Fill_holes.py
@@ -25,7 +25,7 @@ for feat in processing.features(polyLayer):
     progress.setPercentage(int(100 * l / n))
     l += 1
 
-    g = loads(feat.geometry().asWkb())
+    g = loads(feat.geometry().exportToWkb())
 
     if g.geom_type == 'MultiPolygon':
         resg = [Polygon(p.exterior,

--- a/src/analysis/interpolation/qgsinterpolator.cpp
+++ b/src/analysis/interpolation/qgsinterpolator.cpp
@@ -109,7 +109,8 @@ int QgsInterpolator::addVerticesToCache( const QgsGeometry& geom, bool zCoord, d
     return 1;
 
   bool hasZValue = false;
-  QgsConstWkbPtr currentWkbPtr( geom.asWkb(), geom.wkbSize() );
+  QByteArray wkb( geom.exportToWkb() );
+  QgsConstWkbPtr currentWkbPtr( wkb );
   currentWkbPtr.readHeader();
   vertexData theVertex; //the current vertex
 

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -201,7 +201,8 @@ int QgsTINInterpolator::insertData( QgsFeature* f, bool zCoord, int attr, InputT
   //parse WKB. It is ugly, but we cannot use the methods with QgsPoint because they don't contain z-values for 25D types
   bool hasZValue = false;
   double x, y, z;
-  QgsConstWkbPtr currentWkbPtr( g.asWkb(), g.wkbSize() );
+  QByteArray wkb( g.exportToWkb() );
+  QgsConstWkbPtr currentWkbPtr( wkb );
   currentWkbPtr.readHeader();
   //maybe a structure or break line
   Line3D* line = nullptr;

--- a/src/analysis/openstreetmap/qgsosmdatabase.cpp
+++ b/src/analysis/openstreetmap/qgsosmdatabase.cpp
@@ -423,7 +423,8 @@ void QgsOSMDatabase::exportSpatiaLiteNodes( const QString& tableName, const QStr
         sqlite3_bind_null( stmtInsert, ++col );
     }
 
-    sqlite3_bind_blob( stmtInsert, ++col, geom.asWkb(), ( int ) geom.wkbSize(), SQLITE_STATIC );
+    QByteArray wkb( geom.exportToWkb() );
+    sqlite3_bind_blob( stmtInsert, ++col, wkb.constData(), wkb.length(), SQLITE_STATIC );
 
     int insertRes = sqlite3_step( stmtInsert );
     if ( insertRes != SQLITE_DONE )
@@ -504,7 +505,10 @@ void QgsOSMDatabase::exportSpatiaLiteWays( bool closed, const QString& tableName
     }
 
     if ( !geom.isEmpty() )
-      sqlite3_bind_blob( stmtInsert, ++col, geom.asWkb(), ( int ) geom.wkbSize(), SQLITE_STATIC );
+    {
+      QByteArray wkb( geom.exportToWkb() );
+      sqlite3_bind_blob( stmtInsert, ++col, wkb.constData(), wkb.length(), SQLITE_STATIC );
+    }
     else
       sqlite3_bind_null( stmtInsert, ++col );
 

--- a/src/analysis/vector/qgsgeometryanalyzer.cpp
+++ b/src/analysis/vector/qgsgeometryanalyzer.cpp
@@ -1153,7 +1153,8 @@ QgsGeometry QgsGeometryAnalyzer::locateBetweenMeasures( double fromMeasure, doub
   QgsMultiPolyline resultGeom;
 
   //need to go with WKB and z coordinate until QgsGeometry supports M values
-  QgsConstWkbPtr wkbPtr( lineGeom.asWkb(), lineGeom.wkbSize() );
+  QByteArray wkb( lineGeom.exportToWkb() );
+  QgsConstWkbPtr wkbPtr( wkb );
   wkbPtr.readHeader();
 
   QgsWkbTypes::Type wkbType = lineGeom.wkbType();
@@ -1194,7 +1195,8 @@ QgsGeometry QgsGeometryAnalyzer::locateAlongMeasure( double measure, const QgsGe
   QgsMultiPoint resultGeom;
 
   //need to go with WKB and z coordinate until QgsGeometry supports M values
-  QgsConstWkbPtr wkbPtr( lineGeom.asWkb(), lineGeom.wkbSize() );
+  QByteArray wkb( lineGeom.exportToWkb() );
+  QgsConstWkbPtr wkbPtr( wkb );
   QgsWkbTypes::Type wkbType = lineGeom.wkbType();
 
   if ( wkbType != QgsWkbTypes::LineString25D && wkbType != QgsWkbTypes::MultiLineString25D )

--- a/src/analysis/vector/qgsgeometryanalyzer.cpp
+++ b/src/analysis/vector/qgsgeometryanalyzer.cpp
@@ -1063,7 +1063,9 @@ QgsGeometry QgsGeometryAnalyzer::createOffsetGeometry( const QgsGeometry& geom, 
   {
     if ( geom.type() == QgsWkbTypes::LineGeometry )
     {
-      GEOSGeometry* offsetGeom = GEOSOffsetCurve_r( geosctxt, ( *inputGeomIt ).asGeos(), -offset, 8 /*quadSegments*/, 0 /*joinStyle*/, 5.0 /*mitreLimit*/ );
+      GEOSGeometry* inputGeomItGeos = inputGeomIt->exportToGeos();
+      GEOSGeometry* offsetGeom = GEOSOffsetCurve_r( geosctxt, inputGeomItGeos, -offset, 8 /*quadSegments*/, 0 /*joinStyle*/, 5.0 /*mitreLimit*/ );
+      GEOSGeom_destroy_r( geosctxt, inputGeomItGeos );
       if ( !offsetGeom || !GEOSisValid_r( geosctxt, offsetGeom ) )
       {
         return QgsGeometry();

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -419,16 +419,17 @@ void QgsZonalStatistics::statisticsFromMiddlePointTest( void* band, const QgsGeo
   cellCenterY = rasterBBox.yMaximum() - pixelOffsetY * cellSizeY - cellSizeY / 2;
   stats.reset();
 
-  const GEOSGeometry* polyGeos = poly.asGeos();
+  GEOSGeometry* polyGeos = poly.exportToGeos();
   if ( !polyGeos )
   {
     return;
   }
 
   GEOSContextHandle_t geosctxt = QgsGeometry::getGEOSHandler();
-  const GEOSPreparedGeometry* polyGeosPrepared = GEOSPrepare_r( geosctxt, poly.asGeos() );
+  const GEOSPreparedGeometry* polyGeosPrepared = GEOSPrepare_r( geosctxt, polyGeos );
   if ( !polyGeosPrepared )
   {
+    GEOSGeom_destroy_r( geosctxt, polyGeos );
     return;
   }
 
@@ -464,6 +465,7 @@ void QgsZonalStatistics::statisticsFromMiddlePointTest( void* band, const QgsGeo
   GEOSGeom_destroy_r( geosctxt, currentCellCenter );
   CPLFree( scanLine );
   GEOSPreparedGeom_destroy_r( geosctxt, polyGeosPrepared );
+  GEOSGeom_destroy_r( geosctxt, polyGeos );
 }
 
 void QgsZonalStatistics::statisticsFromPreciseIntersection( void* band, const QgsGeometry& poly, int pixelOffsetX,

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -368,7 +368,7 @@ void QgsMapToolOffsetCurve::setOffsetForRubberBand( double offset )
   }
 
   QgsGeometry geomCopy( mOriginalGeometry );
-  const GEOSGeometry* geosGeom = geomCopy.asGeos();
+  GEOSGeometry* geosGeom = geomCopy.exportToGeos();
   if ( geosGeom )
   {
     QSettings s;
@@ -377,6 +377,7 @@ void QgsMapToolOffsetCurve::setOffsetForRubberBand( double offset )
     double mitreLimit = s.value( QStringLiteral( "/qgis/digitizing/offset_miter_limit" ), 5.0 ).toDouble();
 
     GEOSGeometry* offsetGeom = GEOSOffsetCurve_r( QgsGeometry::getGEOSHandler(), geosGeom, offset, quadSegments, joinStyle, mitreLimit );
+    GEOSGeom_destroy_r( QgsGeometry::getGEOSHandler(), geosGeom );
     if ( !offsetGeom )
     {
       deleteRubberBandAndGeometry();

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -125,9 +125,10 @@ class CORE_EXPORT QgsAbstractGeometry
     //import
 
     /** Sets the geometry from a WKB string.
+     * After successful read the wkb argument will be at the position where the reading has stopped.
      * @see fromWkt
      */
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) = 0;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) = 0;
 
     /** Sets the geometry from a WKT string.
      * @see fromWkb
@@ -136,20 +137,14 @@ class CORE_EXPORT QgsAbstractGeometry
 
     //export
 
-    /** Returns the size of the WKB representation of the geometry.
-     * @see asWkb
-     */
-    virtual int wkbSize() const = 0;
-
     /** Returns a WKB representation of the geometry.
-     * @param binarySize will be set to the size of the returned WKB string
-     * @see wkbSize
      * @see asWkt
      * @see asGML2
      * @see asGML3
      * @see asJSON
+     * @note added in 3.0
      */
-    virtual unsigned char* asWkb( int& binarySize ) const = 0;
+    virtual QByteArray asWkb() const = 0;
 
     /** Returns a WKT representation of the geometry.
      * @param precision number of decimal places for coordinates

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -207,7 +207,7 @@ QgsPointSequence QgsCircularString::compassPointsOnSegment( double p1Angle, doub
   return pointList;
 }
 
-bool QgsCircularString::fromWkb( QgsConstWkbPtr wkbPtr )
+bool QgsCircularString::fromWkb( QgsConstWkbPtr& wkbPtr )
 {
   if ( !wkbPtr )
     return false;
@@ -260,24 +260,20 @@ bool QgsCircularString::fromWkt( const QString& wkt )
   return true;
 }
 
-int QgsCircularString::wkbSize() const
+QByteArray QgsCircularString::asWkb() const
 {
-  int size = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
-  size += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );
-  return size;
-}
+  int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
+  binarySize += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );
 
-unsigned char* QgsCircularString::asWkb( int& binarySize ) const
-{
-  binarySize = wkbSize();
-  unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr, binarySize );
+  QByteArray wkbArray;
+  wkbArray.resize( binarySize );
+  QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   QgsPointSequence pts;
   points( pts );
   QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure() );
-  return geomPtr;
+  return wkbArray;
 }
 
 QString QgsCircularString::asWkt( int precision ) const

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -41,11 +41,10 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     virtual QgsCircularString* clone() const override;
     virtual void clear() override;
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) override;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
-    int wkbSize() const override;
-    unsigned char* asWkb( int& binarySize ) const override;
+    QByteArray asWkb() const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -42,11 +42,10 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     virtual QgsCompoundCurve* clone() const override;
     virtual void clear() override;
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) override;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
-    int wkbSize() const override;
-    unsigned char* asWkb( int& binarySize ) const override;
+    QByteArray asWkb() const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -41,11 +41,10 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     virtual QgsCurvePolygon* clone() const override;
     void clear() override;
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) override;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
-    int wkbSize() const override;
-    unsigned char* asWkb( int& binarySize ) const override;
+    QByteArray asWkb() const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -54,11 +54,10 @@ email                : morb at ozemail dot com dot au
 
 struct QgsGeometryPrivate
 {
-  QgsGeometryPrivate(): ref( 1 ), geometry( nullptr ), mGeos( nullptr ) {}
-  ~QgsGeometryPrivate() { delete geometry; GEOSGeom_destroy_r( QgsGeos::getGEOSHandler(), mGeos ); }
+  QgsGeometryPrivate(): ref( 1 ), geometry( nullptr ) {}
+  ~QgsGeometryPrivate() { delete geometry; }
   QAtomicInt ref;
   QgsAbstractGeometry* geometry;
-  mutable GEOSGeometry* mGeos;
 };
 
 QgsGeometry::QgsGeometry(): d( new QgsGeometryPrivate() )
@@ -269,18 +268,14 @@ void QgsGeometry::fromWkb( const QByteArray &wkb )
   d->geometry = QgsGeometryFactory::geomFromWkb( ptr );
 }
 
-const GEOSGeometry* QgsGeometry::asGeos( double precision ) const
+GEOSGeometry* QgsGeometry::exportToGeos( double precision ) const
 {
   if ( !d->geometry )
   {
     return nullptr;
   }
 
-  if ( !d->mGeos )
-  {
-    d->mGeos = QgsGeos::asGeos( d->geometry, precision );
-  }
-  return d->mGeos;
+  return QgsGeos::asGeos( d->geometry, precision );
 }
 
 
@@ -320,7 +315,7 @@ void QgsGeometry::fromGeos( GEOSGeometry *geos )
   detach( false );
   delete d->geometry;
   d->geometry = QgsGeos::fromGeos( geos );
-  d->mGeos = geos;
+  GEOSGeom_destroy_r( QgsGeos::getGEOSHandler(), geos );
 }
 
 QgsPoint QgsGeometry::closestVertex( const QgsPoint& point, int& atVertex, int& beforeVertex, int& afterVertex, double& sqrDist ) const

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -146,21 +146,15 @@ class CORE_EXPORT QgsGeometry
     /**
       Set the geometry, feeding in the buffer containing OGC Well-Known Binary and the buffer's length.
       This class will take ownership of the buffer.
+      @note not available in python bindings
      */
     void fromWkb( unsigned char *wkb, int length );
 
     /**
-       Returns the buffer containing this geometry in WKB format.
-       You may wish to use in conjunction with wkbSize().
-       @see wkbSize
+     * Set the geometry, feeding in the buffer containing OGC Well-Known Binary
+     * @note added in 3.0
      */
-    const unsigned char* asWkb() const;
-
-    /**
-     * Returns the size of the WKB in asWkb().
-     * @see asWkb
-     */
-    int wkbSize() const;
+    void fromWkb( const QByteArray& wkb );
 
     /** Returns a geos geometry. QgsGeometry retains ownership of the geometry, so the returned object should not be deleted.
      *  @param precision The precision of the grid to which to snap the geometry vertices. If 0, no snapping is performed.
@@ -637,6 +631,11 @@ class CORE_EXPORT QgsGeometry
     //! Returns an extruded version of this geometry.
     QgsGeometry extrude( double x, double y );
 
+    /** Export the geometry to WKB
+     * @note added in 3.0
+     */
+    QByteArray exportToWkb() const;
+
     /** Exports the geometry to WKT
      *  @note precision parameter added in 2.4
      *  @return true in case of success and false else
@@ -937,7 +936,6 @@ class CORE_EXPORT QgsGeometry
     QgsGeometryPrivate* d; //implicitely shared data pointer
 
     void detach( bool cloneGeom = true ); //make sure mGeometry only referenced from this instance
-    void removeWkbGeos();
 
     static void convertToPolyline( const QgsPointSequence &input, QgsPolyline& output );
     static void convertPolygon( const QgsPolygonV2& input, QgsPolygon& output );

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -156,12 +156,12 @@ class CORE_EXPORT QgsGeometry
      */
     void fromWkb( const QByteArray& wkb );
 
-    /** Returns a geos geometry. QgsGeometry retains ownership of the geometry, so the returned object should not be deleted.
+    /** Returns a geos geometry - caller takes ownership of the object (should be deleted with GEOSGeom_destroy_r)
      *  @param precision The precision of the grid to which to snap the geometry vertices. If 0, no snapping is performed.
-     *  @note this method was added in version 1.1
+     *  @note added in 3.0
      *  @note not available in python bindings
      */
-    const GEOSGeometry* asGeos( double precision = 0 ) const;
+    GEOSGeometry* exportToGeos( double precision = 0 ) const;
 
     /** Returns type of the geometry as a WKB type (point / linestring / polygon etc.)
      * @see type

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -79,10 +79,9 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 #endif
     virtual void draw( QPainter& p ) const override;
 
-    bool fromWkb( QgsConstWkbPtr wkb ) override;
+    bool fromWkb( QgsConstWkbPtr& wkb ) override;
     virtual bool fromWkt( const QString& wkt ) override;
-    int wkbSize() const override;
-    unsigned char* asWkb( int& binarySize ) const override;
+    QByteArray asWkb() const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -30,7 +30,7 @@
 #include "qgswkbtypes.h"
 #include "qgslogger.h"
 
-QgsAbstractGeometry* QgsGeometryFactory::geomFromWkb( QgsConstWkbPtr wkbPtr )
+QgsAbstractGeometry* QgsGeometryFactory::geomFromWkb( QgsConstWkbPtr& wkbPtr )
 {
   if ( !wkbPtr )
     return nullptr;
@@ -57,7 +57,7 @@ QgsAbstractGeometry* QgsGeometryFactory::geomFromWkb( QgsConstWkbPtr wkbPtr )
   {
     try
     {
-      geom->fromWkb( wkbPtr );
+      geom->fromWkb( wkbPtr );  // also updates wkbPtr
     }
     catch ( const QgsWkbException &e )
     {

--- a/src/core/geometry/qgsgeometryfactory.h
+++ b/src/core/geometry/qgsgeometryfactory.h
@@ -45,8 +45,9 @@ class CORE_EXPORT QgsGeometryFactory
   public:
 
     /** Construct geometry from a WKB string.
+     * Updates position of the passed WKB pointer.
      */
-    static QgsAbstractGeometry* geomFromWkb( QgsConstWkbPtr wkb );
+    static QgsAbstractGeometry* geomFromWkb( QgsConstWkbPtr& wkb );
 
     /** Construct geometry from a WKT string.
      */

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -91,7 +91,7 @@ void QgsLineString::clear()
   clearCache();
 }
 
-bool QgsLineString::fromWkb( QgsConstWkbPtr wkbPtr )
+bool QgsLineString::fromWkb( QgsConstWkbPtr& wkbPtr )
 {
   if ( !wkbPtr )
   {
@@ -158,24 +158,20 @@ bool QgsLineString::fromWkt( const QString& wkt )
   return true;
 }
 
-int QgsLineString::wkbSize() const
+QByteArray QgsLineString::asWkb() const
 {
-  int size = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
-  size += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );
-  return size;
-}
+  int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
+  binarySize += numPoints() * ( 2 + is3D() + isMeasure() ) * sizeof( double );
 
-unsigned char* QgsLineString::asWkb( int& binarySize ) const
-{
-  binarySize = wkbSize();
-  unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr, binarySize );
+  QByteArray wkbArray;
+  wkbArray.resize( binarySize );
+  QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   QgsPointSequence pts;
   points( pts );
   QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure() );
-  return geomPtr;
+  return wkbArray;
 }
 
 /***************************************************************************

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -135,11 +135,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     virtual QgsLineString* clone() const override;
     virtual void clear() override;
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) override;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
-    int wkbSize() const override;
-    unsigned char* asWkb( int& binarySize ) const override;
+    QByteArray asWkb() const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -96,7 +96,7 @@ QgsPointV2 *QgsPointV2::clone() const
   return new QgsPointV2( *this );
 }
 
-bool QgsPointV2::fromWkb( QgsConstWkbPtr wkbPtr )
+bool QgsPointV2::fromWkb( QgsConstWkbPtr& wkbPtr )
 {
   QgsWkbTypes::Type type = wkbPtr.readHeader();
   if ( QgsWkbTypes::flatType( type ) != QgsWkbTypes::Point )
@@ -165,24 +165,20 @@ bool QgsPointV2::fromWkt( const QString& wkt )
   return true;
 }
 
-int QgsPointV2::wkbSize() const
-{
-  int size = sizeof( char ) + sizeof( quint32 );
-  size += ( 2 + is3D() + isMeasure() ) * sizeof( double );
-  return size;
-}
-
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests.
  * See details in QEP #17
  ****************************************************************************/
 
-unsigned char* QgsPointV2::asWkb( int& binarySize ) const
+QByteArray QgsPointV2::asWkb() const
 {
-  binarySize = wkbSize();
-  unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr, binarySize );
+  int binarySize = sizeof( char ) + sizeof( quint32 );
+  binarySize += ( 2 + is3D() + isMeasure() ) * sizeof( double );
+
+  QByteArray wkbArray;
+  wkbArray.resize( binarySize );
+  QgsWkbPtr wkb( wkbArray );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << mX << mY;
@@ -194,7 +190,7 @@ unsigned char* QgsPointV2::asWkb( int& binarySize ) const
   {
     wkb << mM;
   }
-  return geomPtr;
+  return wkbArray;
 }
 
 QString QgsPointV2::asWkt( int precision ) const

--- a/src/core/geometry/qgspointv2.h
+++ b/src/core/geometry/qgspointv2.h
@@ -198,10 +198,9 @@ class CORE_EXPORT QgsPointV2: public QgsAbstractGeometry
     virtual int dimension() const override { return 0; }
     virtual QgsPointV2* clone() const override;
     void clear() override;
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) override;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) override;
     virtual bool fromWkt( const QString& wkt ) override;
-    int wkbSize() const override;
-    unsigned char* asWkb( int& binarySize ) const override;
+    QByteArray asWkb() const override;
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -38,12 +38,11 @@ class CORE_EXPORT QgsPolygonV2: public QgsCurvePolygon
     virtual QgsPolygonV2* clone() const override;
     void clear() override;
 
-    virtual bool fromWkb( QgsConstWkbPtr wkb ) override;
+    virtual bool fromWkb( QgsConstWkbPtr& wkb ) override;
 
     // inherited: bool fromWkt( const QString &wkt );
 
-    int wkbSize() const override;
-    unsigned char* asWkb( int& binarySize ) const override;
+    QByteArray asWkb() const override;
     // inherited: QString asWkt( int precision = 17 ) const;
     // inherited: QDomElement asGML2( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     // inherited: QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;

--- a/src/core/geometry/qgswkbptr.cpp
+++ b/src/core/geometry/qgswkbptr.cpp
@@ -14,6 +14,13 @@
  ***************************************************************************/
 #include "qgswkbptr.h"
 
+QgsWkbPtr::QgsWkbPtr( QByteArray &wkb )
+{
+  mP = reinterpret_cast<unsigned char*>( wkb.data() );
+  mStart = mP;
+  mEnd = mP + wkb.length();
+}
+
 QgsWkbPtr::QgsWkbPtr( unsigned char *p, int size )
 {
   mP = p;
@@ -25,6 +32,14 @@ void QgsWkbPtr::verifyBound( int size ) const
 {
   if ( !mP || mP + size > mEnd )
     throw QgsWkbException( QStringLiteral( "wkb access out of bounds" ) );
+}
+
+QgsConstWkbPtr::QgsConstWkbPtr( const QByteArray &wkb )
+{
+  mP = reinterpret_cast< unsigned char * >( const_cast<char *>( wkb.constData() ) );
+  mEnd = mP + wkb.length();
+  mEndianSwap = false;
+  mWkbType = QgsWkbTypes::Unknown;
 }
 
 QgsConstWkbPtr::QgsConstWkbPtr( const unsigned char *p, int size )

--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -58,7 +58,15 @@ class CORE_EXPORT QgsWkbPtr
       mP += sizeof v;
     }
 
+    void write( const QByteArray& data ) const
+    {
+      verifyBound( data.length() );
+      memcpy( mP, data.constData(), data.length() );
+      mP += data.length();
+    }
+
   public:
+    QgsWkbPtr( QByteArray& wkb );
     QgsWkbPtr( unsigned char *p, int size );
 
     inline const QgsWkbPtr &operator>>( double &v ) const { read( v ); return *this; }
@@ -74,6 +82,7 @@ class CORE_EXPORT QgsWkbPtr
     inline QgsWkbPtr &operator<<( const unsigned int &v ) { write( v ); return *this; }
     inline QgsWkbPtr &operator<<( const char &v ) { write( v ); return *this; }
     inline QgsWkbPtr &operator<<( const QgsWkbTypes::Type &v ) { write( v ); return *this; }
+    inline QgsWkbPtr &operator<<( const QByteArray &data ) { write( data ); return *this; }
 
     inline void operator+=( int n ) { verifyBound( n ); mP += n; }
 
@@ -110,6 +119,7 @@ class CORE_EXPORT QgsConstWkbPtr
     }
 
   public:
+    explicit QgsConstWkbPtr( const QByteArray& wkb );
     QgsConstWkbPtr( const unsigned char *p, int size );
     QgsWkbTypes::Type readHeader() const;
 

--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -66,6 +66,7 @@ class CORE_EXPORT QgsWkbPtr
     }
 
   public:
+    //! Construct WKB pointer from QByteArray
     QgsWkbPtr( QByteArray& wkb );
     QgsWkbPtr( unsigned char *p, int size );
 
@@ -82,6 +83,7 @@ class CORE_EXPORT QgsWkbPtr
     inline QgsWkbPtr &operator<<( const unsigned int &v ) { write( v ); return *this; }
     inline QgsWkbPtr &operator<<( const char &v ) { write( v ); return *this; }
     inline QgsWkbPtr &operator<<( const QgsWkbTypes::Type &v ) { write( v ); return *this; }
+    //! Append data from a byte array
     inline QgsWkbPtr &operator<<( const QByteArray &data ) { write( data ); return *this; }
 
     inline void operator+=( int n ) { verifyBound( n ); mP += n; }
@@ -119,6 +121,7 @@ class CORE_EXPORT QgsConstWkbPtr
     }
 
   public:
+    //! Construct WKB pointer from QByteArray
     explicit QgsConstWkbPtr( const QByteArray& wkb );
     QgsConstWkbPtr( const unsigned char *p, int size );
     QgsWkbTypes::Type readHeader() const;

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -220,7 +220,7 @@ void QgsGeometryValidator::run()
   if ( settings.value( QStringLiteral( "/qgis/digitizing/validate_geometries" ), 1 ).toInt() == 2 )
   {
     char *r = nullptr;
-    const GEOSGeometry *g0 = mG.asGeos();
+    GEOSGeometry *g0 = mG.exportToGeos();
     GEOSContextHandle_t handle = QgsGeometry::getGEOSHandler();
     if ( !g0 )
     {
@@ -229,7 +229,9 @@ void QgsGeometryValidator::run()
     else
     {
       GEOSGeometry *g1 = nullptr;
-      if ( GEOSisValidDetail_r( handle, g0, GEOSVALID_ALLOW_SELFTOUCHING_RING_FORMING_HOLE, &r, &g1 ) != 1 )
+      char res = GEOSisValidDetail_r( handle, g0, GEOSVALID_ALLOW_SELFTOUCHING_RING_FORMING_HOLE, &r, &g1 );
+      GEOSGeom_destroy_r( handle, g0 );
+      if ( res != 1 )
       {
         if ( g1 )
         {

--- a/src/core/qgslabelfeature.cpp
+++ b/src/core/qgslabelfeature.cpp
@@ -35,6 +35,7 @@ QgsLabelFeature::QgsLabelFeature( QgsFeatureId id, GEOSGeometry* geometry, QSize
     , mIsObstacle( false )
     , mObstacleFactor( 1 )
     , mInfo( nullptr )
+    , mPermissibleZoneGeos( nullptr )
     , mPermissibleZoneGeosPrepared( nullptr )
 {
 }
@@ -48,7 +49,10 @@ QgsLabelFeature::~QgsLabelFeature()
     GEOSGeom_destroy_r( QgsGeometry::getGEOSHandler(), mObstacleGeometry );
 
   if ( mPermissibleZoneGeosPrepared )
+  {
     GEOSPreparedGeom_destroy_r( QgsGeometry::getGEOSHandler(), mPermissibleZoneGeosPrepared );
+    GEOSGeom_destroy_r( QgsGeometry::getGEOSHandler(), mPermissibleZoneGeos );
+  }
 
   delete mInfo;
 }
@@ -68,15 +72,17 @@ void QgsLabelFeature::setPermissibleZone( const QgsGeometry &geometry )
   if ( mPermissibleZoneGeosPrepared )
   {
     GEOSPreparedGeom_destroy_r( QgsGeometry::getGEOSHandler(), mPermissibleZoneGeosPrepared );
+    GEOSGeom_destroy_r( QgsGeometry::getGEOSHandler(), mPermissibleZoneGeos );
     mPermissibleZoneGeosPrepared = nullptr;
+    mPermissibleZoneGeos = nullptr;
   }
 
   if ( mPermissibleZone.isEmpty() )
     return;
 
-  const GEOSGeometry* zoneGeos = mPermissibleZone.asGeos();
-  if ( !zoneGeos )
+  mPermissibleZoneGeos = mPermissibleZone.exportToGeos();
+  if ( !mPermissibleZoneGeos )
     return;
 
-  mPermissibleZoneGeosPrepared = GEOSPrepare_r( QgsGeometry::getGEOSHandler(), zoneGeos );
+  mPermissibleZoneGeosPrepared = GEOSPrepare_r( QgsGeometry::getGEOSHandler(), mPermissibleZoneGeos );
 }

--- a/src/core/qgslabelfeature.h
+++ b/src/core/qgslabelfeature.h
@@ -394,6 +394,9 @@ class CORE_EXPORT QgsLabelFeature
 
   private:
 
+    //! GEOS geometry on which mPermissibleZoneGeosPrepared is based on
+    GEOSGeometry* mPermissibleZoneGeos;
+
     // TODO - not required when QgsGeometry caches geos preparedness
     const GEOSPreparedGeometry* mPermissibleZoneGeosPrepared;
 

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1132,7 +1132,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry* geometry, QDomDocumen
                                         const QString& gmlIdBase,
                                         int precision )
 {
-  if ( !geometry || !geometry->asWkb() )
+  if ( !geometry )
     return QDomElement();
 
   // coordinate separator
@@ -1144,7 +1144,8 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry* geometry, QDomDocumen
 
   bool hasZValue = false;
 
-  QgsConstWkbPtr wkbPtr( geometry->asWkb(), geometry->wkbSize() );
+  QByteArray wkb( geometry->exportToWkb() );
+  QgsConstWkbPtr wkbPtr( wkb );
   try
   {
     wkbPtr.readHeader();

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -3407,11 +3407,6 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry& geometry, QgsRen
     }
   }
 
-  // MD: exporting geometry to GEOS just to see if the geometry is wrong...?
-  // if still needed, we could have a more specific test here
-  //if ( !geom.asGeos() )
-  //  return QgsGeometry();  // there is something really wrong with the geometry
-
   // fix invalid polygons
   if ( geom.type() == QgsWkbTypes::PolygonGeometry && !geom.isGeosValid() )
   {

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -325,13 +325,13 @@ static QgsPointLocator::MatchList _geometrySegmentsInRect( QgsGeometry *geom, co
   // we need iterator for segments...
 
   QgsPointLocator::MatchList lst;
-  unsigned char* wkb = const_cast<unsigned char*>( geom->asWkb() ); // we're not changing wkb, just need non-const for QgsWkbPtr
-  if ( !wkb )
+  QByteArray wkb( geom->exportToWkb() );
+  if ( wkb.isEmpty() )
     return lst;
 
   _CohenSutherland cs( rect );
 
-  QgsConstWkbPtr wkbPtr( wkb, geom->wkbSize() );
+  QgsConstWkbPtr wkbPtr( wkb );
   wkbPtr.readHeader();
 
   QgsWkbTypes::Type wkbType = geom->wkbType();

--- a/src/core/qgstracer.cpp
+++ b/src/core/qgstracer.cpp
@@ -533,7 +533,9 @@ bool QgsTracer::initGraph()
   {
     t2a.start();
     // GEOSNode_r may throw an exception
-    GEOSGeometry* allNoded = GEOSNode_r( QgsGeometry::getGEOSHandler(), allGeom.asGeos() );
+    GEOSGeometry* allGeomGeos = allGeom.exportToGeos();
+    GEOSGeometry* allNoded = GEOSNode_r( QgsGeometry::getGEOSHandler(), allGeomGeos );
+    GEOSGeom_destroy_r( QgsGeometry::getGEOSHandler(), allGeomGeos );
     timeNodingCall = t2a.elapsed();
 
     QgsGeometry* noded = new QgsGeometry;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2117,7 +2117,8 @@ OGRFeatureH QgsVectorFileWriter::createFeature( const QgsFeature& feature )
           return nullptr;
         }
 
-        OGRErr err = OGR_G_ImportFromWkb( mGeom2, const_cast<unsigned char *>( geom.asWkb() ), static_cast< int >( geom.wkbSize() ) );
+        QByteArray wkb( geom.exportToWkb() );
+        OGRErr err = OGR_G_ImportFromWkb( mGeom2, reinterpret_cast<unsigned char *>( const_cast<char *>( wkb.constData() ) ), wkb.length() );
         if ( err != OGRERR_NONE )
         {
           mErrorMessage = QObject::tr( "Feature geometry not imported (OGR error: %1)" )
@@ -2133,7 +2134,8 @@ OGRFeatureH QgsVectorFileWriter::createFeature( const QgsFeature& feature )
       }
       else // wkb type matches
       {
-        OGRErr err = OGR_G_ImportFromWkb( mGeom, const_cast<unsigned char *>( geom.asWkb() ), static_cast< int >( geom.wkbSize() ) );
+        QByteArray wkb( geom.exportToWkb() );
+        OGRErr err = OGR_G_ImportFromWkb( mGeom, reinterpret_cast<unsigned char *>( const_cast<char *>( wkb.constData() ) ), wkb.length() );
         if ( err != OGRERR_NONE )
         {
           mErrorMessage = QObject::tr( "Feature geometry not imported (OGR error: %1)" )

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -224,7 +224,7 @@ QgsLabelFeature* QgsVectorLayerDiagramProvider::registerDiagram( QgsFeature& fea
     extentGeom.rotate( -mapSettings.rotation(), mapSettings.visibleExtent().center() );
   }
 
-  const GEOSGeometry* geos_geom = nullptr;
+  GEOSGeometry* geomCopy = nullptr;
   QScopedPointer<QgsGeometry> scopedPreparedGeom;
   if ( QgsPalLabeling::geometryRequiresPreparation( geom, context, mSettings.coordinateTransform(), &extentGeom ) )
   {
@@ -232,35 +232,27 @@ QgsLabelFeature* QgsVectorLayerDiagramProvider::registerDiagram( QgsFeature& fea
     QgsGeometry* preparedGeom = scopedPreparedGeom.data();
     if ( preparedGeom->isEmpty() )
       return nullptr;
-    geos_geom = preparedGeom->asGeos();
+    geomCopy = preparedGeom->exportToGeos();
   }
   else
   {
-    geos_geom = geom.asGeos();
+    geomCopy = geom.exportToGeos();
   }
 
-  if ( !geos_geom )
+  if ( !geomCopy )
     return nullptr; // invalid geometry
 
-  GEOSGeometry* geomCopy = GEOSGeom_clone_r( QgsGeometry::getGEOSHandler(), geos_geom );
-
-  const GEOSGeometry* geosObstacleGeom = nullptr;
+  GEOSGeometry* geosObstacleGeomClone = nullptr;
   QScopedPointer<QgsGeometry> scopedObstacleGeom;
   if ( mSettings.isObstacle() && obstacleGeometry && QgsPalLabeling::geometryRequiresPreparation( *obstacleGeometry, context, mSettings.coordinateTransform(), &extentGeom ) )
   {
     QgsGeometry preparedObstacleGeom = QgsPalLabeling::prepareGeometry( *obstacleGeometry, context, mSettings.coordinateTransform(), &extentGeom );
-    geosObstacleGeom = preparedObstacleGeom.asGeos();
+    geosObstacleGeomClone = preparedObstacleGeom.exportToGeos();
   }
   else if ( mSettings.isObstacle() && obstacleGeometry )
   {
-    geosObstacleGeom = obstacleGeometry->asGeos();
+    geosObstacleGeomClone = obstacleGeometry->exportToGeos();
   }
-  GEOSGeometry* geosObstacleGeomClone = nullptr;
-  if ( geosObstacleGeom )
-  {
-    geosObstacleGeomClone = GEOSGeom_clone_r( QgsGeometry::getGEOSHandler(), geosObstacleGeom );
-  }
-
 
   double diagramWidth = 0;
   double diagramHeight = 0;

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1083,7 +1083,7 @@ bool QgsDb2Provider::addFeatures( QgsFeatureList & flist )
     {
       QgsGeometry geom = it->geometry();
 
-      QByteArray bytea = QByteArray(( char* )geom.asWkb(), ( int ) geom.wkbSize() );
+      QByteArray bytea = geom.exportToWkb();
       query.bindValue( bindIdx,  bytea, QSql::In | QSql::Binary );
     }
 
@@ -1217,7 +1217,7 @@ bool QgsDb2Provider::changeGeometryValues( const QgsGeometryMap &geometry_map )
     }
 
     // add geometry param
-    QByteArray bytea = QByteArray(( char* )it->asWkb(), ( int ) it->wkbSize() );
+    QByteArray bytea = it->exportToWkb();
     query.addBindValue( bytea, QSql::In | QSql::Binary );
 
     if ( !query.exec() )

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -213,7 +213,8 @@ bool QgsGPXProvider::addFeatures( QgsFeatureList & flist )
 
 bool QgsGPXProvider::addFeature( QgsFeature& f )
 {
-  const unsigned char* geo = f.geometry().asWkb();
+  QByteArray wkb( f.geometry().exportToWkb() );
+  const char* geo = wkb.constData();
   QgsWkbTypes::Type wkbType = f.geometry().wkbType();
   bool success = false;
   QgsGPSObject* obj = nullptr;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -936,7 +936,7 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList & flist )
       QgsGeometry geom = it->geometry();
       if ( mUseWkb )
       {
-        QByteArray bytea = QByteArray(( char* )geom.asWkb(), ( int ) geom.wkbSize() );
+        QByteArray bytea = geom.exportToWkb();
         query.addBindValue( bytea, QSql::In | QSql::Binary );
       }
       else
@@ -1255,7 +1255,7 @@ bool QgsMssqlProvider::changeGeometryValues( const QgsGeometryMap &geometry_map 
     // add geometry param
     if ( mUseWkb )
     {
-      QByteArray bytea = QByteArray(( char* )it->asWkb(), ( int ) it->wkbSize() );
+      QByteArray bytea = it->exportToWkb();
       query.addBindValue( bytea, QSql::In | QSql::Binary );
     }
     else

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -270,11 +270,8 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature& feature )
       QByteArray *ba = static_cast<QByteArray*>( mQry.value( col++ ).data() );
       if ( ba->size() > 0 )
       {
-        unsigned char *copy = new unsigned char[ba->size()];
-        memcpy( copy, ba->constData(), ba->size() );
-
         QgsGeometry g;
-        g.fromWkb( copy, ba->size() );
+        g.fromWkb( *ba );
         feature.setGeometry( g );
       }
       else
@@ -381,13 +378,9 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature& feature )
         QByteArray *ba = static_cast<QByteArray*>( v.data() );
         if ( ba->size() > 0 )
         {
-          unsigned char *copy = new unsigned char[ba->size()];
-          memcpy( copy, ba->constData(), ba->size() );
-
-          QgsGeometry *g = new QgsGeometry();
-          g->fromWkb( copy, ba->size() );
-          v = g->exportToWkt();
-          delete g;
+          QgsGeometry g;
+          g.fromWkb( *ba );
+          v = g.exportToWkt();
         }
         else
         {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2498,10 +2498,11 @@ void QgsPostgresProvider::appendGeomParam( const QgsGeometry& geom, QStringList 
   QString param;
 
   QScopedPointer<QgsGeometry> convertedGeom( convertToProviderType( geom ) );
-  const unsigned char *buf = convertedGeom ? convertedGeom->asWkb() : geom.asWkb();
-  size_t wkbSize = convertedGeom ? convertedGeom->wkbSize() : geom.wkbSize();
+  QByteArray wkb( convertedGeom ? convertedGeom->exportToWkb() : geom.exportToWkb() );
+  const char *buf = wkb.constData();
+  int wkbSize = wkb.length();
 
-  for ( size_t i = 0; i < wkbSize; ++i )
+  for ( int i = 0; i < wkbSize; ++i )
   {
     if ( connectionRO()->useWkbHex() )
       param += QStringLiteral( "%1" ).arg(( int ) buf[i], 2, 16, QChar( '0' ) );

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3806,8 +3806,9 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList & flist )
           {
             unsigned char *wkb = nullptr;
             int wkb_size;
-            convertFromGeosWKB( feature->geometry().asWkb(),
-                                feature->geometry().wkbSize(),
+            QByteArray featureWkb = feature->geometry().exportToWkb();
+            convertFromGeosWKB( reinterpret_cast<const unsigned char*>( featureWkb.constData() ),
+                                featureWkb.length(),
                                 &wkb, &wkb_size, nDims );
             if ( !wkb )
               sqlite3_bind_null( stmt, ++ia );
@@ -4216,7 +4217,8 @@ bool QgsSpatiaLiteProvider::changeGeometryValues( const QgsGeometryMap &geometry
     // binding GEOMETRY to Prepared Statement
     unsigned char *wkb = nullptr;
     int wkb_size;
-    convertFromGeosWKB( iter->asWkb(), iter->wkbSize(), &wkb, &wkb_size, nDims );
+    QByteArray iterWkb = iter->exportToWkb();
+    convertFromGeosWKB( reinterpret_cast<const unsigned char*>( iterWkb.constData() ), iterWkb.length(), &wkb, &wkb_size, nDims );
     if ( !wkb )
       sqlite3_bind_null( stmt, 1 );
     else

--- a/src/providers/virtual/qgsvirtuallayerblob.cpp
+++ b/src/providers/virtual/qgsvirtuallayerblob.cpp
@@ -78,7 +78,9 @@ void qgsGeometryToSpatialiteBlob( const QgsGeometry &geom, int32_t srid, char *&
 {
   const int header_len = SpatialiteBlobHeader::length;
 
-  const int wkb_size = geom.wkbSize();
+  QByteArray wkb( geom.exportToWkb() );
+
+  const int wkb_size = wkb.length();
   size = header_len + wkb_size;
   blob = new char[size];
 
@@ -104,9 +106,7 @@ void qgsGeometryToSpatialiteBlob( const QgsGeometry &geom, int32_t srid, char *&
   // blob geometry = header + wkb[1:] + 'end'
 
   // copy wkb
-  const unsigned char* wkb = geom.asWkb();
-
-  memcpy( p, wkb + 1, wkb_size - 1 );
+  memcpy( p, wkb.constData() + 1, wkb_size - 1 );
   p += wkb_size - 1;
 
   // end marker

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -1167,13 +1167,8 @@ void QgsWFSFeatureIterator::copyFeature( const QgsFeature& srcFeature, QgsFeatur
   QgsGeometry geometry = srcFeature.geometry();
   if ( !mShared->mGeometryAttribute.isEmpty() && !geometry.isEmpty() )
   {
-    const unsigned char *geom = geometry.asWkb();
-    int geomSize = geometry.wkbSize();
-    unsigned char* copiedGeom = new unsigned char[geomSize];
-    memcpy( copiedGeom, geom, geomSize );
-
     QgsGeometry g;
-    g.fromWkb( copiedGeom, geomSize );
+    g.fromWkb( geometry.exportToWkb() );
     dstFeature.setGeometry( g );
   }
   else

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -734,13 +734,11 @@ bool QgsWFSSharedData::changeGeometryValues( const QgsGeometryMap &geometry_map 
   QgsChangedAttributesMap newChangedAttrMap;
   for ( QgsGeometryMap::const_iterator iter = geometry_map.constBegin(); iter != geometry_map.constEnd(); ++iter )
   {
-    const unsigned char *geom = iter->asWkb();
-    int geomSize = iter->wkbSize();
-    if ( geomSize )
+    QByteArray wkb = iter->exportToWkb();
+    if ( !wkb.isEmpty() )
     {
       QgsAttributeMap newAttrMap;
-      QByteArray array(( const char* )geom, geomSize );
-      newAttrMap[idx] = QString( array.toHex().data() );
+      newAttrMap[idx] = QString( wkb.toHex().data() );
       newChangedAttrMap[ iter.key()] = newAttrMap;
 
       QgsGeometry polyBoudingBox = QgsGeometry::fromRect( iter.value().boundingBox() );
@@ -872,9 +870,7 @@ void QgsWFSSharedData::serializeFeatures( QVector<QgsWFSFeatureGmlIdPair>& featu
     QgsGeometry geometry = gmlFeature.geometry();
     if ( !mGeometryAttribute.isEmpty() && !geometry.isEmpty() )
     {
-      const unsigned char *geom = geometry.asWkb();
-      int geomSize = geometry.wkbSize();
-      QByteArray array(( const char* )geom, geomSize );
+      QByteArray array( geometry.exportToWkb() );
 
       cachedFeature.setAttribute( hexwkbGeomIdx, QVariant( QString( array.toHex().data() ) ) );
 

--- a/src/providers/wfs/qgswfsutils.cpp
+++ b/src/providers/wfs/qgswfsutils.cpp
@@ -359,9 +359,7 @@ QString QgsWFSUtils::getMD5( const QgsFeature& f )
   QgsGeometry geometry = f.geometry();
   if ( !geometry.isEmpty() )
   {
-    const unsigned char *geom = geometry.asWkb();
-    int geomSize = geometry.wkbSize();
-    hash.addData( QByteArray(( const char* )geom, geomSize ) );
+    hash.addData( geometry.exportToWkb() );
   }
 
   return hash.result().toHex();

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -275,14 +275,14 @@ void TestQgsFeature::geometry()
   feature.setGeometry( QgsGeometry( mGeometry2 ) );
   QVERIFY( feature.hasGeometry() );
   feature.setGeometry( QgsGeometry( mGeometry ) );
-  QCOMPARE( *feature.geometry().asWkb(), *mGeometry.asWkb() );
+  QCOMPARE( feature.geometry().exportToWkb(), mGeometry.exportToWkb() );
 
   //test implicit sharing detachment
   QgsFeature copy( feature );
-  QCOMPARE( *copy.geometry().asWkb(), *feature.geometry().asWkb() );
+  QCOMPARE( copy.geometry().exportToWkb(), feature.geometry().exportToWkb() );
   copy.clearGeometry();
   QVERIFY( ! copy.hasGeometry() );
-  QCOMPARE( *feature.geometry().asWkb(), *mGeometry.asWkb() );
+  QCOMPARE( feature.geometry().exportToWkb(), mGeometry.exportToWkb() );
 
   //test no crash when setting an empty geometry and triggering a detach
   QgsFeature emptyGeomFeature;
@@ -294,18 +294,18 @@ void TestQgsFeature::geometry()
   //setGeometry
   //always start with a copy so that we can test implicit sharing detachment is working
   copy = feature;
-  QCOMPARE( *copy.geometry().asWkb(), *mGeometry.asWkb() );
+  QCOMPARE( copy.geometry().exportToWkb(), mGeometry.exportToWkb() );
   copy.setGeometry( QgsGeometry( mGeometry2 ) );
-  QCOMPARE( *copy.geometry().asWkb(), *mGeometry2.asWkb() );
-  QCOMPARE( *feature.geometry().asWkb(), *mGeometry.asWkb() );
+  QCOMPARE( copy.geometry().exportToWkb(), mGeometry2.exportToWkb() );
+  QCOMPARE( feature.geometry().exportToWkb(), mGeometry.exportToWkb() );
 
   //setGeometry using reference
   copy = feature;
-  QCOMPARE( *copy.geometry().asWkb(), *mGeometry.asWkb() );
+  QCOMPARE( copy.geometry().exportToWkb(), mGeometry.exportToWkb() );
   QgsGeometry geomByRef( mGeometry2 );
   copy.setGeometry( geomByRef );
-  QCOMPARE( *copy.geometry().asWkb(), *geomByRef.asWkb() );
-  QCOMPARE( *feature.geometry().asWkb(), *mGeometry.asWkb() );
+  QCOMPARE( copy.geometry().exportToWkb(), geomByRef.exportToWkb() );
+  QCOMPARE( feature.geometry().exportToWkb(), mGeometry.exportToWkb() );
 
   //clearGeometry
   QgsFeature geomFeature;
@@ -501,7 +501,7 @@ void TestQgsFeature::dataStream()
 
   QCOMPARE( resultFeature.id(), originalFeature.id() );
   QCOMPARE( resultFeature.attributes(), originalFeature.attributes() );
-  QCOMPARE( *resultFeature.geometry().asWkb(), *originalFeature.geometry().asWkb() );
+  QCOMPARE( resultFeature.geometry().exportToWkb(), originalFeature.geometry().exportToWkb() );
   QCOMPARE( resultFeature.isValid(), originalFeature.isValid() );
 
   //also test with feature empty geometry

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -547,25 +547,22 @@ void TestQgsGeometry::point()
 
   //to/from WKB
   QgsPointV2 p12( QgsWkbTypes::PointZM, 1.0, 2.0, 3.0, -4.0 );
-  int size = 0;
-  unsigned char* wkb = p12.asWkb( size );
-  QCOMPARE( size, p12.wkbSize() );
+  QByteArray wkb12 = p12.asWkb();
   QgsPointV2 p13;
-  p13.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  QgsConstWkbPtr wkb12ptr( wkb12 );
+  p13.fromWkb( wkb12ptr );
   QVERIFY( p13 == p12 );
 
   //bad WKB - check for no crash
   p13 = QgsPointV2( 1, 2 );
-  QVERIFY( !p13.fromWkb( QgsConstWkbPtr( nullptr, 0 ) ) );
+  QgsConstWkbPtr nullPtr( nullptr, 0 );
+  QVERIFY( !p13.fromWkb( nullPtr ) );
   QCOMPARE( p13.wkbType(), QgsWkbTypes::Point );
   QgsLineString line;
   p13 = QgsPointV2( 1, 2 );
-  wkb = line.asWkb( size );
-  QVERIFY( !p13.fromWkb( QgsConstWkbPtr( wkb, size ) ) );
-  delete[] wkb;
-  wkb = 0;
+  QByteArray wkbLine = line.asWkb();
+  QgsConstWkbPtr wkbLinePtr( wkbLine );
+  QVERIFY( !p13.fromWkb( wkbLinePtr ) );
   QCOMPARE( p13.wkbType(), QgsWkbTypes::Point );
 
   //to/from WKT
@@ -1390,13 +1387,10 @@ void TestQgsGeometry::lineString()
                  << QgsPointV2( QgsWkbTypes::PointZM, 11, 2, 11, 14 )
                  << QgsPointV2( QgsWkbTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPointV2( QgsWkbTypes::PointZM, 1, 22, 31, 34 ) );
-  int size = 0;
-  unsigned char* wkb = l15.asWkb( size );
-  QCOMPARE( size, l15.wkbSize() );
+  QByteArray wkb15 = l15.asWkb();
   QgsLineString l16;
-  l16.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  QgsConstWkbPtr wkb15ptr( wkb15 );
+  l16.fromWkb( wkb15ptr );
   QCOMPARE( l16.numPoints(), 4 );
   QCOMPARE( l16.vertexCount(), 4 );
   QCOMPARE( l16.nCoordinates(), 4 );
@@ -1412,13 +1406,13 @@ void TestQgsGeometry::lineString()
 
   //bad WKB - check for no crash
   l16.clear();
-  QVERIFY( !l16.fromWkb( QgsConstWkbPtr( nullptr, 0 ) ) );
+  QgsConstWkbPtr nullPtr( nullptr, 0 );
+  QVERIFY( !l16.fromWkb( nullPtr ) );
   QCOMPARE( l16.wkbType(), QgsWkbTypes::LineString );
   QgsPointV2 point( 1, 2 );
-  wkb = point.asWkb( size ) ;
-  QVERIFY( !l16.fromWkb( QgsConstWkbPtr( wkb, size ) ) );
-  delete[] wkb;
-  wkb = 0;
+  QByteArray wkb16 = point.asWkb();
+  QgsConstWkbPtr wkb16ptr( wkb16 );
+  QVERIFY( !l16.fromWkb( wkb16ptr ) );
   QCOMPARE( l16.wkbType(), QgsWkbTypes::LineString );
 
   //to/from WKT
@@ -2147,10 +2141,9 @@ void TestQgsGeometry::lineString()
   l37.clear();
   QVERIFY( l37.boundingBox().isNull() );
   l37.setPoints( QgsPointSequence() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 15 ) );
-  wkb = toAppend->asWkb( size );
-  l37.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  QByteArray wkbToAppend = toAppend->asWkb();
+  QgsConstWkbPtr wkbToAppendPtr( wkbToAppend );
+  l37.fromWkb( wkbToAppendPtr );
   QCOMPARE( l37.boundingBox(), QgsRectangle( 1, 0, 4, 2 ) );
   l37.fromWkt( QStringLiteral( "LineString( 1 5, 3 4, 6 3 )" ) );
   QCOMPARE( l37.boundingBox(), QgsRectangle( 1, 3, 6, 5 ) );
@@ -2786,13 +2779,10 @@ void TestQgsGeometry::polygon()
                    << QgsPointV2( QgsWkbTypes::Point, 1, 9 ) << QgsPointV2( QgsWkbTypes::Point, 9, 9 )
                    << QgsPointV2( QgsWkbTypes::Point, 9, 1 ) << QgsPointV2( QgsWkbTypes::Point, 1, 1 ) );
   p16.addInteriorRing( ring );
-  int size = 0;
-  unsigned char* wkb = p16.asWkb( size );
-  QCOMPARE( size, p16.wkbSize() );
+  QByteArray wkb16 = p16.asWkb();
   QgsPolygonV2 p17;
-  p17.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  QgsConstWkbPtr wkb16ptr( wkb16 );
+  p17.fromWkb( wkb16ptr );
   QCOMPARE( p16, p17 );
   //PolygonZ
   p16.clear();
@@ -2807,12 +2797,9 @@ void TestQgsGeometry::polygon()
                    << QgsPointV2( QgsWkbTypes::PointZ, 1, 9, 2 ) << QgsPointV2( QgsWkbTypes::PointZ, 9, 9, 3 )
                    << QgsPointV2( QgsWkbTypes::PointZ, 9, 1, 4 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 1, 1 ) );
   p16.addInteriorRing( ring );
-  size = 0;
-  wkb = p16.asWkb( size );
-  QCOMPARE( size, p16.wkbSize() );
-  p17.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  wkb16 = p16.asWkb();
+  QgsConstWkbPtr wkb16ptr2( wkb16 );
+  p17.fromWkb( wkb16ptr2 );
   QCOMPARE( p16, p17 );
   //PolygonM
   p16.clear();
@@ -2827,12 +2814,9 @@ void TestQgsGeometry::polygon()
                    << QgsPointV2( QgsWkbTypes::PointM, 1, 9, 0, 2 ) << QgsPointV2( QgsWkbTypes::PointM, 9, 9, 0, 3 )
                    << QgsPointV2( QgsWkbTypes::PointM, 9, 1, 0, 4 ) << QgsPointV2( QgsWkbTypes::PointM, 1, 1, 0, 1 ) );
   p16.addInteriorRing( ring );
-  size = 0;
-  wkb = p16.asWkb( size );
-  QCOMPARE( size, p16.wkbSize() );
-  p17.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  wkb16 = p16.asWkb();
+  QgsConstWkbPtr wkb16ptr3( wkb16 );
+  p17.fromWkb( wkb16ptr3 );
   QCOMPARE( p16, p17 );
   //PolygonZM
   p16.clear();
@@ -2847,12 +2831,9 @@ void TestQgsGeometry::polygon()
                    << QgsPointV2( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) << QgsPointV2( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
                    << QgsPointV2( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) << QgsPointV2( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
   p16.addInteriorRing( ring );
-  size = 0;
-  wkb = p16.asWkb( size );
-  QCOMPARE( size, p16.wkbSize() );
-  p17.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  wkb16 = p16.asWkb();
+  QgsConstWkbPtr wkb16ptr4( wkb16 );
+  p17.fromWkb( wkb16ptr4 );
   QCOMPARE( p16, p17 );
   //Polygon25D
   p16.clear();
@@ -2867,24 +2848,21 @@ void TestQgsGeometry::polygon()
                    << QgsPointV2( QgsWkbTypes::Point25D, 1, 9, 2 ) << QgsPointV2( QgsWkbTypes::Point25D, 9, 9, 3 )
                    << QgsPointV2( QgsWkbTypes::Point25D, 9, 1, 4 ) << QgsPointV2( QgsWkbTypes::Point25D, 1, 1, 1 ) );
   p16.addInteriorRing( ring );
-  size = 0;
-  wkb = p16.asWkb( size );
-  QCOMPARE( size, p16.wkbSize() );
+  wkb16 = p16.asWkb();
   p17.clear();
-  p17.fromWkb( QgsConstWkbPtr( wkb, size ) );
-  delete[] wkb;
-  wkb = 0;
+  QgsConstWkbPtr wkb16ptr5( wkb16 );
+  p17.fromWkb( wkb16ptr5 );
   QCOMPARE( p16, p17 );
 
   //bad WKB - check for no crash
   p17.clear();
-  QVERIFY( !p17.fromWkb( QgsConstWkbPtr( nullptr, 0 ) ) );
+  QgsConstWkbPtr nullPtr( nullptr, 0 );
+  QVERIFY( !p17.fromWkb( nullPtr ) );
   QCOMPARE( p17.wkbType(), QgsWkbTypes::Polygon );
   QgsPointV2 point( 1, 2 );
-  wkb = point.asWkb( size ) ;
-  QVERIFY( !p17.fromWkb( QgsConstWkbPtr( wkb, size ) ) );
-  delete[] wkb;
-  wkb = 0;
+  QByteArray wkbPoint = point.asWkb();
+  QgsConstWkbPtr wkbPointPtr( wkbPoint );
+  QVERIFY( !p17.fromWkb( wkbPointPtr ) );
   QCOMPARE( p17.wkbType(), QgsWkbTypes::Polygon );
 
   //to/from WKT

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -74,7 +74,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         got_geom = got.geometry()
         reference = QgsGeometry.fromWkt('MultiPolygon (((0 0, 0 1, 1 1, 0 0)))')
         # The geometries must be binarily identical
-        self.assertEqual(got_geom.asWkb(), reference.asWkb(), 'Expected {}, got {}'.format(reference.exportToWkt(), got_geom.exportToWkt()))
+        self.assertEqual(got_geom.exportToWkb(), reference.exportToWkb(), 'Expected {}, got {}'.format(reference.exportToWkt(), got_geom.exportToWkt()))
 
     @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     def testCurveGeometryType(self):
@@ -93,7 +93,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         got_geom = got.geometry()
         reference = QgsGeometry.fromWkt('CurvePolygon (((0 0, 0 1, 1 1, 0 0)))')
         # The geometries must be binarily identical
-        self.assertEqual(got_geom.asWkb(), reference.asWkb(), 'Expected {}, got {}'.format(reference.exportToWkt(), got_geom.exportToWkt()))
+        self.assertEqual(got_geom.exportToWkb(), reference.exportToWkb(), 'Expected {}, got {}'.format(reference.exportToWkt(), got_geom.exportToWkt()))
 
     def internalTestBug15351(self, orderClosing):
 

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -3394,7 +3394,7 @@ class TestQgsGeometry(unittest.TestCase):
 
         # Test that importing an invalid WKB (a MultiPolygon with a CurvePolygon) fails
         geom = QgsGeometry.fromWkt('MultiSurface(((0 0,0 1,1 1,0 0)), CurvePolygon ((0 0,0 1,1 1,0 0)))')
-        wkb = geom.asWkb()
+        wkb = geom.exportToWkb()
         wkb = bytearray(wkb)
         if wkb[1] == QgsWkbTypes.MultiSurface:
             wkb[1] = QgsWkbTypes.MultiPolygon
@@ -3434,10 +3434,10 @@ class TestQgsGeometry(unittest.TestCase):
         wkt += ")"
         geom = QgsGeometry.fromWkt(wkt)
         assert geom is not None
-        wkb1 = geom.asWkb()
+        wkb1 = geom.exportToWkb()
         geom = QgsGeometry()
         geom.fromWkb(wkb1)
-        wkb2 = geom.asWkb()
+        wkb2 = geom.exportToWkb()
         self.assertEqual(wkb1, wkb2)
 
     def testMergeLines(self):


### PR DESCRIPTION
Caching of WKB and GEOS inside QgsGeometry has been kept after geometry refactoring due to backwards compatibility. Currently the code barely makes any use of the cached WKB/GEOS representations, so they can be safely removed without negatively affecting the performance. There will be now the only internal representation of the geometries - objects derived from QgsAbstractGeometry. The WKB/GEOS representations can still be obtained by calling exportToWkb() and exportToGeos().

The changes should lower the memory footprint of QGIS especially when keeping an index of geometries (e.g. when using snapping with QgsPointLocator), because the interim WKB representations used when fetching geometries in providers are discarded after import to our native format.