### PR TITLE
[raster] migrate singleband pseudo-color renderer color ramp widget

### DIFF
--- a/python/core/raster/qgscolorrampshader.sip
+++ b/python/core/raster/qgscolorrampshader.sip
@@ -7,6 +7,8 @@ class QgsColorRampShader : QgsRasterShaderFunction
   public:
     QgsColorRampShader( double theMinimumValue = 0.0, double theMaximumValue = 255.0 );
 
+    ~QgsColorRampShader();
+
     //An entry for classification based upon value.
     //Such a classification is typically used for
     //single band layers where a pixel value represents
@@ -40,23 +42,23 @@ class QgsColorRampShader : QgsRasterShaderFunction
     /** \brief Get the color ramp type */
     QgsColorRampShader::ColorRamp_TYPE colorRampType() const;
 
-    /** \brief Get the original color ramp name
+    /** Get the source color ramp
      * @note added in QGIS 3.0
-     * @see setColorRampName()
+     * @see setSourceColorRamp()
      */
-    QString colorRampName() const;
+    QgsColorRamp* sourceColorRamp() const /Factory/;
+
+    /** Set the source color ramp
+     * @note added in QGIS 3.0
+     * @see sourceColorRamp()
+     */
+    void setSourceColorRamp( QgsColorRamp* colorramp /Transfer/ );
 
     /** \brief Get the color ramp type as a string */
     QString colorRampTypeAsQString();
 
     /** \brief Set custom colormap */
     void setColorRampItemList( const QList<QgsColorRampShader::ColorRampItem>& theList ); //TODO: sort on set
-
-    /** \brief Set the source color ramp name
-     * @note added in QGIS 3.0
-     * @see colorRampName()
-     */
-    void setColorRampName( const QString& theName );
 
     /** \brief Set the color ramp type*/
     void setColorRampType( QgsColorRampShader::ColorRamp_TYPE theColorRampType );

--- a/python/gui/qgscolorrampbutton.sip
+++ b/python/gui/qgscolorrampbutton.sip
@@ -147,6 +147,17 @@ class QgsColorRampButton : QToolButton
      */
     bool showGradientOnly() const;
 
+    /** Sets the name of the current color ramp when it's available in the style manager
+     * @param name Name of the saved color ramp
+     * @see colorRampName
+     */
+    void setColorRampName( QString name );
+
+    /** Returns the name of the current color ramp when it's available in the style manager
+     * @see setColorRampName
+     */
+    QString colorRampName() const;
+
   public slots:
 
     /** Sets the current color ramp for the button. Will emit a colorRampChanged() signal if the color ramp is different

--- a/python/gui/raster/qgssinglebandpseudocolorrendererwidget.sip
+++ b/python/gui/raster/qgssinglebandpseudocolorrendererwidget.sip
@@ -22,6 +22,10 @@ class QgsSingleBandPseudoColorRendererWidget : QgsRasterRendererWidget
     void setFromRenderer( const QgsRasterRenderer* r );
 
   public slots:
+
+    /** Executes the single band pseudo raster classficiation
+     */
+    void classify();
     void loadMinMax( int theBandNo, double theMin, double theMax, int theOrigin );
 
 };

--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -24,6 +24,7 @@ originally part of the larger QgsRasterLayer class
 
 #include "qgslogger.h"
 #include "qgis.h"
+#include "qgscolorramp.h"
 #include "qgscolorrampshader.h"
 
 #include <cmath>
@@ -34,10 +35,35 @@ QgsColorRampShader::QgsColorRampShader( double theMinimumValue, double theMaximu
     , mLUTOffset( 0.0 )
     , mLUTFactor( 1.0 )
     , mLUTInitialized( false )
-    , mColorRampName( QString() )
     , mClip( false )
 {
   QgsDebugMsgLevel( "called.", 4 );
+}
+
+QgsColorRampShader::QgsColorRampShader( const QgsColorRampShader& other )
+    : QgsRasterShaderFunction( other )
+    , mLUT( other.mLUT )
+    , mLUTOffset( other.mLUTOffset )
+    , mLUTFactor( other.mLUTFactor )
+    , mLUTInitialized( other.mLUTInitialized )
+    , mClip( other.mClip )
+{
+  mSourceColorRamp.reset( other.sourceColorRamp()->clone() );
+}
+
+QgsColorRampShader & QgsColorRampShader::operator=( const QgsColorRampShader & other )
+{
+  mSourceColorRamp.reset( other.sourceColorRamp()->clone() );
+  mLUT = other.mLUT;
+  mLUTOffset = other.mLUTOffset;
+  mLUTFactor = other.mLUTFactor;
+  mLUTInitialized = other.mLUTInitialized;
+  mClip = other.mClip;
+  return *this;
+}
+
+QgsColorRampShader::~QgsColorRampShader()
+{
 }
 
 QString QgsColorRampShader::colorRampTypeAsQString()
@@ -83,9 +109,14 @@ void QgsColorRampShader::setColorRampType( const QString& theType )
   }
 }
 
-void QgsColorRampShader::setColorRampName( const QString& theName )
+QgsColorRamp* QgsColorRampShader::sourceColorRamp() const
 {
-  mColorRampName = theName;
+  return mSourceColorRamp.data();
+}
+
+void QgsColorRampShader::setSourceColorRamp( QgsColorRamp* colorramp )
+{
+  mSourceColorRamp.reset( colorramp );
 }
 
 

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -24,6 +24,7 @@ originally part of the larger QgsRasterLayer class
 #include <QColor>
 #include <QVector>
 
+#include "qgscolorramp.h"
 #include "qgsrastershaderfunction.h"
 
 /** \ingroup core
@@ -33,7 +34,20 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
 {
 
   public:
+
     QgsColorRampShader( double theMinimumValue = 0.0, double theMaximumValue = 255.0 );
+
+    /** Destructor
+     */
+    virtual ~QgsColorRampShader();
+
+    /** Copy constructor
+     */
+    QgsColorRampShader( const QgsColorRampShader& other );
+
+    /** Assignment operator
+     */
+    QgsColorRampShader& operator=( const QgsColorRampShader& other );
 
     //An entry for classification based upon value.
     //Such a classification is typically used for
@@ -75,23 +89,23 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     //! \brief Get the color ramp type as a string
     QString colorRampTypeAsQString();
 
-    /** Get the original color ramp name
-     * @note added in QGIS 3.0
-     * @see setColorRampName()
-     */
-    QString colorRampName() const { return mColorRampName; }
-
     //! \brief Set custom colormap
     void setColorRampItemList( const QList<QgsColorRampShader::ColorRampItem>& theList ); //TODO: sort on set
 
     //! \brief Set the color ramp type
     void setColorRampType( QgsColorRampShader::ColorRamp_TYPE theColorRampType );
 
-    /** Sets the source color ramp name
+    /** Get the source color ramp
      * @note added in QGIS 3.0
-     * @see colorRampName()
+     * @see setSourceColorRamp()
      */
-    void setColorRampName( const QString& theName );
+    QgsColorRamp* sourceColorRamp() const;
+
+    /** Set the source color ramp. Ownership is transferred to the renderer.
+     * @note added in QGIS 3.0
+     * @see sourceColorRamp()
+     */
+    void setSourceColorRamp( QgsColorRamp* colorramp );
 
     //! \brief Set the color ramp type
     void setColorRampType( const QString& theType );
@@ -116,6 +130,11 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
      */
     bool clip() const { return mClip; }
 
+  protected:
+
+    //! Source color ramp
+    QScopedPointer<QgsColorRamp> mSourceColorRamp;
+
   private:
 
     /** This vector holds the information for classification based on values.
@@ -134,9 +153,6 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     double mLUTOffset;
     double mLUTFactor;
     bool mLUTInitialized;
-
-    //! Color ramp name
-    QString mColorRampName;
 
     //! Do not render values out of range
     bool mClip;

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -63,7 +63,10 @@ QgsSingleBandPseudoColorRenderer* QgsSingleBandPseudoColorRenderer::clone() cons
     {
       QgsColorRampShader * colorRampShader = new QgsColorRampShader( mShader->minimumValue(), mShader->maximumValue() );
 
-      colorRampShader->setColorRampName( origColorRampShader->colorRampName() );
+      if ( origColorRampShader->sourceColorRamp() )
+      {
+        colorRampShader->setSourceColorRamp( origColorRampShader->sourceColorRamp()->clone() );
+      }
       colorRampShader->setColorRampType( origColorRampShader->colorRampType() );
       colorRampShader->setClip( origColorRampShader->clip() );
       colorRampShader->setColorRampItemList( origColorRampShader->colorRampItemList() );

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -89,6 +89,8 @@ void QgsColorRampButton::showColorRampDialog()
   if ( !currentRamp )
     return;
 
+  setColorRampName( QString() );
+
   if ( currentRamp->type() == QLatin1String( "gradient" ) )
   {
     QgsGradientColorRamp* gradRamp = static_cast<QgsGradientColorRamp*>( currentRamp.data() );
@@ -193,16 +195,10 @@ bool QgsColorRampButton::event( QEvent *e )
 {
   if ( e->type() == QEvent::ToolTip )
   {
-    //QString name = this->colorRamp().name();
-    /*int hue = this->color().hue();
-    //int value = this->color().value();
-    //int saturation = this->color().saturation();
-    QString info = QString( "HEX: %1 \n"
-                            "RGB: %2 \n"
-                            "HSV: %3,%4,%5" ).arg( name,
-                                                   QgsSymbolLayerUtils::encodeColor( this->color() ) )
-                   .arg( hue ).arg( saturation ).arg( value );*/
-    setToolTip( QString( "fix" ) );
+    if ( !colorRampName().isEmpty() )
+    {
+      setToolTip( colorRampName() );
+    }
   }
   return QToolButton::event( e );
 }
@@ -328,28 +324,30 @@ void QgsColorRampButton::loadColorRamp()
   if ( selectedItem )
   {
     QString name = selectedItem->text();
+    setColorRampName( name );
     setColorRampFromName( name );
   }
 }
 
 void QgsColorRampButton::createColorRamp()
 {
-  QString rampName;
+  QString name;
   if ( !mShowGradientOnly )
   {
-    rampName = QgsStyleManagerDialog::addColorRampStatic( this, mStyle );
+    name = QgsStyleManagerDialog::addColorRampStatic( this, mStyle );
   }
   else
   {
-    rampName = QgsStyleManagerDialog::addColorRampStatic( this, mStyle, QStringLiteral( "Gradient" ) );
+    name = QgsStyleManagerDialog::addColorRampStatic( this, mStyle, QStringLiteral( "Gradient" ) );
   }
-  if ( rampName.isEmpty() )
+  if ( name.isEmpty() )
     return;
 
   // make sure the color ramp is stored
   mStyle->save();
 
-  setColorRampFromName( rampName );
+  setColorRampName( name );
+  setColorRampFromName( name );
 }
 
 void QgsColorRampButton::invertColorRamp()

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -175,6 +175,17 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      */
     bool showGradientOnly() const { return mShowGradientOnly; }
 
+    /** Sets the name of the current color ramp when it's available in the style manager
+     * @param name Name of the saved color ramp
+     * @see colorRampName
+     */
+    void setColorRampName( const QString& name ) { mColorRampName = name; }
+
+    /** Returns the name of the current color ramp when it's available in the style manager
+     * @see setColorRampName
+     */
+    QString colorRampName() const { return mColorRampName; }
+
   public slots:
 
     /** Sets the current color ramp for the button. Will emit a colorRampChanged() signal if the color ramp is different
@@ -243,6 +254,7 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
     QString mColorRampDialogTitle;
     bool mShowGradientOnly;
     QgsColorRamp* mColorRamp;
+    QString mColorRampName;
     QgsStyle* mStyle;
 
     QgsColorRamp* mDefaultColorRamp;

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -31,8 +31,11 @@ class QgsRasterMinMaxWidget;
 class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendererWidget,
       private Ui::QgsSingleBandPseudoColorRendererWidgetBase
 {
+
     Q_OBJECT
+
   public:
+
     enum Mode
     {
       Continuous = 1, // Using breaks from color palette
@@ -50,9 +53,14 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void setFromRenderer( const QgsRasterRenderer* r );
 
   public slots:
+
+    /** Executes the single band pseudo raster classficiation
+     */
+    void classify();
     void loadMinMax( int theBandNo, double theMin, double theMax, int theOrigin );
 
   private:
+
     enum Column
     {
       ValueColumn = 0,
@@ -65,10 +73,10 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void setUnitFromLabels();
 
   private slots:
+
+    void applyColorRamp();
     void on_mAddEntryButton_clicked();
     void on_mDeleteEntryButton_clicked();
-    void on_mNumberOfEntriesSpinBox_valueChanged();
-    void on_mClassifyButton_clicked();
     void on_mLoadFromBandButton_clicked();
     void on_mLoadFromFileButton_clicked();
     void on_mExportToFileButton_clicked();
@@ -82,15 +90,16 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void on_mMinLineEdit_textEdited( const QString & text ) { Q_UNUSED( text ); mMinMaxOrigin = QgsRasterRenderer::MinMaxUser; showMinMaxOrigin(); }
     void on_mMaxLineEdit_textEdited( const QString & text ) { Q_UNUSED( text ); mMinMaxOrigin = QgsRasterRenderer::MinMaxUser; showMinMaxOrigin(); }
     void on_mClassificationModeComboBox_currentIndexChanged( int index );
-    void on_mColorRampComboBox_currentIndexChanged( int index );
 
   private:
+
     void setLineEditValue( QLineEdit *theLineEdit, double theValue );
     double lineEditValue( const QLineEdit *theLineEdit ) const;
     void resetClassifyButton();
     void showMinMaxOrigin();
     QgsRasterMinMaxWidget * mMinMaxWidget;
     int mMinMaxOrigin;
+
 };
 
 

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -27,30 +27,31 @@
     <number>3</number>
    </property>
    <item row="4" column="1" colspan="4">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QgsColorRampComboBox" name="mColorRampComboBox"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mButtonEditRamp">
-       <property name="text">
-        <string>Edit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="mInvertCheckBox">
-       <property name="text">
-        <string>Invert</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QgsColorRampButton" name="btnColorRamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
    </item>
    <item row="4" column="0">
     <widget class="QLabel" name="mColorInterpolationLabel_2">
      <property name="text">
-      <string>Color</string>
+      <string>Color ramp</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This PR migrates the raster singleband pseudo-color renderer to the new color ramp button widget. Before (left) vs. after (right):
![untitled](https://cloud.githubusercontent.com/assets/1728657/20780837/e4221c28-b7b0-11e6-930e-e84b2da3db37.png)

Benefits (beyond the widget itself) are:
- getting rid of the inverted checkbox check in the classification logic (woupidou!)
- upon restoring the renderer, the color ramp will be restored too; that is, on top of what @alexbruy committed a month ago, customized ramps will also be restored

@nyalldawson , I also fixed the "fix" tooltip 😉 