### PR TITLE
Add support for fine-resolution mouse wheel zooming

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1449,13 +1449,17 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
   }
 
   double zoomFactor = mWheelZoomFactor;
+
+  // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps
+  zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 120.0 * qAbs( e->angleDelta().y() );
+
   if ( e->modifiers() & Qt::ControlModifier )
   {
     //holding ctrl while wheel zooming results in a finer zoom
     zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 20.0;
   }
 
-  double signedWheelFactor = e->delta() > 0 ? 1 / zoomFactor : zoomFactor;
+  double signedWheelFactor = e->angleDelta().y() > 0 ? 1 / zoomFactor : zoomFactor;
 
   // zoom map to mouse cursor by scaling
   QgsPoint oldCenter = center();


### PR DESCRIPTION
Some mouses (notably on mac) have finer resolutions. They send mouse
wheel events in a higher frequency but with smaller angleDelta() values.
So far, zooming with such mouses was leading to unusable fast zoom
actions where you'd end seeing the whole planet after a soft usage of the 
wheel after looking at a grain of sand.

TODO: Check with a normal mouse if everything still works ok.