### PR TITLE
[FEATURE] save existing color ramp function

### DIFF
--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -286,6 +286,10 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      */
     void createColorRamp();
 
+    /** Creates a new color ramp
+     */
+    void saveColorRamp();
+
     /** Inverts the current color ramp
      */
     void invertColorRamp();

--- a/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
@@ -468,8 +468,8 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget* parent, QgsStyle* st
   if ( rampType.isEmpty() )
   {
     QStringList rampTypes;
-    rampTypes << tr( "Gradient" ) << tr( "Random" ) << tr( "ColorBrewer" ) << tr( "Preset colors" );
-    rampTypes << tr( "cpt-city" );
+    rampTypes << tr( "Gradient" ) << tr( "Color presets" ) << tr( "Random" ) << tr( "Catalog: cpt-city" );
+    rampTypes << tr( "Catalog: ColorBrewer" );
     rampType = QInputDialog::getItem( parent, tr( "Color ramp type" ),
                                       tr( "Please select color ramp type:" ), rampTypes, 0, false, &ok );
   }
@@ -499,7 +499,7 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget* parent, QgsStyle* st
     ramp.reset( dlg.ramp().clone() );
     name = tr( "new random ramp" );
   }
-  else if ( rampType == tr( "ColorBrewer" ) )
+  else if ( rampType == tr( "Catalog: ColorBrewer" ) )
   {
     QgsColorBrewerColorRampDialog dlg( QgsColorBrewerColorRamp(), parent );
     if ( !dlg.exec() )
@@ -509,7 +509,7 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget* parent, QgsStyle* st
     ramp.reset( dlg.ramp().clone() );
     name = dlg.ramp().schemeName() + QString::number( dlg.ramp().colors() );
   }
-  else if ( rampType == tr( "Preset colors" ) )
+  else if ( rampType == tr( "Color presets" ) )
   {
     QgsPresetColorRampDialog dlg( QgsPresetSchemeColorRamp(), parent );
     if ( !dlg.exec() )
@@ -519,7 +519,7 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget* parent, QgsStyle* st
     ramp.reset( dlg.ramp().clone() );
     name = tr( "new preset ramp" );
   }
-  else if ( rampType == tr( "cpt-city" ) )
+  else if ( rampType == tr( "Catalog: cpt-city" ) )
   {
     QgsCptCityColorRampDialog dlg( QgsCptCityColorRamp( QLatin1String( "" ), QLatin1String( "" ) ), parent );
     if ( !dlg.exec() )

--- a/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
@@ -469,7 +469,7 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget* parent, QgsStyle* st
   {
     QStringList rampTypes;
     rampTypes << tr( "Gradient" ) << tr( "Random" ) << tr( "ColorBrewer" ) << tr( "Preset colors" );
-    rampTypes << tr( "cpt-city" ); // todo, only for rasters?
+    rampTypes << tr( "cpt-city" );
     rampType = QInputDialog::getItem( parent, tr( "Color ramp type" ),
                                       tr( "Please select color ramp type:" ), rampTypes, 0, false, &ok );
   }


### PR DESCRIPTION
This PR adds functionality to save edited / customized color ramp:
![untitled2](https://cloud.githubusercontent.com/assets/1728657/20856692/380f5cae-b948-11e6-9f7f-448bb8c6e279.png)

This can come in handy when you've worked to refine a color ramp gradient attached to a renderer / symbol layer and want to safeguard it for uses in other projects (or export as.XML and share with others).

I've also taken the occasion to improve the new color ramp type naming to try and better identify what "cpt-city" and "ColorBrewer" are:
![untitled](https://cloud.githubusercontent.com/assets/1728657/20856712/bb1151ca-b948-11e6-86b2-879833ee73c0.png)
