### PR TITLE
Add a PR template for github

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+Include a few sentences describing the overall goals for this pull request.
+
+## Checklist
+
+All checklist items should be addressed before a QGIS maintainer will review the request:
+
+- [ ] I've read the [QGIS Coding Standards](https://www.qgis.org/en/site/getinvolved/development/qgisdevelopersguide/codingstandards.html) and this PR complies with them
+- [ ] This PR passes all existing unit tests
+- [ ] New unit tests have been added for core changes
+- [ ] I've run the scripts/prepare-commit.sh script before each commit
+- [ ] Commit messages are descriptive and explain the rationale for changes
+- [ ] Commits which fix bugs include "fixes #11111" in the commit message
+- [ ] Commits which add new features are tagged with \[FEATURE\] in the commit message
+- [ ] Commits which change the UI or existing user workflows are tagged with \[needs-docs\] in the commit message
+
+ 
+


### PR DESCRIPTION
This PR adds a template with a checklist to help guide new QGIS contributors to create quality pull requests. I believe adding this will help new contributors know exactly what's required to get a PR quickly reviewed (and accepted) by QGIS maintainers.

Here's what it looks like:

## Description
Include a few sentences describing the overall goals for this pull request.

## Checklist

All checklist items should be addressed before a QGIS maintainer will review the request:

- [ ] I've read the [QGIS Coding Standards](https://www.qgis.org/en/site/getinvolved/development/qgisdevelopersguide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests
- [ ] New unit tests have been added for core changes
- [ ] I've run the scripts/prepare-commit.sh script before each commit
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include "fixes #11111" in the commit message
- [ ] Commits which add new features are tagged with \[FEATURE\] in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with \[needs-docs\] in the commit message

 
