### PR TITLE
[MSSQL] Fix an array out of bounds access when committing data

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -818,6 +818,9 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList & flist )
 
     for ( int i = 0; i < attrs.count(); ++i )
     {
+      if ( i >= mAttributeFields.count() )
+        break;
+
       QgsField fld = mAttributeFields.at( i );
 
       if ( fld.typeName().endsWith( QLatin1String( " identity" ), Qt::CaseInsensitive ) )
@@ -889,6 +892,9 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList & flist )
 
     for ( int i = 0; i < attrs.count(); ++i )
     {
+      if ( i >= mAttributeFields.count() )
+        break;
+
       QgsField fld = mAttributeFields.at( i );
 
       if ( fld.typeName().endsWith( QLatin1String( " identity" ), Qt::CaseInsensitive ) )


### PR DESCRIPTION
This fixes an array out of bounds access when using a layer that consists of a main table with joined in attributes.
The provider only tracks the attributes in the main table, but any joined in attributes is also passed to the provider. As the feature attributes is used to govern loop access, there will be an out of bounds access when the first joint attribute is encountered.

The fix is borrowed from the postgres provider which stops looping through the passed in feature attributes when the limit of table attributes has been met.