### PR TITLE
[BUGFIX] Filter Legend By Map Content doesn't maintain point displacement legend

### DIFF
--- a/src/core/symbology-ng/qgspointdistancerenderer.cpp
+++ b/src/core/symbology-ng/qgspointdistancerenderer.cpp
@@ -268,6 +268,13 @@ QgsSymbolList QgsPointDistanceRenderer::originalSymbolsForFeature( QgsFeature& f
   return mRenderer->originalSymbolsForFeature( feat, context );
 }
 
+QSet< QString > QgsPointDistanceRenderer::legendKeysForFeature( QgsFeature& feat, QgsRenderContext& context )
+{
+  if ( !mRenderer )
+    return QSet< QString >() << QString();
+  return mRenderer->legendKeysForFeature( feat, context );
+}
+
 bool QgsPointDistanceRenderer::willRenderFeature( QgsFeature& feat, QgsRenderContext& context )
 {
   if ( !mRenderer )

--- a/src/core/symbology-ng/qgspointdistancerenderer.h
+++ b/src/core/symbology-ng/qgspointdistancerenderer.h
@@ -84,6 +84,7 @@ class CORE_EXPORT QgsPointDistanceRenderer: public QgsFeatureRenderer
     virtual QgsSymbol* originalSymbolForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     virtual QgsSymbolList symbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     virtual QgsSymbolList originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
+    virtual QSet< QString > legendKeysForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
     virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     void stopRender( QgsRenderContext& context ) override;


### PR DESCRIPTION
Fixed #11572
Needs to be backported and adapted to version 2.14