### PR TITLE
Server: Remove base64 encoding supports in WMS responses

### DIFF
--- a/src/server/qgshttprequesthandler.cpp
+++ b/src/server/qgshttprequesthandler.cpp
@@ -259,7 +259,6 @@ void QgsHttpRequestHandler::setGetMapResponse( const QString& service, QImage* i
     bool png16Bit = ( mFormatString.compare( QLatin1String( "image/png; mode=16bit" ), Qt::CaseInsensitive ) == 0 );
     bool png8Bit = ( mFormatString.compare( QLatin1String( "image/png; mode=8bit" ), Qt::CaseInsensitive ) == 0 );
     bool png1Bit = ( mFormatString.compare( QLatin1String( "image/png; mode=1bit" ), Qt::CaseInsensitive ) == 0 );
-    bool isBase64 = mFormatString.endsWith( QLatin1String( ";base64" ), Qt::CaseInsensitive );
     if ( mFormat != QLatin1String( "PNG" ) && mFormat != QLatin1String( "JPG" ) && !png16Bit && !png8Bit && !png1Bit )
     {
       QgsMessageLog::logMessage( QStringLiteral( "service exception - incorrect image format requested..." ) );
@@ -303,10 +302,6 @@ void QgsHttpRequestHandler::setGetMapResponse( const QString& service, QImage* i
       img->save( &buffer, mFormat.toUtf8().data(), imageQuality );
     }
 
-    if ( isBase64 )
-    {
-      ba = ba.toBase64();
-    }
     setHttpResponse( &ba, formatToMimeType( mFormat ) );
   }
 }
@@ -484,10 +479,6 @@ void QgsHttpRequestHandler::setServiceException( const QgsMapServiceException& e
 
 void QgsHttpRequestHandler::setGetPrintResponse( QByteArray* ba )
 {
-  if ( mFormatString.endsWith( QLatin1String( ";base64" ), Qt::CaseInsensitive ) )
-  {
-    *ba = ba->toBase64();
-  }
   setHttpResponse( ba, formatToMimeType( mFormat ) );
 }
 


### PR DESCRIPTION
Unless there is a specification concerning base64 encoded, I suggest to remove base64 enconding supports from WMS response:

* Encoding as ';base64' in format string does not follow the required spec for content-type parameters : https://www.w3.org/Protocols/rfc1341/4_Content-Type.html and thus does not fit in well defined parsing scheme.

* Response does not specify the encoding scheme in the header wich makes the content invalid with respect to the specified mime-type ( A Content-Transfer-Encoding header should be used in this case). 

I strongly advocate for removing this supports unless there is a real and motivated use-case for supporting this.
