### PR TITLE
[color ramp] improve invert() for discrete gradient ramps

### DIFF
--- a/src/core/qgscolorramp.cpp
+++ b/src/core/qgscolorramp.cpp
@@ -162,14 +162,27 @@ QColor QgsGradientColorRamp::color( double value ) const
 
 void QgsGradientColorRamp::invert()
 {
-  QColor tmpColor = mColor1;
-  mColor1 = mColor2;
-  mColor2 = tmpColor;
-
   QgsGradientStopsList newStops;
-  for ( int k = mStops.size() - 1; k >= 0; k-- )
+
+  if ( mDiscrete )
   {
-    newStops << QgsGradientStop( 1 - mStops.at( k ).offset, mStops.at( k ).color );
+    mColor2 = mColor1;
+    mColor1 = mStops.at( mStops.size() - 1 ).color;
+    for ( int k = mStops.size() - 1; k >= 1; k-- )
+    {
+      newStops << QgsGradientStop( 1 - mStops.at( k ).offset, mStops.at( k - 1 ).color );
+    }
+    newStops << QgsGradientStop( 1 - mStops.at( 0 ).offset, mColor2 );
+  }
+  else
+  {
+    QColor tmpColor = mColor2;
+    mColor2 = mColor1;
+    mColor1 = tmpColor;
+    for ( int k = mStops.size() - 1; k >= 0; k-- )
+    {
+      newStops << QgsGradientStop( 1 - mStops.at( k ).offset, mStops.at( k ).color );
+    }
   }
   mStops = newStops;
 }

--- a/tests/src/python/test_qgsvectorcolorramp.py
+++ b/tests/src/python/test_qgsvectorcolorramp.py
@@ -161,11 +161,22 @@ class PyQgsVectorColorRamp(unittest.TestCase):
         self.assertEqual(s[3].offset, 0.8)
         self.assertEqual(s[3].color, QColor(50, 20, 10))
 
-        # test invert function
+        # test continous invert function
         r.invert()
         self.assertEqual(r.color(0), QColor(0, 200, 0))
         self.assertEqual(r.color(1), QColor(200, 0, 0))
         self.assertEqual(r.color(0.2), QColor(50, 20, 10))
+
+        # test discrete invert function
+        r = QgsGradientColorRamp(QColor(255, 255, 255), QColor(0, 0, 0), True, [QgsGradientStop(0.33, QColor(128, 128, 128)),
+                                                                                QgsGradientStop(0.66, QColor(0, 0, 0))])
+        self.assertEqual(r.color(0.2), QColor(255, 255, 255))
+        self.assertEqual(r.color(0.5), QColor(128, 128, 128))
+        self.assertEqual(r.color(0.8), QColor(0, 0, 0))
+        r.invert()
+        self.assertEqual(r.color(0.2), QColor(0, 0, 0))
+        self.assertEqual(r.color(0.5), QColor(128, 128, 128))
+        self.assertEqual(r.color(0.8), QColor(255, 255, 255))
 
     def testQgsLimitedRandomColorRampV2(self):
         # test random color ramp


### PR DESCRIPTION
Turns out inversion of discrete and continuous ramps can't be achieved the same way; this PR greatly improves invert() for discrete ramps:
![untitled](https://cloud.githubusercontent.com/assets/1728657/20863949/f3046c12-ba0f-11e6-8b28-3641f0781ae1.png)
 