### PR TITLE
[style dock] add minimum height to svg image list

### DIFF
--- a/src/ui/symbollayer/widget_svgfill.ui
+++ b/src/ui/symbollayer/widget_svgfill.ui
@@ -274,6 +274,12 @@
      </item>
      <item row="1" column="1">
       <widget class="QListView" name="mSvgListView">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>250</height>
+        </size>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>5</horstretch>

--- a/src/ui/symbollayer/widget_svgmarker.ui
+++ b/src/ui/symbollayer/widget_svgmarker.ui
@@ -170,6 +170,12 @@
            <verstretch>1</verstretch>
           </sizepolicy>
          </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>250</height>
+          </size>
+         </property>
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>


### PR DESCRIPTION
@nyalldawson , @NathanW2 , straight forward minimumSize property addition to avoid having tiny svg image list in the style dock:
![untitled](https://cloud.githubusercontent.com/assets/1728657/20425888/46fc3bfa-adaf-11e6-8216-850ba832c996.png)
