### PR TITLE
Raster UI improvements

### DIFF
--- a/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
+++ b/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
@@ -306,9 +306,19 @@ void QgsMultiBandColorRendererWidget::setFromRenderer( const QgsRasterRenderer* 
   }
   else
   {
-    mRedBandComboBox->setCurrentIndex( mRedBandComboBox->findText( tr( "Red" ) ) );
-    mGreenBandComboBox->setCurrentIndex( mGreenBandComboBox->findText( tr( "Green" ) ) );
-    mBlueBandComboBox->setCurrentIndex( mBlueBandComboBox->findText( tr( "Blue" ) ) );
+    if ( mRedBandComboBox->findText( tr( "Red" ) ) > -1 && mRedBandComboBox->findText( tr( "Green" ) ) > -1 &&
+         mRedBandComboBox->findText( tr( "Blue" ) ) > -1 )
+    {
+      mRedBandComboBox->setCurrentIndex( mRedBandComboBox->findText( tr( "Red" ) ) );
+      mGreenBandComboBox->setCurrentIndex( mGreenBandComboBox->findText( tr( "Green" ) ) );
+      mBlueBandComboBox->setCurrentIndex( mBlueBandComboBox->findText( tr( "Blue" ) ) );
+    }
+    else
+    {
+      mRedBandComboBox->setCurrentIndex( mRedBandComboBox->count() > 1 ? 1 : 0 );
+      mGreenBandComboBox->setCurrentIndex( mRedBandComboBox->count() > 2 ? 2 : 0 );
+      mBlueBandComboBox->setCurrentIndex( mRedBandComboBox->count() > 3 ? 3 : 0 );
+    }
   }
 }
 

--- a/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
+++ b/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
@@ -59,10 +59,10 @@ QgsMultiBandColorRendererWidget::QgsMultiBandColorRendererWidget( QgsRasterLayer
     mBlueBandComboBox->addItem( tr( "Not set" ), -1 );
 
     //contrast enhancement algorithms
-    mContrastEnhancementAlgorithmComboBox->addItem( tr( "No enhancement" ), 0 );
-    mContrastEnhancementAlgorithmComboBox->addItem( tr( "Stretch to MinMax" ), 1 );
-    mContrastEnhancementAlgorithmComboBox->addItem( tr( "Stretch and clip to MinMax" ), 2 );
-    mContrastEnhancementAlgorithmComboBox->addItem( tr( "Clip to MinMax" ), 3 );
+    mContrastEnhancementAlgorithmComboBox->addItem( tr( "No enhancement" ), QgsContrastEnhancement::NoEnhancement );
+    mContrastEnhancementAlgorithmComboBox->addItem( tr( "Stretch to MinMax" ), QgsContrastEnhancement::StretchToMinimumMaximum );
+    mContrastEnhancementAlgorithmComboBox->addItem( tr( "Stretch and clip to MinMax" ), QgsContrastEnhancement::StretchAndClipToMinimumMaximum );
+    mContrastEnhancementAlgorithmComboBox->addItem( tr( "Clip to MinMax" ), QgsContrastEnhancement::ClipToMinimumMaximum );
 
     int nBands = provider->bandCount();
     for ( int i = 1; i <= nBands; ++i ) //band numbering seem to start at 1
@@ -258,6 +258,13 @@ void QgsMultiBandColorRendererWidget::loadMinMax( int theBandNo, double theMin, 
   else
   {
     myMaxLineEdit->setText( QString::number( theMax ) );
+  }
+
+  //automaticlly activate contrast enhancement algorithm if set to none
+  if ( mContrastEnhancementAlgorithmComboBox->currentData().toInt() == QgsContrastEnhancement::NoEnhancement )
+  {
+    mContrastEnhancementAlgorithmComboBox->setCurrentIndex(
+      mContrastEnhancementAlgorithmComboBox->findData( QgsContrastEnhancement::StretchToMinimumMaximum ) );
   }
 }
 

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
@@ -61,10 +61,10 @@ QgsSingleBandGrayRendererWidget::QgsSingleBandGrayRendererWidget( QgsRasterLayer
     }
 
     //contrast enhancement algorithms
-    mContrastEnhancementComboBox->addItem( tr( "No enhancement" ), 0 );
-    mContrastEnhancementComboBox->addItem( tr( "Stretch to MinMax" ), 1 );
-    mContrastEnhancementComboBox->addItem( tr( "Stretch and clip to MinMax" ), 2 );
-    mContrastEnhancementComboBox->addItem( tr( "Clip to MinMax" ), 3 );
+    mContrastEnhancementComboBox->addItem( tr( "No enhancement" ), QgsContrastEnhancement::NoEnhancement );
+    mContrastEnhancementComboBox->addItem( tr( "Stretch to MinMax" ), QgsContrastEnhancement::StretchToMinimumMaximum );
+    mContrastEnhancementComboBox->addItem( tr( "Stretch and clip to MinMax" ), QgsContrastEnhancement::StretchAndClipToMinimumMaximum );
+    mContrastEnhancementComboBox->addItem( tr( "Clip to MinMax" ), QgsContrastEnhancement::ClipToMinimumMaximum );
 
     setFromRenderer( layer->renderer() );
 
@@ -96,8 +96,7 @@ QgsRasterRenderer* QgsSingleBandGrayRendererWidget::renderer()
         provider->dataType( band ) ) );
   e->setMinimumValue( mMinLineEdit->text().toDouble() );
   e->setMaximumValue( mMaxLineEdit->text().toDouble() );
-  e->setContrastEnhancementAlgorithm(( QgsContrastEnhancement::ContrastEnhancementAlgorithm )( mContrastEnhancementComboBox->itemData(
-                                       mContrastEnhancementComboBox->currentIndex() ).toInt() ) );
+  e->setContrastEnhancementAlgorithm(( QgsContrastEnhancement::ContrastEnhancementAlgorithm )( mContrastEnhancementComboBox->currentData().toInt() ) );
 
 
   QgsSingleBandGrayRenderer* renderer = new QgsSingleBandGrayRenderer( provider, band );
@@ -136,6 +135,12 @@ void QgsSingleBandGrayRendererWidget::loadMinMax( int theBandNo, double theMin, 
   else
   {
     mMaxLineEdit->setText( QString::number( theMax ) );
+  }
+
+  //automaticlly activate contrast enhancement algorithm if set to none
+  if ( mContrastEnhancementComboBox->currentData().toInt() == QgsContrastEnhancement::NoEnhancement )
+  {
+    mContrastEnhancementComboBox->setCurrentIndex( mContrastEnhancementComboBox->findData( QgsContrastEnhancement::StretchToMinimumMaximum ) );
   }
 }
 


### PR DESCRIPTION
This PR does two things:
- When a user clicks on the [ load ] button in the collapsible load min/max values group, a contrast enhancement algorithm will be activated if it was set to "no enhancement". It's really confusing when no contrast enhancement is active and click on [ load ] results in no visual change.
- When switching raster renderers to multiband color (away from another renderer type), be more clever about setting bands -- i.e., if the provider hasn't named red/green/blue bands, go with 1st, 2nd, 3rd band instead of showing _nothing_.

Whomever has worked a lot with raster will probably be heard going "haaaaaa, finally!" ;)