### PR TITLE
fix 2.18 build with Qt5 by executing pyuic

### DIFF
--- a/scripts/pyuic-wrapper.sh
+++ b/scripts/pyuic-wrapper.sh
@@ -15,12 +15,12 @@
 ###########################################################################
 
 
-PYUIC4=$1
+PYUIC=$1
 LD_LIBRARY_PATH=$2:$LD_LIBRARY_PATH
 PYTHONPATH=$3:$PYTHONPATH
 PYTHON=$4
 shift 4
 
 export LD_LIBRARY_PATH PYTHONPATH
-
+$PYUIC $@
 exec $PYTHON $(dirname $0)/pyuic-wrapper.py $@


### PR DESCRIPTION
I was trying to build 2.18 with qt5 to play around and I got plenti of missing ui_.....py files

I dont exactly understand what pyuic-wrapper.sh is ment to be doing, but it just does a python import of pyuic.

shouldnt pyuic also be executed @m-kuhn, @jef-n ?