### PR TITLE
[FEATURE] Show field values in autocompleter in form filter mode

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -75,6 +75,7 @@
 %Include qgsfieldmodel.sip
 %Include qgsfieldproxymodel.sip
 %Include qgsfieldvalidator.sip
+%Include qgsfieldvalueslineedit.sip
 %Include qgsfiledropedit.sip
 %Include qgsfilewidget.sip
 %Include qgsfiledownloader.sip

--- a/python/gui/qgsattributeform.sip
+++ b/python/gui/qgsattributeform.sip
@@ -164,6 +164,12 @@ class QgsAttributeForm : QWidget
      */
     void closed();
 
+    /**
+     * Emitted when the user chooses to zoom to a filtered set of features.
+     * @note added in QGIS 3.0
+     */
+    void zoomToFeatures( const QString& filter );
+
   public slots:
     /**
      * Call this to change the content of a given attribute. Will update the editor(s) related to this field.

--- a/python/gui/qgsfieldvalueslineedit.sip
+++ b/python/gui/qgsfieldvalueslineedit.sip
@@ -1,0 +1,59 @@
+/** \class QgsFieldValuesLineEdit
+ * \ingroup gui
+ * A line edit with an autocompleter which takes unique values from a vector layer's fields.
+ * The autocompleter is populated from the vector layer in the background to ensure responsive
+ * interaction with the widget.
+ * \note added in QGIS 3.0
+ */
+class QgsFieldValuesLineEdit: QgsFilterLineEdit
+{
+%TypeHeaderCode
+#include <qgsfieldvalueslineedit.h>
+%End
+  public:
+
+    /** Constructor for QgsFieldValuesLineEdit
+     * @param parent parent widget
+     */
+    QgsFieldValuesLineEdit( QWidget *parent /TransferThis/ = nullptr );
+
+    virtual ~QgsFieldValuesLineEdit();
+
+    /** Sets the layer containing the field that values will be shown from.
+     * @param layer vector layer
+     * @see layer()
+     * @see setAttributeIndex()
+     */
+    void setLayer( QgsVectorLayer* layer );
+
+    /** Returns the layer containing the field that values will be shown from.
+     * @see setLayer()
+     * @see attributeIndex()
+     */
+    QgsVectorLayer* layer() const;
+
+    /** Sets the attribute index for the field containing values to show in the widget.
+     * @param index index of attribute
+     * @see attributeIndex()
+     * @see setLayer()
+     */
+    void setAttributeIndex( int index );
+
+    /** Returns the attribute index for the field containing values shown in the widget.
+     * @see setAttributeIndex()
+     * @see layer()
+     */
+    int attributeIndex() const;
+
+  signals:
+
+    /** Emitted when the layer associated with the widget changes.
+     * @param layer vector layer
+     */
+    void layerChanged( QgsVectorLayer* layer );
+
+    /** Emitted when the field associated with the widget changes.
+     * @param index new attribute index for field
+     */
+    void attributeIndexChanged( int index );
+};

--- a/python/gui/qgsfloatingwidget.sip
+++ b/python/gui/qgsfloatingwidget.sip
@@ -73,6 +73,17 @@ class QgsFloatingWidget : QWidget
      */
     void setAnchorWidgetPoint( AnchorPoint point );
 
+  signals:
+
+    //! Emitted when the anchor widget changes
+    void anchorWidgetChanged( QWidget* widget );
+
+    //! Emitted when the anchor point changes
+    void anchorPointChanged( AnchorPoint point );
+
+    //! Emitted when the anchor widget point changes
+    void anchorWidgetPointChanged( AnchorPoint point );
+
   protected:
     void showEvent( QShowEvent* e );
     virtual void paintEvent( QPaintEvent* e );

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -231,6 +231,10 @@ class QgsMapCanvas : QGraphicsView
     //! Zooms in/out with a given center
     void zoomWithCenter( int x, int y, bool zoomIn );
 
+    //! Zooms to feature extent. Adds a small margin around the extent
+    //! and does a pan if rect is empty (point extent)
+    void zoomToFeatureExtent( QgsRectangle& rect );
+
     //! Returns whether the scale is locked, so zooming can be performed using magnication.
     //! @note added in 2.16
     //! @see setScaleLocked()
@@ -517,10 +521,6 @@ class QgsMapCanvas : QGraphicsView
 
     //! called when panning is in action, reset indicates end of panning
     void moveCanvasContents( bool reset = false );
-
-    //! Zooms to feature extent. Adds a small margin around the extent
-    //! and does a pan if rect is empty (point extent)
-    void zoomToFeatureExtent( QgsRectangle& rect );
 
     //! called on resize or changed extent to notify canvas items to change their rectangle
     void updateCanvasItemPositions();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7521,6 +7521,7 @@ void QgisApp::selectByForm()
 
   QgsSelectByFormDialog* dlg = new QgsSelectByFormDialog( vlayer, context, this );
   dlg->setMessageBar( messageBar() );
+  dlg->setMapCanvas( mapCanvas() );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
   dlg->show();
 }

--- a/src/app/qgsselectbyformdialog.cpp
+++ b/src/app/qgsselectbyformdialog.cpp
@@ -15,11 +15,14 @@
 
 #include "qgsselectbyformdialog.h"
 #include "qgsattributeform.h"
+#include "qgsmapcanvas.h"
 #include <QLayout>
 #include <QSettings>
 
 QgsSelectByFormDialog::QgsSelectByFormDialog( QgsVectorLayer* layer, const QgsAttributeEditorContext& context, QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
+    , mLayer( layer )
+    , mMessageBar( nullptr )
 {
   QgsAttributeEditorContext dlgContext = context;
   dlgContext.setFormMode( QgsAttributeEditorContext::StandaloneDialog );
@@ -51,5 +54,66 @@ QgsSelectByFormDialog::~QgsSelectByFormDialog()
 
 void QgsSelectByFormDialog::setMessageBar( QgsMessageBar* messageBar )
 {
+  mMessageBar = messageBar;
   mForm->setMessageBar( messageBar );
+}
+
+void QgsSelectByFormDialog::setMapCanvas( QgsMapCanvas* canvas )
+{
+  mMapCanvas = canvas;
+  connect( mForm, &QgsAttributeForm::zoomToFeatures, this, &QgsSelectByFormDialog::zoomToFeatures );
+}
+
+void QgsSelectByFormDialog::zoomToFeatures( const QString& filter )
+{
+  QgsFeatureIds ids;
+
+  QgsExpressionContext context;
+  context << QgsExpressionContextUtils::globalScope()
+  << QgsExpressionContextUtils::projectScope()
+  << QgsExpressionContextUtils::layerScope( mLayer );
+
+  QgsFeatureRequest request = QgsFeatureRequest().setFilterExpression( filter )
+                              .setExpressionContext( context )
+                              .setSubsetOfAttributes( QgsAttributeList() );
+
+  QgsFeatureIterator features = mLayer->getFeatures( request );
+
+  QgsRectangle bbox;
+  bbox.setMinimal();
+  QgsFeature feat;
+  int featureCount = 0;
+  while ( features.nextFeature( feat ) )
+  {
+    QgsGeometry geom = feat.geometry();
+    if ( geom.isEmpty() || geom.geometry()->isEmpty() )
+      continue;
+
+    QgsRectangle r = mMapCanvas->mapSettings().layerExtentToOutputExtent( mLayer, geom.boundingBox() );
+    bbox.combineExtentWith( r );
+    featureCount++;
+  }
+  features.close();
+
+  QSettings settings;
+  int timeout = settings.value( QStringLiteral( "/qgis/messageTimeout" ), 5 ).toInt();
+  if ( featureCount > 0 )
+  {
+    mMapCanvas->zoomToFeatureExtent( bbox );
+    if ( mMessageBar )
+    {
+      mMessageBar->pushMessage( QString(),
+                                tr( "Zoomed to %1 matching %2" ).arg( featureCount )
+                                .arg( featureCount == 1 ? tr( "feature" ) : tr( "features" ) ),
+                                QgsMessageBar::INFO,
+                                timeout );
+    }
+  }
+  else if ( mMessageBar )
+  {
+    mMessageBar->pushMessage( QString(),
+                              tr( "No matching features found" ),
+                              QgsMessageBar::INFO,
+                              timeout );
+  }
 }

--- a/src/app/qgsselectbyformdialog.h
+++ b/src/app/qgsselectbyformdialog.h
@@ -22,6 +22,7 @@
 class QgsAttributeForm;
 class QgsMessageBar;
 class QgsVectorLayer;
+class QgsMapCanvas;
 
 /** \ingroup app
  * \class QgsSelectByFormDialog
@@ -54,9 +55,21 @@ class APP_EXPORT QgsSelectByFormDialog : public QDialog
      */
     void setMessageBar( QgsMessageBar* messageBar );
 
+    /**
+     * Sets a map canvas associated with the dialog.
+     */
+    void setMapCanvas( QgsMapCanvas* canvas );
+
+  private slots:
+
+    void zoomToFeatures( const QString& filter );
+
   private:
 
     QgsAttributeForm* mForm;
+    QgsVectorLayer* mLayer;
+    QgsMessageBar* mMessageBar;
+    QgsMapCanvas* mMapCanvas;
 
 };
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -223,6 +223,7 @@ SET(QGIS_GUI_SRCS
   qgsfieldmodel.cpp
   qgsfieldproxymodel.cpp
   qgsfieldvalidator.cpp
+  qgsfieldvalueslineedit.cpp
   qgsfiledropedit.cpp
   qgsfilewidget.cpp
   qgsfilterlineedit.cpp
@@ -391,6 +392,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsfieldmodel.h
   qgsfieldproxymodel.h
   qgsfieldvalidator.h
+  qgsfieldvalueslineedit.h
   qgsfiledropedit.h
   qgsfilewidget.h
   qgsfilterlineedit.h

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -18,6 +18,7 @@
 #include "qgsfields.h"
 #include "qgsfieldvalidator.h"
 #include "qgsexpression.h"
+#include "qgsfieldvalueslineedit.h"
 #include <QSettings>
 #include <QHBoxLayout>
 
@@ -255,10 +256,20 @@ void QgsDefaultSearchWidgetWrapper::initWidget( QWidget* widget )
   mContainer->setLayout( new QHBoxLayout() );
   mContainer->layout()->setMargin( 0 );
   mContainer->layout()->setContentsMargins( 0, 0, 0, 0 );
-  mLineEdit = new QgsFilterLineEdit();
+  QVariant::Type fldType = layer()->fields().at( mFieldIdx ).type();
+
+  if ( fldType == QVariant::String )
+  {
+    mLineEdit = new QgsFieldValuesLineEdit();
+    static_cast< QgsFieldValuesLineEdit* >( mLineEdit )->setLayer( layer() );
+    static_cast< QgsFieldValuesLineEdit* >( mLineEdit )->setAttributeIndex( mFieldIdx );
+  }
+  else
+  {
+    mLineEdit = new QgsFilterLineEdit();
+  }
   mContainer->layout()->addWidget( mLineEdit );
 
-  QVariant::Type fldType = layer()->fields().at( mFieldIdx ).type();
   if ( fldType == QVariant::String )
   {
     mCheckbox = new QCheckBox( QStringLiteral( "Case sensitive" ) );

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSDEFAULTSEARCHWIDGETWRAPPER_H
 
 #include "qgssearchwidgetwrapper.h"
-#include <qgsfilterlineedit.h>
+#include "qgsfilterlineedit.h"
 
 #include <QCheckBox>
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -405,6 +405,15 @@ void QgsAttributeForm::filterTriggered()
     setMode( SingleEditMode );
 }
 
+void QgsAttributeForm::searchZoomTo()
+{
+  QString filter = createFilterExpression();
+  if ( filter.isEmpty() )
+    return;
+
+  emit zoomToFeatures( filter );
+}
+
 void QgsAttributeForm::filterAndTriggered()
 {
   QString filter = createFilterExpression();
@@ -1309,6 +1318,12 @@ void QgsAttributeForm::init()
     connect( clearButton, &QPushButton::clicked, this, &QgsAttributeForm::resetSearch );
     boxLayout->addWidget( clearButton );
     boxLayout->addStretch( 1 );
+
+    QPushButton* zoomButton = new QPushButton();
+    zoomButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );
+    zoomButton->setText( tr( "&Zoom to features" ) );
+    connect( zoomButton, &QToolButton::clicked, this, &QgsAttributeForm::searchZoomTo );
+    boxLayout->addWidget( zoomButton );
 
     QToolButton* selectButton = new QToolButton();
     selectButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -191,6 +191,12 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void closed();
 
+    /**
+     * Emitted when the user chooses to zoom to a filtered set of features.
+     * @note added in QGIS 3.0
+     */
+    void zoomToFeatures( const QString& filter );
+
   public slots:
 
     /**
@@ -250,6 +256,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void filterOrTriggered();
     void filterTriggered();
 
+    void searchZoomTo();
     void searchSetSelection();
     void searchAddToSelection();
     void searchRemoveFromSelection();

--- a/src/gui/qgsfieldvalueslineedit.cpp
+++ b/src/gui/qgsfieldvalueslineedit.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+    qgsfieldvalueslineedit.cpp
+     -------------------------
+    Date                 : 20-08-2016
+    Copyright            : (C) 2016 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsfieldvalueslineedit.h"
+#include "qgsvectorlayer.h"
+#include "qgsfloatingwidget.h"
+#include <QCompleter>
+#include <QStringListModel>
+#include <QTimer>
+#include <QHBoxLayout>
+
+QgsFieldValuesLineEdit::QgsFieldValuesLineEdit( QWidget *parent )
+    : QgsFilterLineEdit( parent )
+    , mLayer( nullptr )
+    , mAttributeIndex( -1 )
+    , mUpdateRequested( false )
+    , mGatherer( nullptr )
+{
+  QCompleter* c = new QCompleter( this );
+  c->setCaseSensitivity( Qt::CaseInsensitive );
+  c->setFilterMode( Qt::MatchContains );
+  setCompleter( c );
+  connect( this, &QgsFieldValuesLineEdit::textEdited, this, &QgsFieldValuesLineEdit::requestCompleterUpdate );
+  mShowPopupTimer.setSingleShot( true );
+  mShowPopupTimer.setInterval( 100 );
+  connect( &mShowPopupTimer, &QTimer::timeout, this, &QgsFieldValuesLineEdit::triggerCompleterUpdate );
+}
+
+QgsFieldValuesLineEdit::~QgsFieldValuesLineEdit()
+{
+  if ( mGatherer )
+  {
+    mGatherer->stop();
+    mGatherer->wait(); // mGatherer is deleted when wait completes
+  }
+}
+
+void QgsFieldValuesLineEdit::setLayer( QgsVectorLayer* layer )
+{
+  if ( mLayer == layer )
+    return;
+
+  mLayer = layer;
+  emit layerChanged( layer );
+}
+
+void QgsFieldValuesLineEdit::setAttributeIndex( int index )
+{
+  if ( mAttributeIndex == index )
+    return;
+
+  mAttributeIndex = index;
+  emit attributeIndexChanged( index );
+}
+
+void QgsFieldValuesLineEdit::requestCompleterUpdate()
+{
+  mUpdateRequested = true;
+  mShowPopupTimer.start();
+}
+
+void QgsFieldValuesLineEdit::triggerCompleterUpdate()
+{
+  mShowPopupTimer.stop();
+  QString currentText = text();
+
+  if ( currentText.isEmpty() )
+  {
+    if ( mGatherer )
+      mGatherer->stop();
+    return;
+  }
+
+  updateCompletionList( currentText );
+}
+
+void QgsFieldValuesLineEdit::updateCompletionList( const QString &text )
+{
+  if ( text.isEmpty() )
+  {
+    if ( mGatherer )
+      mGatherer->stop();
+    return;
+  }
+
+  mUpdateRequested = true;
+  if ( mGatherer )
+  {
+    mRequestedCompletionText = text;
+    mGatherer->stop();
+    return;
+  }
+
+  mGatherer = new QgsFieldValuesLineEditValuesGatherer( mLayer, mAttributeIndex );
+  mGatherer->setSubstring( text );
+
+  connect( mGatherer, &QgsFieldValuesLineEditValuesGatherer::collectedValues, this, &QgsFieldValuesLineEdit::updateCompleter );
+  connect( mGatherer, &QgsFieldValuesLineEditValuesGatherer::finished, this, &QgsFieldValuesLineEdit::gathererThreadFinished );
+
+  mGatherer->start();
+}
+
+void QgsFieldValuesLineEdit::gathererThreadFinished()
+{
+  bool wasCancelled = mGatherer->wasCancelled();
+
+  delete mGatherer;
+  mGatherer = nullptr;
+
+  if ( wasCancelled )
+  {
+    QString text = mRequestedCompletionText;
+    mRequestedCompletionText.clear();
+    updateCompletionList( text );
+    return;
+  }
+}
+
+void QgsFieldValuesLineEdit::updateCompleter( const QStringList& values )
+{
+  mUpdateRequested = false;
+  completer()->setModel( new QStringListModel( values ) );
+  completer()->complete();
+}
+

--- a/src/gui/qgsfieldvalueslineedit.h
+++ b/src/gui/qgsfieldvalueslineedit.h
@@ -1,0 +1,217 @@
+/***************************************************************************
+    qgsfieldvalueslineedit.h
+     -----------------------
+    Date                 : 20-08-2016
+    Copyright            : (C) 2016 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSFIELDVALUESLINEEDIT_H
+#define QGSFIELDVALUESLINEEDIT_H
+
+#include "qgsfilterlineedit.h"
+#include "qgsfeedback.h"
+#include "qgsvectorlayer.h"
+#include <QStringListModel>
+#include <QTreeView>
+#include <QFocusEvent>
+#include <QHeaderView>
+#include <QTimer>
+#include <QThread>
+
+class QgsFloatingWidget;
+
+// just internal guff - definitely not for exposing to public API!
+///@cond PRIVATE
+
+/** \class QgsFieldValuesLineEditValuesGatherer
+ * Collates unique values containing a matching substring in a thread.
+ */
+class QgsFieldValuesLineEditValuesGatherer: public QThread
+{
+    Q_OBJECT
+
+  public:
+    QgsFieldValuesLineEditValuesGatherer( QgsVectorLayer* layer, int attributeIndex )
+        : mLayer( layer )
+        , mAttributeIndex( attributeIndex )
+        , mFeedback( nullptr )
+        , mWasCancelled( false )
+    {}
+
+    /** Sets the substring to find matching values containing
+     */
+    void setSubstring( const QString& string ) { mSubstring = string; }
+
+    virtual void run() override
+    {
+      mWasCancelled = false;
+      if ( mSubstring.isEmpty() )
+      {
+        emit collectedValues( QStringList() );
+        return;
+      }
+
+      // allow responsive cancellation
+      mFeedback = new QgsFeedback();
+      // just get 100 values... maybe less/more would be useful?
+      mValues = mLayer->uniqueStringsMatching( mAttributeIndex, mSubstring, 100, mFeedback );
+
+      // be overly cautious - it's *possible* stop() might be called between deleting mFeedback and nulling it
+      mFeedbackMutex.lock();
+      delete mFeedback;
+      mFeedback = nullptr;
+      mFeedbackMutex.unlock();
+
+      emit collectedValues( mValues );
+    }
+
+    //! Informs the gatherer to immediately stop collecting values
+    void stop()
+    {
+      // be cautious, in case gatherer stops naturally just as we are cancelling it and mFeedback gets deleted
+      mFeedbackMutex.lock();
+      if ( mFeedback )
+        mFeedback->cancel();
+      mFeedbackMutex.unlock();
+
+      mWasCancelled = true;
+    }
+
+    //! Returns true if collection was cancelled before completion
+    bool wasCancelled() const { return mWasCancelled; }
+
+  signals:
+
+    /** Emitted when values have been collected
+     * @param values list of unique matching string values
+     */
+    void collectedValues( const QStringList& values );
+
+  private:
+
+    QgsVectorLayer* mLayer;
+    int mAttributeIndex;
+    QString mSubstring;
+    QStringList mValues;
+    QgsFeedback* mFeedback;
+    QMutex mFeedbackMutex;
+    bool mWasCancelled;
+};
+
+///@endcond
+
+/** \class QgsFieldValuesLineEdit
+ * \ingroup gui
+ * A line edit with an autocompleter which takes unique values from a vector layer's fields.
+ * The autocompleter is populated from the vector layer in the background to ensure responsive
+ * interaction with the widget.
+ * \note added in QGIS 3.0
+ */
+class GUI_EXPORT QgsFieldValuesLineEdit: public QgsFilterLineEdit
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QgsVectorLayer* layer READ layer WRITE setLayer NOTIFY layerChanged )
+    Q_PROPERTY( int attributeIndex READ attributeIndex WRITE setAttributeIndex NOTIFY attributeIndexChanged )
+
+  public:
+
+    /** Constructor for QgsFieldValuesLineEdit
+     * @param parent parent widget
+     */
+    QgsFieldValuesLineEdit( QWidget *parent = nullptr );
+
+    virtual ~QgsFieldValuesLineEdit();
+
+    /** Sets the layer containing the field that values will be shown from.
+     * @param layer vector layer
+     * @see layer()
+     * @see setAttributeIndex()
+     */
+    void setLayer( QgsVectorLayer* layer );
+
+    /** Returns the layer containing the field that values will be shown from.
+     * @see setLayer()
+     * @see attributeIndex()
+     */
+    QgsVectorLayer* layer() const { return mLayer; }
+
+    /** Sets the attribute index for the field containing values to show in the widget.
+     * @param index index of attribute
+     * @see attributeIndex()
+     * @see setLayer()
+     */
+    void setAttributeIndex( int index );
+
+    /** Returns the attribute index for the field containing values shown in the widget.
+     * @see setAttributeIndex()
+     * @see layer()
+     */
+    int attributeIndex() const { return mAttributeIndex; }
+
+  signals:
+
+    /** Emitted when the layer associated with the widget changes.
+     * @param layer vector layer
+     */
+    void layerChanged( QgsVectorLayer* layer );
+
+    /** Emitted when the field associated with the widget changes.
+     * @param index new attribute index for field
+     */
+    void attributeIndexChanged( int index );
+
+  private slots:
+
+    /** Requests that the autocompleter updates its completion list. The update will not occur immediately
+     * but after a preset timeout to avoid multiple updates while a user is quickly typing.
+     */
+    void requestCompleterUpdate();
+
+    /** Updates the autocompleter list immediately. Calling
+     * this will trigger a background request to the layer to fetch matching unique values.
+     */
+    void triggerCompleterUpdate();
+
+    /** Updates the values shown in the completer list.
+     * @param values list of string values to show
+     */
+    void updateCompleter( const QStringList& values );
+
+    /** Called when the gatherer thread is complete, regardless of whether it finished collecting values.
+     * Cleans up the gatherer thread and triggers a new background thread if the widget's text has changed
+     * in the meantime.
+     */
+    void gathererThreadFinished();
+
+  private:
+
+    QgsVectorLayer* mLayer;
+    int mAttributeIndex;
+
+    //! Will be true when a background update of the completer values is occurring
+    bool mUpdateRequested;
+
+    //! Timer to prevent multiple updates of autocomplete list
+    QTimer mShowPopupTimer;
+
+    //! Background value gatherer thread
+    QgsFieldValuesLineEditValuesGatherer* mGatherer;
+
+    //! Will be set to the latest completion text string which should be requested
+    QString mRequestedCompletionText;
+
+    //! Kicks off the gathering of completer text values for a specified substring
+    void updateCompletionList( const QString& substring );
+
+};
+
+
+#endif //QGSFIELDVALUESLINEEDIT_H

--- a/src/gui/qgsfloatingwidget.h
+++ b/src/gui/qgsfloatingwidget.h
@@ -17,18 +17,23 @@
 
 #include <QWidget>
 
+class QgsFloatingWidgetEventFilter;
 
 /** \ingroup gui
  * \class QgsFloatingWidget
  * A QWidget subclass for creating widgets which float outside of the normal Qt layout
  * system. Floating widgets use an "anchor widget" to determine how they are anchored
  * within their parent widget.
- * \note Added in version 2.16
+ * \note Added in version 3.0
  */
 
 class GUI_EXPORT QgsFloatingWidget: public QWidget
 {
     Q_OBJECT
+    Q_ENUMS( AnchorPoint )
+    Q_PROPERTY( QWidget* anchorWidget READ anchorWidget WRITE setAnchorWidget NOTIFY anchorWidgetChanged )
+    Q_PROPERTY( AnchorPoint anchorPoint READ anchorPoint WRITE setAnchorPoint NOTIFY anchorPointChanged )
+    Q_PROPERTY( AnchorPoint anchorWidgetPoint READ anchorWidgetPoint WRITE setAnchorWidgetPoint NOTIFY anchorWidgetPointChanged )
 
   public:
 
@@ -75,7 +80,7 @@ class GUI_EXPORT QgsFloatingWidget: public QWidget
      * @param point anchor point
      * @see anchorPoint()
      */
-    void setAnchorPoint( AnchorPoint point ) { mFloatAnchorPoint = point; anchorPointChanged(); }
+    void setAnchorPoint( AnchorPoint point );
 
     /** Returns the anchor widget's anchor point, which corresponds to the point on the anchor widget which
      * the floating widget should "attach" to. The floating widget should remain fixed in the same relative position
@@ -89,7 +94,18 @@ class GUI_EXPORT QgsFloatingWidget: public QWidget
      * to this anchor widget whenever the widget's parent is resized or moved.
      * @see setAnchorWidgetPoint()
      */
-    void setAnchorWidgetPoint( AnchorPoint point ) { mAnchorWidgetAnchorPoint = point; anchorPointChanged(); }
+    void setAnchorWidgetPoint( AnchorPoint point );
+
+  signals:
+
+    //! Emitted when the anchor widget changes
+    void anchorWidgetChanged( QWidget* widget );
+
+    //! Emitted when the anchor point changes
+    void anchorPointChanged( AnchorPoint point );
+
+    //! Emitted when the anchor widget point changes
+    void anchorWidgetPointChanged( AnchorPoint point );
 
   protected:
     void showEvent( QShowEvent* e ) override;
@@ -98,13 +114,13 @@ class GUI_EXPORT QgsFloatingWidget: public QWidget
   private slots:
 
     //! Repositions the floating widget to a changed anchor point
-    void anchorPointChanged();
+    void onAnchorPointChanged();
 
   private:
 
     QWidget* mAnchorWidget;
-    QObject* mParentEventFilter;
-    QObject* mAnchorEventFilter;
+    QgsFloatingWidgetEventFilter* mParentEventFilter;
+    QgsFloatingWidgetEventFilter* mAnchorEventFilter;
     AnchorPoint mFloatAnchorPoint;
     AnchorPoint mAnchorWidgetAnchorPoint;
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -288,6 +288,10 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Zooms in/out with a given center
     void zoomWithCenter( int x, int y, bool zoomIn );
 
+    //! Zooms to feature extent. Adds a small margin around the extent
+    //! and does a pan if rect is empty (point extent)
+    void zoomToFeatureExtent( QgsRectangle& rect );
+
     //! Returns whether the scale is locked, so zooming can be performed using magnication.
     //! @note added in 2.16
     //! @see setScaleLocked()
@@ -588,10 +592,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! called when panning is in action, reset indicates end of panning
     void moveCanvasContents( bool reset = false );
-
-    //! Zooms to feature extent. Adds a small margin around the extent
-    //! and does a pan if rect is empty (point extent)
-    void zoomToFeatureExtent( QgsRectangle& rect );
 
     //! called on resize or changed extent to notify canvas items to change their rectangle
     void updateCanvasItemPositions();


### PR DESCRIPTION
This adds a new gui widget QgsFieldValuesLineEdit which includes an autocompleter populated with current field values.

The autocompleter is nicely updated in the background so that the gui remains nice and responsive, even if there's millions of records in the associated table.

It's now used as a search widget for text fields, so can be seen in the browser window if you set the filter to a text field, or if you launch the form based select/filter by selecting a layer and pressing F3.

(also some unrelated enhancements to QgsFloatingWidget due to an abandoned approach to this PR)