### PR TITLE
[FEATURE] toggle visibility of opened panels in main window

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -4048,11 +4048,6 @@ void QgsComposer::createComposerView()
 
   //view does not accept focus via tab
   mView->setFocusPolicy( Qt::ClickFocus );
-  //instead, if view is focused and tab is pressed than mActionHidePanels is triggered,
-  //to toggle display of panels
-  QShortcut* tab = new QShortcut( Qt::Key_Tab, mView );
-  tab->setContext( Qt::WidgetWithChildrenShortcut );
-  connect( tab, SIGNAL( activated() ), mActionHidePanels, SLOT( trigger() ) );
 }
 
 void QgsComposer::writeWorldFile( const QString& worldFileName, double a, double b, double c, double d, double e, double f ) const

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1712,6 +1712,7 @@ void QgisApp::createActions()
   // Settings Menu Items
 
   connect( mActionToggleFullScreen, SIGNAL( triggered() ), this, SLOT( toggleFullScreen() ) );
+  connect( mActionTogglePanelsVisibility, SIGNAL( triggered() ), this, SLOT( togglePanelsVisibility() ) );
   connect( mActionProjectProperties, SIGNAL( triggered() ), this, SLOT( projectProperties() ) );
   connect( mActionOptions, SIGNAL( triggered() ), this, SLOT( options() ) );
   connect( mActionCustomProjection, SIGNAL( triggered() ), this, SLOT( customProjection() ) );
@@ -1996,6 +1997,7 @@ void QgisApp::createMenus()
     mViewMenu->addMenu( mPanelMenu );
     mViewMenu->addMenu( mToolbarMenu );
     mViewMenu->addAction( mActionToggleFullScreen );
+    mViewMenu->addAction( mActionTogglePanelsVisibility );
   }
   else
   {
@@ -2004,6 +2006,7 @@ void QgisApp::createMenus()
     mSettingsMenu->insertMenu( before, mPanelMenu );
     mSettingsMenu->insertMenu( before, mToolbarMenu );
     mSettingsMenu->insertAction( before, mActionToggleFullScreen );
+    mSettingsMenu->insertAction( before, mActionTogglePanelsVisibility );
     mSettingsMenu->insertSeparator( before );
   }
 
@@ -5611,6 +5614,62 @@ void QgisApp::toggleFullScreen()
     }
     showFullScreen();
     mFullScreenMode = true;
+  }
+}
+
+void QgisApp::togglePanelsVisibility()
+{
+  QSettings settings;
+
+  QStringList docksTitle = settings.value( "UI/hiddenDocksTitle", QString() ).toStringList();
+  QStringList docksActive = settings.value( "UI/hiddenDocksActive", QString() ).toStringList();
+
+  QList<QDockWidget*> docks = findChildren<QDockWidget*>();
+  QList<QTabBar *> tabBars = findChildren<QTabBar *>();
+
+  if ( docksTitle.isEmpty() )
+  {
+
+    Q_FOREACH ( QDockWidget* dock, docks )
+    {
+      if ( dock->isVisible() && !dock->isFloating() )
+      {
+        docksTitle << dock->windowTitle();
+        dock->setVisible( false );
+      }
+    }
+
+    Q_FOREACH ( QTabBar* tabBar, tabBars )
+    {
+      docksActive << tabBar->tabText( tabBar->currentIndex() );
+    }
+
+    settings.setValue( QStringLiteral( "/UI/hiddenDocksTitle" ), docksTitle );
+    settings.setValue( QStringLiteral( "/UI/hiddenDocksActive" ), docksActive );
+  }
+  else
+  {
+    Q_FOREACH ( QDockWidget* dock, docks )
+    {
+      if ( docksTitle.contains( dock->windowTitle() ) )
+      {
+        dock->setVisible( true );
+      }
+    }
+
+    Q_FOREACH ( QTabBar* tabBar, tabBars )
+    {
+      for ( int i = 0; i < tabBar->count(); ++i )
+      {
+        if ( docksActive.contains( tabBar->tabText( i ) ) )
+        {
+          tabBar->setCurrentIndex( i );
+        }
+      }
+    }
+
+    settings.setValue( QStringLiteral( "/UI/hiddenDocksTitle" ), QStringList() );
+    settings.setValue( QStringLiteral( "/UI/hiddenDocksActive" ), QStringList() );
   }
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -418,6 +418,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionShowPythonDialog() { return mActionShowPythonDialog; }
 
     QAction *actionToggleFullScreen() { return mActionToggleFullScreen; }
+    QAction *actionTogglePanelsVisibility() { return mActionTogglePanelsVisibility; }
     QAction *actionOptions() { return mActionOptions; }
     QAction *actionCustomProjection() { return mActionCustomProjection; }
     QAction *actionConfigureShortcuts() { return mActionConfigureShortcuts; }
@@ -1276,6 +1277,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Toggle full screen mode
     void toggleFullScreen();
+
+    //! Toggle visibility of opened panels
+    void togglePanelsVisibility();
 
     //! Set minimized mode of active window
     void showActiveWindowMinimized();

--- a/src/ui/composer/qgscomposerbase.ui
+++ b/src/ui/composer/qgscomposerbase.ui
@@ -1024,7 +1024,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Toggle Full Scr&amp;een</string>
+    <string>Toggle Full Screen</string>
    </property>
    <property name="toolTip">
     <string>Toggle full screen mode</string>
@@ -1038,13 +1038,13 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Hide Panels</string>
+    <string>&amp;Toggle Panel Visibility</string>
    </property>
    <property name="toolTip">
     <string>Hide panels</string>
    </property>
    <property name="shortcut">
-    <string>F10</string>
+    <string>Ctrl+Tab</string>
    </property>
   </action>
   <action name="mActionShowPage">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1553,6 +1553,14 @@
     <string>F11</string>
    </property>
   </action>
+  <action name="mActionTogglePanelsVisibility">
+   <property name="text">
+    <string>Toggle Panel Visibility</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Tab</string>
+   </property>
+  </action>
   <action name="mActionProjectProperties">
    <property name="icon">
     <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
This PR adds an action to toggle the visibility of opened panels in QGIS' main window. It is accessible via:
- View menu > Toggle Panels Visibility
- Ctrl+Tab keyboard shortcut

The hidden opened panels are remembered across sessions, so your panel & panel-less workspace is remembered.

The action is quite useful when digitizing features (where you want maximum canvas visibility) as well as when you do a (projected/recorded) presentation using QGIS' main canvas.

Live example of this PR in action here: https://www.youtube.com/watch?v=HD3GcovhI9M .

@nyalldawson , I've adjusted the composer window shortcut to Ctrl+Tab too.