### PR TITLE
Split long tooltip into multilines

### DIFF
--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -178,6 +178,7 @@
   <tabstop>mCbxShowForm</tabstop>
   <tabstop>mCbxMapIdentification</tabstop>
   <tabstop>mCbxReadOnly</tabstop>
+  <tabstop>mCbxAllowAddFeatures</tabstop>
   <tabstop>mFilterGroupBox</tabstop>
   <tabstop>mAvailableFieldsList</tabstop>
   <tabstop>mAddFilterButton</tabstop>

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -40,7 +40,7 @@
          <bool>false</bool>
         </property>
         <property name="toolTip">
-         <string>Enforcing the unique constraint prevents committing features which do not meet the constraint. Unenforced constraints display a warning to users, but do not prevent committing the feature.</string>
+         <string>&lt;p&gt;Enforcing the unique constraint prevents committing features which do not meet the constraint.&lt;/p&gt;&lt;p&gt;Unenforced constraints display a warning to users, but do not prevent committing the feature.&lt;/p&gt;</string>
         </property>
         <property name="text">
          <string>Enforce unique constraint</string>
@@ -74,7 +74,7 @@
          <bool>false</bool>
         </property>
         <property name="toolTip">
-         <string>Enforcing the not null constraint prevents committing features which do not meet the constraint. Unenforced constraints display a warning to users, but do not prevent committing the feature.</string>
+         <string>&lt;p&gt;Enforcing the not null constraint prevents committing features which do not meet the constraint.&lt;/p&gt;&lt;p&gt;Unenforced constraints display a warning to users, but do not prevent committing the feature.&lt;/p&gt;</string>
         </property>
         <property name="text">
          <string>Enforce not null constraint</string>
@@ -91,7 +91,7 @@
       <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="mCheckBoxEnforceExpression">
         <property name="toolTip">
-         <string>Enforcing the expression constraint prevents committing features which do not meet the constraint. Unenforced constraints display a warning to users, but do not prevent committing the feature.</string>
+         <string>&lt;p&gt;Enforcing the expression constraint prevents committing features which do not meet the constraint.&lt;/p&gt;&lt;p&gt;Unenforced constraints display a warning to users, but do not prevent committing the feature.&lt;/p&gt;</string>
         </property>
         <property name="text">
          <string>Enforce expression constraint</string>


### PR DESCRIPTION
The issues are in shown below:
![editwidget](https://cloud.githubusercontent.com/assets/7983394/20642054/f0c936f4-b405-11e6-9f7f-56746a7508f8.png)
- long single line tooltip(s)
- the default value expression line widget is too high
- the expression widget for the reference relation expands instead of keeping same height when the "Filter" group is collapsed

For the two last issues, I wonder if it's the best fix; maybe something to set in https://github.com/qgis/QGIS/blob/master/src/gui/qgsexpressionlineedit.cpp instead?