### PR TITLE
[FEATURE] Implement raster pseudocolor updated extent auto classification

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -475,6 +475,7 @@ QgsColorRampShader        {#qgis_api_break_3_0_QgsColorRampShader}
 ------------------
 
 - maximumColorCacheSize() and setMaximumColorCacheSize() were no longer used and are removed.
+- ColorRamp_TYPE enum was renamed to Type, and its value names decapitalized
 
 
 QgsComposerArrow        {#qgis_api_break_3_0_QgsComposerArrow}
@@ -1465,6 +1466,7 @@ QgsSingleSymbolRendererWidget        {#qgis_api_break_3_0_QgsSingleSymbolRendere
 -----------------------------
 
 - sizeScaleFieldChanged() and scaleMethodChanged() were removed. These settings are no longer exposed in the widget's GUI.
+- The Mode enum was removed.
 
 
 QgsSnapper        {#qgis_api_break_3_0_QgsSnapper}

--- a/python/core/raster/qgscolorrampshader.sip
+++ b/python/core/raster/qgscolorrampshader.sip
@@ -5,7 +5,31 @@ class QgsColorRampShader : QgsRasterShaderFunction
 %End
 
   public:
-    QgsColorRampShader( double theMinimumValue = 0.0, double theMaximumValue = 255.0 );
+    //! Supported methods for color interpolation.
+    enum Type
+    {
+      Interpolated, //!< Interpolates the color between two class breaks linearly.
+      Discrete,     //!< Assigns the color of the higher class for every pixel between two class breaks.
+      Exact         //!< Assigns the color of the exact matching value in the color ramp item list
+    };
+
+    //! Classification modes used to create the color ramp shader
+    enum ClassificationMode
+    {
+      Continuous = 1, //!< Uses breaks from color palette
+      EqualInterval = 2, //!< Uses equal interval
+      Quantile = 3 //!< Uses quantile (i.e. equal pixel) count
+    };
+
+    /** Creates a new color ramp shader.
+     * @param theMinimumValue minimum value for the raster shader
+     * @param theMaximumValue maximum value for the raster shader
+     * @param theType interpolation type used
+     * @param theClassificationMode method used to classify the color ramp shader
+     * @param theColorRamp vector color ramp used to classify the color ramp shader
+     * @returns new QgsColorRampShader
+     */
+    QgsColorRampShader( double theMinimumValue = 0.0, double theMaximumValue = 255.0, QgsColorRamp* theColorRamp = nullptr, Type theType = Interpolated, ClassificationMode theClassificationMode = Continuous );
 
     ~QgsColorRampShader();
 
@@ -28,19 +52,11 @@ class QgsColorRampShader : QgsRasterShaderFunction
       bool operator<( const QgsColorRampShader::ColorRampItem& other ) const;
     };
 
-    /** Supported methods for color interpolation. */
-    enum ColorRamp_TYPE
-    {
-      INTERPOLATED, //!< Interpolates the color between two class breaks linearly.
-      DISCRETE,     //!< Assigns the color of the higher class for every pixel between two class breaks.
-      EXACT         //!< Assigns the color of the exact matching value in the color ramp item list
-    };
-
     /** \brief Get the custom colormap*/
     QList<QgsColorRampShader::ColorRampItem> colorRampItemList() const;
 
     /** \brief Get the color ramp type */
-    QgsColorRampShader::ColorRamp_TYPE colorRampType() const;
+    Type colorRampType() const;
 
     /** Get the source color ramp
      * @note added in QGIS 3.0
@@ -61,10 +77,26 @@ class QgsColorRampShader : QgsRasterShaderFunction
     void setColorRampItemList( const QList<QgsColorRampShader::ColorRampItem>& theList ); //TODO: sort on set
 
     /** \brief Set the color ramp type*/
-    void setColorRampType( QgsColorRampShader::ColorRamp_TYPE theColorRampType );
+    void setColorRampType( QgsColorRampShader::Type theColorRampType );
 
     /** \brief Set the color ramp type*/
     void setColorRampType( const QString& theType );
+
+    /** Classify color ramp shader
+     * @param classes number of classes
+     * @param band raster band used in classification (only used in quantile mode)
+     * @param extent extent used in classification (only used in quantile mode)
+     * @param input raster input used in classification (only used in quantile mode)
+     */
+    void classifyColorRamp( const int classes = 0, const int band = -1, const QgsRectangle& extent = QgsRectangle(), QgsRasterInterface* input = nullptr );
+
+    /** Classify color ramp shader
+     * @param band raster band used in classification (only used in quantile mode)
+     * @param extent extent used in classification (only used in quantile mode)
+     * @param input raster input used in classification (only used in quantile mode)
+     */
+    void classifyColorRamp( const int band = -1, const QgsRectangle& extent = QgsRectangle(), QgsRasterInterface* input = nullptr ) /PyName=classifyColorRampV2/;
+
 
     /** \brief Generates and new RGB value based on one input value */
     bool shade( double, int* /Out/, int* /Out/, int* /Out/, int* /Out/ );
@@ -73,6 +105,12 @@ class QgsColorRampShader : QgsRasterShaderFunction
     bool shade( double, double, double, double, int* /Out/, int* /Out/, int* /Out/, int* /Out/);
 
     void legendSymbologyItems( QList< QPair< QString, QColor > >& symbolItems ) const;
+
+    //! Sets classification mode
+    void setClassificationMode( ClassificationMode classificationMode );
+
+    //! Returns the classification mode
+    ClassificationMode classificationMode() const;
 
     /** Sets whether the shader should not render values out of range.
      * @param clip set to true to clip values which are out of range.

--- a/python/core/raster/qgssinglebandpseudocolorrenderer.sip
+++ b/python/core/raster/qgssinglebandpseudocolorrenderer.sip
@@ -4,6 +4,7 @@ class QgsSingleBandPseudoColorRenderer: QgsRasterRenderer
     #include "qgssinglebandpseudocolorrenderer.h"
 %End
   public:
+
     /** Note: takes ownership of QgsRasterShader*/
     QgsSingleBandPseudoColorRenderer( QgsRasterDataProvider* provider, int band, QgsRasterShader* shader /Transfer/ );
     ~QgsSingleBandPseudoColorRenderer();
@@ -15,9 +16,21 @@ class QgsSingleBandPseudoColorRenderer: QgsRasterRenderer
 
     /** Takes ownership of the shader*/
     void setShader( QgsRasterShader* shader /Transfer/ );
+
     QgsRasterShader* shader();
+
     //! @note available in python as constShader
     const QgsRasterShader* shader() const /PyName=constShader/;
+
+    /** Creates a color ramp shader
+     * @param colorRamp vector color ramp
+     * @param colorRampType type of color ramp shader
+     * @param classificationMode classification mode
+     * @param classes number of classes
+     * @param clip clip out of range values
+     * @param extent extent used in classification (only used in quantile mode)
+     */
+    void createShader( QgsColorRamp* colorRamp = nullptr, QgsColorRampShader::Type colorRampType  = QgsColorRampShader::Interpolated, QgsColorRampShader::ClassificationMode classificationMode = QgsColorRampShader::Continuous, int classes = 0, bool clip = false, const QgsRectangle& extent = QgsRectangle() );
 
     void writeXml( QDomDocument& doc, QDomElement& parentElem ) const;
 

--- a/python/gui/raster/qgssinglebandpseudocolorrendererwidget.sip
+++ b/python/gui/raster/qgssinglebandpseudocolorrendererwidget.sip
@@ -5,12 +5,6 @@ class QgsSingleBandPseudoColorRendererWidget : QgsRasterRendererWidget
 %End
 
   public:
-    enum Mode
-    {
-      Continuous,    // Using breaks from color palette
-      EqualInterval,
-      Quantile,
-    };
 
     QgsSingleBandPseudoColorRendererWidget( QgsRasterLayer* layer, const QgsRectangle &extent = QgsRectangle() );
     ~QgsSingleBandPseudoColorRendererWidget();

--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -26,22 +26,28 @@ originally part of the larger QgsRasterLayer class
 #include "qgis.h"
 #include "qgscolorramp.h"
 #include "qgscolorrampshader.h"
+#include "qgsrasterinterface.h"
+#include "qgsrasterminmaxorigin.h"
 
 #include <cmath>
-
-QgsColorRampShader::QgsColorRampShader( double theMinimumValue, double theMaximumValue )
+QgsColorRampShader::QgsColorRampShader( double theMinimumValue, double theMaximumValue, QgsColorRamp* theColorRamp, Type theType, ClassificationMode theClassificationMode )
     : QgsRasterShaderFunction( theMinimumValue, theMaximumValue )
-    , mColorRampType( INTERPOLATED )
+    , mColorRampType( theType )
+    , mClassificationMode( theClassificationMode )
     , mLUTOffset( 0.0 )
     , mLUTFactor( 1.0 )
     , mLUTInitialized( false )
     , mClip( false )
 {
   QgsDebugMsgLevel( "called.", 4 );
+
+  setSourceColorRamp( theColorRamp );
 }
 
 QgsColorRampShader::QgsColorRampShader( const QgsColorRampShader& other )
     : QgsRasterShaderFunction( other )
+    , mColorRampType( other.mColorRampType )
+    , mClassificationMode( other.mClassificationMode )
     , mLUT( other.mLUT )
     , mLUTOffset( other.mLUTOffset )
     , mLUTFactor( other.mLUTFactor )
@@ -54,6 +60,8 @@ QgsColorRampShader::QgsColorRampShader( const QgsColorRampShader& other )
 QgsColorRampShader & QgsColorRampShader::operator=( const QgsColorRampShader & other )
 {
   mSourceColorRamp.reset( other.sourceColorRamp()->clone() );
+  mColorRampType = other.mColorRampType;
+  mClassificationMode = other.mClassificationMode;
   mLUT = other.mLUT;
   mLUTOffset = other.mLUTOffset;
   mLUTFactor = other.mLUTFactor;
@@ -70,11 +78,11 @@ QString QgsColorRampShader::colorRampTypeAsQString()
 {
   switch ( mColorRampType )
   {
-    case INTERPOLATED:
+    case Interpolated:
       return QStringLiteral( "INTERPOLATED" );
-    case DISCRETE:
+    case Discrete:
       return QStringLiteral( "DISCRETE" );
-    case EXACT:
+    case Exact:
       return QStringLiteral( "EXACT" );
   }
   return QStringLiteral( "Unknown" );
@@ -88,7 +96,7 @@ void QgsColorRampShader::setColorRampItemList( const QList<QgsColorRampShader::C
   mLUT.clear();
 }
 
-void QgsColorRampShader::setColorRampType( QgsColorRampShader::ColorRamp_TYPE theColorRampType )
+void QgsColorRampShader::setColorRampType( QgsColorRampShader::Type theColorRampType )
 {
   mColorRampType = theColorRampType;
 }
@@ -97,15 +105,15 @@ void QgsColorRampShader::setColorRampType( const QString& theType )
 {
   if ( theType == QLatin1String( "INTERPOLATED" ) )
   {
-    mColorRampType = INTERPOLATED;
+    mColorRampType = Interpolated;
   }
   else if ( theType == QLatin1String( "DISCRETE" ) )
   {
-    mColorRampType = DISCRETE;
+    mColorRampType = Discrete;
   }
   else
   {
-    mColorRampType = EXACT;
+    mColorRampType = Exact;
   }
 }
 
@@ -119,6 +127,188 @@ void QgsColorRampShader::setSourceColorRamp( QgsColorRamp* colorramp )
   mSourceColorRamp.reset( colorramp );
 }
 
+void QgsColorRampShader::classifyColorRamp( const int classes, const int band, const QgsRectangle& extent, QgsRasterInterface* input )
+{
+  if ( minimumValue() >= maximumValue() )
+  {
+    return;
+  }
+
+  bool discrete = colorRampType() == Discrete;
+
+  QList<double> entryValues;
+  QVector<QColor> entryColors;
+
+  double min = minimumValue();
+  double max = maximumValue();
+
+  if ( classificationMode() == Continuous )
+  {
+    if ( sourceColorRamp() &&  sourceColorRamp()->count() > 1 )
+    {
+      int numberOfEntries = sourceColorRamp()->count();
+      entryValues.reserve( numberOfEntries );
+      if ( discrete )
+      {
+        double intervalDiff = max - min;
+
+        // remove last class when ColorRamp is gradient and discrete, as they are implemented with an extra stop
+        QgsGradientColorRamp* colorGradientRamp = dynamic_cast<QgsGradientColorRamp*>( sourceColorRamp() );
+        if ( colorGradientRamp != NULL && colorGradientRamp->isDiscrete() )
+        {
+          numberOfEntries--;
+        }
+        else
+        {
+          // if color ramp is continuous scale values to get equally distributed classes.
+          // Doesn't work perfectly when stops are non equally distributed.
+          intervalDiff *= ( numberOfEntries - 1 ) / ( double )numberOfEntries;
+        }
+
+        // skip first value (always 0.0)
+        for ( int i = 1; i < numberOfEntries; ++i )
+        {
+          double value = sourceColorRamp()->value( i );
+          entryValues.push_back( min + value * intervalDiff );
+        }
+        entryValues.push_back( std::numeric_limits<double>::infinity() );
+      }
+      else
+      {
+        for ( int i = 0; i < numberOfEntries; ++i )
+        {
+          double value = sourceColorRamp()->value( i );
+          entryValues.push_back( min + value * ( max - min ) );
+        }
+      }
+      // for continuous mode take original color map colors
+      for ( int i = 0; i < numberOfEntries; ++i )
+      {
+        int idx = i;
+        entryColors.push_back( sourceColorRamp()->color( sourceColorRamp()->value( idx ) ) );
+      }
+    }
+  }
+  else // for other classification modes interpolate colors linearly
+  {
+    if ( classes < 2 )
+      return; // < 2 classes is not useful, shouldn't happen, but if it happens save it from crashing
+
+    if ( classificationMode() == Quantile )
+    { // Quantile
+      if ( band < 0 || !input )
+        return; // quantile classificationr requires a valid band, minMaxOrigin, and input
+
+      double cut1 = std::numeric_limits<double>::quiet_NaN();
+      double cut2 = std::numeric_limits<double>::quiet_NaN();
+      int sampleSize = 250000;
+
+      // set min and max from histogram, used later to calculate number of decimals to display
+      input->cumulativeCut( band, 0.0, 1.0, min, max, extent, sampleSize );
+
+      entryValues.reserve( classes );
+      if ( discrete )
+      {
+        double intervalDiff = 1.0 / ( classes );
+        for ( int i = 1; i < classes; ++i )
+        {
+          input->cumulativeCut( band, 0.0, i * intervalDiff, cut1, cut2, extent, sampleSize );
+          entryValues.push_back( cut2 );
+        }
+        entryValues.push_back( std::numeric_limits<double>::infinity() );
+      }
+      else
+      {
+        double intervalDiff = 1.0 / ( classes - 1 );
+        for ( int i = 0; i < classes; ++i )
+        {
+          input->cumulativeCut( band, 0.0, i * intervalDiff, cut1, cut2, extent, sampleSize );
+          entryValues.push_back( cut2 );
+        }
+      }
+    }
+    else // EqualInterval
+    {
+      entryValues.reserve( classes );
+      if ( discrete )
+      {
+        // in discrete mode the lowest value is not an entry and the highest
+        // value is inf, there are ( numberOfEntries ) of which the first
+        // and last are not used.
+        double intervalDiff = ( max - min ) / ( classes );
+
+        for ( int i = 1; i < classes; ++i )
+        {
+          entryValues.push_back( min + i * intervalDiff );
+        }
+        entryValues.push_back( std::numeric_limits<double>::infinity() );
+      }
+      else
+      {
+        //because the highest value is also an entry, there are (numberOfEntries - 1) intervals
+        double intervalDiff = ( max - min ) / ( classes - 1 );
+
+        for ( int i = 0; i < classes; ++i )
+        {
+          entryValues.push_back( min + i * intervalDiff );
+        }
+      }
+    }
+
+    if ( !sourceColorRamp() || sourceColorRamp()->count() == 1 )
+    {
+      //hard code color range from blue -> red (previous default)
+      int colorDiff = 0;
+      if ( classes != 0 )
+      {
+        colorDiff = ( int )( 255 / classes );
+      }
+
+      entryColors.reserve( classes );
+      for ( int i = 0; i < classes; ++i )
+      {
+        QColor currentColor;
+        int idx = i;
+        currentColor.setRgb( colorDiff*idx, 0, 255 - colorDiff * idx );
+        entryColors.push_back( currentColor );
+      }
+    }
+    else
+    {
+      entryColors.reserve( classes );
+      for ( int i = 0; i < classes; ++i )
+      {
+        int idx = i;
+        entryColors.push_back( sourceColorRamp()->color((( double ) idx ) / ( classes - 1 ) ) );
+      }
+    }
+  }
+
+  QList<double>::const_iterator value_it = entryValues.begin();
+  QVector<QColor>::const_iterator color_it = entryColors.begin();
+
+  // calculate a reasonable number of decimals to display
+  double maxabs = log10( qMax( qAbs( max ), qAbs( min ) ) );
+  int nDecimals = qRound( qMax( 3.0 + maxabs - log10( max - min ), maxabs <= 15.0 ? maxabs + 0.49 : 0.0 ) );
+
+  QList<QgsColorRampShader::ColorRampItem> colorRampItems;
+  for ( ; value_it != entryValues.end(); ++value_it, ++color_it )
+  {
+    QgsColorRampShader::ColorRampItem newColorRampItem;
+    newColorRampItem.value = *value_it;
+    newColorRampItem.color = *color_it;
+    newColorRampItem.label = QString::number( *value_it, 'g', nDecimals );
+    colorRampItems.append( newColorRampItem );
+  }
+
+  qSort( colorRampItems );
+  setColorRampItemList( colorRampItems );
+}
+
+void QgsColorRampShader::classifyColorRamp( const int band, const QgsRectangle& extent, QgsRasterInterface* input )
+{
+  classifyColorRamp( colorRampItemList().count(), band, extent, input );
+}
 
 bool QgsColorRampShader::shade( double theValue, int* theReturnRedValue, int* theReturnGreenValue, int* theReturnBlueValue, int *theReturnAlphaValue )
 {
@@ -201,7 +391,7 @@ bool QgsColorRampShader::shade( double theValue, int* theReturnRedValue, int* th
 
   const QgsColorRampShader::ColorRampItem& currentColorRampItem = mColorRampItemList.at( idx );
 
-  if ( QgsColorRampShader::INTERPOLATED == mColorRampType )
+  if ( colorRampType() == Interpolated )
   { // Interpolate the color between two class breaks linearly.
     if ( idx < 1 || overflow || currentColorRampItem.value - DOUBLE_DIFF_THRESHOLD <= theValue )
     {
@@ -229,7 +419,7 @@ bool QgsColorRampShader::shade( double theValue, int* theReturnRedValue, int* th
     *theReturnAlphaValue = static_cast< int >( static_cast< double >( previousColorRampItem.color.alpha() ) + ( static_cast< double >( currentColorRampItem.color.alpha() - previousColorRampItem.color.alpha() ) * scale ) );
     return true;
   }
-  else if ( QgsColorRampShader::DISCRETE == mColorRampType )
+  else if ( colorRampType() == Discrete )
   { // Assign the color of the higher class for every pixel between two class breaks.
     // NOTE: The implementation has always been different than the documentation,
     //       which said lower class before, see http://hub.qgis.org/issues/13995

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -25,7 +25,9 @@ originally part of the larger QgsRasterLayer class
 #include <QVector>
 
 #include "qgscolorramp.h"
+#include "qgsrasterinterface.h"
 #include "qgsrastershaderfunction.h"
+#include "qgsrectangle.h"
 
 /** \ingroup core
  * A ramp shader will color a raster pixel based on a list of values ranges in a ramp.
@@ -35,7 +37,31 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
 
   public:
 
-    QgsColorRampShader( double theMinimumValue = 0.0, double theMaximumValue = 255.0 );
+    //! Supported methods for color interpolation.
+    enum Type
+    {
+      Interpolated, //!< Interpolates the color between two class breaks linearly.
+      Discrete,     //!< Assigns the color of the higher class for every pixel between two class breaks.
+      Exact         //!< Assigns the color of the exact matching value in the color ramp item list
+    };
+
+    //! Classification modes used to create the color ramp shader
+    enum ClassificationMode
+    {
+      Continuous = 1, //!< Uses breaks from color palette
+      EqualInterval = 2, //!< Uses equal interval
+      Quantile = 3 //!< Uses quantile (i.e. equal pixel) count
+    };
+
+    /** Creates a new color ramp shader.
+     * @param theMinimumValue minimum value for the raster shader
+     * @param theMaximumValue maximum value for the raster shader
+     * @param theType interpolation type used
+     * @param theClassificationMode method used to classify the color ramp shader
+     * @param theColorRamp vector color ramp used to classify the color ramp shader
+     * @returns new QgsColorRampShader
+     */
+    QgsColorRampShader( double theMinimumValue = 0.0, double theMaximumValue = 255.0, QgsColorRamp* theColorRamp = nullptr, Type theType = Interpolated, ClassificationMode theClassificationMode = Continuous );
 
     /** Destructor
      */
@@ -72,19 +98,11 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
       bool operator<( const ColorRampItem& other ) const { return value < other.value; }
     };
 
-    //! Supported methods for color interpolation.
-    enum ColorRamp_TYPE
-    {
-      INTERPOLATED, //!< Interpolates the color between two class breaks linearly.
-      DISCRETE,     //!< Assigns the color of the higher class for every pixel between two class breaks.
-      EXACT         //!< Assigns the color of the exact matching value in the color ramp item list
-    };
-
     //! \brief Get the custom colormap
     QList<QgsColorRampShader::ColorRampItem> colorRampItemList() const { return mColorRampItemList.toList(); }
 
     //! \brief Get the color ramp type
-    QgsColorRampShader::ColorRamp_TYPE colorRampType() const { return mColorRampType; }
+    Type colorRampType() const { return mColorRampType; }
 
     //! \brief Get the color ramp type as a string
     QString colorRampTypeAsQString();
@@ -93,7 +111,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     void setColorRampItemList( const QList<QgsColorRampShader::ColorRampItem>& theList ); //TODO: sort on set
 
     //! \brief Set the color ramp type
-    void setColorRampType( QgsColorRampShader::ColorRamp_TYPE theColorRampType );
+    void setColorRampType( QgsColorRampShader::Type theColorRampType );
 
     /** Get the source color ramp
      * @note added in QGIS 3.0
@@ -110,6 +128,21 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     //! \brief Set the color ramp type
     void setColorRampType( const QString& theType );
 
+    /** Classify color ramp shader
+     * @param classes number of classes
+     * @param band raster band used in classification (only used in quantile mode)
+     * @param extent extent used in classification (only used in quantile mode)
+     * @param input raster input used in classification (only used in quantile mode)
+     */
+    void classifyColorRamp( const int classes = 0, const int band = -1, const QgsRectangle& extent = QgsRectangle(), QgsRasterInterface* input = nullptr );
+
+    /** Classify color ramp shader
+     * @param band raster band used in classification (quantile mode only)
+     * @param extent extent used in classification (quantile mode only)
+     * @param input raster input used in classification (quantile mode only)
+     */
+    void classifyColorRamp( const int band = -1, const QgsRectangle& extent = QgsRectangle(), QgsRasterInterface* input = nullptr );
+
     //! \brief Generates and new RGB value based on one input value
     bool shade( double, int*, int*, int*, int* ) override;
 
@@ -118,6 +151,12 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
 
     //! \brief Get symbology items if provided by renderer
     void legendSymbologyItems( QList< QPair< QString, QColor > >& symbolItems ) const override;
+
+    //! Sets classification mode
+    void setClassificationMode( ClassificationMode classificationMode ) { mClassificationMode = classificationMode; }
+
+    //! Returns the classification mode
+    ClassificationMode classificationMode() const { return mClassificationMode; }
 
     /** Sets whether the shader should not render values out of range.
      * @param clip set to true to clip values which are out of range.
@@ -144,8 +183,8 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
      * interpolated for values between the item values (false)*/
     QVector<QgsColorRampShader::ColorRampItem> mColorRampItemList;
 
-    //! \brief The color ramp type
-    QgsColorRampShader::ColorRamp_TYPE mColorRampType;
+    Type mColorRampType;
+    ClassificationMode mClassificationMode;
 
     /** Look up table to speed up finding the right color.
       * It is initialized on the first call to shade(). */

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1057,8 +1057,30 @@ void QgsRasterLayer::refreshRendererIfNeeded( QgsRasterRenderer* rasterRenderer,
                    SAMPLE_SIZE, min, max );
     sbpcr->setClassificationMin( min );
     sbpcr->setClassificationMax( max );
+
+    if ( sbpcr->shader() )
+    {
+      QgsColorRampShader* colorRampShader = dynamic_cast<QgsColorRampShader*>( sbpcr->shader()->rasterShaderFunction() );
+      if ( colorRampShader )
+      {
+        colorRampShader->classifyColorRamp( sbpcr->band(), theExtent, rasterRenderer->input() );
+      }
+    }
+
+    QgsSingleBandPseudoColorRenderer* r = dynamic_cast<QgsSingleBandPseudoColorRenderer*>( renderer() );
     dynamic_cast<QgsSingleBandPseudoColorRenderer*>( renderer() )->setClassificationMin( min );
     dynamic_cast<QgsSingleBandPseudoColorRenderer*>( renderer() )->setClassificationMax( max );
+
+    if ( r->shader() )
+    {
+      QgsColorRampShader* colorRampShader = dynamic_cast<QgsColorRampShader*>( r->shader()->rasterShaderFunction() );
+      if ( colorRampShader )
+      {
+        colorRampShader->classifyColorRamp( sbpcr->band(), theExtent, rasterRenderer->input() );
+      }
+    }
+
+    emit repaintRequested();
     emit styleChanged();
     emit rendererChanged();
     return;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -550,7 +550,7 @@ QPixmap QgsRasterLayer::paletteAsPixmap( int theBandNumber )
     {
       QgsDebugMsgLevel( "....got color ramp item list", 4 );
       myShader.setColorRampItemList( myColorRampItemList );
-      myShader.setColorRampType( QgsColorRampShader::DISCRETE );
+      myShader.setColorRampType( QgsColorRampShader::Discrete );
       // Draw image
       int mySize = 100;
       QPixmap myPalettePixmap( mySize, mySize );
@@ -758,7 +758,7 @@ void QgsRasterLayer::setDataProvider( QString const & provider )
       // TODO: this should go somewhere else
       QgsRasterShader* shader = new QgsRasterShader();
       QgsColorRampShader* colorRampShader = new QgsColorRampShader();
-      colorRampShader->setColorRampType( QgsColorRampShader::INTERPOLATED );
+      colorRampShader->setColorRampType( QgsColorRampShader::Interpolated );
       colorRampShader->setColorRampItemList( colorTable );
       shader->setRasterShaderFunction( colorRampShader );
       r->setShader( shader );

--- a/src/core/raster/qgsrastershader.cpp
+++ b/src/core/raster/qgsrastershader.cpp
@@ -147,6 +147,7 @@ void QgsRasterShader::writeXml( QDomDocument& doc, QDomElement& parent ) const
   {
     QDomElement colorRampShaderElem = doc.createElement( QStringLiteral( "colorrampshader" ) );
     colorRampShaderElem.setAttribute( "colorRampType", colorRampShader->colorRampTypeAsQString() );
+    colorRampShaderElem.setAttribute( "classificationMode", colorRampShader->classificationMode() );
     colorRampShaderElem.setAttribute( QStringLiteral( "clip" ), colorRampShader->clip() );
 
     // save source color ramp
@@ -189,6 +190,7 @@ void QgsRasterShader::readXml( const QDomElement& elem )
     }
 
     colorRampShader->setColorRampType( colorRampShaderElem.attribute( QStringLiteral( "colorRampType" ), QStringLiteral( "INTERPOLATED" ) ) );
+    colorRampShader->setClassificationMode( static_cast< QgsColorRampShader::ClassificationMode >( colorRampShaderElem.attribute( QStringLiteral( "classificationMode" ), QStringLiteral( "1" ) ).toInt() ) );
     colorRampShader->setClip( colorRampShaderElem.attribute( QStringLiteral( "clip" ), QStringLiteral( "0" ) ) == QLatin1String( "1" ) );
 
     QList<QgsColorRampShader::ColorRampItem> itemList;

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.h
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.h
@@ -18,7 +18,10 @@
 #ifndef QGSSINGLEBANDPSEUDOCOLORRENDERER_H
 #define QGSSINGLEBANDPSEUDOCOLORRENDERER_H
 
+#include "qgscolorramp.h"
+#include "qgscolorrampshader.h"
 #include "qgsrasterrenderer.h"
+#include "qgsrectangle.h"
 
 class QDomElement;
 class QgsRasterShader;
@@ -28,9 +31,11 @@ class QgsRasterShader;
   */
 class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
 {
+
   public:
+
     //! Note: takes ownership of QgsRasterShader
-    QgsSingleBandPseudoColorRenderer( QgsRasterInterface* input, int band, QgsRasterShader* shader );
+    QgsSingleBandPseudoColorRenderer( QgsRasterInterface* input, int band = -1, QgsRasterShader* shader = nullptr );
     ~QgsSingleBandPseudoColorRenderer();
     QgsSingleBandPseudoColorRenderer * clone() const override;
 
@@ -40,9 +45,22 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
 
     //! Takes ownership of the shader
     void setShader( QgsRasterShader* shader );
+
+    //! Returns the raster shader
     QgsRasterShader* shader() { return mShader; }
+
     //! @note available in python as constShader
     const QgsRasterShader* shader() const { return mShader; }
+
+    /** Creates a color ramp shader
+     * @param colorRamp vector color ramp
+     * @param colorRampType type of color ramp shader
+     * @param classificationMode classification mode
+     * @param classes number of classes
+     * @param clip clip out of range values
+     * @param extent extent used in classification (only used in quantile mode)
+     */
+    void createShader( QgsColorRamp* colorRamp = nullptr, QgsColorRampShader::Type colorRampType  = QgsColorRampShader::Interpolated, QgsColorRampShader::ClassificationMode classificationMode = QgsColorRampShader::Continuous, int classes = 0, bool clip = false, const QgsRectangle& extent = QgsRectangle() );
 
     void writeXml( QDomDocument& doc, QDomElement& parentElem ) const override;
 
@@ -63,10 +81,11 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
 
     double classificationMin() const { return mClassificationMin; }
     double classificationMax() const { return mClassificationMax; }
-    void setClassificationMin( double min ) { mClassificationMin = min; }
-    void setClassificationMax( double max ) { mClassificationMax = max; }
+    void setClassificationMin( double min );
+    void setClassificationMax( double max );
 
   private:
+
     QgsRasterShader* mShader;
     int mBand;
 

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -99,14 +99,15 @@ QgsSingleBandPseudoColorRendererWidget::QgsSingleBandPseudoColorRendererWidget( 
     mBandComboBox->addItem( displayBandName( i ), i );
   }
 
-  mColorInterpolationComboBox->addItem( tr( "Discrete" ), QgsColorRampShader::DISCRETE );
-  mColorInterpolationComboBox->addItem( tr( "Linear" ), QgsColorRampShader::INTERPOLATED );
-  mColorInterpolationComboBox->addItem( tr( "Exact" ), QgsColorRampShader::EXACT );
-  mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::INTERPOLATED ) );
+  mColorInterpolationComboBox->addItem( tr( "Discrete" ), QgsColorRampShader::Discrete );
+  mColorInterpolationComboBox->addItem( tr( "Linear" ), QgsColorRampShader::Interpolated );
+  mColorInterpolationComboBox->addItem( tr( "Exact" ), QgsColorRampShader::Exact );
+  mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::Interpolated ) );
 
-  mClassificationModeComboBox->addItem( tr( "Continuous" ), Continuous );
-  mClassificationModeComboBox->addItem( tr( "Equal interval" ), EqualInterval );
-  mClassificationModeComboBox->addItem( tr( "Quantile" ), Quantile );
+  mClassificationModeComboBox->addItem( tr( "Continuous" ), QgsColorRampShader::Continuous );
+  mClassificationModeComboBox->addItem( tr( "Equal interval" ), QgsColorRampShader::EqualInterval );
+  mClassificationModeComboBox->addItem( tr( "Quantile" ), QgsColorRampShader::Quantile );
+  mClassificationModeComboBox->setCurrentIndex( mClassificationModeComboBox->findData( QgsColorRampShader::Continuous ) );
 
   mNumberOfEntriesSpinBox->setValue( 5 ); // some default
 
@@ -143,7 +144,9 @@ QgsSingleBandPseudoColorRendererWidget::~QgsSingleBandPseudoColorRendererWidget(
 QgsRasterRenderer* QgsSingleBandPseudoColorRendererWidget::renderer()
 {
   QgsRasterShader* rasterShader = new QgsRasterShader();
-  QgsColorRampShader* colorRampShader = new QgsColorRampShader();
+  QgsColorRampShader* colorRampShader = new QgsColorRampShader( lineEditValue( mMinLineEdit ), lineEditValue( mMaxLineEdit ) );
+  colorRampShader->setColorRampType( static_cast< QgsColorRampShader::Type >( mColorInterpolationComboBox->currentData().toInt() ) );
+  colorRampShader->setClassificationMode( static_cast< QgsColorRampShader::ClassificationMode >( mClassificationModeComboBox->currentData().toInt() ) );
   colorRampShader->setClip( mClipCheckBox->isChecked() );
 
   //iterate through mColormapTreeWidget and set colormap info of layer
@@ -167,10 +170,6 @@ QgsRasterRenderer* QgsSingleBandPseudoColorRendererWidget::renderer()
   qSort( colorRampItems );
   colorRampShader->setColorRampItemList( colorRampItems );
 
-  QgsColorRampShader::ColorRamp_TYPE interpolation = static_cast< QgsColorRampShader::ColorRamp_TYPE >( mColorInterpolationComboBox->currentData().toInt() );
-  colorRampShader->setColorRampType( interpolation );
-
-
   if ( !btnColorRamp->isNull() )
   {
     colorRampShader->setSourceColorRamp( btnColorRamp->colorRamp() );
@@ -180,7 +179,6 @@ QgsRasterRenderer* QgsSingleBandPseudoColorRendererWidget::renderer()
 
   int bandNumber = mBandComboBox->currentData().toInt();
   QgsSingleBandPseudoColorRenderer *renderer = new QgsSingleBandPseudoColorRenderer( mRasterLayer->dataProvider(), bandNumber, rasterShader );
-
   renderer->setClassificationMin( lineEditValue( mMinLineEdit ) );
   renderer->setClassificationMax( lineEditValue( mMaxLineEdit ) );
   renderer->setMinMaxOrigin( mMinMaxWidget->minMaxOrigin() );
@@ -206,8 +204,8 @@ void QgsSingleBandPseudoColorRendererWidget::setMapCanvas( QgsMapCanvas* canvas 
  */
 void QgsSingleBandPseudoColorRendererWidget::autoLabel()
 {
-  QgsColorRampShader::ColorRamp_TYPE interpolation = static_cast< QgsColorRampShader::ColorRamp_TYPE >( mColorInterpolationComboBox->currentData().toInt() );
-  bool discrete = interpolation == QgsColorRampShader::DISCRETE;
+  QgsColorRampShader::Type interpolation = static_cast< QgsColorRampShader::Type >( mColorInterpolationComboBox->currentData().toInt() );
+  bool discrete = interpolation == QgsColorRampShader::Discrete;
   QString unit = mUnitLineEdit->text();
   QString label;
   int topLevelItemCount = mColormapTreeWidget->topLevelItemCount();
@@ -252,8 +250,8 @@ void QgsSingleBandPseudoColorRendererWidget::autoLabel()
 //! Extract the unit out of the current labels and set the unit field.
 void QgsSingleBandPseudoColorRendererWidget::setUnitFromLabels()
 {
-  QgsColorRampShader::ColorRamp_TYPE interpolation = static_cast< QgsColorRampShader::ColorRamp_TYPE >( mColorInterpolationComboBox->currentData().toInt() );
-  bool discrete = interpolation == QgsColorRampShader::DISCRETE;
+  QgsColorRampShader::Type interpolation = static_cast< QgsColorRampShader::Type >( mColorInterpolationComboBox->currentData().toInt() );
+  bool discrete = interpolation == QgsColorRampShader::Discrete;
   QStringList allSuffixes;
   QString label;
   int topLevelItemCount = mColormapTreeWidget->topLevelItemCount();
@@ -346,201 +344,51 @@ void QgsSingleBandPseudoColorRendererWidget::on_mDeleteEntryButton_clicked()
 
 void QgsSingleBandPseudoColorRendererWidget::classify()
 {
-  int bandComboIndex = mBandComboBox->currentIndex();
-  if ( bandComboIndex == -1 || !mRasterLayer )
+  QScopedPointer< QgsColorRamp > ramp( btnColorRamp->colorRamp() );
+  if ( !ramp )
   {
     return;
   }
 
-  //int bandNr = mBandComboBox->itemData( bandComboIndex ).toInt();
-  //QgsRasterBandStats myRasterBandStats = mRasterLayer->dataProvider()->bandStatistics( bandNr );
-  int numberOfEntries;
+  QgsSingleBandPseudoColorRenderer *pr = new QgsSingleBandPseudoColorRenderer( mRasterLayer->dataProvider(), mBandComboBox->currentData().toInt(), nullptr );
+  pr->setClassificationMin( lineEditValue( mMinLineEdit ) );
+  pr->setClassificationMax( lineEditValue( mMaxLineEdit ) );
+  pr->createShader( ramp.data(), static_cast< QgsColorRampShader::Type >( mColorInterpolationComboBox->currentData().toInt() ), static_cast< QgsColorRampShader::ClassificationMode >( mClassificationModeComboBox->currentData().toInt() ), mNumberOfEntriesSpinBox->value(), mClipCheckBox->isChecked(), minMaxWidget()->extent() );
 
-  QgsColorRampShader::ColorRamp_TYPE interpolation = static_cast< QgsColorRampShader::ColorRamp_TYPE >( mColorInterpolationComboBox->currentData().toInt() );
-  bool discrete = interpolation == QgsColorRampShader::DISCRETE;
-
-  QList<double> entryValues;
-  QVector<QColor> entryColors;
-
-  double min = lineEditValue( mMinLineEdit );
-  double max = lineEditValue( mMaxLineEdit );
-
-  QScopedPointer< QgsColorRamp > colorRamp( btnColorRamp->colorRamp() );
-
-  if ( mClassificationModeComboBox->currentData().toInt() == Continuous )
+  const QgsRasterShader* rasterShader = pr->shader();
+  if ( rasterShader )
   {
-    if ( colorRamp.data() &&  colorRamp->count() > 1 )
+    const QgsColorRampShader* colorRampShader = dynamic_cast<const QgsColorRampShader*>( rasterShader->rasterShaderFunction() );
+    if ( colorRampShader )
     {
-      numberOfEntries = colorRamp->count();
-      entryValues.reserve( numberOfEntries );
-      if ( discrete )
+      mColormapTreeWidget->clear();
+
+      const QList<QgsColorRampShader::ColorRampItem> colorRampItemList = colorRampShader->colorRampItemList();
+      QList<QgsColorRampShader::ColorRampItem>::const_iterator it = colorRampItemList.constBegin();
+      for ( ; it != colorRampItemList.end(); ++it )
       {
-        double intervalDiff = max - min;
-
-        // remove last class when ColorRamp is gradient and discrete, as they are implemented with an extra stop
-        QgsGradientColorRamp* colorGradientRamp = dynamic_cast<QgsGradientColorRamp*>( colorRamp.data() );
-        if ( colorGradientRamp != NULL && colorGradientRamp->isDiscrete() )
-        {
-          numberOfEntries--;
-        }
-        else
-        {
-          // if color ramp is continuous scale values to get equally distributed classes.
-          // Doesn't work perfectly when stops are non equally distributed.
-          intervalDiff *= ( numberOfEntries - 1 ) / ( double )numberOfEntries;
-        }
-
-        // skip first value (always 0.0)
-        for ( int i = 1; i < numberOfEntries; ++i )
-        {
-          double value = colorRamp->value( i );
-          entryValues.push_back( min + value * intervalDiff );
-        }
-        entryValues.push_back( std::numeric_limits<double>::infinity() );
+        QgsTreeWidgetItemObject* newItem = new QgsTreeWidgetItemObject( mColormapTreeWidget );
+        newItem->setText( ValueColumn, QString::number( it->value, 'g', 15 ) );
+        newItem->setBackground( ColorColumn, QBrush( it->color ) );
+        newItem->setText( LabelColumn, it->label );
+        newItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsSelectable );
+        connect( newItem, SIGNAL( itemEdited( QTreeWidgetItem*, int ) ),
+                 this, SLOT( mColormapTreeWidget_itemEdited( QTreeWidgetItem*, int ) ) );
       }
-      else
-      {
-        for ( int i = 0; i < numberOfEntries; ++i )
-        {
-          double value = colorRamp->value( i );
-          entryValues.push_back( min + value * ( max - min ) );
-        }
-      }
-      // for continuous mode take original color map colors
-      for ( int i = 0; i < numberOfEntries; ++i )
-      {
-        int idx = i;
-        entryColors.push_back( colorRamp->color( colorRamp->value( idx ) ) );
-      }
-    }
-  }
-  else // for other classification modes interpolate colors linearly
-  {
-    numberOfEntries = mNumberOfEntriesSpinBox->value();
-    if ( numberOfEntries < 2 )
-      return; // < 2 classes is not useful, shouldn't happen, but if it happens save it from crashing
-
-    if ( mClassificationModeComboBox->currentData().toInt() == Quantile )
-    { // Quantile
-      int bandNr = mBandComboBox->itemData( bandComboIndex ).toInt();
-      //QgsRasterHistogram rasterHistogram = mRasterLayer->dataProvider()->histogram( bandNr );
-
-      double cut1 = std::numeric_limits<double>::quiet_NaN();
-      double cut2 = std::numeric_limits<double>::quiet_NaN();
-
-      QgsRectangle extent = mMinMaxWidget->extent();
-      int sampleSize = mMinMaxWidget->sampleSize();
-
-      // set min and max from histogram, used later to calculate number of decimals to display
-      mRasterLayer->dataProvider()->cumulativeCut( bandNr, 0.0, 1.0, min, max, extent, sampleSize );
-
-      entryValues.reserve( numberOfEntries );
-      if ( discrete )
-      {
-        double intervalDiff = 1.0 / ( numberOfEntries );
-        for ( int i = 1; i < numberOfEntries; ++i )
-        {
-          mRasterLayer->dataProvider()->cumulativeCut( bandNr, 0.0, i * intervalDiff, cut1, cut2, extent, sampleSize );
-          entryValues.push_back( cut2 );
-        }
-        entryValues.push_back( std::numeric_limits<double>::infinity() );
-      }
-      else
-      {
-        double intervalDiff = 1.0 / ( numberOfEntries - 1 );
-        for ( int i = 0; i < numberOfEntries; ++i )
-        {
-          mRasterLayer->dataProvider()->cumulativeCut( bandNr, 0.0, i * intervalDiff, cut1, cut2, extent, sampleSize );
-          entryValues.push_back( cut2 );
-        }
-      }
-    }
-    else // EqualInterval
-    {
-      entryValues.reserve( numberOfEntries );
-      if ( discrete )
-      {
-        // in discrete mode the lowest value is not an entry and the highest
-        // value is inf, there are ( numberOfEntries ) of which the first
-        // and last are not used.
-        double intervalDiff = ( max - min ) / ( numberOfEntries );
-
-        for ( int i = 1; i < numberOfEntries; ++i )
-        {
-          entryValues.push_back( min + i * intervalDiff );
-        }
-        entryValues.push_back( std::numeric_limits<double>::infinity() );
-      }
-      else
-      {
-        //because the highest value is also an entry, there are (numberOfEntries - 1) intervals
-        double intervalDiff = ( max - min ) / ( numberOfEntries - 1 );
-
-        for ( int i = 0; i < numberOfEntries; ++i )
-        {
-          entryValues.push_back( min + i * intervalDiff );
-        }
-      }
-    }
-
-    if ( !colorRamp.data() || colorRamp->count() == 1 )
-    {
-      //hard code color range from blue -> red (previous default)
-      int colorDiff = 0;
-      if ( numberOfEntries != 0 )
-      {
-        colorDiff = ( int )( 255 / numberOfEntries );
-      }
-
-      entryColors.reserve( numberOfEntries );
-      for ( int i = 0; i < numberOfEntries; ++i )
-      {
-        QColor currentColor;
-        int idx = i;
-        currentColor.setRgb( colorDiff*idx, 0, 255 - colorDiff * idx );
-        entryColors.push_back( currentColor );
-      }
-    }
-    else
-    {
-      entryColors.reserve( numberOfEntries );
-      for ( int i = 0; i < numberOfEntries; ++i )
-      {
-        int idx = i;
-        entryColors.push_back( colorRamp->color((( double ) idx ) / ( numberOfEntries - 1 ) ) );
-      }
+      mClipCheckBox->setChecked( colorRampShader->clip() );
     }
   }
 
-  mColormapTreeWidget->clear();
-
-  QList<double>::const_iterator value_it = entryValues.begin();
-  QVector<QColor>::const_iterator color_it = entryColors.begin();
-
-  // calculate a reasonable number of decimals to display
-  double maxabs = log10( qMax( qAbs( max ), qAbs( min ) ) );
-  int nDecimals = qRound( qMax( 3.0 + maxabs - log10( max - min ), maxabs <= 15.0 ? maxabs + 0.49 : 0.0 ) );
-
-  for ( ; value_it != entryValues.end(); ++value_it, ++color_it )
-  {
-    QgsTreeWidgetItemObject* newItem = new QgsTreeWidgetItemObject( mColormapTreeWidget );
-    newItem->setText( ValueColumn, QString::number( *value_it, 'g', nDecimals ) );
-    newItem->setBackground( ColorColumn, QBrush( *color_it ) );
-    newItem->setText( LabelColumn, QString() );
-    newItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsSelectable );
-    connect( newItem, SIGNAL( itemEdited( QTreeWidgetItem*, int ) ),
-             this, SLOT( mColormapTreeWidget_itemEdited( QTreeWidgetItem*, int ) ) );
-  }
   autoLabel();
   emit widgetChanged();
 }
 
 void QgsSingleBandPseudoColorRendererWidget::on_mClassificationModeComboBox_currentIndexChanged( int index )
 {
-  Mode mode = static_cast< Mode >( mClassificationModeComboBox->itemData( index ).toInt() );
-  mNumberOfEntriesSpinBox->setEnabled( mode != Continuous );
-  mMinLineEdit->setEnabled( mode != Quantile );
-  mMaxLineEdit->setEnabled( mode != Quantile );
+  QgsColorRampShader::ClassificationMode mode = static_cast< QgsColorRampShader::ClassificationMode >( mClassificationModeComboBox->itemData( index ).toInt() );
+  mNumberOfEntriesSpinBox->setEnabled( mode != QgsColorRampShader::Continuous );
+  mMinLineEdit->setEnabled( mode != QgsColorRampShader::Quantile );
+  mMaxLineEdit->setEnabled( mode != QgsColorRampShader::Quantile );
 }
 
 void QgsSingleBandPseudoColorRendererWidget::applyColorRamp()
@@ -562,7 +410,7 @@ void QgsSingleBandPseudoColorRendererWidget::applyColorRamp()
   mClassificationModeComboBox->setEnabled( enableContinuous );
   if ( !enableContinuous )
   {
-    mClassificationModeComboBox->setCurrentIndex( mClassificationModeComboBox->findData( EqualInterval ) );
+    mClassificationModeComboBox->setCurrentIndex( mClassificationModeComboBox->findData( QgsColorRampShader::EqualInterval ) );
   }
 
   classify();
@@ -599,7 +447,7 @@ void QgsSingleBandPseudoColorRendererWidget::on_mLoadFromBandButton_clicked()
   if ( !colorRampList.isEmpty() )
   {
     populateColormapTreeWidget( colorRampList );
-    mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::INTERPOLATED ) );
+    mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::Interpolated ) );
   }
   else
   {
@@ -643,15 +491,15 @@ void QgsSingleBandPseudoColorRendererWidget::on_mLoadFromFileButton_clicked()
             {
               if ( inputStringComponents[1].trimmed().toUpper().compare( QLatin1String( "INTERPOLATED" ), Qt::CaseInsensitive ) == 0 )
               {
-                mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::INTERPOLATED ) );
+                mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::Interpolated ) );
               }
               else if ( inputStringComponents[1].trimmed().toUpper().compare( QLatin1String( "DISCRETE" ), Qt::CaseInsensitive ) == 0 )
               {
-                mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::DISCRETE ) );
+                mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::Discrete ) );
               }
               else
               {
-                mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::EXACT ) );
+                mColorInterpolationComboBox->setCurrentIndex( mColorInterpolationComboBox->findData( QgsColorRampShader::Exact ) );
               }
             }
             else
@@ -716,16 +564,16 @@ void QgsSingleBandPseudoColorRendererWidget::on_mExportToFileButton_clicked()
       QTextStream outputStream( &outputFile );
       outputStream << "# " << tr( "QGIS Generated Color Map Export File" ) << '\n';
       outputStream << "INTERPOLATION:";
-      QgsColorRampShader::ColorRamp_TYPE interpolation = static_cast< QgsColorRampShader::ColorRamp_TYPE >( mColorInterpolationComboBox->currentData().toInt() );
+      QgsColorRampShader::Type interpolation = static_cast< QgsColorRampShader::Type >( mColorInterpolationComboBox->currentData().toInt() );
       switch ( interpolation )
       {
-        case QgsColorRampShader::INTERPOLATED:
+        case QgsColorRampShader::Interpolated:
           outputStream << "INTERPOLATED\n";
           break;
-        case QgsColorRampShader::DISCRETE:
+        case QgsColorRampShader::Discrete:
           outputStream << "DISCRETE\n";
           break;
-        case QgsColorRampShader::EXACT:
+        case QgsColorRampShader::Exact:
           outputStream << "EXACT\n";
           break;
       }
@@ -852,6 +700,9 @@ void QgsSingleBandPseudoColorRendererWidget::setFromRenderer( const QgsRasterRen
         }
         setUnitFromLabels();
         mClipCheckBox->setChecked( colorRampShader->clip() );
+
+        mClassificationModeComboBox->setCurrentIndex( mClassificationModeComboBox->findData( colorRampShader->classificationMode() ) );
+        mNumberOfEntriesSpinBox->setValue( colorRampShader->colorRampItemList().count() ); // some default
       }
     }
     setLineEditValue( mMinLineEdit, pr->classificationMin() );
@@ -870,23 +721,23 @@ void QgsSingleBandPseudoColorRendererWidget::on_mBandComboBox_currentIndexChange
 
 void QgsSingleBandPseudoColorRendererWidget::on_mColorInterpolationComboBox_currentIndexChanged( int index )
 {
-  QgsColorRampShader::ColorRamp_TYPE interpolation = static_cast< QgsColorRampShader::ColorRamp_TYPE >( mColorInterpolationComboBox->itemData( index ).toInt() );
+  QgsColorRampShader::Type interpolation = static_cast< QgsColorRampShader::Type >( mColorInterpolationComboBox->itemData( index ).toInt() );
 
-  mClipCheckBox->setEnabled( interpolation == QgsColorRampShader::INTERPOLATED );
+  mClipCheckBox->setEnabled( interpolation == QgsColorRampShader::Interpolated );
 
   QString valueLabel;
   QString valueToolTip;
   switch ( interpolation )
   {
-    case QgsColorRampShader::INTERPOLATED:
+    case QgsColorRampShader::Interpolated:
       valueLabel = tr( "Value" );
       valueToolTip = tr( "Value for color stop" );
       break;
-    case QgsColorRampShader::DISCRETE:
+    case QgsColorRampShader::Discrete:
       valueLabel = tr( "Value <=" );
       valueToolTip = tr( "Maximum value for class" );
       break;
-    case QgsColorRampShader::EXACT:
+    case QgsColorRampShader::Exact:
       valueLabel = tr( "Value =" );
       valueToolTip = tr( "Value for color" );
       break;

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -86,11 +86,8 @@ QgsSingleBandPseudoColorRendererWidget::QgsSingleBandPseudoColorRendererWidget( 
   mMinMaxContainerWidget->setLayout( layout );
   layout->addWidget( mMinMaxWidget );
 
-  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::widgetChanged,
-           this, &QgsSingleBandPseudoColorRendererWidget::widgetChanged );
-
-  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::load,
-           this, &QgsSingleBandPseudoColorRendererWidget::loadMinMax );
+  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::widgetChanged, this, &QgsSingleBandPseudoColorRendererWidget::widgetChanged );
+  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::load, this, &QgsSingleBandPseudoColorRendererWidget::loadMinMax );
 
   //fill available bands into combo box
   int nBands = provider->bandCount();
@@ -775,6 +772,7 @@ void QgsSingleBandPseudoColorRendererWidget::loadMinMax( int theBandNo, double t
     mMaxLineEdit->setText( QString::number( theMax ) );
   }
   mDisableMinMaxWidgetRefresh = false;
+  classify();
 }
 
 void QgsSingleBandPseudoColorRendererWidget::setLineEditValue( QLineEdit * theLineEdit, double theValue )

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -36,13 +36,6 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
 
   public:
 
-    enum Mode
-    {
-      Continuous = 1, // Using breaks from color palette
-      EqualInterval = 2,
-      Quantile = 3
-    };
-
     QgsSingleBandPseudoColorRendererWidget( QgsRasterLayer* layer, const QgsRectangle &extent = QgsRectangle() );
     ~QgsSingleBandPseudoColorRendererWidget();
 

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -101,7 +101,7 @@ class TestQgsRasterLayer : public QObject
                                   QgsColorRamp* colorRamp,
                                   int numberOfEntries );
     bool testColorRamp( const QString& name, QgsColorRamp* colorRamp,
-                        QgsColorRampShader::ColorRamp_TYPE type, int numberOfEntries );
+                        QgsColorRampShader::Type type, int numberOfEntries );
     QString mTestDataDir;
     QgsRasterLayer * mpRasterLayer;
     QgsRasterLayer * mpLandsatRasterLayer;
@@ -222,7 +222,7 @@ void TestQgsRasterLayer::pseudoColor()
 {
   QgsRasterShader* rasterShader = new QgsRasterShader();
   QgsColorRampShader* colorRampShader = new QgsColorRampShader();
-  colorRampShader->setColorRampType( QgsColorRampShader::INTERPOLATED );
+  colorRampShader->setColorRampType( QgsColorRampShader::Interpolated );
 
   //items to imitate old pseudo color renderer
   QList<QgsColorRampShader::ColorRampItem> colorRampItems;
@@ -297,7 +297,7 @@ void TestQgsRasterLayer::populateColorRampShader( QgsColorRampShader* colorRampS
 }
 
 bool TestQgsRasterLayer::testColorRamp( const QString& name, QgsColorRamp* colorRamp,
-                                        QgsColorRampShader::ColorRamp_TYPE type, int numberOfEntries )
+                                        QgsColorRampShader::Type type, int numberOfEntries )
 {
   QgsRasterShader* rasterShader = new QgsRasterShader();
   QgsColorRampShader* colorRampShader = new QgsColorRampShader();
@@ -320,8 +320,8 @@ void TestQgsRasterLayer::colorRamp1()
   stops.append( QgsGradientStop( 0.5, QColor( Qt::white ) ) );
   colorRamp->setStops( stops );
 
-  // QVERIFY( testColorRamp( "raster_colorRamp1", colorRamp, QgsColorRampShader::INTERPOLATED, 5 ) );
-  QVERIFY( testColorRamp( "raster_colorRamp1", colorRamp, QgsColorRampShader::DISCRETE, 10 ) );
+  // QVERIFY( testColorRamp( "raster_colorRamp1", colorRamp, QgsColorRampShader::Interpolated, 5 ) );
+  QVERIFY( testColorRamp( "raster_colorRamp1", colorRamp, QgsColorRampShader::Discrete, 10 ) );
   delete colorRamp;
 }
 
@@ -331,7 +331,7 @@ void TestQgsRasterLayer::colorRamp2()
   // ColorBrewer ramp
   QVERIFY( testColorRamp( "raster_colorRamp2",
                           &ramp,
-                          QgsColorRampShader::DISCRETE, 10 ) );
+                          QgsColorRampShader::Discrete, 10 ) );
 }
 
 void TestQgsRasterLayer::colorRamp3()
@@ -341,7 +341,7 @@ void TestQgsRasterLayer::colorRamp3()
   QgsCptCityColorRamp ramp( QStringLiteral( "cb/div/BrBG" ), QStringLiteral( "_10" ) );
   QVERIFY( testColorRamp( "raster_colorRamp3",
                           &ramp,
-                          QgsColorRampShader::DISCRETE, 10 ) );
+                          QgsColorRampShader::Discrete, 10 ) );
   QgsCptCityArchive::clearArchives();
 }
 
@@ -351,7 +351,7 @@ void TestQgsRasterLayer::colorRamp4()
   QgsCptCityColorRamp ramp( QStringLiteral( "grass/elevation" ), QLatin1String( "" ) );
   QVERIFY( testColorRamp( "raster_colorRamp4",
                           &ramp,
-                          QgsColorRampShader::DISCRETE, 10 ) );
+                          QgsColorRampShader::Discrete, 10 ) );
 }
 
 void TestQgsRasterLayer::landsatBasic()

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -171,7 +171,7 @@ class TestQgsRasterLayer(unittest.TestCase):
 
         myRasterShader = QgsRasterShader()
         myColorRampShader = QgsColorRampShader()
-        myColorRampShader.setColorRampType(QgsColorRampShader.INTERPOLATED)
+        myColorRampShader.setColorRampType(QgsColorRampShader.Interpolated)
         myItems = []
         myItem = QgsColorRampShader.ColorRampItem(
             10, QColor('#ffff00'), 'foo')
@@ -193,7 +193,7 @@ class TestQgsRasterLayer(unittest.TestCase):
 
         myRasterShader = QgsRasterShader()
         myColorRampShader = QgsColorRampShader()
-        myColorRampShader.setColorRampType(QgsColorRampShader.INTERPOLATED)
+        myColorRampShader.setColorRampType(QgsColorRampShader.Interpolated)
         myItems = []
         myItem = QgsColorRampShader.ColorRampItem(10,
                                                   QColor('#ffff00'), 'foo')

--- a/tests/testdata/landsat.tif.aux.xml
+++ b/tests/testdata/landsat.tif.aux.xml
@@ -22,7 +22,7 @@
       <MDI key="STATISTICS_MAXIMUM">130</MDI>
       <MDI key="STATISTICS_MEAN">126.001725</MDI>
       <MDI key="STATISTICS_MINIMUM">122</MDI>
-      <MDI key="STATISTICS_STDDEV">1.1294343825018</MDI>
+      <MDI key="STATISTICS_STDDEV">1.1294343825008</MDI>
     </Metadata>
   </PAMRasterBand>
   <PAMRasterBand band="2">
@@ -48,7 +48,7 @@
       <MDI key="STATISTICS_MAXIMUM">148</MDI>
       <MDI key="STATISTICS_MEAN">140.388625</MDI>
       <MDI key="STATISTICS_MINIMUM">133</MDI>
-      <MDI key="STATISTICS_STDDEV">1.8804376111365</MDI>
+      <MDI key="STATISTICS_STDDEV">1.880437611136</MDI>
     </Metadata>
   </PAMRasterBand>
   <PAMRasterBand band="3">
@@ -74,7 +74,7 @@
       <MDI key="STATISTICS_MAXIMUM">172</MDI>
       <MDI key="STATISTICS_MEAN">111.602125</MDI>
       <MDI key="STATISTICS_MINIMUM">51</MDI>
-      <MDI key="STATISTICS_STDDEV">7.6436882775512</MDI>
+      <MDI key="STATISTICS_STDDEV">7.6436882775513</MDI>
     </Metadata>
   </PAMRasterBand>
   <PAMRasterBand band="4">


### PR DESCRIPTION
@rouault , @wonder-sk , this PR is a WIP, mostly looking for your feedbacks here. What it does is moving the classification code that creates the color ramp shader for the pseudocolor renderer away from gui into core so the classification can occur outside the context of the style dock / layer properties window.

Moving the classification to be attached to the renderer allows for @rouault 's recently added "updated extent" mode to function with the pseudo color renderer. It also allows for the raster toolbar buttons to function with that renderer too.