### PR TITLE
Processing raster calculator

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
@@ -78,7 +78,8 @@ class GdalParametersPanel(ParametersPanel):
         self.parametersHaveChanged()
 
     def connectParameterSignals(self):
-        for w in list(self.widgets.values()):
+        for wrapper in list(self.wrappers.values()):
+            w = wrapper.widget
             if isinstance(w, QLineEdit):
                 w.textChanged.connect(self.parametersHaveChanged)
             elif isinstance(w, QComboBox):

--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -552,3 +552,18 @@ qgis:voronoipolygons: >
 
 qgis:zonalstatistics:
 
+qgis:rastercalculator: >
+    This algorithm allows to perform algebraic operations using raster layers.
+    
+    The resulting layer will have its values computed according to an expression. The expression can contain numerical values, operators and references to any of the layers in the current project. The following functions are also supported:
+    
+    - sin(), cos(), tan(), atan2(), ln(), log10()
+    
+    The extent and cellsize can be defined by the user. If the extent is not specified, the minimum extent that covers the input layers will be used. If the cellsize is not specified, the minimum cellsize of all input layers will be used.
+    
+    The cellsize is assumed to be the same in both X and Y axes.
+    
+    Layers are refered by their name as displayed in the layer list and the number of the band to use (based on 1), using the pattern 'layer_name@band number'. For instance, the first band from a layer named DEM will be referred as DEM@1.
+    
+    When using the calculator in the batch interface or from the console, the files to use have to be specified. The corresponding layers are refered using the base name of the file (without the full path). For instance, is using a layer at path/to/my/rasterfile.tif, the first band of that layer will be refered as rasterfile.tif@1.
+    

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -86,7 +86,6 @@ class FieldsMapper(GeoAlgorithm):
                         return False
                 return False
 
-
         self.addParameter(ParameterFieldsMapping(self.FIELDS_MAPPING,
                                                  self.tr('Fields mapping'),
                                                  self.INPUT_LAYER))

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -178,6 +178,7 @@ from .ExtractSpecificNodes import ExtractSpecificNodes
 from .GeometryByExpression import GeometryByExpression
 from .SnapGeometries import SnapGeometriesToLayer
 from .PoleOfInaccessibility import PoleOfInaccessibility
+from .RasterCalculator import RasterCalculator
 from .CreateAttributeIndex import CreateAttributeIndex
 from .DropGeometry import DropGeometry
 from .BasicStatistics import BasicStatisticsForField
@@ -245,7 +246,7 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                         RemoveNullGeometry(), ExtractByExpression(), ExtendLines(),
                         ExtractSpecificNodes(), GeometryByExpression(), SnapGeometriesToLayer(),
                         PoleOfInaccessibility(), CreateAttributeIndex(), DropGeometry(),
-                        BasicStatisticsForField()
+                        BasicStatisticsForField(), RasterCalculator()
                         ]
 
         if hasMatplotlib:

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -103,7 +103,7 @@ class RasterCalculator(GeoAlgorithm):
 
         entries = []
         for name, lyr in layersDict.items():
-            for n in xrange(lyr.bandCount()):
+            for n in range(lyr.bandCount()):
                 entry = QgsRasterCalculatorEntry()
                 entry.ref = '{:s}@{:d}'.format(name, n + 1)
                 entry.raster = lyr

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -61,20 +61,19 @@ class RasterCalculator(GeoAlgorithm):
         class ParameterRasterCalculatorExpression(ParameterString):
 
             def evaluateForModeler(self, value, model):
-                # print value
                 for i in list(model.inputs.values()):
                     param = i.param
                     if isinstance(param, ParameterRaster):
-                        new = "%s@" % os.path.basename(param.value)
-                        old = "%s@" % param.name
+                        new = "{}@".format(os.path.basename(param.value))
+                        old = "{}@".format(param.name)
                         value = value.replace(old, new)
 
                     for alg in list(model.algs.values()):
                         for out in alg.algorithm.outputs:
                             if isinstance(out, OutputRaster):
                                 if out.value:
-                                    new = "%s@" % os.path.basename(out.value)
-                                    old = "%s:%s@" % (alg.name, out.name)
+                                    new = "{}@".format(os.path.basename(out.value))
+                                    old = "{}:{}@".format(alg.name, out.name)
                                     value = value.replace(old, new)
                 return value
 
@@ -106,7 +105,7 @@ class RasterCalculator(GeoAlgorithm):
         for name, lyr in layersDict.items():
             for n in xrange(lyr.bandCount()):
                 entry = QgsRasterCalculatorEntry()
-                entry.ref = '%s@%i' % (name, n + 1)
+                entry.ref = '{:s}@{:d}'.format(name, n + 1)
                 entry.raster = lyr
                 entry.bandNumber = n + 1
                 entries.append(entry)
@@ -149,7 +148,7 @@ class RasterCalculator(GeoAlgorithm):
         expression = algorithm.params[self.EXPRESSION]
         for i in list(model.inputs.values()):
             param = i.param
-            if isinstance(param, ParameterRaster) and "%s@" % param.name in expression:
+            if isinstance(param, ParameterRaster) and "{}@".format(param.name) in expression:
                 values.append(ValueFromInput(param.name))
 
         if algorithm.name:
@@ -160,7 +159,7 @@ class RasterCalculator(GeoAlgorithm):
             if alg.name not in dependent:
                 for out in alg.algorithm.outputs:
                     if (isinstance(out, OutputRaster)
-                            and "%s:%s@" % (alg.name, out.name) in expression):
+                            and "{}:{}@".format(alg.name, out.name) in expression):
                         values.append(ValueFromOutput(alg.name, out.name))
 
         algorithm.params[self.LAYERS] = values

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -119,7 +119,7 @@ class RasterCalculator(GeoAlgorithm):
                                 float(extent[1]), float(extent[3]))
         else:
             if layersDict:
-                bbox = layersDict.values()[0].extent()
+                bbox = list(layersDict.values())[0].extent()
                 for lyr in layersDict.values():
                     bbox.combineExtentWith(lyr.extent())
             else:

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -68,7 +68,6 @@ class RasterCalculator(GeoAlgorithm):
     
                     for alg in list(model.algs.values()):
                         for out in alg.algorithm.outputs:
-                            print out, out.value
                             if isinstance(out, OutputRaster):
                                 if out.value:
                                     new = "%s@" % os.path.basename(out.value)

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    RasterLayerCalculator.py
+    ---------------------
+    Date                 : November 2016
+    Copyright            : (C) 2016 by Victor Olaya
+    Email                : volayaf at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+from processing.modeler.ModelerAlgorithm import ValueFromInput, ValueFromOutput
+import os
+
+
+__author__ = 'Victor Olaya'
+__date__ = 'November 2016'
+__copyright__ = '(C) 2016, Victor Olaya'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+import math
+from processing.core.GeoAlgorithm import GeoAlgorithm
+from processing.core.parameters import ParameterMultipleInput, ParameterExtent, ParameterString, ParameterRaster, ParameterNumber
+from processing.core.outputs import OutputRaster
+from processing.tools import dataobjects
+from processing.algs.gdal.GdalUtils import GdalUtils
+from qgis.core import QgsRectangle
+from qgis.analysis import QgsRasterCalculator, QgsRasterCalculatorEntry
+from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
+from processing.algs.qgis.ui.RasterCalculatorWidgets import LayersListWidgetWrapper, ExpressionWidgetWrapper
+
+class RasterCalculator(GeoAlgorithm):
+
+    LAYERS = 'LAYERS'
+    EXTENT = 'EXTENT'
+    CELLSIZE = 'CELLSIZE'
+    EXPRESSION = 'EXPRESSION'
+    OUTPUT = 'OUTPUT'
+
+    def defineCharacteristics(self):
+        self.name, self.i18n_name = self.trAlgorithm('Raster calculator')
+        self.group, self.i18n_group = self.trAlgorithm('Raster')
+
+        self.addParameter(ParameterMultipleInput(self.LAYERS,
+                                          self.tr('Input layers'),
+                                          datatype=dataobjects.TYPE_RASTER,
+                                          optional=True,
+                                          metadata = {'widget_wrapper': LayersListWidgetWrapper}))
+        class ParameterExpression(ParameterString):
+            def evaluateForModeler(self, value, model): 
+                #print value                   
+                for i in list(model.inputs.values()):
+                    param = i.param
+                    if isinstance(param, ParameterRaster):
+                        new = "%s@" % os.path.basename(param.value)
+                        old = "%s@" % param.name
+                        value = value.replace(old, new)
+    
+                    for alg in list(model.algs.values()):
+                        for out in alg.algorithm.outputs:
+                            print out, out.value
+                            if isinstance(out, OutputRaster):
+                                if out.value:
+                                    new = "%s@" % os.path.basename(out.value)
+                                    old = "%s:%s@" % (alg.name, out.name)
+                                    value = value.replace(old, new)
+                return value
+
+        self.addParameter(ParameterExpression(self.EXPRESSION, self.tr('Expression'), 
+                                          multiline=True,
+                                          metadata = {'widget_wrapper': ExpressionWidgetWrapper}))
+        self.addParameter(ParameterNumber(self.CELLSIZE,
+                                          self.tr('Cellsize (use 0 or empty to set it automatically)'),
+                                          minValue=0.0, default=0.0, optional=True))
+        self.addParameter(ParameterExtent(self.EXTENT,
+                                          self.tr('Output extent'),
+                                          optional=True))        
+        self.addOutput(OutputRaster(self.OUTPUT, self.tr('Output')))
+
+
+    def processAlgorithm(self, progress):
+        expression = self.getParameterValue(self.EXPRESSION)
+        layersValue = self.getParameterValue(self.LAYERS)
+        layersDict = {}
+        if layersValue:
+            layers = [dataobjects.getObjectFromUri(f) for f in layersValue.split(";")]
+            layersDict = {os.path.basename(lyr.source()): lyr for lyr in layers}
+
+        for lyr in dataobjects.getRasterLayers():
+            name = lyr.name()
+            if (name + "@") in expression:
+                layersDict[name] = lyr
+
+        entries = []
+        for name, lyr in layersDict.iteritems():
+            for n in xrange(lyr.bandCount()):
+                entry = QgsRasterCalculatorEntry()
+                entry.ref = '%s@%i' % (name, n + 1)
+                entry.raster = lyr
+                entry.bandNumber = n + 1
+                entries.append(entry)
+
+        output = self.getOutputValue(self.OUTPUT)
+        extentValue = self.getParameterValue(self.EXTENT)
+
+        if extentValue:
+            extent = extentValue.split(',')
+            bbox = QgsRectangle(float(extent[0]), float(extent[2]),
+                                float(extent[1]), float(extent[3]))
+        else:
+            if layersDict:
+                bbox = layersDict.values()[0].extent()
+                for lyr in layersDict.values():
+                    bbox.combineExtentWith(lyr.extent())
+            else:
+                raise GeoAlgorithmExecutionException(self.tr("No layers selected"))
+        def _cellsize(layer):
+            return (layer.extent().xMaximum() - layer.extent().xMinimum()) / layer.width()
+        cellsize = self.getParameterValue(self.CELLSIZE) or min([_cellsize(lyr) for lyr in layersDict.values()])
+        width = math.floor((bbox.xMaximum() - bbox.xMinimum()) / cellsize)
+        height = math.floor((bbox.yMaximum() - bbox.yMinimum()) / cellsize)
+        driverName = GdalUtils.getFormatShortNameFromFilename(output)
+        calc = QgsRasterCalculator(expression,
+                                    output,
+                                    driverName,
+                                    bbox,
+                                    width,
+                                    height,
+                                    entries)
+
+        res = calc.processCalculation()
+        if res == QgsRasterCalculator.ParserError:
+            raise GeoAlgorithmExecutionException(self.tr("Error parsing formula"))
+
+    def processBeforeAddingToModeler(self, algorithm, model):
+        values = []
+        expression = algorithm.params[self.EXPRESSION]
+        for i in list(model.inputs.values()):
+            param = i.param
+            if isinstance(param, ParameterRaster) and "%s@" % param.name in expression:
+                values.append(ValueFromInput(param.name))
+
+        if algorithm.name:            
+            dependent = model.getDependentAlgorithms(algorithm.name)
+        else:
+            dependent = []
+        for alg in list(model.algs.values()):
+            if alg.name not in dependent:
+                for out in alg.algorithm.outputs:
+                    if (isinstance(out, OutputRaster) 
+                            and "%s:%s@" % (alg.name, out.name) in expression):
+                        values.append(ValueFromOutput(alg.name, out.name))
+
+        algorithm.params[self.LAYERS] = values

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -101,7 +101,7 @@ class RasterCalculator(GeoAlgorithm):
                 layersDict[name] = lyr
 
         entries = []
-        for name, lyr in layersDict.iteritems():
+        for name, lyr in layersDict.items():
             for n in xrange(lyr.bandCount()):
                 entry = QgsRasterCalculatorEntry()
                 entry.ref = '%s@%i' % (name, n + 1)

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -55,17 +55,17 @@ class RasterCalculator(GeoAlgorithm):
                                           self.tr('Input layers'),
                                           datatype=dataobjects.TYPE_RASTER,
                                           optional=True,
-                                          metadata = {'widget_wrapper': LayersListWidgetWrapper}))
-        class ParameterExpression(ParameterString):
-            def evaluateForModeler(self, value, model): 
-                #print value                   
+                                          metadata={'widget_wrapper': LayersListWidgetWrapper}))
+        class ParameterRasterCalculatorExpression(ParameterString):
+            def evaluateForModeler(self, value, model):
+                # print value
                 for i in list(model.inputs.values()):
                     param = i.param
                     if isinstance(param, ParameterRaster):
                         new = "%s@" % os.path.basename(param.value)
                         old = "%s@" % param.name
                         value = value.replace(old, new)
-    
+
                     for alg in list(model.algs.values()):
                         for out in alg.algorithm.outputs:
                             if isinstance(out, OutputRaster):
@@ -75,15 +75,15 @@ class RasterCalculator(GeoAlgorithm):
                                     value = value.replace(old, new)
                 return value
 
-        self.addParameter(ParameterExpression(self.EXPRESSION, self.tr('Expression'), 
+        self.addParameter(ParameterRasterCalculatorExpression(self.EXPRESSION, self.tr('Expression'),
                                           multiline=True,
-                                          metadata = {'widget_wrapper': ExpressionWidgetWrapper}))
+                                          metadata={'widget_wrapper': ExpressionWidgetWrapper}))
         self.addParameter(ParameterNumber(self.CELLSIZE,
                                           self.tr('Cellsize (use 0 or empty to set it automatically)'),
                                           minValue=0.0, default=0.0, optional=True))
         self.addParameter(ParameterExtent(self.EXTENT,
                                           self.tr('Output extent'),
-                                          optional=True))        
+                                          optional=True))
         self.addOutput(OutputRaster(self.OUTPUT, self.tr('Output')))
 
 
@@ -149,14 +149,14 @@ class RasterCalculator(GeoAlgorithm):
             if isinstance(param, ParameterRaster) and "%s@" % param.name in expression:
                 values.append(ValueFromInput(param.name))
 
-        if algorithm.name:            
+        if algorithm.name:
             dependent = model.getDependentAlgorithms(algorithm.name)
         else:
             dependent = []
         for alg in list(model.algs.values()):
             if alg.name not in dependent:
                 for out in alg.algorithm.outputs:
-                    if (isinstance(out, OutputRaster) 
+                    if (isinstance(out, OutputRaster)
                             and "%s:%s@" % (alg.name, out.name) in expression):
                         values.append(ValueFromOutput(alg.name, out.name))
 

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -39,6 +39,7 @@ from qgis.analysis import QgsRasterCalculator, QgsRasterCalculatorEntry
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
 from processing.algs.qgis.ui.RasterCalculatorWidgets import LayersListWidgetWrapper, ExpressionWidgetWrapper
 
+
 class RasterCalculator(GeoAlgorithm):
 
     LAYERS = 'LAYERS'
@@ -52,11 +53,13 @@ class RasterCalculator(GeoAlgorithm):
         self.group, self.i18n_group = self.trAlgorithm('Raster')
 
         self.addParameter(ParameterMultipleInput(self.LAYERS,
-                                          self.tr('Input layers'),
-                                          datatype=dataobjects.TYPE_RASTER,
-                                          optional=True,
-                                          metadata={'widget_wrapper': LayersListWidgetWrapper}))
+                                                 self.tr('Input layers'),
+                                                 datatype=dataobjects.TYPE_RASTER,
+                                                 optional=True,
+                                                 metadata={'widget_wrapper': LayersListWidgetWrapper}))
+
         class ParameterRasterCalculatorExpression(ParameterString):
+
             def evaluateForModeler(self, value, model):
                 # print value
                 for i in list(model.inputs.values()):
@@ -76,8 +79,8 @@ class RasterCalculator(GeoAlgorithm):
                 return value
 
         self.addParameter(ParameterRasterCalculatorExpression(self.EXPRESSION, self.tr('Expression'),
-                                          multiline=True,
-                                          metadata={'widget_wrapper': ExpressionWidgetWrapper}))
+                                                              multiline=True,
+                                                              metadata={'widget_wrapper': ExpressionWidgetWrapper}))
         self.addParameter(ParameterNumber(self.CELLSIZE,
                                           self.tr('Cellsize (use 0 or empty to set it automatically)'),
                                           minValue=0.0, default=0.0, optional=True))
@@ -85,7 +88,6 @@ class RasterCalculator(GeoAlgorithm):
                                           self.tr('Output extent'),
                                           optional=True))
         self.addOutput(OutputRaster(self.OUTPUT, self.tr('Output')))
-
 
     def processAlgorithm(self, progress):
         expression = self.getParameterValue(self.EXPRESSION)
@@ -123,6 +125,7 @@ class RasterCalculator(GeoAlgorithm):
                     bbox.combineExtentWith(lyr.extent())
             else:
                 raise GeoAlgorithmExecutionException(self.tr("No layers selected"))
+
         def _cellsize(layer):
             return (layer.extent().xMaximum() - layer.extent().xMinimum()) / layer.width()
         cellsize = self.getParameterValue(self.CELLSIZE) or min([_cellsize(lyr) for lyr in layersDict.values()])
@@ -130,12 +133,12 @@ class RasterCalculator(GeoAlgorithm):
         height = math.floor((bbox.yMaximum() - bbox.yMinimum()) / cellsize)
         driverName = GdalUtils.getFormatShortNameFromFilename(output)
         calc = QgsRasterCalculator(expression,
-                                    output,
-                                    driverName,
-                                    bbox,
-                                    width,
-                                    height,
-                                    entries)
+                                   output,
+                                   driverName,
+                                   bbox,
+                                   width,
+                                   height,
+                                   entries)
 
         res = calc.processCalculation()
         if res == QgsRasterCalculator.ParserError:

--- a/python/plugins/processing/algs/qgis/ui/ExpressionWidget.ui
+++ b/python/plugins/processing/algs/qgis/ui/ExpressionWidget.ui
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>644</width>
+    <height>296</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="margin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QGroupBox" name="verticalGroupBox">
+       <property name="title">
+        <string>Layers (double-click to add)</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QListWidget" name="listWidget">
+          <property name="minimumSize">
+           <size>
+            <width>300</width>
+            <height>150</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="buttonsGroupBox">
+       <property name="title">
+        <string>Values and operators</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="horizontalSpacing">
+         <number>0</number>
+        </property>
+        <property name="verticalSpacing">
+         <number>-1</number>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <item row="2" column="9">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="4" column="1">
+         <widget class="QPushButton" name="button7">
+          <property name="text">
+           <string>7</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QPushButton" name="button4">
+          <property name="text">
+           <string>4</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QPushButton" name="button2">
+          <property name="text">
+           <string>2</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="7">
+         <widget class="QPushButton" name="mOpenBracketPushButton">
+          <property name="text">
+           <string>(</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="button1">
+          <property name="text">
+           <string>1</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QPushButton" name="button5">
+          <property name="text">
+           <string>5</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QPushButton" name="button8">
+          <property name="text">
+           <string>8</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="4">
+         <widget class="QPushButton" name="mSqrtButton">
+          <property name="text">
+           <string>sqrt</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="8">
+         <widget class="QPushButton" name="mCloseBracketPushButton">
+          <property name="text">
+           <string>)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QPushButton" name="button3">
+          <property name="text">
+           <string>3</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="6">
+         <widget class="QPushButton" name="mExpButton">
+          <property name="text">
+           <string>^</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="6">
+         <widget class="QPushButton" name="mMinusPushButton">
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="8">
+         <widget class="QPushButton" name="mDividePushButton">
+          <property name="text">
+           <string>/</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1" colspan="2">
+         <widget class="QPushButton" name="button0">
+          <property name="text">
+           <string>0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="6">
+         <widget class="QPushButton" name="mGreaterButton">
+          <property name="text">
+           <string>&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="7">
+         <widget class="QPushButton" name="mMultiplyPushButton">
+          <property name="text">
+           <string>*</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="7">
+         <widget class="QPushButton" name="mAndButton">
+          <property name="text">
+           <string>AND</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="4">
+         <widget class="QPushButton" name="mLesserEqualButton">
+          <property name="text">
+           <string>&lt;=</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="4">
+         <widget class="QPushButton" name="mLessButton">
+          <property name="text">
+           <string>&lt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="6">
+         <widget class="QPushButton" name="mGreaterEqualButton">
+          <property name="text">
+           <string>&gt;=</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="5">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="5" column="8">
+         <widget class="QPushButton" name="mOrButton">
+          <property name="text">
+           <string>OR</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="8">
+         <widget class="QPushButton" name="mEqualButton">
+          <property name="text">
+           <string>=</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QPushButton" name="button6">
+          <property name="text">
+           <string>6</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="3">
+         <widget class="QPushButton" name="buttonDot">
+          <property name="text">
+           <string>.</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="7">
+         <widget class="QPushButton" name="mNotEqualButton">
+          <property name="text">
+           <string>!=</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="4">
+         <widget class="QPushButton" name="mPlusPushButton">
+          <property name="text">
+           <string>+</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="3">
+         <widget class="QPushButton" name="button9">
+          <property name="text">
+           <string>9</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Expression</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPlainTextEdit" name="text">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>100</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
@@ -60,7 +60,7 @@ class ExpressionWidgetWrapper(WidgetWrapper):
             layers = dataobjects.getRasterLayers(sorting=False)
             options = {}
             for lyr in layers:
-                for n in xrange(lyr.bandCount()):
+                for n in range(lyr.bandCount()):
                     name = '{:s}@{:d}'.format(lyr.name(), n + 1)
                     options[name] = name
             return self._panel(options)
@@ -75,7 +75,7 @@ class ExpressionWidgetWrapper(WidgetWrapper):
         layers = dataobjects.getRasterLayers()
         options = {}
         for lyr in layers:
-            for n in xrange(lyr.bandCount()):
+            for n in range(lyr.bandCount()):
                 options[lyr.name()] = '{:s}@{:d}'.format(lyr.name(), n + 1)
         self.widget.setList(options)
 

--- a/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
@@ -20,37 +20,38 @@ class ExpressionWidget(BASE, WIDGET):
     def __init__(self, options):
         super(ExpressionWidget, self).__init__(None)
         self.setupUi(self)
-        
+
         self.setList(options)
-        
+
         def doubleClicked(item):
             self.text.insertPlainText(self.options[item.text()])
+
         def addButtonText(text):
             if any(c for c in text if c.islower()):
                 self.text.insertPlainText(" %s()" % text)
                 self.text.moveCursor(QTextCursor.PreviousCharacter, QTextCursor.MoveAnchor)
             else:
-                self.text.insertPlainText(" %s " % text)                         
+                self.text.insertPlainText(" %s " % text)
         buttons = [b for b in self.buttonsGroupBox.children()if isinstance(b, QPushButton)]
         for button in buttons:
             button.clicked.connect(partial(addButtonText, button.text()))
         self.listWidget.itemDoubleClicked.connect(doubleClicked)
-    
+
     def setList(self, options):
         self.options = options
         self.listWidget.clear()
         for opt in options.keys():
             self.listWidget.addItem(opt)
-              
+
     def setValue(self, value):
         self.text.setPlainText(value)
-        
+
     def value(self):
         return self.text.toPlainText()
 
-    
+
 class ExpressionWidgetWrapper(WidgetWrapper):
-    
+
     def _panel(self, options):
         return ExpressionWidget(options)
 
@@ -61,7 +62,7 @@ class ExpressionWidgetWrapper(WidgetWrapper):
             for lyr in layers:
                 for n in xrange(lyr.bandCount()):
                     name = '%s@%i' % (lyr.name(), n + 1)
-                    options[name] = name 
+                    options[name] = name
             return self._panel(options)
         elif self.dialogType == DIALOG_BATCH:
             return QLineEdit()
@@ -109,7 +110,6 @@ class LayersListWidgetWrapper(WidgetWrapper):
         if self.dialogType == DIALOG_BATCH:
             return self.widget.setText(value)
 
-
     def value(self):
         if self.dialogType == DIALOG_STANDARD:
             if self.param.datatype == dataobjects.TYPE_FILE:
@@ -130,6 +130,3 @@ class LayersListWidgetWrapper(WidgetWrapper):
             if len(values) == 0 and not self.param.optional:
                 raise InvalidParameterValue()
             return values
-
-    
-        

--- a/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
@@ -1,0 +1,135 @@
+from processing.gui.wrappers import WidgetWrapper, DIALOG_STANDARD, DIALOG_BATCH
+from processing.tools import dataobjects
+from processing.gui.BatchInputSelectionPanel import BatchInputSelectionPanel
+from qgis.PyQt.QtWidgets import QListWidget, QLineEdit, QPushButton
+from qgis.PyQt.QtGui import QTextCursor
+from processing.core.outputs import OutputRaster
+from processing.core.parameters import ParameterRaster
+from processing.gui.wrappers import InvalidParameterValue
+import os
+from qgis.PyQt import uic
+from functools import partial
+
+pluginPath = os.path.dirname(__file__)
+WIDGET, BASE = uic.loadUiType(
+    os.path.join(pluginPath, 'ExpressionWidget.ui'))
+
+
+class ExpressionWidget(BASE, WIDGET):
+
+    def __init__(self, options):
+        super(ExpressionWidget, self).__init__(None)
+        self.setupUi(self)
+        
+        self.setList(options)
+        
+        def doubleClicked(item):
+            self.text.insertPlainText(self.options[item.text()])
+        def addButtonText(text):
+            if any(c for c in text if c.islower()):
+                self.text.insertPlainText(" %s()" % text)
+                self.text.moveCursor(QTextCursor.PreviousCharacter, QTextCursor.MoveAnchor)
+            else:
+                self.text.insertPlainText(" %s " % text)                         
+        buttons = [b for b in self.buttonsGroupBox.children()if isinstance(b, QPushButton)]
+        for button in buttons:
+            button.clicked.connect(partial(addButtonText, button.text()))
+        self.listWidget.itemDoubleClicked.connect(doubleClicked)
+    
+    def setList(self, options):
+        self.options = options
+        self.listWidget.clear()
+        for opt in options.keys():
+            self.listWidget.addItem(opt)
+              
+    def setValue(self, value):
+        self.text.setPlainText(value)
+        
+    def value(self):
+        return self.text.toPlainText()
+
+    
+class ExpressionWidgetWrapper(WidgetWrapper):
+    
+    def _panel(self, options):
+        return ExpressionWidget(options)
+
+    def createWidget(self):
+        if self.dialogType == DIALOG_STANDARD:
+            layers = dataobjects.getRasterLayers(sorting=False)
+            options = {}
+            for lyr in layers:
+                for n in xrange(lyr.bandCount()):
+                    name = '%s@%i' % (lyr.name(), n + 1)
+                    options[name] = name 
+            return self._panel(options)
+        elif self.dialogType == DIALOG_BATCH:
+            return QLineEdit()
+        else:
+            layers = self.dialog.getAvailableValuesOfType(ParameterRaster, OutputRaster)
+            options = {self.dialog.resolveValueDescription(lyr): "%s@1" % lyr for lyr in layers}
+            return self._panel(options)
+
+    def refresh(self):
+        layers = dataobjects.getRasterLayers()
+        options = {}
+        for lyr in layers:
+            for n in xrange(lyr.bandCount()):
+                options[lyr.name()] = '%s@%i' % (lyr.name(), n + 1)
+        self.widget.setList(options)
+
+    def setValue(self, value):
+        if self.dialogType == DIALOG_STANDARD:
+            pass  # TODO
+        elif self.dialogType == DIALOG_BATCH:
+            return self.widget.setText(value)
+        else:
+            self.widget.setValue(value)
+
+    def value(self):
+        if self.dialogType in DIALOG_STANDARD:
+            return self.widget.value()
+        elif self.dialogType == DIALOG_BATCH:
+            return self.widget.text()
+        else:
+            return self.widget.value()
+
+
+class LayersListWidgetWrapper(WidgetWrapper):
+
+    def createWidget(self):
+        if self.dialogType == DIALOG_BATCH:
+            widget = BatchInputSelectionPanel(self.param, self.row, self.col, self.dialog)
+            widget.valueChanged.connect(lambda: self.widgetValueHasChanged.emit(self))
+            return widget
+        else:
+            return None
+
+    def setValue(self, value):
+        if self.dialogType == DIALOG_BATCH:
+            return self.widget.setText(value)
+
+
+    def value(self):
+        if self.dialogType == DIALOG_STANDARD:
+            if self.param.datatype == dataobjects.TYPE_FILE:
+                return self.param.setValue(self.widget.selectedoptions)
+            else:
+                if self.param.datatype == dataobjects.TYPE_RASTER:
+                    options = dataobjects.getRasterLayers(sorting=False)
+                elif self.param.datatype == dataobjects.TYPE_VECTOR_ANY:
+                    options = dataobjects.getVectorLayers(sorting=False)
+                else:
+                    options = dataobjects.getVectorLayers([self.param.datatype], sorting=False)
+                return [options[i] for i in self.widget.selectedoptions]
+        elif self.dialogType == DIALOG_BATCH:
+            return self.widget.getText()
+        else:
+            options = self._getOptions()
+            values = [options[i] for i in self.widget.selectedoptions]
+            if len(values) == 0 and not self.param.optional:
+                raise InvalidParameterValue()
+            return values
+
+    
+        

--- a/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
@@ -28,10 +28,10 @@ class ExpressionWidget(BASE, WIDGET):
 
         def addButtonText(text):
             if any(c for c in text if c.islower()):
-                self.text.insertPlainText(" %s()" % text)
+                self.text.insertPlainText(" {}()".format(text))
                 self.text.moveCursor(QTextCursor.PreviousCharacter, QTextCursor.MoveAnchor)
             else:
-                self.text.insertPlainText(" %s " % text)
+                self.text.insertPlainText(" {} ".format(text))
         buttons = [b for b in self.buttonsGroupBox.children()if isinstance(b, QPushButton)]
         for button in buttons:
             button.clicked.connect(partial(addButtonText, button.text()))
@@ -61,14 +61,14 @@ class ExpressionWidgetWrapper(WidgetWrapper):
             options = {}
             for lyr in layers:
                 for n in xrange(lyr.bandCount()):
-                    name = '%s@%i' % (lyr.name(), n + 1)
+                    name = '{:s}@{:d}'.format(lyr.name(), n + 1)
                     options[name] = name
             return self._panel(options)
         elif self.dialogType == DIALOG_BATCH:
             return QLineEdit()
         else:
             layers = self.dialog.getAvailableValuesOfType(ParameterRaster, OutputRaster)
-            options = {self.dialog.resolveValueDescription(lyr): "%s@1" % lyr for lyr in layers}
+            options = {self.dialog.resolveValueDescription(lyr): "{}@1".format(lyr) for lyr in layers}
             return self._panel(options)
 
     def refresh(self):
@@ -76,7 +76,7 @@ class ExpressionWidgetWrapper(WidgetWrapper):
         options = {}
         for lyr in layers:
             for n in xrange(lyr.bandCount()):
-                options[lyr.name()] = '%s@%i' % (lyr.name(), n + 1)
+                options[lyr.name()] = '{:s}@{:d}'.format(lyr.name(), n + 1)
         self.widget.setList(options)
 
     def setValue(self, value):

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -48,6 +48,7 @@ from processing.algs.gdal.GdalUtils import GdalUtils
 from processing.tools import dataobjects, vector
 from processing.algs.help import shortHelp
 
+
 class GeoAlgorithm(object):
 
     def __init__(self):
@@ -132,10 +133,9 @@ class GeoAlgorithm(object):
         """
         pass
 
-
     def getParametersPanel(self, parent):
-        return ParametersPanel(parent, self) 
-    
+        return ParametersPanel(parent, self)
+
     def getCustomParametersDialog(self):
         """If the algorithm has a custom parameters dialog, it should
         be returned here, ready to be executed.
@@ -185,12 +185,12 @@ class GeoAlgorithm(object):
         calling from the console.
         """
         return None
-    
+
     def processBeforeAddingToModeler(self, alg, model):
         """Add here any task that has to be performed before adding an algorithm
         to a model, such as changing the value of a parameter depending on value
-        of another one""" 
-        pass 
+        of another one"""
+        pass
 
     # =========================================================
 

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from builtins import str
-from builtins import object
-
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'
@@ -38,6 +35,9 @@ from qgis.PyQt.QtCore import QCoreApplication, QSettings
 
 from qgis.core import QgsVectorLayer, QgsRasterLayer
 
+from builtins import str
+from builtins import object
+from processing.gui.ParametersPanel import ParametersPanel
 from processing.core.ProcessingLog import ProcessingLog
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
@@ -46,9 +46,7 @@ from processing.core.parameters import ParameterRaster, ParameterVector, Paramet
 from processing.core.outputs import OutputVector, OutputRaster, OutputTable, OutputHTML, Output
 from processing.algs.gdal.GdalUtils import GdalUtils
 from processing.tools import dataobjects, vector
-from processing.tools.system import setTempOutput
 from processing.algs.help import shortHelp
-
 
 class GeoAlgorithm(object):
 
@@ -134,6 +132,10 @@ class GeoAlgorithm(object):
         """
         pass
 
+
+    def getParametersPanel(self, parent):
+        return ParametersPanel(parent, self) 
+    
     def getCustomParametersDialog(self):
         """If the algorithm has a custom parameters dialog, it should
         be returned here, ready to be executed.
@@ -183,6 +185,12 @@ class GeoAlgorithm(object):
         calling from the console.
         """
         return None
+    
+    def processBeforeAddingToModeler(self, alg, model):
+        """Add here any task that has to be performed before adding an algorithm
+        to a model, such as changing the value of a parameter depending on value
+        of another one""" 
+        pass 
 
     # =========================================================
 

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -123,7 +123,6 @@ class Parameter(object):
 
         self.optional = parseBool(optional)
 
-        # TODO: make deep copy and deep update
         self.metadata = deepcopy(self.default_metadata)
         self.metadata.update(deepcopy(metadata))
 
@@ -179,7 +178,7 @@ class Parameter(object):
     def wrapper(self, dialog, row=0, col=0):
         wrapper = self.metadata.get('widget_wrapper', None)
         # wrapper metadata should be a class path
-        if isinstance(wrapper, str):
+        if isinstance(wrapper, basestring):
             tokens = wrapper.split('.')
             mod = __import__('.'.join(tokens[:-1]), fromlist=[tokens[-1]])
             wrapper = getattr(mod, tokens[-1])
@@ -362,7 +361,10 @@ class ParameterExtent(Parameter):
             return False
 
     def getValueAsCommandLineParameter(self):
-        return '"' + str(self.value) + '"'
+        if self.value is not None:
+            return '"' + str(self.value) + '"'
+        else:
+            return str(None)
 
     def getAsScriptCode(self):
         param_type = ''
@@ -582,8 +584,8 @@ class ParameterMultipleInput(ParameterDataObject):
 
     exported = None
 
-    def __init__(self, name='', description='', datatype=-1, optional=False):
-        ParameterDataObject.__init__(self, name, description, None, optional)
+    def __init__(self, name='', description='', datatype=-1, optional=False, metadata={}):
+        ParameterDataObject.__init__(self, name, description, None, optional, metadata=metadata)
         self.datatype = int(float(datatype))
         self.exported = None
         self.minNumInputs = 0
@@ -1133,8 +1135,8 @@ class ParameterString(Parameter):
     ESCAPED_NEWLINE = '\\n'
 
     def __init__(self, name='', description='', default=None, multiline=False,
-                 optional=False, evaluateExpressions=False):
-        Parameter.__init__(self, name, description, default, optional)
+                 optional=False, evaluateExpressions=False, metadata={}):
+        Parameter.__init__(self, name, description, default, optional, metadata)
         self.multiline = parseBool(multiline)
         self.evaluateExpressions = parseBool(evaluateExpressions)
 

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -178,7 +178,7 @@ class Parameter(object):
     def wrapper(self, dialog, row=0, col=0):
         wrapper = self.metadata.get('widget_wrapper', None)
         # wrapper metadata should be a class path
-        if isinstance(wrapper, basestring):
+        if isinstance(wrapper, str):
             tokens = wrapper.split('.')
             mod = __import__('.'.join(tokens[:-1]), fromlist=[tokens[-1]])
             wrapper = getattr(mod, tokens[-1])

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -39,7 +39,6 @@ from processing.core.ProcessingLog import ProcessingLog
 from processing.core.ProcessingConfig import ProcessingConfig
 
 from processing.gui.BatchAlgorithmDialog import BatchAlgorithmDialog
-from processing.gui.ParametersPanel import ParametersPanel
 from processing.gui.AlgorithmDialogBase import AlgorithmDialogBase
 from processing.gui.AlgorithmExecutor import runalg, runalgIterating
 from processing.gui.Postprocessing import handleAlgorithmResults
@@ -63,7 +62,7 @@ class AlgorithmDialog(AlgorithmDialogBase):
 
         self.alg = alg
 
-        self.setMainWidget(ParametersPanel(self, alg))
+        self.setMainWidget(alg.getParametersPanel(self))
 
         self.bar = QgsMessageBar()
         self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
@@ -99,14 +98,17 @@ class AlgorithmDialog(AlgorithmDialogBase):
         for output in outputs:
             if output.hidden:
                 continue
-            output.value = self.mainWidget.valueItems[output.name].getValue()
+            output.value = self.mainWidget.outputWidgets[output.name].getValue()
             if isinstance(output, (OutputRaster, OutputVector, OutputTable)):
                 output.open = self.mainWidget.checkBoxes[output.name].isChecked()
 
         return True
 
-    def setParamValue(self, param, wrapper, alg=None):
-        return param.setValue(wrapper.value())
+    def setParamValue(self, param, wrapper):
+        if wrapper.widget:
+            return param.setValue(wrapper.value())
+        else:
+            return True
 
     def checkExtentCRS(self):
         unmatchingCRS = False
@@ -131,7 +133,7 @@ class AlgorithmDialog(AlgorithmDialogBase):
                             if p.crs() != projectCRS:
                                 unmatchingCRS = True
             if isinstance(param, ParameterExtent):
-                value = self.mainWidget.valueItems[param.name].leText.text().strip()
+                value = self.mainWidget.wrappers[param.name].widget.leText.text().strip()
                 if value:
                     hasExtent = True
 

--- a/python/plugins/processing/gui/ExtentSelectionPanel.py
+++ b/python/plugins/processing/gui/ExtentSelectionPanel.py
@@ -59,7 +59,7 @@ class ExtentSelectionPanel(BASE, WIDGET):
         if self.param.optional:
             if hasattr(self.leText, 'setPlaceholderText'):
                 self.leText.setPlaceholderText(
-                    self.tr('[Use "auto" to use min covering extent]'))
+                    self.tr('[Leave blank to use min covering extent]'))
 
         self.btnSelect.clicked.connect(self.selectExtent)
 
@@ -104,7 +104,7 @@ class ExtentSelectionPanel(BASE, WIDGET):
         popupmenu.exec_(QCursor.pos())
 
     def useMinCoveringExtent(self):
-        self.leText.setText('auto')
+        self.leText.setText('')
 
     def useLayerExtent(self):
         CANVAS_KEY = 'Use canvas extent'

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -119,10 +119,10 @@ class ParametersPanel(BASE, WIDGET):
                     button.toggled.connect(self.buttonToggled)
                     widget = QWidget()
                     widget.setLayout(layout)
-    
+
                 tooltips = self.alg.getParameterDescriptions()
                 widget.setToolTip(tooltips.get(param.name, param.description))
-    
+
                 label = QLabel(desc)
                 # label.setToolTip(tooltip)
                 self.labels[param.name] = label

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -67,10 +67,9 @@ class ParametersPanel(BASE, WIDGET):
 
         self.parent = parent
         self.alg = alg
-        self.valueItems = {}
         self.wrappers = {}
+        self.outputWidgets = {}
         self.labels = {}
-        self.widgets = {}
         self.checkBoxes = {}
         self.dependentItems = {}
         self.iterateButtons = {}
@@ -102,41 +101,39 @@ class ParametersPanel(BASE, WIDGET):
 
             wrapper = self.getWidgetWrapperFromParameter(param)
             self.wrappers[param.name] = wrapper
-            self.valueItems[param.name] = wrapper.widget
             widget = wrapper.widget
 
-            if isinstance(param, ParameterVector):
-                layout = QHBoxLayout()
-                layout.setSpacing(2)
-                layout.setMargin(0)
-                layout.addWidget(widget)
-                button = QToolButton()
-                icon = QIcon(os.path.join(pluginPath, 'images', 'iterate.png'))
-                button.setIcon(icon)
-                button.setToolTip(self.tr('Iterate over this layer'))
-                button.setCheckable(True)
-                layout.addWidget(button)
-                self.iterateButtons[param.name] = button
-                button.toggled.connect(self.buttonToggled)
-                widget = QWidget()
-                widget.setLayout(layout)
-
-            tooltips = self.alg.getParameterDescriptions()
-            widget.setToolTip(tooltips.get(param.name, param.description))
-
-            label = QLabel(desc)
-            # label.setToolTip(tooltip)
-            self.labels[param.name] = label
-            if param.isAdvanced:
-                self.layoutAdvanced.addWidget(label)
-                self.layoutAdvanced.addWidget(widget)
-            else:
-                self.layoutMain.insertWidget(
-                    self.layoutMain.count() - 2, label)
-                self.layoutMain.insertWidget(
-                    self.layoutMain.count() - 2, widget)
-
-            self.widgets[param.name] = widget
+            if widget is not None:
+                if isinstance(param, ParameterVector):
+                    layout = QHBoxLayout()
+                    layout.setSpacing(2)
+                    layout.setMargin(0)
+                    layout.addWidget(widget)
+                    button = QToolButton()
+                    icon = QIcon(os.path.join(pluginPath, 'images', 'iterate.png'))
+                    button.setIcon(icon)
+                    button.setToolTip(self.tr('Iterate over this layer'))
+                    button.setCheckable(True)
+                    layout.addWidget(button)
+                    self.iterateButtons[param.name] = button
+                    button.toggled.connect(self.buttonToggled)
+                    widget = QWidget()
+                    widget.setLayout(layout)
+    
+                tooltips = self.alg.getParameterDescriptions()
+                widget.setToolTip(tooltips.get(param.name, param.description))
+    
+                label = QLabel(desc)
+                # label.setToolTip(tooltip)
+                self.labels[param.name] = label
+                if param.isAdvanced:
+                    self.layoutAdvanced.addWidget(label)
+                    self.layoutAdvanced.addWidget(widget)
+                else:
+                    self.layoutMain.insertWidget(
+                        self.layoutMain.count() - 2, label)
+                    self.layoutMain.insertWidget(
+                        self.layoutMain.count() - 2, widget)
 
         for output in self.alg.outputs:
             if output.hidden:
@@ -152,8 +149,7 @@ class ParametersPanel(BASE, WIDGET):
                 check.setChecked(True)
                 self.layoutMain.insertWidget(self.layoutMain.count() - 1, check)
                 self.checkBoxes[output.name] = check
-            self.valueItems[output.name] = widget
-
+            self.outputWidgets[output.name] = widget
         for wrapper in list(self.wrappers.values()):
             wrapper.postInitialize(list(self.wrappers.values()))
 

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -831,7 +831,7 @@ class StringWidgetWrapper(WidgetWrapper):
             else:
                 text = self.widget.getValue()
             return text
-        if self.dialogType == DIALOG_BATCH:
+        elif self.dialogType == DIALOG_BATCH:
             return self.widget.text()
         else:
             if self.param.multiline:

--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -200,7 +200,7 @@ class ValueFromOutput(object):
             return False
 
     def __str__(self):
-        return self.alg + "," + self.output
+        return self.alg + ":" + self.output
 
     def asPythonParameter(self):
         return "outputs_%s['%s']" % (self.alg, self.output)

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -146,20 +146,21 @@ class ModelerParametersDialog(QDialog):
             self.wrappers[param.name] = wrapper
 
             widget = wrapper.widget
-            self.valueItems[param.name] = widget
-            if param.name in list(tooltips.keys()):
-                tooltip = tooltips[param.name]
-            else:
-                tooltip = param.description
-            label.setToolTip(tooltip)
-            widget.setToolTip(tooltip)
-            if param.isAdvanced:
-                label.setVisible(self.showAdvanced)
-                widget.setVisible(self.showAdvanced)
-                self.widgets[param.name] = widget
-
-            self.verticalLayout.addWidget(label)
-            self.verticalLayout.addWidget(widget)
+            if widget:
+                self.valueItems[param.name] = widget
+                if param.name in list(tooltips.keys()):
+                    tooltip = tooltips[param.name]
+                else:
+                    tooltip = param.description
+                label.setToolTip(tooltip)
+                widget.setToolTip(tooltip)
+                if param.isAdvanced:
+                    label.setVisible(self.showAdvanced)
+                    widget.setVisible(self.showAdvanced)
+                    self.widgets[param.name] = widget
+    
+                self.verticalLayout.addWidget(label)
+                self.verticalLayout.addWidget(widget)
 
         for output in self._alg.outputs:
             if output.hidden:
@@ -301,34 +302,6 @@ class ModelerParametersDialog(QDialog):
             alg = self.model.algs[value.alg]
             return self.tr("'%s' from algorithm '%s'") % (alg.algorithm.getOutputFromName(value.output).description, alg.description)
 
-    def setTableContent(self):
-        params = self._alg.parameters
-        outputs = self._alg.outputs
-        visibleParams = [p for p in params if not p.hidden]
-        visibleOutputs = [p for o in outputs if not o.hidden]
-        self.tableWidget.setRowCount(len(visibleParams) + len(visibleOutputs))
-
-        for i, param in visibleParams:
-            item = QTableWidgetItem(param.description)
-            item.setFlags(Qt.ItemIsEnabled)
-            self.tableWidget.setItem(i, 0, item)
-            item = self.getWidgetFromParameter(param)
-            self.valueItems[param.name] = item
-            self.tableWidget.setCellWidget(i, 1, item)
-            self.tableWidget.setRowHeight(i, 22)
-
-        for i, output in visibleOutputs:
-            item = QTableWidgetItem(output.description + '<'
-                                    + output.__module__.split('.')[-1] + '>')
-            item.setFlags(Qt.ItemIsEnabled)
-            self.tableWidget.setItem(i, 0, item)
-            item = QLineEdit()
-            if hasattr(item, 'setPlaceholderText'):
-                item.setPlaceholderText(ModelerParametersDialog.ENTER_NAME)
-            self.valueItems[output.name] = item
-            self.tableWidget.setCellWidget(i, 1, item)
-            self.tableWidget.setRowHeight(i, 22)
-
     def setPreviousValues(self):
         if self._algName is not None:
             alg = self.model.algs[self._algName]
@@ -376,12 +349,14 @@ class ModelerParametersDialog(QDialog):
         for selected in selectedOptions:
             alg.dependencies.append(availableDependencies[selected].name)
 
+        self._alg.processBeforeAddingToModeler(alg, self.model)
         return alg
 
     def setParamValue(self, alg, param, wrapper):
         try:
-            value = wrapper.value()
-            alg.params[param.name] = value
+            if wrapper.widget:
+                value = wrapper.value()
+                alg.params[param.name] = value
             return True
         except InvalidParameterValue:
             return False

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -158,7 +158,7 @@ class ModelerParametersDialog(QDialog):
                     label.setVisible(self.showAdvanced)
                     widget.setVisible(self.showAdvanced)
                     self.widgets[param.name] = widget
-    
+
                 self.verticalLayout.addWidget(label)
                 self.verticalLayout.addWidget(widget)
 

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1837,7 +1837,7 @@ tests:
       EXPRESSION: dem@1
     results:
       OUTPUT:
-        hash: ef97a22ee16e0e28bbdc0341449777b1527e37febc3c4339b2c057c9
+        hash: 826f313761324710ed542ec9e9c4fa06c30d25df24f8399d1ca756ca
         type: rasterhash
 
   - algorithm: qgis:rastercalculator
@@ -1852,5 +1852,5 @@ tests:
       EXPRESSION: dem@1 * 2
     results:
       OUTPUT:
-        hash: fe6e018be13c5a3c17f3f4d0f0dc7686c628cb440b74c4642aa0c939
+        hash: c4c6b70c262e2f125f321b45d8403d2428503e33e69f6a48196e1a94
         type: rasterhash

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1824,3 +1824,33 @@ tests:
           - 'Minimum value: 03:29:40'
           - 'Maximum value: 15:29:22'
           - 'NULL \(missing\) values: 1'
+
+  - algorithm: qgis:rastercalculator
+    name: Raster Calculator with cellsize
+    params:
+      LAYERS:
+        params:
+          - name: dem.tif
+            type: raster
+        type: multi
+      CELLSIZE: 0.001
+      EXPRESSION: dem@1
+    results:
+      OUTPUT:
+        hash: ef97a22ee16e0e28bbdc0341449777b1527e37febc3c4339b2c057c9
+        type: rasterhash
+
+  - algorithm: qgis:rastercalculator
+    name: Raster Calculator 
+    params:
+      LAYERS:
+        params:
+          - name: dem.tif
+            type: raster
+        type: multi
+      CELLSIZE: 0.0
+      EXPRESSION: dem@1 * 2
+    results:
+      OUTPUT:
+        hash: fe6e018be13c5a3c17f3f4d0f0dc7686c628cb440b74c4642aa0c939
+        type: rasterhash


### PR DESCRIPTION
This PR adds a raster calculator algorithm that uses the native QGIS classes for this type of calculations. It has a custom interface and can be run from the toolbox, modeler and batch processing dialog.

When run from the console, it provides a quick alternative to using the corresponding classes. It can work on layers that are not loaded in the current project, but also with loaded layers, and in this last case it is not needed to specify the layer objects or filepaths, since they are infered from the formula itself.

Once this is merged and well-tested, I would suggest removing all other calculators from Processing (GDAL, SAGA, GRASS...), to avoid confusion. This one is versatile enough to replace the other ones, and if there is any functionality missing, it can be added to the core QgsRasterCalculator class

We should also discuss if the current raster calculator UI should be replaced with this one, like it has been done for other core algorithms (ftools, interpolation...) once an equivalent Processing algorithm has been added.

The PR includes some fixes and small changes needed to accomodate the specific characteristics of the calculator algorithm.