### PR TITLE
[FEATURE][raster] transparency support for paletted renderer

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1246,6 +1246,11 @@ has improved sort capabilities including the ability to set custom sort values f
 and for forcing certain items to always sort on top.
 
 
+QgsPalettedRasterRenderer        {#qgis_api_break_3_0_QgsPalettedRasterRenderer}
+-------------------------
+
+- The rgbArray() method was made private
+
 QgsPalLabeling        {#qgis_api_break_3_0_QgsPalLabeling}
 --------------
 

--- a/python/core/raster/qgspalettedrasterrenderer.sip
+++ b/python/core/raster/qgspalettedrasterrenderer.sip
@@ -17,11 +17,6 @@ class QgsPalettedRasterRenderer : QgsRasterRenderer
     /** Returns copy of color array (caller takes ownership)*/
     QColor* colors() const /Factory/;
 
-    /** Returns copy of rgb array (caller takes ownership)
-     @note not available in python bindings
-     */
-    // QRgb* rgbArray() const;
-
     /** Return optional category label
      *  @note added in 2.1 */
     QString label( int idx ) const;

--- a/src/core/raster/qgspalettedrasterrenderer.h
+++ b/src/core/raster/qgspalettedrasterrenderer.h
@@ -31,6 +31,7 @@ class QDomElement;
 class CORE_EXPORT QgsPalettedRasterRenderer: public QgsRasterRenderer
 {
   public:
+
     //! Renderer owns color array
     QgsPalettedRasterRenderer( QgsRasterInterface* input, int bandNumber, QColor* colorArray, int nColors, const QVector<QString>& labels = QVector<QString>() );
     QgsPalettedRasterRenderer( QgsRasterInterface* input, int bandNumber, QRgb* colorArray, int nColors, const QVector<QString>& labels = QVector<QString>() );
@@ -44,11 +45,6 @@ class CORE_EXPORT QgsPalettedRasterRenderer: public QgsRasterRenderer
     int nColors() const { return mNColors; }
     //! Returns copy of color array (caller takes ownership)
     QColor* colors() const;
-
-    /** Returns copy of rgb array (caller takes ownership)
-     @note not available in python bindings
-     */
-    QRgb* rgbArray() const;
 
     /** Return optional category label
      *  @note added in 2.1 */
@@ -65,8 +61,13 @@ class CORE_EXPORT QgsPalettedRasterRenderer: public QgsRasterRenderer
     QList<int> usesBands() const override;
 
   private:
+
+    /** Returns copy of premultiplied rgb array (caller takes ownership)
+     */
+    QRgb* rgbArray() const;
+
     int mBand;
-    //! Color array
+    //! Premultiplied color array
     QRgb* mColors;
     //! Number of colors
     int mNColors;

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -31,6 +31,7 @@ QgsPalettedRendererWidget::QgsPalettedRendererWidget( QgsRasterLayer* layer, con
 
   contextMenu = new QMenu( tr( "Options" ), this );
   contextMenu->addAction( tr( "Change color" ), this, SLOT( changeColor() ) );
+  contextMenu->addAction( tr( "Change transparency" ), this, SLOT( changeTransparency() ) );
 
   mTreeWidget->setColumnWidth( ColorColumn, 50 );
   mTreeWidget->setContextMenuPolicy( Qt::CustomContextMenu );
@@ -87,7 +88,7 @@ void QgsPalettedRendererWidget::on_mTreeWidget_itemDoubleClicked( QTreeWidgetIte
   if ( column == ColorColumn && item ) //change item color
   {
     item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    QColor c = QgsColorDialog::getColor( item->background( column ).color(), nullptr );
+    QColor c = QgsColorDialog::getColor( item->background( column ).color(), this, QStringLiteral( "Change color" ), true );
     if ( c.isValid() )
     {
       item->setBackground( column, QBrush( c ) );
@@ -162,6 +163,32 @@ void QgsPalettedRendererWidget::changeColor()
     Q_FOREACH ( QTreeWidgetItem *item, itemList )
     {
       item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
+      item->setBackground( ColorColumn, QBrush( newColor ) );
+    }
+    emit widgetChanged();
+  }
+}
+
+void QgsPalettedRendererWidget::changeTransparency()
+{
+  QList<QTreeWidgetItem *> itemList;
+  itemList = mTreeWidget->selectedItems();
+  if ( itemList.isEmpty() )
+  {
+    return;
+  }
+  QTreeWidgetItem* firstItem = itemList.first();
+
+  bool ok;
+  double oldTransparency = ( firstItem->background( ColorColumn ).color().alpha() / 255.0 ) * 100.0;
+  double transparency = QInputDialog::getDouble( this, tr( "Transparency" ), tr( "Change color transparency [%]" ), oldTransparency, 0.0, 100.0, 0, &ok );
+  if ( ok )
+  {
+    int newTransparency = transparency / 100 * 255;
+    Q_FOREACH ( QTreeWidgetItem *item, itemList )
+    {
+      QColor newColor = item->background( ColorColumn ).color();
+      newColor.setAlpha( newTransparency );
       item->setBackground( ColorColumn, QBrush( newColor ) );
     }
     emit widgetChanged();

--- a/src/gui/raster/qgspalettedrendererwidget.h
+++ b/src/gui/raster/qgspalettedrendererwidget.h
@@ -56,6 +56,7 @@ class GUI_EXPORT QgsPalettedRendererWidget: public QgsRasterRendererWidget, priv
     void on_mTreeWidget_itemDoubleClicked( QTreeWidgetItem * item, int column );
     void on_mTreeWidget_itemChanged( QTreeWidgetItem * item, int column );
     void changeColor();
+    void changeTransparency();
 };
 
 #endif // QGSPALETTEDRENDERERWIDGET_H

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -982,7 +982,7 @@ void QgsSingleBandPseudoColorRendererWidget::changeTransparency()
 
   bool ok;
   double oldTransparency = firstItem->background( ColorColumn ).color().alpha() / 255 * 100;
-  double transparency = QInputDialog::getDouble( this, tr( "Transparency" ), tr( "Change symbol transparency [%]" ), oldTransparency, 0.0, 100.0, 0, &ok );
+  double transparency = QInputDialog::getDouble( this, tr( "Transparency" ), tr( "Change color transparency [%]" ), oldTransparency, 0.0, 100.0, 0, &ok );
   if ( ok )
   {
     int newTransparency = transparency / 100 * 255;


### PR DESCRIPTION
This PR adds transparency support for the paletted renderer. We shouldn't leave 2016 without having transparency support for all of our raster renderers ;)
![untitled](https://cloud.githubusercontent.com/assets/1728657/21071016/00927cd8-bec6-11e6-9720-8d6103ac665b.png)

It's quite useful to be able to play with transparency value for paletted rasters. For e.g., in the screenshot above, I've loaded a recently released global surface water transition raster, and was able to quickly disable the categories I'm not interested in (namely non-water) by switching the transparency to 0. That way, I can easily show an underlying base map to accompany the raster.

_Note: I realize the custom transparency option can achieve the same result. Let's give people freedom ;)_