### PR TITLE
[color ramp] save/restore invert state for cpt-city ramps

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -647,6 +647,10 @@ QgsCoordinateTransformCache        {#qgis_api_break_3_0_QgsCoordinateTransformCa
 - transform() now returns a QgsCoordinateTransform object, not a pointer. An invalid QgsCoordinateTransform will
 be returned in place of a null pointer.
 
+QgsCptCityColorRamp        {#qgis_api_break_3_0_QgsCptCityColorRamp}
+-------------------
+
+- The constructor's doLoadFile parameter order has changed due to the addition of an inverted parameter
 
 QgsCptCityColorRampDialog        {#qgis_api_break_3_0_QgsCptCityColorRampDialog}
 -------------------------

--- a/python/core/qgscolorramp.sip
+++ b/python/core/qgscolorramp.sip
@@ -401,11 +401,25 @@ class QgsCptCityColorRamp : QgsGradientColorRamp
 #include <qgscolorramp.h>
 %End
   public:
+    /** Constructor for QgsCptCityColorRamp
+     * @param schemeName cpt-city scheme name
+     * @param variantName cpt-city variant name
+     * @param inverted invert ramp ordering
+     * @param doLoadFile load cpt-city ramp from file
+     */
     QgsCptCityColorRamp( const QString& schemeName = DEFAULT_CPTCITY_SCHEMENAME,
                            const QString& variantName = DEFAULT_CPTCITY_VARIANTNAME,
-                           bool doLoadFile = true );
+                           bool inverted = false, bool doLoadFile = true );
+    /** Constructor for QgsCptCityColorRamp
+     * @param schemeName cpt-city scheme name
+     * @param variantList cpt-city variant list
+     * @param variantName cpt-city variant name
+     * @param inverted invert ramp ordering
+     * @param doLoadFile load cpt-city ramp from file
+     */
     QgsCptCityColorRamp( const QString& schemeName, const QStringList& variantList,
-                           const QString& variantName = QString(), bool doLoadFile = true );
+                           const QString& variantName = QString(), bool inverted = false,
+                           bool doLoadFile = true );
 
     static QgsColorRamp* create( const QgsStringMap& properties = QgsStringMap() ) /Factory/;
 

--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -540,15 +540,34 @@ class CORE_EXPORT QgsColorBrewerColorRamp : public QgsColorRamp
 class CORE_EXPORT QgsCptCityColorRamp : public QgsGradientColorRamp
 {
   public:
+
+    /** Constructor for QgsCptCityColorRamp
+     * @param schemeName cpt-city scheme name
+     * @param variantName cpt-city variant name
+     * @param inverted invert ramp ordering
+     * @param doLoadFile load cpt-city ramp from file
+     */
     QgsCptCityColorRamp( const QString& schemeName = DEFAULT_CPTCITY_SCHEMENAME,
                          const QString& variantName = DEFAULT_CPTCITY_VARIANTNAME,
+                         bool inverted = false,
                          bool doLoadFile = true );
+
+    /** Constructor for QgsCptCityColorRamp
+     * @param schemeName cpt-city scheme name
+     * @param variantList cpt-city variant list
+     * @param variantName cpt-city variant name
+     * @param inverted invert ramp ordering
+     * @param doLoadFile load cpt-city ramp from file
+     */
     QgsCptCityColorRamp( const QString& schemeName, const QStringList& variantList,
-                         const QString& variantName = QString(), bool doLoadFile = true );
+                         const QString& variantName = QString(), bool inverted = false,
+                         bool doLoadFile = true );
 
     static QgsColorRamp* create( const QgsStringMap& properties = QgsStringMap() );
 
     virtual QString type() const override { return QStringLiteral( "cpt-city" ); }
+
+    virtual void invert() override;
 
     virtual QgsCptCityColorRamp* clone() const override;
     void copy( const QgsCptCityColorRamp* other );
@@ -585,6 +604,7 @@ class CORE_EXPORT QgsCptCityColorRamp : public QgsGradientColorRamp
     QStringList mVariantList;
     bool mFileLoaded;
     bool mMultiStops;
+    bool mInverted;
 };
 
 


### PR DESCRIPTION
Tiny change to properly save and restore the inverted state of a cpt-city ramp (i.e. a cpt-city ramp that hasn't been converted into a QgsGradientColorRamp). 

(Just checking travis turns green, then I'll commit)