### PR TITLE
[symbology] draw effect(s) when rendering preview icon

### DIFF
--- a/python/core/effects/qgspainteffect.sip
+++ b/python/core/effects/qgspainteffect.sip
@@ -306,3 +306,36 @@ class QgsDrawSourceEffect : QgsPaintEffect
     virtual void draw( QgsRenderContext& context );
 
 };
+
+class QgsEffectPainter
+{
+%TypeHeaderCode
+#include <qgspainteffect.h>
+%End
+  public:
+
+    /**
+     * QgsEffectPainter constructor
+     *
+     * @param renderContext the QgsRenderContext object
+     * @note Added in QGIS 3.0
+     */
+    QgsEffectPainter( QgsRenderContext& renderContext );
+
+    /**
+     * QgsEffectPainter constructor alternative if no painter translation is needed
+     *
+     * @param renderContext the QgsRenderContext object
+     * @param effect the QgsPaintEffect object
+     * @note Added in QGIS 3.0
+     */
+    QgsEffectPainter( QgsRenderContext& renderContext, QgsPaintEffect* effect );
+    ~QgsEffectPainter();
+
+    /**
+     * Sets the effect to be painted
+     *
+     * @param effect the QgsPaintEffect object
+     */
+    void setEffect( QgsPaintEffect* effect );
+};

--- a/src/core/effects/qgspainteffect.cpp
+++ b/src/core/effects/qgspainteffect.cpp
@@ -322,3 +322,41 @@ void QgsDrawSourceEffect::readProperties( const QgsStringMap &props )
   mEnabled = props.value( QStringLiteral( "enabled" ), QStringLiteral( "1" ) ).toInt();
   mDrawMode = static_cast< QgsPaintEffect::DrawMode >( props.value( QStringLiteral( "draw_mode" ), QStringLiteral( "2" ) ).toInt() );
 }
+
+
+//
+// QgsEffectPainter
+//
+
+QgsEffectPainter::QgsEffectPainter( QgsRenderContext& renderContext )
+    : mRenderContext( renderContext )
+    , mEffect( nullptr )
+{
+  mPainter = renderContext.painter();
+  mPainter->save();
+}
+
+QgsEffectPainter::QgsEffectPainter( QgsRenderContext& renderContext, QgsPaintEffect* effect )
+    : mRenderContext( renderContext )
+    , mEffect( effect )
+{
+  mPainter = mRenderContext.painter();
+  mPainter->save();
+  mEffect->begin( mRenderContext );
+}
+
+void QgsEffectPainter::setEffect( QgsPaintEffect* effect )
+{
+  Q_ASSERT( !mEffect );
+
+  mEffect = effect;
+  mEffect->begin( mRenderContext );
+}
+
+QgsEffectPainter::~QgsEffectPainter()
+{
+  Q_ASSERT( mEffect );
+
+  mEffect->end( mRenderContext );
+  mPainter->restore();
+}

--- a/src/core/effects/qgspainteffect.h
+++ b/src/core/effects/qgspainteffect.h
@@ -309,5 +309,56 @@ class CORE_EXPORT QgsDrawSourceEffect : public QgsPaintEffect
     QPainter::CompositionMode mBlendMode;
 };
 
+/** \ingroup core
+ * \class QgsEffectPainter
+ * \brief A class to manager painter saving and restoring required for effect drawing
+ *
+ * \note Added in version 3.0
+ */
+class CORE_EXPORT QgsEffectPainter
+{
+  public:
+
+    /**
+     * QgsEffectPainter constructor
+     *
+     * @param renderContext the QgsRenderContext object
+     * @note Added in QGIS 3.0
+     */
+    QgsEffectPainter( QgsRenderContext& renderContext );
+
+    /**
+     * QgsEffectPainter constructor alternative if no painter translation is needed
+     *
+     * @param renderContext the QgsRenderContext object
+     * @param effect the QgsPaintEffect object
+     * @note Added in QGIS 3.0
+     */
+    QgsEffectPainter( QgsRenderContext& renderContext, QgsPaintEffect* effect );
+    ~QgsEffectPainter();
+
+    /**
+     * Sets the effect to be painted
+     *
+     * @param effect the QgsPaintEffect object
+     */
+    void setEffect( QgsPaintEffect* effect );
+
+    ///@cond PRIVATE
+
+    /**
+     * Access to the painter object
+     *
+     * @note Added in QGIS 3.0
+     */
+    QPainter* operator->() { return mPainter; }
+    ///@endcond
+
+  private:
+    QgsRenderContext& mRenderContext;
+    QPainter* mPainter;
+    QgsPaintEffect* mEffect;
+};
+
 #endif // QGSPAINTEFFECT_H
 

--- a/src/core/symbology-ng/qgssymbol.cpp
+++ b/src/core/symbology-ng/qgssymbol.cpp
@@ -624,14 +624,8 @@ void QgsSymbol::renderUsingLayer( QgsSymbolLayer* layer, QgsSymbolRenderContext&
   QgsPaintEffect* effect = generatorLayer->paintEffect();
   if ( effect && effect->enabled() )
   {
-    QPainter* p = context.renderContext().painter();
-    p->save();
-
-    effect->begin( context.renderContext() );
+    QgsEffectPainter p( context.renderContext(), effect );
     generatorLayer->render( context );
-    effect->end( context.renderContext() );
-
-    p->restore();
   }
   else
   {
@@ -1428,15 +1422,10 @@ void QgsMarkerSymbol::renderPointUsingLayer( QgsMarkerSymbolLayer* layer, QPoint
   QgsPaintEffect* effect = layer->paintEffect();
   if ( effect && effect->enabled() )
   {
-    QPainter* p = context.renderContext().painter();
-    p->save();
+    QgsEffectPainter p( context.renderContext() );
     p->translate( point );
-
-    effect->begin( context.renderContext() );
+    p.setEffect( effect );
     layer->renderPoint( nullPoint, context );
-    effect->end( context.renderContext() );
-
-    p->restore();
   }
   else
   {
@@ -1709,15 +1698,10 @@ void QgsLineSymbol::renderPolylineUsingLayer( QgsLineSymbolLayer *layer, const Q
   QgsPaintEffect* effect = layer->paintEffect();
   if ( effect && effect->enabled() )
   {
-    QPainter* p = context.renderContext().painter();
-    p->save();
+    QgsEffectPainter p( context.renderContext() );
     p->translate( points.boundingRect().topLeft() );
-
-    effect->begin( context.renderContext() );
+    p.setEffect( effect );
     layer->renderPolyline( points.translated( -points.boundingRect().topLeft() ), context );
-    effect->end( context.renderContext() );
-
-    p->restore();
   }
   else
   {
@@ -1794,11 +1778,9 @@ void QgsFillSymbol::renderPolygonUsingLayer( QgsSymbolLayer* layer, const QPolyg
     QRectF bounds = polygonBounds( points, rings );
     QList<QPolygonF>* translatedRings = translateRings( rings, -bounds.left(), -bounds.top() );
 
-    QPainter* p = context.renderContext().painter();
-    p->save();
+    QgsEffectPainter p( context.renderContext() );
     p->translate( bounds.topLeft() );
-
-    effect->begin( context.renderContext() );
+    p.setEffect( effect );
     if ( layertype == QgsSymbol::Fill )
     {
       ( static_cast<QgsFillSymbolLayer*>( layer ) )->renderPolygon( points.translated( -bounds.topLeft() ), translatedRings, context );
@@ -1808,9 +1790,6 @@ void QgsFillSymbol::renderPolygonUsingLayer( QgsSymbolLayer* layer, const QPolyg
       ( static_cast<QgsLineSymbolLayer*>( layer ) )->renderPolygonOutline( points.translated( -bounds.topLeft() ), translatedRings, context );
     }
     delete translatedRings;
-
-    effect->end( context.renderContext() );
-    p->restore();
   }
   else
   {

--- a/src/core/symbology-ng/qgssymbollayer.cpp
+++ b/src/core/symbology-ng/qgssymbollayer.cpp
@@ -421,7 +421,16 @@ void QgsMarkerSymbolLayer::startRender( QgsSymbolRenderContext& context )
 void QgsMarkerSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext& context, QSize size )
 {
   startRender( context );
-  renderPoint( QPointF( size.width() / 2, size.height() / 2 ), context );
+  QgsPaintEffect* effect = paintEffect();
+  if ( effect && effect->enabled() )
+  {
+    QgsEffectPainter p( context.renderContext(), effect );
+    renderPoint( QPointF( size.width() / 2, size.height() / 2 ), context );
+  }
+  else
+  {
+    renderPoint( QPointF( size.width() / 2, size.height() / 2 ), context );
+  }
   stopRender( context );
 }
 
@@ -590,7 +599,16 @@ void QgsLineSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext& context, QSize
   points << QPointF( 0, int( size.height() / 2 ) + 0.5 ) << QPointF( size.width(), int( size.height() / 2 ) + 0.5 );
 
   startRender( context );
-  renderPolyline( points, context );
+  QgsPaintEffect* effect = paintEffect();
+  if ( effect && effect->enabled() )
+  {
+    QgsEffectPainter p( context.renderContext(), effect );
+    renderPolyline( points, context );
+  }
+  else
+  {
+    renderPolyline( points, context );
+  }
   stopRender( context );
 }
 
@@ -615,7 +633,16 @@ void QgsFillSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext& context, QSize
 {
   QPolygonF poly = QRectF( QPointF( 0, 0 ), QPointF( size.width(), size.height() ) );
   startRender( context );
-  renderPolygon( poly, nullptr, context );
+  QgsPaintEffect* effect = paintEffect();
+  if ( effect && effect->enabled() )
+  {
+    QgsEffectPainter p( context.renderContext(), effect );
+    renderPolygon( poly, nullptr, context );
+  }
+  else
+  {
+    renderPolygon( poly, nullptr, context );
+  }
   stopRender( context );
 }
 


### PR DESCRIPTION
This PR enables layer effect(s) when drawing preview icons. This most positively impacts on composer legend items, which until now failed to render layer effects:
![untitled](https://cloud.githubusercontent.com/assets/1728657/20291739/e1ffdc20-ab1a-11e6-8770-1fe0192ccb13.png)
_Current rendering (left), vs. improved rendering (right) via this PR_

It also benefits the style manager and the symbols list widget, which both failed to render effect(s). Now, things look great:
![untitled2](https://cloud.githubusercontent.com/assets/1728657/20291754/05ed7a16-ab1b-11e6-973e-a607055922b7.png)

(Note: this is also part of a grand plan - introduced by PR #3755 - to improve the saved symbols QGIS ships by default.)

