### PR TITLE
[processing] fix ExtentSelectionPanel's getValue()

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -211,7 +211,7 @@ class AlgorithmDialog(AlgorithmDialogBase):
                     self.resetGUI()
         except AlgorithmDialogBase.InvalidParameterValue as e:
             try:
-                self.buttonBox.accepted.connect(lambda:
+                self.buttonBox.accepted.connect(lambda e=e:
                                                 e.widget.setPalette(QPalette()))
                 palette = e.widget.palette()
                 palette.setColor(QPalette.Base, QColor(255, 255, 0))

--- a/python/plugins/processing/gui/ExtentSelectionPanel.py
+++ b/python/plugins/processing/gui/ExtentSelectionPanel.py
@@ -153,7 +153,7 @@ class ExtentSelectionPanel(BASE, WIDGET):
         self.dialog.activateWindow()
 
     def getValue(self):
-        if str(self.leText.text()).strip() == '':
+        if str(self.leText.text()).strip() != '':
             return str(self.leText.text())
         else:
             return None


### PR DESCRIPTION
Since the addition of GUI wrappers to algorithm parameters, ParameterExtent was not functioning. A one character fix to resurrect the following algorithms:
- GridLine
- GridPolygon
- IdwInterpolationAttribute
- IdwInterpolationZValue
- RandomPointsExtent
- RegularPoints
- TinInterpolationZValue
- TinInterpolationValue
- VectorGridLines
- VectorGridPolygons

The commit also fix a lambda in AlgorithmDialog I spotted while dissecting what was wrong with extent parameter.