### PR TITLE
Tweak edit/view menus

### DIFF
--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -483,6 +483,11 @@ class QgisInterface : QObject
     virtual QAction *actionHideAllLayers() = 0;
     virtual QAction *actionShowAllLayers() = 0;
     virtual QAction *actionHideSelectedLayers() = 0;
+    /**
+     * Returns the Hide Deselected Layers action.
+     * @note added in QGIS 3.0
+     */
+    virtual QAction *actionHideDeselectedLayers() = 0;
     virtual QAction *actionShowSelectedLayers() = 0;
 
     // Plugin menu actions

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1707,6 +1707,7 @@ void QgisApp::createActions()
   connect( mActionHideAllLayers, SIGNAL( triggered() ), this, SLOT( hideAllLayers() ) );
   connect( mActionShowSelectedLayers, SIGNAL( triggered() ), this, SLOT( showSelectedLayers() ) );
   connect( mActionHideSelectedLayers, SIGNAL( triggered() ), this, SLOT( hideSelectedLayers() ) );
+  connect( mActionHideDeselectedLayers, &QAction::triggered, this, &QgisApp::hideDeselectedLayers );
 
   // Plugin Menu Items
 
@@ -5783,6 +5784,17 @@ void QgisApp::hideSelectedLayers()
   }
 }
 
+void QgisApp::hideDeselectedLayers()
+{
+  QList<QgsLayerTreeLayer*> selectedLayerNodes = mLayerTreeView->selectedLayerNodes();
+
+  Q_FOREACH ( QgsLayerTreeLayer* nodeLayer, mLayerTreeView->layerTreeModel()->rootGroup()->findLayers() )
+  {
+    if ( selectedLayerNodes.contains( nodeLayer ) )
+      continue;
+    nodeLayer->setVisible( Qt::Unchecked );
+  }
+}
 
 // reimplements method from base (gui) class
 void QgisApp::showSelectedLayers()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -411,6 +411,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionHideAllLayers() { return mActionHideAllLayers; }
     QAction *actionShowAllLayers() { return mActionShowAllLayers; }
     QAction *actionHideSelectedLayers() { return mActionHideSelectedLayers; }
+    QAction *actionHideDeselectedLayers() { return mActionHideDeselectedLayers; }
     QAction *actionShowSelectedLayers() { return mActionShowSelectedLayers; }
 
     QAction *actionManagePlugins() { return mActionManagePlugins; }
@@ -1027,6 +1028,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void showAllLayers();
     //reimplements method from base (gui) class
     void hideSelectedLayers();
+    //! Hides any layers which are not selected
+    void hideDeselectedLayers();
     //reimplements method from base (gui) class
     void showSelectedLayers();
     //! Return pointer to the active layer

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -631,6 +631,7 @@ QAction *QgisAppInterface::actionRemoveAllFromOverview() { return qgis->actionRe
 QAction *QgisAppInterface::actionHideAllLayers() { return qgis->actionHideAllLayers(); }
 QAction *QgisAppInterface::actionShowAllLayers() { return qgis->actionShowAllLayers(); }
 QAction *QgisAppInterface::actionHideSelectedLayers() { return qgis->actionHideSelectedLayers(); }
+QAction*QgisAppInterface::actionHideDeselectedLayers() { return qgis->actionHideDeselectedLayers(); }
 QAction *QgisAppInterface::actionShowSelectedLayers() { return qgis->actionShowSelectedLayers(); }
 
 //! Plugin menu actions

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -445,6 +445,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     virtual QAction *actionHideAllLayers() override;
     virtual QAction *actionShowAllLayers() override;
     virtual QAction *actionHideSelectedLayers() override;
+    virtual QAction *actionHideDeselectedLayers() override;
     virtual QAction *actionShowSelectedLayers() override;
 
     //! Plugin menu actions

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -42,6 +42,7 @@ QgsMapThemes::QgsMapThemes()
   mMenu->addAction( QgisApp::instance()->actionHideAllLayers() );
   mMenu->addAction( QgisApp::instance()->actionShowSelectedLayers() );
   mMenu->addAction( QgisApp::instance()->actionHideSelectedLayers() );
+  mMenu->addAction( QgisApp::instance()->actionHideDeselectedLayers() );
   mMenu->addSeparator();
 
   mReplaceMenu = new QMenu( tr( "Replace Theme" ) );

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -539,6 +539,12 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual QAction *actionHideAllLayers() = 0;
     virtual QAction *actionShowAllLayers() = 0;
     virtual QAction *actionHideSelectedLayers() = 0;
+
+    /**
+     * Returns the Hide Deselected Layers action.
+     * @note added in QGIS 3.0
+     */
+    virtual QAction *actionHideDeselectedLayers() = 0;
     virtual QAction *actionShowSelectedLayers() = 0;
 
     // Plugin menu actions

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -17,7 +17,7 @@
      <x>0</x>
      <y>0</y>
      <width>1018</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
    <property name="toolTip">
@@ -64,20 +64,6 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <widget class="QMenu" name="menuSelect">
-     <property name="title">
-      <string>Select</string>
-     </property>
-     <addaction name="mActionSelectFeatures"/>
-     <addaction name="mActionSelectPolygon"/>
-     <addaction name="mActionSelectFreehand"/>
-     <addaction name="mActionSelectRadius"/>
-     <addaction name="mActionSelectByForm"/>
-     <addaction name="mActionSelectByExpression"/>
-     <addaction name="mActionDeselectAll"/>
-     <addaction name="mActionSelectAll"/>
-     <addaction name="mActionInvertSelection"/>
-    </widget>
     <widget class="QMenu" name="menuMeasure">
      <property name="title">
       <string>Measure</string>
@@ -110,7 +96,6 @@
     <addaction name="mActionZoomIn"/>
     <addaction name="mActionZoomOut"/>
     <addaction name="separator"/>
-    <addaction name="menuSelect"/>
     <addaction name="mActionIdentify"/>
     <addaction name="menuMeasure"/>
     <addaction name="mActionStatisticalSummary"/>
@@ -257,6 +242,20 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <widget class="QMenu" name="menuSelect">
+     <property name="title">
+      <string>Select</string>
+     </property>
+     <addaction name="mActionSelectFeatures"/>
+     <addaction name="mActionSelectPolygon"/>
+     <addaction name="mActionSelectFreehand"/>
+     <addaction name="mActionSelectRadius"/>
+     <addaction name="mActionSelectByForm"/>
+     <addaction name="mActionSelectByExpression"/>
+     <addaction name="mActionDeselectAll"/>
+     <addaction name="mActionSelectAll"/>
+     <addaction name="mActionInvertSelection"/>
+    </widget>
     <widget class="QMenu" name="mMenuPasteAs">
      <property name="title">
       <string>Paste Features as</string>
@@ -271,6 +270,7 @@
     <addaction name="mActionCopyFeatures"/>
     <addaction name="mActionPasteFeatures"/>
     <addaction name="mMenuPasteAs"/>
+    <addaction name="menuSelect"/>
     <addaction name="separator"/>
     <addaction name="mActionAddFeature"/>
     <addaction name="mActionCircularStringCurvePoint"/>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -118,6 +118,7 @@
     <addaction name="mActionHideAllLayers"/>
     <addaction name="mActionShowSelectedLayers"/>
     <addaction name="mActionHideSelectedLayers"/>
+    <addaction name="mActionHideDeselectedLayers"/>
     <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="mLayerMenu">
@@ -2423,6 +2424,15 @@ Acts on currently active editable layer</string>
    </property>
    <property name="text">
     <string>Hide Selected Layers</string>
+   </property>
+  </action>
+  <action name="mActionHideDeselectedLayers">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionHideSelectedLayers.png</normaloff>:/images/themes/default/mActionHideSelectedLayers.png</iconset>
+   </property>
+   <property name="text">
+    <string>Hide Deselected Layers</string>
    </property>
   </action>
   <action name="mActionNewMemoryLayer">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -114,6 +114,11 @@
     <addaction name="mActionShowBookmarks"/>
     <addaction name="mActionDraw"/>
     <addaction name="separator"/>
+    <addaction name="mActionShowAllLayers"/>
+    <addaction name="mActionHideAllLayers"/>
+    <addaction name="mActionShowSelectedLayers"/>
+    <addaction name="mActionHideSelectedLayers"/>
+    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="mLayerMenu">
     <property name="title">
@@ -175,11 +180,6 @@
     <addaction name="mActionAddToOverview"/>
     <addaction name="mActionAddAllToOverview"/>
     <addaction name="mActionRemoveAllFromOverview"/>
-    <addaction name="separator"/>
-    <addaction name="mActionShowAllLayers"/>
-    <addaction name="mActionHideAllLayers"/>
-    <addaction name="mActionShowSelectedLayers"/>
-    <addaction name="mActionHideSelectedLayers"/>
    </widget>
    <widget class="QMenu" name="mPluginMenu">
     <property name="title">


### PR DESCRIPTION
This PR makes some changes to the structure of the view/layer/edit menus to improve UX. Specifically:

- The selection tools have been moved from the view menu to the edit menu. Selection tools are usually located within the edit menu directly after the clipboard tools. The view menu is usually populated with actions which affect only the view, rather then editing the document (project or layer) state.
- The Show/Hide Layer actions have been moved from the Layer menu to the View menu, since these affect the map view (and also since they can operate on more than a single layer) it's more logical to locate them within the view menu.