### PR TITLE
[raster] re-compute min/max when band(s) changed

### DIFF
--- a/src/gui/raster/qgsrasterminmaxwidget.cpp
+++ b/src/gui/raster/qgsrasterminmaxwidget.cpp
@@ -34,6 +34,7 @@ QgsRasterMinMaxWidget::QgsRasterMinMaxWidget( QgsRasterLayer* theLayer, QWidget 
     , mLayer( theLayer )
     , mCanvas( nullptr )
     , mLastRectangleValid( false )
+    , mBandsChanged( false )
 {
   QgsDebugMsg( "Entered." );
   setupUi( this );
@@ -54,6 +55,12 @@ void QgsRasterMinMaxWidget::setMapCanvas( QgsMapCanvas* canvas )
 QgsMapCanvas* QgsRasterMinMaxWidget::mapCanvas()
 {
   return mCanvas;
+}
+
+void QgsRasterMinMaxWidget::setBands( const QList<int> & theBands )
+{
+  mBandsChanged = theBands != mBands;
+  mBands = theBands;
 }
 
 QgsRectangle QgsRasterMinMaxWidget::extent()
@@ -178,7 +185,8 @@ void QgsRasterMinMaxWidget::doComputations()
 
   QgsRasterMinMaxOrigin newMinMaxOrigin = minMaxOrigin();
   if ( mLastRectangleValid && mLastRectangle == myExtent &&
-       mLastMinMaxOrigin == newMinMaxOrigin )
+       mLastMinMaxOrigin == newMinMaxOrigin &&
+       !mBandsChanged )
   {
     QgsDebugMsg( "Does not need to redo statistics computations" );
     return;
@@ -187,6 +195,7 @@ void QgsRasterMinMaxWidget::doComputations()
   mLastRectangleValid = true;
   mLastRectangle = myExtent;
   mLastMinMaxOrigin = newMinMaxOrigin;
+  mBandsChanged = false;
 
   Q_FOREACH ( int myBand, mBands )
   {

--- a/src/gui/raster/qgsrasterminmaxwidget.h
+++ b/src/gui/raster/qgsrasterminmaxwidget.h
@@ -61,7 +61,7 @@ class GUI_EXPORT QgsRasterMinMaxWidget: public QWidget, private Ui::QgsRasterMin
      */
     QgsMapCanvas* mapCanvas();
 
-    void setBands( const QList<int> & theBands ) { mBands = theBands; }
+    void setBands( const QList<int> & theBands );
 
     /** Return the extent selected by the user.
      * Either an empty extent for 'full' or the current visible extent.
@@ -125,6 +125,8 @@ class GUI_EXPORT QgsRasterMinMaxWidget: public QWidget, private Ui::QgsRasterMin
     bool mLastRectangleValid;
     QgsRectangle mLastRectangle;
     QgsRasterMinMaxOrigin mLastMinMaxOrigin;
+
+    bool mBandsChanged;
 };
 
 #endif // QGSRASTERMINMAXWIDGET_H


### PR DESCRIPTION
When changing band(s) in the UI, the min/max values should also be updated to keep the UI sync'ed with min/max values. This PR implements that.