### PR TITLE
fix exception when selecting string function

### DIFF
--- a/python/plugins/db_manager/dlg_query_builder.py
+++ b/python/plugins/db_manager/dlg_query_builder.py
@@ -163,7 +163,7 @@ class QueryBuilderDlg(QDialog):
         self.ui.functions.setCurrentIndex(0)
 
     def add_stringfct(self):
-        if self.ui.stringFct.currentIndex() <= 0:
+        if self.ui.stringfct.currentIndex() <= 0:
             return
         ag = self.ui.stringfct.currentText()
 


### PR DESCRIPTION
Just a typo error causing an exception when selecting a string function in query builder dialog