### PR TITLE
Some cleanups in server

### DIFF
--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -37,9 +37,11 @@ class CORE_EXPORT QgsMessageLog : public QObject
 
     enum MessageLevel
     {
+      ALL = 0,
       INFO = 0,
       WARNING = 1,
-      CRITICAL = 2
+      CRITICAL = 2,
+      NONE = 3
     };
 
     //! add a message to the instance (and create it if necessary)

--- a/src/server/qgsmapserviceexception.cpp
+++ b/src/server/qgsmapserviceexception.cpp
@@ -17,7 +17,9 @@
 
 #include "qgsmapserviceexception.h"
 
-QgsMapServiceException::QgsMapServiceException( const QString& code, const QString& message ): mCode( code ), mMessage( message )
+QgsMapServiceException::QgsMapServiceException( const QString& code, const QString& message ):
+    QgsException( message ),
+    mCode( code ), mMessage( message )
 {
 
 }

--- a/src/server/qgsmapserviceexception.h
+++ b/src/server/qgsmapserviceexception.h
@@ -20,6 +20,8 @@
 
 #include <QString>
 
+#include "qgsexception.h"
+
 /** \ingroup server
  * \class  QgsMapServiceException
  * \brief Exception class for WMS service exceptions.
@@ -31,7 +33,7 @@
  *  * "OperationNotSupported"
  */
 
-class SERVER_EXPORT QgsMapServiceException
+class SERVER_EXPORT QgsMapServiceException : public QgsException
 {
   public:
     QgsMapServiceException( const QString& code, const QString& message );

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -179,9 +179,9 @@ QFileInfo QgsServer::defaultProjectFile()
  * @param parameterMap
  * @param logLevel
  */
-void QgsServer::printRequestParameters( const QMap< QString, QString>& parameterMap, int logLevel )
+void QgsServer::printRequestParameters( const QMap< QString, QString>& parameterMap, QgsMessageLog::MessageLevel logLevel )
 {
-  if ( logLevel > 0 )
+  if ( logLevel > QgsMessageLog::INFO )
   {
     return;
   }
@@ -434,13 +434,13 @@ QPair<QByteArray, QByteArray> QgsServer::handleRequest( const QString& queryStri
   if ( ! queryString.isEmpty() )
     putenv( QStringLiteral( "QUERY_STRING" ), queryString );
 
-  int logLevel = QgsServerLogger::instance()->logLevel();
+  QgsMessageLog::MessageLevel logLevel = QgsServerLogger::instance()->logLevel();
   QTime time; //used for measuring request time if loglevel < 1
   QgsProject::instance()->removeAllMapLayers();
 
   qApp->processEvents();
 
-  if ( logLevel < 1 )
+  if ( logLevel == QgsMessageLog::INFO )
   {
     time.start();
     printRequestInfos();
@@ -614,7 +614,7 @@ QPair<QByteArray, QByteArray> QgsServer::handleRequest( const QString& queryStri
 
   theRequestHandler->sendResponse();
 
-  if ( logLevel < 1 )
+  if ( logLevel == QgsMessageLog::INFO )
   {
     QgsMessageLog::logMessage( "Request finished in " + QString::number( time.elapsed() ) + " ms", QStringLiteral( "Server" ), QgsMessageLog::INFO );
   }

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -33,6 +33,7 @@
 #include "qgsconfigcache.h"
 #include "qgscapabilitiescache.h"
 #include "qgsmapsettings.h"
+#include "qgsmessagelog.h"
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 #include "qgsserverplugins.h"
@@ -105,10 +106,16 @@ class SERVER_EXPORT QgsServer
     static void dummyMessageHandler( QtMsgType type, const char *msg );
     // Mainly for debug
     static void printRequestInfos();
-    // Mainly for debug
+
+    /**
+     * @brief QgsServer::printRequestParameters prints the request parameters
+     * @param parameterMap
+     * @param logLevel
+     */
     static void printRequestParameters(
       const QMap< QString, QString>& parameterMap,
-      int logLevel );
+      QgsMessageLog::MessageLevel logLevel );
+
     static QFileInfo defaultProjectFile();
     static QFileInfo defaultAdminSLD();
     static void setupNetworkAccessManager();

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -74,10 +74,6 @@ class SERVER_EXPORT QgsServer
      * @return the response headers and body QPair of QByteArray if called from python bindings, empty otherwise
      */
     QPair<QByteArray, QByteArray> handleRequest( const QString& queryString = QString() );
-#if 0
-    // The following code was used to test type conversion in python bindings
-    QPair<QByteArray, QByteArray> testQPair( QPair<QByteArray, QByteArray> pair );
-#endif
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     //! Returns a pointer to the server interface
@@ -92,11 +88,6 @@ class SERVER_EXPORT QgsServer
 
     //! Server initialization
     static bool init();
-
-    void saveEnvVars();
-
-    //! Saves environment variable into mEnvironmentVariables if defined
-    void saveEnvVar( const QString& variableName );
 
     // All functions that where previously in the main file are now
     // static methods of this class
@@ -134,9 +125,6 @@ class SERVER_EXPORT QgsServer
     //! Initialization must run once for all servers
     static bool sInitialised;
     static bool sCaptureOutput;
-
-    //! Pass important environment variables to the fcgi processes
-    QHash< QString, QString > mEnvironmentVariables;
 };
 #endif // QGSSERVER_H
 

--- a/src/server/qgsserverlogger.cpp
+++ b/src/server/qgsserverlogger.cpp
@@ -36,7 +36,7 @@ QgsServerLogger* QgsServerLogger::instance()
 
 QgsServerLogger::QgsServerLogger()
     : mLogFile( nullptr )
-    , mLogLevel( 3 )
+    , mLogLevel( QgsMessageLog::NONE )
 {
   //logfile
   QString filePath = getenv( "QGIS_SERVER_LOG_FILE" );
@@ -53,7 +53,7 @@ QgsServerLogger::QgsServerLogger()
   char* logLevelChar = getenv( "QGIS_SERVER_LOG_LEVEL" );
   if ( logLevelChar )
   {
-    mLogLevel = atoi( logLevelChar );
+    mLogLevel = static_cast<QgsMessageLog::MessageLevel>( atoi( logLevelChar ) );
   }
 
   connect( QgsMessageLog::instance(), SIGNAL( messageReceived( QString, QString, QgsMessageLog::MessageLevel ) ), this,

--- a/src/server/qgsserverlogger.h
+++ b/src/server/qgsserverlogger.h
@@ -30,12 +30,26 @@ class QgsServerLogger: public QObject
 {
     Q_OBJECT
   public:
+
+    /**
+     * Get the singleton instance
+     */
     static QgsServerLogger* instance();
 
-    int logLevel() const { return mLogLevel; }
-    //QString logFile() const { return mLogFile; }
+    /**
+     * Get the current log level
+     */
+    QgsMessageLog::MessageLevel logLevel() const { return mLogLevel; }
 
   public slots:
+
+    /**
+     * Log a message from the server context
+     *
+     * @param message the message
+     * @param tag tag of the message
+     * @param level log level of the message
+     */
     void logMessage( const QString& message, const QString& tag, QgsMessageLog::MessageLevel level );
 
   protected:
@@ -46,7 +60,7 @@ class QgsServerLogger: public QObject
 
     QFile mLogFile;
     QTextStream mTextStream;
-    int mLogLevel;
+    QgsMessageLog::MessageLevel mLogLevel;
 };
 
 #endif // QGSSERVERLOGGER_H


### PR DESCRIPTION
A bit of server cleanup.

- Use enums for server loglevels
- Remove some uncompiled lines (#if 0)
- Remove saveEnvVars / putenv at the beginning of a request. Please someone shout if it breaks things, but I couldn't find what it does
- Replace integer codes by boolean or exceptions in wmsserver
- And then use RAII for exception safety