### PR TITLE
[processing] Fix hangs when running algorithms

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -71,6 +71,10 @@ def _expressionContext():
     context = QgsExpressionContext()
     context.appendScope(QgsExpressionContextUtils.globalScope())
     context.appendScope(QgsExpressionContextUtils.projectScope())
+
+    if iface.mapCanvas():
+        context.appendScope(QgsExpressionContextUtils.mapSettingsScope(iface.mapCanvas().mapSettings()))
+
     processingScope = QgsExpressionContextScope()
     layers = dataobjects.getAllLayers()
     for layer in layers:
@@ -92,12 +96,6 @@ def _expressionContext():
             processingScope.setVariable('%s_band%i_stddev' % (name, i + 1), stats.stdDev)
             processingScope.setVariable('%s_band%i_min' % (name, i + 1), stats.minimumValue)
             processingScope.setVariable('%s_band%i_max' % (name, i + 1), stats.maximumValue)
-
-    extent = iface.mapCanvas().extent()
-    processingScope.setVariable('canvasextent_minx', extent.xMinimum())
-    processingScope.setVariable('canvasextent_miny', extent.yMinimum())
-    processingScope.setVariable('canvasextent_maxx', extent.xMaximum())
-    processingScope.setVariable('canvasextent_maxy', extent.yMaximum())
 
     extent = iface.mapCanvas().fullExtent()
     processingScope.setVariable('fullextent_minx', extent.xMinimum())

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -76,26 +76,6 @@ def _expressionContext():
         context.appendScope(QgsExpressionContextUtils.mapSettingsScope(iface.mapCanvas().mapSettings()))
 
     processingScope = QgsExpressionContextScope()
-    layers = dataobjects.getAllLayers()
-    for layer in layers:
-        name = layer.name()
-        processingScope.setVariable('%s_minx' % name, layer.extent().xMinimum())
-        processingScope.setVariable('%s_miny' % name, layer.extent().yMinimum())
-        processingScope.setVariable('%s_maxx' % name, layer.extent().xMaximum())
-        processingScope.setVariable('%s_maxy' % name, layer.extent().yMaximum())
-        if isinstance(layer, QgsRasterLayer):
-            cellsize = (layer.extent().xMaximum()
-                        - layer.extent().xMinimum()) / layer.width()
-            processingScope.setVariable('%s_cellsize' % name, cellsize)
-
-    layers = dataobjects.getRasterLayers()
-    for layer in layers:
-        for i in range(layer.bandCount()):
-            stats = layer.dataProvider().bandStatistics(i + 1)
-            processingScope.setVariable('%s_band%i_avg' % (name, i + 1), stats.mean)
-            processingScope.setVariable('%s_band%i_stddev' % (name, i + 1), stats.stdDev)
-            processingScope.setVariable('%s_band%i_min' % (name, i + 1), stats.minimumValue)
-            processingScope.setVariable('%s_band%i_max' % (name, i + 1), stats.maximumValue)
 
     extent = iface.mapCanvas().fullExtent()
     processingScope.setVariable('fullextent_minx', extent.xMinimum())

--- a/resources/function_help/json/raster_statistic
+++ b/resources/function_help/json/raster_statistic
@@ -1,0 +1,14 @@
+{
+  "name": "raster_statistic",
+  "type": "function",
+  "description": "Returns statistics from a raster layer.",
+  "arguments": [
+	{"arg":"layer", "description":"a string, representing either a raster layer name or layer ID"},
+	{"arg":"band", "description":"integer representing the band number from the raster layer, starting at 1"},
+	{"arg":"property", "description":"a string corresponding to the property to return. Valid options are:<br /><ul><li>min: minimum value</li><li>max: maximum value</li><li>avg: average (mean) value</li><li>stdev: standard deviation of values</li><li>range: range of values (max - min)</li><li>sum: sum of all values from raster</li></ul>"}
+  ],
+  "examples": [
+	{ "expression":"raster_statistic('lc',1,'avg')", "returns":"Average value from band 1 from 'lc' raster layer"},
+	{ "expression":"raster_statistic('ac2010',3,'min')", "returns":"Minimum value from band 3 from 'ac2010' raster layer"}
+  ]
+}


### PR DESCRIPTION
The calculation of the extent of all open layers and band stats for all open rasters causes large hangs before an algorithm starts running. Eg add some moderately large rasters to a project, then try to run any processing algorithm and QGIS will freeze.

To fix this I've removed some of the custom expression variables added by processing:

The layer extent can already be used in expressions via the layer_property function, which only evaluates the extent if required and only for layers it is used for.

The band stats for raster layers should be moved to a band_statistic function in core which behaves the same way.