### PR TITLE
Fix mapping for 2to3 fix_pyqt

### DIFF
--- a/scripts/qgis_fixes/fix_pyqt.py
+++ b/scripts/qgis_fixes/fix_pyqt.py
@@ -359,7 +359,7 @@ MAPPING = {
         ]),
     ],
     "PyQt4": [
-        ("PyQt", [
+        ("qgis.PyQt", [
             "QtCore",
             "QtGui",
             "QtNetwork",


### PR DESCRIPTION
Fix issue [#15921](https://hub.qgis.org/issues/15921):

```
>>> from PyQt import uic
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named 'PyQt'
>>> from qgis.PyQt import uic
```