### PR TITLE
Store QgsPointV2 for QgsLineString rather then seperate lists of x/y/m/z values

### DIFF
--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -156,7 +156,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     virtual QgsLineString* curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const override;
 
     int numPoints() const override;
-    virtual int nCoordinates() const override { return mX.size(); }
+    virtual int nCoordinates() const override { return mPoints.size(); }
     void points( QgsPointSequence &pt ) const override;
 
     void draw( QPainter& p ) const override;
@@ -190,15 +190,144 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     bool convertTo( QgsWkbTypes::Type type ) override;
 
+#if 0
+    //iterators
+    ///@cond PRIVATE
+
+    class const_iterator;
+
+    class iterator
+    {
+      public:
+        int index;
+        QgsLineString* line;
+
+        typedef std::random_access_iterator_tag  iterator_category;
+        typedef qptrdiff difference_type;
+
+        inline iterator()
+            : index( -1 )
+            , line( nullptr )
+        {}
+
+        inline QgsPointV2& operator*() const { return line->field; }
+        inline QgsPointV2* operator->() const { return &d->field; }
+        inline QgsPointV2& operator[]( difference_type j ) const { return d[j].field; }
+        inline bool operator==( const iterator &o ) const noexcept { return d == o.d; } // clazy:exclude=function-args-by-value
+        inline bool operator!=( const iterator &o ) const noexcept { return d != o.d; } // clazy:exclude=function-args-by-value
+        inline bool operator<( const iterator& other ) const noexcept { return d < other.d; } // clazy:exclude=function-args-by-value
+        inline bool operator<=( const iterator& other ) const noexcept { return d <= other.d; } // clazy:exclude=function-args-by-value
+        inline bool operator>( const iterator& other ) const noexcept { return d > other.d; } // clazy:exclude=function-args-by-value
+        inline bool operator>=( const iterator& other ) const noexcept { return d >= other.d; } // clazy:exclude=function-args-by-value
+
+        inline iterator& operator++() { ++d; return *this; }
+        inline iterator operator++( int ) { QgsFields::Field* n = d; ++d; return n; }
+        inline iterator& operator--() { d--; return *this; }
+        inline iterator operator--( int ) { QgsFields::Field* n = d; d--; return n; }
+        inline iterator& operator+=( difference_type j ) { d += j; return *this; }
+        inline iterator& operator-=( difference_type j ) { d -= j; return *this; }
+        inline iterator operator+( difference_type j ) const { return iterator( d + j ); }
+        inline iterator operator-( difference_type j ) const { return iterator( d -j ); }
+        inline int operator-( iterator j ) const { return int( d - j.d ); }
+    };
+    friend class iterator;
+
+    class const_iterator // clazy:exclude=rule-of-three
+    {
+      public:
+        const QgsFields::Field* d;
+
+        typedef std::random_access_iterator_tag  iterator_category;
+        typedef qptrdiff difference_type;
+
+        inline const_iterator()
+            : d( nullptr ) {}
+        inline const_iterator( const QgsFields::Field* f )
+            : d( f ) {}
+        inline const_iterator( const const_iterator &o )
+            : d( o.d ) {}
+        inline explicit const_iterator( const iterator &o ) // clazy:exclude=function-args-by-value
+            : d( o.d ) {}
+        inline const QgsField& operator*() const { return d->field; }
+        inline const QgsField* operator->() const { return &d->field; }
+        inline const QgsField& operator[]( difference_type j ) const noexcept { return d[j].field; }
+        inline bool operator==( const const_iterator &o ) const noexcept { return d == o.d; }
+        inline bool operator!=( const const_iterator &o ) const noexcept { return d != o.d; }
+        inline bool operator<( const const_iterator& other ) const noexcept { return d < other.d; }
+        inline bool operator<=( const const_iterator& other ) const noexcept { return d <= other.d; }
+        inline bool operator>( const const_iterator& other ) const noexcept { return d > other.d; }
+        inline bool operator>=( const const_iterator& other ) const noexcept { return d >= other.d; }
+        inline const_iterator& operator++() { ++d; return *this; }
+        inline const_iterator operator++( int ) { const QgsFields::Field* n = d; ++d; return n; }
+        inline const_iterator& operator--() { d--; return *this; }
+        inline const_iterator operator--( int ) { const QgsFields::Field* n = d; --d; return n; }
+        inline const_iterator& operator+=( difference_type j ) { d += j; return *this; }
+        inline const_iterator& operator-=( difference_type j ) { d -= j; return *this; }
+        inline const_iterator operator+( difference_type j ) const { return const_iterator( d + j ); }
+        inline const_iterator operator-( difference_type j ) const { return const_iterator( d -j ); }
+        inline int operator-( const_iterator j ) const { return int( d - j.d ); } // clazy:exclude=function-args-by-ref
+    };
+    friend class const_iterator;
+    ///@endcond
+
+
+    /**
+     * Returns a const STL-style iterator pointing to the first node in the linestring.
+     *
+     * @note added in 3.0
+     * @note not available in Python bindings
+     */
+    const_iterator constBegin() const noexcept;
+
+    /**
+     * Returns a const STL-style iterator pointing to the imaginary node after the last node in the linestring.
+     *
+     * @note added in 3.0
+     * @note not available in Python bindings
+     */
+    const_iterator constEnd() const noexcept;
+
+    /**
+     * Returns a const STL-style iterator pointing to the first node in the linestring.
+     *
+     * @note added in 3.0
+     * @note not available in Python bindings
+     */
+    const_iterator begin() const noexcept;
+
+    /**
+     * Returns a const STL-style iterator pointing to the imaginary node after the last node in the linestring.
+     *
+     * @note added in 3.0
+     * @note not available in Python bindings
+     */
+    const_iterator end() const noexcept;
+
+    /**
+     * Returns an STL-style iterator pointing to the first node in the linestring.
+     *
+     * @note added in 3.0
+     * @note not available in Python bindings
+     */
+    iterator begin();
+
+
+    /**
+     * Returns an STL-style iterator pointing to the imaginary node after the last node in the linestring.
+     *
+     * @note added in 3.0
+     * @note not available in Python bindings
+     */
+    iterator end();
+
+#endif
+
   protected:
 
     virtual QgsRectangle calculateBoundingBox() const override;
 
   private:
-    QVector<double> mX;
-    QVector<double> mY;
-    QVector<double> mZ;
-    QVector<double> mM;
+    QgsPointSequence mPoints;
 
     void importVerticesFromWkb( const QgsConstWkbPtr& wkb );
 

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -63,8 +63,8 @@ QgsPointV2::QgsPointV2( QPointF p )
 QgsPointV2::QgsPointV2( QgsWkbTypes::Type type, double x, double y, double z, double m )
     : mX( x )
     , mY( y )
-    , mZ( z )
-    , mM( m )
+    , mZ( QgsWkbTypes::hasZ( type ) ? z : 0.0 )
+    , mM( QgsWkbTypes::hasM( type ) ? m : 0.0 )
 {
   //protect against non-point WKB types
   Q_ASSERT( QgsWkbTypes::flatType( type ) == QgsWkbTypes::Point );

--- a/src/core/geometry/qgswkbtypes.h
+++ b/src/core/geometry/qgswkbtypes.h
@@ -802,13 +802,18 @@ class CORE_EXPORT QgsWkbTypes
         return Unknown;
       else if ( type == NoGeometry )
         return NoGeometry;
-      else if ( type == Point25D ||
-                type == LineString25D ||
-                type == Polygon25D ||
-                type == MultiPoint25D ||
-                type == MultiLineString25D ||
-                type == MultiPolygon25D )
-        return type; //can't add M dimension to these types
+      else if ( type == Point25D )
+        return PointZM;
+      else if ( type == LineString25D )
+        return LineStringZM;
+      else if ( type == Polygon25D )
+        return PolygonZM;
+      else if ( type == MultiPoint25D )
+        return MultiPointZM;
+      else if ( type == MultiLineString25D )
+        return MultiLineString;
+      else if ( type == MultiPolygon25D )
+        return MultiPolygonZM;
 
       //upgrade with m dimension
       Type flat = flatType( type );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -120,7 +120,7 @@ static QgsCircularString* parseCircularString( const QVariantMap& curveData, Qgs
   QVariantList coordsList = curveData[QStringLiteral( "c" )].toList();
   if ( coordsList.isEmpty() )
     return nullptr;
-  QList<QgsPointV2> points;
+  QgsPointSequence points;
   points.append( startPoint );
   foreach ( const QVariant& coordData, coordsList )
   {

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -2210,7 +2210,7 @@ void TestQgsGeometry::lineString()
 
   //removing the second to last vertex should remove the whole line
   QgsLineString l39;
-  l39.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 1 ) );
+  l39.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 1 ) );
   QVERIFY( l39.numPoints() == 2 );
   l39.deleteVertex( QgsVertexId( 0, 0, 1 ) );
   QVERIFY( l39.numPoints() == 0 );
@@ -2218,7 +2218,7 @@ void TestQgsGeometry::lineString()
   //boundary
   QgsLineString boundary1;
   QVERIFY( !boundary1.boundary() );
-  boundary1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
+  boundary1.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
   QgsAbstractGeometry* boundary = boundary1.boundary();
   QgsMultiPointV2* mpBoundary = dynamic_cast< QgsMultiPointV2* >( boundary );
   QVERIFY( mpBoundary );
@@ -2229,12 +2229,12 @@ void TestQgsGeometry::lineString()
   delete boundary;
 
   // closed string = no boundary
-  boundary1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 0 ) );
+  boundary1.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 0 ) );
   QVERIFY( !boundary1.boundary() );
   \
 
   //boundary with z
-  boundary1.setPoints( QList<QgsPointV2>() << QgsPointV2( QgsWkbTypes::PointZ, 0, 0, 10 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 0, 15 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 1, 20 ) );
+  boundary1.setPoints( QgsPointSequence() << QgsPointV2( QgsWkbTypes::PointZ, 0, 0, 10 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 0, 15 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 1, 20 ) );
   boundary = boundary1.boundary();
   mpBoundary = dynamic_cast< QgsMultiPointV2* >( boundary );
   QVERIFY( mpBoundary );
@@ -2251,7 +2251,7 @@ void TestQgsGeometry::lineString()
   //extend
   QgsLineString extend1;
   extend1.extend( 10, 10 ); //test no crash
-  extend1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
+  extend1.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
   extend1.extend( 1, 2 );
   QCOMPARE( extend1.pointN( 0 ), QgsPointV2( QgsWkbTypes::Point, -1, 0 ) );
   QCOMPARE( extend1.pointN( 1 ), QgsPointV2( QgsWkbTypes::Point, 1, 0 ) );
@@ -2960,7 +2960,7 @@ void TestQgsGeometry::polygon()
   //removing the fourth to last vertex removes the whole ring
   QgsPolygonV2 p20;
   QgsLineString* p20ExteriorRing = new QgsLineString();
-  p20ExteriorRing->setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 0 ) );
+  p20ExteriorRing->setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 0 ) );
   p20.setExteriorRing( p20ExteriorRing );
   QVERIFY( p20.exteriorRing() );
   p20.deleteVertex( QgsVertexId( 0, 0, 2 ) );
@@ -2968,7 +2968,7 @@ void TestQgsGeometry::polygon()
 
   //boundary
   QgsLineString boundary1;
-  boundary1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 )  << QgsPointV2( 0, 0 ) );
+  boundary1.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 )  << QgsPointV2( 0, 0 ) );
   QgsPolygonV2 boundaryPolygon;
   QVERIFY( !boundaryPolygon.boundary() );
 
@@ -2989,9 +2989,9 @@ void TestQgsGeometry::polygon()
 
   // add interior rings
   QgsLineString boundaryRing1;
-  boundaryRing1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.2, 0.1 ) << QgsPointV2( 0.2, 0.2 )  << QgsPointV2( 0.1, 0.1 ) );
+  boundaryRing1.setPoints( QgsPointSequence() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.2, 0.1 ) << QgsPointV2( 0.2, 0.2 )  << QgsPointV2( 0.1, 0.1 ) );
   QgsLineString boundaryRing2;
-  boundaryRing2.setPoints( QList<QgsPointV2>() << QgsPointV2( 0.8, 0.8 ) << QgsPointV2( 0.9, 0.8 ) << QgsPointV2( 0.9, 0.9 )  << QgsPointV2( 0.8, 0.8 ) );
+  boundaryRing2.setPoints( QgsPointSequence() << QgsPointV2( 0.8, 0.8 ) << QgsPointV2( 0.9, 0.8 ) << QgsPointV2( 0.9, 0.9 )  << QgsPointV2( 0.8, 0.8 ) );
   boundaryPolygon.setInteriorRings( QList< QgsCurve* >() << boundaryRing1.clone() << boundaryRing2.clone() );
   boundary = boundaryPolygon.boundary();
   QgsMultiLineString* multiLineBoundary = dynamic_cast< QgsMultiLineString* >( boundary );
@@ -3028,7 +3028,7 @@ void TestQgsGeometry::polygon()
   delete boundary;
 
   //test boundary with z
-  boundary1.setPoints( QList<QgsPointV2>() << QgsPointV2( QgsWkbTypes::PointZ, 0, 0, 10 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 0, 15 )
+  boundary1.setPoints( QgsPointSequence() << QgsPointV2( QgsWkbTypes::PointZ, 0, 0, 10 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 0, 15 )
                        << QgsPointV2( QgsWkbTypes::PointZ, 1, 1, 20 )  << QgsPointV2( QgsWkbTypes::PointZ, 0, 0, 10 ) );
   boundaryPolygon.setExteriorRing( boundary1.clone() );
   boundary = boundaryPolygon.boundary();
@@ -3045,7 +3045,7 @@ void TestQgsGeometry::polygon()
   // point distance to boundary
 
   QgsLineString pd1;
-  pd1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 1 ) << QgsPointV2( 0, 0 ) );
+  pd1.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 1 ) << QgsPointV2( 0, 0 ) );
   QgsPolygonV2 pd;
   // no meaning, but let's not crash
   ( void )pd.pointDistanceToBoundary( 0, 0 );
@@ -3056,7 +3056,7 @@ void TestQgsGeometry::polygon()
   QGSCOMPARENEAR( pd.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
   // with a ring
   QgsLineString pdRing1;
-  pdRing1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.2, 0.1 ) << QgsPointV2( 0.2, 0.6 )  << QgsPointV2( 0.1, 0.6 ) << QgsPointV2( 0.1, 0.1 ) );
+  pdRing1.setPoints( QgsPointSequence() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.2, 0.1 ) << QgsPointV2( 0.2, 0.6 )  << QgsPointV2( 0.1, 0.6 ) << QgsPointV2( 0.1, 0.1 ) );
   pd.setInteriorRings( QList< QgsCurve* >() << pdRing1.clone() );
   QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
   QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0.1, 0.5 ), 0.0, 0.0000000001 );
@@ -3067,7 +3067,7 @@ void TestQgsGeometry::polygon()
 
   // remove interior rings
   QgsLineString removeRingsExt;
-  removeRingsExt.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 )  << QgsPointV2( 0, 0 ) );
+  removeRingsExt.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 )  << QgsPointV2( 0, 0 ) );
   QgsPolygonV2 removeRings1;
   removeRings1.removeInteriorRings();
 
@@ -3077,9 +3077,9 @@ void TestQgsGeometry::polygon()
 
   // add interior rings
   QgsLineString removeRingsRing1;
-  removeRingsRing1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.2, 0.1 ) << QgsPointV2( 0.2, 0.2 )  << QgsPointV2( 0.1, 0.1 ) );
+  removeRingsRing1.setPoints( QgsPointSequence() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.2, 0.1 ) << QgsPointV2( 0.2, 0.2 )  << QgsPointV2( 0.1, 0.1 ) );
   QgsLineString removeRingsRing2;
-  removeRingsRing1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0.6, 0.8 ) << QgsPointV2( 0.9, 0.8 ) << QgsPointV2( 0.9, 0.9 )  << QgsPointV2( 0.6, 0.8 ) );
+  removeRingsRing1.setPoints( QgsPointSequence() << QgsPointV2( 0.6, 0.8 ) << QgsPointV2( 0.9, 0.8 ) << QgsPointV2( 0.9, 0.9 )  << QgsPointV2( 0.6, 0.8 ) );
   removeRings1.setInteriorRings( QList< QgsCurve* >() << removeRingsRing1.clone() << removeRingsRing2.clone() );
 
   // remove ring with size filter
@@ -3117,7 +3117,7 @@ void TestQgsGeometry::multiLineString()
   QgsMultiLineString multiLine1;
   QVERIFY( !multiLine1.boundary() );
   QgsLineString boundaryLine1;
-  boundaryLine1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
+  boundaryLine1.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
   multiLine1.addGeometry( boundaryLine1.clone() );
   QgsAbstractGeometry* boundary = multiLine1.boundary();
   QgsMultiPointV2* mpBoundary = dynamic_cast< QgsMultiPointV2* >( boundary );
@@ -3130,7 +3130,7 @@ void TestQgsGeometry::multiLineString()
   delete boundary;
   // add another linestring
   QgsLineString boundaryLine2;
-  boundaryLine2.setPoints( QList<QgsPointV2>() << QgsPointV2( 10, 10 ) << QgsPointV2( 11, 10 ) << QgsPointV2( 11, 11 ) );
+  boundaryLine2.setPoints( QgsPointSequence() << QgsPointV2( 10, 10 ) << QgsPointV2( 11, 10 ) << QgsPointV2( 11, 11 ) );
   multiLine1.addGeometry( boundaryLine2.clone() );
   boundary = multiLine1.boundary();
   mpBoundary = dynamic_cast< QgsMultiPointV2* >( boundary );
@@ -3148,7 +3148,7 @@ void TestQgsGeometry::multiLineString()
 
   // add a closed string = no boundary
   QgsLineString boundaryLine3;
-  boundaryLine3.setPoints( QList<QgsPointV2>() << QgsPointV2( 20, 20 ) << QgsPointV2( 21, 20 ) << QgsPointV2( 21, 21 ) << QgsPointV2( 20, 20 ) );
+  boundaryLine3.setPoints( QgsPointSequence() << QgsPointV2( 20, 20 ) << QgsPointV2( 21, 20 ) << QgsPointV2( 21, 21 ) << QgsPointV2( 20, 20 ) );
   multiLine1.addGeometry( boundaryLine3.clone() );
   boundary = multiLine1.boundary();
   mpBoundary = dynamic_cast< QgsMultiPointV2* >( boundary );
@@ -3166,9 +3166,9 @@ void TestQgsGeometry::multiLineString()
 
   //boundary with z
   QgsLineString boundaryLine4;
-  boundaryLine4.setPoints( QList<QgsPointV2>() << QgsPointV2( QgsWkbTypes::PointZ, 0, 0, 10 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 0, 15 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 1, 20 ) );
+  boundaryLine4.setPoints( QgsPointSequence() << QgsPointV2( QgsWkbTypes::PointZ, 0, 0, 10 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 0, 15 ) << QgsPointV2( QgsWkbTypes::PointZ, 1, 1, 20 ) );
   QgsLineString boundaryLine5;
-  boundaryLine5.setPoints( QList<QgsPointV2>() << QgsPointV2( QgsWkbTypes::PointZ, 10, 10, 100 ) << QgsPointV2( QgsWkbTypes::PointZ, 10, 20, 150 ) << QgsPointV2( QgsWkbTypes::PointZ, 20, 20, 200 ) );
+  boundaryLine5.setPoints( QgsPointSequence() << QgsPointV2( QgsWkbTypes::PointZ, 10, 10, 100 ) << QgsPointV2( QgsWkbTypes::PointZ, 10, 20, 150 ) << QgsPointV2( QgsWkbTypes::PointZ, 20, 20, 200 ) );
   QgsMultiLineString multiLine2;
   multiLine2.addGeometry( boundaryLine4.clone() );
   multiLine2.addGeometry( boundaryLine5.clone() );
@@ -3202,7 +3202,7 @@ void TestQgsGeometry::multiPolygon()
   QVERIFY( !multiPolygon1.boundary() );
 
   QgsLineString ring1;
-  ring1.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 )  << QgsPointV2( 0, 0 ) );
+  ring1.setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 )  << QgsPointV2( 0, 0 ) );
   QgsPolygonV2 polygon1;
   polygon1.setExteriorRing( ring1.clone() );
   multiPolygon1.addGeometry( polygon1.clone() );
@@ -3224,13 +3224,13 @@ void TestQgsGeometry::multiPolygon()
 
   // add polygon with interior rings
   QgsLineString ring2;
-  ring2.setPoints( QList<QgsPointV2>() << QgsPointV2( 10, 10 ) << QgsPointV2( 11, 10 ) << QgsPointV2( 11, 11 )  << QgsPointV2( 10, 10 ) );
+  ring2.setPoints( QgsPointSequence() << QgsPointV2( 10, 10 ) << QgsPointV2( 11, 10 ) << QgsPointV2( 11, 11 )  << QgsPointV2( 10, 10 ) );
   QgsPolygonV2 polygon2;
   polygon2.setExteriorRing( ring2.clone() );
   QgsLineString boundaryRing1;
-  boundaryRing1.setPoints( QList<QgsPointV2>() << QgsPointV2( 10.1, 10.1 ) << QgsPointV2( 10.2, 10.1 ) << QgsPointV2( 10.2, 10.2 )  << QgsPointV2( 10.1, 10.1 ) );
+  boundaryRing1.setPoints( QgsPointSequence() << QgsPointV2( 10.1, 10.1 ) << QgsPointV2( 10.2, 10.1 ) << QgsPointV2( 10.2, 10.2 )  << QgsPointV2( 10.1, 10.1 ) );
   QgsLineString boundaryRing2;
-  boundaryRing2.setPoints( QList<QgsPointV2>() << QgsPointV2( 10.8, 10.8 ) << QgsPointV2( 10.9, 10.8 ) << QgsPointV2( 10.9, 10.9 )  << QgsPointV2( 10.8, 10.8 ) );
+  boundaryRing2.setPoints( QgsPointSequence() << QgsPointV2( 10.8, 10.8 ) << QgsPointV2( 10.9, 10.8 ) << QgsPointV2( 10.9, 10.9 )  << QgsPointV2( 10.8, 10.8 ) );
   polygon2.setInteriorRings( QList< QgsCurve* >() << boundaryRing1.clone() << boundaryRing2.clone() );
   multiPolygon1.addGeometry( polygon2.clone() );
 
@@ -3287,7 +3287,7 @@ void TestQgsGeometry::geometryCollection()
   QVERIFY( !boundaryCollection.boundary() );
   // add a geometry and retest, should still be undefined
   QgsLineString* lineBoundary = new QgsLineString();
-  lineBoundary->setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) );
+  lineBoundary->setPoints( QgsPointSequence() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) );
   boundaryCollection.addGeometry( lineBoundary );
   QVERIFY( !boundaryCollection.boundary() );
 }

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -57,17 +57,17 @@ class TestQgsGeometryUtils: public QObject
 void TestQgsGeometryUtils::testExtractLinestrings()
 {
   QgsLineString* outerRing1 = new QgsLineString();
-  outerRing1->setPoints( QList<QgsPointV2>() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
+  outerRing1->setPoints( QgsPointSequence() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
   QgsPolygonV2* polygon1 = new QgsPolygonV2();
   polygon1->setExteriorRing( outerRing1 );
 
   QgsLineString* outerRing2 = new QgsLineString();
-  outerRing2->setPoints( QList<QgsPointV2>() << QgsPointV2( 10, 10 ) << QgsPointV2( 10, 20 ) << QgsPointV2( 20, 20 ) << QgsPointV2( 20, 10 ) << QgsPointV2( 10, 10 ) );
+  outerRing2->setPoints( QgsPointSequence() << QgsPointV2( 10, 10 ) << QgsPointV2( 10, 20 ) << QgsPointV2( 20, 20 ) << QgsPointV2( 20, 10 ) << QgsPointV2( 10, 10 ) );
   QgsPolygonV2* polygon2 = new QgsPolygonV2();
   polygon2->setExteriorRing( outerRing2 );
 
   QgsLineString* innerRing2 = new QgsLineString();
-  innerRing2->setPoints( QList<QgsPointV2>() << QgsPointV2( 14, 14 ) << QgsPointV2( 14, 16 ) << QgsPointV2( 16, 16 ) << QgsPointV2( 16, 14 ) << QgsPointV2( 14, 14 ) );
+  innerRing2->setPoints( QgsPointSequence() << QgsPointV2( 14, 14 ) << QgsPointV2( 14, 16 ) << QgsPointV2( 16, 16 ) << QgsPointV2( 16, 14 ) << QgsPointV2( 14, 14 ) );
   polygon2->setInteriorRings( QList<QgsCurve*>() << innerRing2 );
 
   QgsMultiPolygonV2 mpg;
@@ -342,7 +342,7 @@ void TestQgsGeometryUtils::testAdjacentVertices()
 {
   // test polygon - should wrap around!
   QgsLineString* closedRing1 = new QgsLineString();
-  closedRing1->setPoints( QList<QgsPointV2>() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
+  closedRing1->setPoints( QgsPointSequence() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
   QgsPolygonV2 polygon1;
   polygon1.setExteriorRing( closedRing1 );
   QgsVertexId previous;
@@ -363,7 +363,7 @@ void TestQgsGeometryUtils::testDistanceToVertex()
 {
   //test with linestring
   QgsLineString* outerRing1 = new QgsLineString();
-  outerRing1->setPoints( QList<QgsPointV2>() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
+  outerRing1->setPoints( QgsPointSequence() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
   QCOMPARE( QgsGeometryUtils::distanceToVertex( *outerRing1, QgsVertexId( 0, 0, 0 ) ), 0.0 );
   QCOMPARE( QgsGeometryUtils::distanceToVertex( *outerRing1, QgsVertexId( 0, 0, 1 ) ), 1.0 );
   QCOMPARE( QgsGeometryUtils::distanceToVertex( *outerRing1, QgsVertexId( 0, 0, 2 ) ), 2.0 );
@@ -397,7 +397,7 @@ void TestQgsGeometryUtils::testVerticesAtDistance()
   QgsVertexId next;
   QVERIFY( !QgsGeometryUtils::verticesAtDistance( *outerRing1, .5, previous, next ) );
 
-  outerRing1->setPoints( QList<QgsPointV2>() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 3, 1 ) );
+  outerRing1->setPoints( QgsPointSequence() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 3, 1 ) );
   QVERIFY( QgsGeometryUtils::verticesAtDistance( *outerRing1, .5, previous, next ) );
   QCOMPARE( previous, QgsVertexId( 0, 0, 0 ) );
   QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
@@ -431,7 +431,7 @@ void TestQgsGeometryUtils::testVerticesAtDistance()
 
   // test closed line
   QgsLineString* closedRing1 = new QgsLineString();
-  closedRing1->setPoints( QList<QgsPointV2>() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
+  closedRing1->setPoints( QgsPointSequence() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 1 ) );
   QVERIFY( QgsGeometryUtils::verticesAtDistance( *closedRing1, 0, previous, next ) );
   QCOMPARE( previous, QgsVertexId( 0, 0, 0 ) );
   QCOMPARE( next, QgsVertexId( 0, 0, 0 ) );


### PR DESCRIPTION
I'm not sure on this one... so I'm opening it up for discussion.

Here's the situation:
- currently QgsLineString stores x/y/z/m in 4 separate lists of doubles. For 2d linestrings the z/m lists are empty, saving the memory required and speeding up copies of lines. QgsPointV2 objects are created on demand using the values from these lists
- but... this comes at a cost of some code complexity and also slows some operations as points are created on demand, rather than in advance. Up till now I've thought that the memory saving is more valuable then this complexity.
- HOWEVER.. I'd really like to clean up how nodes are accessed in the new geometry classes. Currently much of qgis uses QgsGeometry.asPolygon()/asPolyline() which creates a new list of QgsPoint (not QgsPointV2) objects for the caller to iterate through. This sucks, because it requires lots of copies and creation of new lists and new QgsPoints, and also drops the z/m values. Instead I'd like to add iterators to the geometry classes so that nodes can be iterated through in place, without all this extra copying and translation and chucking z/m values in the bin. You *can* do this currently if you work with the abstract geometry classes themselves, but the api is really tricky and cumbersome and almost no-one does it as a result.
- The issue that this introduces is that it's not possible to iterate over the points in a linestring, because they don't actually exist and are only created on demand. An iterator requires access to reference/pointers to the current value and since this value (QgsPointV2) is just a temporary object this is not possible.
- So as a result I'd like to change QgsLineString (and by extension, QgsPolygonV2) to instead store nodes as a list of QgsPointV2. This makes creating a node iterator trivial.
- I don't believe the extra cost of copying z/m values will be an issue, since this would only be incurred when nodes themselves are inserted/moved/deleted, as otherwise all copies will just be copying the implicitly shared qlist of points. Ie... no extra cost until this list is detached. These detachments won't occur often enough to be an issue.
- The bigger issue is the memory requirements, as it means that 2d lines/polygons will almost double their memory usage.

And that's where I get stuck. Is this extra memory use a problem when it limits the api and results in more inefficient use of these classes? Feedback/suggestions welcome...

(Btw - this PR should not be merged as is. Consider it a proof of concept).
