### PR TITLE
Initial exploration for porting processing params to c++

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -78,6 +78,9 @@ SET(QGIS_CORE_SRCS
   auth/qgsauthmethodmetadata.cpp
   auth/qgsauthmethodregistry.cpp
 
+  processing/qgsprocessingparameterregistry.cpp
+  processing/qgsprocessingparameters.cpp
+
   qgis.cpp
   qgsapplication.cpp
   qgsaction.cpp
@@ -781,6 +784,9 @@ SET(QGIS_CORE_HDRS
   composer/qgsscalebarstyle.h
   composer/qgssingleboxscalebarstyle.h
   composer/qgsticksscalebarstyle.h
+
+  processing/qgsprocessingparameters.h
+  processing/qgsprocessingparameterregistry.h
 
   raster/qgsbilinearrasterresampler.h
   raster/qgsbrightnesscontrastfilter.h

--- a/src/core/processing/qgsprocessingparameterregistry.cpp
+++ b/src/core/processing/qgsprocessingparameterregistry.cpp
@@ -1,0 +1,103 @@
+/***************************************************************************
+                         qgsprocessingparameterregistry.cpp
+                         ----------------------------------
+    begin                : December 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingparameterregistry.h"
+#include "qgsprocessingparameters.h"
+#include <QRegularExpression>
+
+
+QgsProcessingParameterRegistry::QgsProcessingParameterRegistry()
+{
+  addParameterType( new QgsProcessingParameterMetadata( QStringLiteral( "boolean" ), QgsProcessingParameterBoolean::createFromScriptCode, nullptr ) );
+}
+
+QgsProcessingParameterRegistry::~QgsProcessingParameterRegistry()
+{
+  qDeleteAll( mMetadata );
+}
+
+bool QgsProcessingParameterRegistry::parseScriptCodeParameterOptions( const QString& code, bool& isOptional, QString& name, QString& type, QString& definition )
+{
+  QRegularExpression re( "(.*?)=\\s*(.*)" );
+  QRegularExpressionMatch m = re.match( code );
+  if ( !m.hasMatch() )
+    return false;
+
+  name = m.captured( 1 );
+  QString tokens = m.captured( 2 );
+  if ( tokens.toLower().startsWith( QStringLiteral( "optional" ) ) )
+  {
+    isOptional = true;
+    tokens.remove( 0, 8 ); // length "optional" = 8
+  }
+  else
+  {
+    isOptional = false;
+  }
+
+  QRegularExpression re2( "(.*?)\\s*(.*)" );
+  m = re2.match( tokens );
+  if ( !m.hasMatch() )
+  {
+    type = tokens;
+    definition.clear();
+  }
+  else
+  {
+    type = m.captured( 1 );
+    definition = m.captured( 2 );
+  }
+  return true;
+}
+
+QgsProcessingParameterAbstractMetadata*QgsProcessingParameterRegistry::parameterMetadata( const QString& type ) const
+{
+  return mMetadata.value( type );
+}
+
+bool QgsProcessingParameterRegistry::addParameterType( QgsProcessingParameterAbstractMetadata* metadata )
+{
+  if ( !metadata || mMetadata.contains( metadata->type() ) )
+    return false;
+
+  mMetadata[metadata->type()] = metadata;
+  return true;
+}
+
+QgsProcessingParameter* QgsProcessingParameterRegistry::createFromScriptCode( const QString& code ) const
+{
+  bool isOptional = false;
+  QString name;
+  QString definition;
+  QString type;
+  if ( !parseScriptCodeParameterOptions( code, isOptional, name, type, definition ) )
+    return nullptr;
+
+  if ( !mMetadata.contains( type ) )
+    return nullptr;
+
+  QString description = createDescription( name );
+
+  return mMetadata[type]->createParameterFromScriptCode( name, description, isOptional, definition );
+}
+
+QString QgsProcessingParameterRegistry::createDescription( const QString& name )
+{
+  QString desc = name;
+  return desc.replace( '_', ' ' );
+}
+

--- a/src/core/processing/qgsprocessingparameterregistry.h
+++ b/src/core/processing/qgsprocessingparameterregistry.h
@@ -1,0 +1,168 @@
+/***************************************************************************
+                         qgsprocessingparameterregistry.h
+                         -------------------------------
+    begin                : December 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGPARAMETERREGISTRY_H
+#define QGSPROCESSINGPARAMETERREGISTRY_H
+
+#include <QString>
+#include <QMap>
+
+class QWidget;
+class QgsProcessingParameter;
+
+/**
+ * \class QgsProcessingParameterAbstractMetadata
+ * \ingroup core
+ * Stores metadata about one processing parameter class.
+ * \note In C++ you can use QgsProcessingParameterMetadata convenience class.
+ * \note added in QGIS 3.0
+ */
+class CORE_EXPORT QgsProcessingParameterAbstractMetadata
+{
+  public:
+
+    /**
+     * Constructor for parameter abstract metadata. The type parameter must be unique.
+     */
+    QgsProcessingParameterAbstractMetadata( const QString& type )
+        : mType( type )
+    {}
+
+    virtual ~QgsProcessingParameterAbstractMetadata() {}
+
+    /**
+     * Returns the unique type string which identifies the parameter type.
+     */
+    QString type() const { return mType; }
+
+    /**
+     * Creates a new parameter of this type from an encoded script code line. The name, description and optional flag will have already
+     * been parsed when this function is called, so only any extra handling of the remaining definition string needs to be done by the class.
+     */
+    virtual QgsProcessingParameter* createParameterFromScriptCode( const QString& name, const QString& description, bool isOptional, const QString& definition )
+    {
+      Q_UNUSED( definition );
+      Q_UNUSED( description );
+      Q_UNUSED( name );
+      Q_UNUSED( isOptional );
+      return nullptr;
+    }
+
+    virtual QWidget* createWidget() { return nullptr; }
+
+  protected:
+    QString mType;
+};
+
+//! Function to create a widget for the parameter
+typedef QWidget*( *QgsProcessingParameterWidgetFunc )();
+//! Function to create a parameter from an encoded script code line
+typedef QgsProcessingParameter*( *QgsProcessingParameterFromScriptCodeFunc )( const QString&, const QString&, bool, const QString& );
+
+/**
+ * \class QgsProcessingParameterMetadata
+ * \ingroup core
+ * Convenience class that uses static functions to create parameter metadata.
+ * \note Not available in Python bindings
+ * \note added in QGIS 3.0
+ */
+class CORE_EXPORT QgsProcessingParameterMetadata : public QgsProcessingParameterAbstractMetadata
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingParameterMetadata which accepts static functions for the
+     * parameter creation functions.
+     */
+    QgsProcessingParameterMetadata( const QString& type,
+                                    QgsProcessingParameterFromScriptCodeFunc pfCreateFromScriptCode = nullptr,
+                                    QgsProcessingParameterWidgetFunc pfWidget = nullptr )
+        : QgsProcessingParameterAbstractMetadata( type )
+        , mCreateFromScriptCodeFunc( pfCreateFromScriptCode )
+        , mWidgetFunc( pfWidget )
+    {}
+
+    /**
+     * Returns the parameter's widget creation function.
+     * @see setWidgetFunction()
+     */
+    QgsProcessingParameterWidgetFunc widgetFunction() const { return mWidgetFunc; }
+
+    /**
+     * Sets the parameter's widget creation function.
+     * @see widgetFunction()
+     */
+    void setWidgetFunction( QgsProcessingParameterWidgetFunc f ) { mWidgetFunc = f; }
+
+    virtual QgsProcessingParameter* createParameterFromScriptCode( const QString& name, const QString& description, bool isOptional, const QString& definition ) override { return mCreateFromScriptCodeFunc ? mCreateFromScriptCodeFunc( name, description, isOptional, definition ) : nullptr; }
+    virtual QWidget* createWidget() override { return mWidgetFunc ? mWidgetFunc() : nullptr; }
+
+  private:
+    QgsProcessingParameterFromScriptCodeFunc mCreateFromScriptCodeFunc;
+    QgsProcessingParameterWidgetFunc mWidgetFunc;
+
+};
+
+/**
+ * \class QgsProcessingParameterRegistry
+ * \ingroup core
+ * Registry of available processing parameter types.
+ * \note added in QGIS 3.0
+ */
+class CORE_EXPORT QgsProcessingParameterRegistry
+{
+  public:
+
+    /**
+     * Constructs a new QgsProcessingParameterRegistry including all the default parameter types.
+     */
+    QgsProcessingParameterRegistry();
+
+    ~QgsProcessingParameterRegistry();
+
+    /**
+     * Returns a pointer to the metadata for a parameter type.
+     */
+    QgsProcessingParameterAbstractMetadata* parameterMetadata( const QString& type ) const;
+
+    /**
+     * Adds metadata for a new parameter type to the registry. Ownership of the metadata is transferred.
+     * Returns true if the parameter type was successfully registered, or false if the type could not
+     * be registered (eg as a result of a duplicate type string).
+     */
+    bool addParameterType( QgsProcessingParameterAbstractMetadata* metadata );
+
+    /**
+     * Creates a new parameter from an encoded script code.
+     */
+    QgsProcessingParameter* createFromScriptCode( const QString& code ) const;
+
+  private:
+
+    QMap<QString, QgsProcessingParameterAbstractMetadata*> mMetadata;
+
+    QgsProcessingParameterRegistry( const QgsProcessingParameterRegistry& rh );
+    QgsProcessingParameterRegistry& operator=( const QgsProcessingParameterRegistry& rh );
+
+    static bool parseScriptCodeParameterOptions( const QString& code, bool& isOptional, QString& name, QString& type, QString& definition );
+
+    static QString createDescription( const QString& name );
+
+};
+#endif // QGSPROCESSINGPARAMETERREGISTRY_H
+
+

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -1,0 +1,112 @@
+/***************************************************************************
+                         qgsprocessingparameters.cpp
+                         --------------------------
+    begin                : December 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingparameters.h"
+
+#include <QRegularExpression>
+
+
+//
+// QgsProcessingParameter
+//
+
+QgsProcessingParameter::QgsProcessingParameter( const QString& name, const QString& description, const QVariant& defaultValue, bool optional )
+    : mName( name )
+    , mDescription( description )
+    , mDefault( defaultValue )
+    , mFlags( optional ? QgsProcessingParameter::FlagOptional : 0 )
+{
+
+}
+
+void QgsProcessingParameter::setName( const QString& name )
+{
+  mName = name;
+}
+
+
+void QgsProcessingParameter::setDescription( const QString& description )
+{
+  mDescription = description;
+}
+
+
+bool QgsProcessingParameter::setDefaultValue( const QVariant& value )
+{
+  if ( !acceptsValue( value ) )
+    return false;
+
+  mDefault = parseValue( value );
+  return true;
+}
+
+void QgsProcessingParameter::setFlags( const Flags& flags )
+{
+  mFlags = flags;
+}
+
+QString QgsProcessingParameter::valueAsCommandLineParameter( const QVariant& value ) const
+{
+  return value.toString();
+}
+
+QString QgsProcessingParameter::asScriptCode() const
+{
+  QString code = QStringLiteral( "##%1=" ).arg( mName );
+  if ( mFlags && FlagOptional )
+    code += QStringLiteral( "optional " );
+  code += type() + ' ';
+  code += mDefault.toString();
+  return code;
+}
+
+//
+// QgsProcessingParameter
+//
+QgsProcessingParameterBoolean::QgsProcessingParameterBoolean( const QString& name, const QString& description, const QVariant& defaultValue, bool optional )
+    : QgsProcessingParameter( name, description, defaultValue, optional )
+{}
+
+bool QgsProcessingParameterBoolean::acceptsValue( const QVariant& value ) const
+{
+  if ( !value.isValid() && !( mFlags & FlagOptional ) )
+    return false;
+
+  return true;
+}
+
+QVariant QgsProcessingParameterBoolean::parseValue( const QVariant& value ) const
+{
+  return convertToBool( value );
+}
+
+QgsProcessingParameter* QgsProcessingParameterBoolean::createFromScriptCode( const QString& name, const QString& description, bool isOptional, const QString& definition )
+{
+  QVariant defaultVal = convertToBool( definition );
+  return new QgsProcessingParameterBoolean( name, description, defaultVal, isOptional );
+}
+
+QVariant QgsProcessingParameterBoolean::convertToBool( const QVariant& value )
+{
+  if ( value.type() == QVariant::String )
+    return value.toString().toLower().trimmed() == QStringLiteral( "true" );
+  else
+    return value.toBool();
+}
+
+
+

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -1,0 +1,153 @@
+/***************************************************************************
+                         qgsprocessingparameters.h
+                         -----------------------
+    begin                : December 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGPARAMETERS_H
+#define QGSPROCESSINGPARAMETERS_H
+
+#include <QString>
+#include <QVariant>
+
+class CORE_EXPORT QgsProcessingParameter
+{
+  public:
+
+    enum Flag
+    {
+      FlagAdvanced = 1 << 1, //!< Parameter is an advanced parameter which should be hidden from users by default
+      FlagHidden = 1 << 2, //!< Parameter is hidden and should not be shown to users
+      FlagOptional = 1 << 3, //!< Parameter is optional
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    QgsProcessingParameter( const QString& name, const QString& description = QString(), const QVariant& defaultValue = QVariant(),
+                            bool optional = false );
+
+    virtual QString type() const = 0;
+
+    /**
+     * Returns the name of the parameter. This is the internal identifier by which
+     * algorithms access this parameter.
+     * @see setName()
+     */
+    QString name() const { return mName; }
+
+    /**
+     * Sets the name of the parameter. This is the internal identifier by which
+     * algorithms access this parameter.
+     * @see name()
+     */
+    void setName( const QString& name );
+
+    /**
+     * Returns the description for the parameter. This is the user-visible string
+     * used to identify this parameter.
+     * @see setDescription()
+     */
+    QString description() const { return mDescription; }
+
+    /**
+     * Sets the description for the parameter. This is the user-visible string
+     * used to identify this parameter.
+     * @see description()
+     */
+    void setDescription( const QString& description );
+
+    /**
+     * Returns the default value for the parameter.
+     * @see setDefaultValue()
+     */
+    virtual QVariant defaultValue() const { return mDefault; }
+
+    /**
+     * Sets the default value for the parameter. Returns true if default value was successfully set,
+     * or false if value is not acceptable for the parameter.
+     * @see defaultValue()
+     */
+    virtual bool setDefaultValue( const QVariant& value );
+
+    /**
+     * Returns any flags associated with the parameter.
+     * @see setFlags()
+     */
+    Flags flags() const { return mFlags; }
+
+    /**
+     * Sets the flags associated with the parameter.
+     * @see flags()
+     */
+    void setFlags( const Flags& flags );
+
+    /**
+     * Returns true if the specified value is acceptable for the parameter.
+     */
+    virtual bool acceptsValue( const QVariant& value ) const = 0;
+
+    virtual QVariant parseValue( const QVariant& value ) const { return value; }
+
+    /**
+     * Returns the value of this parameter as it should have been entered in the console if calling
+     * an algorithm manually.
+     */
+    virtual QString valueAsCommandLineParameter( const QVariant& value ) const;
+
+    virtual QString asScriptCode() const;
+
+  protected:
+
+    //! Parameter name
+    QString mName;
+
+    //! Parameter description
+    QString mDescription;
+
+    //! Default value for parameter
+    QVariant mDefault;
+
+    //! Parameter flags
+    Flags mFlags;
+
+
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProcessingParameter::Flags )
+
+
+class CORE_EXPORT QgsProcessingParameterBoolean : public QgsProcessingParameter
+{
+  public:
+
+    QgsProcessingParameterBoolean( const QString& name, const QString& description = QString(), const QVariant& defaultValue = QVariant(),
+                                   bool optional = false );
+
+    QString type() const override { return QStringLiteral( "boolean" ); }
+
+    bool acceptsValue( const QVariant& value ) const override;
+
+    QVariant parseValue( const QVariant& value ) const override;
+
+    static QgsProcessingParameter* createFromScriptCode( const QString& name, const QString& description, bool isOptional, const QString& definition );
+
+  private:
+
+    static QVariant convertToBool( const QVariant& value );
+
+};
+
+
+#endif // QGSPROCESSINGPARAMETERS_H
+
+


### PR DESCRIPTION
Consider this just a research project for now. I thought I'd give a try to see how straightforward it is to port processing parameters to c++. Here's the (incomplete) result, for discussion.

Some notes:
- I've based this partly on the way symbol layers are handled, with a registry + functions for creating the gui which are not part of core, and methods like createFromScriptCode as part of the registry. Python algorithms implementing custom parameter types would then register these types in a similar way to how python plugins can register custom symbol renderers.
- I think the parameter handling in processing needs to be refactored to split a parameter's definition from a parameter value. IMO we should have QgsProcessingParameter (and subclasses) as just handling the definition of a parameter (such as min/max/default/optional/etc), and use QVariants for storing an actual parameters value. An algorithm would owns its QgsProcessingParameter definitions.
- It's not as straightforward as I was first thinking!

