### PR TITLE
[processing] fix grass/grass7 installation check

### DIFF
--- a/python/plugins/processing/algs/grass/GrassUtils.py
+++ b/python/plugins/processing/algs/grass/GrassUtils.py
@@ -383,7 +383,7 @@ class GrassUtils(object):
                 points(),
                 False,
                 False,
-                'None',
+                None,
                 -1,
                 0.0001,
                 0,

--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -363,7 +363,7 @@ class Grass7Utils(object):
                 points(),
                 False,
                 False,
-                'None',
+                None,
                 -1,
                 0.0001,
                 0,


### PR DESCRIPTION
An empty extent parameter returns None, not a 'None' string. This PR fixes Grass/Grass7 installation check, (re-)unlocking the door to use those algorithms.