### PR TITLE
[processing] support non-ogr layers in merge vector layers algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/Merge.py
+++ b/python/plugins/processing/algs/qgis/Merge.py
@@ -61,13 +61,12 @@ class Merge(GeoAlgorithm):
 
     def processAlgorithm(self, progress):
         inLayers = self.getParameterValue(self.LAYERS)
-        paths = inLayers.split(';')
 
         layers = []
         fields = QgsFields()
         totalFeatureCount = 0
-        for x in range(len(paths)):
-            layer = QgsVectorLayer(paths[x], str(x), 'ogr')
+        for layerSource in inLayers.split(';'):
+            layer = dataobjects.getObjectFromUri(layerSource)
 
             if (len(layers) > 0):
                 if (layer.wkbType() != layers[0].wkbType()):

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -500,7 +500,7 @@ class MultipleInputWidgetWrapper(WidgetWrapper):
                 options = dataobjects.getTables(sorting=False)
             else:
                 options = dataobjects.getVectorLayers([self.param.datatype], sorting=False)
-            opts = [self.getExtendedLayerName(opt) for opt in options]
+            opts = [getExtendedLayerName(opt) for opt in options]
             self.widget.updateForOptions(opts)
 
     def setValue(self, value):


### PR DESCRIPTION
Looking into @anitagraser 's PR had me stumble on a flaw in our merge vector layers' algorithm whereas it would only support OGR layers. This PR fixes that (and a small error in MultipleInputWidgerWrapper).