### PR TITLE
Processing gdal opts

### DIFF
--- a/python/gui/qgsrasterformatsaveoptionswidget.sip
+++ b/python/gui/qgsrasterformatsaveoptionswidget.sip
@@ -50,7 +50,8 @@ class QgsRasterFormatSaveOptionsWidget : QWidget
     QStringList options() const;
 
     /**
-     * Populate widget with user-defined options
+     * Populate widget with user-defined options. String should contain
+     * key=value pairs separated by spaces, e.g. "TILED=YES TFW=YES"
      * @see options()
      * @note added in QGIS 3.0
      */

--- a/python/gui/qgsrasterformatsaveoptionswidget.sip
+++ b/python/gui/qgsrasterformatsaveoptionswidget.sip
@@ -54,7 +54,7 @@ class QgsRasterFormatSaveOptionsWidget : QWidget
      * @see options()
      * @note added in QGIS 3.0
      */
-    void setOptions( const QString& options);
+    void setOptions( const QString& options );
 
     /**
      * Set widget look and feel

--- a/python/gui/qgsrasterformatsaveoptionswidget.sip
+++ b/python/gui/qgsrasterformatsaveoptionswidget.sip
@@ -21,19 +21,69 @@ class QgsRasterFormatSaveOptionsWidget : QWidget
                                       const QString& provider = "gdal" );
     ~QgsRasterFormatSaveOptionsWidget();
 
+    /**
+     * Set output raster format, it is used to determine list
+     * of available options
+     */
     void setFormat( const QString& format );
+
+    /**
+     * Set provider key, , it is used to determine list
+     * of available options
+     */
     void setProvider( const QString& provider );
+
+    /**
+     * Set output raster layer
+     */
     void setRasterLayer( QgsRasterLayer* rasterLayer );
+
+    /**
+     * Set output raster file name
+     */
     void setRasterFileName( const QString& file );
+
+    /**
+     * Returns list of selected options
+     * @see setOptions()
+     */
     QStringList options() const;
+
+    /**
+     * Populate widget with user-defined options
+     * @see options()
+     * @note added in QGIS 3.0
+     */
+    void setOptions( const QString& options);
+
+    /**
+     * Set widget look and feel
+     */
     void setType( QgsRasterFormatSaveOptionsWidget::Type type = Default );
+
+    /**
+     * Set pyramids format to use
+     */
     void setPyramidsFormat( QgsRaster::RasterPyramidsFormat format );
 
   public slots:
 
     void apply();
+
+    /**
+     * Opens window with options desctiption for given provider
+     * and output format
+     */
     void helpOptions();
+
+    /**
+     * Validates options correctness
+     */
     QString validateOptions( bool gui = true, bool reportOk = true );
+
+    /**
+     * Reloads profiles list from QGIS settings
+     */
     void updateProfiles();
 
   private slots:

--- a/python/plugins/processing/algs/gdal/CMakeLists.txt
+++ b/python/plugins/processing/algs/gdal/CMakeLists.txt
@@ -1,3 +1,5 @@
 FILE(GLOB PY_FILES *.py)
 
+ADD_SUBDIRECTORY(ui)
+
 PLUGIN_INSTALL(processing ./algs/gdal ${PY_FILES})

--- a/python/plugins/processing/algs/gdal/ClipByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipByExtent.py
@@ -32,13 +32,11 @@ from qgis.PyQt.QtGui import QIcon
 
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 
-from processing.core.parameters import ParameterRaster
-from processing.core.parameters import ParameterExtent
-from processing.core.parameters import ParameterString
+from processing.core.parameters import (ParameterRaster,
+                                        ParameterExtent,
+                                        ParameterString,
+                                        ParameterSelection)
 from processing.core.outputs import OutputRaster
-from processing.core.parameters import ParameterSelection
-from processing.core.parameters import ParameterNumber
-from processing.core.parameters import ParameterBoolean
 
 from processing.algs.gdal.GdalUtils import GdalUtils
 
@@ -51,18 +49,9 @@ class ClipByExtent(GdalAlgorithm):
     OUTPUT = 'OUTPUT'
     NO_DATA = 'NO_DATA'
     PROJWIN = 'PROJWIN'
-    EXTRA = 'EXTRA'
+    OPTIONS = 'OPTIONS'
     RTYPE = 'RTYPE'
     TYPE = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64']
-    TILED = 'TILED'
-    COMPRESS = 'COMPRESS'
-    JPEGCOMPRESSION = 'JPEGCOMPRESSION'
-    PREDICTOR = 'PREDICTOR'
-    ZLEVEL = 'ZLEVEL'
-    BIGTIFF = 'BIGTIFF'
-    BIGTIFFTYPE = ['', 'YES', 'NO', 'IF_NEEDED', 'IF_SAFER']
-    COMPRESSTYPE = ['NONE', 'JPEG', 'LZW', 'PACKBITS', 'DEFLATE']
-    TFW = 'TFW'
 
     def getIcon(self):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'raster-clip.png'))
@@ -70,58 +59,31 @@ class ClipByExtent(GdalAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Clip raster by extent')
         self.group, self.i18n_group = self.trAlgorithm('[GDAL] Extraction')
-        self.addParameter(ParameterRaster(
-            self.INPUT, self.tr('Input layer'), False))
+
+        self.addParameter(ParameterRaster(self.INPUT, self.tr('Input layer')))
         self.addParameter(ParameterString(self.NO_DATA,
                                           self.tr("Nodata value, leave blank to take the nodata value from input"),
-                                          '', optional=True))
+                                          '',
+                                          optional=True))
         self.addParameter(ParameterExtent(self.PROJWIN, self.tr('Clipping extent')))
-
-        params = []
-        params.append(ParameterSelection(self.RTYPE,
-                                         self.tr('Output raster type'), self.TYPE, 5))
-        params.append(ParameterSelection(self.COMPRESS,
-                                         self.tr('GeoTIFF options. Compression type:'), self.COMPRESSTYPE, 4))
-        params.append(ParameterNumber(self.JPEGCOMPRESSION,
-                                      self.tr('Set the JPEG compression level'),
-                                      1, 100, 75))
-        params.append(ParameterNumber(self.ZLEVEL,
-                                      self.tr('Set the DEFLATE compression level'),
-                                      1, 9, 6))
-        params.append(ParameterNumber(self.PREDICTOR,
-                                      self.tr('Set the predictor for LZW or DEFLATE compression'),
-                                      1, 3, 1))
-        params.append(ParameterBoolean(self.TILED,
-                                       self.tr('Create tiled output (only used for the GTiff format)'), False))
-        params.append(ParameterSelection(self.BIGTIFF,
-                                         self.tr('Control whether the created file is a BigTIFF or a classic TIFF'), self.BIGTIFFTYPE, 0))
-        params.append(ParameterBoolean(self.TFW,
-                                       self.tr('Force the generation of an associated ESRI world file (.tfw))'), False))
-        params.append(ParameterString(self.EXTRA,
-                                      self.tr('Additional creation parameters'), '', optional=True))
-
-        for param in params:
-            param.isAdvanced = True
-            self.addParameter(param)
+        self.addParameter(ParameterString(self.OPTIONS,
+                                          self.tr('Additional creation options'),
+                                          optional=True,
+                                          metadata={'widget_wrapper': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}))
+        self.addParameter(ParameterSelection(self.RTYPE,
+                                             self.tr('Output raster type'),
+                                             self.TYPE, 5))
 
         self.addOutput(OutputRaster(self.OUTPUT, self.tr('Clipped (extent)')))
 
     def getConsoleCommands(self):
         out = self.getOutputValue(self.OUTPUT)
         noData = self.getParameterValue(self.NO_DATA)
+        opts = self.getParameterValue(self.OPTIONS)
+        projwin = self.getParameterValue(self.PROJWIN)
+
         if noData is not None:
             noData = str(noData)
-        projwin = str(self.getParameterValue(self.PROJWIN))
-        extra = self.getParameterValue(self.EXTRA)
-        if extra is not None:
-            extra = str(extra)
-        jpegcompression = str(self.getParameterValue(self.JPEGCOMPRESSION))
-        predictor = str(self.getParameterValue(self.PREDICTOR))
-        zlevel = str(self.getParameterValue(self.ZLEVEL))
-        tiled = str(self.getParameterValue(self.TILED))
-        compress = self.COMPRESSTYPE[self.getParameterValue(self.COMPRESS)]
-        bigtiff = self.BIGTIFFTYPE[self.getParameterValue(self.BIGTIFF)]
-        tfw = str(self.getParameterValue(self.TFW))
 
         arguments = []
         arguments.append('-of')
@@ -139,22 +101,9 @@ class ClipByExtent(GdalAlgorithm):
         arguments.append(regionCoords[1])
         arguments.append(regionCoords[2])
 
-        if extra and len(extra) > 0:
-            arguments.append(extra)
-        if GdalUtils.getFormatShortNameFromFilename(out) == "GTiff":
-            arguments.append("-co COMPRESS=" + compress)
-            if compress == 'JPEG':
-                arguments.append("-co JPEG_QUALITY=" + jpegcompression)
-            elif (compress == 'LZW') or (compress == 'DEFLATE'):
-                arguments.append("-co PREDICTOR=" + predictor)
-            if compress == 'DEFLATE':
-                arguments.append("-co ZLEVEL=" + zlevel)
-            if tiled == "True":
-                arguments.append("-co TILED=YES")
-            if tfw == "True":
-                arguments.append("-co TFW=YES")
-            if len(bigtiff) > 0:
-                arguments.append("-co BIGTIFF=" + bigtiff)
+        if opts:
+            arguments.append('-co')
+            arguments.append(opts)
 
         arguments.append(self.getParameterValue(self.INPUT))
         arguments.append(out)

--- a/python/plugins/processing/algs/gdal/ClipByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipByMask.py
@@ -32,12 +32,11 @@ from qgis.PyQt.QtGui import QIcon
 
 from osgeo import gdal
 
-from processing.core.parameters import ParameterRaster
-from processing.core.parameters import ParameterVector
-from processing.core.parameters import ParameterBoolean
-from processing.core.parameters import ParameterString
-from processing.core.parameters import ParameterSelection
-from processing.core.parameters import ParameterNumber
+from processing.core.parameters import (ParameterRaster,
+                                        ParameterVector,
+                                        ParameterBoolean,
+                                        ParameterString,
+                                        ParameterSelection)
 
 from processing.core.outputs import OutputRaster
 
@@ -59,18 +58,9 @@ class ClipByMask(GdalAlgorithm):
     ALPHA_BAND = 'ALPHA_BAND'
     CROP_TO_CUTLINE = 'CROP_TO_CUTLINE'
     KEEP_RESOLUTION = 'KEEP_RESOLUTION'
-    EXTRA = 'EXTRA'
+    OPTIONS = 'OPTIONS'
     RTYPE = 'RTYPE'
     TYPE = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64']
-    TILED = 'TILED'
-    COMPRESS = 'COMPRESS'
-    JPEGCOMPRESSION = 'JPEGCOMPRESSION'
-    PREDICTOR = 'PREDICTOR'
-    ZLEVEL = 'ZLEVEL'
-    BIGTIFF = 'BIGTIFF'
-    BIGTIFFTYPE = ['', 'YES', 'NO', 'IF_NEEDED', 'IF_SAFER']
-    COMPRESSTYPE = ['NONE', 'JPEG', 'LZW', 'PACKBITS', 'DEFLATE']
-    TFW = 'TFW'
 
     def getIcon(self):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'raster-clip.png'))
@@ -78,6 +68,7 @@ class ClipByMask(GdalAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Clip raster by mask layer')
         self.group, self.i18n_group = self.trAlgorithm('[GDAL] Extraction')
+
         self.addParameter(ParameterRaster(self.INPUT, self.tr('Input layer'), False))
         self.addParameter(ParameterVector(self.MASK, self.tr('Mask layer'),
                                           [dataobjects.TYPE_VECTOR_POLYGON]))
@@ -85,38 +76,21 @@ class ClipByMask(GdalAlgorithm):
                                           self.tr("Nodata value, leave blank to take the nodata value from input"),
                                           '', optional=True))
         self.addParameter(ParameterBoolean(self.ALPHA_BAND,
-                                           self.tr('Create and output alpha band'), False))
+                                           self.tr('Create and output alpha band'),
+                                           False))
         self.addParameter(ParameterBoolean(self.CROP_TO_CUTLINE,
-                                           self.tr('Crop the extent of the target dataset to the extent of the cutline'), True))
+                                           self.tr('Crop the extent of the target dataset to the extent of the cutline'),
+                                           True))
         self.addParameter(ParameterBoolean(self.KEEP_RESOLUTION,
-                                           self.tr('Keep resolution of output raster'), False))
-
-        params = []
-        params.append(ParameterSelection(self.RTYPE,
-                                         self.tr('Output raster type'), self.TYPE, 5))
-        params.append(ParameterSelection(self.COMPRESS,
-                                         self.tr('GeoTIFF options. Compression type:'), self.COMPRESSTYPE, 4))
-        params.append(ParameterNumber(self.JPEGCOMPRESSION,
-                                      self.tr('Set the JPEG compression level'),
-                                      1, 100, 75))
-        params.append(ParameterNumber(self.ZLEVEL,
-                                      self.tr('Set the DEFLATE compression level'),
-                                      1, 9, 6))
-        params.append(ParameterNumber(self.PREDICTOR,
-                                      self.tr('Set the predictor for LZW or DEFLATE compression'),
-                                      1, 3, 1))
-        params.append(ParameterBoolean(self.TILED,
-                                       self.tr('Create tiled output (only used for the GTiff format)'), False))
-        params.append(ParameterSelection(self.BIGTIFF,
-                                         self.tr('Control whether the created file is a BigTIFF or a classic TIFF'), self.BIGTIFFTYPE, 0))
-        params.append(ParameterBoolean(self.TFW,
-                                       self.tr('Force the generation of an associated ESRI world file (.tfw))'), False))
-        params.append(ParameterString(self.EXTRA,
-                                      self.tr('Additional creation parameters'), '', optional=True))
-
-        for param in params:
-            param.isAdvanced = True
-            self.addParameter(param)
+                                           self.tr('Keep resolution of output raster'),
+                                           False))
+        self.addParameter(ParameterString(self.OPTIONS,
+                                          self.tr('Additional creation options'),
+                                          optional=True,
+                                          metadata={'widget_wrapper': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}))
+        self.addParameter(ParameterSelection(self.RTYPE,
+                                         self.tr('Output raster type'),
+                                         self.TYPE, 5))
 
         self.addOutput(OutputRaster(self.OUTPUT, self.tr('Clipped (mask)')))
 
@@ -127,21 +101,14 @@ class ClipByMask(GdalAlgorithm):
             self.getParameterValue(self.MASK))
         ogrMask = ogrConnectionString(mask)[1:-1]
         noData = self.getParameterValue(self.NO_DATA)
+        opts = self.getParameterValue(self.OPTIONS)
+
         if noData is not None:
             noData = str(noData)
+
         addAlphaBand = self.getParameterValue(self.ALPHA_BAND)
         cropToCutline = self.getParameterValue(self.CROP_TO_CUTLINE)
         keepResolution = self.getParameterValue(self.KEEP_RESOLUTION)
-        extra = self.getParameterValue(self.EXTRA)
-        if extra is not None:
-            extra = str(extra)
-        jpegcompression = str(self.getParameterValue(self.JPEGCOMPRESSION))
-        predictor = str(self.getParameterValue(self.PREDICTOR))
-        zlevel = str(self.getParameterValue(self.ZLEVEL))
-        tiled = str(self.getParameterValue(self.TILED))
-        compress = self.COMPRESSTYPE[self.getParameterValue(self.COMPRESS)]
-        bigtiff = self.BIGTIFFTYPE[self.getParameterValue(self.BIGTIFF)]
-        tfw = str(self.getParameterValue(self.TFW))
 
         arguments = []
         arguments.append('-ot')
@@ -174,24 +141,9 @@ class ClipByMask(GdalAlgorithm):
         if addAlphaBand:
             arguments.append('-dstalpha')
 
-        if extra and len(extra) > 0:
-            arguments.append(extra)
-        if GdalUtils.getFormatShortNameFromFilename(out) == "GTiff":
-            arguments.append("-co COMPRESS=" + compress)
-            if compress == 'JPEG':
-                arguments.append("-co JPEG_QUALITY=" + jpegcompression)
-            elif (compress == 'LZW') or (compress == 'DEFLATE'):
-                arguments.append("-co PREDICTOR=" + predictor)
-            if compress == 'DEFLATE':
-                arguments.append("-co ZLEVEL=" + zlevel)
-            if tiled == "True":
-                arguments.append("-co TILED=YES")
-            if tfw == "True":
-                arguments.append("-co TFW=YES")
-            if len(bigtiff) > 0:
-                arguments.append("-co BIGTIFF=" + bigtiff)
-
-            arguments.append("-wo OPTIMIZE_SIZE=TRUE")
+        if opts:
+            arguments.append('-co')
+            arguments.append(opts)
 
         if GdalUtils.version() in [2010000, 2010100]:
             arguments.append("--config GDALWARP_IGNORE_BAD_CUTLINE YES")

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -175,6 +175,7 @@ class GdalUtils(object):
     def escapeAndJoin(strList):
         joined = ''
         for s in strList:
+            print(s)
             if s[0] != '-' and ' ' in s:
                 escaped = '"' + s.replace('\\', '\\\\').replace('"', '\\"') \
                     + '"'

--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -30,12 +30,14 @@ import os
 from qgis.PyQt.QtGui import QIcon
 
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
+from processing.core.parameters import (ParameterBoolean,
+                                        ParameterString,
+                                        ParameterSelection,
+                                        ParameterMultipleInput)
 from processing.core.outputs import OutputRaster
-from processing.core.parameters import ParameterBoolean
-from processing.core.parameters import ParameterMultipleInput
-from processing.core.parameters import ParameterSelection
 from processing.tools.system import isWindows
 from processing.tools import dataobjects
+
 from processing.algs.gdal.GdalUtils import GdalUtils
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
@@ -44,10 +46,11 @@ pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 class merge(GdalAlgorithm):
 
     INPUT = 'INPUT'
-    OUTPUT = 'OUTPUT'
+    OPTIONS = 'OPTIONS'
     PCT = 'PCT'
     SEPARATE = 'SEPARATE'
     RTYPE = 'RTYPE'
+    OUTPUT = 'OUTPUT'
 
     TYPE = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64']
 
@@ -57,31 +60,44 @@ class merge(GdalAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Merge')
         self.group, self.i18n_group = self.trAlgorithm('[GDAL] Miscellaneous')
-        self.addParameter(ParameterMultipleInput(merge.INPUT,
-                                                 self.tr('Input layers'), dataobjects.TYPE_RASTER))
-        self.addParameter(ParameterBoolean(merge.PCT,
-                                           self.tr('Grab pseudocolor table from first layer'), False))
-        self.addParameter(ParameterBoolean(merge.SEPARATE,
-                                           self.tr('Place each input file into a separate band'), False))
+        self.addParameter(ParameterMultipleInput(self.INPUT,
+                                                 self.tr('Input layers'),
+                                                 dataobjects.TYPE_RASTER))
+        self.addParameter(ParameterString(self.OPTIONS,
+                                          self.tr('Additional creation options'),
+                                          optional=True,
+                                          metadata={'widget_wrapper': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}))
+        self.addParameter(ParameterBoolean(self.PCT,
+                                           self.tr('Grab pseudocolor table from first layer'),
+                                           False))
+        self.addParameter(ParameterBoolean(self.SEPARATE,
+                                           self.tr('Place each input file into a separate band'),
+                                           False))
         self.addParameter(ParameterSelection(self.RTYPE,
-                                             self.tr('Output raster type'), self.TYPE, 5))
+                                             self.tr('Output raster type'),
+                                             self.TYPE, 5))
 
-        self.addOutput(OutputRaster(merge.OUTPUT, self.tr('Merged')))
+        self.addOutput(OutputRaster(self.OUTPUT, self.tr('Merged')))
 
     def getConsoleCommands(self):
         arguments = []
         arguments.append('-ot')
         arguments.append(self.TYPE[self.getParameterValue(self.RTYPE)])
-        if self.getParameterValue(merge.SEPARATE):
+        if self.getParameterValue(self.SEPARATE):
             arguments.append('-separate')
-        if self.getParameterValue(merge.PCT):
+        if self.getParameterValue(self.PCT):
             arguments.append('-pct')
+        opts = self.getParameterValue(self.OPTIONS)
+        if opts:
+            arguments.append('-co')
+            arguments.append(opts)
+
         arguments.append('-o')
-        out = self.getOutputValue(merge.OUTPUT)
+        out = self.getOutputValue(self.OUTPUT)
         arguments.append(out)
         arguments.append('-of')
         arguments.append(GdalUtils.getFormatShortNameFromFilename(out))
-        arguments.extend(self.getParameterValue(merge.INPUT).split(';'))
+        arguments.extend(self.getParameterValue(self.INPUT).split(';'))
 
         commands = []
         if isWindows():

--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -64,9 +64,10 @@ class rasterize_over(GdalAlgorithm):
                                           self.tr('Existing raster layer'), False))
 
     def getConsoleCommands(self):
-        inLayer = self.getParameterValue(self.INPUT)
+        inLayer = dataobjects.getObjectFromUri(self.getParameterValue(self.INPUT))
+        inRasterLayer = dataobjects.getObjectFromUri(self.getParameterValue(self.INPUT_RASTER))
+
         ogrLayer = ogrConnectionString(inLayer)[1:-1]
-        inRasterLayer = self.getParameterValue(self.INPUT_RASTER)
         ogrRasterLayer = ogrConnectionString(inRasterLayer)[1:-1]
 
         arguments = []

--- a/python/plugins/processing/algs/gdal/translate.py
+++ b/python/plugins/processing/algs/gdal/translate.py
@@ -31,13 +31,13 @@ import os
 from qgis.PyQt.QtGui import QIcon
 
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
-from processing.core.parameters import ParameterString
-from processing.core.parameters import ParameterRaster
-from processing.core.parameters import ParameterNumber
-from processing.core.parameters import ParameterBoolean
-from processing.core.parameters import ParameterSelection
-from processing.core.parameters import ParameterExtent
-from processing.core.parameters import ParameterCrs
+from processing.core.parameters import (ParameterRaster,
+                                        ParameterString,
+                                        ParameterNumber,
+                                        ParameterBoolean,
+                                        ParameterSelection,
+                                        ParameterExtent,
+                                        ParameterCrs)
 from processing.core.outputs import OutputRaster
 
 from processing.algs.gdal.GdalUtils import GdalUtils
@@ -56,18 +56,9 @@ class translate(GdalAlgorithm):
     PROJWIN = 'PROJWIN'
     SRS = 'SRS'
     SDS = 'SDS'
-    EXTRA = 'EXTRA'
     RTYPE = 'RTYPE'
+    OPTIONS = 'OPTIONS'
     TYPE = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64']
-    TILED = 'TILED'
-    COMPRESS = 'COMPRESS'
-    JPEGCOMPRESSION = 'JPEGCOMPRESSION'
-    PREDICTOR = 'PREDICTOR'
-    ZLEVEL = 'ZLEVEL'
-    BIGTIFF = 'BIGTIFF'
-    BIGTIFFTYPE = ['', 'YES', 'NO', 'IF_NEEDED', 'IF_SAFER']
-    COMPRESSTYPE = ['NONE', 'JPEG', 'LZW', 'PACKBITS', 'DEFLATE']
-    TFW = 'TFW'
 
     def getIcon(self):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'translate.png'))
@@ -78,7 +69,8 @@ class translate(GdalAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Translate (convert format)')
         self.group, self.i18n_group = self.trAlgorithm('[GDAL] Conversion')
-        self.addParameter(ParameterRaster(self.INPUT, self.tr('Input layer'), False))
+
+        self.addParameter(ParameterRaster(self.INPUT, self.tr('Input layer')))
         self.addParameter(ParameterNumber(self.OUTSIZE,
                                           self.tr('Set the size of the output file (In pixels or %)'),
                                           1, None, 100))
@@ -97,32 +89,13 @@ class translate(GdalAlgorithm):
                                            self.tr('Copy all subdatasets of this file to individual output files'),
                                            False))
 
-        params = []
-        params.append(ParameterSelection(self.RTYPE,
-                                         self.tr('Output raster type'), self.TYPE, 5))
-        params.append(ParameterSelection(self.COMPRESS,
-                                         self.tr('GeoTIFF options. Compression type:'), self.COMPRESSTYPE, 4))
-        params.append(ParameterNumber(self.JPEGCOMPRESSION,
-                                      self.tr('Set the JPEG compression level'),
-                                      1, 100, 75))
-        params.append(ParameterNumber(self.ZLEVEL,
-                                      self.tr('Set the DEFLATE compression level'),
-                                      1, 9, 6))
-        params.append(ParameterNumber(self.PREDICTOR,
-                                      self.tr('Set the predictor for LZW or DEFLATE compression'),
-                                      1, 3, 1))
-        params.append(ParameterBoolean(self.TILED,
-                                       self.tr('Create tiled output (only used for the GTiff format)'), False))
-        params.append(ParameterSelection(self.BIGTIFF,
-                                         self.tr('Control whether the created file is a BigTIFF or a classic TIFF'), self.BIGTIFFTYPE, 0))
-        params.append(ParameterBoolean(self.TFW,
-                                       self.tr('Force the generation of an associated ESRI world file (.tfw))'), False))
-        params.append(ParameterString(self.EXTRA,
-                                      self.tr('Additional creation parameters'), '', optional=True))
-
-        for param in params:
-            param.isAdvanced = True
-            self.addParameter(param)
+        self.addParameter(ParameterString(self.OPTIONS,
+                                          self.tr('Additional creation options'),
+                                          optional=True,
+                                          metadata={'widget_wrapper': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}))
+        self.addParameter(ParameterSelection(self.RTYPE,
+                                             self.tr('Output raster type'),
+                                             self.TYPE, 5))
 
         self.addOutput(OutputRaster(self.OUTPUT, self.tr('Converted')))
 
@@ -131,23 +104,15 @@ class translate(GdalAlgorithm):
         outsize = str(self.getParameterValue(self.OUTSIZE))
         outsizePerc = str(self.getParameterValue(self.OUTSIZE_PERC))
         noData = self.getParameterValue(self.NO_DATA)
-        if noData is not None:
-            noData = str(noData)
         expand = str(self.getParameterFromName(
             self.EXPAND).options[self.getParameterValue(self.EXPAND)])
         projwin = str(self.getParameterValue(self.PROJWIN))
         crsId = self.getParameterValue(self.SRS)
         sds = self.getParameterValue(self.SDS)
-        extra = self.getParameterValue(self.EXTRA)
-        if extra is not None:
-            extra = str(extra)
-        jpegcompression = str(self.getParameterValue(self.JPEGCOMPRESSION))
-        predictor = str(self.getParameterValue(self.PREDICTOR))
-        zlevel = str(self.getParameterValue(self.ZLEVEL))
-        tiled = str(self.getParameterValue(self.TILED))
-        compress = self.COMPRESSTYPE[self.getParameterValue(self.COMPRESS)]
-        bigtiff = self.BIGTIFFTYPE[self.getParameterValue(self.BIGTIFF)]
-        tfw = str(self.getParameterValue(self.TFW))
+        opts = self.getParameterValue(self.OPTIONS)
+
+        if noData is not None:
+            noData = str(noData)
 
         arguments = []
         arguments.append('-of')
@@ -185,22 +150,10 @@ class translate(GdalAlgorithm):
             arguments.append(str(crsId))
         if sds:
             arguments.append('-sds')
-        if extra and len(extra) > 0:
-            arguments.append(extra)
-        if GdalUtils.getFormatShortNameFromFilename(out) == "GTiff":
-            arguments.append("-co COMPRESS=" + compress)
-            if compress == 'JPEG':
-                arguments.append("-co JPEG_QUALITY=" + jpegcompression)
-            elif (compress == 'LZW') or (compress == 'DEFLATE'):
-                arguments.append("-co PREDICTOR=" + predictor)
-            if compress == 'DEFLATE':
-                arguments.append("-co ZLEVEL=" + zlevel)
-            if tiled == "True":
-                arguments.append("-co TILED=YES")
-            if tfw == "True":
-                arguments.append("-co TFW=YES")
-            if len(bigtiff) > 0:
-                arguments.append("-co BIGTIFF=" + bigtiff)
+
+        if opts:
+            arguments.append('-co')
+            arguments.append(opts)
 
         arguments.append(self.getParameterValue(self.INPUT))
         arguments.append(out)

--- a/python/plugins/processing/algs/gdal/ui/CMakeLists.txt
+++ b/python/plugins/processing/algs/gdal/ui/CMakeLists.txt
@@ -1,0 +1,4 @@
+FILE(GLOB PY_FILES *.py)
+FILE(GLOB UI_FILES *.ui)
+
+PLUGIN_INSTALL(processing ./algs/gdal/ui ${PY_FILES} ${UI_FILES})

--- a/python/plugins/processing/algs/gdal/ui/RasterOptionsWidget.py
+++ b/python/plugins/processing/algs/gdal/ui/RasterOptionsWidget.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    RasterOptionsWidget.py
+    ---------------------
+    Date                 : December 2016
+    Copyright            : (C) 2016 by Alexander Bruy
+    Email                : alexander dot bruy at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Alexander Bruy'
+__date__ = 'December 2016'
+__copyright__ = '(C) 2016, Alexander Bruy'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+from qgis.gui import QgsRasterFormatSaveOptionsWidget
+
+from processing.gui.wrappers import WidgetWrapper
+
+
+class RasterOptionsWidgetWrapper(WidgetWrapper):
+
+    def createWidget(self):
+        return QgsRasterFormatSaveOptionsWidget()
+
+    def setValue(self, value):
+        if value is None:
+            value = ''
+        self.widget.setValue(value)
+
+    def value(self):
+        return ' '.join(self.widget.options())

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -31,13 +31,13 @@ import os
 from qgis.PyQt.QtGui import QIcon
 
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
-from processing.core.parameters import ParameterRaster
-from processing.core.parameters import ParameterExtent
-from processing.core.parameters import ParameterSelection
-from processing.core.parameters import ParameterCrs
-from processing.core.parameters import ParameterNumber
-from processing.core.parameters import ParameterString
-from processing.core.parameters import ParameterBoolean
+from processing.core.parameters import (ParameterRaster,
+                                        ParameterExtent,
+                                        ParameterSelection,
+                                        ParameterCrs,
+                                        ParameterNumber,
+                                        ParameterString,
+                                        ParameterBoolean)
 from processing.core.outputs import OutputRaster
 from processing.algs.gdal.GdalUtils import GdalUtils
 
@@ -51,23 +51,15 @@ class warp(GdalAlgorithm):
     SOURCE_SRS = 'SOURCE_SRS'
     DEST_SRS = 'DEST_SRS'
     METHOD = 'METHOD'
-    METHOD_OPTIONS = ['near', 'bilinear', 'cubic', 'cubicspline', 'lanczos']
     TR = 'TR'
     NO_DATA = 'NO_DATA'
-    EXTRA = 'EXTRA'
-    RTYPE = 'RTYPE'
-    TYPE = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64']
-    TILED = 'TILED'
-    COMPRESS = 'COMPRESS'
-    JPEGCOMPRESSION = 'JPEGCOMPRESSION'
-    PREDICTOR = 'PREDICTOR'
-    ZLEVEL = 'ZLEVEL'
-    BIGTIFF = 'BIGTIFF'
-    BIGTIFFTYPE = ['', 'YES', 'NO', 'IF_NEEDED', 'IF_SAFER']
-    COMPRESSTYPE = ['NONE', 'JPEG', 'LZW', 'PACKBITS', 'DEFLATE']
-    TFW = 'TFW'
     RAST_EXT = 'RAST_EXT'
     EXT_CRS = 'EXT_CRS'
+    RTYPE = 'RTYPE'
+    OPTIONS = 'OPTIONS'
+
+    METHOD_OPTIONS = ['near', 'bilinear', 'cubic', 'cubicspline', 'lanczos']
+    TYPE = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64']
 
     def getIcon(self):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'warp.png'))
@@ -75,12 +67,16 @@ class warp(GdalAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Warp (reproject)')
         self.group, self.i18n_group = self.trAlgorithm('[GDAL] Projections')
+
         self.tags = self.tr('transform,reproject,crs,srs')
         self.addParameter(ParameterRaster(self.INPUT, self.tr('Input layer'), False))
         self.addParameter(ParameterCrs(self.SOURCE_SRS,
-                                       self.tr('Source SRS'), '', optional=True))
+                                       self.tr('Source SRS'),
+                                       '',
+                                       optional=True))
         self.addParameter(ParameterCrs(self.DEST_SRS,
-                                       self.tr('Destination SRS'), 'EPSG:4326'))
+                                       self.tr('Destination SRS'),
+                                       'EPSG:4326'))
         self.addParameter(ParameterString(self.NO_DATA,
                                           self.tr("Nodata value, leave blank to take the nodata value from input"),
                                           '', optional=True))
@@ -88,58 +84,37 @@ class warp(GdalAlgorithm):
                                           self.tr('Output file resolution in target georeferenced units (leave 0 for no change)'),
                                           0.0, None, 0.0))
         self.addParameter(ParameterSelection(self.METHOD,
-                                             self.tr('Resampling method'), self.METHOD_OPTIONS))
-        self.addParameter(ParameterExtent(self.RAST_EXT, self.tr('Raster extent'), optional=True))
+                                             self.tr('Resampling method'),
+                                             self.METHOD_OPTIONS))
+        self.addParameter(ParameterExtent(self.RAST_EXT,
+                                          self.tr('Raster extent'),
+                                          optional=True))
 
         if GdalUtils.version() >= 2000000:
             self.addParameter(ParameterCrs(self.EXT_CRS,
                                            self.tr('CRS of the raster extent, leave blank for using Destination SRS'),
                                            optional=True))
 
-        params = []
-        params.append(ParameterSelection(self.RTYPE,
-                                         self.tr('Output raster type'), self.TYPE, 5))
-        params.append(ParameterSelection(self.COMPRESS,
-                                         self.tr('GeoTIFF options. Compression type:'), self.COMPRESSTYPE, 4))
-        params.append(ParameterNumber(self.JPEGCOMPRESSION,
-                                      self.tr('Set the JPEG compression level'),
-                                      1, 100, 75))
-        params.append(ParameterNumber(self.ZLEVEL,
-                                      self.tr('Set the DEFLATE compression level'),
-                                      1, 9, 6))
-        params.append(ParameterNumber(self.PREDICTOR,
-                                      self.tr('Set the predictor for LZW or DEFLATE compression'),
-                                      1, 3, 1))
-        params.append(ParameterBoolean(self.TILED,
-                                       self.tr('Create tiled output (only used for the GTiff format)'), False))
-        params.append(ParameterSelection(self.BIGTIFF,
-                                         self.tr('Control whether the created file is a BigTIFF or a classic TIFF'), self.BIGTIFFTYPE, 0))
-        params.append(ParameterBoolean(self.TFW,
-                                       self.tr('Force the generation of an associated ESRI world file (.tfw))'), False))
-        params.append(ParameterString(self.EXTRA,
-                                      self.tr('Additional creation parameters'), '', optional=True))
-
-        for param in params:
-            param.isAdvanced = True
-            self.addParameter(param)
+        self.addParameter(ParameterString(self.OPTIONS,
+                                          self.tr('Additional creation options'),
+                                          optional=True,
+                                          metadata={'widget_wrapper': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}))
+        self.addParameter(ParameterSelection(self.RTYPE,
+                                             self.tr('Output raster type'),
+                                             self.TYPE, 5))
 
         self.addOutput(OutputRaster(self.OUTPUT, self.tr('Reprojected')))
 
     def getConsoleCommands(self):
-        noData = self.getParameterValue(self.NO_DATA)
-        if noData is not None:
-            noData = str(noData)
         srccrs = self.getParameterValue(self.SOURCE_SRS)
         dstcrs = self.getParameterValue(self.DEST_SRS)
-        jpegcompression = str(self.getParameterValue(self.JPEGCOMPRESSION))
-        predictor = str(self.getParameterValue(self.PREDICTOR))
-        zlevel = str(self.getParameterValue(self.ZLEVEL))
-        tiled = str(self.getParameterValue(self.TILED))
-        compress = self.COMPRESSTYPE[self.getParameterValue(self.COMPRESS)]
-        bigtiff = self.BIGTIFFTYPE[self.getParameterValue(self.BIGTIFF)]
-        tfw = str(self.getParameterValue(self.TFW))
         rastext = self.getParameterValue(self.RAST_EXT)
         rastext_crs = self.getParameterValue(self.EXT_CRS)
+        opts = self.getParameterValue(self.OPTIONS)
+        noData = self.getParameterValue(self.NO_DATA)
+
+        if noData is not None:
+            noData = str(noData)
 
         arguments = []
         arguments.append('-ot')
@@ -153,19 +128,20 @@ class warp(GdalAlgorithm):
         if noData:
             arguments.append('-dstnodata')
             arguments.append(noData)
+
         arguments.append('-r')
         arguments.append(
             self.METHOD_OPTIONS[self.getParameterValue(self.METHOD)])
+
         arguments.append('-of')
         out = self.getOutputValue(self.OUTPUT)
         arguments.append(GdalUtils.getFormatShortNameFromFilename(out))
+
         if self.getParameterValue(self.TR) != 0:
             arguments.append('-tr')
             arguments.append(str(self.getParameterValue(self.TR)))
             arguments.append(str(self.getParameterValue(self.TR)))
-        extra = self.getParameterValue(self.EXTRA)
-        if extra is not None:
-            extra = str(extra)
+
         if rastext:
             regionCoords = rastext.split(',')
             if len(regionCoords) >= 4:
@@ -180,24 +156,9 @@ class warp(GdalAlgorithm):
                         arguments.append('-te_srs')
                         arguments.append(rastext_crs)
 
-        if extra and len(extra) > 0:
-            arguments.append(extra)
-        if GdalUtils.getFormatShortNameFromFilename(out) == "GTiff":
-            arguments.append("-co COMPRESS=" + compress)
-            if compress == 'JPEG':
-                arguments.append("-co JPEG_QUALITY=" + jpegcompression)
-            elif (compress == 'LZW') or (compress == 'DEFLATE'):
-                arguments.append("-co PREDICTOR=" + predictor)
-            if compress == 'DEFLATE':
-                arguments.append("-co ZLEVEL=" + zlevel)
-            if tiled == "True":
-                arguments.append("-co TILED=YES")
-            if tfw == "True":
-                arguments.append("-co TFW=YES")
-            if len(bigtiff) > 0:
-                arguments.append("-co BIGTIFF=" + bigtiff)
-
-            arguments.append("-wo OPTIMIZE_SIZE=TRUE")
+        if opts:
+            arguments.append('-co')
+            arguments.append(opts)
 
         if GdalUtils.version() in [2010000, 2010100]:
             arguments.append("--config GDALWARP_IGNORE_BAD_CUTLINE YES")

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -1,31 +1,6 @@
 # See ../README.md for a description of the file format
 
 tests:
-# MK: 23.2.2016 / Fails on travis:OSX
-#  - algorithm: gdal:rasterize
-#    name: Test (gdal:rasterize)
-#    params:
-#      BIGTIFF: 0
-#      COMPRESS: 4
-#      DIMENSIONS: 0
-#      EXTRA: ""
-#      FIELD: "Bfloatval"
-#      HEIGHT: 100
-#      INPUT:
-#        name: multipolys.gml
-#        type: vector
-#      JPEGCOMPRESSION: 75
-#      NO_DATA: -9999
-#      PREDICTOR: 1
-#      RTYPE: 5
-#      TFW: False
-#      TILED: False
-#      WIDTH: 100
-#      ZLEVEL: 6
-#    results:
-#      OUTPUT:
-#        hash: f1fedeb6782f9389cf43590d4c85ada9155ab61fef6dc285aaeb54d6
-#        type: rasterhash
 
   - algorithm: gdal:gdalinfo
     name: gdalinfo
@@ -43,18 +18,6 @@ tests:
           - 'Origin = \(270736.067325068172067,4459029.574521748349071\)'
           - 'Band 1 Block=16x14 Type=Float32, ColorInterp=Gray'
           - '  NoData Value=-32768'
-
-#  - algorithm: gdal:polygonize
-#    name: GDAL polygonize
-#    params:
-#      FIELD: DN
-#      INPUT:
-#        name: raster.tif
-#        type: raster
-#    results:
-#      OUTPUT:
-#        name: expected/gdal/polygonize.gml
-#        type: vector
 
   - algorithm: gdal:ogrinfo
     name: ogrinfo

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -1,7 +1,6 @@
 # See ../README.md for a description of the file format
 
 tests:
-
   - algorithm: gdal:gdalinfo
     name: gdalinfo
     params:

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -644,10 +644,13 @@ void QgsRasterFormatSaveOptionsWidget::setOptions( const QString& options )
     mOptionsTable->insertRow( rowCount );
 
     values = opt.split( '=' );
-    QTableWidgetItem* nameItem = new QTableWidgetItem( values.at( 0 ) );
-    mOptionsTable->setItem( rowCount, 0, nameItem );
-    QTableWidgetItem* valueItem = new QTableWidgetItem( values.at( 1 ) );
-    mOptionsTable->setItem( rowCount, 0, valueItem );
+    if ( values.count() == 2 )
+    {
+      QTableWidgetItem* nameItem = new QTableWidgetItem( values.at( 0 ) );
+      mOptionsTable->setItem( rowCount, 0, nameItem );
+      QTableWidgetItem* valueItem = new QTableWidgetItem( values.at( 1 ) );
+      mOptionsTable->setItem( rowCount, 0, valueItem );
+    }
   }
 
   mOptionsMap[ currentProfileKey()] = options.trimmed();

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -631,3 +631,28 @@ void QgsRasterFormatSaveOptionsWidget::showEvent( QShowEvent * event )
   QgsDebugMsg( "done" );
 }
 
+void QgsRasterFormatSaveOptionsWidget::setOptions( const QString& options)
+{
+  mOptionsTable->blockSignals( true );
+  mOptionsTable->clearContents();
+
+  QStringList values;
+  QStringList optionsList = options.trimmed().split( ' ', QString::SkipEmptyParts );
+  Q_FOREACH ( const QString &opt, optionsList )
+  {
+    int rowCount = mOptionsTable->rowCount();
+    mOptionsTable->insertRow( rowCount );
+
+    values = opt.split( '=' );
+    QTableWidgetItem* nameItem = new QTableWidgetItem( values.at( 0 ) );
+    mOptionsTable->setItem( rowCount, 0, nameItem );
+    QTableWidgetItem* valueItem = new QTableWidgetItem( values.at( 1 ) );
+    mOptionsTable->setItem( rowCount, 0, valueItem );
+  }
+
+  mOptionsMap[ currentProfileKey()] = options.trimmed();
+  mOptionsLineEdit->setText( options.trimmed() );
+  mOptionsLineEdit->setCursorPosition( 0 );
+
+  mOptionsTable->blockSignals( false );
+}

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -631,7 +631,7 @@ void QgsRasterFormatSaveOptionsWidget::showEvent( QShowEvent * event )
   QgsDebugMsg( "done" );
 }
 
-void QgsRasterFormatSaveOptionsWidget::setOptions( const QString& options)
+void QgsRasterFormatSaveOptionsWidget::setOptions( const QString& options )
 {
   mOptionsTable->blockSignals( true );
   mOptionsTable->clearContents();

--- a/src/gui/qgsrasterformatsaveoptionswidget.h
+++ b/src/gui/qgsrasterformatsaveoptionswidget.h
@@ -76,7 +76,8 @@ class GUI_EXPORT QgsRasterFormatSaveOptionsWidget: public QWidget,
     QStringList options() const;
 
     /**
-     * Populate widget with user-defined options
+     * Populate widget with user-defined options. String should contain
+     * key=value pairs separated by spaces, e.g. "TILED=YES TFW=YES"
      * @see options()
      * @note added in QGIS 3.0
      */

--- a/src/gui/qgsrasterformatsaveoptionswidget.h
+++ b/src/gui/qgsrasterformatsaveoptionswidget.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsRasterFormatSaveOptionsWidget: public QWidget,
      * @see options()
      * @note added in QGIS 3.0
      */
-    void setOptions( const QString& options);
+    void setOptions( const QString& options );
 
     /**
      * Set widget look and feel

--- a/src/gui/qgsrasterformatsaveoptionswidget.h
+++ b/src/gui/qgsrasterformatsaveoptionswidget.h
@@ -47,20 +47,70 @@ class GUI_EXPORT QgsRasterFormatSaveOptionsWidget: public QWidget,
                                       QgsRasterFormatSaveOptionsWidget::Type type = Default,
                                       const QString& provider = "gdal" );
 
+    /**
+     * Set output raster format, it is used to determine list
+     * of available options
+     */
     void setFormat( const QString& format );
+
+    /**
+     * Set provider key, , it is used to determine list
+     * of available options
+     */
     void setProvider( const QString& provider );
+
+    /**
+     * Set output raster layer
+     */
     void setRasterLayer( QgsRasterLayer* rasterLayer ) { mRasterLayer = rasterLayer; mRasterFileName = QString(); }
+
+    /**
+     * Set output raster file name
+     */
     void setRasterFileName( const QString& file ) { mRasterLayer = nullptr; mRasterFileName = file; }
+
+    /**
+     * Returns list of selected options
+     * @see setOptions()
+     */
     QStringList options() const;
+
+    /**
+     * Populate widget with user-defined options
+     * @see options()
+     * @note added in QGIS 3.0
+     */
+    void setOptions( const QString& options);
+
+    /**
+     * Set widget look and feel
+     */
     void setType( QgsRasterFormatSaveOptionsWidget::Type type = Default );
+
+    /**
+     * Set pyramids format to use
+     */
     void setPyramidsFormat( QgsRaster::RasterPyramidsFormat format )
     { mPyramids = true; mPyramidsFormat = format; }
 
   public slots:
 
     void apply();
+
+    /**
+     * Opens window with options desctiption for given provider
+     * and output format
+     */
     void helpOptions();
+
+    /**
+     * Validates options correctness
+     */
     QString validateOptions( bool gui = true, bool reportOk = true );
+
+    /**
+     * Reloads profiles list from QGIS settings
+     */
     void updateProfiles();
 
   private slots:


### PR DESCRIPTION
Add new method to `QgsRasterFormatSaveOptionsWidget` for setting options from string, so user can populate widget with desired options. Update GDAL algorithms to use this widget for additional creation options.

Before — each option requires separate algorithm parameter, making dialog too cluttered and code too complex
![before](https://cloud.githubusercontent.com/assets/776954/21565785/b1a7334a-cea4-11e6-8dad-b495c01209e3.png)

After — custom widget used, single parameter for handling all options. Also adds profiles support and make UI uniform with other QGIS parts, like raster "Save as" dialog
![after](https://cloud.githubusercontent.com/assets/776954/21565809/d9140c0a-cea4-11e6-89ae-e197c288668c.png)