### PR TITLE
Flatpak recipes

### DIFF
--- a/flatpak/.gitignore
+++ b/flatpak/.gitignore
@@ -1,0 +1,4 @@
+qgis-app
+repo
+.flatpak-builder
+qgis.tar.gz

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,39 @@
+Flatpak
+=======
+
+Flatpak is an alternative system for distributing applications that allows
+to deploy QGIS
+
+ * very fast
+ * bundle dependencies
+
+That means you no longer have to worry that your system only ships with old
+versions of libraries.
+
+It also means, that everything that is contained in the app is installed in a
+sandbox that can easily live next to your system's QGIS installation.
+
+Installing
+----------
+
+Flatpak is available on various distributions, although in general only in their
+very latest release. [Get flatpak!](http://flatpak.org/getting.html)
+
+Building
+--------
+
+Since we don't have an online repository (yet), you need to build a package locally.
+
+In the QGIS sourcecode folder
+
+    cd flatpak
+    ./create-flatpak.sh
+    # Wait for everything to be built, this takes some time when done the first time
+
+    flatpak --user remote-add --no-gpg-verify qgis-repo-local repo
+    flatpak --user install qgis-repo-local org.qgis.qgis
+
+Notes:
+
+ * The `--user` flag does not require root permissions.
+ * `remote-add` is only required to do once

--- a/flatpak/create-flatpak.sh
+++ b/flatpak/create-flatpak.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+wget http://distribute.kde.org/kdeflatpak.gpg
+flatpak --user remote-add kde http://distribute.kde.org/flatpak-testing/ --gpg-import=kdeflatpak.gpg
+rm kdeflatpak.gpg
+flatpak --user install kde org.kde.Platform
+flatpak --user install kde org.kde.Sdk
+
+git -C .. archive --format=tar.gz --prefix=qgis-HEAD/ HEAD > qgis.tar.gz
+flatpak-builder --ccache --require-changes --force-clean --subject="build of org.qgis, `date`" qgis-app qgis.json
+flatpak build-export repo qgis-app

--- a/flatpak/qca_qio.patch
+++ b/flatpak/qca_qio.patch
@@ -1,0 +1,11 @@
+diff a/include/QtCrypto/qca_basic.h b/include/QtCrypto/qca_basic.h
+--- a/include/QtCrypto/qca_basic.h
++++ b/include/QtCrypto/qca_basic.h
+@@ -34,6 +34,7 @@
+ #define QCA_BASIC_H
+ 
+ #include "qca_core.h"
++#include <QIODevice>
+ 
+ // Qt5 comes with QStringLiteral for wrapping string literals, which Qt4 does
+ // not have. It is needed if the headers are built with QT_NO_CAST_FROM_ASCII.

--- a/flatpak/qgis.json
+++ b/flatpak/qgis.json
@@ -1,0 +1,118 @@
+{
+    "id": "org.qgis.qgis",
+    "branch": "master",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "master",
+    "sdk": "org.kde.Sdk",
+    "command": "qgis",
+    "tags": ["nightly"],
+    "desktop-file-name-prefix": "(Nightly) ",
+    "finish-args": ["--share=ipc", "--socket=x11", "--filesystem=host" ],
+    "separate-locales": false,
+
+    "modules": [
+        {
+            "name": "qgis",
+            "cmake": true,
+            "sources": [
+              {
+                "type": "archive",
+                "path": "qgis.tar.gz"
+              }
+            ],
+            "config-opts": [
+              "-DQWT_LIBRARY=/app/lib/libqwt.so"
+            ],
+            "post-install": [ "mkdir -p /app/share/applications", "cp debian/qgis.desktop /app/share/applications/org.qgis.qgis.desktop" ],
+            "modules": [
+              {
+                "name": "proj",
+                "sources": [ { "type": "archive", "url": "http://download.osgeo.org/proj/proj-4.9.3.tar.gz", "sha256": "6984542fea333488de5c82eea58d699e4aff4b359200a9971537cd7e047185f7" } ]
+              },
+              {
+                "name": "geos",
+                "sources": [ { "type": "archive", "url": "http://download.osgeo.org/geos/geos-3.6.0.tar.bz2", "sha256": "1fe7644f3240c8422b0143830ff142e44e8b01333c12f67681ccaab92142f2ea" }
+                ]
+              },
+              {
+                "name": "spatialindex",
+                "sources": [ { "type": "archive", "url": "http://download.osgeo.org/libspatialindex/spatialindex-src-1.8.5.tar.bz2", "sha256": "31ec0a9305c3bd6b4ad60a5261cba5402366dd7d1969a8846099717778e9a50a" } ]
+              },
+              {
+                "name": "sip",
+                "sources": [
+                  { "type": "archive", "url": "http://sourceforge.net/projects/pyqt/files/sip/sip-4.18/sip-4.18.tar.gz", "sha256": "f1dc5c81c07a9ad97edcd4a0af964a41e420024ba7ca165afd2b351efd249cb6" },
+                  {
+                      "type": "script",
+                      "commands": ["python3 configure.py -b /app/bin -d /app/lib/python3.4/site-packages -e /app/include -v /app/share/sip" ],
+                      "dest-filename": "configure"
+                  }
+                ]
+              },
+              {
+                "name": "pyqt5",
+                "sources": [
+                  { "type": "archive", "url": "http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.7/PyQt5_gpl-5.7.tar.gz", "sha256": "892693ba5f79989abb2061dad2d5c4e6f127e9dd3240f73f8220c7152cd35b05" },
+                  {
+                      "type": "script",
+                      "commands": ["python3 configure.py -b /app/bin -d /app/lib/python3.4/site-packages -v /app/share/sip/PyQt5 --qml-plugindir=/app/lib/plugins/PyQt5 --confirm-license" ],
+                      "dest-filename": "configure"
+                  }
+                ]
+              },
+              {
+                "name": "spatialite",
+                "sources": [ { "type": "archive", "url": "http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz", "sha256": "88900030a4762904a7880273f292e5e8ca6b15b7c6c3fb88ffa9e67ee8a5a499" } ],
+                "modules": [
+                  {
+                    "name": "freexl",
+                    "sources": [ { "type": "archive", "url": "http://www.gaia-gis.it/gaia-sins/freexl-sources/freexl-1.0.2.tar.gz", "sha256": "b39a4814a0f53f5e09a9192c41e3e51bd658843f770399023a963eb064f6409d" } ]
+                  }
+                ]
+              },
+              {
+                "name": "postgresql",
+                "sources": [ { "type": "archive", "url": "https://ftp.postgresql.org/pub/source/v9.6.0/postgresql-9.6.0.tar.bz2", "sha256": "3b5fe9634b80a4511aac1832a087586a7caa8c3413619562bdda009a015863ce" } ]
+              },
+              {
+                "name": "gdal",
+                "sources": [ { "type": "archive", "url": "http://download.osgeo.org/gdal/2.1.2/gdal-2.1.2.tar.gz", "sha256": "69761c38acac8c6d3ea71304341f6982b5d66125a1a80d9088b6bfd2019125c9" } ]
+              },
+              {
+                "name": "qca",
+                "cmake": true,
+                "config-opts": ["-DQT4_BUILD=OFF", "-DQCA_SUFFIX=qt5"],
+                "sources": [
+                  { "type": "archive", "url": "http://delta.affinix.com/download/qca/2.0/qca-2.1.0.tar.gz", "sha256": "226dcd76138c3738cdc15863607a96b3758a4c3efd3c47295939bcea4e7a9284" },
+                  { "type": "patch", "path": "qca_qio.patch" }
+                ]
+              },
+              {
+                "name": "qscintilla",
+                "sources": [
+                  { "type": "archive", "url": "http://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.9.3/QScintilla_gpl-2.9.3.tar.gz", "sha256": "98aab93d73b05635867c2fc757acb383b5856a0b416e3fd7659f1879996ddb7e" },
+                  { "type": "patch", "path": "qscintilla.patch" },
+                  {
+                      "type": "script",
+                      "commands": ["qmake" ],
+                      "dest-filename": "Qt4Qt5/configure"
+                  }
+                ],
+                "subdir": "Qt4Qt5"
+              },
+              {
+                "name": "qwt",
+                "sources": [
+                  { "type": "archive", "url": "http://downloads.sourceforge.net/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2", "sha256": "2b08f18d1d3970e7c3c6096d850f17aea6b54459389731d3ce715d193e243d0c" },
+                  { "type": "patch", "path": "qwt.patch" },
+                  {
+                      "type": "script",
+                      "commands": ["qmake" ],
+                      "dest-filename": "configure"
+                  }
+                ]
+              }
+            ]
+        }
+    ]
+}

--- a/flatpak/qscintilla.patch
+++ b/flatpak/qscintilla.patch
@@ -1,0 +1,133 @@
+diff -Naur qscintilla-a/Python/configure.py qscintilla-3/Python/configure.py
+--- qscintilla-a/Python/configure.py	2016-11-17 16:48:51.402995006 +0100
++++ qscintilla-3/Python/configure.py	2016-11-17 16:49:17.180969716 +0100
+@@ -293,7 +293,7 @@
+         version of Qt.  target_configuration is the target configuration.
+         """
+ 
+-        qmake = {'CONFIG': 'qscintilla2'}
++        qmake = {'CONFIG': 'qscintilla2-qt5'}
+ 
+         if target_configuration.qsci_inc_dir is not None:
+             qmake['INCLUDEPATH'] = quote(target_configuration.qsci_inc_dir)
+@@ -319,7 +319,7 @@
+             lib_dir = target_configuration.qt_lib_dir
+ 
+         return os.path.join(lib_dir,
+-                'libqscintilla2.%s.dylib' % QSCI_API_MAJOR)
++                'libqscintilla2-qt5.%s.dylib' % QSCI_API_MAJOR)
+ 
+ 
+ ###############################################################################
+diff -Naur qscintilla-a/Qt4Qt5/features/qscintilla2.prf qscintilla-3/Qt4Qt5/features/qscintilla2.prf
+--- qscintilla-a/Qt4Qt5/features/qscintilla2.prf	2016-11-17 16:48:51.407995002 +0100
++++ qscintilla-3/Qt4Qt5/features/qscintilla2.prf	1970-01-01 01:00:00.000000000 +0100
+@@ -1,27 +0,0 @@
+-greaterThan(QT_MAJOR_VERSION, 4) {
+-    QT += widgets printsupport
+-
+-    greaterThan(QT_MINOR_VERSION, 1) {
+-        macx:QT += macextras
+-    }
+-}
+-
+-DEFINES += QSCINTILLA_DLL
+-
+-INCLUDEPATH += $$[QT_INSTALL_HEADERS]
+-
+-LIBS += -L$$[QT_INSTALL_LIBS]
+-
+-CONFIG(debug, debug|release) {
+-    mac: {
+-        LIBS += -lqscintilla2_debug
+-    } else {
+-        win32: {
+-            LIBS += -lqscintilla2d
+-        } else {
+-            LIBS += -lqscintilla2
+-        }
+-    }
+-} else {
+-    LIBS += -lqscintilla2
+-}
+diff -Naur qscintilla-a/Qt4Qt5/features/qscintilla2-qt5.prf qscintilla-3/Qt4Qt5/features/qscintilla2-qt5.prf
+--- qscintilla-a/Qt4Qt5/features/qscintilla2-qt5.prf	1970-01-01 01:00:00.000000000 +0100
++++ qscintilla-3/Qt4Qt5/features/qscintilla2-qt5.prf	2016-11-17 16:49:17.182969714 +0100
+@@ -0,0 +1,27 @@
++greaterThan(QT_MAJOR_VERSION, 4) {
++    QT += widgets printsupport
++
++    greaterThan(QT_MINOR_VERSION, 1) {
++        macx:QT += macextras
++    }
++}
++
++DEFINES += QSCINTILLA_DLL
++
++INCLUDEPATH += $$[QT_INSTALL_HEADERS]
++
++LIBS += -L$$[QT_INSTALL_LIBS]
++
++CONFIG(debug, debug|release) {
++    mac: {
++        LIBS += -lqscintilla2-qt5_debug
++    } else {
++        win32: {
++            LIBS += -lqscintilla2d
++        } else {
++            LIBS += -lqscintilla2-qt5
++        }
++    }
++} else {
++    LIBS += -lqscintilla2-qt5
++}
+diff -Naur qscintilla-a/Qt4Qt5/qscintilla.pro qscintilla-3/Qt4Qt5/qscintilla.pro
+--- qscintilla-a/Qt4Qt5/qscintilla.pro	2016-11-17 16:48:51.411994998 +0100
++++ qscintilla-3/Qt4Qt5/qscintilla.pro	2016-11-17 16:52:18.689791638 +0100
+@@ -23,7 +23,7 @@
+ !win32:VERSION = 12.0.2
+ 
+ TEMPLATE = lib
+-TARGET = qscintilla2
++TARGET = qscintilla2-qt5
+ CONFIG += qt warn_off release thread exceptions hide_symbols
+ INCLUDEPATH += . ../include ../lexlib ../src
+ 
+@@ -47,30 +47,26 @@
+ # Scintilla namespace rather than pollute the global namespace.
+ #DEFINES += SCI_NAMESPACE
+ 
+-target.path = $$[QT_INSTALL_LIBS]
++target.path = /app/lib
+ INSTALLS += target
+ 
+-header.path = $$[QT_INSTALL_HEADERS]
++header.path = /app/include
+ header.files = Qsci
+ INSTALLS += header
+ 
+-trans.path = $$[QT_INSTALL_TRANSLATIONS]
++trans.path = /app/translations
+ trans.files = qscintilla_*.qm
+ INSTALLS += trans
+ 
+-qsci.path = $$[QT_INSTALL_DATA]
++qsci.path = /app/share
+ qsci.files = ../qsci
+ INSTALLS += qsci
+ 
+-greaterThan(QT_MAJOR_VERSION, 4) {
+-    features.path = $$[QT_HOST_DATA]/mkspecs/features
+-} else {
+-    features.path = $$[QT_INSTALL_DATA]/mkspecs/features
+-}
++features.path = /app/share/mkspecs/features
+ CONFIG(staticlib) {
+-    features.files = $$PWD/features_staticlib/qscintilla2.prf
++    features.files = $$PWD/features_staticlib/qscintilla2-qt5.prf
+ } else {
+-    features.files = $$PWD/features/qscintilla2.prf
++    features.files = $$PWD/features/qscintilla2-qt5.prf
+ }
+ INSTALLS += features
+ 

--- a/flatpak/qwt.patch
+++ b/flatpak/qwt.patch
@@ -1,0 +1,12 @@
+diff -Naur qwt-1/qwtconfig.pri qwt-2/qwtconfig.pri
+--- qwt-1/qwtconfig.pri	2014-12-11 15:13:13.513186492 +0100
++++ qwt-2/qwtconfig.pri	2016-11-17 15:49:24.272532454 +0100
+@@ -19,7 +19,7 @@
+ QWT_INSTALL_PREFIX = $$[QT_INSTALL_PREFIX]
+ 
+ unix {
+-    QWT_INSTALL_PREFIX    = /usr/local/qwt-$$QWT_VERSION
++    QWT_INSTALL_PREFIX    = /app
+     # QWT_INSTALL_PREFIX = /usr/local/qwt-$$QWT_VERSION-qt-$$QT_VERSION
+ }
+ 


### PR DESCRIPTION
Flatpak is a cross-distribution way of shipping applications to users including dependencies (bye-bye Qt 5.6)

There is a readme included in this pr, that explains how to build it. It's potentially the simplest way to build QGIS yourself ;)

My long-term goals are

 * Building packages directly on the CI (be it Flatpak or [AppImage](http://appimage.org/) or whatever)
 * Shipping packages that have been tested - including the dependencies
 * Automatically ship master builds from CI (No need to wait for nightlies)
 * Potentially even ship builds from pull requests (Get feedback of non-dev people)

Installing
----------

Flatpak is available on various distributions, although in general only in their
very latest release. [Get flatpak!](http://flatpak.org/getting.html)

Building
--------

Since we don't have an online repository (yet), you need to build a package locally.

In the QGIS sourcecode folder

    cd flatpak
    ./create-flatpak.sh
    # Wait for everything to be built, this takes some time when done the first time

    flatpak --user remote-add --no-gpg-verify qgis-repo-local repo
    flatpak --user install qgis-repo-local org.qgis.qgis