### PR TITLE
[processing] Create cost allocation map output

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.cost.coordinates.txt
+++ b/python/plugins/processing/algs/grass7/description/r.cost.coordinates.txt
@@ -10,3 +10,4 @@ ParameterNumber|max_cost|Maximum cumulative cost|0|None|0
 ParameterNumber|null_cost|Cost assigned to null cells. By default, null cells are excluded|None|None|0
 ParameterNumber|memory|Maximum memory to be used in MB|0|None|300
 OutputRaster|output|Cumulative cost
+OutputRaster|nearest|Cost allocation map

--- a/python/plugins/processing/algs/grass7/description/r.cost.points.txt
+++ b/python/plugins/processing/algs/grass7/description/r.cost.points.txt
@@ -7,3 +7,4 @@ ParameterVector|stop_points|Stop points|0|True
 ParameterBoolean|-k|Use the 'Knight's move'; slower, but more accurate|False
 ParameterBoolean|-n|Keep null values in output raster layer|True
 OutputRaster|output|Cumulative cost
+OutputRaster|nearest|Cost allocation map

--- a/python/plugins/processing/algs/grass7/description/r.cost.raster.txt
+++ b/python/plugins/processing/algs/grass7/description/r.cost.raster.txt
@@ -9,3 +9,4 @@ ParameterNumber|max_cost|Maximum cumulative cost|0|None|0
 ParameterNumber|null_cost|Cost assigned to null cells. By default, null cells are excluded|None|None|0
 ParameterNumber|memory|Maximum memory to be used in MB|0|None|300
 OutputRaster|output|Cumulative cost
+OutputRaster|nearest|Cost allocation map


### PR DESCRIPTION
Second output raster contains cost allocation map, as described in https://grass.osgeo.org/grass70/manuals/r.cost.html#cost-allocation