### PR TITLE
[color ramp] do not automatically save new ramps

### DIFF
--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -336,7 +336,7 @@ void QgsSingleBandPseudoColorRendererWidget::classify()
 
   if ( mClassificationModeComboBox->currentData().toInt() == Continuous )
   {
-    if ( colorRamp.data() )
+    if ( colorRamp.data() &&  colorRamp->count() > 1 )
     {
       numberOfEntries = colorRamp->count();
       entryValues.reserve( numberOfEntries );
@@ -450,7 +450,7 @@ void QgsSingleBandPseudoColorRendererWidget::classify()
       }
     }
 
-    if ( !colorRamp.data() )
+    if ( !colorRamp.data() || colorRamp->count() == 1 )
     {
       //hard code color range from blue -> red (previous default)
       int colorDiff = 0;


### PR DESCRIPTION
Now that we have a/ a clear separation between saved ramps and the source ramp associated with the color ramp button widget. and b/ a save current color ramp function in the widget,  IMHO we should _not_ automatically save newly created color ramps. 

This PR implements that. When a user choose to "create a new color ramp", a new QgsColorRamp object will be created and attached to the color ramp button widget. If the user doesn't need to save the ramp into his/her style manager, there's no need to. If he/she wants to save the created ramp, that can be done.

Benefits are:
- avoiding saving color ramps if its a one-time need (or if you want to simply load a ramp from a catalogue);
- allows for newly created ramp's dialog to open in the style dock as a panel ( @nyalldawson , this one's for you :) )
- removes the reliance on QgsStyleManager