### PR TITLE
[SERVER][BUGFIX] Plugin re enable

### DIFF
--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -39,6 +39,9 @@ int main( int argc, char * argv[] )
 {
   QgsApplication app( argc, argv, getenv( "DISPLAY" ), QString(), QStringLiteral( "server" ) );
   QgsServer server( false );
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+  server.initPython();
+#endif
   // Starts FCGI loop
   while ( fcgi_accept() >= 0 )
   {

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -64,7 +64,6 @@ QgsCapabilitiesCache* QgsServer::sCapabilitiesCache = nullptr;
 QgsMapRenderer* QgsServer::sMapRenderer = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 QgsServerInterfaceImpl*QgsServer::sServerInterface = nullptr;
-bool QgsServer::sInitPython = true;
 #endif
 // Initialization must run once for all servers
 bool QgsServer::sInitialised =  false;
@@ -316,10 +315,6 @@ bool QgsServer::init( )
     return false;
   }
 
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
-  sInitPython = false;
-#endif
-
   QgsServerLogger::instance();
 
 #ifndef _MSC_VER
@@ -398,27 +393,13 @@ bool QgsServer::init( )
   QgsFontUtils::loadStandardTestFonts( QStringList() << QStringLiteral( "Roman" ) << QStringLiteral( "Bold" ) );
 #endif
 
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
-  sServerInterface = new QgsServerInterfaceImpl( sCapabilitiesCache );
-  if ( sInitPython )
-  {
-    // Init plugins
-    if ( ! QgsServerPlugins::initPlugins( sServerInterface ) )
-    {
-      QgsMessageLog::logMessage( QStringLiteral( "No server python plugins are available" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-    }
-    else
-    {
-      QgsMessageLog::logMessage( QStringLiteral( "Server python plugins loaded" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-    }
-  }
-#endif
-
   QgsEditorWidgetRegistry::initEditors();
   sInitialised = true;
   QgsMessageLog::logMessage( QStringLiteral( "Server initialized" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
   return true;
 }
+
+
 
 void QgsServer::putenv( const QString &var, const QString &val )
 {
@@ -644,6 +625,24 @@ QPair<QByteArray, QByteArray> QgsServer::handleRequest( const QString& queryStri
   // Returns the header and response bytestreams (to be used in Python bindings)
   return theRequestHandler->getResponse();
 }
+
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+void QgsServer::initPython()
+{
+  /*
+  sServerInterface = new QgsServerInterfaceImpl( sCapabilitiesCache );
+    // Init plugins
+  if ( ! QgsServerPlugins::initPlugins( sServerInterface ) )
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "No server python plugins are available" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  else
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "Server python plugins loaded" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  */
+}
+#endif
 
 #if 0
 // The following code was used to test type conversion in python bindings

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -394,6 +394,11 @@ bool QgsServer::init( )
 #endif
 
   QgsEditorWidgetRegistry::initEditors();
+
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+  sServerInterface = new QgsServerInterfaceImpl( sCapabilitiesCache );
+#endif
+
   sInitialised = true;
   QgsMessageLog::logMessage( QStringLiteral( "Server initialized" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
   return true;
@@ -629,9 +634,7 @@ QPair<QByteArray, QByteArray> QgsServer::handleRequest( const QString& queryStri
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 void QgsServer::initPython()
 {
-  /*
-  sServerInterface = new QgsServerInterfaceImpl( sCapabilitiesCache );
-    // Init plugins
+  // Init plugins
   if ( ! QgsServerPlugins::initPlugins( sServerInterface ) )
   {
     QgsMessageLog::logMessage( QStringLiteral( "No server python plugins are available" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
@@ -640,7 +643,6 @@ void QgsServer::initPython()
   {
     QgsMessageLog::logMessage( QStringLiteral( "Server python plugins loaded" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
   }
-  */
 }
 #endif
 

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -78,9 +78,13 @@ class SERVER_EXPORT QgsServer
     QPair<QByteArray, QByteArray> testQPair( QPair<QByteArray, QByteArray> pair );
 #endif
 
-    //! Returns a pointer to the server interface
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
+    //! Returns a pointer to the server interface
     QgsServerInterfaceImpl* serverInterface() { return sServerInterface; }
+
+    //! Intialize python
+    //! Note: not in python bindings
+    void initPython( );
 #endif
 
   private:
@@ -120,7 +124,6 @@ class SERVER_EXPORT QgsServer
     static QgsMapRenderer* sMapRenderer;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     static QgsServerInterfaceImpl* sServerInterface;
-    static bool sInitPython;
 #endif
     //! Initialization must run once for all servers
     static bool sInitialised;


### PR DESCRIPTION
Re-enable plugins when running in (F)CGI mode, also makes python activation explicit because since when I removed the ctor overload there is no way from the code to know if the server has been created from within Python or from C++.