### PR TITLE
[FEATURE] cpt-city catalog support in color ramp's gradient-only mode

### DIFF
--- a/src/core/effects/qgsgloweffect.cpp
+++ b/src/core/effects/qgsgloweffect.cpp
@@ -176,7 +176,14 @@ void QgsGlowEffect::readProperties( const QgsStringMap &props )
 
   //attempt to create color ramp from props
   delete mRamp;
-  mRamp = QgsGradientColorRamp::create( props );
+  if ( props.contains( QStringLiteral( "gradientType" ) ) && props[QStringLiteral( "gradientType" )] == QStringLiteral( "cpt-city" ) )
+  {
+    mRamp = QgsCptCityColorRamp::create( props );
+  }
+  else
+  {
+    mRamp = QgsGradientColorRamp::create( props );
+  }
 }
 
 void QgsGlowEffect::setRamp( QgsColorRamp *ramp )

--- a/src/core/qgscolorramp.cpp
+++ b/src/core/qgscolorramp.cpp
@@ -205,6 +205,7 @@ QgsStringMap QgsGradientColorRamp::properties() const
     map["info_" + it.key()] = it.value();
   }
 
+  map[QStringLiteral( "gradientType" )] = type();
   return map;
 }
 void QgsGradientColorRamp::convertToDiscrete( bool discrete )
@@ -354,6 +355,7 @@ QgsStringMap QgsLimitedRandomColorRamp::properties() const
   map[QStringLiteral( "satMax" )] = QString::number( mSatMax );
   map[QStringLiteral( "valMin" )] = QString::number( mValMin );
   map[QStringLiteral( "valMax" )] = QString::number( mValMax );
+  map[QStringLiteral( "gradientType" )] = type();
   return map;
 }
 
@@ -571,6 +573,7 @@ QgsStringMap QgsColorBrewerColorRamp::properties() const
   map[QStringLiteral( "schemeName" )] = mSchemeName;
   map[QStringLiteral( "colors" )] = QString::number( mColors );
   map[QStringLiteral( "inverted" )] = QString::number( mInverted );
+  map[QStringLiteral( "gradientType" )] = type();
   return map;
 }
 
@@ -659,6 +662,7 @@ QgsStringMap QgsCptCityColorRamp::properties() const
   QgsStringMap map;
   map[QStringLiteral( "schemeName" )] = mSchemeName;
   map[QStringLiteral( "variantName" )] = mVariantName;
+  map[QStringLiteral( "gradientType" )] = type();
   return map;
 }
 
@@ -873,6 +877,7 @@ QgsStringMap QgsPresetSchemeColorRamp::properties() const
     props.insert( QStringLiteral( "preset_color_%1" ).arg( i ), QgsSymbolLayerUtils::encodeColor( mColors.at( i ).first ) );
     props.insert( QStringLiteral( "preset_color_name_%1" ).arg( i ), mColors.at( i ).second );
   }
+  props[QStringLiteral( "gradientType" )] = type();
   return props;
 }
 

--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -538,7 +538,15 @@ QgsSymbolLayer* QgsGradientFillSymbolLayer::create( const QgsStringMap& props )
     offset = QgsSymbolLayerUtils::decodePoint( props[QStringLiteral( "offset" )] );
 
   //attempt to create color ramp from props
-  QgsColorRamp* gradientRamp = QgsGradientColorRamp::create( props );
+  QgsColorRamp* gradientRamp;
+  if ( props.contains( QStringLiteral( "gradientType" ) ) && props[QStringLiteral( "gradientType" )] == QStringLiteral( "cpt-city" ) )
+  {
+    gradientRamp = QgsCptCityColorRamp::create( props );
+  }
+  else
+  {
+    gradientRamp = QgsGradientColorRamp::create( props );
+  }
 
   //create a new gradient fill layer with desired properties
   QgsGradientFillSymbolLayer* sl = new QgsGradientFillSymbolLayer( color, color2, colorType, type, coordinateMode, gradientSpread );
@@ -815,7 +823,8 @@ void QgsGradientFillSymbolLayer::applyGradient( const QgsSymbolRenderContext &co
   }
 
   //add stops to gradient
-  if ( gradientColorType == QgsGradientFillSymbolLayer::ColorRamp && gradientRamp && gradientRamp->type() == QLatin1String( "gradient" ) )
+  if ( gradientColorType == QgsGradientFillSymbolLayer::ColorRamp && gradientRamp &&
+       ( gradientRamp->type() == QLatin1String( "gradient" ) || gradientRamp->type() == QLatin1String( "cpt-city" ) ) )
   {
     //color ramp gradient
     QgsGradientColorRamp* gradRamp = static_cast<QgsGradientColorRamp*>( gradientRamp );
@@ -1017,7 +1026,15 @@ QgsSymbolLayer* QgsShapeburstFillSymbolLayer::create( const QgsStringMap& props 
   }
 
   //attempt to create color ramp from props
-  QgsColorRamp* gradientRamp = QgsGradientColorRamp::create( props );
+  QgsColorRamp* gradientRamp;
+  if ( props.contains( QStringLiteral( "gradientType" ) ) && props["gradientType"] == QStringLiteral( "cpt-city" ) )
+  {
+    gradientRamp = QgsCptCityColorRamp::create( props );
+  }
+  else
+  {
+    gradientRamp = QgsGradientColorRamp::create( props );
+  }
 
   //create a new shapeburst fill layer with desired properties
   QgsShapeburstFillSymbolLayer* sl = new QgsShapeburstFillSymbolLayer( color, color2, colorType, blurRadius, useWholeShape, maxDistance );

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -278,7 +278,7 @@ void QgsColorRampButton::prepareMenu()
   {
     QScopedPointer< QgsColorRamp > ramp( mStyle->colorRamp( *it ) );
 
-    if ( !mShowGradientOnly || ramp->type() == QLatin1String( "gradient" ) )
+    if ( !mShowGradientOnly || ( ramp->type() == QLatin1String( "gradient" ) || ramp->type() == QLatin1String( "cpt-city" ) ) )
     {
       QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), QSize( 16, 16 ) );
       QAction* ra = new QAction( *it, this );
@@ -298,7 +298,7 @@ void QgsColorRampButton::prepareMenu()
   {
     QScopedPointer< QgsColorRamp > ramp( mStyle->colorRamp( *it ) );
 
-    if ( !mShowGradientOnly || ramp->type() == QLatin1String( "gradient" ) )
+    if ( !mShowGradientOnly || ( ramp->type() == QLatin1String( "gradient" ) || ramp->type() == QLatin1String( "cpt-city" ) ) )
     {
       QIcon icon = QgsSymbolLayerUtils::colorRampPreviewIcon( ramp.data(), QSize( 16, 16 ) );
       QAction* ra = new QAction( *it, this );


### PR DESCRIPTION
This PR brings cpt-city catalog ramps to:
- shapeburst fill
- gradient fill
- inner/outer glow effect

Ugly proof of life:
![fixed](https://cloud.githubusercontent.com/assets/1728657/20863839/28b1f810-ba0c-11e6-8534-3b374672595e.png)