### PR TITLE
[NEEDS-DOCS] Shorten the option label

### DIFF
--- a/src/ui/qgslabelingwidget.ui
+++ b/src/ui/qgslabelingwidget.ui
@@ -47,7 +47,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Show labels</string>
+         <string>Single labels</string>
         </property>
         <property name="icon">
          <iconset resource="../../images/images.qrc">

--- a/src/ui/qgslabelingwidget.ui
+++ b/src/ui/qgslabelingwidget.ui
@@ -47,7 +47,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Show labels for this layer</string>
+         <string>Show labels</string>
         </property>
         <property name="icon">
          <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
Layer properties --> Labels tab, it's obvious that "show labels" is already for the current layer, so this PR removes "_for this layer_". It also makes it coherent with the other items such as "No labels" and "Rule-based labeling"
refs http://hub.qgis.org/issues/15902