### PR TITLE
compatible for Qt 5.7

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -46,7 +46,7 @@ email                : morb at ozemail dot com dot au
 #include "qgspolygon.h"
 #include "qgslinestring.h"
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
 #include <netinet/in.h>
 #else
 #include <winsock.h>


### PR DESCRIPTION
There's no MACRO Q_WS_WIN anymore in Qt5.7, so change it to Q_OS_WIN