### PR TITLE
[symbology] add padding value for symbol/coloramp preview

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1423,6 +1423,7 @@ QgsSymbolLayerUtils (renamed from QgsSymbolLayerUtilsV2)        {#qgis_api_break
 
 - encodeOutputUnit() and decodeOutputUnit() were removed. QgsUnitTypes::encodeUnit() and QgsUnitTypes::decodeRenderUnit() should be used instead.
 - The signatures for wellKnownMarkerToSld() and wellKnownMarkerFromSld() were changed.
+- The symbolPreviewPixmap() customContext is now the fourth parameter
 
 
 QgsSymbolSelectorWidget        {#qgis_api_break_3_0_QgsSymbolSelectorWidget}

--- a/python/core/symbology-ng/qgssymbollayerutils.sip
+++ b/python/core/symbology-ng/qgssymbollayerutils.sip
@@ -95,7 +95,23 @@ class QgsSymbolLayerUtils
 
     static QPainter::CompositionMode decodeBlendMode( const QString& s );
 
-    static QIcon symbolPreviewIcon( QgsSymbol* symbol, QSize size );
+    /** Returns an icon preview for a color ramp.
+     * @param symbol symbol
+     * @param size target pixmap size
+     * @param padding space between icon edge and symbol
+     * @see symbolPreviewPixmap()
+     */
+    static QIcon symbolPreviewIcon( QgsSymbol* symbol, QSize size, int padding = 0 );
+
+    /** Returns a pixmap preview for a color ramp.
+     * @param symbol symbol
+     * @param size target pixmap size
+     * @param padding space between icon edge and symbol
+     * @param customContext render context to use when rendering symbol
+     * @note customContext parameter added in 2.6
+     * @see symbolPreviewIcon()
+     */
+    static QPixmap symbolPreviewPixmap( QgsSymbol* symbol, QSize size, int padding = 0, QgsRenderContext* customContext = 0 );
 
     /** Draws a symbol layer preview to a QPicture
      * @param layer symbol layer to draw
@@ -118,13 +134,22 @@ class QgsSymbolLayerUtils
      */
     static QIcon symbolLayerPreviewIcon( QgsSymbolLayer* layer, QgsUnitTypes::RenderUnit u, QSize size, const QgsMapUnitScale& scale = QgsMapUnitScale() );
 
-    static QIcon colorRampPreviewIcon( QgsColorRamp* ramp, QSize size );
+    /** Returns a icon preview for a color ramp.
+     * @param ramp color ramp
+     * @param size target icon size
+     * @param padding space between icon edge and symbol
+     * @see colorRampPreviewPixmap()
+     */
+    static QIcon colorRampPreviewIcon( QgsColorRamp* ramp, QSize size, int padding = 0 );
+    /** Returns a pixmap preview for a color ramp.
+     * @param ramp color ramp
+     * @param size target pixmap size
+     * @param padding space between icon edge and symbol
+     * @see colorRampPreviewIcon()
+     */
+    static QPixmap colorRampPreviewPixmap( QgsColorRamp* ramp, QSize size, int padding = 0 );
 
     static void drawStippledBackground( QPainter* painter, QRect rect );
-
-    //! @note customContext parameter added in 2.6
-    static QPixmap symbolPreviewPixmap( QgsSymbol* symbol, QSize size, QgsRenderContext* customContext = 0 );
-    static QPixmap colorRampPreviewPixmap( QgsColorRamp* ramp, QSize size );
 
     /** Returns the maximum estimated bleed for the symbol */
     static double estimateMaxSymbolBleed( QgsSymbol* symbol );

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -168,7 +168,7 @@ QSize QgsSymbolLegendNode::minimumIconSize( QgsRenderContext* context ) const
   if ( mItem.symbol() && mItem.symbol()->type() == QgsSymbol::Marker )
   {
     minSz = QgsImageOperation::nonTransparentImageRect(
-              QgsSymbolLayerUtils::symbolPreviewPixmap( mItem.symbol(), QSize( 512, 512 ),
+              QgsSymbolLayerUtils::symbolPreviewPixmap( mItem.symbol(), QSize( 512, 512 ), 0,
                   context ).toImage(),
               minSz,
               true ).size();
@@ -176,7 +176,7 @@ QSize QgsSymbolLegendNode::minimumIconSize( QgsRenderContext* context ) const
   else if ( mItem.symbol() && mItem.symbol()->type() == QgsSymbol::Line )
   {
     minSz = QgsImageOperation::nonTransparentImageRect(
-              QgsSymbolLayerUtils::symbolPreviewPixmap( mItem.symbol(), QSize( minSz.width(), 512 ),
+              QgsSymbolLayerUtils::symbolPreviewPixmap( mItem.symbol(), QSize( minSz.width(), 512 ), 0,
                   context ).toImage(),
               minSz,
               true ).size();
@@ -273,7 +273,7 @@ QVariant QgsSymbolLegendNode::data( int role ) const
       if ( mItem.symbol() )
       {
         QScopedPointer<QgsRenderContext> context( createTemporaryRenderContext() );
-        pix = QgsSymbolLayerUtils::symbolPreviewPixmap( mItem.symbol(), mIconSize, context.data() );
+        pix = QgsSymbolLayerUtils::symbolPreviewPixmap( mItem.symbol(), mIconSize, 0, context.data() );
       }
       else
       {

--- a/src/core/symbology-ng/qgssymbollayerutils.h
+++ b/src/core/symbology-ng/qgssymbollayerutils.h
@@ -138,7 +138,23 @@ class CORE_EXPORT QgsSymbolLayerUtils
 
     static QPainter::CompositionMode decodeBlendMode( const QString& s );
 
-    static QIcon symbolPreviewIcon( QgsSymbol* symbol, QSize size );
+    /** Returns an icon preview for a color ramp.
+     * @param symbol symbol
+     * @param size target pixmap size
+     * @param padding space between icon edge and symbol
+     * @see symbolPreviewPixmap()
+     */
+    static QIcon symbolPreviewIcon( QgsSymbol* symbol, QSize size, int padding = 0 );
+
+    /** Returns a pixmap preview for a color ramp.
+     * @param symbol symbol
+     * @param size target pixmap size
+     * @param padding space between icon edge and symbol
+     * @param customContext render context to use when rendering symbol
+     * @note customContext parameter added in 2.6
+     * @see symbolPreviewIcon()
+     */
+    static QPixmap symbolPreviewPixmap( QgsSymbol* symbol, QSize size, int padding = 0, QgsRenderContext* customContext = nullptr );
 
     /** Draws a symbol layer preview to a QPicture
      * @param layer symbol layer to draw
@@ -161,24 +177,23 @@ class CORE_EXPORT QgsSymbolLayerUtils
      */
     static QIcon symbolLayerPreviewIcon( QgsSymbolLayer* layer, QgsUnitTypes::RenderUnit u, QSize size, const QgsMapUnitScale& scale = QgsMapUnitScale() );
 
-    /** Returns a icon preview for a color ramp.
+    /** Returns an icon preview for a color ramp.
      * @param ramp color ramp
      * @param size target icon size
+     * @param padding space between icon edge and color ramp
      * @see colorRampPreviewPixmap()
      */
-    static QIcon colorRampPreviewIcon( QgsColorRamp* ramp, QSize size );
+    static QIcon colorRampPreviewIcon( QgsColorRamp* ramp, QSize size, int padding = 0 );
 
     /** Returns a pixmap preview for a color ramp.
      * @param ramp color ramp
      * @param size target pixmap size
+     * @param padding space between icon edge and color ramp
      * @see colorRampPreviewIcon()
      */
-    static QPixmap colorRampPreviewPixmap( QgsColorRamp* ramp, QSize size );
+    static QPixmap colorRampPreviewPixmap( QgsColorRamp* ramp, QSize size, int padding = 0 );
 
     static void drawStippledBackground( QPainter* painter, QRect rect );
-
-    //! @note customContext parameter added in 2.6
-    static QPixmap symbolPreviewPixmap( QgsSymbol* symbol, QSize size, QgsRenderContext* customContext = nullptr );
 
     //! Returns the maximum estimated bleed for the symbol
     static double estimateMaxSymbolBleed( QgsSymbol* symbol );

--- a/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
@@ -236,17 +236,8 @@ void QgsStyleManagerDialog::on_tabItemType_currentChanged( int )
   actnExportAsPNG->setVisible( flag );
   actnExportAsSVG->setVisible( flag );
 
-  // set icon and grid size, depending on type
-  if ( currentItemType() == 1 || currentItemType() == 3 )
-  {
-    listItems->setIconSize( QSize( 75, 50 ) );
-    listItems->setGridSize( QSize( 100, 80 ) );
-  }
-  else
-  {
-    listItems->setIconSize( QSize( 50, 50 ) );
-    listItems->setGridSize( QSize( 75, 80 ) );
-  }
+  listItems->setIconSize( QSize( 100, 90 ) );
+  listItems->setGridSize( QSize( 120, 110 ) );
 
   populateList();
 }
@@ -275,7 +266,7 @@ void QgsStyleManagerDialog::populateSymbols( const QStringList& symbolNames, boo
     if ( symbol && symbol->type() == type )
     {
       QStandardItem* item = new QStandardItem( name );
-      QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( symbol, listItems->iconSize() );
+      QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( symbol, listItems->iconSize(), 18 );
       item->setIcon( icon );
       item->setData( name ); // used to find out original name when user edited the name
       item->setCheckable( check );
@@ -301,7 +292,7 @@ void QgsStyleManagerDialog::populateColorRamps( const QStringList& colorRamps, b
     QScopedPointer< QgsColorRamp > ramp( mStyle->colorRamp( name ) );
 
     QStandardItem* item = new QStandardItem( name );
-    QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), listItems->iconSize() );
+    QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), listItems->iconSize(), 18 );
     item->setIcon( icon );
     item->setData( name ); // used to find out original name when user edited the name
     item->setCheckable( check );

--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -243,7 +243,7 @@ void QgsSymbolsListWidget::populateSymbols( const QStringList& names )
     itemFont.setPointSize( 10 );
     item->setFont( itemFont );
     // create preview icon
-    QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( s, previewSize );
+    QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( s, previewSize, 15 );
     item->setIcon( icon );
     // add to model
     model->appendRow( item );

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -37,8 +37,8 @@
      </property>
      <property name="iconSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>77</width>
+       <height>70</height>
       </size>
      </property>
      <property name="textElideMode">


### PR DESCRIPTION
This PR adds an optional padding parameter to symbol and color ramp's PreviewIcon+PreviewPixmap pair of functions to improve the symbols list widget and style manager's symbol preview rendering.

The padding is added to avoid chopping of the edges of symbols who end up drawing outside of the passed on size area. For e.g., symbols with effects such as drop shadow or blur, polygons using a large outline and/or marker outlines, etc.

Here's a before vs. proposed screenshot of the polygon symbols list widget:
![poly](https://cloud.githubusercontent.com/assets/1728657/20376718/c8b388aa-acbb-11e6-8ff1-c4e125b0a16a.png)
_Take note of the symbols that are blurred, have a drop shadow effect, and large outlines_

Before vs. proposed screenshot of the line symbols list widget:
![lines](https://cloud.githubusercontent.com/assets/1728657/20376733/e2331caa-acbb-11e6-90ef-6783ac350b22.png)
_Check the line with a glow effect, but also look at the cap-end of the lines now showing whether it's rounded, or squared... wouhou!_

Before vs. proposed screenshot of the style manager:
![sm](https://cloud.githubusercontent.com/assets/1728657/20376751/01ae43f2-acbc-11e6-9a00-9cd207601312.png)

The padding also makes for a cleaner display by adding needed spacing in between symbols.