### PR TITLE
Remove some singletons by moving instances to QgsApplication

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -477,6 +477,11 @@ QgsColorRampShader        {#qgis_api_break_3_0_QgsColorRampShader}
 - maximumColorCacheSize() and setMaximumColorCacheSize() were no longer used and are removed.
 - ColorRamp_TYPE enum was renamed to Type, and its value names decapitalized
 
+QgsColorSchemeRegistry        {#qgis_api_break_3_0_QgsColorSchemeRegistry}
+----------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::colorSchemeRegistry() to access an application-wide registry.
+
 
 QgsComposerArrow        {#qgis_api_break_3_0_QgsComposerArrow}
 ----------------
@@ -726,6 +731,12 @@ QgsDataItem        {#qgis_api_break_3_0_QgsDataItem}
 - capabilities() has been removed. Use capabilities2() instead (TODO: rename back to capabilities()).
 - emitBeginInsertItems(), emitEndInsertItems(), emitBeginRemoveItems(), emitEndRemoveItems(), emitDataChanged(), emitStateChanged() have been removed.
 - Favourites was renamed to Favorites
+
+QgsDataItemProviderRegistry        {#qgis_api_break_3_0_QgsDataItemProviderRegistry}
+---------------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::dataItemProviderRegistry() to access an application-wide registry.
+
 
 QgsDataProvider        {#qgis_api_break_3_0_QgsDataProvider}
 ---------------
@@ -986,6 +997,11 @@ QgsEditorWidgetFactory         {#qgis_api_break_3_0_QgsEditorWidgetFactory}
 - `alignmentFlag` has been removed. Use QgsFieldFormatter::representValue() instead
 - `createCache` has been removed. Use QgsFieldFormatter::representValue() instead
 
+QgsGPSConnectionRegistry        {#qgis_api_break_3_0_QgsGPSConnectionRegistry}
+------------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::gpsConnectionRegistry() to access an application-wide registry.
+
 
 QgsGraduatedRenderer        {#qgis_api_break_3_0_QgsGraduatedRenderer}
 --------------------
@@ -1208,6 +1224,12 @@ QgsMarkerSymbolLayer        {#qgis_api_break_3_0_QgsMarkerSymbolLayer}
 - bounds() is now pure virtual and must be implemented in all subclasses.
 
 
+QgsMessageLog        {#qgis_api_break_3_0_QgsMessageLog}
+---------------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::messageLog() to access an application-wide log.
+
+
 QgsMimeDataUtils        {#qgis_api_break_3_0_QgsMimeDataUtils}
 ----------------
 
@@ -1258,6 +1280,11 @@ QgsNumericSortTreeWidgetItem        {#qgis_api_break_3_0_QgsNumericSortTreeWidge
 has improved sort capabilities including the ability to set custom sort values for items
 and for forcing certain items to always sort on top.
 
+QgsPaintEffectRegistry        {#qgis_api_break_3_0_QgsPaintEffectRegistry}
+----------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::paintEffectRegistry() to access an application-wide registry.
+
 
 QgsPalettedRasterRenderer        {#qgis_api_break_3_0_QgsPalettedRasterRenderer}
 -------------------------
@@ -1298,6 +1325,12 @@ QgsPluginLayer        {#qgis_api_break_3_0_QgsPluginLayer}
 --------------
 
 - createMapRenderer(): default implementation (which called plugin's draw() method) has been removed. Plugin layers must implement createMapRenderer().
+
+
+QgsPluginLayerRegistry        {#qgis_api_break_3_0_QgsPluginLayerRegistry}
+----------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::pluginLayerRegistry() to access an application-wide registry.
 
 
 QgsPointDisplacementRenderer        {#qgis_api_break_3_0_QgsPointDisplacementRenderer}
@@ -1405,6 +1438,12 @@ be returned instead of a null pointer if no transformation is required.
 - setCoordinateTransform() now takes a QgsCoordinateTransform reference, not a pointer. An invalid QgsCoordinateTransform should be used instead of a null pointer if no transformation is required.
 
 
+QgsRendererRegistry        {#qgis_api_break_3_0_QgsRendererRegistry}
+----------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::rendererRegistry() to access an application-wide registry.
+
+
 QgsRendererWidget        {#qgis_api_break_3_0_QgsRendererWidget}
 -----------------
 
@@ -1486,6 +1525,7 @@ QgsSublayersDialog        {#qgis_api_break_3_0_QgsSublayersDialog}
 QgsSvgCache        {#qgis_api_break_3_0_QgsSvgCache}
 -----------
 
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::svgCache() to access an application-wide cache.
 - containsParamsV2() was removed. Use containsParamsV3() instead.
 
 QgsStyle (renamed from QgsStyleV2)        {#qgis_api_break_3_0_QgsStyle}
@@ -1518,6 +1558,11 @@ the variant which takes QgsSymbolRenderContext instead.
 - setDataDefinedProperty( const QString& property, const QString& expressionString ) was removed. Use setDataDefinedProperty( const QString& property, QgsDataDefined* dataDefined ) instead.
 - evaluateDataDefinedProperty( const QString& property, const QgsFeature* feature ) was removed. Use the variant which takes QgsSymbolRenderContext instead.
 - expression() was removed. Use getDataDefinedProperty or evaluateDataDefinedProperty instead.
+
+QgsSymbolLayerRegistry        {#qgis_api_break_3_0_QgsSymbolLayerRegistry}
+----------------------
+
+- This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::symbolLayerRegistry() to access an application-wide registry.
 
 
 QgsSymbolLayerWidget        {#qgis_api_break_3_0_QgsSymbolLayerWidget}

--- a/python/core/__init__.py
+++ b/python/core/__init__.py
@@ -246,7 +246,7 @@ def fromFunction(description, function, *args, on_finished=None, flags=QgsTask.A
 
     task = QgsTask.fromFunction('my task', calculate,
             on_finished=calculation_finished)
-    QgsTaskManager.instance().addTask(task)
+    QgsApplication.taskManager().addTask(task)
 
     """
 

--- a/python/core/effects/qgspainteffectregistry.sip
+++ b/python/core/effects/qgspainteffectregistry.sip
@@ -67,9 +67,8 @@ class QgsPaintEffectRegistry
 
   public:
 
-    /** Returns a reference to the singleton instance of the paint effect registry.
-     */
-    static QgsPaintEffectRegistry* instance();
+    QgsPaintEffectRegistry();
+    ~QgsPaintEffectRegistry();
 
     /** Returns the metadata for a specific effect.
      * @param name unique string name for paint effect class
@@ -119,10 +118,6 @@ class QgsPaintEffectRegistry
      * @see defaultStack()
      */
     static bool isDefaultStack( QgsPaintEffect* effect );
-
-  protected:
-    QgsPaintEffectRegistry();
-    ~QgsPaintEffectRegistry();
 
   private:
     QgsPaintEffectRegistry( const QgsPaintEffectRegistry& rh );

--- a/python/core/gps/qgsgpsconnectionregistry.sip
+++ b/python/core/gps/qgsgpsconnectionregistry.sip
@@ -6,7 +6,7 @@ class QgsGPSConnectionRegistry
 #include <qgsgpsconnectionregistry.h>
 %End
   public:
-    static QgsGPSConnectionRegistry* instance();
+    QgsGPSConnectionRegistry();
     ~QgsGPSConnectionRegistry();
 
     /** Inserts a connection into the registry. The connection is owned by the registry class until it is unregistered again*/
@@ -15,9 +15,6 @@ class QgsGPSConnectionRegistry
     void unregisterConnection( QgsGPSConnection* c );
 
     QList< QgsGPSConnection *> connectionList() const;
-
-  protected:
-    QgsGPSConnectionRegistry();
 
   private:
 

--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -381,6 +381,62 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
      */
     static QgsTaskManager* taskManager();
 
+    /**
+     * Returns the application's color scheme registry, used for managing color schemes.
+     * @note added in QGIS 3.0
+     */
+    static QgsColorSchemeRegistry* colorSchemeRegistry();
+
+    /**
+     * Returns the application's paint effect registry, used for managing paint effects.
+     * @note added in QGIS 3.0
+     */
+    static QgsPaintEffectRegistry* paintEffectRegistry();
+
+    /**
+     * Returns the application's renderer registry, used for managing vector layer renderers.
+     * @note added in QGIS 3.0
+     */
+    static QgsRendererRegistry* rendererRegistry();
+
+    /**
+     * Returns the application's data item provider registry, which keeps a list of data item
+     * providers that may add items to the browser tree.
+     * @note added in QGIS 3.0
+     */
+    static QgsDataItemProviderRegistry* dataItemProviderRegistry();
+
+    /**
+     * Returns the application's SVG cache, used for caching SVG images and handling parameter replacement
+     * within SVG files.
+     * @note added in QGIS 3.0
+     */
+    static QgsSvgCache* svgCache();
+
+    /**
+     * Returns the application's symbol layer registry, used for managing symbol layers.
+     * @note added in QGIS 3.0
+     */
+    static QgsSymbolLayerRegistry* symbolLayerRegistry();
+
+    /**
+     * Returns the application's GPS connection registry, used for managing GPS connections.
+     * @note added in QGIS 3.0
+     */
+    static QgsGPSConnectionRegistry* gpsConnectionRegistry();
+
+    /**
+     * Returns the application's plugin layer registry, used for managing plugin layer types.
+     * @note added in QGIS 3.0
+     */
+    static QgsPluginLayerRegistry* pluginLayerRegistry();
+
+    /**
+     * Returns the application's message log.
+     * @note added in QGIS 3.0
+     */
+    static QgsMessageLog* messageLog();
+
 %If(ANDROID)
     //dummy method to workaround sip generation issue issue
     bool x11EventFilter ( XEvent * event );

--- a/python/core/qgscolorschemeregistry.sip
+++ b/python/core/qgscolorschemeregistry.sip
@@ -14,10 +14,6 @@ class QgsColorSchemeRegistry
 %End
   public:
 
-    /** Returns the global instance pointer, creating the object on the first call.
-     */
-    static QgsColorSchemeRegistry * instance();
-
     /** Constructor for an empty color scheme registry
      */
     QgsColorSchemeRegistry();

--- a/python/core/qgsdataitemproviderregistry.sip
+++ b/python/core/qgsdataitemproviderregistry.sip
@@ -11,8 +11,7 @@ class QgsDataItemProviderRegistry
 #include <qgsdataitemproviderregistry.h>
 %End
   public:
-    static QgsDataItemProviderRegistry * instance();
-
+    QgsDataItemProviderRegistry();
     ~QgsDataItemProviderRegistry();
 
     //! Get list of available providers
@@ -25,7 +24,7 @@ class QgsDataItemProviderRegistry
     void removeProvider( QgsDataItemProvider* provider );
 
   private:
-    QgsDataItemProviderRegistry();
+
     QgsDataItemProviderRegistry( const QgsDataItemProviderRegistry& rh );
 
 };

--- a/python/core/qgsmessagelog.sip
+++ b/python/core/qgsmessagelog.sip
@@ -5,7 +5,7 @@ class QgsMessageLog : QObject
 %End
 
   public:
-    static QgsMessageLog *instance();
+    QgsMessageLog();
 
     enum MessageLevel
     {
@@ -20,8 +20,6 @@ class QgsMessageLog : QObject
   signals:
     void messageReceived( const QString& message, const QString& tag, MessageLevel level );
 
-  private:
-    QgsMessageLog();
 };
 
 

--- a/python/core/qgspluginlayerregistry.sip
+++ b/python/core/qgspluginlayerregistry.sip
@@ -37,8 +37,7 @@ class QgsPluginLayerRegistry
 
   public:
 
-    /** Means of accessing canonical single instance  */
-    static QgsPluginLayerRegistry* instance();
+    QgsPluginLayerRegistry();
 
     ~QgsPluginLayerRegistry();
 
@@ -62,8 +61,6 @@ class QgsPluginLayerRegistry
 
   private:
 
-    /** Private since instance() creates it */
-    QgsPluginLayerRegistry();
     QgsPluginLayerRegistry( const QgsPluginLayerRegistry& rh );
 
 };

--- a/python/core/symbology-ng/qgsrendererregistry.sip
+++ b/python/core/symbology-ng/qgsrendererregistry.sip
@@ -100,8 +100,8 @@ class QgsRendererRegistry
 
   public:
 
-    //! Returns a pointer to the QgsRendererRegistry singleton
-    static QgsRendererRegistry* instance();
+    QgsRendererRegistry();
+    ~QgsRendererRegistry();
 
     //! Adds a renderer to the registry. Takes ownership of the metadata object.
     //! @param metadata renderer metadata
@@ -127,11 +127,6 @@ class QgsRendererRegistry
     //! @param layer vector layer
     //! @note added in QGIS 2.16
     QStringList renderersList( const QgsVectorLayer* layer ) const;
-
-  protected:
-    //! protected constructor
-    QgsRendererRegistry();
-    ~QgsRendererRegistry();
 
   private:
     QgsRendererRegistry( const QgsRendererRegistry& rh );

--- a/python/core/symbology-ng/qgssvgcache.sip
+++ b/python/core/symbology-ng/qgssvgcache.sip
@@ -65,7 +65,8 @@ class QgsSvgCache : QObject
 
   public:
 
-    static QgsSvgCache* instance();
+    QgsSvgCache( QObject * parent /TransferThis/ = 0 );
+
     ~QgsSvgCache();
 
     /** Get SVG as QImage.
@@ -151,8 +152,6 @@ class QgsSvgCache : QObject
     void statusChanged( const QString&  theStatusQString );
 
   protected:
-    //! protected constructor
-    QgsSvgCache( QObject * parent /TransferThis/ = 0 );
 
     /** Creates new cache entry and returns pointer to it
      * @param file Absolute or relative path to SVG file. If the path is relative the file is searched by QgsSymbolLayerUtils::symbolNameToPath() in SVG paths.

--- a/python/core/symbology-ng/qgssymbollayerregistry.sip
+++ b/python/core/symbology-ng/qgssymbollayerregistry.sip
@@ -54,8 +54,8 @@ class QgsSymbolLayerRegistry
 
   public:
 
-    //! return the single instance of this class (instantiate it if not exists)
-    static QgsSymbolLayerRegistry* instance();
+    QgsSymbolLayerRegistry();
+    ~QgsSymbolLayerRegistry();
 
     //! return metadata for specified symbol layer. Returns NULL if not found
     QgsSymbolLayerAbstractMetadata* symbolLayerMetadata( const QString& name ) const;
@@ -74,10 +74,6 @@ class QgsSymbolLayerRegistry
 
     //! create a new instance of symbol layer for specified symbol type with default settings
     static QgsSymbolLayer* defaultSymbolLayer( QgsSymbol::SymbolType type ) /Factory/;
-
-  protected:
-    QgsSymbolLayerRegistry();
-    ~QgsSymbolLayerRegistry();
 
   private:
     QgsSymbolLayerRegistry( const QgsSymbolLayerRegistry& rh );

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -417,7 +417,7 @@ QIcon QgsComposerPictureWidget::svgToIcon( const QString& filePath ) const
   bool fillParam, fillOpacityParam, outlineParam, outlineWidthParam, outlineOpacityParam;
   bool hasDefaultFillColor = false, hasDefaultFillOpacity = false, hasDefaultOutlineColor = false,
                              hasDefaultOutlineWidth = false, hasDefaultOutlineOpacity = false;
-  QgsSvgCache::instance()->containsParams( filePath, fillParam, hasDefaultFillColor, fill,
+  QgsApplication::svgCache()->containsParams( filePath, fillParam, hasDefaultFillColor, fill,
       fillOpacityParam, hasDefaultFillOpacity, fillOpacity,
       outlineParam, hasDefaultOutlineColor, outline,
       outlineWidthParam, hasDefaultOutlineWidth, outlineWidth,
@@ -434,7 +434,7 @@ QIcon QgsComposerPictureWidget::svgToIcon( const QString& filePath ) const
     outlineWidth = 0.6;
 
   bool fitsInCache; // should always fit in cache at these sizes (i.e. under 559 px ^ 2, or half cache size)
-  const QImage& img = QgsSvgCache::instance()->svgAsImage( filePath, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, 1.0, fitsInCache );
+  const QImage& img = QgsApplication::svgCache()->svgAsImage( filePath, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, 1.0, fitsInCache );
 
   return QIcon( QPixmap::fromImage( img ) );
 }
@@ -458,7 +458,7 @@ void QgsComposerPictureWidget::updateSvgParamGui( bool resetValues )
   QColor defaultFill, defaultOutline;
   double defaultOutlineWidth, defaultFillOpacity, defaultOutlineOpacity;
   bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultOutlineColor, hasDefaultOutlineWidth, hasDefaultOutlineOpacity;
-  QgsSvgCache::instance()->containsParams( picturePath, hasFillParam, hasDefaultFillColor, defaultFill,
+  QgsApplication::svgCache()->containsParams( picturePath, hasFillParam, hasDefaultFillColor, defaultFill,
       hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
       hasOutlineParam, hasDefaultOutlineColor, defaultOutline,
       hasOutlineWidthParam, hasDefaultOutlineWidth, defaultOutlineWidth,

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -441,7 +441,7 @@ void QgsGPSInformationWidget::connected( QgsGPSConnection *conn )
   mGPSPlainTextEdit->appendPlainText( tr( "Connected!" ) );
   mConnectButton->setText( tr( "Dis&connect" ) );
   //insert connection into registry such that it can also be used by other dialogs or plugins
-  QgsGPSConnectionRegistry::instance()->registerConnection( mNmea );
+  QgsApplication::gpsConnectionRegistry()->registerConnection( mNmea );
   showStatusBarMessage( tr( "Connected to GPS device." ) );
 
   if ( mLogFileGroupBox->isChecked() && ! mTxtLogFile->text().isEmpty() )
@@ -481,7 +481,7 @@ void QgsGPSInformationWidget::disconnectGps()
     mLogFile = nullptr;
   }
 
-  QgsGPSConnectionRegistry::instance()->unregisterConnection( mNmea );
+  QgsApplication::gpsConnectionRegistry()->unregisterConnection( mNmea );
   delete mNmea;
   mNmea = nullptr;
   if ( mpMapMarker )  // marker should not be shown on GPS disconnected - not current position

--- a/src/app/ogr/qgsnewogrconnection.cpp
+++ b/src/app/ogr/qgsnewogrconnection.cpp
@@ -22,6 +22,7 @@
 #include "qgslogger.h"
 #include "qgsproviderregistry.h"
 #include "qgsogrhelperfunctions.h"
+#include "qgsapplication.h"
 #include <ogr_api.h>
 #include <cpl_error.h>
 

--- a/src/app/ogr/qgsopenvectorlayerdialog.cpp
+++ b/src/app/ogr/qgsopenvectorlayerdialog.cpp
@@ -31,6 +31,7 @@
 #include "qgsnewogrconnection.h"
 #include "qgsogrhelperfunctions.h"
 #include "qgscontexthelp.h"
+#include "qgsapplication.h"
 
 QgsOpenVectorLayerDialog::QgsOpenVectorLayerDialog( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -879,7 +879,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mLogDock->hide();
   connect( mMessageButton, SIGNAL( toggled( bool ) ), mLogDock, SLOT( setVisible( bool ) ) );
   connect( mLogDock, SIGNAL( visibilityChanged( bool ) ), mMessageButton, SLOT( setChecked( bool ) ) );
-  connect( QgsMessageLog::instance(), SIGNAL( messageReceived( bool ) ), this, SLOT( toggleLogMessageIcon( bool ) ) );
+  connect( QgsApplication::messageLog(), SIGNAL( messageReceived( bool ) ), this, SLOT( toggleLogMessageIcon( bool ) ) );
   connect( mMessageButton, SIGNAL( toggled( bool ) ), this, SLOT( toggleLogMessageIcon( bool ) ) );
   mVectorLayerTools = new QgsGuiVectorLayerTools();
 
@@ -11356,7 +11356,7 @@ bool QgisApp::addRasterLayers( QStringList const &theFileNameQStringList, bool g
 
 QgsPluginLayer* QgisApp::addPluginLayer( const QString& uri, const QString& baseName, const QString& providerKey )
 {
-  QgsPluginLayer* layer = QgsPluginLayerRegistry::instance()->createLayer( providerKey, uri );
+  QgsPluginLayer* layer = QgsApplication::pluginLayerRegistry()->createLayer( providerKey, uri );
   if ( !layer )
     return nullptr;
 
@@ -11673,7 +11673,7 @@ void QgisApp::showLayerProperties( QgsMapLayer *ml )
     if ( !pl )
       return;
 
-    QgsPluginLayerType* plt = QgsPluginLayerRegistry::instance()->pluginLayerType( pl->pluginLayerType() );
+    QgsPluginLayerType* plt = QgsApplication::pluginLayerRegistry()->pluginLayerType( pl->pluginLayerType() );
     if ( !plt )
       return;
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -169,7 +169,7 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
             //add recent colors action
             QList<QgsRecentColorScheme *> recentSchemes;
-            QgsColorSchemeRegistry::instance()->schemes( recentSchemes );
+            QgsApplication::colorSchemeRegistry()->schemes( recentSchemes );
             if ( !recentSchemes.isEmpty() )
             {
               QgsColorSwatchGridAction* recentColorAction = new QgsColorSwatchGridAction( recentSchemes.at( 0 ), menuStyleManager, QStringLiteral( "symbology" ), menuStyleManager );
@@ -306,7 +306,7 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         //add recent colors action
         QList<QgsRecentColorScheme *> recentSchemes;
-        QgsColorSchemeRegistry::instance()->schemes( recentSchemes );
+        QgsApplication::colorSchemeRegistry()->schemes( recentSchemes );
         if ( !recentSchemes.isEmpty() )
         {
           QgsColorSwatchGridAction* recentColorAction = new QgsColorSwatchGridAction( recentSchemes.at( 0 ), menu, QStringLiteral( "symbology" ), menu );

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -241,7 +241,7 @@ void QgsLayerStylingWidget::apply()
     {
       widget->apply();
       QgsVectorLayer* layer = qobject_cast<QgsVectorLayer*>( mCurrentLayer );
-      QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( layer->renderer()->type() );
+      QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( layer->renderer()->type() );
       undoName = QStringLiteral( "Style Change - %1" ).arg( m->visibleName() );
       styleWasChanged = true;
     }

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -753,7 +753,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl )
 
   //find custom color scheme from registry
   QList<QgsCustomColorScheme *> customSchemes;
-  QgsColorSchemeRegistry::instance()->schemes( customSchemes );
+  QgsApplication::colorSchemeRegistry()->schemes( customSchemes );
   if ( customSchemes.length() > 0 )
   {
     mTreeCustomColors->setScheme( customSchemes.at( 0 ) );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -674,7 +674,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   connect( mButtonExportColors, SIGNAL( clicked( bool ) ), mTreeProjectColors, SLOT( showExportColorsDialog() ) );
 
   QList<QgsProjectColorScheme *> projectSchemes;
-  QgsColorSchemeRegistry::instance()->schemes( projectSchemes );
+  QgsApplication::colorSchemeRegistry()->schemes( projectSchemes );
   if ( projectSchemes.length() > 0 )
   {
     mTreeProjectColors->setScheme( projectSchemes.at( 0 ) );

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -361,17 +361,17 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanv
   }
 
   //insert renderer widgets into registry
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "paletted" ), QgsPalettedRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "multibandcolor" ), QgsMultiBandColorRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "singlebandpseudocolor" ), QgsSingleBandPseudoColorRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "singlebandgray" ), QgsSingleBandGrayRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "hillshade" ), QgsHillshadeRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "paletted" ), QgsPalettedRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "multibandcolor" ), QgsMultiBandColorRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "singlebandpseudocolor" ), QgsSingleBandPseudoColorRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "singlebandgray" ), QgsSingleBandGrayRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "hillshade" ), QgsHillshadeRendererWidget::create );
 
   //fill available renderers into combo box
   QgsRasterRendererRegistryEntry entry;
-  Q_FOREACH ( const QString& name, QgsRasterRendererRegistry::instance()->renderersList() )
+  Q_FOREACH ( const QString& name, QgsApplication::rasterRendererRegistry()->renderersList() )
   {
-    if ( QgsRasterRendererRegistry::instance()->rendererData( name, entry ) )
+    if ( QgsApplication::rasterRendererRegistry()->rendererData( name, entry ) )
     {
       if (( mRasterLayer->rasterType() != QgsRasterLayer::ColorLayer && entry.name != QLatin1String( "singlebandcolordata" ) ) ||
           ( mRasterLayer->rasterType() == QgsRasterLayer::ColorLayer && entry.name == QLatin1String( "singlebandcolordata" ) ) )
@@ -542,7 +542,7 @@ void QgsRasterLayerProperties::setRendererWidget( const QString& rendererName )
   QgsRasterRendererWidget* oldWidget = mRendererWidget;
 
   QgsRasterRendererRegistryEntry rendererEntry;
-  if ( QgsRasterRendererRegistry::instance()->rendererData( rendererName, rendererEntry ) )
+  if ( QgsApplication::rasterRendererRegistry()->rendererData( rendererName, rendererEntry ) )
   {
     if ( rendererEntry.widgetCreateFunction ) //single band color data renderer e.g. has no widget
     {
@@ -553,12 +553,12 @@ void QgsRasterLayerProperties::setRendererWidget( const QString& rendererName )
       {
         if ( rendererName == "singlebandgray" )
         {
-          whileBlocking( mRasterLayer )->setRenderer( QgsRasterRendererRegistry::instance()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
+          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
           whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
         }
         else if ( rendererName == "multibandcolor" )
         {
-          whileBlocking( mRasterLayer )->setRenderer( QgsRasterRendererRegistry::instance()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
+          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
           whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
         }
       }

--- a/src/app/qgsversioninfo.cpp
+++ b/src/app/qgsversioninfo.cpp
@@ -15,7 +15,7 @@
 
 #include "qgsversioninfo.h"
 #include "qgis.h"
-
+#include "qgsapplication.h"
 #include "qgsnetworkaccessmanager.h"
 
 QgsVersionInfo::QgsVersionInfo( QObject *parent )

--- a/src/browser/main.cpp
+++ b/src/browser/main.cpp
@@ -114,8 +114,6 @@ int main( int argc, char ** argv )
     }
   }
 
-  QgsNetworkAccessManager::instance();
-
   QgsBrowser w;
 
   a.connect( &a, SIGNAL( aboutToQuit() ), &w, SLOT( saveWindowState() ) );

--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -258,7 +258,7 @@ void QgsComposerArrow::drawSVGMarker( QPainter* p, MarkerType type, const QStrin
     return;
 
   QSvgRenderer r;
-  const QByteArray &svgContent = QgsSvgCache::instance()->svgContent( svgFileName, mArrowHeadWidth, mArrowHeadFillColor, mArrowHeadOutlineColor, mArrowHeadOutlineWidth,
+  const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( svgFileName, mArrowHeadWidth, mArrowHeadFillColor, mArrowHeadOutlineColor, mArrowHeadOutlineWidth,
                                  1.0, 1.0 );
   r.load( svgContent );
 

--- a/src/core/composer/qgscomposerpicture.cpp
+++ b/src/core/composer/qgscomposerpicture.cpp
@@ -377,7 +377,7 @@ void QgsComposerPicture::loadLocalPicture( const QString &path )
     if ( sourceFileSuffix.compare( QLatin1String( "svg" ), Qt::CaseInsensitive ) == 0 )
     {
       //try to open svg
-      const QByteArray &svgContent = QgsSvgCache::instance()->svgContent( pic.fileName(), rect().width(), mSvgFillColor, mSvgBorderColor, mSvgBorderWidth,
+      const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( pic.fileName(), rect().width(), mSvgFillColor, mSvgBorderColor, mSvgBorderWidth,
                                      1.0, 1.0 );
       mSVG.load( svgContent );
       if ( mSVG.isValid() )

--- a/src/core/effects/qgseffectstack.cpp
+++ b/src/core/effects/qgseffectstack.cpp
@@ -183,7 +183,7 @@ bool QgsEffectStack::readProperties( const QDomElement &element )
   for ( int i = 0; i < childNodes.size(); ++i )
   {
     QDomElement childElement = childNodes.at( i ).toElement();
-    QgsPaintEffect* effect = QgsPaintEffectRegistry::instance()->createEffect( childElement );
+    QgsPaintEffect* effect = QgsApplication::paintEffectRegistry()->createEffect( childElement );
     if ( effect )
       mEffectList << effect;
   }

--- a/src/core/effects/qgspainteffectregistry.cpp
+++ b/src/core/effects/qgspainteffectregistry.cpp
@@ -56,12 +56,6 @@ QgsPaintEffectRegistry::~QgsPaintEffectRegistry()
   qDeleteAll( mMetadata );
 }
 
-QgsPaintEffectRegistry* QgsPaintEffectRegistry::instance()
-{
-  static QgsPaintEffectRegistry sInstance;
-  return &sInstance;
-}
-
 QgsPaintEffectAbstractMetadata *QgsPaintEffectRegistry::effectMetadata( const QString &name ) const
 {
   if ( mMetadata.contains( name ) )
@@ -97,7 +91,7 @@ QgsPaintEffect *QgsPaintEffectRegistry::createEffect( const QDomElement &element
 
   QString type = element.attribute( QStringLiteral( "type" ) );
 
-  QgsPaintEffect* effect = instance()->createEffect( type );
+  QgsPaintEffect* effect = QgsApplication::paintEffectRegistry()->createEffect( type );
   if ( !effect )
     return nullptr;
 

--- a/src/core/effects/qgspainteffectregistry.h
+++ b/src/core/effects/qgspainteffectregistry.h
@@ -147,7 +147,10 @@ class CORE_EXPORT QgsPaintEffectMetadata : public QgsPaintEffectAbstractMetadata
 
 /** \ingroup core
  * \class QgsPaintEffectRegistry
- * \brief Singleton registry of available paint effects
+ * \brief Registry of available paint effects.
+ *
+ * QgsPaintEffectRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::paintEffectRegistry().
  *
  * \note Added in version 2.9
  */
@@ -155,9 +158,8 @@ class CORE_EXPORT QgsPaintEffectRegistry
 {
   public:
 
-    /** Returns a reference to the singleton instance of the paint effect registry.
-     */
-    static QgsPaintEffectRegistry* instance();
+    QgsPaintEffectRegistry();
+    ~QgsPaintEffectRegistry();
 
     /** Returns the metadata for a specific effect.
      * @param name unique string name for paint effect class
@@ -208,16 +210,12 @@ class CORE_EXPORT QgsPaintEffectRegistry
      */
     static bool isDefaultStack( QgsPaintEffect* effect );
 
-  protected:
-    QgsPaintEffectRegistry();
-    ~QgsPaintEffectRegistry();
-
-    QMap<QString, QgsPaintEffectAbstractMetadata*> mMetadata;
-
   private:
 
     QgsPaintEffectRegistry( const QgsPaintEffectRegistry& rh );
     QgsPaintEffectRegistry& operator=( const QgsPaintEffectRegistry& rh );
+
+    QMap<QString, QgsPaintEffectAbstractMetadata*> mMetadata;
 };
 
 #endif //QGSPAINTEFFECTREGISTRY_H

--- a/src/core/gps/qgsgpsconnectionregistry.cpp
+++ b/src/core/gps/qgsgpsconnectionregistry.cpp
@@ -27,12 +27,6 @@ QgsGPSConnectionRegistry::~QgsGPSConnectionRegistry()
   qDeleteAll( mConnections );
 }
 
-QgsGPSConnectionRegistry* QgsGPSConnectionRegistry::instance()
-{
-  static QgsGPSConnectionRegistry mInstance;
-  return &mInstance;
-}
-
 void QgsGPSConnectionRegistry::registerConnection( QgsGPSConnection* c )
 {
   mConnections.insert( c );

--- a/src/core/gps/qgsgpsconnectionregistry.h
+++ b/src/core/gps/qgsgpsconnectionregistry.h
@@ -24,12 +24,17 @@
 class QgsGPSConnection;
 
 /** \ingroup core
- * A singleton class to register / unregister existing GPS connections such that the information
-  is available to all classes and plugins*/
+ * A class to register / unregister existing GPS connections such that the information
+ * is available to all classes and plugins.
+ *
+ * QgsGPSConnectionRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::gpsConnectionRegistry().
+*/
 class CORE_EXPORT QgsGPSConnectionRegistry
 {
   public:
-    static QgsGPSConnectionRegistry* instance();
+    QgsGPSConnectionRegistry();
+
     ~QgsGPSConnectionRegistry();
 
     //! Inserts a connection into the registry. The connection is owned by the registry class until it is unregistered again
@@ -39,17 +44,13 @@ class CORE_EXPORT QgsGPSConnectionRegistry
 
     QList< QgsGPSConnection *> connectionList() const;
 
-  protected:
-    QgsGPSConnectionRegistry();
-
-    static QgsGPSConnectionRegistry* mInstance;
-
-    QSet<QgsGPSConnection*> mConnections;
 
   private:
 
     QgsGPSConnectionRegistry( const QgsGPSConnectionRegistry& rh );
     QgsGPSConnectionRegistry& operator=( const QgsGPSConnectionRegistry& rh );
+
+    QSet<QgsGPSConnection*> mConnections;
 };
 
 #endif // QGSGPSCONNECTIONREGISTRY_H

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -113,6 +113,20 @@ const char* QgsApplication::QGIS_APPLICATION_NAME = "QGIS3";
 */
 QgsApplication::QgsApplication( int & argc, char ** argv, bool GUIenabled, const QString& customConfigPath, const QString& platformName )
     : QApplication( argc, argv, GUIenabled )
+    , mActionScopeRegistry( nullptr )
+    , mProfiler( nullptr )
+    , mTaskManager( nullptr )
+    , mFieldFormatterRegistry( nullptr )
+    , mColorSchemeRegistry( nullptr )
+    , mPaintEffectRegistry( nullptr )
+    , mRendererRegistry( nullptr )
+    , mSvgCache( nullptr )
+    , mSymbolLayerRegistry( nullptr )
+    , mRasterRendererRegistry( nullptr )
+    , mGpsConnectionRegistry( nullptr )
+    , mDataItemProviderRegistry( nullptr )
+    , mPluginLayerRegistry( nullptr )
+    , mMessageLog( nullptr )
 {
   sPlatformName = platformName;
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -27,6 +27,15 @@
 #include "qgsruntimeprofiler.h"
 #include "qgstaskmanager.h"
 #include "qgsfieldformatterregistry.h"
+#include "qgssvgcache.h"
+#include "qgscolorschemeregistry.h"
+#include "qgspainteffectregistry.h"
+#include "qgsrasterrendererregistry.h"
+#include "qgsrendererregistry.h"
+#include "qgssymbollayerregistry.h"
+#include "gps/qgsgpsconnectionregistry.h"
+#include "qgspluginlayerregistry.h"
+#include "qgsmessagelog.h"
 
 #include <QDir>
 #include <QFile>
@@ -109,10 +118,20 @@ QgsApplication::QgsApplication( int & argc, char ** argv, bool GUIenabled, const
 
   // don't use initializer lists or scoped pointers - as more objects are added here we
   // will need to be careful with the order of creation/destruction
-  mTaskManager = new QgsTaskManager();
+  mMessageLog = new QgsMessageLog();
   mProfiler = new QgsRuntimeProfiler();
+  mTaskManager = new QgsTaskManager();
   mActionScopeRegistry = new QgsActionScopeRegistry();
   mFieldFormatterRegistry = new QgsFieldFormatterRegistry();
+  mSvgCache = new QgsSvgCache();
+  mColorSchemeRegistry = new QgsColorSchemeRegistry();
+  mColorSchemeRegistry->addDefaultSchemes();
+  mPaintEffectRegistry = new QgsPaintEffectRegistry();
+  mSymbolLayerRegistry = new QgsSymbolLayerRegistry();
+  mRendererRegistry = new QgsRendererRegistry();
+  mRasterRendererRegistry = new QgsRasterRendererRegistry();
+  mGpsConnectionRegistry = new QgsGPSConnectionRegistry();
+  mPluginLayerRegistry = new QgsPluginLayerRegistry();
 
   init( customConfigPath ); // init can also be called directly by e.g. unit tests that don't inherit QApplication.
 }
@@ -246,8 +265,18 @@ QgsApplication::~QgsApplication()
 {
   delete mActionScopeRegistry;
   delete mTaskManager;
-  delete mProfiler;
   delete mFieldFormatterRegistry;
+  delete mRasterRendererRegistry;
+  delete mRendererRegistry;
+  delete mSymbolLayerRegistry;
+  delete mPaintEffectRegistry;
+  delete mColorSchemeRegistry;
+  delete mSvgCache;
+  delete mGpsConnectionRegistry;
+  delete mPluginLayerRegistry;
+  delete mDataItemProviderRegistry;
+  delete mProfiler;
+  delete mMessageLog;
 }
 
 QgsApplication* QgsApplication::instance()
@@ -904,6 +933,8 @@ void QgsApplication::initQgis()
   // set the provider plugin path (this creates provider registry)
   QgsProviderRegistry::instance( pluginPath() );
 
+  instance()->mDataItemProviderRegistry = new QgsDataItemProviderRegistry();
+
   // create project instance if doesn't exist
   QgsProject::instance();
 
@@ -1506,6 +1537,56 @@ void QgsApplication::setMaxThreads( int maxThreads )
 QgsTaskManager* QgsApplication::taskManager()
 {
   return instance()->mTaskManager;
+}
+
+QgsColorSchemeRegistry* QgsApplication::colorSchemeRegistry()
+{
+  return instance()->mColorSchemeRegistry;
+}
+
+QgsPaintEffectRegistry* QgsApplication::paintEffectRegistry()
+{
+  return instance()->mPaintEffectRegistry;
+}
+
+QgsRendererRegistry*QgsApplication::rendererRegistry()
+{
+  return instance()->mRendererRegistry;
+}
+
+QgsRasterRendererRegistry* QgsApplication::rasterRendererRegistry()
+{
+  return instance()->mRasterRendererRegistry;
+}
+
+QgsDataItemProviderRegistry*QgsApplication::dataItemProviderRegistry()
+{
+  return instance()->mDataItemProviderRegistry;
+}
+
+QgsSvgCache* QgsApplication::svgCache()
+{
+  return instance()->mSvgCache;
+}
+
+QgsSymbolLayerRegistry* QgsApplication::symbolLayerRegistry()
+{
+  return instance()->mSymbolLayerRegistry;
+}
+
+QgsGPSConnectionRegistry* QgsApplication::gpsConnectionRegistry()
+{
+  return instance()->mGpsConnectionRegistry;
+}
+
+QgsPluginLayerRegistry*QgsApplication::pluginLayerRegistry()
+{
+  return instance()->mPluginLayerRegistry;
+}
+
+QgsMessageLog* QgsApplication::messageLog()
+{
+  return instance()->mMessageLog;
 }
 
 QgsFieldFormatterRegistry* QgsApplication::fieldFormatterRegistry()

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -26,6 +26,16 @@ class QgsActionScopeRegistry;
 class QgsRuntimeProfiler;
 class QgsTaskManager;
 class QgsFieldFormatterRegistry;
+class QgsColorSchemeRegistry;
+class QgsPaintEffectRegistry;
+class QgsRendererRegistry;
+class QgsSvgCache;
+class QgsSymbolLayerRegistry;
+class QgsRasterRendererRegistry;
+class QgsGPSConnectionRegistry;
+class QgsDataItemProviderRegistry;
+class QgsPluginLayerRegistry;
+class QgsMessageLog;
 
 /** \ingroup core
  * Extends QApplication to provide access to QGIS specific resources such
@@ -375,6 +385,69 @@ class CORE_EXPORT QgsApplication : public QApplication
      */
     static QgsTaskManager* taskManager();
 
+    /**
+     * Returns the application's color scheme registry, used for managing color schemes.
+     * @note added in QGIS 3.0
+     */
+    static QgsColorSchemeRegistry* colorSchemeRegistry();
+
+    /**
+     * Returns the application's paint effect registry, used for managing paint effects.
+     * @note added in QGIS 3.0
+     */
+    static QgsPaintEffectRegistry* paintEffectRegistry();
+
+    /**
+     * Returns the application's renderer registry, used for managing vector layer renderers.
+     * @note added in QGIS 3.0
+     */
+    static QgsRendererRegistry* rendererRegistry();
+
+    /**
+     * Returns the application's raster renderer registry, used for managing raster layer renderers.
+     * @note added in QGIS 3.0
+     * @note not available in Python bindings
+     */
+    static QgsRasterRendererRegistry* rasterRendererRegistry();
+
+    /**
+     * Returns the application's data item provider registry, which keeps a list of data item
+     * providers that may add items to the browser tree.
+     * @note added in QGIS 3.0
+     */
+    static QgsDataItemProviderRegistry* dataItemProviderRegistry();
+
+    /**
+     * Returns the application's SVG cache, used for caching SVG images and handling parameter replacement
+     * within SVG files.
+     * @note added in QGIS 3.0
+     */
+    static QgsSvgCache* svgCache();
+
+    /**
+     * Returns the application's symbol layer registry, used for managing symbol layers.
+     * @note added in QGIS 3.0
+     */
+    static QgsSymbolLayerRegistry* symbolLayerRegistry();
+
+    /**
+     * Returns the application's GPS connection registry, used for managing GPS connections.
+     * @note added in QGIS 3.0
+     */
+    static QgsGPSConnectionRegistry* gpsConnectionRegistry();
+
+    /**
+     * Returns the application's plugin layer registry, used for managing plugin layer types.
+     * @note added in QGIS 3.0
+     */
+    static QgsPluginLayerRegistry* pluginLayerRegistry();
+
+    /**
+     * Returns the application's message log.
+     * @note added in QGIS 3.0
+     */
+    static QgsMessageLog* messageLog();
+
 #ifdef ANDROID
     //dummy method to workaround sip generation issue issue
     bool x11EventFilter( XEvent * event )
@@ -509,6 +582,16 @@ class CORE_EXPORT QgsApplication : public QApplication
     QgsRuntimeProfiler* mProfiler;
     QgsTaskManager* mTaskManager;
     QgsFieldFormatterRegistry* mFieldFormatterRegistry;
+    QgsColorSchemeRegistry* mColorSchemeRegistry;
+    QgsPaintEffectRegistry* mPaintEffectRegistry;
+    QgsRendererRegistry* mRendererRegistry;
+    QgsSvgCache* mSvgCache;
+    QgsSymbolLayerRegistry* mSymbolLayerRegistry;
+    QgsRasterRendererRegistry* mRasterRendererRegistry;
+    QgsGPSConnectionRegistry* mGpsConnectionRegistry;
+    QgsDataItemProviderRegistry* mDataItemProviderRegistry;
+    QgsPluginLayerRegistry* mPluginLayerRegistry;
+    QgsMessageLog* mMessageLog;
     QString mNullRepresentation;
 };
 

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -133,7 +133,7 @@ void QgsBrowserModel::addRootItems()
   // container for displaying providers as sorted groups (by QgsDataProvider::DataCapability enum)
   QMap<int, QgsDataItem *> providerMap;
 
-  Q_FOREACH ( QgsDataItemProvider* pr, QgsDataItemProviderRegistry::instance()->providers() )
+  Q_FOREACH ( QgsDataItemProvider* pr, QgsApplication::dataItemProviderRegistry()->providers() )
   {
     int capabilities = pr->capabilities();
     if ( capabilities == QgsDataProvider::NoDataCapabilities )

--- a/src/core/qgscolorschemeregistry.cpp
+++ b/src/core/qgscolorschemeregistry.cpp
@@ -21,28 +21,6 @@
 #include <QDir>
 #include <QFileInfoList>
 
-//
-// Static calls to enforce singleton behaviour
-//
-QgsColorSchemeRegistry *QgsColorSchemeRegistry::mInstance = nullptr;
-QgsColorSchemeRegistry *QgsColorSchemeRegistry::instance()
-{
-  if ( !mInstance )
-  {
-    mInstance = new QgsColorSchemeRegistry();
-
-    //add default color schemes
-    mInstance->addDefaultSchemes();
-    //add user schemes
-    mInstance->addUserSchemes();
-  }
-
-  return mInstance;
-}
-
-//
-// Main class begins now...
-//
 
 QgsColorSchemeRegistry::QgsColorSchemeRegistry()
 {
@@ -57,7 +35,7 @@ QgsColorSchemeRegistry::~QgsColorSchemeRegistry()
 void QgsColorSchemeRegistry::populateFromInstance()
 {
   //get schemes from global instance
-  QList< QgsColorScheme* > schemeList = QgsColorSchemeRegistry::instance()->schemes();
+  QList< QgsColorScheme* > schemeList = QgsApplication::colorSchemeRegistry()->schemes();
 
   //add to this scheme registry
   QList< QgsColorScheme* >::iterator it = schemeList.begin();

--- a/src/core/qgscolorschemeregistry.h
+++ b/src/core/qgscolorschemeregistry.h
@@ -26,17 +26,13 @@
  * \brief Registry of color schemes
  *
  * A registry of QgsColorScheme color schemes. This class can be created directly, or
- * accessed via a global instance.
+ * accessed via a QgsApplication::colorSchemeRegistry().
  * \note Added in version 2.5
  */
 class CORE_EXPORT QgsColorSchemeRegistry
 {
 
   public:
-
-    /** Returns the global instance pointer, creating the object on the first call.
-     */
-    static QgsColorSchemeRegistry * instance();
 
     /** Constructor for an empty color scheme registry
      */
@@ -97,8 +93,6 @@ class CORE_EXPORT QgsColorSchemeRegistry
     template<class T> void schemes( QList<T*>& schemeList );
 
   private:
-
-    static QgsColorSchemeRegistry *mInstance;
 
     QList< QgsColorScheme* > mColorSchemeList;
 

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -838,7 +838,7 @@ QVector<QgsDataItem*> QgsDirectoryItem::createChildren()
       }
     }
 
-    Q_FOREACH ( QgsDataItemProvider* provider, QgsDataItemProviderRegistry::instance()->providers() )
+    Q_FOREACH ( QgsDataItemProvider* provider, QgsApplication::dataItemProviderRegistry()->providers() )
     {
       int capabilities = provider->capabilities();
 
@@ -1171,7 +1171,7 @@ QVector<QgsDataItem*> QgsFavoritesItem::createChildren( const QString& favDir )
 {
   QVector<QgsDataItem*> children;
   QString pathName = pathComponent( favDir );
-  Q_FOREACH ( QgsDataItemProvider* provider, QgsDataItemProviderRegistry::instance()->providers() )
+  Q_FOREACH ( QgsDataItemProvider* provider, QgsApplication::dataItemProviderRegistry()->providers() )
   {
     int capabilities = provider->capabilities();
 

--- a/src/core/qgsdataitemproviderregistry.cpp
+++ b/src/core/qgsdataitemproviderregistry.cpp
@@ -95,12 +95,6 @@ QgsDataItemProviderRegistry::QgsDataItemProviderRegistry()
   }
 }
 
-QgsDataItemProviderRegistry* QgsDataItemProviderRegistry::instance()
-{
-  static QgsDataItemProviderRegistry sInstance;
-  return &sInstance;
-}
-
 QgsDataItemProviderRegistry::~QgsDataItemProviderRegistry()
 {
   qDeleteAll( mProviders );

--- a/src/core/qgsdataitemproviderregistry.h
+++ b/src/core/qgsdataitemproviderregistry.h
@@ -21,15 +21,19 @@
 class QgsDataItemProvider;
 
 /** \ingroup core
- * This singleton class keeps a list of data item providers that may add items to the browser tree.
+ * This class keeps a list of data item providers that may add items to the browser tree.
  * When created, it automatically adds providers from provider plugins (e.g. PostGIS, WMS, ...)
+ *
+ * QgsDataItemProviderRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::dataItemProviderRegistry().
  *
  * @note added in 2.10
  */
 class CORE_EXPORT QgsDataItemProviderRegistry
 {
   public:
-    static QgsDataItemProviderRegistry* instance();
+
+    QgsDataItemProviderRegistry();
 
     ~QgsDataItemProviderRegistry();
 
@@ -43,7 +47,6 @@ class CORE_EXPORT QgsDataItemProviderRegistry
     void removeProvider( QgsDataItemProvider* provider );
 
   private:
-    QgsDataItemProviderRegistry();
 
     //! available providers. this class owns the pointers
     QList<QgsDataItemProvider*> mProviders;

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -823,7 +823,7 @@ QList<QgsMapLayer*> QgsMapLayer::fromLayerDefinition( QDomDocument& document, bo
     else if ( type == QLatin1String( "plugin" ) )
     {
       QString typeName = layerElem.attribute( QStringLiteral( "name" ) );
-      layer = QgsPluginLayerRegistry::instance()->createLayer( typeName );
+      layer = QgsApplication::pluginLayerRegistry()->createLayer( typeName );
     }
 
     if ( !layer )

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsmessagelog.h"
+#include "qgsapplication.h"
 #include <qgslogger.h>
 #include <QDateTime>
 #include <QMetaType>
@@ -21,30 +22,15 @@
 
 class QgsMessageLogConsole;
 
-QgsMessageLog *QgsMessageLog::sInstance = nullptr;
-
 QgsMessageLog::QgsMessageLog()
     : QObject()
-{
-  sInstance = this;
-}
-
-QgsMessageLog *QgsMessageLog::instance()
-{
-  if ( !sInstance )
-  {
-    qRegisterMetaType<QgsMessageLog::MessageLevel>( "QgsMessageLog::MessageLevel" );
-    sInstance = new QgsMessageLog();
-  }
-
-  return sInstance;
-}
+{}
 
 void QgsMessageLog::logMessage( const QString& message, const QString& tag, QgsMessageLog::MessageLevel level )
 {
   QgsDebugMsg( QString( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( level ).arg( message ) );
 
-  QgsMessageLog::instance()->emitMessage( message, tag, level );
+  QgsApplication::messageLog()->emitMessage( message, tag, level );
 }
 
 void QgsMessageLog::emitMessage( const QString& message, const QString& tag, QgsMessageLog::MessageLevel level )
@@ -57,9 +43,9 @@ void QgsMessageLog::emitMessage( const QString& message, const QString& tag, Qgs
 }
 
 QgsMessageLogConsole::QgsMessageLogConsole()
-    : QObject( QgsMessageLog::instance() )
+    : QObject( QgsApplication::messageLog() )
 {
-  connect( QgsMessageLog::instance(), SIGNAL( messageReceived( QString, QString, QgsMessageLog::MessageLevel ) ),
+  connect( QgsApplication::messageLog(), SIGNAL( messageReceived( QString, QString, QgsMessageLog::MessageLevel ) ),
            this, SLOT( logMessage( QString, QString, QgsMessageLog::MessageLevel ) ) );
 }
 

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -24,7 +24,9 @@ class QgsMessageLogConsole;
 
 QgsMessageLog::QgsMessageLog()
     : QObject()
-{}
+{
+  qRegisterMetaType< QgsMessageLog::MessageLevel >( "QgsMessageLog::MessageLevel" );
+}
 
 void QgsMessageLog::logMessage( const QString& message, const QString& tag, QgsMessageLog::MessageLevel level )
 {

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -34,6 +34,7 @@
 class CORE_EXPORT QgsMessageLog : public QObject
 {
     Q_OBJECT
+    Q_ENUMS( MessageLevel )
 
   public:
 
@@ -61,7 +62,6 @@ class CORE_EXPORT QgsMessageLog : public QObject
     void emitMessage( const QString& message, const QString& tag, QgsMessageLog::MessageLevel level );
 
 };
-
 
 /** \ingroup core
 \brief Default implementation of message logging interface

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -27,13 +27,15 @@
 
  * QGIS application uses QgsMessageLog class for logging messages in a dockable
  * window for the user.
+ *
+ * QgsMessageLog is not usually directly created, but rather accessed through
+ * QgsApplication::messageLog().
 */
 class CORE_EXPORT QgsMessageLog : public QObject
 {
     Q_OBJECT
 
   public:
-    static QgsMessageLog *instance();
 
     enum MessageLevel
     {
@@ -44,6 +46,8 @@ class CORE_EXPORT QgsMessageLog : public QObject
       NONE = 3
     };
 
+    QgsMessageLog();
+
     //! add a message to the instance (and create it if necessary)
     static void logMessage( const QString& message, const QString& tag = QString::null, MessageLevel level = WARNING );
 
@@ -53,11 +57,9 @@ class CORE_EXPORT QgsMessageLog : public QObject
     void messageReceived( bool received );
 
   private:
-    QgsMessageLog();
 
     void emitMessage( const QString& message, const QString& tag, QgsMessageLog::MessageLevel level );
 
-    static QgsMessageLog *sInstance;
 };
 
 

--- a/src/core/qgspluginlayerregistry.cpp
+++ b/src/core/qgspluginlayerregistry.cpp
@@ -52,19 +52,9 @@ bool QgsPluginLayerType::showLayerProperties( QgsPluginLayer *layer )
   return false;
 }
 
-//=============================================================================
-
-//! Static calls to enforce singleton behaviour
-QgsPluginLayerRegistry* QgsPluginLayerRegistry::_instance = nullptr;
-QgsPluginLayerRegistry* QgsPluginLayerRegistry::instance()
-{
-  if ( !_instance )
-  {
-    _instance = new QgsPluginLayerRegistry();
-  }
-  return _instance;
-}
-
+//
+// QgsPluginLayerRegistry
+//
 
 QgsPluginLayerRegistry::QgsPluginLayerRegistry()
 {

--- a/src/core/qgspluginlayerregistry.h
+++ b/src/core/qgspluginlayerregistry.h
@@ -54,14 +54,16 @@ class CORE_EXPORT QgsPluginLayerType
 //=============================================================================
 
 /** \ingroup core
-    a registry of plugin layers types
+ * A registry of plugin layers types.
+ *
+ * QgsPluginLayerRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::pluginLayerRegistry().
 */
 class CORE_EXPORT QgsPluginLayerRegistry
 {
   public:
 
-    //! Means of accessing canonical single instance
-    static QgsPluginLayerRegistry* instance();
+    QgsPluginLayerRegistry();
 
     ~QgsPluginLayerRegistry();
 
@@ -87,13 +89,8 @@ class CORE_EXPORT QgsPluginLayerRegistry
 
     typedef QMap<QString, QgsPluginLayerType*> PluginLayerTypes;
 
-    //! Private since instance() creates it
-    QgsPluginLayerRegistry();
     QgsPluginLayerRegistry( const QgsPluginLayerRegistry& rh );
     QgsPluginLayerRegistry& operator=( const QgsPluginLayerRegistry& rh );
-
-    //! Pointer to canonical Singleton object
-    static QgsPluginLayerRegistry* _instance;
 
     PluginLayerTypes mPluginLayerTypes;
 };

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -719,7 +719,7 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   else if ( type == QLatin1String( "plugin" ) )
   {
     QString typeName = layerElem.attribute( QStringLiteral( "name" ) );
-    mapLayer = QgsPluginLayerRegistry::instance()->createLayer( typeName );
+    mapLayer = QgsApplication::pluginLayerRegistry()->createLayer( typeName );
   }
 
   if ( !mapLayer )

--- a/src/core/qgsprojectbadlayerhandler.cpp
+++ b/src/core/qgsprojectbadlayerhandler.cpp
@@ -16,15 +16,16 @@
 #include "qgsprojectbadlayerhandler.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
+#include "qgsapplication.h"
 
 #include <QFileInfo>
 
 void QgsProjectBadLayerHandler::handleBadLayers( const QList<QDomNode>& layers )
 {
-  QgsMessageLog::instance()->logMessage( QStringLiteral( "%1 bad layers dismissed:" ).arg( layers.size() ) );
+  QgsApplication::messageLog()->logMessage( QStringLiteral( "%1 bad layers dismissed:" ).arg( layers.size() ) );
   Q_FOREACH ( const QDomNode& layer, layers )
   {
-    QgsMessageLog::instance()->logMessage( QStringLiteral( " * %1" ).arg( dataSource( layer ) ) );
+    QgsApplication::messageLog()->logMessage( QStringLiteral( " * %1" ).arg( dataSource( layer ) ) );
   }
 }
 

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -20,6 +20,7 @@
 #include "qgsrasteridentifyresult.h"
 #include "qgsrasterprojector.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 #include <QTime>
 #include <QMap>

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -242,7 +242,7 @@ QString QgsRasterLayer::bandName( int theBandNo ) const
 
 void QgsRasterLayer::setRendererForDrawingStyle( QgsRaster::DrawingStyle theDrawingStyle )
 {
-  setRenderer( QgsRasterRendererRegistry::instance()->defaultRendererForDrawingStyle( theDrawingStyle, mDataProvider ) );
+  setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( theDrawingStyle, mDataProvider ) );
 }
 
 /**
@@ -1390,7 +1390,7 @@ bool QgsRasterLayer::readSymbology( const QDomNode& layer_node, QString& errorMe
   {
     QString rendererType = rasterRendererElem.attribute( QStringLiteral( "type" ) );
     QgsRasterRendererRegistryEntry rendererEntry;
-    if ( QgsRasterRendererRegistry::instance()->rendererData( rendererType, rendererEntry ) )
+    if ( QgsApplication::rasterRendererRegistry()->rendererData( rendererType, rendererEntry ) )
     {
       QgsRasterRenderer *renderer = rendererEntry.rendererCreateFunction( rasterRendererElem, dataProvider() );
       mPipe.set( renderer );

--- a/src/core/raster/qgsrasterrendererregistry.cpp
+++ b/src/core/raster/qgsrasterrendererregistry.cpp
@@ -49,12 +49,6 @@ QIcon QgsRasterRendererRegistryEntry::icon()
   return QgsApplication::getThemeIcon( QString( "styleicons/%1.svg" ).arg( name ) );
 }
 
-QgsRasterRendererRegistry* QgsRasterRendererRegistry::instance()
-{
-  static QgsRasterRendererRegistry mInstance;
-  return &mInstance;
-}
-
 QgsRasterRendererRegistry::QgsRasterRendererRegistry()
 {
   // insert items in a particular order, which is returned in renderersList()

--- a/src/core/raster/qgsrasterrendererregistry.h
+++ b/src/core/raster/qgsrasterrendererregistry.h
@@ -48,12 +48,17 @@ struct CORE_EXPORT QgsRasterRendererRegistryEntry
 
 /** \ingroup core
   * Registry for raster renderers.
+  *
+  * QgsRasterRendererRegistry is not usually directly created, but rather accessed through
+  * QgsApplication::rasterRendererRegistry().
+  *
   * \note not available in Python bindings
   */
 class CORE_EXPORT QgsRasterRendererRegistry
 {
   public:
-    static QgsRasterRendererRegistry* instance();
+
+    QgsRasterRendererRegistry();
 
     void insert( const QgsRasterRendererRegistryEntry& entry );
     void insertWidgetFunction( const QString& rendererName, QgsRasterRendererWidgetCreateFunc func );
@@ -65,11 +70,7 @@ class CORE_EXPORT QgsRasterRendererRegistry
         Caller takes ownership*/
     QgsRasterRenderer* defaultRendererForDrawingStyle( QgsRaster::DrawingStyle theDrawingStyle, QgsRasterDataProvider* provider ) const;
 
-  protected:
-    QgsRasterRendererRegistry();
-
   private:
-    static QgsRasterRendererRegistry* mInstance;
     QHash< QString, QgsRasterRendererRegistryEntry > mEntries;
     QStringList mSortedEntries;
 

--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -1825,7 +1825,7 @@ QgsMapUnitScale QgsSVGFillSymbolLayer::mapUnitScale() const
 
 void QgsSVGFillSymbolLayer::setSvgFilePath( const QString& svgPath )
 {
-  mSvgData = QgsSvgCache::instance()->getImageData( svgPath );
+  mSvgData = QgsApplication::svgCache()->getImageData( svgPath );
   storeViewBox();
 
   mSvgFilePath = svgPath;
@@ -1964,11 +1964,11 @@ void QgsSVGFillSymbolLayer::applyPattern( QBrush& brush, const QString& svgFileP
   {
     bool fitsInCache = true;
     double outlineWidth = QgsSymbolLayerUtils::convertToPainterUnits( context.renderContext(), svgOutlineWidth, svgOutlineWidthUnit, svgOutlineWidthMapUnitScale );
-    const QImage& patternImage = QgsSvgCache::instance()->svgAsImage( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
+    const QImage& patternImage = QgsApplication::svgCache()->svgAsImage( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
                                  context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), fitsInCache );
     if ( !fitsInCache )
     {
-      const QPicture& patternPict = QgsSvgCache::instance()->svgAsPicture( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
+      const QPicture& patternPict = QgsApplication::svgCache()->svgAsPicture( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
                                     context.renderContext().scaleFactor(), 1.0 );
       double hwRatio = 1.0;
       if ( patternPict.width() > 0 )
@@ -2280,7 +2280,7 @@ void QgsSVGFillSymbolLayer::setDefaultSvgParams()
   bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultOutlineColor, hasDefaultOutlineWidth, hasDefaultOutlineOpacity;
   QColor defaultFillColor, defaultOutlineColor;
   double defaultOutlineWidth, defaultFillOpacity, defaultOutlineOpacity;
-  QgsSvgCache::instance()->containsParams( mSvgFilePath, hasFillParam, hasDefaultFillColor, defaultFillColor,
+  QgsApplication::svgCache()->containsParams( mSvgFilePath, hasFillParam, hasDefaultFillColor, defaultFillColor,
       hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
       hasOutlineParam, hasDefaultOutlineColor, defaultOutlineColor,
       hasOutlineWidthParam, hasDefaultOutlineWidth, defaultOutlineWidth,

--- a/src/core/symbology-ng/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayer.cpp
@@ -1751,7 +1751,7 @@ QgsSymbolLayer* QgsSvgMarkerSymbolLayer::create( const QgsStringMap& props )
     double outlineWidth;
     bool hasFillParam = false, hasFillOpacityParam = false, hasOutlineParam = false, hasOutlineWidthParam = false, hasOutlineOpacityParam = false;
     bool hasDefaultFillColor = false, hasDefaultFillOpacity = false, hasDefaultOutlineColor = false, hasDefaultOutlineWidth = false, hasDefaultOutlineOpacity = false;
-    QgsSvgCache::instance()->containsParams( name, hasFillParam, hasDefaultFillColor, fillColor,
+    QgsApplication::svgCache()->containsParams( name, hasFillParam, hasDefaultFillColor, fillColor,
         hasFillOpacityParam, hasDefaultFillOpacity, fillOpacity,
         hasOutlineParam, hasDefaultOutlineColor, outlineColor,
         hasOutlineWidthParam, hasDefaultOutlineWidth, outlineWidth,
@@ -1861,7 +1861,7 @@ void QgsSvgMarkerSymbolLayer::setPath( const QString& path )
   double outlineWidth, fillOpacity, outlineOpacity;
   bool hasFillParam = false, hasFillOpacityParam = false, hasOutlineParam = false, hasOutlineWidthParam = false, hasOutlineOpacityParam = false;
   bool hasDefaultFillColor = false, hasDefaultFillOpacity = false, hasDefaultOutlineColor = false, hasDefaultOutlineWidth = false, hasDefaultOutlineOpacity = false;
-  QgsSvgCache::instance()->containsParams( path, hasFillParam, hasDefaultFillColor, defaultFillColor,
+  QgsApplication::svgCache()->containsParams( path, hasFillParam, hasDefaultFillColor, defaultFillColor,
       hasFillOpacityParam, hasDefaultFillOpacity, fillOpacity,
       hasOutlineParam, hasDefaultOutlineColor, defaultOutlineColor,
       hasOutlineWidthParam, hasDefaultOutlineWidth, outlineWidth,
@@ -1983,7 +1983,7 @@ void QgsSvgMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext
   if ( !context.renderContext().forceVectorOutput() && !rotated )
   {
     usePict = false;
-    const QImage& img = QgsSvgCache::instance()->svgAsImage( path, size, fillColor, outlineColor, outlineWidth,
+    const QImage& img = QgsApplication::svgCache()->svgAsImage( path, size, fillColor, outlineColor, outlineWidth,
                         context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), fitsInCache );
     if ( fitsInCache && img.width() > 1 )
     {
@@ -2006,7 +2006,7 @@ void QgsSvgMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext
   if ( usePict || !fitsInCache )
   {
     p->setOpacity( context.alpha() );
-    const QPicture& pct = QgsSvgCache::instance()->svgAsPicture( path, size, fillColor, outlineColor, outlineWidth,
+    const QPicture& pct = QgsApplication::svgCache()->svgAsPicture( path, size, fillColor, outlineColor, outlineWidth,
                           context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), context.renderContext().forceVectorOutput() );
 
     if ( pct.width() > 1 )
@@ -2358,7 +2358,7 @@ bool QgsSvgMarkerSymbolLayer::writeDxf( QgsDxfExport& e, double mmMapUnitScaleFa
       outlineColor = QgsSymbolLayerUtils::decodeColor( colorString );
   }
 
-  const QByteArray &svgContent = QgsSvgCache::instance()->svgContent( path, size, fillColor, outlineColor, outlineWidth,
+  const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( path, size, fillColor, outlineColor, outlineWidth,
                                  context.renderContext().scaleFactor(),
                                  context.renderContext().rasterScaleFactor() );
 
@@ -2441,7 +2441,7 @@ QRectF QgsSvgMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext& c
       outlineColor = QgsSymbolLayerUtils::decodeColor( colorString );
   }
 
-  QSizeF svgViewbox = QgsSvgCache::instance()->svgViewboxSize( path, scaledSize, fillColor, outlineColor, outlineWidth,
+  QSizeF svgViewbox = QgsApplication::svgCache()->svgViewboxSize( path, scaledSize, fillColor, outlineColor, outlineWidth,
                       context.renderContext().scaleFactor(),
                       context.renderContext().rasterScaleFactor() );
 

--- a/src/core/symbology-ng/qgsrenderer.cpp
+++ b/src/core/symbology-ng/qgsrenderer.cpp
@@ -125,7 +125,7 @@ QgsFeatureRenderer* QgsFeatureRenderer::load( QDomElement& element )
   // load renderer
   QString rendererType = element.attribute( QStringLiteral( "type" ) );
 
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( rendererType );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( rendererType );
   if ( !m )
     return nullptr;
 
@@ -139,7 +139,7 @@ QgsFeatureRenderer* QgsFeatureRenderer::load( QDomElement& element )
     QDomElement effectElem = element.firstChildElement( QStringLiteral( "effect" ) );
     if ( !effectElem.isNull() )
     {
-      r->setPaintEffect( QgsPaintEffectRegistry::instance()->createEffect( effectElem ) );
+      r->setPaintEffect( QgsApplication::paintEffectRegistry()->createEffect( effectElem ) );
     }
 
     // restore order by
@@ -247,7 +247,7 @@ QgsFeatureRenderer* QgsFeatureRenderer::loadSld( const QDomNode &node, QgsWkbTyp
   QgsDebugMsg( QString( "Instantiating a '%1' renderer..." ).arg( rendererType ) );
 
   // create the renderer and return it
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( rendererType );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( rendererType );
   if ( !m )
   {
     errorMessage = QStringLiteral( "Error: Unable to get metadata for '%1' renderer." ).arg( rendererType );

--- a/src/core/symbology-ng/qgsrendererregistry.cpp
+++ b/src/core/symbology-ng/qgsrendererregistry.cpp
@@ -94,13 +94,6 @@ QgsRendererRegistry::~QgsRendererRegistry()
   qDeleteAll( mRenderers );
 }
 
-QgsRendererRegistry* QgsRendererRegistry::instance()
-{
-  static QgsRendererRegistry mInstance;
-  return &mInstance;
-}
-
-
 bool QgsRendererRegistry::addRenderer( QgsRendererAbstractMetadata* metadata )
 {
   if ( !metadata || mRenderers.contains( metadata->name() ) )

--- a/src/core/symbology-ng/qgsrendererregistry.h
+++ b/src/core/symbology-ng/qgsrendererregistry.h
@@ -175,15 +175,17 @@ class CORE_EXPORT QgsRendererMetadata : public QgsRendererAbstractMetadata
  * \class QgsRendererRegistry
  * \brief Registry of renderers.
  *
- * This is a singleton, renderers can be added / removed at any time
+ * QgsRendererRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::rendererRegistry().
+ *
  */
 
 class CORE_EXPORT QgsRendererRegistry
 {
   public:
 
-    //! Returns a pointer to the QgsRendererRegistry singleton
-    static QgsRendererRegistry* instance();
+    QgsRendererRegistry();
+    ~QgsRendererRegistry();
 
     //! Adds a renderer to the registry. Takes ownership of the metadata object.
     //! @param metadata renderer metadata
@@ -210,20 +212,15 @@ class CORE_EXPORT QgsRendererRegistry
     //! @note added in QGIS 2.16
     QStringList renderersList( const QgsVectorLayer* layer ) const;
 
-  protected:
-    //! protected constructor
-    QgsRendererRegistry();
-    ~QgsRendererRegistry();
+  private:
+    QgsRendererRegistry( const QgsRendererRegistry& rh );
+    QgsRendererRegistry& operator=( const QgsRendererRegistry& rh );
 
     //! Map of name to renderer
     QMap<QString, QgsRendererAbstractMetadata*> mRenderers;
 
     //! List of renderers, maintained in the order that they have been added
     QStringList mRenderersOrder;
-
-  private:
-    QgsRendererRegistry( const QgsRendererRegistry& rh );
-    QgsRendererRegistry& operator=( const QgsRendererRegistry& rh );
 };
 
 #endif // QGSRENDERERV2REGISTRY_H

--- a/src/core/symbology-ng/qgssvgcache.cpp
+++ b/src/core/symbology-ng/qgssvgcache.cpp
@@ -94,12 +94,6 @@ int QgsSvgCacheEntry::dataSize() const
   return size;
 }
 
-QgsSvgCache* QgsSvgCache::instance()
-{
-  static QgsSvgCache mInstance;
-  return &mInstance;
-}
-
 QgsSvgCache::QgsSvgCache( QObject *parent )
     : QObject( parent )
     , mTotalSize( 0 )

--- a/src/core/symbology-ng/qgssvgcache.h
+++ b/src/core/symbology-ng/qgssvgcache.h
@@ -92,6 +92,9 @@ class CORE_EXPORT QgsSvgCacheEntry
  * A cache for images / pictures derived from svg files. This class supports parameter replacement in svg files
 according to the svg params specification (http://www.w3.org/TR/2009/WD-SVGParamPrimer-20090616/). Supported are
 the parameters 'fill-color', 'pen-color', 'outline-width', 'stroke-width'. E.g. <circle fill="param(fill-color red)" stroke="param(pen-color black)" stroke-width="param(outline-width 1)"
+ *
+ * QgsSvgCache is not usually directly created, but rather accessed through
+ * QgsApplication::svgCache().
 */
 class CORE_EXPORT QgsSvgCache : public QObject
 {
@@ -99,7 +102,11 @@ class CORE_EXPORT QgsSvgCache : public QObject
 
   public:
 
-    static QgsSvgCache* instance();
+    /**
+     * Constructor for QgsSvgCache.
+     */
+    QgsSvgCache( QObject * parent = nullptr );
+
     ~QgsSvgCache();
 
     /** Get SVG as QImage.
@@ -186,8 +193,6 @@ class CORE_EXPORT QgsSvgCache : public QObject
     void statusChanged( const QString&  theStatusQString );
 
   protected:
-    //! protected constructor
-    QgsSvgCache( QObject * parent = nullptr );
 
     /** Creates new cache entry and returns pointer to it
      * @param file Absolute or relative path to SVG file. If the path is relative the file is searched by QgsSymbolLayerUtils::symbolNameToPath() in SVG paths.

--- a/src/core/symbology-ng/qgssymbollayerregistry.cpp
+++ b/src/core/symbology-ng/qgssymbollayerregistry.cpp
@@ -86,12 +86,6 @@ QgsSymbolLayerAbstractMetadata* QgsSymbolLayerRegistry::symbolLayerMetadata( con
   return mMetadata.value( name );
 }
 
-QgsSymbolLayerRegistry* QgsSymbolLayerRegistry::instance()
-{
-  static QgsSymbolLayerRegistry mInstance;
-  return &mInstance;
-}
-
 QgsSymbolLayer* QgsSymbolLayerRegistry::defaultSymbolLayer( QgsSymbol::SymbolType type )
 {
   switch ( type )

--- a/src/core/symbology-ng/qgssymbollayerregistry.h
+++ b/src/core/symbology-ng/qgssymbollayerregistry.h
@@ -111,15 +111,17 @@ class CORE_EXPORT QgsSymbolLayerMetadata : public QgsSymbolLayerAbstractMetadata
 
 
 /** \ingroup core
- Registry of available symbol layer classes.
- Implemented as a singleton.
+ * Registry of available symbol layer classes.
+ *
+ * QgsSymbolLayerRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::symbolLayerRegistry().
  */
 class CORE_EXPORT QgsSymbolLayerRegistry
 {
   public:
 
-    //! return the single instance of this class (instantiate it if not exists)
-    static QgsSymbolLayerRegistry* instance();
+    QgsSymbolLayerRegistry();
+    ~QgsSymbolLayerRegistry();
 
     //! return metadata for specified symbol layer. Returns NULL if not found
     QgsSymbolLayerAbstractMetadata* symbolLayerMetadata( const QString& name ) const;
@@ -139,15 +141,11 @@ class CORE_EXPORT QgsSymbolLayerRegistry
     //! create a new instance of symbol layer for specified symbol type with default settings
     static QgsSymbolLayer* defaultSymbolLayer( QgsSymbol::SymbolType type );
 
-  protected:
-    QgsSymbolLayerRegistry();
-    ~QgsSymbolLayerRegistry();
-
-    QMap<QString, QgsSymbolLayerAbstractMetadata*> mMetadata;
-
   private:
     QgsSymbolLayerRegistry( const QgsSymbolLayerRegistry& rh );
     QgsSymbolLayerRegistry& operator=( const QgsSymbolLayerRegistry& rh );
+
+    QMap<QString, QgsSymbolLayerAbstractMetadata*> mMetadata;
 };
 
 #endif

--- a/src/core/symbology-ng/qgssymbollayerutils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerutils.cpp
@@ -888,7 +888,7 @@ QgsSymbolLayer* QgsSymbolLayerUtils::loadSymbolLayer( QDomElement& element )
   QgsStringMap props = parseProperties( element );
 
   QgsSymbolLayer* layer;
-  layer = QgsSymbolLayerRegistry::instance()->createSymbolLayer( layerClass, props );
+  layer = QgsApplication::symbolLayerRegistry()->createSymbolLayer( layerClass, props );
   if ( layer )
   {
     layer->setLocked( locked );
@@ -899,7 +899,7 @@ QgsSymbolLayer* QgsSymbolLayerUtils::loadSymbolLayer( QDomElement& element )
     QDomElement effectElem = element.firstChildElement( QStringLiteral( "effect" ) );
     if ( !effectElem.isNull() )
     {
-      layer->setPaintEffect( QgsPaintEffectRegistry::instance()->createEffect( effectElem ) );
+      layer->setPaintEffect( QgsApplication::paintEffectRegistry()->createEffect( effectElem ) );
     }
     return layer;
   }
@@ -997,7 +997,7 @@ bool QgsSymbolLayerUtils::createSymbolLayerListFromSld( QDomElement& element,
       {
         case QgsWkbTypes::PolygonGeometry:
           // polygon layer and point symbolizer: draw poligon centroid
-          l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "CentroidFill" ), element );
+          l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "CentroidFill" ), element );
           if ( l )
             layers.append( l );
 
@@ -1013,7 +1013,7 @@ bool QgsSymbolLayerUtils::createSymbolLayerListFromSld( QDomElement& element,
 
         case QgsWkbTypes::LineGeometry:
           // line layer and point symbolizer: draw central point
-          l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "SimpleMarker" ), element );
+          l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "SimpleMarker" ), element );
           if ( l )
             layers.append( l );
 
@@ -1049,7 +1049,7 @@ bool QgsSymbolLayerUtils::createSymbolLayerListFromSld( QDomElement& element,
 
         case QgsWkbTypes::PointGeometry:
           // point layer and line symbolizer: draw a little line marker
-          l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "MarkerLine" ), element );
+          l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "MarkerLine" ), element );
           if ( l )
             layers.append( l );
 
@@ -1132,13 +1132,13 @@ QgsSymbolLayer* QgsSymbolLayerUtils::createFillLayerFromSld( QDomElement &elemen
   QgsSymbolLayer *l = nullptr;
 
   if ( needLinePatternFill( element ) )
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "LinePatternFill" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "LinePatternFill" ), element );
   else if ( needPointPatternFill( element ) )
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "PointPatternFill" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "PointPatternFill" ), element );
   else if ( needSvgFill( element ) )
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "SVGFill" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "SVGFill" ), element );
   else
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "SimpleFill" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "SimpleFill" ), element );
 
   return l;
 }
@@ -1155,9 +1155,9 @@ QgsSymbolLayer* QgsSymbolLayerUtils::createLineLayerFromSld( QDomElement &elemen
   QgsSymbolLayer *l = nullptr;
 
   if ( needMarkerLine( element ) )
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "MarkerLine" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "MarkerLine" ), element );
   else
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "SimpleLine" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "SimpleLine" ), element );
 
   return l;
 }
@@ -1174,13 +1174,13 @@ QgsSymbolLayer* QgsSymbolLayerUtils::createMarkerLayerFromSld( QDomElement &elem
   QgsSymbolLayer *l = nullptr;
 
   if ( needFontMarker( element ) )
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "FontMarker" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "FontMarker" ), element );
   else if ( needSvgMarker( element ) )
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "SvgMarker" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "SvgMarker" ), element );
   else if ( needEllipseMarker( element ) )
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "EllipseMarker" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "EllipseMarker" ), element );
   else
-    l = QgsSymbolLayerRegistry::instance()->createSymbolLayerFromSld( QStringLiteral( "SimpleMarker" ), element );
+    l = QgsApplication::symbolLayerRegistry()->createSymbolLayerFromSld( QStringLiteral( "SimpleMarker" ), element );
 
   return l;
 }
@@ -1426,7 +1426,7 @@ bool QgsSymbolLayerUtils::convertPolygonSymbolizerToPointMarker( QDomElement &el
       map[QStringLiteral( "size" )] = QString::number( 6 );
       map[QStringLiteral( "angle" )] = QString::number( 0 );
       map[QStringLiteral( "offset" )] = encodePoint( QPointF( 0, 0 ) );
-      layers.append( QgsSymbolLayerRegistry::instance()->createSymbolLayer( QStringLiteral( "SimpleMarker" ), map ) );
+      layers.append( QgsApplication::symbolLayerRegistry()->createSymbolLayer( QStringLiteral( "SimpleMarker" ), map ) );
     }
   }
 
@@ -1607,7 +1607,7 @@ bool QgsSymbolLayerUtils::convertPolygonSymbolizerToPointMarker( QDomElement &el
           map[QStringLiteral( "angle" )] = QString::number( angle );
         if ( !offset.isNull() )
           map[QStringLiteral( "offset" )] = encodePoint( offset );
-        layers.append( QgsSymbolLayerRegistry::instance()->createSymbolLayer( QStringLiteral( "SvgMarker" ), map ) );
+        layers.append( QgsApplication::symbolLayerRegistry()->createSymbolLayer( QStringLiteral( "SvgMarker" ), map ) );
       }
       else if ( format == QLatin1String( "ttf" ) )
       {
@@ -1621,7 +1621,7 @@ bool QgsSymbolLayerUtils::convertPolygonSymbolizerToPointMarker( QDomElement &el
           map[QStringLiteral( "angle" )] = QString::number( angle );
         if ( !offset.isNull() )
           map[QStringLiteral( "offset" )] = encodePoint( offset );
-        layers.append( QgsSymbolLayerRegistry::instance()->createSymbolLayer( QStringLiteral( "FontMarker" ), map ) );
+        layers.append( QgsApplication::symbolLayerRegistry()->createSymbolLayer( QStringLiteral( "FontMarker" ), map ) );
       }
     }
   }

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -193,12 +193,12 @@ bool QgsEditorWidgetRegistry::registerWidget( const QString& widgetId, QgsEditor
 {
   if ( !widgetFactory )
   {
-    QgsMessageLog::instance()->logMessage( QStringLiteral( "QgsEditorWidgetRegistry: Factory not valid." ) );
+    QgsApplication::messageLog()->logMessage( QStringLiteral( "QgsEditorWidgetRegistry: Factory not valid." ) );
     return false;
   }
   else if ( mWidgetFactories.contains( widgetId ) )
   {
-    QgsMessageLog::instance()->logMessage( QStringLiteral( "QgsEditorWidgetRegistry: Factory with id %1 already registered." ).arg( widgetId ) );
+    QgsApplication::messageLog()->logMessage( QStringLiteral( "QgsEditorWidgetRegistry: Factory with id %1 already registered." ).arg( widgetId ) );
     return false;
   }
   else

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -84,9 +84,9 @@ void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
   }
   else
   {
-    QgsMessageLog::instance()->logMessage( tr( "The usual date/time widget QDateTimeEdit cannot be configured to allow NULL values. "
-                                           "For that the QGIS custom widget QgsDateTimeEdit needs to be used." ),
-                                           QStringLiteral( "field widgets" ) );
+    QgsApplication::messageLog()->logMessage( tr( "The usual date/time widget QDateTimeEdit cannot be configured to allow NULL values. "
+        "For that the QGIS custom widget QgsDateTimeEdit needs to be used." ),
+        QStringLiteral( "field widgets" ) );
   }
 
   if ( mQgsDateTimeEdit )

--- a/src/gui/effects/qgseffectstackpropertieswidget.cpp
+++ b/src/gui/effects/qgseffectstackpropertieswidget.cpp
@@ -61,7 +61,7 @@ class EffectItem : public QStandardItem
     {
       if ( role == Qt::DisplayRole || role == Qt::EditRole )
       {
-        return QgsPaintEffectRegistry::instance()->effectMetadata( mEffect->type() )->visibleName();
+        return QgsApplication::paintEffectRegistry()->effectMetadata( mEffect->type() )->visibleName();
       }
       if ( role == Qt::CheckStateRole )
       {

--- a/src/gui/effects/qgspainteffectpropertieswidget.cpp
+++ b/src/gui/effects/qgspainteffectpropertieswidget.cpp
@@ -29,7 +29,7 @@
 
 static bool _initWidgetFunction( const QString& name, QgsPaintEffectWidgetFunc f )
 {
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
 
   QgsPaintEffectAbstractMetadata* abstractMetadata = registry->effectMetadata( name );
   if ( !abstractMetadata )
@@ -88,7 +88,7 @@ QgsPaintEffectPropertiesWidget::QgsPaintEffectPropertiesWidget( QgsPaintEffect* 
 
 void QgsPaintEffectPropertiesWidget::populateEffectTypes()
 {
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QStringList types = registry->effects();
 
   Q_FOREACH ( const QString& type, types )
@@ -116,7 +116,7 @@ void QgsPaintEffectPropertiesWidget::updateEffectWidget( QgsPaintEffect* effect 
     stackedWidget->removeWidget( stackedWidget->currentWidget() );
   }
 
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QgsPaintEffectAbstractMetadata* am = registry->effectMetadata( effect->type() );
   if ( am )
   {
@@ -146,7 +146,7 @@ void QgsPaintEffectPropertiesWidget::effectTypeChanged()
     return;
 
   // get creation function for new effect from registry
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QgsPaintEffectAbstractMetadata* am = registry->effectMetadata( newEffectType );
   if ( !am ) // check whether the metadata is assigned
     return;

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -55,7 +55,7 @@ QgsColorButton::QgsColorButton( QWidget *parent, const QString& cdt, QgsColorSch
 
 {
   //if a color scheme registry was specified, use it, otherwise use the global instance
-  mColorSchemeRegistry = registry ? registry : QgsColorSchemeRegistry::instance();
+  mColorSchemeRegistry = registry ? registry : QgsApplication::colorSchemeRegistry();
 
   setAcceptDrops( true );
   setMinimumSize( QSize( 24, 16 ) );

--- a/src/gui/qgscompoundcolorwidget.cpp
+++ b/src/gui/qgscompoundcolorwidget.cpp
@@ -60,7 +60,7 @@ QgsCompoundColorWidget::QgsCompoundColorWidget( QWidget *parent, const QColor& c
 
   //get schemes with ShowInColorDialog set
   refreshSchemeComboBox();
-  QList<QgsColorScheme *> schemeList = QgsColorSchemeRegistry::instance()->schemes( QgsColorScheme::ShowInColorDialog );
+  QList<QgsColorScheme *> schemeList = QgsApplication::colorSchemeRegistry()->schemes( QgsColorScheme::ShowInColorDialog );
 
   //choose a reasonable starting scheme
   int activeScheme = settings.value( QStringLiteral( "/Windows/ColorDialog/activeScheme" ), 0 ).toInt();
@@ -270,7 +270,7 @@ void QgsCompoundColorWidget::refreshSchemeComboBox()
 {
   mSchemeComboBox->blockSignals( true );
   mSchemeComboBox->clear();
-  QList<QgsColorScheme *> schemeList = QgsColorSchemeRegistry::instance()->schemes( QgsColorScheme::ShowInColorDialog );
+  QList<QgsColorScheme *> schemeList = QgsApplication::colorSchemeRegistry()->schemes( QgsColorScheme::ShowInColorDialog );
   QList<QgsColorScheme *>::const_iterator schemeIt = schemeList.constBegin();
   for ( ; schemeIt != schemeList.constEnd(); ++schemeIt )
   {
@@ -323,7 +323,7 @@ void QgsCompoundColorWidget::importPalette()
   importedScheme->setName( paletteName );
   importedScheme->setColors( importedColors );
 
-  QgsColorSchemeRegistry::instance()->addColorScheme( importedScheme );
+  QgsApplication::colorSchemeRegistry()->addColorScheme( importedScheme );
 
   //refresh combobox
   refreshSchemeComboBox();
@@ -333,7 +333,7 @@ void QgsCompoundColorWidget::importPalette()
 void QgsCompoundColorWidget::removePalette()
 {
   //get current scheme
-  QList<QgsColorScheme *> schemeList = QgsColorSchemeRegistry::instance()->schemes( QgsColorScheme::ShowInColorDialog );
+  QList<QgsColorScheme *> schemeList = QgsApplication::colorSchemeRegistry()->schemes( QgsColorScheme::ShowInColorDialog );
   int prevIndex = mSchemeComboBox->currentIndex();
   if ( prevIndex >= schemeList.length() )
   {
@@ -363,7 +363,7 @@ void QgsCompoundColorWidget::removePalette()
   }
 
   //remove scheme from registry
-  QgsColorSchemeRegistry::instance()->removeColorScheme( userScheme );
+  QgsApplication::colorSchemeRegistry()->removeColorScheme( userScheme );
   refreshSchemeComboBox();
   prevIndex = qMax( qMin( prevIndex, mSchemeComboBox->count() - 1 ), 0 );
   mSchemeComboBox->setCurrentIndex( prevIndex );
@@ -401,7 +401,7 @@ void QgsCompoundColorWidget::newPalette()
   QgsUserColorScheme* newScheme = new QgsUserColorScheme( destFileInfo.fileName() );
   newScheme->setName( name );
 
-  QgsColorSchemeRegistry::instance()->addColorScheme( newScheme );
+  QgsApplication::colorSchemeRegistry()->addColorScheme( newScheme );
 
   //refresh combobox and set new scheme as active
   refreshSchemeComboBox();
@@ -430,7 +430,7 @@ void QgsCompoundColorWidget::schemeIndexChanged( int index )
   }
 
   //get schemes with ShowInColorDialog set
-  QList<QgsColorScheme *> schemeList = QgsColorSchemeRegistry::instance()->schemes( QgsColorScheme::ShowInColorDialog );
+  QList<QgsColorScheme *> schemeList = QgsApplication::colorSchemeRegistry()->schemes( QgsColorScheme::ShowInColorDialog );
   if ( index >= schemeList.length() )
   {
     return;

--- a/src/gui/qgsfiledownloader.cpp
+++ b/src/gui/qgsfiledownloader.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsfiledownloader.h"
 #include "qgsnetworkaccessmanager.h"
+#include "qgsapplication.h"
 
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -36,7 +36,7 @@ QgsMessageLogViewer::QgsMessageLogViewer( QStatusBar *statusBar, QWidget *parent
   Q_UNUSED( statusBar )
   setupUi( this );
 
-  connect( QgsMessageLog::instance(), SIGNAL( messageReceived( QString, QString, QgsMessageLog::MessageLevel ) ),
+  connect( QgsApplication::messageLog(), SIGNAL( messageReceived( QString, QString, QgsMessageLog::MessageLevel ) ),
            this, SLOT( logMessage( QString, QString, QgsMessageLog::MessageLevel ) ) );
 
   connect( tabWidget, SIGNAL( tabCloseRequested( int ) ), this, SLOT( closeTab( int ) ) );

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -36,6 +36,7 @@
 #include "qgsdataprovider.h"
 #include "qgsowssourceselect.h"
 #include "qgsnetworkaccessmanager.h"
+#include "qgsapplication.h"
 
 #include <QButtonGroup>
 #include <QFileDialog>

--- a/src/gui/qgsprojectbadlayerguihandler.cpp
+++ b/src/gui/qgsprojectbadlayerguihandler.cpp
@@ -25,6 +25,7 @@
 #include "qgisgui.h"
 #include "qgsproviderregistry.h"
 #include "qgsproject.h"
+#include "qgsapplication.h"
 
 QgsProjectBadLayerGuiHandler::QgsProjectBadLayerGuiHandler()
 {

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1205,7 +1205,7 @@ void QgsTextFormatWidget::updateSvgWidgets( const QString& svgPath )
   bool fillParam = false, outlineParam = false, outlineWidthParam = false;
   if ( validSVG )
   {
-    QgsSvgCache::instance()->containsParams( resolvedPath, fillParam, fill, outlineParam, outline, outlineWidthParam, outlineWidth );
+    QgsApplication::svgCache()->containsParams( resolvedPath, fillParam, fill, outlineParam, outline, outlineWidthParam, outlineWidth );
   }
 
   mShapeSVGParamsBtn->setEnabled( validSVG && ( fillParam || outlineParam || outlineWidthParam ) );

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -39,11 +39,11 @@ static void _initRendererWidgetFunctions()
   if ( initialized )
     return;
 
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "paletted" ), QgsPalettedRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "multibandcolor" ), QgsMultiBandColorRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "singlebandpseudocolor" ), QgsSingleBandPseudoColorRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "singlebandgray" ), QgsSingleBandGrayRendererWidget::create );
-  QgsRasterRendererRegistry::instance()->insertWidgetFunction( QStringLiteral( "hillshade" ), QgsHillshadeRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "paletted" ), QgsPalettedRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "multibandcolor" ), QgsMultiBandColorRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "singlebandpseudocolor" ), QgsSingleBandPseudoColorRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "singlebandgray" ), QgsSingleBandGrayRendererWidget::create );
+  QgsApplication::rasterRendererRegistry()->insertWidgetFunction( QStringLiteral( "hillshade" ), QgsHillshadeRendererWidget::create );
 
   initialized = true;
 }
@@ -196,9 +196,9 @@ void QgsRendererRasterPropertiesWidget::syncToLayer( QgsRasterLayer* layer )
   cboRenderers->blockSignals( true );
   cboRenderers->clear();
   QgsRasterRendererRegistryEntry entry;
-  Q_FOREACH ( const QString& name, QgsRasterRendererRegistry::instance()->renderersList() )
+  Q_FOREACH ( const QString& name, QgsApplication::rasterRendererRegistry()->renderersList() )
   {
-    if ( QgsRasterRendererRegistry::instance()->rendererData( name, entry ) )
+    if ( QgsApplication::rasterRendererRegistry()->rendererData( name, entry ) )
     {
       if (( mRasterLayer->rasterType() != QgsRasterLayer::ColorLayer && entry.name != QLatin1String( "singlebandcolordata" ) ) ||
           ( mRasterLayer->rasterType() == QgsRasterLayer::ColorLayer && entry.name == QLatin1String( "singlebandcolordata" ) ) )
@@ -326,7 +326,7 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
   QgsRasterRendererWidget* oldWidget = mRendererWidget;
 
   QgsRasterRendererRegistryEntry rendererEntry;
-  if ( QgsRasterRendererRegistry::instance()->rendererData( rendererName, rendererEntry ) )
+  if ( QgsApplication::rasterRendererRegistry()->rendererData( rendererName, rendererEntry ) )
   {
     if ( rendererEntry.widgetCreateFunction ) //single band color data renderer e.g. has no widget
     {
@@ -337,12 +337,12 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
       {
         if ( rendererName == "singlebandgray" )
         {
-          whileBlocking( mRasterLayer )->setRenderer( QgsRasterRendererRegistry::instance()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
+          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
           whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
         }
         else if ( rendererName == "multibandcolor" )
         {
-          whileBlocking( mRasterLayer )->setRenderer( QgsRasterRendererRegistry::instance()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
+          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
           whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
         }
       }

--- a/src/gui/symbology-ng/qgsinvertedpolygonrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgsinvertedpolygonrendererwidget.cpp
@@ -68,7 +68,7 @@ QgsInvertedPolygonRendererWidget::QgsInvertedPolygonRendererWidget( QgsVectorLay
 
   int currentEmbeddedIdx = 0;
   //insert possible renderer types
-  QStringList rendererList = QgsRendererRegistry::instance()->renderersList( QgsRendererAbstractMetadata::PolygonLayer );
+  QStringList rendererList = QgsApplication::rendererRegistry()->renderersList( QgsRendererAbstractMetadata::PolygonLayer );
   QStringList::const_iterator it = rendererList.constBegin();
   int idx = 0;
   mRendererComboBox->blockSignals( true );
@@ -76,7 +76,7 @@ QgsInvertedPolygonRendererWidget::QgsInvertedPolygonRendererWidget( QgsVectorLay
   {
     if ( *it != QLatin1String( "invertedPolygonRenderer" ) ) //< an inverted renderer cannot contain another inverted renderer
     {
-      QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( *it );
+      QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( *it );
       mRendererComboBox->addItem( m->icon(), m->visibleName(), /* data */ *it );
       const QgsFeatureRenderer* embeddedRenderer = mRenderer->embeddedRenderer();
       if ( embeddedRenderer && embeddedRenderer->type() == m->name() )
@@ -120,7 +120,7 @@ void QgsInvertedPolygonRendererWidget::setContext( const QgsSymbolWidgetContext&
 void QgsInvertedPolygonRendererWidget::on_mRendererComboBox_currentIndexChanged( int index )
 {
   QString rendererId = mRendererComboBox->itemData( index ).toString();
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( rendererId );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( rendererId );
   if ( m )
   {
     mEmbeddedRendererWidget.reset( m->createRendererWidget( mLayer, mStyle, const_cast<QgsFeatureRenderer*>( mRenderer->embeddedRenderer() )->clone() ) );

--- a/src/gui/symbology-ng/qgslayerpropertieswidget.cpp
+++ b/src/gui/symbology-ng/qgslayerpropertieswidget.cpp
@@ -39,7 +39,7 @@
 
 static bool _initWidgetFunction( const QString& name, QgsSymbolLayerWidgetFunc f )
 {
-  QgsSymbolLayerRegistry* reg = QgsSymbolLayerRegistry::instance();
+  QgsSymbolLayerRegistry* reg = QgsApplication::symbolLayerRegistry();
 
   QgsSymbolLayerAbstractMetadata* abstractMetadata = reg->symbolLayerMetadata( name );
   if ( !abstractMetadata )
@@ -171,17 +171,17 @@ void QgsLayerPropertiesWidget::setDockMode( bool dockMode )
 
 void QgsLayerPropertiesWidget::populateLayerTypes()
 {
-  QStringList symbolLayerIds = QgsSymbolLayerRegistry::instance()->symbolLayersForType( mSymbol->type() );
+  QStringList symbolLayerIds = QgsApplication::symbolLayerRegistry()->symbolLayersForType( mSymbol->type() );
 
   Q_FOREACH ( const QString& symbolLayerId, symbolLayerIds )
-    cboLayerType->addItem( QgsSymbolLayerRegistry::instance()->symbolLayerMetadata( symbolLayerId )->visibleName(), symbolLayerId );
+    cboLayerType->addItem( QgsApplication::symbolLayerRegistry()->symbolLayerMetadata( symbolLayerId )->visibleName(), symbolLayerId );
 
   if ( mSymbol->type() == QgsSymbol::Fill )
   {
-    QStringList lineLayerIds = QgsSymbolLayerRegistry::instance()->symbolLayersForType( QgsSymbol::Line );
+    QStringList lineLayerIds = QgsApplication::symbolLayerRegistry()->symbolLayersForType( QgsSymbol::Line );
     Q_FOREACH ( const QString& lineLayerId, lineLayerIds )
     {
-      QgsSymbolLayerAbstractMetadata* layerInfo = QgsSymbolLayerRegistry::instance()->symbolLayerMetadata( lineLayerId );
+      QgsSymbolLayerAbstractMetadata* layerInfo = QgsApplication::symbolLayerRegistry()->symbolLayerMetadata( lineLayerId );
       if ( layerInfo->type() != QgsSymbol::Hybrid )
       {
         QString visibleName = layerInfo->visibleName();
@@ -201,7 +201,7 @@ void QgsLayerPropertiesWidget::updateSymbolLayerWidget( QgsSymbolLayer* layer )
     stackedWidget->removeWidget( stackedWidget->currentWidget() );
   }
 
-  QgsSymbolLayerRegistry* pReg = QgsSymbolLayerRegistry::instance();
+  QgsSymbolLayerRegistry* pReg = QgsApplication::symbolLayerRegistry();
 
   QString layerType = layer->layerType();
   QgsSymbolLayerAbstractMetadata* am = pReg->symbolLayerMetadata( layerType );
@@ -286,7 +286,7 @@ void QgsLayerPropertiesWidget::layerTypeChanged()
     return;
 
   // get creation function for new layer from registry
-  QgsSymbolLayerRegistry* pReg = QgsSymbolLayerRegistry::instance();
+  QgsSymbolLayerRegistry* pReg = QgsApplication::symbolLayerRegistry();
   QgsSymbolLayerAbstractMetadata* am = pReg->symbolLayerMetadata( newLayerType );
   if ( !am ) // check whether the metadata is assigned
     return;

--- a/src/gui/symbology-ng/qgspointclusterrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgspointclusterrendererwidget.cpp
@@ -62,13 +62,13 @@ QgsPointClusterRendererWidget::QgsPointClusterRendererWidget( QgsVectorLayer* la
   blockAllSignals( true );
 
   //insert possible renderer types
-  QStringList rendererList = QgsRendererRegistry::instance()->renderersList( QgsRendererAbstractMetadata::PointLayer );
+  QStringList rendererList = QgsApplication::rendererRegistry()->renderersList( QgsRendererAbstractMetadata::PointLayer );
   QStringList::const_iterator it = rendererList.constBegin();
   for ( ; it != rendererList.constEnd(); ++it )
   {
     if ( *it != QLatin1String( "pointDisplacement" ) && *it != QLatin1String( "pointCluster" ) && *it != QLatin1String( "heatmapRenderer" ) )
     {
-      QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( *it );
+      QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( *it );
       mRendererComboBox->addItem( m->icon(), m->visibleName(), *it );
     }
   }
@@ -114,7 +114,7 @@ void QgsPointClusterRendererWidget::setContext( const QgsSymbolWidgetContext& co
 void QgsPointClusterRendererWidget::on_mRendererComboBox_currentIndexChanged( int index )
 {
   QString rendererId = mRendererComboBox->itemData( index ).toString();
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( rendererId );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( rendererId );
   if ( m )
   {
     // unfortunately renderer conversion is only available through the creation of a widget...
@@ -130,7 +130,7 @@ void QgsPointClusterRendererWidget::on_mRendererSettingsButton_clicked()
   if ( !mRenderer )
     return;
 
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( mRenderer->embeddedRenderer()->type() );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( mRenderer->embeddedRenderer()->type() );
   if ( m )
   {
     QgsRendererWidget* w = m->createRendererWidget( mLayer, mStyle, mRenderer->embeddedRenderer()->clone() );

--- a/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
@@ -86,13 +86,13 @@ QgsPointDisplacementRendererWidget::QgsPointDisplacementRendererWidget( QgsVecto
   }
 
   //insert possible renderer types
-  QStringList rendererList = QgsRendererRegistry::instance()->renderersList( QgsRendererAbstractMetadata::PointLayer );
+  QStringList rendererList = QgsApplication::rendererRegistry()->renderersList( QgsRendererAbstractMetadata::PointLayer );
   QStringList::const_iterator it = rendererList.constBegin();
   for ( ; it != rendererList.constEnd(); ++it )
   {
     if ( *it != QLatin1String( "pointDisplacement" ) && *it != QLatin1String( "pointCluster" ) && *it != QLatin1String( "heatmapRenderer" ) )
     {
-      QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( *it );
+      QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( *it );
       mRendererComboBox->addItem( m->icon(), m->visibleName(), *it );
     }
   }
@@ -184,7 +184,7 @@ void QgsPointDisplacementRendererWidget::on_mLabelFieldComboBox_currentIndexChan
 void QgsPointDisplacementRendererWidget::on_mRendererComboBox_currentIndexChanged( int index )
 {
   QString rendererId = mRendererComboBox->itemData( index ).toString();
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( rendererId );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( rendererId );
   if ( m )
   {
     // unfortunately renderer conversion is only available through the creation of a widget...
@@ -209,7 +209,7 @@ void QgsPointDisplacementRendererWidget::on_mRendererSettingsButton_clicked()
   if ( !mRenderer )
     return;
 
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( mRenderer->embeddedRenderer()->type() );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( mRenderer->embeddedRenderer()->type() );
   if ( m )
   {
     QgsRendererWidget* w = m->createRendererWidget( mLayer, mStyle, mRenderer->embeddedRenderer()->clone() );

--- a/src/gui/symbology-ng/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererpropertiesdialog.cpp
@@ -41,7 +41,7 @@
 
 static bool _initRenderer( const QString& name, QgsRendererWidgetFunc f, const QString& iconName = QString() )
 {
-  QgsRendererRegistry* reg = QgsRendererRegistry::instance();
+  QgsRendererRegistry* reg = QgsApplication::rendererRegistry();
   QgsRendererAbstractMetadata* am = reg->rendererMetadata( name );
   if ( !am )
     return false;
@@ -103,7 +103,7 @@ QgsRendererPropertiesDialog::QgsRendererPropertiesDialog( QgsVectorLayer* layer,
   // initialize registry's widget functions
   _initRendererWidgetFunctions();
 
-  QgsRendererRegistry* reg = QgsRendererRegistry::instance();
+  QgsRendererRegistry* reg = QgsApplication::rendererRegistry();
   QStringList renderers = reg->renderersList( mLayer );
   Q_FOREACH ( const QString& name, renderers )
   {
@@ -238,7 +238,7 @@ void QgsRendererPropertiesDialog::rendererChanged()
   }
 
   QgsRendererWidget* w = nullptr;
-  QgsRendererAbstractMetadata* m = QgsRendererRegistry::instance()->rendererMetadata( rendererName );
+  QgsRendererAbstractMetadata* m = QgsApplication::rendererRegistry()->rendererMetadata( rendererName );
   if ( m )
     w = m->createRendererWidget( mLayer, mStyle, oldRenderer );
   delete oldRenderer;

--- a/src/gui/symbology-ng/qgssvgselectorwidget.cpp
+++ b/src/gui/symbology-ng/qgssvgselectorwidget.cpp
@@ -242,7 +242,7 @@ QPixmap QgsSvgSelectorListModel::createPreview( const QString& entry ) const
   bool fillParam, fillOpacityParam, outlineParam, outlineWidthParam, outlineOpacityParam;
   bool hasDefaultFillColor = false, hasDefaultFillOpacity = false, hasDefaultOutlineColor = false,
                              hasDefaultOutlineWidth = false, hasDefaultOutlineOpacity = false;
-  QgsSvgCache::instance()->containsParams( entry, fillParam, hasDefaultFillColor, fill,
+  QgsApplication::svgCache()->containsParams( entry, fillParam, hasDefaultFillColor, fill,
       fillOpacityParam, hasDefaultFillOpacity, fillOpacity,
       outlineParam, hasDefaultOutlineColor, outline,
       outlineWidthParam, hasDefaultOutlineWidth, outlineWidth,
@@ -259,7 +259,7 @@ QPixmap QgsSvgSelectorListModel::createPreview( const QString& entry ) const
     outlineWidth = 0.2;
 
   bool fitsInCache; // should always fit in cache at these sizes (i.e. under 559 px ^ 2, or half cache size)
-  const QImage& img = QgsSvgCache::instance()->svgAsImage( entry, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, 1.0, fitsInCache );
+  const QImage& img = QgsApplication::svgCache()->svgAsImage( entry, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, 1.0, fitsInCache );
   return QPixmap::fromImage( img );
 }
 

--- a/src/gui/symbology-ng/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerwidget.cpp
@@ -1841,7 +1841,7 @@ void QgsSvgMarkerSymbolLayerWidget::setGuiForSvg( const QgsSvgMarkerSymbolLayer*
   QColor defaultFill, defaultOutline;
   double defaultOutlineWidth, defaultFillOpacity, defaultOutlineOpacity;
   bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultOutlineColor, hasDefaultOutlineWidth, hasDefaultOutlineOpacity;
-  QgsSvgCache::instance()->containsParams( layer->path(), hasFillParam, hasDefaultFillColor, defaultFill,
+  QgsApplication::svgCache()->containsParams( layer->path(), hasFillParam, hasDefaultFillColor, defaultFill,
       hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
       hasOutlineParam, hasDefaultOutlineColor, defaultOutline,
       hasOutlineWidthParam, hasDefaultOutlineWidth, defaultOutlineWidth,
@@ -2334,7 +2334,7 @@ void QgsSVGFillSymbolLayerWidget::updateParamGui( bool resetValues )
   QColor defaultFill, defaultOutline;
   double defaultOutlineWidth, defaultFillOpacity, defaultOutlineOpacity;
   bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultOutlineColor, hasDefaultOutlineWidth, hasDefaultOutlineOpacity;
-  QgsSvgCache::instance()->containsParams( mSVGLineEdit->text(), hasFillParam, hasDefaultFillColor, defaultFill,
+  QgsApplication::svgCache()->containsParams( mSVGLineEdit->text(), hasFillParam, hasDefaultFillColor, defaultFill,
       hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
       hasOutlineParam, hasDefaultOutlineColor, defaultOutline,
       hasOutlineWidthParam, hasDefaultOutlineWidth, defaultOutlineWidth,

--- a/src/gui/symbology-ng/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolselectordialog.cpp
@@ -175,7 +175,7 @@ class SymbolLayerItem : public QStandardItem
       if ( role == Qt::DisplayRole || role == Qt::EditRole )
       {
         if ( mIsLayer )
-          return QgsSymbolLayerRegistry::instance()->symbolLayerMetadata( mLayer->layerType() )->visibleName();
+          return QgsApplication::symbolLayerRegistry()->symbolLayerMetadata( mLayer->layerType() )->visibleName();
         else
         {
           switch ( mSymbol->type() )
@@ -522,7 +522,7 @@ void QgsSymbolSelectorWidget::addLayer()
                            ? static_cast<QgsLineSymbol *>( parentSymbol )->dataDefinedWidth()
                            : QgsDataDefined() ;
 
-  QgsSymbolLayer* newLayer = QgsSymbolLayerRegistry::instance()->defaultSymbolLayer( parentSymbol->type() );
+  QgsSymbolLayer* newLayer = QgsApplication::symbolLayerRegistry()->defaultSymbolLayer( parentSymbol->type() );
   if ( insertIdx == -1 )
     parentSymbol->appendSymbolLayer( newLayer );
   else

--- a/src/plugins/grass/qgsgrasseditrenderer.cpp
+++ b/src/plugins/grass/qgsgrasseditrenderer.cpp
@@ -231,7 +231,7 @@ QgsFeatureRenderer* QgsGrassEditRenderer::create( QDomElement& element )
     {
       QString rendererType = elem.attribute( QStringLiteral( "type" ) );
       QgsDebugMsg( "childElem.tagName() = " + childElem.tagName() + " rendererType = " + rendererType );
-      QgsRendererAbstractMetadata* meta = QgsRendererRegistry::instance()->rendererMetadata( rendererType );
+      QgsRendererAbstractMetadata* meta = QgsApplication::rendererRegistry()->rendererMetadata( rendererType );
       if ( meta )
       {
         QgsFeatureRenderer* subRenderer = meta->createRenderer( elem );

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -289,9 +289,9 @@ void QgsGrassPlugin::initGui()
   qGisInterface->addDockWidget( Qt::RightDockWidgetArea, mTools );
 
   // add edit renderer immediately so that if project was saved during editing, the layer can be loaded
-  if ( !QgsRendererRegistry::instance()->renderersList().contains( QStringLiteral( "grassEdit" ) ) )
+  if ( !QgsApplication::rendererRegistry()->renderersList().contains( QStringLiteral( "grassEdit" ) ) )
   {
-    QgsRendererRegistry::instance()->addRenderer( new QgsRendererMetadata( QStringLiteral( "grassEdit" ),
+    QgsApplication::rendererRegistry()->addRenderer( new QgsRendererMetadata( QStringLiteral( "grassEdit" ),
         QObject::tr( "GRASS edit" ),
         QgsGrassEditRenderer::create,
         QIcon( QgsApplication::defaultThemePath() + "rendererGrassSymbol.svg" ),

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
 #include "qgsnetworkaccessmanager.h"
+#include "qgsapplication.h"
 
 #include <QEventLoop>
 #include <QNetworkCacheMetaData>

--- a/src/providers/wms/qgstilecache.cpp
+++ b/src/providers/wms/qgstilecache.cpp
@@ -16,7 +16,7 @@
 #include "qgstilecache.h"
 
 #include "qgsnetworkaccessmanager.h"
-
+#include "qgsapplication.h"
 #include <QAbstractNetworkCache>
 #include <QImage>
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -28,6 +28,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsunittypes.h"
 #include "qgscsexception.h"
+#include "qgsapplication.h"
 
 // %%% copied from qgswmsprovider.cpp
 static QString DEFAULT_LATLON_CRS = QStringLiteral( "CRS:84" );

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -36,6 +36,7 @@
 #include "qgswmtsdimensions.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgswmscapabilities.h"
+#include "qgsapplication.h"
 
 #include <QButtonGroup>
 #include <QFileDialog>

--- a/src/server/qgsmslayerbuilder.cpp
+++ b/src/server/qgsmslayerbuilder.cpp
@@ -95,7 +95,7 @@ void QgsMSLayerBuilder::clearRasterSymbology( QgsRasterLayer* rl ) const
     if ( rl->rasterType() == QgsRasterLayer::GrayOrUndefined )
     {
       //rl->setDrawingStyle( QgsRasterLayer::SingleBandPseudoColor );
-      rl->setRenderer( QgsRasterRendererRegistry::instance()->defaultRendererForDrawingStyle( QgsRaster::SingleBandPseudoColor, rl->dataProvider() ) );
+      rl->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::SingleBandPseudoColor, rl->dataProvider() ) );
     }
   }
 }

--- a/src/server/qgsserverlogger.cpp
+++ b/src/server/qgsserverlogger.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsserverlogger.h"
+#include "qgsapplication.h"
 #include <QCoreApplication>
 #include <QFile>
 #include <QTextStream>
@@ -56,7 +57,7 @@ QgsServerLogger::QgsServerLogger()
     mLogLevel = static_cast<QgsMessageLog::MessageLevel>( atoi( logLevelChar ) );
   }
 
-  connect( QgsMessageLog::instance(), SIGNAL( messageReceived( QString, QString, QgsMessageLog::MessageLevel ) ), this,
+  connect( QgsApplication::messageLog(), SIGNAL( messageReceived( QString, QString, QgsMessageLog::MessageLevel ) ), this,
            SLOT( logMessage( QString, QString, QgsMessageLog::MessageLevel ) ) );
 }
 

--- a/tests/src/core/testqgscolorschemeregistry.cpp
+++ b/tests/src/core/testqgscolorschemeregistry.cpp
@@ -102,7 +102,7 @@ void TestQgsColorSchemeRegistry::cleanup()
 
 void TestQgsColorSchemeRegistry::createInstance()
 {
-  QgsColorSchemeRegistry* registry = QgsColorSchemeRegistry::instance();
+  QgsColorSchemeRegistry* registry = QgsApplication::colorSchemeRegistry();
   QVERIFY( registry );
 }
 
@@ -110,7 +110,7 @@ void TestQgsColorSchemeRegistry::instanceHasDefaultSchemes()
 {
   //check that scheme instance is initially populated with some schemes
   //(assumes that there is some default schemes)
-  QgsColorSchemeRegistry* registry = QgsColorSchemeRegistry::instance();
+  QgsColorSchemeRegistry* registry = QgsApplication::colorSchemeRegistry();
   QVERIFY( registry->schemes().length() > 0 );
 }
 
@@ -148,7 +148,7 @@ void TestQgsColorSchemeRegistry::populateFromInstance()
   QVERIFY( registry->schemes().length() == 0 );
   //add schemes from instance
   registry->populateFromInstance();
-  QCOMPARE( registry->schemes().length(), QgsColorSchemeRegistry::instance()->schemes().length() );
+  QCOMPARE( registry->schemes().length(), QgsApplication::colorSchemeRegistry()->schemes().length() );
 }
 
 void TestQgsColorSchemeRegistry::removeScheme()

--- a/tests/src/core/testqgspainteffect.cpp
+++ b/tests/src/core/testqgspainteffect.cpp
@@ -142,7 +142,7 @@ void TestQgsPaintEffect::initTestCase()
   mReport += QLatin1String( "<h1>Paint Effect Tests</h1>\n" );
   mPicture = 0;
 
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   registry->addEffectType( new QgsPaintEffectMetadata( QStringLiteral( "Dummy" ), QStringLiteral( "Dummy effect" ), DummyPaintEffect::create ) );
 
   QString myDataDir( TEST_DATA_DIR ); //defined in CmakeLists.txt
@@ -206,17 +206,17 @@ void TestQgsPaintEffect::saveRestore()
   QCOMPARE( effectElem.attribute( "type" ), QString( "Dummy" ) );
 
   //test reading empty node
-  QgsPaintEffect* restoredEffect = QgsPaintEffectRegistry::instance()->createEffect( noNode );
+  QgsPaintEffect* restoredEffect = QgsApplication::paintEffectRegistry()->createEffect( noNode );
   QVERIFY( !restoredEffect );
 
   //test reading bad node
   QDomElement badEffectElem = doc.createElement( QStringLiteral( "parent" ) );
   badEffectElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "bad" ) );
-  restoredEffect = QgsPaintEffectRegistry::instance()->createEffect( badEffectElem );
+  restoredEffect = QgsApplication::paintEffectRegistry()->createEffect( badEffectElem );
   QVERIFY( !restoredEffect );
 
   //test reading node
-  restoredEffect = QgsPaintEffectRegistry::instance()->createEffect( effectElem );
+  restoredEffect = QgsApplication::paintEffectRegistry()->createEffect( effectElem );
   QVERIFY( restoredEffect );
   DummyPaintEffect* restoredDummyEffect = dynamic_cast<DummyPaintEffect*>( restoredEffect );
   QVERIFY( restoredDummyEffect );
@@ -268,7 +268,7 @@ void TestQgsPaintEffect::stackSaveRestore()
   QCOMPARE( childNodeList.at( 1 ).toElement().attribute( "type" ), shadow->type() );
 
   //test reading node
-  QgsPaintEffect* restoredEffect = QgsPaintEffectRegistry::instance()->createEffect( effectElem );
+  QgsPaintEffect* restoredEffect = QgsApplication::paintEffectRegistry()->createEffect( effectElem );
   QVERIFY( restoredEffect );
   QgsEffectStack* restoredStack = dynamic_cast<QgsEffectStack*>( restoredEffect );
   QVERIFY( restoredStack );

--- a/tests/src/core/testqgspainteffectregistry.cpp
+++ b/tests/src/core/testqgspainteffectregistry.cpp
@@ -96,7 +96,7 @@ void TestQgsPaintEffectRegistry::metadata()
 
 void TestQgsPaintEffectRegistry::createInstance()
 {
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QVERIFY( registry );
 }
 
@@ -104,14 +104,14 @@ void TestQgsPaintEffectRegistry::instanceHasDefaultEffects()
 {
   //check that effect instance is initially populated with some effects
   //(assumes that there is some default effects)
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QVERIFY( registry->effects().length() > 0 );
 }
 
 void TestQgsPaintEffectRegistry::addEffect()
 {
   //create an empty registry
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   int previousCount = registry->effects().length();
 
   registry->addEffectType( new QgsPaintEffectMetadata( QStringLiteral( "Dummy" ), QStringLiteral( "Dummy effect" ), DummyPaintEffect::create ) );
@@ -127,7 +127,7 @@ void TestQgsPaintEffectRegistry::addEffect()
 
 void TestQgsPaintEffectRegistry::fetchEffects()
 {
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QStringList effects = registry->effects();
 
   QVERIFY( effects.contains( "Dummy" ) );
@@ -142,7 +142,7 @@ void TestQgsPaintEffectRegistry::fetchEffects()
 
 void TestQgsPaintEffectRegistry::createEffect()
 {
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QgsPaintEffect* effect = registry->createEffect( QStringLiteral( "Dummy" ) );
 
   QVERIFY( effect );
@@ -157,7 +157,7 @@ void TestQgsPaintEffectRegistry::createEffect()
 
 void TestQgsPaintEffectRegistry::defaultStack()
 {
-  QgsPaintEffectRegistry* registry = QgsPaintEffectRegistry::instance();
+  QgsPaintEffectRegistry* registry = QgsApplication::paintEffectRegistry();
   QgsEffectStack* effect = static_cast<QgsEffectStack*>( registry->defaultStack() );
   QVERIFY( registry->isDefaultStack( effect ) );
   effect->effect( 1 )->setEnabled( true );

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -31,7 +31,7 @@ from qgis.core import (
     QgsPoint,
     QgsVectorDataProvider,
     QgsFeatureRequest,
-    QgsMessageLog
+    QgsApplication
 )
 from qgis.testing import (start_app,
                           unittest
@@ -56,11 +56,11 @@ class MessageLogger(QObject):
         self.tag = tag
 
     def __enter__(self):
-        QgsMessageLog.instance().messageReceived.connect(self.logMessage)
+        QgsApplication.messageLog().messageReceived.connect(self.logMessage)
         return self
 
     def __exit__(self, type, value, traceback):
-        QgsMessageLog.instance().messageReceived.disconnect(self.logMessage)
+        QgsApplication.messageLog().messageReceived.disconnect(self.logMessage)
 
     def logMessage(self, msg, tag, level):
         if tag == self.tag or not self.tag:

--- a/tests/src/python/test_qgscolorschemeregistry.py
+++ b/tests/src/python/test_qgscolorschemeregistry.py
@@ -14,8 +14,10 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
 
-from qgis.testing import unittest
+from qgis.testing import start_app, unittest
 from qgis.core import QgsColorSchemeRegistry, QgsRecentColorScheme, QgsApplication
+
+start_app()
 
 
 class TestQgsColorSchemeRegistry(unittest.TestCase):

--- a/tests/src/python/test_qgscolorschemeregistry.py
+++ b/tests/src/python/test_qgscolorschemeregistry.py
@@ -15,19 +15,19 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 from qgis.testing import unittest
-from qgis.core import QgsColorSchemeRegistry, QgsRecentColorScheme
+from qgis.core import QgsColorSchemeRegistry, QgsRecentColorScheme, QgsApplication
 
 
 class TestQgsColorSchemeRegistry(unittest.TestCase):
 
     def testCreateInstance(self):
         """Test creating global color scheme registry instance"""
-        registry = QgsColorSchemeRegistry.instance()
+        registry = QgsApplication.colorSchemeRegistry()
         self.assertTrue(registry)
 
     def testInstanceHasDefaultScheme(self):
         """Test global color scheme registry has default schemes"""
-        registry = QgsColorSchemeRegistry.instance()
+        registry = QgsApplication.colorSchemeRegistry()
         self.assertGreater(len(registry.schemes()), 0)
 
     def testCreateEmpty(self):
@@ -55,7 +55,7 @@ class TestQgsColorSchemeRegistry(unittest.TestCase):
         registry = QgsColorSchemeRegistry()
         self.assertEqual(len(registry.schemes()), 0)
         registry.populateFromInstance()
-        self.assertEqual(len(registry.schemes()), len(QgsColorSchemeRegistry.instance().schemes()))
+        self.assertEqual(len(registry.schemes()), len(QgsApplication.colorSchemeRegistry().schemes()))
 
     def testRemoveScheme(self):
         """Test removing a scheme from a registry"""

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -43,7 +43,7 @@ from qgis.core import (
     QgsVectorLayer,
     QgsFeatureRequest,
     QgsRectangle,
-    QgsMessageLog,
+    QgsApplication,
     QgsFeature,
     QgsFeatureIterator
 )
@@ -118,11 +118,11 @@ class MessageLogger(QObject):
         self.tag = tag
 
     def __enter__(self):
-        QgsMessageLog.instance().messageReceived.connect(self.logMessage)
+        QgsApplication.messageLog().messageReceived.connect(self.logMessage)
         return self
 
     def __exit__(self, type, value, traceback):
-        QgsMessageLog.instance().messageReceived.disconnect(self.logMessage)
+        QgsApplication.messageLog().messageReceived.disconnect(self.logMessage)
 
     def logMessage(self, msg, tag, level):
         if tag == self.tag or not self.tag:

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -16,7 +16,7 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
 
-from qgis.core import QgsProject, QgsMessageLog, QgsUnitTypes, QgsCoordinateReferenceSystem
+from qgis.core import QgsProject, QgsApplication, QgsUnitTypes, QgsCoordinateReferenceSystem
 
 from qgis.testing import start_app, unittest
 
@@ -90,7 +90,7 @@ class TestQgsProject(unittest.TestCase):
         for c in validInlineChars:
             validTokens.append(validBase[:4] + c + validBase[4:])
 
-        logger = QgsMessageLog.instance()
+        logger = QgsApplication.messageLog()
         logger.messageReceived.connect(self.catchMessage)
         prj = QgsProject.instance()
 

--- a/tests/src/python/test_qgsrenderer.py
+++ b/tests/src/python/test_qgsrenderer.py
@@ -17,6 +17,7 @@ import qgis  # NOQA
 from qgis.core import (QgsFeatureRenderer,
                        QgsRendererAbstractMetadata,
                        QgsRendererRegistry,
+                       QgsApplication,
                        QgsVectorLayer
                        )
 from qgis.testing import start_app, unittest
@@ -55,69 +56,69 @@ class TestRenderer(QgsRendererAbstractMetadata):
 
 def clearRegistry():
     # clear registry to start with
-    for r in QgsRendererRegistry.instance().renderersList():
+    for r in QgsApplication.rendererRegistry().renderersList():
         if r == 'singleSymbol':
             continue
-        QgsRendererRegistry.instance().removeRenderer(r)
+        QgsApplication.rendererRegistry().removeRenderer(r)
 
 
 class TestQgsRendererV2Registry(unittest.TestCase):
 
     def testInstance(self):
         """ test retrieving global instance """
-        self.assertTrue(QgsRendererRegistry.instance())
+        self.assertTrue(QgsApplication.rendererRegistry())
 
         # instance should be initially populated with some default renderers
-        self.assertTrue('singleSymbol' in QgsRendererRegistry.instance().renderersList())
+        self.assertTrue('singleSymbol' in QgsApplication.rendererRegistry().renderersList())
 
         # register a renderer to the singleton, to test that the same instance is always returned
-        self.assertFalse('test' in QgsRendererRegistry.instance().renderersList())
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(TestRenderer('test')))
-        self.assertTrue('test' in QgsRendererRegistry.instance().renderersList())
+        self.assertFalse('test' in QgsApplication.rendererRegistry().renderersList())
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(TestRenderer('test')))
+        self.assertTrue('test' in QgsApplication.rendererRegistry().renderersList())
 
     def testAddRenderer(self):
         """ test adding renderers to registry """
         clearRegistry()
 
         # add a renderer
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(TestRenderer('test2')))
-        self.assertTrue('test2' in QgsRendererRegistry.instance().renderersList())
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(TestRenderer('test2')))
+        self.assertTrue('test2' in QgsApplication.rendererRegistry().renderersList())
 
         # try adding it again - should be rejected due to duplicate name
-        self.assertFalse(QgsRendererRegistry.instance().addRenderer(TestRenderer('test2')))
-        self.assertTrue('test2' in QgsRendererRegistry.instance().renderersList())
+        self.assertFalse(QgsApplication.rendererRegistry().addRenderer(TestRenderer('test2')))
+        self.assertTrue('test2' in QgsApplication.rendererRegistry().renderersList())
 
     def testRemoveRenderer(self):
         """ test removing renderers from registry """
         clearRegistry()
 
         # try removing non-existant renderer
-        self.assertFalse(QgsRendererRegistry.instance().removeRenderer('test3'))
+        self.assertFalse(QgsApplication.rendererRegistry().removeRenderer('test3'))
 
         # now add it
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(TestRenderer('test3')))
-        self.assertTrue('test3' in QgsRendererRegistry.instance().renderersList())
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(TestRenderer('test3')))
+        self.assertTrue('test3' in QgsApplication.rendererRegistry().renderersList())
 
         # try removing it again - should be ok this time
-        self.assertTrue(QgsRendererRegistry.instance().removeRenderer('test3'))
-        self.assertFalse('test3' in QgsRendererRegistry.instance().renderersList())
+        self.assertTrue(QgsApplication.rendererRegistry().removeRenderer('test3'))
+        self.assertFalse('test3' in QgsApplication.rendererRegistry().renderersList())
 
         # try removing it again - should be false since already removed
-        self.assertFalse(QgsRendererRegistry.instance().removeRenderer('test3'))
+        self.assertFalse(QgsApplication.rendererRegistry().removeRenderer('test3'))
 
     def testRetrieveRenderer(self):
         """ test retrieving renderer by name """
         clearRegistry()
 
         # try non-existant renderer
-        self.assertFalse(QgsRendererRegistry.instance().rendererMetadata('test4'))
+        self.assertFalse(QgsApplication.rendererRegistry().rendererMetadata('test4'))
 
         # now add it
         r = TestRenderer('test4')
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r))
 
         # try retrieving it
-        result = QgsRendererRegistry.instance().rendererMetadata('test4')
+        result = QgsApplication.rendererRegistry().rendererMetadata('test4')
         self.assertTrue(result)
         self.assertEqual(result.name(), 'test4')
 
@@ -125,25 +126,25 @@ class TestQgsRendererV2Registry(unittest.TestCase):
         """ test getting list of renderers from registry """
         clearRegistry()
 
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(), ['singleSymbol'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(), ['singleSymbol'])
 
         # add some renderers
         r1 = TestRenderer('test1', QgsRendererAbstractMetadata.PointLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r1))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r1))
         r2 = TestRenderer('test2', QgsRendererAbstractMetadata.LineLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r2))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r2))
         r3 = TestRenderer('test3', QgsRendererAbstractMetadata.PolygonLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r3))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r3))
         r4 = TestRenderer('test4', QgsRendererAbstractMetadata.PointLayer | QgsRendererAbstractMetadata.LineLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r4))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r4))
 
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(), ['singleSymbol', 'test1', 'test2', 'test3', 'test4'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(), ['singleSymbol', 'test1', 'test2', 'test3', 'test4'])
 
         # test subsets
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(QgsRendererAbstractMetadata.PointLayer), ['singleSymbol', 'test1', 'test4'])
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(QgsRendererAbstractMetadata.LineLayer), ['singleSymbol', 'test2', 'test4'])
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(QgsRendererAbstractMetadata.PolygonLayer), ['singleSymbol', 'test3'])
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(QgsRendererAbstractMetadata.LineLayer | QgsRendererAbstractMetadata.PolygonLayer), ['singleSymbol', 'test2', 'test3', 'test4'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(QgsRendererAbstractMetadata.PointLayer), ['singleSymbol', 'test1', 'test4'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(QgsRendererAbstractMetadata.LineLayer), ['singleSymbol', 'test2', 'test4'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(QgsRendererAbstractMetadata.PolygonLayer), ['singleSymbol', 'test3'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(QgsRendererAbstractMetadata.LineLayer | QgsRendererAbstractMetadata.PolygonLayer), ['singleSymbol', 'test2', 'test3', 'test4'])
 
     def testRenderersByLayerType(self):
         """ test retrieving compatible renderers by layer type """
@@ -151,13 +152,13 @@ class TestQgsRendererV2Registry(unittest.TestCase):
 
         # add some renderers
         r1 = TestRenderer('test1', QgsRendererAbstractMetadata.PointLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r1))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r1))
         r2 = TestRenderer('test2', QgsRendererAbstractMetadata.LineLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r2))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r2))
         r3 = TestRenderer('test3', QgsRendererAbstractMetadata.PolygonLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r3))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r3))
         r4 = TestRenderer('test4', QgsRendererAbstractMetadata.PointLayer | QgsRendererAbstractMetadata.LineLayer)
-        self.assertTrue(QgsRendererRegistry.instance().addRenderer(r4))
+        self.assertTrue(QgsApplication.rendererRegistry().addRenderer(r4))
 
         # make some layers
         point_layer = QgsVectorLayer("Point?field=fldtxt:string",
@@ -168,9 +169,9 @@ class TestQgsRendererV2Registry(unittest.TestCase):
                                        "polylayer", "memory")
 
         # test subsets
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(point_layer), ['singleSymbol', 'test1', 'test4'])
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(line_layer), ['singleSymbol', 'test2', 'test4'])
-        self.assertEqual(QgsRendererRegistry.instance().renderersList(polygon_layer), ['singleSymbol', 'test3'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(point_layer), ['singleSymbol', 'test1', 'test4'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(line_layer), ['singleSymbol', 'test2', 'test4'])
+        self.assertEqual(QgsApplication.rendererRegistry().renderersList(polygon_layer), ['singleSymbol', 'test3'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR removes the singleton instance from:

- QgsColorSchemeRegistry
- QgsDataItemProviderRegistry
- QgsGPSConnectionRegistry
- QgsMessageLog
- QgsPaintEffectRegistry
- QgsPluginLayerRegistry
- QgsRasterRendererRegistry
- QgsRendererRegistry
- QgsSvgCache
- QgsSymbolLayerRegistry

Remaining core singletons are
- QgsProject
- QgsProviderRegistry
- QgsNetworkAccessManager
- The authentication system singletons
