### PR TITLE
[symbology] migrate graduated renderer color ramp widget

### DIFF
--- a/python/core/symbology-ng/qgsgraduatedsymbolrenderer.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrenderer.sip
@@ -197,6 +197,16 @@ class QgsGraduatedSymbolRenderer : QgsFeatureRenderer
     //! @note Added in 2.6
     void calculateLabelPrecision( bool updateRanges = true );
 
+    /** Creates a new graduated renderer.
+     * @param vlayer vector layer
+     * @param attrName attribute to classify
+     * @param classes number of classes
+     * @param mode classification mode
+     * @param symbol base symbol
+     * @param ramp color ramp for classes
+     * @param legendFormat
+     * @returns new QgsGraduatedSymbolRenderer object
+     */
     static QgsGraduatedSymbolRenderer* createRenderer(
       QgsVectorLayer* vlayer,
       const QString& attrName,
@@ -204,7 +214,6 @@ class QgsGraduatedSymbolRenderer : QgsFeatureRenderer
       Mode mode,
       QgsSymbol* symbol /Transfer/,
       QgsColorRamp* ramp /Transfer/,
-      bool inverted = false,
       const QgsRendererRangeLabelFormat& legendFormat = QgsRendererRangeLabelFormat()
     );
 
@@ -252,16 +261,11 @@ class QgsGraduatedSymbolRenderer : QgsFeatureRenderer
      */
     void setSourceColorRamp( QgsColorRamp* ramp /Transfer/ );
 
-    //! @note added in 2.1
-    bool invertedColorRamp();
-    void setInvertedColorRamp( bool inverted );
-
     /** Update the color ramp used. Also updates all symbols colors.
      * Doesn't alter current breaks.
      * @param ramp color ramp. Ownership is transferred to the renderer
-     * @param inverted set to true to invert ramp colors
      */
-    void updateColorRamp( QgsColorRamp* ramp /Transfer/ = 0, bool inverted = false );
+    void updateColorRamp( QgsColorRamp* ramp /Transfer/ = 0 );
 
     /** Update all the symbols but leave breaks and colors. This method also sets the source
      * symbol for the renderer.

--- a/src/core/symbology-ng/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrenderer.h
@@ -235,7 +235,6 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      * @param mode classification mode
      * @param symbol base symbol
      * @param ramp color ramp for classes
-     * @param inverted set to true to invert color ramp
      * @param legendFormat
      * @returns new QgsGraduatedSymbolRenderer object
      */
@@ -246,7 +245,6 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
       Mode mode,
       QgsSymbol* symbol,
       QgsColorRamp* ramp,
-      bool inverted = false,
       const QgsRendererRangeLabelFormat& legendFormat = QgsRendererRangeLabelFormat()
     );
 
@@ -285,16 +283,11 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      */
     void setSourceColorRamp( QgsColorRamp* ramp );
 
-    //! @note added in 2.1
-    bool invertedColorRamp() { return mInvertedColorRamp; }
-    void setInvertedColorRamp( bool inverted ) { mInvertedColorRamp = inverted; }
-
     /** Update the color ramp used. Also updates all symbols colors.
      * Doesn't alter current breaks.
      * @param ramp color ramp. Ownership is transferred to the renderer
-     * @param inverted set to true to invert ramp colors
      */
-    void updateColorRamp( QgsColorRamp* ramp = nullptr, bool inverted = false );
+    void updateColorRamp( QgsColorRamp* ramp = nullptr );
 
     /** Update all the symbols but leave breaks and colors. This method also sets the source
      * symbol for the renderer.
@@ -343,7 +336,6 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
     Mode mMode;
     QScopedPointer<QgsSymbol> mSourceSymbol;
     QScopedPointer<QgsColorRamp> mSourceColorRamp;
-    bool mInvertedColorRamp;
     QgsRendererRangeLabelFormat mLabelFormat;
 
     QScopedPointer<QgsExpression> mExpression;

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -226,7 +226,7 @@ QPixmap QgsColorRampButton::createMenuIcon( QgsColorRamp* colorramp )
 
 void QgsColorRampButton::buttonClicked()
 {
-  if ( !isRandomColorRamp() )
+  if ( !isRandomColorRamp() && !isNull() )
   {
     showColorRampDialog();
   }
@@ -241,7 +241,7 @@ void QgsColorRampButton::prepareMenu()
   mMenu->clear();
 
   QAction* invertAction = new QAction( tr( "Invert color ramp" ), this );
-  invertAction->setEnabled( !isRandomColorRamp() );
+  invertAction->setEnabled( !isNull() && !isRandomColorRamp() );
   mMenu->addAction( invertAction );
   connect( invertAction, &QAction::triggered, this, &QgsColorRampButton::invertColorRamp );
 
@@ -317,6 +317,7 @@ void QgsColorRampButton::prepareMenu()
   mMenu->addAction( newColorRampAction );
 
   QAction* editColorRampAction = new QAction( tr( "Edit color ramp..." ), this );
+  editColorRampAction->setEnabled( !isNull() && !isRandomColorRamp() );
   connect( editColorRampAction, &QAction::triggered, this, &QgsColorRampButton::showColorRampDialog );
   mMenu->addAction( editColorRampAction );
 }

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererwidget.cpp
@@ -421,6 +421,12 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
   {
     btnColorRamp->setColorRampFromName( defaultColorRamp );
   }
+  else
+  {
+    QgsColorRamp* ramp = new QgsGradientColorRamp( QColor( 255, 255, 255 ), QColor( 255, 0, 0 ) );
+    btnColorRamp->setColorRamp( ramp );
+    delete ramp;
+  }
 
   mCategorizedSymbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
 

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererwidget.h
@@ -122,6 +122,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
   private slots:
     void cleanUpSymbolSelector( QgsPanelWidget* container );
     void updateSymbolsFromWidget();
+    void toggleMethodWidgets( int idx );
 
   protected:
     void updateUiFromRenderer( bool updateCount = true );

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -148,137 +148,106 @@ Negative rounds to powers of 10</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QStackedWidget" name="mMethodStackedWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>50</height>
-      </size>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0,0,0">
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_7">
+       
+       <item row="4" column="0">
+        <widget class="QLabel" name="lblColorRamp">
          <property name="text">
           <string>Color ramp</string>
          </property>
          <property name="buddy">
-          <cstring>cboGraduatedColorRamp</cstring>
+          <cstring>btnColorRamp</cstring>
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QgsColorRampComboBox" name="cboGraduatedColorRamp"/>
-       </item>
-       <item>
-        <widget class="QPushButton" name="mButtonEditRamp">
-         <property name="text">
-          <string>Edit</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbxInvertedColorRamp">
-         <property name="text">
-          <string>Invert</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="page_2">
-      <layout class="QGridLayout" name="gridLayout_2">
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <item row="0" column="2">
-        <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="maximum">
-          <double>999999999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-         <property name="value">
-          <double>1.000000000000000</double>
-         </property>
-         <property name="showClearButton" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>Size from </string>
-         </property>
-         <property name="buddy">
-          <cstring>cboGraduatedColorRamp</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QgsDoubleSpinBox" name="maxSizeSpinBox">
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="maximum">
-          <double>999999999.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-         <property name="value">
-          <double>10.000000000000000</double>
-         </property>
-         <property name="showClearButton" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="label_2">
+       <item row="4" column="1">
+        <widget class="QgsColorRampButton" name="btnColorRamp">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>to</string>
+         <property name="minimumSize">
+          <size>
+           <width>120</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
          </property>
         </widget>
        </item>
-       <item row="0" column="5">
+       
+       <item row="5" column="0">
+        <widget class="QLabel" name="lblSize">
+         <property name="text">
+          <string>Size from </string>
+         </property>
+         <property name="buddy">
+          <cstring>minSizeSpinBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <layout class="QHBoxLayout" name="layoutSize">
+         <item>
+          <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
+           <property name="decimals">
+            <number>6</number>
+           </property>
+           <property name="maximum">
+            <double>999999999.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.200000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="showClearButton" stdset="0">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item> 
+         <item>
+          <widget class="QLabel" name="lblSizeTo">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>to</string>
+           </property>
+          </widget>
+         </item>  
+         <item>
+          <widget class="QgsDoubleSpinBox" name="maxSizeSpinBox">
+           <property name="decimals">
+            <number>6</number>
+           </property>
+           <property name="maximum">
+            <double>999999999.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.200000000000000</double>
+           </property>
+           <property name="value">
+            <double>10.000000000000000</double>
+           </property>
+           <property name="showClearButton" stdset="0">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="6" column="1">
         <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
          <property name="minimumSize">
           <size>
@@ -291,11 +260,9 @@ Negative rounds to powers of 10</string>
          </property>
         </widget>
        </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
+       
+       
+   <item row="7" column="0" colspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -522,9 +489,10 @@ Negative rounds to powers of 10</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorRampComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscolorrampcombobox.h</header>
+   <class>QgsColorRampButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorrampbutton.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -545,9 +513,7 @@ Negative rounds to powers of 10</string>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>cboGraduatedColorRamp</tabstop>
-  <tabstop>mButtonEditRamp</tabstop>
-  <tabstop>cbxInvertedColorRamp</tabstop>
+  <tabstop>btnColorRamp</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
   <tabstop>spinGraduatedClasses</tabstop>
   <tabstop>btnGraduatedClassify</tabstop>

--- a/tests/src/python/test_qgsgraduatedsymbolrenderer.py
+++ b/tests/src/python/test_qgsgraduatedsymbolrenderer.py
@@ -142,7 +142,6 @@ def dumpGraduatedRenderer(r):
     else:
         rstr = rstr + symbol.dump() + ':'
     rstr = rstr + dumpColorRamp(r.sourceColorRamp())
-    rstr = rstr + str(r.invertedColorRamp()) + ':'
     rstr = rstr + dumpRangeList(r.ranges())
     return rstr
 
@@ -304,13 +303,6 @@ class TestQgsGraduatedSymbolRenderer(unittest.TestCase):
             dumpColorRamp(ramp),
             dumpColorRamp(renderer.sourceColorRamp()),
             "Get/set renderer color ramp")
-
-        renderer.setInvertedColorRamp(True)
-        self.assertTrue(renderer.invertedColorRamp(),
-                        "Get/set renderer inverted color ramp")
-        renderer.setInvertedColorRamp(False)
-        self.assertFalse(renderer.invertedColorRamp(),
-                         "Get/set renderer inverted color ramp")
 
         renderer.setSourceColorRamp(ramp)
         self.assertEqual(


### PR DESCRIPTION
This PR migrates the graduated renderer from the deprecated color ramp combo box to the new color ramp button. I've also taken the opportunity to clean up the layout a bit (i.e. look at the now-aligned "color ramp" label, etc.).

The end result in one screenshot:
![untitled](https://cloud.githubusercontent.com/assets/1728657/20744143/b2f10cf8-b70c-11e6-88d8-66beaad5d5de.png)

Even with the addition of code to deal with the layout improvements, the PR results in fewer lines of code, thanks to the invert logic moved away from UI / renderer into the color ramp itself.

@nyalldawson , as always, your keen eye is most welcome.