### PR TITLE
sipdiff: preprocess headers to reduce noise

### DIFF
--- a/scripts/sipdiff
+++ b/scripts/sipdiff
@@ -1,10 +1,29 @@
 #!/bin/bash
 
 for file in $*; do
-	d=${file#*/}
-	d=${d%/*}
-	f=${file##*/}
-	f=${f%.*}
+  d=${file#*/}
+  d=${d%/*}
+  f=${file##*/}
+  f=${f%.*}
 
-	vimdiff src/$d/$f.h python/$d/$f.sip
+  tempfile=$(mktemp ${f}XXXX --suffix=.h)
+
+  # Remove comments
+  sed 's/a/aA/g;s/__/aB/g;s/#/aC/g' "src/$d/$f.h" | gcc -P -E $arg - | sed 's/aC/#/g;s/aB/__/g;s/aA/a/g' > $tempfile
+
+  # Remove override keyword
+  sed -i 's/ override;/;/g' $tempfile
+
+  # Remove preprocessor directives
+  sed -i '/^#/d' $tempfile
+
+  # Remove CORE_EXPORT etc
+  sed -i 's/ [A-Z]*_EXPORT//g' $tempfile
+
+  # Remove public keyword from inherited classes
+  sed -i 's/\(class.*:\) public\(.*\)/\1\2/g' $tempfile
+
+  vimdiff $tempfile python/$d/$f.sip
+
+  rm $tempfile
 done


### PR DESCRIPTION
... and avoid common sources of trouble.

What it does is

* Strips comments (headers, doxygen, others...)
* Strips `override` keyword
* Strips `public` keyword from inherited classes
* Strips preprocessor directives (`#ifdef` etc)

This makes it very quick to generate new sip bindings because it does a lot of the boring stuff.

This way, we also no longer have to take care of synchronizing the duplicated files in the .sip files.

**Question**

Is it important to keep the file headers? I think I would like it for license etc. but I was too lazy.

**Space for improvement**

* Automagically insert `%TypoHeaderCode` includes
* Reinsert the doxymentation as proper `%DocString` annotations
* Strip `private` section(s)