### PR TITLE
fix loading of models containing user-defined scripts

### DIFF
--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -566,7 +566,10 @@ class ModelerAlgorithm(GeoAlgorithm):
         def fromdict(d):
             try:
                 fullClassName = d["class"]
-                tokens = fullClassName.split(".")
+                if isinstance(fullClassName, basestring):
+                    tokens = fullClassName.split(".")
+                else:
+                    tokens = fullClassName.__class__.__name__.split(".")
                 className = tokens[-1]
                 moduleName = ".".join(tokens[:-1])
                 values = d["values"]


### PR DESCRIPTION
Fixes loading of models when they contain user-defined scripts. Without this loading failed with error like `ModelerParameter instance has no attribute 'split'`