### PR TITLE
QgsVectorLayer::featureCount( QgsSymbol* symbol ) to featureCount( const QString& legendKey )

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1572,6 +1572,7 @@ displayExpression instead. For the map tip use mapTipTemplate() instead.
 - getStyleFromDatabase(): msgError argument is correctly declared as output argument
 - loadNamedStyle(): theResultFlag argument is correctly declared as output argument
 - The duplicate selectionChanged() signal was removed. Use selectionChanged( const QgsFeatureIds&, const QgsFeatureIds&, const bool ) instead.
+- featureCount() now requires a legend key string instead of a QgsSymbol pointer argument.
 
 QgsVectorLayerEditBuffer        {#qgis_api_break_3_0_QgsVectorLayerEditBuffer}
 ------------------------

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1016,6 +1016,11 @@ QgsLayerTreeModel        {#qgis_api_break_3_0_QgsLayerTreeMode}
 - setAutoCollapseSymbologyNodes() was removed. Use setAutoCollapseLegendNodes() instead.
 - autoCollapseSymbologyNodes() was removed. Use autoCollapseLegendNodes() instead.
 
+QgsLayerTreeModelLegendNode        {#qgis_api_break_3_0_QgsLayerTreeModelLegendNode}
+---------------------------
+
+- The SymbolLegacyRuleKeyRole role was removed. Use RuleKeyRole instead.
+
 
 QgsLayerTreeNode        {#qgis_api_break_3_0_QgsLayerTreeNode}
 ----------------

--- a/python/core/layertree/qgslayertreemodellegendnode.sip
+++ b/python/core/layertree/qgslayertreemodellegendnode.sip
@@ -20,7 +20,6 @@ class QgsLayerTreeModelLegendNode : QObject
     enum LegendNodeRoles
     {
       RuleKeyRole,                    //!< rule key of the node (QString)
-      SymbolLegacyRuleKeyRole,      //!< for QgsSymbolLegendNode only - legacy rule key (void ptr, to be cast to QgsSymbol ptr)
       ParentRuleKeyRole               //!< rule key of the parent legend node - for legends with tree hierarchy (QString). Added in 2.8
     };
 

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -732,12 +732,11 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     bool readSld( const QDomNode& node, QString& errorMessage );
 
     /**
-     * Number of features rendered with specified symbol. Features must be first
+     * Number of features rendered with specified legend key. Features must be first
      * calculated by countSymbolFeatures()
-     * @param symbol the symbol
      * @return number of features rendered by symbol or -1 if failed or counts are not available
      */
-    long featureCount( QgsSymbol* symbol ) const;
+    long featureCount( const QString& legendKey ) const;
 
     /**
      * Update the data source of the layer. The layer's renderer and legend will be preserved only
@@ -752,7 +751,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     void setDataSource( const QString& dataSource, const QString& baseName, const QString& provider, bool loadDefaultStyleFlag = false );
 
     /**
-     * Count features for symbols. Feature counts may be get by featureCount( QgsSymbol*).
+     * Count features for symbols. Feature counts may be get by featureCount().
      * @param showProgress show progress dialog
      * @return true if calculated, false if failed or was canceled by user
      */

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1130,15 +1130,18 @@ QList<QgsLayerTreeModelLegendNode*> QgsLayerTreeModel::filterLegendNodes( const 
   {
     Q_FOREACH ( QgsLayerTreeModelLegendNode* node, nodes )
     {
-      QgsSymbol* ruleKey = reinterpret_cast< QgsSymbol* >( node->data( QgsSymbolLegendNode::SymbolLegacyRuleKeyRole ).value<void*>() );
+      QString ruleKey = node->data( QgsSymbolLegendNode::RuleKeyRole ).toString();
       bool checked = mLegendFilterUsesExtent || node->data( Qt::CheckStateRole ).toInt() == Qt::Checked;
-      if ( ruleKey && checked )
+      if ( checked )
       {
-        QString ruleKey = node->data( QgsSymbolLegendNode::RuleKeyRole ).toString();
         if ( QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( node->layerNode()->layer() ) )
         {
           if ( mLegendFilterHitTest->legendKeyVisible( ruleKey, vl ) )
             filtered << node;
+        }
+        else
+        {
+          filtered << node;
         }
       }
       else  // unknown node type or unchecked

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -468,8 +468,8 @@ void QgsSymbolLegendNode::updateLabel()
   else
   {
     mLabel = mUserLabel.isEmpty() ? mItem.label() : mUserLabel;
-    if ( showFeatureCount && vl && mItem.legacyRuleKey() )
-      mLabel += QStringLiteral( " [%1]" ).arg( vl->featureCount( mItem.legacyRuleKey() ) );
+    if ( showFeatureCount && vl )
+      mLabel += QStringLiteral( " [%1]" ).arg( vl->featureCount( mItem.ruleKey() ) );
   }
 }
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -311,10 +311,6 @@ QVariant QgsSymbolLegendNode::data( int role ) const
   {
     return mItem.ruleKey();
   }
-  else if ( role == SymbolLegacyRuleKeyRole )
-  {
-    return QVariant::fromValue<void*>( mItem.legacyRuleKey() );
-  }
   else if ( role == ParentRuleKeyRole )
   {
     return mItem.parentRuleKey();

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -49,7 +49,6 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
     enum LegendNodeRoles
     {
       RuleKeyRole = Qt::UserRole,     //!< Rule key of the node (QString)
-      SymbolLegacyRuleKeyRole,      //!< For QgsSymbolLegendNode only - legacy rule key (void ptr, to be cast to QgsSymbol ptr)
       ParentRuleKeyRole               //!< Rule key of the parent legend node - for legends with tree hierarchy (QString). Added in 2.8
     };
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -622,12 +622,12 @@ bool QgsVectorLayer::diagramsEnabled() const
   return false;
 }
 
-long QgsVectorLayer::featureCount( QgsSymbol* symbol ) const
+long QgsVectorLayer::featureCount( const QString& legendKey ) const
 {
   if ( !mSymbolFeatureCounted )
     return -1;
 
-  return mSymbolFeatureCountMap.value( symbol );
+  return mSymbolFeatureCountMap.value( legendKey );
 }
 
 /** \ingroup core
@@ -697,7 +697,7 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
 
   for ( ; symbolIt != symbolList.constEnd(); ++symbolIt )
   {
-    mSymbolFeatureCountMap.insert( symbolIt->second, 0 );
+    mSymbolFeatureCountMap.insert( symbolIt->first, 0 );
   }
 
   long nFeatures = featureCount();
@@ -749,10 +749,10 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
   while ( fit.nextFeature( f ) )
   {
     renderContext.expressionContext().setFeature( f );
-    QgsSymbolList featureSymbolList = mRenderer->originalSymbolsForFeature( f, renderContext );
-    for ( QgsSymbolList::iterator symbolIt = featureSymbolList.begin(); symbolIt != featureSymbolList.end(); ++symbolIt )
+    QSet<QString> featureKeyList = mRenderer->legendKeysForFeature( f, renderContext );
+    Q_FOREACH ( const QString& key, featureKeyList )
     {
-      mSymbolFeatureCountMap[*symbolIt] += 1;
+      mSymbolFeatureCountMap[key] += 1;
     }
     ++featuresCounted;
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -837,12 +837,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     bool readSld( const QDomNode& node, QString& errorMessage ) override;
 
     /**
-     * Number of features rendered with specified symbol. Features must be first
+     * Number of features rendered with specified legend key. Features must be first
      * calculated by countSymbolFeatures()
-     * @param symbol the symbol
      * @return number of features rendered by symbol or -1 if failed or counts are not available
      */
-    long featureCount( QgsSymbol* symbol ) const;
+    long featureCount( const QString& legendKey ) const;
 
     /**
      * Update the data source of the layer. The layer's renderer and legend will be preserved only
@@ -857,7 +856,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void setDataSource( const QString& dataSource, const QString& baseName, const QString& provider, bool loadDefaultStyleFlag = false );
 
     /**
-     * Count features for symbols. Feature counts may be get by featureCount( QgsSymbol*).
+     * Count features for symbols. Feature counts may be get by featureCount().
      * @param showProgress show progress dialog
      * @return true if calculated, false if failed or was canceled by user
      */
@@ -2080,8 +2079,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     // Features in renderer classes counted
     bool mSymbolFeatureCounted;
 
-    // Feature counts for each renderer symbol
-    QMap<QgsSymbol*, long> mSymbolFeatureCountMap;
+    // Feature counts for each renderer legend key
+    QHash<QString, long> mSymbolFeatureCountMap;
 
     //! True while an undo command is active
     bool mEditCommandActive;


### PR DESCRIPTION
Change QgsVectorLayer::featureCount( QgsSymbol* symbol ) to instead use a legend key string. Avoids crashes due to symbol pointer lifetime issues.

I also would like to remove QgsLegendSymbolItem::legacyRuleKey() but unfortunately this is in use by... server.