### PR TITLE
Add relation dialog improvements

### DIFF
--- a/src/app/qgsrelationadddlg.h
+++ b/src/app/qgsrelationadddlg.h
@@ -27,8 +27,6 @@ class APP_EXPORT QgsRelationAddDlg : public QDialog, private Ui::QgsRelationAddD
   public:
     explicit QgsRelationAddDlg( QWidget *parent = nullptr );
 
-    void addLayers( const QList<QgsVectorLayer*>& layers );
-
     QString referencingLayerId();
     QString referencedLayerId();
     QList< QPair< QString, QString > > references();
@@ -37,15 +35,8 @@ class APP_EXPORT QgsRelationAddDlg : public QDialog, private Ui::QgsRelationAddD
 
 
   private slots:
-    void on_mCbxReferencingLayer_currentIndexChanged( int index );
-    void on_mCbxReferencedLayer_currentIndexChanged( int index );
 
     void checkDefinitionValid();
-
-  private:
-    void loadLayerAttributes( QComboBox* cbx, QgsVectorLayer* layer );
-
-    QMap< QString, QgsVectorLayer* > mLayers;
 
 };
 

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -84,7 +84,6 @@ void QgsRelationManagerDialog::addRelation( const QgsRelation &rel )
 void QgsRelationManagerDialog::on_mBtnAddRelation_clicked()
 {
   QgsRelationAddDlg addDlg;
-  addDlg.addLayers( mLayers );
 
   if ( addDlg.exec() )
   {

--- a/src/ui/qgsrelationadddlgbase.ui
+++ b/src/ui/qgsrelationadddlgbase.ui
@@ -14,46 +14,6 @@
    <string>Add relation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencingField"/>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencingLayer"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Referencing Field</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Referenced Layer (Parent)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Referenced Field</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencedLayer"/>
-   </item>
-   <item row="6" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencedField"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Referencing Layer (Child)</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
@@ -61,7 +21,17 @@
      </property>
     </widget>
    </item>
-   <item row="14" column="0" colspan="3">
+   <item row="4" column="1" colspan="2">
+    <widget class="QComboBox" name="mCbxReferencingLayer"/>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Id</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -71,29 +41,58 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_5">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Id</string>
+      <string>Referencing Layer (Child)</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="5" column="1" colspan="2">
+    <widget class="QComboBox" name="mCbxReferencingField"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Referencing Field</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Referenced Layer (Parent)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Referenced Field</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QComboBox" name="mCbxReferencedField"/>
+   </item>
+   <item row="9" column="1" colspan="2">
     <widget class="QLineEdit" name="mTxtRelationId"/>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1" colspan="2">
+    <widget class="QComboBox" name="mCbxReferencedLayer"/>
+   </item>
+   <item row="1" column="1" colspan="2">
     <widget class="QLineEdit" name="mTxtRelationName"/>
    </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>mTxtRelationName</tabstop>
-  <tabstop>mCbxReferencingLayer</tabstop>
-  <tabstop>mCbxReferencingField</tabstop>
   <tabstop>mCbxReferencedLayer</tabstop>
   <tabstop>mCbxReferencedField</tabstop>
+  <tabstop>mCbxReferencingLayer</tabstop>
+  <tabstop>mCbxReferencingField</tabstop>
   <tabstop>mTxtRelationId</tabstop>
-  <tabstop>mButtonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsrelationadddlgbase.ui
+++ b/src/ui/qgsrelationadddlgbase.ui
@@ -22,7 +22,7 @@
     </widget>
    </item>
    <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencingLayer"/>
+    <widget class="QgsMapLayerComboBox" name="mCbxReferencingLayer"/>
    </item>
    <item row="9" column="0">
     <widget class="QLabel" name="label_5">
@@ -49,7 +49,7 @@
     </widget>
    </item>
    <item row="5" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencingField"/>
+    <widget class="QgsFieldComboBox" name="mCbxReferencingField"/>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_2">
@@ -73,19 +73,31 @@
     </widget>
    </item>
    <item row="3" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencedField"/>
+    <widget class="QgsFieldComboBox" name="mCbxReferencedField"/>
    </item>
    <item row="9" column="1" colspan="2">
     <widget class="QLineEdit" name="mTxtRelationId"/>
    </item>
    <item row="2" column="1" colspan="2">
-    <widget class="QComboBox" name="mCbxReferencedLayer"/>
+    <widget class="QgsMapLayerComboBox" name="mCbxReferencedLayer"/>
    </item>
    <item row="1" column="1" colspan="2">
     <widget class="QLineEdit" name="mTxtRelationName"/>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">qgsfieldcombobox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>mTxtRelationName</tabstop>
   <tabstop>mCbxReferencedLayer</tabstop>


### PR DESCRIPTION
- Swaps the dialog so parent layer is defined first. I *ALWAYS* get this backwards, and I think it's because the dialog is backwards and it's more natural to define the parent first
- Use proper layer/field comboboxes in dialog