### PR TITLE
[FEATURE][processing] Create attribute index algorithm

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -93,6 +93,9 @@ qgis:countuniquepointsinpolygon: >
 
   A new polygons layer is generated, with the exact same content as the input polygons layer, but containing an additional field with the points count corresponding to each polygon.
 
+qgis:createattributeindex: >
+  Creates an index to speed up queries made against a field in a table. Support for index creation is dependant on the layer's data provider and the field type.
+
 qgis:createconstantrasterlayer: >
   Given an input raster layer an a value, this algorithm generates a new layer with the same extent and cellsize as the input one, and all cells with the specified value.
 

--- a/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
+++ b/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    CreateAttributeIndex.py
+    -----------------------
+    Date                 : November 2016
+    Copyright            : (C) 2016 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Nyall Dawson'
+__date__ = 'November 2016'
+__copyright__ = '(C) 2016, Nyall Dawson'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+from qgis.core import QgsVectorDataProvider, QgsFields
+
+from processing.core.GeoAlgorithm import GeoAlgorithm
+from processing.core.parameters import ParameterVector
+from processing.core.parameters import ParameterTableField
+from processing.core.outputs import OutputVector
+
+from processing.tools import dataobjects
+
+
+class CreateAttributeIndex(GeoAlgorithm):
+
+    INPUT = 'INPUT'
+    FIELD = 'FIELD'
+    OUTPUT = 'OUTPUT'
+
+    def defineCharacteristics(self):
+        self.name, self.i18n_name = self.trAlgorithm('Create attribute index')
+        self.group, self.i18n_group = self.trAlgorithm('Vector general tools')
+
+        self.addParameter(ParameterVector(self.INPUT,
+                                          self.tr('Input Layer')))
+        self.addParameter(ParameterTableField(self.FIELD,
+                                              self.tr('Attribute to index'), self.INPUT))
+        self.addOutput(OutputVector(self.OUTPUT,
+                                    self.tr('Indexed layer'), True))
+
+    def processAlgorithm(self, progress):
+        file_name = self.getParameterValue(self.INPUT)
+        layer = dataobjects.getObjectFromUri(file_name)
+        field = self.getParameterValue(self.FIELD)
+        provider = layer.dataProvider()
+
+        field_index = layer.fields().lookupField(field)
+        if field_index < 0 or layer.fields().fieldOrigin(field_index) != QgsFields.OriginProvider:
+            progress.setInfo(self.tr('Can not create attribute index on "{}"').format(field))
+        else:
+            provider_index = layer.fields().fieldOriginIndex(field_index)
+            if provider.capabilities() & QgsVectorDataProvider.CreateAttributeIndex:
+                if not provider.createAttributeIndex(provider_index):
+                    progress.setInfo(self.tr('Could not create attribute index'))
+            else:
+                progress.setInfo(self.tr("Layer's data provider does not support "
+                                         "creating attribute indexes"))
+
+        self.setOutputValue(self.OUTPUT, file_name)

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -177,6 +177,7 @@ from .ExtractSpecificNodes import ExtractSpecificNodes
 from .GeometryByExpression import GeometryByExpression
 from .SnapGeometries import SnapGeometriesToLayer
 from .PoleOfInaccessibility import PoleOfInaccessibility
+from .CreateAttributeIndex import CreateAttributeIndex
 
 pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
@@ -240,7 +241,7 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                         TinInterpolationZValue(), TinInterpolationAttribute(),
                         RemoveNullGeometry(), ExtractByExpression(), ExtendLines(),
                         ExtractSpecificNodes(), GeometryByExpression(), SnapGeometriesToLayer(),
-                        PoleOfInaccessibility()
+                        PoleOfInaccessibility(), CreateAttributeIndex()
                         ]
 
         if hasMatplotlib:

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1544,4 +1544,11 @@ tests:
         name: expected/extract_by_attribute_greater.gml
         type: vector
 
-
+  - algorithm: qgis:createattributeindex
+    name: Create Attribute Index (only tests for python errors, does not check result)
+    params:
+      FIELD: fid
+      INPUT:
+        name: lines.gml
+        type: vector
+    results: {}


### PR DESCRIPTION
Allows creation of an index on an attribute in a layer for faster attribute based filtering

Support depends on the underlying data provider for the layer. (QGIS currently has only limited support in OGR provider (creating a new index drops any existing indices on other attributes) and mssql provider.)