### PR TITLE
[style manager] imporve import and export experience, save symbols' tags & favorite flag

### DIFF
--- a/python/core/symbology-ng/qgsstyle.sip
+++ b/python/core/symbology-ng/qgsstyle.sip
@@ -208,6 +208,9 @@ class QgsStyle : QObject
     //! Changes ramp's name
     bool renameColorRamp( const QString& oldName, const QString& newName );
 
+    //! Creates a temporary memory database
+    bool createMemoryDB();
+
     //! Loads a file into the style
     bool load( const QString& filename );
 

--- a/src/core/symbology-ng/qgsstyle.cpp
+++ b/src/core/symbology-ng/qgsstyle.cpp
@@ -1533,10 +1533,26 @@ bool QgsStyle::importXml( const QString& filename )
     {
       if ( e.tagName() == QLatin1String( "symbol" ) )
       {
+        QString name = e.attribute( QStringLiteral( "name" ) );
+        QStringList tags;
+        if ( e.hasAttribute( QStringLiteral( "tags" ) ) )
+        {
+          tags = e.attribute( QStringLiteral( "tags" ) ).split( "," );
+        }
+        bool favorite = false;
+        if ( e.hasAttribute( QStringLiteral( "favorite" ) ) && e.attribute( QStringLiteral( "favorite" ) ) == "1" )
+        {
+          favorite = true;
+        }
+
         QgsSymbol* symbol = QgsSymbolLayerUtils::loadSymbol( e );
         if ( symbol )
         {
-          symbols.insert( e.attribute( QStringLiteral( "name" ) ), symbol );
+          addSymbol( name, symbol );
+          if ( mCurrentDB )
+          {
+            saveSymbol( name, symbol, favorite, tags );
+          }
         }
       }
       else
@@ -1550,12 +1566,12 @@ bool QgsStyle::importXml( const QString& filename )
   {
     // for the old version, use the utility function to solve @symbol@layer subsymbols
     symbols = QgsSymbolLayerUtils::loadSymbols( symbolsElement );
-  }
 
-  // save the symbols with proper name
-  for ( QMap<QString, QgsSymbol*>::iterator it = symbols.begin(); it != symbols.end(); ++it )
-  {
-    addSymbol( it.key(), it.value() );
+    // save the symbols with proper name
+    for ( QMap<QString, QgsSymbol*>::iterator it = symbols.begin(); it != symbols.end(); ++it )
+    {
+      addSymbol( it.key(), it.value() );
+    }
   }
 
   // load color ramps
@@ -1565,10 +1581,26 @@ bool QgsStyle::importXml( const QString& filename )
   {
     if ( e.tagName() == QLatin1String( "colorramp" ) )
     {
+      QString name = e.attribute( QStringLiteral( "name" ) );
+      QStringList tags;
+      if ( e.hasAttribute( QStringLiteral( "tags" ) ) )
+      {
+        tags = e.attribute( QStringLiteral( "tags" ) ).split( "," );
+      }
+      bool favorite = false;
+      if ( e.hasAttribute( QStringLiteral( "favorite" ) ) && e.attribute( QStringLiteral( "favorite" ) ) == "1" )
+      {
+        favorite = true;
+      }
+
       QgsColorRamp* ramp = QgsSymbolLayerUtils::loadColorRamp( e );
       if ( ramp )
       {
-        addColorRamp( e.attribute( QStringLiteral( "name" ) ), ramp );
+        addColorRamp( name, ramp );
+        if ( mCurrentDB )
+        {
+          saveColorRamp( name, ramp, favorite, tags );
+        }
       }
     }
     else

--- a/src/core/symbology-ng/qgsstyle.h
+++ b/src/core/symbology-ng/qgsstyle.h
@@ -273,7 +273,19 @@ class CORE_EXPORT QgsStyle : public QObject
     //! Changes ramp's name
     bool renameColorRamp( const QString& oldName, const QString& newName );
 
-    //! Loads a file into the style
+    /** Creates a temporary memory database
+     *
+     *  This function is used if you do not need to associate styles with a permanent on-disk database.
+     *  \return returns the success state of the temporary memory database creation
+     */
+    bool createMemoryDB();
+
+    /** Loads a file into the style
+     *
+     *  This function will populate styles from an on-disk database.
+     *  \param filename location of the database to load styles from
+     *  \return returns the success state of the database being loaded
+     */
     bool load( const QString& filename );
 
     //! Saves style into a file (will use current filename if empty string is passed)

--- a/src/gui/symbology-ng/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstyleexportimportdialog.cpp
@@ -151,6 +151,12 @@ void QgsStyleExportImportDialog::doExportImport()
                             .arg( mTempStyle->errorString() ) );
       return;
     }
+    else
+    {
+      QMessageBox::information( this, tr( "Export successful" ),
+                                tr( "The selected symbols were successfully exported to file:\n%1" )
+                                .arg( mFileName ) );
+    }
   }
   else // import
   {
@@ -192,7 +198,7 @@ bool QgsStyleExportImportDialog::populateStyles( QgsStyle* style )
     name = styleNames[i];
     QgsSymbol* symbol = style->symbol( name );
     QStandardItem* item = new QStandardItem( name );
-    QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( symbol, listItems->iconSize() );
+    QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( symbol, listItems->iconSize(), 15 );
     item->setIcon( icon );
     model->appendRow( item );
     delete symbol;
@@ -207,7 +213,7 @@ bool QgsStyleExportImportDialog::populateStyles( QgsStyle* style )
     QScopedPointer< QgsColorRamp > ramp( style->colorRamp( name ) );
 
     QStandardItem* item = new QStandardItem( name );
-    QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), listItems->iconSize() );
+    QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), listItems->iconSize(), 15 );
     item->setIcon( icon );
     model->appendRow( item );
   }

--- a/src/gui/symbology-ng/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstyleexportimportdialog.cpp
@@ -50,7 +50,6 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle* style, QWidget
   connect( pb, SIGNAL( clicked() ), this, SLOT( clearSelection() ) );
 
   QStandardItemModel* model = new QStandardItemModel( listItems );
-
   listItems->setModel( model );
   connect( listItems->selectionModel(), SIGNAL( selectionChanged( const QItemSelection&, const QItemSelection& ) ),
            this, SLOT( selectionChanged( const QItemSelection&, const QItemSelection& ) ) );
@@ -196,10 +195,16 @@ bool QgsStyleExportImportDialog::populateStyles( QgsStyle* style )
   for ( int i = 0; i < styleNames.count(); ++i )
   {
     name = styleNames[i];
+    QStringList tags = style->tagsOfSymbol( QgsStyle::SymbolEntity, name );
     QgsSymbol* symbol = style->symbol( name );
     QStandardItem* item = new QStandardItem( name );
     QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( symbol, listItems->iconSize(), 15 );
     item->setIcon( icon );
+    item->setToolTip( QString( "<b>%1</b><br><i>%2</i>" ).arg( name ).arg( tags.count() > 0 ? tags.join( ", " ) : tr( "Not tagged" ) ) );
+    // Set font to 10points to show reasonable text
+    QFont itemFont = item->font();
+    itemFont.setPointSize( 10 );
+    item->setFont( itemFont );
     model->appendRow( item );
     delete symbol;
   }

--- a/src/ui/qgsstyleexportimportdialogbase.ui
+++ b/src/ui/qgsstyleexportimportdialogbase.ui
@@ -43,10 +43,10 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="tagLabel">
        <property name="text">
-        <string>Tag(s)</string>
+        <string>Additional tag(s)</string>
        </property>
       </widget>
      </item>
@@ -63,10 +63,23 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1" colspan="2">
-      <widget class="QLineEdit" name="mSymbolTags"/>
+     <item row="3" column="0" colspan="3">
+      <widget class="QCheckBox" name="mIgnoreXMLTags">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Do not import embedded tags</string>
+       </property>
+      </widget>
      </item>
      <item row="4" column="1" colspan="2">
+      <widget class="QLineEdit" name="mSymbolTags"/>
+     </item>
+     <item row="5" column="1" colspan="2">
       <widget class="QLabel" name="tagHintLabel">
        <property name="text">
         <string>Tip: separate multiple tags with commas</string>

--- a/src/ui/qgsstyleexportimportdialogbase.ui
+++ b/src/ui/qgsstyleexportimportdialogbase.ui
@@ -111,12 +111,15 @@
      </property>
      <property name="iconSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>77</width>
+       <height>70</height>
       </size>
      </property>
-     <property name="movement">
-      <enum>QListView::Static</enum>
+     <property name="textElideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="flow">
+      <enum>QListView::LeftToRight</enum>
      </property>
      <property name="resizeMode">
       <enum>QListView::Adjust</enum>
@@ -126,6 +129,12 @@
      </property>
      <property name="viewMode">
       <enum>QListView::IconMode</enum>
+     </property>
+     <property name="uniformItemSizes">
+      <bool>true</bool>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This PR (greatly, IMHO) improves the usefulness of saved symbols' import and export function by implementing a //TODO within QgsStyle: the import and export of symbols' tags and favorite flag. If someone spends a fair share of time classifying his/her symbols with an elaborate set of tags, not being able to export tags amounts to significant losses. 

In order to do so, I've added the possibility of creating a temporary memory spatialite DB that is used to temporarily store a symbol's full set of information (name, xml, favorite, and tags). ( @nyalldawson , this temporary db is very useful for the test unit, it avoids us clashing with symbols we ship by default will testing the QgsStyle class)

On the import front, this opens the door for symbol creators to ship a .XML with a pre-defined tagging structure (v. useful). For users uninterested by pre-defined tags, they are given the option to ignore tags:
![untitled2](https://cloud.githubusercontent.com/assets/1728657/20453513/94fcf37a-ae5a-11e6-8d11-af7e859265c8.png)

I've also cleaned up the UI a bit, mostly by making the import / export symbol preview list use padding for its icons, as well as making sure the icons are aligned to a grid to avoid a sense of chaos:
![untitled](https://cloud.githubusercontent.com/assets/1728657/20453512/779f9ad0-ae5a-11e6-805b-a57898b62101.png)
_Ahhh, orderly presentation & symbol padding_