### PR TITLE
Rework the Edit widget properties dialog

### DIFF
--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -14,19 +14,6 @@
    <string>Edit Widget Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="0" rowspan="3">
-    <widget class="QListWidget" name="selectionListWidget"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QCheckBox" name="labelOnTopCheckBox">
-     <property name="text">
-      <string>Label on top</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
@@ -40,54 +27,78 @@
    <item row="6" column="1">
     <widget class="QStackedWidget" name="stackedWidget"/>
    </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Defaults</string>
+   <item row="5" column="0" rowspan="3">
+    <widget class="QListWidget" name="selectionListWidget"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Widget Type</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Default value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Preview</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsExpressionLineEdit" name="mExpressionWidget" native="true">
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="mDefaultPreviewLabel">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QCheckBox" name="isFieldEditableCheckBox">
-     <property name="text">
-      <string>Editable</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QGridLayout" name="gridLayout_4">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="isFieldEditableCheckBox">
+       <property name="text">
+        <string>Editable</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="labelOnTopCheckBox">
+       <property name="text">
+        <string>Label on top</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Defaults</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Default value</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Preview</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QgsExpressionLineEdit" name="mExpressionWidget" native="true">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="mDefaultPreviewLabel">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="2" column="1">
+   <item row="0" column="1">
     <widget class="QgsCollapsibleGroupBox" name="groupBox">
      <property name="title">
       <string>Constraints</string>
@@ -121,7 +132,7 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QgsFieldExpressionWidget" name="constraintExpressionWidget" native="true">
+       <widget class="QgsFieldExpressionWidget" name="constraintExpressionWidget">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
         </property>
@@ -174,13 +185,6 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Widget Type</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -191,15 +195,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsExpressionLineEdit</class>
-   <extends>QWidget</extends>
-   <header>qgsexpressionlineedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExpressionLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgsexpressionlineedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -207,6 +211,7 @@
   <tabstop>isFieldEditableCheckBox</tabstop>
   <tabstop>labelOnTopCheckBox</tabstop>
   <tabstop>mExpressionWidget</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>notNullCheckBox</tabstop>
   <tabstop>mCheckBoxEnforceNotNull</tabstop>
   <tabstop>mUniqueCheckBox</tabstop>
@@ -215,6 +220,7 @@
   <tabstop>leConstraintExpressionDescription</tabstop>
   <tabstop>mCheckBoxEnforceExpression</tabstop>
   <tabstop>selectionListWidget</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -14,10 +14,87 @@
    <string>Edit Widget Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="1">
+   <item row="5" column="0" rowspan="3">
+    <widget class="QListWidget" name="selectionListWidget">
+     <property name="minimumSize">
+      <size>
+       <width>333</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="labelOnTopCheckBox">
+     <property name="text">
+      <string>Label on top</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
     <widget class="QStackedWidget" name="stackedWidget"/>
    </item>
-   <item row="4" column="1">
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Defaults</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Default value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Preview</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsExpressionLineEdit" name="mExpressionWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="mDefaultPreviewLabel">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="isFieldEditableCheckBox">
+     <property name="text">
+      <string>Editable</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
     <widget class="QgsCollapsibleGroupBox" name="groupBox">
      <property name="title">
       <string>Constraints</string>
@@ -104,73 +181,10 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QCheckBox" name="isFieldEditableCheckBox">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Editable</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Defaults</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Default value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Preview</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsExpressionLineEdit" name="mExpressionWidget" native="true">
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="mDefaultPreviewLabel">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QCheckBox" name="labelOnTopCheckBox">
-     <property name="text">
-      <string>Label on top</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" rowspan="7">
-    <widget class="QListWidget" name="selectionListWidget"/>
-   </item>
-   <item row="6" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <string>Widget Type</string>
      </property>
     </widget>
    </item>
@@ -197,7 +211,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>selectionListWidget</tabstop>
   <tabstop>isFieldEditableCheckBox</tabstop>
   <tabstop>labelOnTopCheckBox</tabstop>
   <tabstop>mExpressionWidget</tabstop>
@@ -208,6 +221,7 @@
   <tabstop>constraintExpressionWidget</tabstop>
   <tabstop>leConstraintExpressionDescription</tabstop>
   <tabstop>mCheckBoxEnforceExpression</tabstop>
+  <tabstop>selectionListWidget</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -15,14 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="5" column="0" rowspan="3">
-    <widget class="QListWidget" name="selectionListWidget">
-     <property name="minimumSize">
-      <size>
-       <width>333</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
+    <widget class="QListWidget" name="selectionListWidget"/>
    </item>
    <item row="1" column="0">
     <widget class="QCheckBox" name="labelOnTopCheckBox">


### PR DESCRIPTION
Currently the Edit Widget Properties dialog looks like this

![capture d ecran 2016-11-16 a 12 53 26](https://cloud.githubusercontent.com/assets/7983394/20346347/cc8b4848-abfb-11e6-89e0-6ada4c50455f.png)

I do not find obvious that all the parts containing (Editable,label on top, default and constraints) are generic settings that apply to the field, regardless the selected widget.
I propose to reorganise the items so that widget selection and configuration are clearly identified and a bit separated from field global behavior (something like below). Going further, maybe should the selectionListWidget and stackedWidget be moved into a groupbox?

![capture d ecran 2016-11-16 a 16 20 09](https://cloud.githubusercontent.com/assets/7983394/20352724/9dbdeba2-ac18-11e6-8f06-c62228a20e7b.png)

For widget size comparison, this is what the old dialog looks like, without widget filled

![capture d ecran 2016-11-16 a 16 08 32](https://cloud.githubusercontent.com/assets/7983394/20352331/2ba3dca8-ac17-11e6-86e3-70d1a6cfa21d.png)

@m-kuhn @nyalldawson ?