### PR TITLE
[FEATURE] color ramp button widget

### DIFF
--- a/python/core/qgscolorramp.sip
+++ b/python/core/qgscolorramp.sip
@@ -48,6 +48,8 @@ class QgsColorRamp
      */
     virtual QString type() const = 0;
 
+    virtual void invert() = 0;
+
     /** Creates a clone of the color ramp.
      */
     virtual QgsColorRamp* clone() const = 0 /Factory/;
@@ -118,6 +120,7 @@ class QgsGradientColorRamp : QgsColorRamp
     virtual double value( int index ) const;
     virtual QColor color( double value ) const;
     virtual QString type() const;
+    virtual void invert();
     virtual QgsGradientColorRamp* clone() const /Factory/;
     virtual QgsStringMap properties() const;
 
@@ -223,6 +226,8 @@ class QgsLimitedRandomColorRamp : QgsColorRamp
 
     virtual QString type() const;
 
+   virtual void invert();
+
     virtual QgsLimitedRandomColorRamp* clone() const /Factory/;
 
     virtual QgsStringMap properties() const;
@@ -282,6 +287,8 @@ class QgsRandomColorRamp : QgsColorRamp
 
     QString type() const;
 
+    virtual void invert();
+
     virtual QgsRandomColorRamp* clone() const /Factory/;
 
     QgsStringMap properties() const;
@@ -333,6 +340,7 @@ class QgsPresetSchemeColorRamp : QgsColorRamp, QgsColorScheme
     virtual double value( int index ) const;
     virtual QColor color( double value ) const;
     virtual QString type() const;
+    virtual void invert();
     virtual QgsPresetSchemeColorRamp* clone() const /Factory/;
     virtual QgsStringMap properties() const;
     int count() const;
@@ -355,7 +363,8 @@ class QgsColorBrewerColorRamp : QgsColorRamp
 %End
   public:
     QgsColorBrewerColorRamp( const QString& schemeName = DEFAULT_COLORBREWER_SCHEMENAME,
-                                     int colors = DEFAULT_COLORBREWER_COLORS );
+                                     int colors = DEFAULT_COLORBREWER_COLORS,
+                                     bool inverted = false );
 
     static QgsColorRamp* create( const QgsStringMap& properties = QgsStringMap() ) /Factory/;
 
@@ -364,6 +373,8 @@ class QgsColorBrewerColorRamp : QgsColorRamp
     virtual QColor color( double value ) const;
 
     virtual QString type() const;
+
+    virtual void invert();
 
     virtual QgsColorBrewerColorRamp* clone() const /Factory/;
 
@@ -403,7 +414,7 @@ class QgsCptCityColorRamp : QgsGradientColorRamp
     static QgsColorRamp* create( const QgsStringMap& properties = QgsStringMap() ) /Factory/;
 
     virtual QString type() const;
-
+    virtual void invert();
     virtual QgsCptCityColorRamp* clone() const /Factory/;
     void copy( const QgsCptCityColorRamp* other );
     QgsGradientColorRamp* cloneGradientRamp() const /Factory/;

--- a/python/core/qgscolorramp.sip
+++ b/python/core/qgscolorramp.sip
@@ -48,7 +48,7 @@ class QgsColorRamp
      */
     virtual QString type() const = 0;
 
-    virtual void invert() = 0;
+    virtual void invert();
 
     /** Creates a clone of the color ramp.
      */
@@ -226,8 +226,6 @@ class QgsLimitedRandomColorRamp : QgsColorRamp
 
     virtual QString type() const;
 
-   virtual void invert();
-
     virtual QgsLimitedRandomColorRamp* clone() const /Factory/;
 
     virtual QgsStringMap properties() const;
@@ -286,8 +284,6 @@ class QgsRandomColorRamp : QgsColorRamp
     virtual void setTotalColorCount( const int colorCount );
 
     QString type() const;
-
-    virtual void invert();
 
     virtual QgsRandomColorRamp* clone() const /Factory/;
 

--- a/python/core/symbology-ng/qgscategorizedsymbolrenderer.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrenderer.sip
@@ -157,16 +157,11 @@ class QgsCategorizedSymbolRenderer : QgsFeatureRenderer
       */
     void setSourceColorRamp( QgsColorRamp* ramp /Transfer/ );
 
-    //! @note added in 2.1
-    bool invertedColorRamp();
-    void setInvertedColorRamp( bool inverted );
-
     /** Update the color ramp used and all symbols colors.
       * @param ramp color ramp. Ownership is transferred to the renderer
-      * @param inverted set to true to invert ramp colors
       * @note added in 2.5
       */
-    void updateColorRamp( QgsColorRamp* ramp /Transfer/, bool inverted = false );
+    void updateColorRamp( QgsColorRamp* ramp /Transfer/ );
 
     //! items of symbology items in legend should be checkable
     //! @note added in 2.5

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -41,7 +41,7 @@
 %Include qgscharacterselectdialog.sip
 %Include qgscolorbrewercolorrampdialog.sip
 %Include qgscolorbutton.sip
-%Include qgscolorbutton.sip
+%Include qgscolorrampbutton.sip
 %Include qgscolordialog.sip
 %Include qgscolorschemelist.sip
 %Include qgscolorswatchgrid.sip

--- a/python/gui/qgscolorrampbutton.sip
+++ b/python/gui/qgscolorrampbutton.sip
@@ -1,0 +1,239 @@
+
+/** \ingroup gui
+ * \class QgsColorRampButton
+ * A cross platform button subclass for selecting color ramps. Will open color ramp dialogs when clicked.
+ * Offers live updates to button from color ramp dialog. An attached drop down menu allows for access to
+ * saved color ramps, as well as option to invert the current color ramp and create new ramps.
+ * \note Added in version 3.0
+ */
+
+class QgsColorRampButton : QToolButton
+{
+%TypeHeaderCode
+#include <qgscolorrampbutton.h>
+%End
+
+  public:
+
+    /** Specifies the behaviour when the button is clicked
+     */
+    enum Behaviour
+    {
+      ShowDialog, /*!< show a color picker dialog when clicked */
+      SignalOnly /*!< emit colorClicked signal only, no dialog */
+    };
+
+    /** Construct a new color ramp button.
+     * @param parent The parent QWidget for the dialog
+     * @param dialogTitle The title to show in the color ramp dialog
+     */
+    QgsColorRampButton( QWidget *parent = nullptr, const QString& dialogTitle = QString() );
+
+    virtual ~QgsColorRampButton();
+
+    virtual QSize sizeHint() const;
+
+    /** Return the current color ramp.
+     * @returns currently selected color
+     * @see setColor
+     */
+    QgsColorRamp* colorRamp() const;
+
+    /** Set the title for the color ramp dialog window.
+     * @param title Title for the color ramp dialog
+     * @see colorRampDialogTitle
+     */
+    void setColorRampDialogTitle( const QString& title );
+
+    /** Returns the title for the color ramp dialog window.
+     * @returns title for the color ramp dialog
+     * @see setColorRampDialogTitle
+     */
+    QString colorRampDialogTitle() const;
+
+    /** Returns whether the button accepts live updates from QgsColorRampDialog.
+     * @returns true if the button will be accepted immediately when the dialog's color ramp changes
+     * @see setAcceptLiveUpdates
+     */
+    bool acceptLiveUpdates() const;
+
+    /** Sets whether the button accepts live updates from QgsColorRampDialog. Live updates may cause changes
+     * that are not undoable on QColorRampDialog cancel.
+     * @param accept set to true to enable live updates
+     * @see acceptLiveUpdates
+     */
+    void setAcceptLiveUpdates( const bool accept );
+
+    /** Sets whether the drop down menu should be shown for the button. The default behaviour is to
+     * show the menu.
+     * @param showMenu set to false to hide the drop down menu
+     * @see showMenu
+     */
+    void setShowMenu( const bool showMenu );
+
+    /** Returns whether the drop down menu is shown for the button.
+     * @returns true if drop down menu is shown
+     * @see setShowMenu
+     */
+    bool showMenu() const;
+
+    /** Sets the behaviour for when the button is clicked. The default behaviour is to show
+     * a color ramp dialog.
+     * @param behaviour behaviour when button is clicked
+     * @see behaviour
+     */
+    void setBehaviour( const Behaviour behaviour );
+
+    /** Returns the behaviour for when the button is clicked.
+     * @returns behaviour when button is clicked
+     * @see setBehaviour
+     */
+    Behaviour behaviour() const;
+
+    /** Sets the default color ramp for the button, which is shown in the button's drop down menu for the
+     * "default color ramp" option.
+     * @param colorramp default color ramp for the button. Set to a null pointer to disable the default color
+     * ramp option.
+     * @see defaultColorRamp
+     */
+    void setDefaultColorRamp( QgsColorRamp* colorramp );
+
+    /** Returns the default color ramp for the button, which is shown in the button's drop down menu for the
+     * "default color ramp" option.
+     * @returns default color ramp for the button. Returns a null pointer if the default color ramp
+     * option is disabled.
+     * @see setDefaultColorRamp
+     */
+    QgsColorRamp* defaultColorRamp() const;
+
+    /** Sets whether a random colors option is shown in the button's drop down menu.
+     * @param showNull set to true to show a null option
+     * @see showRandom()
+     */
+    void setShowRandomColorRamp( bool showRandom );
+
+    /** Returns whether random colors option is shown in the button's drop down menu.
+     * @see setShowRandom()
+     */
+    bool showRandomColorRamp() const;
+
+    /** Returns true if the current color is null.
+     * @see setShowNull()
+     * @see showNull()
+     */
+    bool isRandomColorRamp() const;
+
+    /** Sets whether a set to null (clear) option is shown in the button's drop down menu.
+     * @param showNull set to true to show a null option
+     * @see showNull()
+     * @see isNull()
+     */
+    void setShowNull( bool showNull );
+
+    /** Returns whether the set to null (clear) option is shown in the button's drop down menu.
+     * @see setShowNull()
+     * @see isNull()
+     */
+    bool showNull() const;
+
+    /** Returns true if the current color is null.
+     * @see setShowNull()
+     * @see showNull()
+     */
+    bool isNull() const;
+
+    /** Sets the context string for the color ramp button. The context string is passed to all color ramp
+     * preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
+     * based on the context.
+     * @param context context string for the color dialog button's color ramp preview icons
+     * @see context
+     */
+    void setContext( const QString& context );
+
+    /** Returns the context string for the color ramp button. The context string is passed to all color ramp
+     * preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
+     * based on the context.
+     * @returns context context string for the color dialog button's color ramp preview icons
+     * @see setContext
+     */
+    QString context() const;
+
+    /** Sets whether the color ramp button only shows gradient type ramps
+     * @param gradientonly set to true to show only gradient type ramps
+     * @see showGradientOnly
+     */
+    void setShowGradientOnly( bool gradientonly );
+
+    /** Returns true if the color ramp button only shows gradient type ramps
+     * @see setShowGradientOnly
+     */
+    bool showGradientOnly() const;
+
+  public slots:
+
+    /** Sets the current color ramp for the button. Will emit a colorRampChanged() signal if the color ramp is different
+     * to the previous color ramp.
+     * @param colorramp New color ramp for the button
+     * @see setRandomColorRamp, setColorRampFromName, colorRamp
+     */
+    void setColorRamp( QgsColorRamp* colorramp );
+
+    /** Sets the current color ramp for the button to random colors. Will emit a colorRampChanged() signal
+     * if the color ramp is different to the previous color ramp.
+     * @see setColorRamp, setColorRampFromName, colorRamp
+     */
+    void setRandomColorRamp();
+
+    /** Sets the current color ramp for the button using a saved color ramp name. Will emit a colorRampChanged() signal
+     * if the color ramp is different to the previous color ramp.
+     * @param name Name of saved color ramp
+     * @see setColorRamp, setRandomColorRamp, colorRamp
+     */
+    void setColorRampFromName( QString name = QString() );
+
+    /** Sets the background pixmap for the button based upon current color ramp.
+     * @param colorramp Color ramp for button background. If no color ramp is specified, the button's current
+     * color ramp will be used
+     */
+    void setButtonBackground( QgsColorRamp* colorramp = nullptr );
+
+    /** Sets color ramp to the button's default color ramp, if set.
+     * @see setDefaultColorRamp
+     * @see defaultColorRamp
+     * @see setToNull()
+     */
+    void setToDefaultColorRamp();
+
+    /** Sets color ramp to null.
+     * @see setToDefaultColorRamp()
+     */
+    void setToNull();
+
+  signals:
+
+    /** Emitted whenever a new color ramp is set for the button. The color ramp is always valid.
+     * In case the new color ramp is the same, no signal is emitted to avoid infinite loops.
+     */
+    void colorRampChanged();
+
+    /** Emitted when the button is clicked, if the button's behaviour is set to SignalOnly
+     * @param colorramp Button's current color ramp
+     * @see setBehaviour
+     * @see behaviour
+     * @note may not be available in Python bindings on some platforms
+     */
+    void colorRampClicked( const QgsColorRamp* colorramp );
+
+  protected:
+
+    bool event( QEvent *e );
+    void changeEvent( QEvent* e );
+    void showEvent( QShowEvent* e );
+    void resizeEvent( QResizeEvent *event );
+
+    /**
+     * Reimplemented to detect right mouse button clicks on the color ramp button
+     */
+    void mousePressEvent( QMouseEvent* e );
+
+};

--- a/python/gui/qgscolorrampbutton.sip
+++ b/python/gui/qgscolorrampbutton.sip
@@ -15,14 +15,6 @@ class QgsColorRampButton : QToolButton
 
   public:
 
-    /** Specifies the behaviour when the button is clicked
-     */
-    enum Behaviour
-    {
-      ShowDialog, /*!< show a color picker dialog when clicked */
-      SignalOnly /*!< emit colorClicked signal only, no dialog */
-    };
-
     /** Construct a new color ramp button.
      * @param parent The parent QWidget for the dialog
      * @param dialogTitle The title to show in the color ramp dialog
@@ -76,19 +68,6 @@ class QgsColorRampButton : QToolButton
      * @see setShowMenu
      */
     bool showMenu() const;
-
-    /** Sets the behaviour for when the button is clicked. The default behaviour is to show
-     * a color ramp dialog.
-     * @param behaviour behaviour when button is clicked
-     * @see behaviour
-     */
-    void setBehaviour( const Behaviour behaviour );
-
-    /** Returns the behaviour for when the button is clicked.
-     * @returns behaviour when button is clicked
-     * @see setBehaviour
-     */
-    Behaviour behaviour() const;
 
     /** Sets the default color ramp for the button, which is shown in the button's drop down menu for the
      * "default color ramp" option.
@@ -215,14 +194,6 @@ class QgsColorRampButton : QToolButton
      * In case the new color ramp is the same, no signal is emitted to avoid infinite loops.
      */
     void colorRampChanged();
-
-    /** Emitted when the button is clicked, if the button's behaviour is set to SignalOnly
-     * @param colorramp Button's current color ramp
-     * @see setBehaviour
-     * @see behaviour
-     * @note may not be available in Python bindings on some platforms
-     */
-    void colorRampClicked( const QgsColorRamp* colorramp );
 
   protected:
 

--- a/python/gui/symbology-ng/qgscategorizedsymbolrendererwidget.sip
+++ b/python/gui/symbology-ng/qgscategorizedsymbolrendererwidget.sip
@@ -72,8 +72,6 @@ class QgsCategorizedSymbolRendererWidget : QgsRendererWidget
 
     void changeCategorySymbol();
 
-    QgsColorRamp* getColorRamp();
-
     QList<QgsSymbol*> selectedSymbols();
     QgsCategoryList selectedCategoryList();
     void refreshSymbolView();

--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -51,7 +51,9 @@ class CORE_EXPORT QgsColorRamp
     virtual QString type() const = 0;
 
 
-    virtual void invert() = 0;
+    /** Inverts the ordering of the color ramp.
+     */
+    virtual void invert() {}
 
     /** Creates a clone of the color ramp.
      */
@@ -259,7 +261,6 @@ class CORE_EXPORT QgsLimitedRandomColorRamp : public QgsColorRamp
     virtual double value( int index ) const override;
     virtual QColor color( double value ) const override;
     virtual QString type() const override { return QStringLiteral( "random" ); }
-    virtual void invert() override { return; }
     virtual QgsLimitedRandomColorRamp* clone() const override;
     virtual QgsStringMap properties() const override;
     int count() const override { return mCount; }
@@ -374,8 +375,6 @@ class CORE_EXPORT QgsRandomColorRamp: public QgsColorRamp
     virtual void setTotalColorCount( const int colorCount );
 
     QString type() const override;
-
-    virtual void invert() override { return; }
 
     QgsRandomColorRamp* clone() const override;
 

--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -50,6 +50,9 @@ class CORE_EXPORT QgsColorRamp
      */
     virtual QString type() const = 0;
 
+
+    virtual void invert() = 0;
+
     /** Creates a clone of the color ramp.
      */
     virtual QgsColorRamp* clone() const = 0;
@@ -123,6 +126,7 @@ class CORE_EXPORT QgsGradientColorRamp : public QgsColorRamp
     virtual double value( int index ) const override;
     virtual QColor color( double value ) const override;
     virtual QString type() const override { return QStringLiteral( "gradient" ); }
+    virtual void invert() override;
     virtual QgsGradientColorRamp* clone() const override;
     virtual QgsStringMap properties() const override;
 
@@ -255,6 +259,7 @@ class CORE_EXPORT QgsLimitedRandomColorRamp : public QgsColorRamp
     virtual double value( int index ) const override;
     virtual QColor color( double value ) const override;
     virtual QString type() const override { return QStringLiteral( "random" ); }
+    virtual void invert() override { return; }
     virtual QgsLimitedRandomColorRamp* clone() const override;
     virtual QgsStringMap properties() const override;
     int count() const override { return mCount; }
@@ -370,6 +375,8 @@ class CORE_EXPORT QgsRandomColorRamp: public QgsColorRamp
 
     QString type() const override;
 
+    virtual void invert() override { return; }
+
     QgsRandomColorRamp* clone() const override;
 
     QgsStringMap properties() const override;
@@ -424,6 +431,7 @@ class CORE_EXPORT QgsPresetSchemeColorRamp : public QgsColorRamp, public QgsColo
     virtual double value( int index ) const override;
     virtual QColor color( double value ) const override;
     virtual QString type() const override { return QStringLiteral( "preset" ); }
+    virtual void invert() override;
     virtual QgsPresetSchemeColorRamp* clone() const override;
     virtual QgsStringMap properties() const override;
     int count() const override;
@@ -455,9 +463,11 @@ class CORE_EXPORT QgsColorBrewerColorRamp : public QgsColorRamp
     /** Constructor for QgsColorBrewerColorRamp
      * @param schemeName color brewer scheme name
      * @param colors number of colors in ramp
+     * @param inverted invert ramp ordering
      */
     QgsColorBrewerColorRamp( const QString& schemeName = DEFAULT_COLORBREWER_SCHEMENAME,
-                             int colors = DEFAULT_COLORBREWER_COLORS );
+                             int colors = DEFAULT_COLORBREWER_COLORS,
+                             bool inverted = false );
 
     /** Returns a new QgsColorBrewerColorRamp color ramp created using the properties encoded in a string
      * map.
@@ -469,6 +479,7 @@ class CORE_EXPORT QgsColorBrewerColorRamp : public QgsColorRamp
     virtual double value( int index ) const override;
     virtual QColor color( double value ) const override;
     virtual QString type() const override { return QStringLiteral( "colorbrewer" ); }
+    virtual void invert() override;
     virtual QgsColorBrewerColorRamp* clone() const override;
     virtual QgsStringMap properties() const override;
     virtual int count() const override { return mColors; }
@@ -517,6 +528,7 @@ class CORE_EXPORT QgsColorBrewerColorRamp : public QgsColorRamp
     QString mSchemeName;
     int mColors;
     QList<QColor> mPalette;
+    bool mInverted;
 };
 
 

--- a/src/core/symbology-ng/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrenderer.h
@@ -167,16 +167,11 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
       */
     void setSourceColorRamp( QgsColorRamp* ramp );
 
-    //! @note added in 2.1
-    bool invertedColorRamp() { return mInvertedColorRamp; }
-    void setInvertedColorRamp( bool inverted ) { mInvertedColorRamp = inverted; }
-
     /** Update the color ramp used and all symbols colors.
       * @param ramp color ramp. Ownership is transferred to the renderer
-      * @param inverted set to true to invert ramp colors
       * @note added in 2.5
       */
-    void updateColorRamp( QgsColorRamp* ramp, bool inverted = false );
+    void updateColorRamp( QgsColorRamp* ramp );
 
     virtual bool legendSymbolItemsCheckable() const override;
     virtual bool legendSymbolItemChecked( const QString& key ) override;
@@ -194,7 +189,6 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
     QgsCategoryList mCategories;
     QScopedPointer<QgsSymbol> mSourceSymbol;
     QScopedPointer<QgsColorRamp> mSourceColorRamp;
-    bool mInvertedColorRamp;
     QScopedPointer<QgsExpression> mExpression;
 
     //! attribute index (derived from attribute name in startRender)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -188,6 +188,7 @@ SET(QGIS_GUI_SRCS
   qgscollapsiblegroupbox.cpp
   qgscolorbrewercolorrampdialog.cpp
   qgscolorbutton.cpp
+  qgscolorrampbutton.cpp
   qgscolordialog.cpp
   qgscolorschemelist.cpp
   qgscolorswatchgrid.cpp
@@ -356,6 +357,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgscollapsiblegroupbox.h
   qgscolorbrewercolorrampdialog.h
   qgscolorbutton.h
+  qgscolorrampbutton.h
   qgscolordialog.h
   qgscolorschemelist.h
   qgscolorswatchgrid.h

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -1,0 +1,593 @@
+/***************************************************************************
+    qgscolorrampbutton.cpp - Color ramp button
+     --------------------------------------
+    Date                 : November 27, 2016
+    Copyright            : (C) 2016 by Mathieu Pellerin
+    Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscolorrampbutton.h"
+#include "qgscolorramp.h"
+#include "qgsapplication.h"
+#include "qgslogger.h"
+#include "qgssymbollayerutils.h"
+#include "qgsstyle.h"
+
+#include "qgsstylemanagerdialog.h"
+#include "qgsgradientcolorrampdialog.h"
+#include "qgslimitedrandomcolorrampdialog.h"
+#include "qgscolorbrewercolorrampdialog.h"
+#include "qgscptcitycolorrampdialog.h"
+#include "qgspresetcolorrampdialog.h"
+
+#include <QAction>
+#include <QMouseEvent>
+#include <QMenu>
+#include <QPainter>
+#include <QPushButton>
+#include <QWidget>
+
+QgsColorRampButton::QgsColorRampButton( QWidget *parent, const QString& dialogTitle )
+    : QToolButton( parent )
+    , mBehaviour( QgsColorRampButton::ShowDialog )
+    , mColorRampDialogTitle( dialogTitle.isEmpty() ? tr( "Select Color Ramp" ) : dialogTitle )
+    , mShowGradientOnly( false )
+    , mColorRamp( nullptr )
+    , mDefaultColorRamp( nullptr ) //default to invalid ramp
+    , mAcceptLiveUpdates( true )
+    , mColorRampSet( false )
+    , mShowRandomColorRamp( false )
+    , mShowNull( false )
+    , mMenu( nullptr )
+
+{
+  setAcceptDrops( true );
+  setMinimumSize( QSize( 24, 16 ) );
+  connect( this, &QPushButton::clicked, this, &QgsColorRampButton::buttonClicked );
+
+  //setup dropdown menu
+  mMenu = new QMenu( this );
+  connect( mMenu, &QMenu::aboutToShow, this, &QgsColorRampButton::prepareMenu );
+  setMenu( mMenu );
+
+  mAllRampsMenu = new QMenu( mMenu );
+  mAllRampsMenu->setTitle( tr( "All color ramps" ) );
+
+  setPopupMode( QToolButton::MenuButtonPopup );
+
+  mStyle = QgsStyle::defaultStyle();
+}
+
+QgsColorRampButton::~QgsColorRampButton()
+{
+  delete mColorRamp;
+  delete mDefaultColorRamp;
+}
+
+QSize QgsColorRampButton::sizeHint() const
+{
+  //make sure height of button looks good under different platforms
+#ifdef Q_OS_WIN
+  return QSize( 120, 22 );
+#else
+  return QSize( 120, 28 );
+#endif
+}
+
+void QgsColorRampButton::showColorRampDialog()
+{
+  QgsPanelWidget* panel = QgsPanelWidget::findParentPanel( this );
+  bool panelMode = panel && panel->dockMode();
+
+  QScopedPointer< QgsColorRamp > currentRamp( colorRamp() );
+  if ( !currentRamp )
+    return;
+
+  if ( currentRamp->type() == QLatin1String( "gradient" ) )
+  {
+    QgsGradientColorRamp* gradRamp = static_cast<QgsGradientColorRamp*>( currentRamp.data() );
+    QgsGradientColorRampDialog dlg( *gradRamp, this );
+    dlg.setWindowTitle( mColorRampDialogTitle );
+    if ( dlg.exec() )
+    {
+      setColorRamp( dlg.ramp().clone() );
+    }
+  }
+  else if ( currentRamp->type() == QLatin1String( "random" ) )
+  {
+    QgsLimitedRandomColorRamp* randRamp = static_cast<QgsLimitedRandomColorRamp*>( currentRamp.data() );
+    if ( panelMode )
+    {
+      QgsLimitedRandomColorRampWidget* widget = new QgsLimitedRandomColorRampWidget( *randRamp, this );
+      widget->setPanelTitle( tr( "Edit ramp" ) );
+      connect( widget, &QgsLimitedRandomColorRampWidget::changed, this, &QgsColorRampButton::rampWidgetUpdated );
+      panel->openPanel( widget );
+    }
+    else
+    {
+      QgsLimitedRandomColorRampDialog dlg( *randRamp, this );
+      if ( dlg.exec() )
+      {
+        setColorRamp( dlg.ramp().clone() );
+      }
+    }
+  }
+  else if ( currentRamp->type() == QLatin1String( "preset" ) )
+  {
+    QgsPresetSchemeColorRamp* presetRamp = static_cast<QgsPresetSchemeColorRamp*>( currentRamp.data() );
+    if ( panelMode )
+    {
+      QgsPresetColorRampWidget* widget = new QgsPresetColorRampWidget( *presetRamp, this );
+      widget->setPanelTitle( tr( "Edit ramp" ) );
+      connect( widget, &QgsPresetColorRampWidget::changed, this, &QgsColorRampButton::rampWidgetUpdated );
+      panel->openPanel( widget );
+    }
+    else
+    {
+      QgsPresetColorRampDialog dlg( *presetRamp, this );
+      if ( dlg.exec() )
+      {
+        setColorRamp( dlg.ramp().clone() );
+      }
+    }
+  }
+  else if ( currentRamp->type() == QLatin1String( "colorbrewer" ) )
+  {
+    QgsColorBrewerColorRamp* brewerRamp = static_cast<QgsColorBrewerColorRamp*>( currentRamp.data() );
+    if ( panelMode )
+    {
+      QgsColorBrewerColorRampWidget* widget = new QgsColorBrewerColorRampWidget( *brewerRamp, this );
+      widget->setPanelTitle( tr( "Edit ramp" ) );
+      connect( widget, &QgsColorBrewerColorRampWidget::changed, this, &QgsColorRampButton::rampWidgetUpdated );
+      panel->openPanel( widget );
+    }
+    else
+    {
+      QgsColorBrewerColorRampDialog dlg( *brewerRamp, this );
+      if ( dlg.exec() )
+      {
+        setColorRamp( dlg.ramp().clone() );
+      }
+    }
+  }
+  else if ( currentRamp->type() == QLatin1String( "cpt-city" ) )
+  {
+    QgsCptCityColorRamp* cptCityRamp = static_cast<QgsCptCityColorRamp*>( currentRamp.data() );
+    QgsCptCityColorRampDialog dlg( *cptCityRamp, this );
+    if ( dlg.exec() )
+    {
+      if ( dlg.saveAsGradientRamp() )
+      {
+        setColorRamp( dlg.ramp().cloneGradientRamp() );
+      }
+      else
+      {
+        setColorRamp( dlg.ramp().clone() );
+      }
+    }
+  }
+}
+
+void QgsColorRampButton::setToDefaultColorRamp()
+{
+  if ( mDefaultColorRamp == nullptr )
+  {
+    return;
+  }
+
+  setColorRamp( mDefaultColorRamp );
+}
+
+void QgsColorRampButton::setToNull()
+{
+  setColorRamp( nullptr );
+}
+
+bool QgsColorRampButton::event( QEvent *e )
+{
+  if ( e->type() == QEvent::ToolTip )
+  {
+    //QString name = this->colorRamp().name();
+    /*int hue = this->color().hue();
+    //int value = this->color().value();
+    //int saturation = this->color().saturation();
+    QString info = QString( "HEX: %1 \n"
+                            "RGB: %2 \n"
+                            "HSV: %3,%4,%5" ).arg( name,
+                                                   QgsSymbolLayerUtils::encodeColor( this->color() ) )
+                   .arg( hue ).arg( saturation ).arg( value );*/
+    setToolTip( QString( "fix" ) );
+  }
+  return QToolButton::event( e );
+}
+
+void QgsColorRampButton::mousePressEvent( QMouseEvent *e )
+{
+  if ( e->button() == Qt::RightButton )
+  {
+    QToolButton::showMenu();
+    return;
+  }
+  QToolButton::mousePressEvent( e );
+}
+
+QPixmap QgsColorRampButton::createMenuIcon( QgsColorRamp* colorramp )
+{
+  //create an icon pixmap
+  QPixmap pixmap = QgsSymbolLayerUtils::colorRampPreviewPixmap( colorramp, QSize( 16, 16 ) );
+  return pixmap;
+}
+
+void QgsColorRampButton::buttonClicked()
+{
+  switch ( mBehaviour )
+  {
+    case ShowDialog:
+      if ( !isRandomColorRamp() )
+      {
+        showColorRampDialog();
+      }
+      else
+      {
+        QToolButton::showMenu();
+      }
+      return;
+    case SignalOnly:
+      emit colorRampClicked( mColorRamp );
+      return;
+  }
+}
+
+void QgsColorRampButton::prepareMenu()
+{
+  mMenu->clear();
+
+  QAction* invertAction = new QAction( tr( "Invert color ramp" ), this );
+  invertAction->setEnabled( !isRandomColorRamp() );
+  mMenu->addAction( invertAction );
+  connect( invertAction, &QAction::triggered, this, &QgsColorRampButton::invertColorRamp );
+
+  if ( mShowNull )
+  {
+    QAction* nullAction = new QAction( tr( "Clear current ramp" ), this );
+    mMenu->addAction( nullAction );
+    connect( nullAction, &QAction::triggered, this, &QgsColorRampButton::setToNull );
+  }
+
+  mMenu->addSeparator();
+
+  //show default color option if set
+  if ( mDefaultColorRamp != nullptr )
+  {
+    QAction* defaultColorRampAction = new QAction( tr( "Default color ramp" ), this );
+    defaultColorRampAction->setIcon( createMenuIcon( mDefaultColorRamp ) );
+    mMenu->addAction( defaultColorRampAction );
+    connect( defaultColorRampAction, &QAction::triggered, this, &QgsColorRampButton::setToDefaultColorRamp );
+  }
+
+  if ( mShowRandomColorRamp )
+  {
+    QAction* randomColorRampAction = new QAction( tr( "Random color ramp" ), this );
+    randomColorRampAction->setCheckable( true );
+    randomColorRampAction->setChecked( isRandomColorRamp() );
+    mMenu->addAction( randomColorRampAction );
+    connect( randomColorRampAction, &QAction::triggered, this, &QgsColorRampButton::setRandomColorRamp );
+  }
+
+  mMenu->addSeparator();
+
+  QStringList rampNames = mStyle->symbolsOfFavorite( QgsStyle::ColorrampEntity );
+  rampNames.sort();
+  for ( QStringList::iterator it = rampNames.begin(); it != rampNames.end(); ++it )
+  {
+    QScopedPointer< QgsColorRamp > ramp( mStyle->colorRamp( *it ) );
+
+    if ( !mShowGradientOnly || ramp->type() == QLatin1String( "gradient" ) )
+    {
+      QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), QSize( 16, 16 ) );
+      QAction* ra = new QAction( *it, this );
+      ra->setIcon( icon );
+      connect( ra, &QAction::triggered, this, &QgsColorRampButton::loadColorRamp );
+      mMenu->addAction( ra );
+    }
+  }
+
+  mMenu->addSeparator();
+
+  mAllRampsMenu->clear();
+  mMenu->addMenu( mAllRampsMenu );
+  rampNames = mStyle->colorRampNames();
+  rampNames.sort();
+  for ( QStringList::iterator it = rampNames.begin(); it != rampNames.end(); ++it )
+  {
+    QScopedPointer< QgsColorRamp > ramp( mStyle->colorRamp( *it ) );
+
+    if ( !mShowGradientOnly || ramp->type() == QLatin1String( "gradient" ) )
+    {
+      QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), QSize( 16, 16 ) );
+      QAction* ra = new QAction( *it, this );
+      ra->setIcon( icon );
+      connect( ra, &QAction::triggered, this, &QgsColorRampButton::loadColorRamp );
+      mAllRampsMenu->addAction( ra );
+    }
+  }
+
+  mMenu->addSeparator();
+
+  QAction* newColorRampAction = new QAction( tr( "Create new color ramp..." ), this );
+  connect( newColorRampAction, &QAction::triggered, this, &QgsColorRampButton::createColorRamp );
+  mMenu->addAction( newColorRampAction );
+
+  QAction* editColorRampAction = new QAction( tr( "Edit color ramp..." ), this );
+  connect( editColorRampAction, &QAction::triggered, this, &QgsColorRampButton::showColorRampDialog );
+  mMenu->addAction( editColorRampAction );
+}
+
+void QgsColorRampButton::loadColorRamp()
+{
+  QAction* selectedItem = qobject_cast<QAction*>( sender() );
+  if ( selectedItem )
+  {
+    QString name = selectedItem->text();
+    setColorRampFromName( name );
+  }
+}
+
+void QgsColorRampButton::createColorRamp()
+{
+  QString rampName;
+  if ( !mShowGradientOnly )
+  {
+    rampName = QgsStyleManagerDialog::addColorRampStatic( this, mStyle );
+  }
+  else
+  {
+    rampName = QgsStyleManagerDialog::addColorRampStatic( this, mStyle, QStringLiteral( "Gradient" ) );
+  }
+  if ( rampName.isEmpty() )
+    return;
+
+  // make sure the color ramp is stored
+  mStyle->save();
+
+  setColorRampFromName( rampName );
+}
+
+void QgsColorRampButton::invertColorRamp()
+{
+  mColorRamp->invert();
+  setButtonBackground();
+  emit colorRampChanged();
+}
+
+void QgsColorRampButton::changeEvent( QEvent* e )
+{
+  if ( e->type() == QEvent::EnabledChange )
+  {
+    setButtonBackground();
+  }
+  QToolButton::changeEvent( e );
+}
+
+#if 0 // causes too many cyclical updates, but may be needed on some platforms
+void QgsColorRampButton::paintEvent( QPaintEvent* e )
+{
+  QToolButton::paintEvent( e );
+
+  if ( !mBackgroundSet )
+  {
+    setButtonBackground();
+  }
+}
+#endif
+
+void QgsColorRampButton::showEvent( QShowEvent* e )
+{
+  setButtonBackground();
+  QToolButton::showEvent( e );
+}
+
+void QgsColorRampButton::resizeEvent( QResizeEvent *event )
+{
+  QToolButton::resizeEvent( event );
+  //recalculate icon size and redraw icon
+  mIconSize = QSize();
+  setButtonBackground( mColorRamp );
+}
+
+void QgsColorRampButton::setColorRamp( QgsColorRamp* colorramp )
+{
+  QgsColorRamp* oldColorRamp = mColorRamp;
+  mColorRamp = colorramp->clone();
+
+  // handle when initially set color is same as default (Qt::black); consider it a color change
+  if (( oldColorRamp != mColorRamp ) || !mColorRampSet )
+  {
+    setButtonBackground();
+    if ( isEnabled() )
+    {
+      emit colorRampChanged();
+    }
+  }
+  delete oldColorRamp;
+  mColorRampSet = true;
+}
+
+void QgsColorRampButton::setColorRampFromName( QString name )
+{
+  if ( !name.isEmpty() )
+  {
+    QScopedPointer< QgsColorRamp > ramp( mStyle->colorRamp( name ) );
+    if ( ramp )
+    {
+      setColorRamp( ramp.data() );
+    }
+  }
+}
+
+void QgsColorRampButton::setRandomColorRamp()
+{
+  if ( !isRandomColorRamp() )
+  {
+    setColorRamp( new QgsRandomColorRamp() );
+  }
+}
+
+void QgsColorRampButton::setButtonBackground( QgsColorRamp* colorramp )
+{
+  QgsColorRamp* backgroundColorRamp = colorramp;
+  if ( colorramp == nullptr )
+  {
+    backgroundColorRamp = mColorRamp;
+  }
+
+  QSize currentIconSize;
+  //icon size is button size with a small margin
+  if ( menu() )
+  {
+    if ( !mIconSize.isValid() )
+    {
+      //calculate size of push button part of widget (ie, without the menu dropdown button part)
+      QStyleOptionToolButton opt;
+      initStyleOption( &opt );
+      QRect buttonSize = QApplication::style()->subControlRect( QStyle::CC_ToolButton, &opt, QStyle::SC_ToolButton,
+                         this );
+      //make sure height of icon looks good under different platforms
+#ifdef Q_OS_WIN
+      mIconSize = QSize( buttonSize.width() - 10, height() - 6 );
+#else
+      mIconSize = QSize( buttonSize.width() - 10, height() - 12 );
+#endif
+    }
+    currentIconSize = mIconSize;
+  }
+  else
+  {
+    //no menu
+#ifdef Q_OS_WIN
+    currentIconSize = QSize( width() - 10, height() - 6 );
+#else
+    currentIconSize = QSize( width() - 10, height() - 12 );
+#endif
+  }
+
+  if ( !currentIconSize.isValid() || currentIconSize.width() <= 0 || currentIconSize.height() <= 0 )
+  {
+    return;
+  }
+
+  QPixmap pm;
+  if ( isRandomColorRamp() )
+  {
+    //create a "random colors" label
+    pm = QPixmap( currentIconSize );
+    pm.fill( Qt::transparent );
+
+    QPainter painter;
+    QPen pen  = ( QApplication::palette().buttonText().color() );
+
+    painter.begin( &pm );
+    painter.setPen( pen );
+    painter.drawText( QRect( 0, 0, currentIconSize.width(), currentIconSize.height() ), Qt::AlignCenter, "Random colors" );
+    painter.end();
+  }
+  else
+  {
+    //create an icon pixmap
+    if ( backgroundColorRamp )
+    {
+      pm = QgsSymbolLayerUtils::colorRampPreviewPixmap( backgroundColorRamp, currentIconSize );
+    }
+  }
+
+  setIconSize( currentIconSize );
+  setIcon( pm );
+}
+
+QgsColorRamp* QgsColorRampButton::colorRamp() const
+{
+  return mColorRamp ? mColorRamp->clone() : nullptr;
+}
+
+void QgsColorRampButton::setColorRampDialogTitle( const QString& title )
+{
+  mColorRampDialogTitle = title;
+}
+
+QString QgsColorRampButton::colorRampDialogTitle() const
+{
+  return mColorRampDialogTitle;
+}
+
+void QgsColorRampButton::setShowMenu( const bool showMenu )
+{
+  setMenu( showMenu ? mMenu : nullptr );
+  setPopupMode( showMenu ? QToolButton::MenuButtonPopup : QToolButton::DelayedPopup );
+  //force recalculation of icon size
+  mIconSize = QSize();
+  setButtonBackground( mColorRamp );
+}
+
+void QgsColorRampButton::setBehaviour( const QgsColorRampButton::Behaviour behaviour )
+{
+  mBehaviour = behaviour;
+}
+
+void QgsColorRampButton::setDefaultColorRamp( QgsColorRamp* colorramp )
+{
+  delete mDefaultColorRamp;
+  mDefaultColorRamp = colorramp->clone();
+}
+
+bool QgsColorRampButton::isRandomColorRamp() const
+{
+  QgsRandomColorRamp* randomRamp = dynamic_cast<QgsRandomColorRamp*>( mColorRamp );
+  return randomRamp ? true : false;
+}
+
+void QgsColorRampButton::setShowNull( bool showNull )
+{
+  mShowNull = showNull;
+}
+
+bool QgsColorRampButton::showNull() const
+{
+  return mShowNull;
+}
+
+bool QgsColorRampButton::isNull() const
+{
+  return mColorRamp == nullptr;
+}
+
+void QgsColorRampButton::rampWidgetUpdated()
+{
+  QgsLimitedRandomColorRampWidget* limitedRampWidget = qobject_cast< QgsLimitedRandomColorRampWidget* >( sender() );
+  if ( limitedRampWidget )
+  {
+    setColorRamp( limitedRampWidget->ramp().clone() );
+    emit colorRampChanged();
+    return;
+  }
+  QgsColorBrewerColorRampWidget* colorBrewerRampWidget = qobject_cast< QgsColorBrewerColorRampWidget* >( sender() );
+  if ( colorBrewerRampWidget )
+  {
+    setColorRamp( colorBrewerRampWidget->ramp().clone() );
+    emit colorRampChanged();
+    return;
+  }
+  QgsPresetColorRampWidget* presetRampWidget = qobject_cast< QgsPresetColorRampWidget* >( sender() );
+  if ( presetRampWidget )
+  {
+    setColorRamp( presetRampWidget->ramp().clone() );
+    emit colorRampChanged();
+    return;
+  }
+}

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -36,7 +36,6 @@
 
 QgsColorRampButton::QgsColorRampButton( QWidget *parent, const QString& dialogTitle )
     : QToolButton( parent )
-    , mBehaviour( QgsColorRampButton::ShowDialog )
     , mColorRampDialogTitle( dialogTitle.isEmpty() ? tr( "Select Color Ramp" ) : dialogTitle )
     , mShowGradientOnly( false )
     , mColorRamp( nullptr )
@@ -227,21 +226,13 @@ QPixmap QgsColorRampButton::createMenuIcon( QgsColorRamp* colorramp )
 
 void QgsColorRampButton::buttonClicked()
 {
-  switch ( mBehaviour )
+  if ( !isRandomColorRamp() )
   {
-    case ShowDialog:
-      if ( !isRandomColorRamp() )
-      {
-        showColorRampDialog();
-      }
-      else
-      {
-        QToolButton::showMenu();
-      }
-      return;
-    case SignalOnly:
-      emit colorRampClicked( mColorRamp );
-      return;
+    showColorRampDialog();
+  }
+  else
+  {
+    QToolButton::showMenu();
   }
 }
 
@@ -533,11 +524,6 @@ void QgsColorRampButton::setShowMenu( const bool showMenu )
   //force recalculation of icon size
   mIconSize = QSize();
   setButtonBackground( mColorRamp );
-}
-
-void QgsColorRampButton::setBehaviour( const QgsColorRampButton::Behaviour behaviour )
-{
-  mBehaviour = behaviour;
 }
 
 void QgsColorRampButton::setDefaultColorRamp( QgsColorRamp* colorramp )

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -1,0 +1,322 @@
+/***************************************************************************
+    qgscolorrampbutton.h - Color ramp button
+     --------------------------------------
+    Date                 : November 27, 2016
+    Copyright            : (C) 2016 by Mathieu Pellerin
+    Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCOLORRAMPBUTTON_H
+#define QGSCOLORRAMPBUTTON_H
+
+#include "qgscolorrampbutton.h"
+
+#include "qgscolorramp.h"
+#include "qgsstyle.h"
+
+#include <QToolButton>
+
+class QgsPanelWidget;
+
+/** \ingroup gui
+ * \class QgsColorRampButton
+ * A cross platform button subclass for selecting color ramps. Will open color ramp dialogs when clicked.
+ * Offers live updates to button from color ramp dialog. An attached drop down menu allows for access to
+ * saved color ramps, as well as option to invert the current color ramp and create new ramps.
+ * \note Added in version 3.0
+ */
+
+class GUI_EXPORT QgsColorRampButton : public QToolButton
+{
+    Q_OBJECT
+    Q_ENUMS( Behaviour )
+    Q_PROPERTY( QString colorRampDialogTitle READ colorRampDialogTitle WRITE setColorRampDialogTitle )
+    Q_PROPERTY( bool acceptLiveUpdates READ acceptLiveUpdates WRITE setAcceptLiveUpdates )
+    Q_PROPERTY( bool showMenu READ showMenu WRITE setShowMenu )
+    Q_PROPERTY( Behaviour behaviour READ behaviour WRITE setBehaviour )
+    Q_PROPERTY( QgsColorRamp* defaultColorRamp READ defaultColorRamp WRITE setDefaultColorRamp )
+    Q_PROPERTY( QString context READ context WRITE setContext )
+
+  public:
+
+    /** Specifies the behaviour when the button is clicked
+     */
+    enum Behaviour
+    {
+      ShowDialog = 0, //!< Show a color ramp dialog when clicked
+      SignalOnly //!< Emit colorRampClicked signal only, no dialog
+    };
+
+    /** Construct a new color ramp button.
+     * @param parent The parent QWidget for the dialog
+     * @param dialogTitle The title to show in the color ramp dialog
+     */
+    QgsColorRampButton( QWidget *parent = nullptr, const QString& dialogTitle = QString() );
+
+    virtual ~QgsColorRampButton();
+
+    virtual QSize sizeHint() const override;
+
+    /** Return the current color ramp.
+     * @returns currently selected color
+     * @see setColor
+     */
+    QgsColorRamp* colorRamp() const;
+
+    /** Set the title for the color ramp dialog window.
+     * @param title Title for the color ramp dialog
+     * @see colorRampDialogTitle
+     */
+    void setColorRampDialogTitle( const QString& title );
+
+    /** Returns the title for the color ramp dialog window.
+     * @returns title for the color ramp dialog
+     * @see setColorRampDialogTitle
+     */
+    QString colorRampDialogTitle() const;
+
+    /** Returns whether the button accepts live updates from QgsColorRampDialog.
+     * @returns true if the button will be accepted immediately when the dialog's color ramp changes
+     * @see setAcceptLiveUpdates
+     */
+    bool acceptLiveUpdates() const { return mAcceptLiveUpdates; }
+
+    /** Sets whether the button accepts live updates from QgsColorRampDialog. Live updates may cause changes
+     * that are not undoable on QColorRampDialog cancel.
+     * @param accept set to true to enable live updates
+     * @see acceptLiveUpdates
+     */
+    void setAcceptLiveUpdates( const bool accept ) { mAcceptLiveUpdates = accept; }
+
+    /** Sets whether the drop down menu should be shown for the button. The default behaviour is to
+     * show the menu.
+     * @param showMenu set to false to hide the drop down menu
+     * @see showMenu
+     */
+    void setShowMenu( const bool showMenu );
+
+    /** Returns whether the drop down menu is shown for the button.
+     * @returns true if drop down menu is shown
+     * @see setShowMenu
+     */
+    bool showMenu() const { return menu() ? true : false; }
+
+    /** Sets the behaviour for when the button is clicked. The default behaviour is to show
+     * a color ramp dialog.
+     * @param behaviour behaviour when button is clicked
+     * @see behaviour
+     */
+    void setBehaviour( const Behaviour behaviour );
+
+    /** Returns the behaviour for when the button is clicked.
+     * @returns behaviour when button is clicked
+     * @see setBehaviour
+     */
+    Behaviour behaviour() const { return mBehaviour; }
+
+    /** Sets the default color ramp for the button, which is shown in the button's drop down menu for the
+     * "default color ramp" option.
+     * @param colorramp default color ramp for the button. Set to a null pointer to disable the default color
+     * ramp option.
+     * @see defaultColorRamp
+     */
+    void setDefaultColorRamp( QgsColorRamp* colorramp );
+
+    /** Returns the default color ramp for the button, which is shown in the button's drop down menu for the
+     * "default color ramp" option.
+     * @returns default color ramp for the button. Returns a null pointer if the default color ramp
+     * option is disabled.
+     * @see setDefaultColorRamp
+     */
+    QgsColorRamp* defaultColorRamp() const { return mDefaultColorRamp; }
+
+    /** Sets whether a random colors option is shown in the button's drop down menu.
+     * @param showRandom set to true to show a random colors option
+     * @see showRandom()
+     */
+    void setShowRandomColorRamp( bool showRandom ) { mShowRandomColorRamp = showRandom; }
+
+    /** Returns whether random colors option is shown in the button's drop down menu.
+     * @see setShowRandom()
+     */
+    bool showRandomColorRamp() const { return mShowRandomColorRamp; }
+
+    /** Returns true if the current color is null.
+     * @see setShowNull()
+     * @see showNull()
+     */
+    bool isRandomColorRamp() const;
+
+    /** Sets whether a set to null (clear) option is shown in the button's drop down menu.
+     * @param showNull set to true to show a null option
+     * @see showNull()
+     * @see isNull()
+     */
+    void setShowNull( bool showNull );
+
+    /** Returns whether the set to null (clear) option is shown in the button's drop down menu.
+     * @see setShowNull()
+     * @see isNull()
+     */
+    bool showNull() const;
+
+    /** Returns true if the current color is null.
+     * @see setShowNull()
+     * @see showNull()
+     */
+    bool isNull() const;
+
+    /** Sets the context string for the color ramp button. The context string is passed to all color ramp
+     * preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
+     * based on the context.
+     * @param context context string for the color dialog button's color ramp preview icons
+     * @see context
+     */
+    void setContext( const QString& context ) { mContext = context; }
+
+    /** Returns the context string for the color ramp button. The context string is passed to all color ramp
+     * preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
+     * based on the context.
+     * @returns context context string for the color dialog button's color ramp preview icons
+     * @see setContext
+     */
+    QString context() const { return mContext; }
+
+    /** Sets whether the color ramp button only shows gradient type ramps
+     * @param gradientonly set to true to show only gradient type ramps
+     * @see showGradientOnly
+     */
+    void setShowGradientOnly( bool gradientonly ) { mShowGradientOnly = gradientonly; }
+
+    /** Returns true if the color ramp button only shows gradient type ramps
+     * @see setShowGradientOnly
+     */
+    bool showGradientOnly() const { return mShowGradientOnly; }
+
+  public slots:
+
+    /** Sets the current color ramp for the button. Will emit a colorRampChanged() signal if the color ramp is different
+     * to the previous color ramp.
+     * @param colorramp New color ramp for the button
+     * @see setRandomColorRamp, setColorRampFromName, colorRamp
+     */
+    void setColorRamp( QgsColorRamp* colorramp );
+
+    /** Sets the current color ramp for the button to random colors. Will emit a colorRampChanged() signal
+     * if the color ramp is different to the previous color ramp.
+     * @see setColorRamp, setColorRampFromName, colorRamp
+     */
+    void setRandomColorRamp();
+
+    /** Sets the current color ramp for the button using a saved color ramp name. Will emit a colorRampChanged() signal
+     * if the color ramp is different to the previous color ramp.
+     * @param name Name of saved color ramp
+     * @see setColorRamp, setRandomColorRamp, colorRamp
+     */
+    void setColorRampFromName( QString name = QString() );
+
+    /** Sets the background pixmap for the button based upon current color ramp.
+     * @param colorramp Color ramp for button background. If no color ramp is specified, the button's current
+     * color ramp will be used
+     */
+    void setButtonBackground( QgsColorRamp* colorramp = nullptr );
+
+    /** Sets color ramp to the button's default color ramp, if set.
+     * @see setDefaultColorRamp
+     * @see defaultColorRamp
+     * @see setToNull()
+     */
+    void setToDefaultColorRamp();
+
+    /** Sets color ramp to null.
+     * @see setToDefaultColorRamp()
+     */
+    void setToNull();
+
+  private slots:
+
+    void rampWidgetUpdated();
+
+  signals:
+
+    /** Emitted whenever a new color ramp is set for the button. The color ramp is always valid.
+     * In case the new color ramp is the same, no signal is emitted to avoid infinite loops.
+     */
+    void colorRampChanged();
+
+    /** Emitted when the button is clicked, if the button's behaviour is set to SignalOnly
+     * @param colorramp Button's current color ramp
+     * @see setBehaviour
+     * @see behaviour
+     */
+    void colorRampClicked( const QgsColorRamp* colorramp );
+
+  protected:
+
+    bool event( QEvent *e ) override;
+    void changeEvent( QEvent* e ) override;
+    void showEvent( QShowEvent* e ) override;
+    void resizeEvent( QResizeEvent *event ) override;
+
+    /**
+     * Reimplemented to detect right mouse button clicks on the color ramp button
+     */
+    void mousePressEvent( QMouseEvent* e ) override;
+
+  private:
+
+    Behaviour mBehaviour;
+    QString mColorRampDialogTitle;
+    bool mShowGradientOnly;
+    QgsColorRamp* mColorRamp;
+    QgsStyle* mStyle;
+
+    QgsColorRamp* mDefaultColorRamp;
+    QString mContext;
+    bool mAcceptLiveUpdates;
+    bool mColorRampSet;
+    bool mShowRandomColorRamp;
+    bool mShowNull;
+
+    QMenu* mMenu;
+    QMenu *mAllRampsMenu;
+
+    QSize mIconSize;
+
+    /** Create a color ramp icon for display in the drop down menu
+     * @param colorramp Color ramp to create an icon from
+     */
+    QPixmap createMenuIcon( QgsColorRamp* colorramp );
+
+  private slots:
+
+    void buttonClicked();
+
+    /** Show a color ramp dialog based on the ramp type
+     */
+    void showColorRampDialog();
+
+    /** Creates a new color ramp
+     */
+    void createColorRamp();
+
+    /** Inverts the current color ramp
+     */
+    void invertColorRamp();
+
+    /** Load a color ramp from a menu entry
+     */
+    void loadColorRamp();
+
+    /** Creates the drop down menu entries
+     */
+    void prepareMenu();
+};
+
+#endif

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -35,23 +35,13 @@ class QgsPanelWidget;
 class GUI_EXPORT QgsColorRampButton : public QToolButton
 {
     Q_OBJECT
-    Q_ENUMS( Behaviour )
     Q_PROPERTY( QString colorRampDialogTitle READ colorRampDialogTitle WRITE setColorRampDialogTitle )
     Q_PROPERTY( bool acceptLiveUpdates READ acceptLiveUpdates WRITE setAcceptLiveUpdates )
     Q_PROPERTY( bool showMenu READ showMenu WRITE setShowMenu )
-    Q_PROPERTY( Behaviour behaviour READ behaviour WRITE setBehaviour )
     Q_PROPERTY( QgsColorRamp* defaultColorRamp READ defaultColorRamp WRITE setDefaultColorRamp )
     Q_PROPERTY( QString context READ context WRITE setContext )
 
   public:
-
-    /** Specifies the behaviour when the button is clicked
-     */
-    enum Behaviour
-    {
-      ShowDialog = 0, //!< Show a color ramp dialog when clicked
-      SignalOnly //!< Emit colorRampClicked signal only, no dialog
-    };
 
     /** Construct a new color ramp button.
      * @param parent The parent QWidget for the dialog
@@ -106,19 +96,6 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      * @see setShowMenu
      */
     bool showMenu() const { return menu() ? true : false; }
-
-    /** Sets the behaviour for when the button is clicked. The default behaviour is to show
-     * a color ramp dialog.
-     * @param behaviour behaviour when button is clicked
-     * @see behaviour
-     */
-    void setBehaviour( const Behaviour behaviour );
-
-    /** Returns the behaviour for when the button is clicked.
-     * @returns behaviour when button is clicked
-     * @see setBehaviour
-     */
-    Behaviour behaviour() const { return mBehaviour; }
 
     /** Sets the default color ramp for the button, which is shown in the button's drop down menu for the
      * "default color ramp" option.
@@ -250,13 +227,6 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      */
     void colorRampChanged();
 
-    /** Emitted when the button is clicked, if the button's behaviour is set to SignalOnly
-     * @param colorramp Button's current color ramp
-     * @see setBehaviour
-     * @see behaviour
-     */
-    void colorRampClicked( const QgsColorRamp* colorramp );
-
   protected:
 
     bool event( QEvent *e ) override;
@@ -271,7 +241,6 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
 
   private:
 
-    Behaviour mBehaviour;
     QString mColorRampDialogTitle;
     bool mShowGradientOnly;
     QgsColorRamp* mColorRamp;

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererwidget.h
@@ -107,7 +107,11 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void categoriesDoubleClicked( const QModelIndex & idx );
     void addCategory();
     void addCategories();
+
+    /** Applies the color ramp passed on by the color ramp button
+     */
     void applyColorRamp();
+
     void deleteCategories();
     void deleteAllCategories();
 
@@ -155,8 +159,6 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void changeSelectedSymbols();
 
     void changeCategorySymbol();
-
-    QgsColorRamp* getColorRamp();
 
     QList<QgsSymbol*> selectedSymbols() override;
     QgsCategoryList selectedCategoryList();

--- a/src/gui/symbology-ng/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerwidget.cpp
@@ -1012,8 +1012,7 @@ QgsGradientFillSymbolLayerWidget::QgsGradientFillSymbolLayerWidget( const QgsVec
   setupUi( this );
   mOffsetUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels );
 
-  cboGradientColorRamp->setShowGradientOnly( true );
-  cboGradientColorRamp->populate( QgsStyle::defaultStyle() );
+  btnColorRamp->setShowGradientOnly( true );
 
   btnChangeColor->setAllowAlpha( true );
   btnChangeColor->setColorDialogTitle( tr( "Select gradient color" ) );
@@ -1031,9 +1030,7 @@ QgsGradientFillSymbolLayerWidget::QgsGradientFillSymbolLayerWidget( const QgsVec
 
   connect( btnChangeColor, SIGNAL( colorChanged( const QColor& ) ), this, SLOT( setColor( const QColor& ) ) );
   connect( btnChangeColor2, SIGNAL( colorChanged( const QColor& ) ), this, SLOT( setColor2( const QColor& ) ) );
-  connect( cboGradientColorRamp, SIGNAL( currentIndexChanged( int ) ), this, SLOT( applyColorRamp() ) );
-  connect( cboGradientColorRamp, SIGNAL( sourceRampEdited() ), this, SLOT( applyColorRamp() ) );
-  connect( mButtonEditRamp, SIGNAL( clicked() ), cboGradientColorRamp, SLOT( editSourceRamp() ) );
+  connect( btnColorRamp, &QgsColorRampButton::colorRampChanged, this, &QgsGradientFillSymbolLayerWidget::applyColorRamp );
   connect( cboGradientType, SIGNAL( currentIndexChanged( int ) ), this, SLOT( setGradientType( int ) ) );
   connect( cboCoordinateMode, SIGNAL( currentIndexChanged( int ) ), this, SLOT( setCoordinateMode( int ) ) );
   connect( cboGradientSpread, SIGNAL( currentIndexChanged( int ) ), this, SLOT( setGradientSpread( int ) ) );
@@ -1067,7 +1064,7 @@ void QgsGradientFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer* layer )
   if ( mLayer->gradientColorType() == QgsGradientFillSymbolLayer::SimpleTwoColor )
   {
     radioTwoColor->setChecked( true );
-    cboGradientColorRamp->setEnabled( false );
+    btnColorRamp->setEnabled( false );
   }
   else
   {
@@ -1079,9 +1076,9 @@ void QgsGradientFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer* layer )
   // set source color ramp
   if ( mLayer->colorRamp() )
   {
-    cboGradientColorRamp->blockSignals( true );
-    cboGradientColorRamp->setSourceColorRamp( mLayer->colorRamp() );
-    cboGradientColorRamp->blockSignals( false );
+    btnColorRamp->blockSignals( true );
+    btnColorRamp->setColorRamp( mLayer->colorRamp() );
+    btnColorRamp->blockSignals( false );
   }
 
   cboGradientType->blockSignals( true );
@@ -1219,11 +1216,10 @@ void QgsGradientFillSymbolLayerWidget::colorModeChanged()
 
 void QgsGradientFillSymbolLayerWidget::applyColorRamp()
 {
-  QgsColorRamp* ramp = cboGradientColorRamp->currentColorRamp();
-  if ( !ramp )
+  if ( btnColorRamp->isNull() )
     return;
 
-  mLayer->setColorRamp( ramp );
+  mLayer->setColorRamp( btnColorRamp->colorRamp()->clone() );
   emit changed();
 }
 

--- a/src/gui/symbology-ng/qgssymbollayerwidget.h
+++ b/src/gui/symbology-ng/qgssymbollayerwidget.h
@@ -314,7 +314,11 @@ class GUI_EXPORT QgsGradientFillSymbolLayerWidget : public QgsSymbolLayerWidget,
   public slots:
     void setColor( const QColor& color );
     void setColor2( const QColor& color );
+
+    /** Applies the color ramp passed on by the color ramp button
+     */
     void applyColorRamp();
+
     void setGradientType( int index );
     void setCoordinateMode( int index );
     void setGradientSpread( int index );

--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -76,32 +76,24 @@
    <item row="2" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QgsColorRampComboBox" name="cboCategorizedColorRamp">
+      <widget class="QgsColorRampButton" name="btnColorRamp">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mButtonEditRamp">
-       <property name="text">
-        <string>Edit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="cbxInvertedColorRamp">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string>Invert</string>
+       <property name="minimumSize">
+        <size>
+         <width>120</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
        </property>
       </widget>
      </item>
@@ -223,9 +215,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorRampComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscolorrampcombobox.h</header>
+   <class>QgsColorRampButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorrampbutton.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -331,9 +331,10 @@ suffix</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorRampComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscolorrampcombobox.h</header>
+   <class>QgsColorRampButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorrampbutton.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/ui/symbollayer/widget_gradientfill.ui
+++ b/src/ui/symbollayer/widget_gradientfill.ui
@@ -152,18 +152,24 @@
    <item row="2" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
-      <widget class="QgsColorRampComboBox" name="cboGradientColorRamp"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mButtonEditRamp">
-       <property name="maximumSize">
+      <widget class="QgsColorRampButton" name="btnColorRamp">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
         <size>
-         <width>100</width>
-         <height>16777215</height>
+         <width>120</width>
+         <height>0</height>
         </size>
        </property>
-       <property name="text">
-        <string>Edit</string>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
        </property>
       </widget>
      </item>
@@ -545,6 +551,12 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsColorRampButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorrampbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDataDefinedButton</class>
    <extends>QToolButton</extends>
    <header>qgsdatadefinedbutton.h</header>
@@ -560,18 +572,13 @@
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsColorRampComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscolorrampcombobox.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>radioTwoColor</tabstop>
   <tabstop>btnChangeColor</tabstop>
   <tabstop>btnChangeColor2</tabstop>
   <tabstop>radioColorRamp</tabstop>
-  <tabstop>cboGradientColorRamp</tabstop>
+  <tabstop>btnColorRamp</tabstop>
   <tabstop>mButtonEditRamp</tabstop>
   <tabstop>cboGradientType</tabstop>
   <tabstop>cboCoordinateMode</tabstop>
@@ -623,7 +630,7 @@
   <connection>
    <sender>radioColorRamp</sender>
    <signal>toggled(bool)</signal>
-   <receiver>cboGradientColorRamp</receiver>
+   <receiver>btnColorRamp</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/tests/src/python/test_qgsvectorcolorramp.py
+++ b/tests/src/python/test_qgsvectorcolorramp.py
@@ -161,6 +161,12 @@ class PyQgsVectorColorRamp(unittest.TestCase):
         self.assertEqual(s[3].offset, 0.8)
         self.assertEqual(s[3].color, QColor(50, 20, 10))
 
+        # test invert function
+        r.invert()
+        self.assertEqual(r.color(0), QColor(0, 200, 0))
+        self.assertEqual(r.color(1), QColor(200, 0, 0))
+        self.assertEqual(r.color(0.2), QColor(50, 20, 10))
+
     def testQgsLimitedRandomColorRampV2(self):
         # test random color ramp
         r = QgsLimitedRandomColorRamp(5)
@@ -310,6 +316,11 @@ class PyQgsVectorColorRamp(unittest.TestCase):
         self.assertEqual(cloned.count(), 2)
         self.assertEqual(cloned.fetchColors(), r.fetchColors())
 
+        # test invert function
+        r.invert()
+        self.assertEqual(r.color(0), QColor(0, 255, 0))
+        self.assertEqual(r.color(1), QColor(255, 0, 0))
+
     def testQgsColorBrewerColorRampV2(self):
         # test color brewer color ramps
         r = QgsColorBrewerColorRamp('OrRd', 6)
@@ -372,6 +383,13 @@ class PyQgsVectorColorRamp(unittest.TestCase):
         self.assertEqual(r.color(0.6), QColor(251, 106, 74))
         self.assertEqual(r.color(0.8), QColor(222, 45, 38))
         self.assertEqual(r.color(1.0), QColor(165, 15, 21))
+
+        # test invert function
+        r.invert()
+        self.assertEqual(r.color(0), QColor(165, 15, 21))
+        self.assertEqual(r.color(0.2), QColor(222, 45, 38))
+        self.assertEqual(r.color(1), QColor(254, 229, 217))
+        r.invert()
 
         # set colors
         r.setColors(3)


### PR DESCRIPTION
This PR implements a new color ramp button widget. The advantages over the old color ramp combo box are:
- color ramp selection, editing, *and* ramp invert function all bundled within one widget
- the invert function modifies the ramp itself and is now attached to QgsColorRamp itself; this is a much cleaner logic and allows to remove code all over the place to deal with the RIP (and never come back!) [x] invert checkbox/state
- UI wise, the widget takes far less horizontal space than what the old color ramp combo box used to, and therefore behaves much better with the style dock:
![a](https://cloud.githubusercontent.com/assets/1728657/20700244/bfdb3f3e-b63e-11e6-8129-4b530c5a5aef.png)
- the color ramp button widget makes use of the style manager's newly-added favorite features
- increased harmony in QGIS, with the color ramp button behaving like the existing color button:
![z](https://cloud.githubusercontent.com/assets/1728657/20701479/e0b41792-b645-11e6-85e0-eea96df5df2a.png)


Here's a brief video (https://www.youtube.com/watch?v=lRtRPFiwSHE) demonstration:
[![alt](https://img.youtube.com/vi/lRtRPFiwSHE/0.jpg)](https://www.youtube.com/watch?v=lRtRPFiwSHE)

I have only migrated two color ramp combo box instances in this PR (gradient fill and categorized renderer) to get all of this reviewed before moving forward.

Once the PR is reviewed and merged, the plan is to migrate all remaining color ramp combo box widgets to this new widget.