### PR TITLE
[symbology] respect mixed unit when applying symbol from list widget

### DIFF
--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -582,7 +582,6 @@ void QgsSymbolsListWidget::setSymbolFromStyle( const QModelIndex & index )
   lblSymbolName->setText( symbolName );
   // get new instance of symbol from style
   QgsSymbol* s = mStyle->symbol( symbolName );
-  QgsUnitTypes::RenderUnit unit = s->outputUnit();
   // remove all symbol layers from original symbolgroupsCombo
   while ( mSymbol->symbolLayerCount() )
     mSymbol->deleteSymbolLayer( 0 );
@@ -593,7 +592,7 @@ void QgsSymbolsListWidget::setSymbolFromStyle( const QModelIndex & index )
     mSymbol->appendSymbolLayer( sl );
   }
   mSymbol->setAlpha( s->alpha() );
-  mSymbol->setOutputUnit( unit );
+
   // delete the temporary symbol
   delete s;
 


### PR DESCRIPTION
@nyalldawson , while improving the style manager, I stumbled on this irritating bug whereas a saved symbol containing mixed unit types (say a market with a map unit size and a millimeter outline) would fail to apply properly when selecting the saved symbol using the symbols list widget (i.e. our main way of serving symbols).

This PR fixes the situation by not calling setOutputUnit() when the unit type identifies a mixed-unit scenario.