### PR TITLE
Raster renderer UI improvements

### DIFF
--- a/src/gui/raster/qgspalettedrendererwidget.h
+++ b/src/gui/raster/qgspalettedrendererwidget.h
@@ -31,6 +31,7 @@ class GUI_EXPORT QgsPalettedRendererWidget: public QgsRasterRendererWidget, priv
     Q_OBJECT
 
   public:
+
     QgsPalettedRendererWidget( QgsRasterLayer* layer, const QgsRectangle &extent = QgsRectangle() );
     static QgsRasterRendererWidget* create( QgsRasterLayer* layer, const QgsRectangle &theExtent ) { return new QgsPalettedRendererWidget( layer, theExtent ); }
     ~QgsPalettedRendererWidget();
@@ -39,9 +40,22 @@ class GUI_EXPORT QgsPalettedRendererWidget: public QgsRasterRendererWidget, priv
 
     void setFromRenderer( const QgsRasterRenderer* r );
 
+  private:
+
+    enum Column
+    {
+      ValueColumn = 0,
+      ColorColumn = 1,
+      LabelColumn = 2,
+    };
+
+    QMenu* contextMenu;
+
   private slots:
+
     void on_mTreeWidget_itemDoubleClicked( QTreeWidgetItem * item, int column );
     void on_mTreeWidget_itemChanged( QTreeWidgetItem * item, int column );
+    void changeColor();
 };
 
 #endif // QGSPALETTEDRENDERERWIDGET_H

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -315,10 +315,16 @@ void QgsSingleBandPseudoColorRendererWidget::on_mAddEntryButton_clicked()
 
 void QgsSingleBandPseudoColorRendererWidget::on_mDeleteEntryButton_clicked()
 {
-  QTreeWidgetItem* currentItem = mColormapTreeWidget->currentItem();
-  if ( currentItem )
+  QList<QTreeWidgetItem *> itemList;
+  itemList = mColormapTreeWidget->selectedItems();
+  if ( itemList.isEmpty() )
   {
-    delete currentItem;
+    return;
+  }
+
+  Q_FOREACH ( QTreeWidgetItem *item, itemList )
+  {
+    delete item;
   }
   emit widgetChanged();
 }

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -29,11 +29,15 @@
 #include "qgscolorrampbutton.h"
 #include "qgscolordialog.h"
 
+#include <QCursor>
 #include <QPushButton>
+#include <QInputDialog>
 #include <QFileDialog>
+#include <QMenu>
 #include <QMessageBox>
 #include <QSettings>
 #include <QTextStream>
+#include <QTreeView>
 
 QgsSingleBandPseudoColorRendererWidget::QgsSingleBandPseudoColorRendererWidget( QgsRasterLayer* layer, const QgsRectangle &extent )
     : QgsRasterRendererWidget( layer, extent )
@@ -44,7 +48,15 @@ QgsSingleBandPseudoColorRendererWidget::QgsSingleBandPseudoColorRendererWidget( 
 
   setupUi( this );
 
+  contextMenu = new QMenu( tr( "Options" ), this );
+  contextMenu->addAction( tr( "Change color" ), this, SLOT( changeColor() ) );
+  contextMenu->addAction( tr( "Change transparency" ), this, SLOT( changeTransparency() ) );
+
   mColormapTreeWidget->setColumnWidth( ColorColumn, 50 );
+  mColormapTreeWidget->setContextMenuPolicy( Qt::CustomContextMenu );
+  mColormapTreeWidget->setSelectionMode( QAbstractItemView::ExtendedSelection );
+  connect( mColormapTreeWidget, &QTreeView::customContextMenuRequested,  [=]( const QPoint& ) { contextMenu->exec( QCursor::pos() ); }
+         );
 
   QString defaultPalette = settings.value( QStringLiteral( "/Raster/defaultPalette" ), "" ).toString();
   btnColorRamp->setColorRampFromName( defaultPalette );
@@ -775,6 +787,7 @@ void QgsSingleBandPseudoColorRendererWidget::mColormapTreeWidget_itemEdited( QTr
   {
     // call autoLabel to fill when empty or gray out when same as autoLabel
     autoLabel();
+    emit widgetChanged();
   }
 }
 
@@ -926,5 +939,53 @@ void QgsSingleBandPseudoColorRendererWidget::resetClassifyButton()
   if ( qIsNaN( min ) || qIsNaN( max ) || min >= max )
   {
     mClassifyButton->setEnabled( false );
+  }
+}
+
+void QgsSingleBandPseudoColorRendererWidget::changeColor()
+{
+  QList<QTreeWidgetItem *> itemList;
+  itemList = mColormapTreeWidget->selectedItems();
+  if ( itemList.isEmpty() )
+  {
+    return;
+  }
+  QTreeWidgetItem* firstItem = itemList.first();
+
+  QColor newColor = QgsColorDialog::getColor( firstItem->background( ColorColumn ).color(), this, QStringLiteral( "Change color" ), true );
+  if ( newColor.isValid() )
+  {
+    Q_FOREACH ( QTreeWidgetItem *item, itemList )
+    {
+      item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
+      item->setBackground( ColorColumn, QBrush( newColor ) );
+    }
+    emit widgetChanged();
+  }
+}
+
+void QgsSingleBandPseudoColorRendererWidget::changeTransparency()
+{
+  QList<QTreeWidgetItem *> itemList;
+  itemList = mColormapTreeWidget->selectedItems();
+  if ( itemList.isEmpty() )
+  {
+    return;
+  }
+  QTreeWidgetItem* firstItem = itemList.first();
+
+  bool ok;
+  double oldTransparency = firstItem->background( ColorColumn ).color().alpha() / 255 * 100;
+  double transparency = QInputDialog::getDouble( this, tr( "Transparency" ), tr( "Change symbol transparency [%]" ), oldTransparency, 0.0, 100.0, 0, &ok );
+  if ( ok )
+  {
+    int newTransparency = transparency / 100 * 255;
+    Q_FOREACH ( QTreeWidgetItem *item, itemList )
+    {
+      QColor newColor = item->background( ColorColumn ).color();
+      newColor.setAlpha( newTransparency );
+      item->setBackground( ColorColumn, QBrush( newColor ) );
+    }
+    emit widgetChanged();
   }
 }

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -72,6 +72,8 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void autoLabel();
     void setUnitFromLabels();
 
+    QMenu* contextMenu;
+
   private slots:
 
     void applyColorRamp();
@@ -90,6 +92,8 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void on_mMinLineEdit_textEdited( const QString & text ) { Q_UNUSED( text ); mMinMaxOrigin = QgsRasterRenderer::MinMaxUser; showMinMaxOrigin(); }
     void on_mMaxLineEdit_textEdited( const QString & text ) { Q_UNUSED( text ); mMinMaxOrigin = QgsRasterRenderer::MinMaxUser; showMinMaxOrigin(); }
     void on_mClassificationModeComboBox_currentIndexChanged( int index );
+    void changeColor();
+    void changeTransparency();
 
   private:
 

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -127,7 +127,7 @@
      <item>
       <widget class="QPushButton" name="mDeleteEntryButton">
        <property name="toolTip">
-        <string>Remove selected row</string>
+        <string>Remove selected row(s)</string>
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
This PR adds a right-click menu for the singleband pseudo-color renderer and the paletted tree view widgets to modify the color and transparency of multiple items in a single shot:
![untitled](https://cloud.githubusercontent.com/assets/1728657/21040713/220811fa-be19-11e6-8374-68ac618400a3.png)

In addition, users can now delete multiple rows.