### PR TITLE
[ui] fix circular string button location and relocate undo/redo buttons

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2339,6 +2339,15 @@ void QgisApp::createToolBars()
     layout->itemAt( i )->setAlignment( Qt::AlignLeft );
   }
 
+  //circular string digitize tool button
+  QToolButton* tbAddCircularString = new QToolButton( mDigitizeToolBar );
+  tbAddCircularString->setPopupMode( QToolButton::MenuButtonPopup );
+  tbAddCircularString->addAction( mActionCircularStringCurvePoint );
+  tbAddCircularString->addAction( mActionCircularStringRadius );
+  tbAddCircularString->setDefaultAction( mActionCircularStringCurvePoint );
+  connect( tbAddCircularString, SIGNAL( triggered( QAction * ) ), this, SLOT( toolButtonActionTriggered( QAction * ) ) );
+  mDigitizeToolBar->insertWidget( mActionNodeTool, tbAddCircularString );
+
   // move feature tool button
   QToolButton* moveFeatureButton = new QToolButton( mDigitizeToolBar );
   moveFeatureButton->setPopupMode( QToolButton::MenuButtonPopup );
@@ -2357,15 +2366,6 @@ void QgisApp::createToolBars()
   moveFeatureButton->setDefaultAction( defAction );
   connect( moveFeatureButton, SIGNAL( triggered( QAction * ) ), this, SLOT( toolButtonActionTriggered( QAction * ) ) );
   mDigitizeToolBar->insertWidget( mActionNodeTool, moveFeatureButton );
-
-  //circular string digitize tool button
-  QToolButton* tbAddCircularString = new QToolButton( mDigitizeToolBar );
-  tbAddCircularString->setPopupMode( QToolButton::MenuButtonPopup );
-  tbAddCircularString->addAction( mActionCircularStringCurvePoint );
-  tbAddCircularString->addAction( mActionCircularStringRadius );
-  tbAddCircularString->setDefaultAction( mActionCircularStringCurvePoint );
-  connect( tbAddCircularString, SIGNAL( triggered( QAction * ) ), this, SLOT( toolButtonActionTriggered( QAction * ) ) );
-  mDigitizeToolBar->insertWidget( mActionMoveFeature, tbAddCircularString );
 
   bt = new QToolButton();
   bt->setPopupMode( QToolButton::MenuButtonPopup );

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -374,6 +374,8 @@
    <addaction name="mActionCutFeatures"/>
    <addaction name="mActionCopyFeatures"/>
    <addaction name="mActionPasteFeatures"/>
+   <addaction name="mActionUndo"/>
+   <addaction name="mActionRedo"/>
   </widget>
   <widget class="QToolBar" name="mAdvancedDigitizeToolBar">
    <property name="windowTitle">
@@ -388,9 +390,6 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="mActionEnableTracing"/>
-   <addaction name="mActionUndo"/>
-   <addaction name="mActionRedo"/>
    <addaction name="mActionRotateFeature"/>
    <addaction name="mActionSimplifyFeature"/>
    <addaction name="mActionAddRing"/>


### PR DESCRIPTION
Current (top) vs. proposed (bottom):
![untitled](https://cloud.githubusercontent.com/assets/1728657/20996129/f3e0d014-bd2d-11e6-8d7b-ebd19e1ecf68.png)

This PR fixes the add circular string toolbar button (which was wrongly inserted at the end of the toolbar for a while now), as well as relocating the undo / redo button away from the advanced digitizing toolbar onto the (basic) digitizing toolbar. Undo and redo are located next to cut / copy / paste buttons in most applications, we should respect that.