### PR TITLE
[processing] Make ParameterFixedTable scriptable

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -561,12 +561,19 @@ class ParameterFixedTable(Parameter):
         tablestring = tablestring[:-1]
         return tablestring
 
+    def getAsScriptCode(self):
+        param_type = ''
+        if self.optional:
+            param_type += 'optional '
+        param_type += 'fixedtable'
+        return '##' + self.name + '=' + param_type
+
     @classmethod
     def fromScriptCode(self, line):
         isOptional, name, definition = _splitParameterOptions(line)
-        if definition.startswith("point"):
+        if definition.startswith("fixedtable"):
             descName = _createDescriptiveName(name)
-            default = definition.strip()[len('point') + 1:] or None
+            default = definition.strip()[len('fixedtable') + 1:] or None
             return ParameterFixedTable(name, descName, default, isOptional)
 
 


### PR DESCRIPTION
That should fix the current travis issues we have

https://travis-ci.org/qgis/QGIS/builds/185752355#L849

```
======================================================================
ERROR: testScriptCode (__main__.ParameterPointTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/qgis/QGIS/python/plugins/processing/tests/ParametersTest.py", line 236, in testScriptCode
    result = getParameterFromString(code)
  File "/home/travis/build/qgis/QGIS/build/output/python/plugins/processing/core/parameters.py", line 1552, in getParameterFromString
    param = paramClass.fromScriptCode(s)
  File "/home/travis/build/qgis/QGIS/build/output/python/plugins/processing/core/parameters.py", line 570, in fromScriptCode
    return ParameterFixedTable(name, descName, default, isOptional)
  File "/home/travis/build/qgis/QGIS/build/output/python/plugins/processing/core/parameters.py", line 535, in __init__
    self.numRows = int(numRows)
TypeError: int() argument must be a string or a number, not 'NoneType'
```

Is this fix the proper approach?