### PR TITLE
Rename QgsProperty to QgsProjectProperty

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -115,6 +115,9 @@ Renamed Classes        {#qgis_api_break_3_0_renamed_classes}
 <tr><td>QgsMultiLineStringV2<td>QgsMultiLineString
 <tr><td>QgsMultiSurfaceV2<td>QgsMultiSurface
 <tr><td>QgsPointSequenceV2<td>QgsPointSequence
+<tr><td>QgsProperty<td>QgsProjectProperty
+<tr><td>QgsPropertyKey<td>QgsProjectPropertyKey
+<tr><td>QgsPropertyValue<td>QgsProjectPropertyValue
 <tr><td>QgsRandomColorsV2<td>QgsRandomColorRamp
 <tr><td>QgsRendererCategoryV2<td>QgsRendererCategory
 <tr><td>QgsRendererRangeV2<td>QgsRendererRange

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1363,6 +1363,10 @@ QgsProject        {#qgis_api_break_3_0_QgsProject}
 - dirty( bool b ) was removed. Use setDirty() instead.
 - clearProperties() was removed. Use clear() instead.
 
+QgsProjectPropertyValue        {#qgis_api_break_3_0_QgsProjectPropertyValue}
+-----------------------
+
+- The unused count() and entryList() methods were removed.
 
 QgsRaster        {#qgis_api_break_3_0_QgsRaster}
 ---------

--- a/python/core/qgsprojectproperty.sip
+++ b/python/core/qgsprojectproperty.sip
@@ -34,7 +34,7 @@ class QgsProjectProperty
      *
      *  Used for restoring properties from project file
      */
-    virtual bool readXml( QDomNode & keyNode ) = 0;
+    virtual bool readXml( const QDomNode& keyNode ) = 0;
 
     /**
      * adds property hierarchy to given Dom element
@@ -91,18 +91,11 @@ class QgsProjectPropertyValue : QgsProjectProperty
 
     void dump( int tabs = 0 ) const;
 
-    bool readXml( QDomNode & keyNode );
+    bool readXml( const QDomNode& keyNode );
 
     bool writeXml( const QString & nodeName,
                    QDomElement   & element,
                    QDomDocument  & document );
-
-    int count() const;
-
-    /** Return keys that do not contain other keys
-     * Since QgsPropertyValue isn't a key, don't do anything.
-     */
-    void entryList( QStringList & keyName, QStringList & entries ) const;
 
 };
 
@@ -155,7 +148,7 @@ class QgsProjectPropertyKey : QgsProjectProperty
 
     void dump( int tabs = 0 ) const;
 
-    bool readXml( QDomNode & keyNode );
+    bool readXml( const QDomNode& keyNode );
 
     bool writeXml( const QString &nodeName, QDomElement & element, QDomDocument & document );
 

--- a/python/core/qgsprojectproperty.sip
+++ b/python/core/qgsprojectproperty.sip
@@ -1,12 +1,12 @@
-class QgsProperty
+class QgsProjectProperty
 {
 %TypeHeaderCode
 #include <qgsprojectproperty.h>
 %End
 
   public:
-    QgsProperty();
-    virtual ~QgsProperty();
+    QgsProjectProperty();
+    virtual ~QgsProjectProperty();
 
     /** Dumps out the keys and values
      *
@@ -63,16 +63,16 @@ class QgsProperty
 }; // class QgsProperty
 
 
-class QgsPropertyValue : QgsProperty
+class QgsProjectPropertyValue : QgsProjectProperty
 {
 %TypeHeaderCode
 #include <qgsprojectproperty.h>
 %End
 
   public:
-    QgsPropertyValue();
-    QgsPropertyValue( const QVariant &value );
-    virtual ~QgsPropertyValue();
+    QgsProjectPropertyValue();
+    QgsProjectPropertyValue( const QVariant &value );
+    virtual ~QgsProjectPropertyValue();
 
     /** Returns true if is a QgsPropertyKey */
     virtual bool isKey() const;
@@ -106,15 +106,15 @@ class QgsPropertyValue : QgsProperty
 
 };
 
-class QgsPropertyKey : QgsProperty
+class QgsProjectPropertyKey : QgsProjectProperty
 {
 %TypeHeaderCode
 #include <qgsprojectproperty.h>
 %End
 
   public:
-    QgsPropertyKey( const QString& name = QString() );
-    virtual ~QgsPropertyKey();
+    QgsProjectPropertyKey( const QString& name = QString() );
+    virtual ~QgsProjectPropertyKey();
 
     /**
      * The name of the property is used as identifier.
@@ -133,7 +133,7 @@ class QgsPropertyKey : QgsProperty
 
 
     /// add the given property key
-    QgsPropertyKey * addKey( const QString & keyName );
+    QgsProjectPropertyKey * addKey( const QString & keyName );
 
     /// remove the given key
     void removeKey( const QString & keyName );
@@ -143,14 +143,14 @@ class QgsPropertyKey : QgsProperty
      * @param value is the value to set
      * @return pointer to property value
      */
-    QgsPropertyValue * setValue( const QString & name, const QVariant & value );
+    QgsProjectPropertyValue * setValue( const QString & name, const QVariant & value );
 
     /** Set the value associated with this key
      *
      * @note that the single value node associated with each key is always
      * stored keyed by the current key name
      */
-    QgsPropertyValue * setValue( const QVariant & value );
+    QgsProjectPropertyValue * setValue( const QVariant & value );
 
 
     void dump( int tabs = 0 ) const;
@@ -189,5 +189,5 @@ class QgsPropertyKey : QgsProperty
     /// delete any sub-nodes
     virtual void clearKeys();
 
-    QgsProperty * find( QString & propertyName );
+    QgsProjectProperty * find( QString & propertyName );
 }; // class QgsPropertyKey

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -106,16 +106,16 @@ QStringList makeKeyTokens_( const QString& scope, const QString& key )
 
    @param scope scope of key
    @param key keyname
-   @param rootProperty is likely to be the top level QgsPropertyKey in QgsProject:e:Imp.
+   @param rootProperty is likely to be the top level QgsProjectPropertyKey in QgsProject:e:Imp.
 
    @return null if not found, otherwise located Property
 */
-QgsProperty* findKey_( const QString& scope,
-                       const QString& key,
-                       QgsPropertyKey& rootProperty )
+QgsProjectProperty* findKey_( const QString& scope,
+                              const QString& key,
+                              QgsProjectPropertyKey& rootProperty )
 {
-  QgsPropertyKey* currentProperty = &rootProperty;
-  QgsProperty* nextProperty;           // link to next property down hiearchy
+  QgsProjectPropertyKey* currentProperty = &rootProperty;
+  QgsProjectProperty* nextProperty;           // link to next property down hiearchy
 
   QStringList keySequence = makeKeyTokens_( scope, key );
 
@@ -144,7 +144,7 @@ QgsProperty* findKey_( const QString& scope,
       {
         if ( nextProperty->isKey() )
         {
-          currentProperty = static_cast<QgsPropertyKey*>( nextProperty );
+          currentProperty = static_cast<QgsProjectPropertyKey*>( nextProperty );
         }
         else if ( nextProperty->isValue() && 1 == keySequence.count() )
         {
@@ -156,7 +156,7 @@ QgsProperty* findKey_( const QString& scope,
         }
         else
         {
-          // QgsPropertyValue not Key, so return null
+          // QgsProjectPropertyValue not Key, so return null
           return nullptr;
         }
       }
@@ -185,17 +185,17 @@ QgsProperty* findKey_( const QString& scope,
 @param rootProperty is the property from which to start adding
 @param value the value associated with the key
 */
-QgsProperty *addKey_( const QString& scope,
-                      const QString& key,
-                      QgsPropertyKey* rootProperty,
-                      const QVariant& value )
+QgsProjectProperty *addKey_( const QString& scope,
+                             const QString& key,
+                             QgsProjectPropertyKey* rootProperty,
+                             const QVariant& value )
 {
   QStringList keySequence = makeKeyTokens_( scope, key );
 
   // cursor through property key/value hierarchy
-  QgsPropertyKey *currentProperty = rootProperty;
-  QgsProperty *nextProperty; // link to next property down hiearchy
-  QgsPropertyKey* newPropertyKey;
+  QgsProjectPropertyKey *currentProperty = rootProperty;
+  QgsProjectProperty *nextProperty; // link to next property down hiearchy
+  QgsProjectPropertyKey* newPropertyKey;
 
   while ( ! keySequence.isEmpty() )
   {
@@ -223,13 +223,13 @@ QgsProperty *addKey_( const QString& scope,
       }
       else if (( nextProperty = currentProperty->find( keySequence.first() ) ) )
       {
-        currentProperty = dynamic_cast<QgsPropertyKey*>( nextProperty );
+        currentProperty = dynamic_cast<QgsProjectPropertyKey*>( nextProperty );
 
         if ( currentProperty )
         {
           continue;
         }
-        else            // QgsPropertyValue not Key, so return null
+        else            // QgsProjectPropertyValue not Key, so return null
         {
           return nullptr;
         }
@@ -256,12 +256,12 @@ QgsProperty *addKey_( const QString& scope,
 
 void removeKey_( const QString& scope,
                  const QString& key,
-                 QgsPropertyKey &rootProperty )
+                 QgsProjectPropertyKey &rootProperty )
 {
-  QgsPropertyKey *currentProperty = &rootProperty;
+  QgsProjectPropertyKey *currentProperty = &rootProperty;
 
-  QgsProperty *nextProperty = nullptr;   // link to next property down hiearchy
-  QgsPropertyKey *previousQgsPropertyKey = nullptr; // link to previous property up hiearchy
+  QgsProjectProperty *nextProperty = nullptr;   // link to next property down hiearchy
+  QgsProjectPropertyKey *previousQgsPropertyKey = nullptr; // link to previous property up hiearchy
 
   QStringList keySequence = makeKeyTokens_( scope, key );
 
@@ -290,13 +290,13 @@ void removeKey_( const QString& scope,
       else if (( nextProperty = currentProperty->find( keySequence.first() ) ) )
       {
         previousQgsPropertyKey = currentProperty;
-        currentProperty = dynamic_cast<QgsPropertyKey*>( nextProperty );
+        currentProperty = dynamic_cast<QgsProjectPropertyKey*>( nextProperty );
 
         if ( currentProperty )
         {
           continue;
         }
-        else            // QgsPropertyValue not Key, so return null
+        else            // QgsProjectPropertyValue not Key, so return null
         {
           return;
         }
@@ -475,7 +475,7 @@ void QgsProject::clear()
 }
 
 // basically a debugging tool to dump property list values
-void dump_( const QgsPropertyKey& topQgsPropertyKey )
+void dump_( const QgsProjectPropertyKey& topQgsPropertyKey )
 {
   QgsDebugMsg( "current properties:" );
   topQgsPropertyKey.dump();
@@ -509,10 +509,10 @@ scope.  "layers" is a list containing three string values.
 \endcode
 
 @param doc xml document
-@param project_properties should be the top QgsPropertyKey node.
+@param project_properties should be the top QgsProjectPropertyKey node.
 
 */
-void _getProperties( const QDomDocument& doc, QgsPropertyKey& project_properties )
+void _getProperties( const QDomDocument& doc, QgsProjectPropertyKey& project_properties )
 {
   QDomNodeList properties = doc.elementsByTagName( QStringLiteral( "properties" ) );
 
@@ -1397,7 +1397,7 @@ QStringList QgsProject::readListEntry( const QString& scope,
                                        const QStringList& def,
                                        bool* ok ) const
 {
-  QgsProperty* property = findKey_( scope, key, mProperties );
+  QgsProjectProperty* property = findKey_( scope, key, mProperties );
 
   QVariant value;
 
@@ -1424,7 +1424,7 @@ QString QgsProject::readEntry( const QString& scope,
                                const QString& def,
                                bool* ok ) const
 {
-  QgsProperty *property = findKey_( scope, key, mProperties );
+  QgsProjectProperty *property = findKey_( scope, key, mProperties );
 
   QVariant value;
 
@@ -1446,7 +1446,7 @@ QString QgsProject::readEntry( const QString& scope,
 int QgsProject::readNumEntry( const QString& scope, const QString &key, int def,
                               bool* ok ) const
 {
-  QgsProperty *property = findKey_( scope, key, mProperties );
+  QgsProjectProperty *property = findKey_( scope, key, mProperties );
 
   QVariant value;
 
@@ -1474,7 +1474,7 @@ double QgsProject::readDoubleEntry( const QString& scope, const QString& key,
                                     double def,
                                     bool* ok ) const
 {
-  QgsProperty *property = findKey_( scope, key, mProperties );
+  QgsProjectProperty *property = findKey_( scope, key, mProperties );
   if ( property )
   {
     QVariant value = property->value();
@@ -1493,7 +1493,7 @@ double QgsProject::readDoubleEntry( const QString& scope, const QString& key,
 bool QgsProject::readBoolEntry( const QString& scope, const QString &key, bool def,
                                 bool* ok ) const
 {
-  QgsProperty *property = findKey_( scope, key, mProperties );
+  QgsProjectProperty *property = findKey_( scope, key, mProperties );
 
   if ( property )
   {
@@ -1523,13 +1523,13 @@ bool QgsProject::removeEntry( const QString& scope, const QString& key )
 
 QStringList QgsProject::entryList( const QString& scope, const QString& key ) const
 {
-  QgsProperty *foundProperty = findKey_( scope, key, mProperties );
+  QgsProjectProperty *foundProperty = findKey_( scope, key, mProperties );
 
   QStringList entries;
 
   if ( foundProperty )
   {
-    QgsPropertyKey *propertyKey = dynamic_cast<QgsPropertyKey*>( foundProperty );
+    QgsProjectPropertyKey *propertyKey = dynamic_cast<QgsProjectPropertyKey*>( foundProperty );
 
     if ( propertyKey )
       { propertyKey->entryList( entries ); }
@@ -1540,13 +1540,13 @@ QStringList QgsProject::entryList( const QString& scope, const QString& key ) co
 
 QStringList QgsProject::subkeyList( const QString& scope, const QString& key ) const
 {
-  QgsProperty *foundProperty = findKey_( scope, key, mProperties );
+  QgsProjectProperty *foundProperty = findKey_( scope, key, mProperties );
 
   QStringList entries;
 
   if ( foundProperty )
   {
-    QgsPropertyKey *propertyKey = dynamic_cast<QgsPropertyKey*>( foundProperty );
+    QgsProjectPropertyKey *propertyKey = dynamic_cast<QgsProjectPropertyKey*>( foundProperty );
 
     if ( propertyKey )
       { propertyKey->subkeyList( entries ); }

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -997,7 +997,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QVariantMap mCustomVariables;
 
     QFile mFile;                 // current physical project file
-    mutable QgsPropertyKey mProperties;  // property hierarchy, TODO: this shouldn't be mutable
+    mutable QgsProjectPropertyKey mProperties;  // property hierarchy, TODO: this shouldn't be mutable
     QString mTitle;              // project title
     bool mAutoTransaction;       // transaction grouped editing
     bool mEvaluateDefaultValues; // evaluate default values immediately

--- a/src/core/qgsprojectfiletransform.cpp
+++ b/src/core/qgsprojectfiletransform.cpp
@@ -404,7 +404,7 @@ void QgsProjectFileTransform::transform1100to1200()
   for ( int i = 0; i < tolList.childNodes().count(); i++ )
     units << QStringLiteral( "0" );
 
-  QgsPropertyValue value( units );
+  QgsProjectPropertyValue value( units );
   value.writeXml( QStringLiteral( "LayerSnappingToleranceUnitList" ), digitizing, mDom );
 }
 

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -21,18 +21,18 @@
 #include <QDomDocument>
 #include <QStringList>
 
-QgsProperty::QgsProperty()
+QgsProjectProperty::QgsProjectProperty()
 {
 }
 
-void QgsPropertyValue::dump( int tabs ) const
+void QgsProjectPropertyValue::dump( int tabs ) const
 {
   QString tabString;
   tabString.fill( '\t', tabs );
 
-  if ( QVariant::StringList == value_.type() )
+  if ( QVariant::StringList == mValue.type() )
   {
-    QStringList sl = value_.toStringList();
+    QStringList sl = mValue.toStringList();
 
     for ( QStringList::const_iterator i = sl.begin(); i != sl.end(); ++i )
     {
@@ -41,12 +41,12 @@ void QgsPropertyValue::dump( int tabs ) const
   }
   else
   {
-    QgsDebugMsg( QString( "%1%2" ).arg( tabString, value_.toString() ) );
+    QgsDebugMsg( QString( "%1%2" ).arg( tabString, mValue.toString() ) );
   }
 } // QgsPropertyValue::dump()
 
 
-bool QgsPropertyValue::readXml( QDomNode & keyNode )
+bool QgsProjectPropertyValue::readXml( QDomNode & keyNode )
 {
   // this *should* be a Dom element node
   QDomElement subkeyElement = keyNode.toElement();
@@ -63,7 +63,7 @@ bool QgsPropertyValue::readXml( QDomNode & keyNode )
 
   // the values come in as strings; we need to restore them to their
   // original values *and* types
-  value_.clear();
+  mValue.clear();
 
   // get the type associated with the value first
   QVariant::Type type = QVariant::nameToType( typeString.toLocal8Bit().constData() );
@@ -90,7 +90,7 @@ bool QgsPropertyValue::readXml( QDomNode & keyNode )
       return false;
 
     case QVariant::String:
-      value_ = subkeyElement.text();  // no translating necessary
+      mValue = subkeyElement.text();  // no translating necessary
       break;
 
     case QVariant::StringList:
@@ -115,7 +115,7 @@ bool QgsPropertyValue::readXml( QDomNode & keyNode )
         ++i;
       }
 
-      value_ = valueStringList;
+      mValue = valueStringList;
       break;
     }
 
@@ -156,23 +156,23 @@ bool QgsPropertyValue::readXml( QDomNode & keyNode )
       return false;
 
     case QVariant::Int:
-      value_ = QVariant( subkeyElement.text() ).toInt();
+      mValue = QVariant( subkeyElement.text() ).toInt();
       break;
 
     case QVariant::UInt:
-      value_ = QVariant( subkeyElement.text() ).toUInt();
+      mValue = QVariant( subkeyElement.text() ).toUInt();
       break;
 
     case QVariant::Bool:
-      value_ = QVariant( subkeyElement.text() ).toBool();
+      mValue = QVariant( subkeyElement.text() ).toBool();
       break;
 
     case QVariant::Double:
-      value_ = QVariant( subkeyElement.text() ).toDouble();
+      mValue = QVariant( subkeyElement.text() ).toDouble();
       break;
 
     case QVariant::ByteArray:
-      value_ = QVariant( subkeyElement.text() ).toByteArray();
+      mValue = QVariant( subkeyElement.text() ).toByteArray();
       break;
 
     case QVariant::Polygon:
@@ -225,25 +225,25 @@ bool QgsPropertyValue::readXml( QDomNode & keyNode )
 
 
 /**
-   keyElement created by parent QgsPropertyKey
+   keyElement created by parent QgsProjectPropertyKey
 */
-bool QgsPropertyValue::writeXml( QString const & nodeName,
-                                 QDomElement   & keyElement,
-                                 QDomDocument  & document )
+bool QgsProjectPropertyValue::writeXml( QString const & nodeName,
+                                        QDomElement   & keyElement,
+                                        QDomDocument  & document )
 {
   QDomElement valueElement = document.createElement( nodeName );
 
   // remember the type so that we can rebuild it when the project is read in
-  valueElement.setAttribute( QStringLiteral( "type" ), value_.typeName() );
+  valueElement.setAttribute( QStringLiteral( "type" ), mValue.typeName() );
 
 
   // we handle string lists differently from other types in that we
   // create a sequence of repeated elements to cover all the string list
   // members; each value will be in a <value></value> tag.
   // XXX Not the most elegant way to handle string lists?
-  if ( QVariant::StringList == value_.type() )
+  if ( QVariant::StringList == mValue.type() )
   {
-    QStringList sl = value_.toStringList();
+    QStringList sl = mValue.toStringList();
 
     for ( QStringList::iterator i = sl.begin();
           i != sl.end();
@@ -258,7 +258,7 @@ bool QgsPropertyValue::writeXml( QString const & nodeName,
   }
   else                    // we just plop the value in as plain ole text
   {
-    QDomText valueText = document.createTextNode( value_.toString() );
+    QDomText valueText = document.createTextNode( mValue.toString() );
     valueElement.appendChild( valueText );
   }
 
@@ -268,18 +268,18 @@ bool QgsPropertyValue::writeXml( QString const & nodeName,
 } // QgsPropertyValue::writeXml
 
 
-QgsPropertyKey::QgsPropertyKey( const QString &name )
+QgsProjectPropertyKey::QgsProjectPropertyKey( const QString &name )
     : mName( name )
 {}
 
-QgsPropertyKey::~QgsPropertyKey()
+QgsProjectPropertyKey::~QgsProjectPropertyKey()
 {
   clearKeys();
 }
 
-QVariant QgsPropertyKey::value() const
+QVariant QgsProjectPropertyKey::value() const
 {
-  QgsProperty *foundQgsProperty = mProperties.value( name() );
+  QgsProjectProperty *foundQgsProperty = mProperties.value( name() );
 
   if ( !foundQgsProperty )
   {
@@ -291,7 +291,7 @@ QVariant QgsPropertyKey::value() const
 } // QVariant QgsPropertyKey::value()
 
 
-void QgsPropertyKey::dump( int tabs ) const
+void QgsProjectPropertyKey::dump( int tabs ) const
 {
   QString tabString;
 
@@ -304,12 +304,12 @@ void QgsPropertyKey::dump( int tabs ) const
 
   if ( ! mProperties.isEmpty() )
   {
-    QHashIterator < QString, QgsProperty* > i( mProperties );
+    QHashIterator < QString, QgsProjectProperty* > i( mProperties );
     while ( i.hasNext() )
     {
       if ( i.next().value()->isValue() )
       {
-        QgsPropertyValue * propertyValue = static_cast<QgsPropertyValue*>( i.value() );
+        QgsProjectPropertyValue * propertyValue = static_cast<QgsProjectPropertyValue*>( i.value() );
 
         if ( QVariant::StringList == propertyValue->value().type() )
         {
@@ -326,7 +326,7 @@ void QgsPropertyKey::dump( int tabs ) const
         QgsDebugMsg( QString( "%1key: <%2>  subkey: <%3>" )
                      .arg( tabString,
                            i.key(),
-                           dynamic_cast<QgsPropertyKey*>( i.value() )->name() ) );
+                           dynamic_cast<QgsProjectPropertyKey*>( i.value() )->name() ) );
         i.value()->dump( tabs + 1 );
       }
 
@@ -350,7 +350,7 @@ void QgsPropertyKey::dump( int tabs ) const
 
 
 
-bool QgsPropertyKey::readXml( QDomNode & keyNode )
+bool QgsProjectPropertyKey::readXml( QDomNode & keyNode )
 {
   int i = 0;
   QDomNodeList subkeys = keyNode.childNodes();
@@ -365,7 +365,7 @@ bool QgsPropertyKey::readXml( QDomNode & keyNode )
          subkeys.item( i ).toElement().hasAttribute( QStringLiteral( "type" ) ) ) // and we have a "type" attribute
     {                   // then we're a key value
       delete mProperties.take( subkeys.item( i ).nodeName() );
-      mProperties.insert( subkeys.item( i ).nodeName(), new QgsPropertyValue );
+      mProperties.insert( subkeys.item( i ).nodeName(), new QgsProjectPropertyValue );
 
       QDomNode subkey = subkeys.item( i );
 
@@ -397,7 +397,7 @@ bool QgsPropertyKey::readXml( QDomNode & keyNode )
   Property keys will always create a Dom element for itself and then
   recursively call writeXml for any constituent properties.
 */
-bool QgsPropertyKey::writeXml( QString const &nodeName, QDomElement & element, QDomDocument & document )
+bool QgsProjectPropertyKey::writeXml( QString const &nodeName, QDomElement & element, QDomDocument & document )
 {
   // If it's an _empty_ node (i.e., one with no properties) we need to emit
   // an empty place holder; else create new Dom elements as necessary.
@@ -406,7 +406,7 @@ bool QgsPropertyKey::writeXml( QString const &nodeName, QDomElement & element, Q
 
   if ( ! mProperties.isEmpty() )
   {
-    QHashIterator < QString, QgsProperty* > i( mProperties );
+    QHashIterator < QString, QgsProjectProperty* > i( mProperties );
     while ( i.hasNext() )
     {
       i.next();
@@ -426,10 +426,10 @@ bool QgsPropertyKey::writeXml( QString const &nodeName, QDomElement & element, Q
 
 /** Return keys that do not contain other keys
  */
-void QgsPropertyKey::entryList( QStringList & entries ) const
+void QgsProjectPropertyKey::entryList( QStringList & entries ) const
 {
   // now add any leaf nodes to the entries list
-  QHashIterator < QString, QgsProperty* > i( mProperties );
+  QHashIterator < QString, QgsProjectProperty* > i( mProperties );
   while ( i.hasNext() )
   {
     // add any of the nodes that have just a single value
@@ -442,10 +442,10 @@ void QgsPropertyKey::entryList( QStringList & entries ) const
 
 
 
-void QgsPropertyKey::subkeyList( QStringList & entries ) const
+void QgsProjectPropertyKey::subkeyList( QStringList & entries ) const
 {
   // now add any leaf nodes to the entries list
-  QHashIterator < QString, QgsProperty* > i( mProperties );
+  QHashIterator < QString, QgsProjectProperty* > i( mProperties );
   while ( i.hasNext() )
   {
     // add any of the nodes that have just a single value
@@ -457,7 +457,7 @@ void QgsPropertyKey::subkeyList( QStringList & entries ) const
 } // QgsPropertyKey::subkeyList
 
 
-bool QgsPropertyKey::isLeaf() const
+bool QgsProjectPropertyKey::isLeaf() const
 {
   if ( 0 == count() )
   {
@@ -465,7 +465,7 @@ bool QgsPropertyKey::isLeaf() const
   }
   else if ( 1 == count() )
   {
-    QHashIterator < QString, QgsProperty* > i( mProperties );
+    QHashIterator < QString, QgsProjectProperty* > i( mProperties );
 
     if ( i.hasNext() && i.next().value()->isValue() )
     {
@@ -476,7 +476,7 @@ bool QgsPropertyKey::isLeaf() const
   return false;
 }
 
-void QgsPropertyKey::setName( const QString& name )
+void QgsProjectPropertyKey::setName( const QString& name )
 {
   mName = name;
 } // QgsPropertyKey::isLeaf

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -43,10 +43,9 @@ void QgsProjectPropertyValue::dump( int tabs ) const
   {
     QgsDebugMsg( QString( "%1%2" ).arg( tabString, mValue.toString() ) );
   }
-} // QgsPropertyValue::dump()
+}
 
-
-bool QgsProjectPropertyValue::readXml( QDomNode & keyNode )
+bool QgsProjectPropertyValue::readXml( const QDomNode& keyNode )
 {
   // this *should* be a Dom element node
   QDomElement subkeyElement = keyNode.toElement();
@@ -203,30 +202,26 @@ bool QgsProjectPropertyValue::readXml( QDomNode & keyNode )
       QgsDebugMsg( "no support for QVariant::Pen" );
       return false;
 
-      //
-      // QGIS DIES NOT SUPPORT THESE VARIANT TYPES IN VERSION 3.1 DISABLING FOR NOW
-      //
-      /*
-        case QVariant::LongLong :
-        value_ = QVariant(subkeyElement.text()).toLongLong();
-        break;
+#if 0 // Currently unsupported variant types
+    case QVariant::LongLong :
+      value_ = QVariant( subkeyElement.text() ).toLongLong();
+      break;
 
-        case QVariant::ULongLong :
-        value_ = QVariant(subkeyElement.text()).toULongLong();
-        break;
-      */
+    case QVariant::ULongLong :
+      value_ = QVariant( subkeyElement.text() ).toULongLong();
+      break;
+#endif
+
     default :
       QgsDebugMsg( QString( "unsupported value type %1 .. not propertly translated to QVariant" ).arg( typeString ) );
   }
 
   return true;
 
-} // QgsPropertyValue::readXml
+}
 
 
-/**
-   keyElement created by parent QgsProjectPropertyKey
-*/
+// keyElement is created by parent QgsProjectPropertyKey
 bool QgsProjectPropertyValue::writeXml( QString const & nodeName,
                                         QDomElement   & keyElement,
                                         QDomDocument  & document )
@@ -265,7 +260,7 @@ bool QgsProjectPropertyValue::writeXml( QString const & nodeName,
   keyElement.appendChild( valueElement );
 
   return true;
-} // QgsPropertyValue::writeXml
+}
 
 
 QgsProjectPropertyKey::QgsProjectPropertyKey( const QString &name )
@@ -288,7 +283,7 @@ QVariant QgsProjectPropertyKey::value() const
   }
 
   return foundQgsProperty->value();
-} // QVariant QgsPropertyKey::value()
+}
 
 
 void QgsProjectPropertyKey::dump( int tabs ) const
@@ -346,11 +341,11 @@ void QgsProjectPropertyKey::dump( int tabs ) const
     }
   }
 
-} // QgsPropertyKey::dump
+}
 
 
 
-bool QgsProjectPropertyKey::readXml( QDomNode & keyNode )
+bool QgsProjectPropertyKey::readXml( const QDomNode& keyNode )
 {
   int i = 0;
   QDomNodeList subkeys = keyNode.childNodes();
@@ -390,10 +385,10 @@ bool QgsProjectPropertyKey::readXml( QDomNode & keyNode )
   }
 
   return true;
-} // QgsPropertyKey::readXml(QDomNode & keyNode)
+}
 
 
-/**
+/*
   Property keys will always create a Dom element for itself and then
   recursively call writeXml for any constituent properties.
 */
@@ -420,12 +415,8 @@ bool QgsProjectPropertyKey::writeXml( QString const &nodeName, QDomElement & ele
   element.appendChild( keyElement );
 
   return true;
-} // QgsPropertyKey::writeXml
+}
 
-
-
-/** Return keys that do not contain other keys
- */
 void QgsProjectPropertyKey::entryList( QStringList & entries ) const
 {
   // now add any leaf nodes to the entries list
@@ -438,9 +429,7 @@ void QgsProjectPropertyKey::entryList( QStringList & entries ) const
       entries.append( i.key() );
     }
   }
-} // QgsPropertyKey::entryList
-
-
+}
 
 void QgsProjectPropertyKey::subkeyList( QStringList & entries ) const
 {
@@ -454,7 +443,7 @@ void QgsProjectPropertyKey::subkeyList( QStringList & entries ) const
       entries.append( i.key() );
     }
   }
-} // QgsPropertyKey::subkeyList
+}
 
 
 bool QgsProjectPropertyKey::isLeaf() const
@@ -479,4 +468,4 @@ bool QgsProjectPropertyKey::isLeaf() const
 void QgsProjectPropertyKey::setName( const QString& name )
 {
   mName = name;
-} // QgsPropertyKey::isLeaf
+}

--- a/src/core/qgsprojectproperty.h
+++ b/src/core/qgsprojectproperty.h
@@ -34,9 +34,9 @@ class QDomDocument;
 /** \ingroup core
  * An Abstract Base Class for QGIS project property hierarchies.
 
-   Each sub-class is either a QgsPropertyKey or QgsPropertyValue.  QgsPropertyKeys can
-   contain either QgsPropertyKeys or QgsPropertyValues, thus describing an
-   hierarchy.  QgsPropertyValues are always graph leaves.
+   Each sub-class is either a QgsProjectPropertyKey or QgsProjectPropertyValue.  QgsProjectPropertyKey can
+   contain either QgsProjectPropertyKey or QgsProjectPropertyValues, thus describing an
+   hierarchy.  QgsProjectPropertyValues are always graph leaves.
 
    @note
 
@@ -44,11 +44,11 @@ class QDomDocument;
    too large and unwieldy, so it's broken out here into separate files.
 
 */
-class CORE_EXPORT QgsProperty
+class CORE_EXPORT QgsProjectProperty
 {
   public:
-    QgsProperty();
-    virtual ~QgsProperty() = default;
+    QgsProjectProperty();
+    virtual ~QgsProjectProperty() = default;
 
     /** Dumps out the keys and values
      *
@@ -56,10 +56,10 @@ class CORE_EXPORT QgsProperty
      */
     virtual void dump( int tabs = 0 ) const = 0;
 
-    //! Returns true if is a QgsPropertyKey
+    //! Returns true if is a QgsProjectPropertyKey
     virtual bool isKey() const = 0;
 
-    //! Returns true if is a QgsPropertyValue
+    //! Returns true if is a QgsProjectPropertyValue
     virtual bool isValue() const = 0;
 
     /** Returns true if a leaf node
@@ -93,41 +93,36 @@ class CORE_EXPORT QgsProperty
 
     /** Return the node's value
      *
-     * For QgsPropertyValue nodes, this is straightforward -- just return the
-     * embedded QVariant, _value.  For QgsPropertyKey, this means returning
-     * the QgsPropertyValue _value that is keyed by its name, if it exists;
-     * i.e., QgsPropertyKey "foo" will return the property value mapped to its
+     * For QgsProjectPropertyValue nodes, this is straightforward -- just return the
+     * embedded QVariant, _value.  For QgsProjectPropertyKey, this means returning
+     * the QgsProjectPropertyValue _value that is keyed by its name, if it exists;
+     * i.e., QgsProjectPropertyKey "foo" will return the property value mapped to its
      * name, "foo", in its QHash of QProperties.
      *
      */
     virtual QVariant value() const = 0;
 
-}; // class QgsProperty
-
-
+};
 
 
 /** \ingroup core
- * QgsPropertyValue node
+ * QgsProjectPropertyValue node
 
-Contains a QgsPropertyKey's value
+Contains a QgsProjectPropertyKey's value
 */
-class CORE_EXPORT QgsPropertyValue : public QgsProperty
+class CORE_EXPORT QgsProjectPropertyValue : public QgsProjectProperty
 {
   public:
-    QgsPropertyValue() {}
+    QgsProjectPropertyValue() = default;
 
-    QgsPropertyValue( const QVariant &value )
-        : value_( value )
+    QgsProjectPropertyValue( const QVariant &value )
+        : mValue( value )
     {}
 
-    //! Returns true if is a QgsPropertyKey
     virtual bool isKey() const override { return false; }
-
-    //! Returns true if is a QgsPropertyValue
     virtual bool isValue() const override { return true; }
 
-    QVariant value() const override { return value_; }
+    QVariant value() const override { return mValue; }
 
     /** Returns true if is a leaf node
      *
@@ -147,7 +142,7 @@ class CORE_EXPORT QgsPropertyValue : public QgsProperty
     int count() const { return 0; }
 
     /** Return keys that do not contain other keys
-     * Since QgsPropertyValue isn't a key, don't do anything.
+     * Since QgsProjectPropertyValue isn't a key, don't do anything.
      */
     void entryList( QStringList & keyName, QStringList & entries ) const
     { Q_UNUSED( keyName ); Q_UNUSED( entries ); /* NOP */ }
@@ -157,38 +152,36 @@ class CORE_EXPORT QgsPropertyValue : public QgsProperty
     /** We use QVariant as it's very handy to keep multiple types and provides
      * type conversions
      */
-    QVariant value_;
+    QVariant mValue;
 
-}; // class QgsPropertyValue
-
-
+};
 
 
 /** \ingroup core
-   QgsPropertyKey node
+   QgsProjectPropertyKey node
 
-   Can, itself, contain QgsPropertyKeys and QgsPropertyValues.
+   Can, itself, contain QgsProjectPropertyKey and QgsProjectPropertyValues.
 
    The internal QHash, mProperties, maps key names to their respective
-   QgsPropertyValue or next QgsPropertyKey in the key name sequence.  The key with
-   the current name should contain its QgsPropertyValue.
+   QgsProjectPropertyValue or next QgsProjectPropertyKey in the key name sequence.  The key with
+   the current name should contain its QgsProjectPropertyValue.
 
    E.g., given the key sequence "/foo/bar", "foo" will have a corresponding
-   QgsPropertyKey with a name "foo".  It will contain an element in its
-   mProperties that maps to "bar", which is another QgsPropertyKey.  The "bar"
-   QgsPropertyKey will, in turn, have an element that maps to itself, i.e. "bar",
-   that will contain a QgsPropertyValue.
+   QgsProjectPropertyKey with a name "foo".  It will contain an element in its
+   mProperties that maps to "bar", which is another QgsProjectPropertyKey.  The "bar"
+   QgsProjectPropertyKey will, in turn, have an element that maps to itself, i.e. "bar",
+   that will contain a QgsProjectPropertyValue.
 
 */
-class CORE_EXPORT QgsPropertyKey : public QgsProperty
+class CORE_EXPORT QgsProjectPropertyKey : public QgsProjectProperty
 {
   public:
 
     /**
-     * Create a new QgsPropertyKey with the specified identifier.
+     * Create a new QgsProjectPropertyKey with the specified identifier.
      */
-    QgsPropertyKey( const QString& name = QString() );
-    virtual ~QgsPropertyKey();
+    QgsProjectPropertyKey( const QString& name = QString() );
+    virtual ~QgsProjectPropertyKey();
 
     /**
      * The name of the property is used as identifier.
@@ -210,12 +203,12 @@ class CORE_EXPORT QgsPropertyKey : public QgsProperty
 
 
     /// add the given property key
-    QgsPropertyKey *addKey( const QString & keyName )
+    QgsProjectPropertyKey *addKey( const QString & keyName )
     {
       delete mProperties.take( keyName );
-      mProperties.insert( keyName, new QgsPropertyKey( keyName ) );
+      mProperties.insert( keyName, new QgsProjectPropertyKey( keyName ) );
 
-      return dynamic_cast<QgsPropertyKey*>( mProperties.value( keyName ) );
+      return dynamic_cast<QgsProjectPropertyKey*>( mProperties.value( keyName ) );
     }
 
 
@@ -230,12 +223,12 @@ class CORE_EXPORT QgsPropertyKey : public QgsProperty
      * @param value is the value to set
      * @return pointer to property value
      */
-    QgsPropertyValue * setValue( const QString & name, const QVariant & value )
+    QgsProjectPropertyValue * setValue( const QString & name, const QVariant & value )
     {
       delete mProperties.take( name );
-      mProperties.insert( name, new QgsPropertyValue( value ) );
+      mProperties.insert( name, new QgsProjectPropertyValue( value ) );
 
-      return dynamic_cast<QgsPropertyValue*>( mProperties.value( name ) );
+      return dynamic_cast<QgsProjectPropertyValue*>( mProperties.value( name ) );
     }
 
     /** Set the value associated with this key
@@ -243,7 +236,7 @@ class CORE_EXPORT QgsPropertyKey : public QgsProperty
      * @note that the single value node associated with each key is always
      * stored keyed by the current key name
      */
-    QgsPropertyValue * setValue( const QVariant & value )
+    QgsProjectPropertyValue * setValue( const QVariant & value )
     {
       return setValue( name(), value );
     }
@@ -260,10 +253,7 @@ class CORE_EXPORT QgsPropertyKey : public QgsProperty
     /// Does this property not have any subkeys or values?
     /* virtual */ bool isEmpty() const { return mProperties.isEmpty(); }
 
-    //! Returns true if is a QgsPropertyKey
     virtual bool isKey() const override { return true; }
-
-    //! Returns true if is a QgsPropertyValue
     virtual bool isValue() const override { return false; }
 
     /// return keys that do not contain other keys
@@ -292,7 +282,7 @@ class CORE_EXPORT QgsPropertyKey : public QgsProperty
       mProperties.clear();
     }
 
-    QgsProperty * find( QString & propertyName )
+    QgsProjectProperty * find( QString & propertyName )
     {
       return mProperties.value( propertyName );
     }
@@ -303,8 +293,8 @@ class CORE_EXPORT QgsPropertyKey : public QgsProperty
     QString mName;
 
     /// sub-keys
-    QHash < QString, QgsProperty* > mProperties;
+    QHash < QString, QgsProjectProperty* > mProperties;
 
-}; // class QgsPropertyKey
+};
 
 #endif

--- a/src/core/qgsprojectproperty.h
+++ b/src/core/qgsprojectproperty.h
@@ -31,18 +31,18 @@ class QDomElement;
 class QDomDocument;
 
 
-/** \ingroup core
+/**
+ * \class QgsProjectProperty
+ * \ingroup core
  * An Abstract Base Class for QGIS project property hierarchies.
-
-   Each sub-class is either a QgsProjectPropertyKey or QgsProjectPropertyValue.  QgsProjectPropertyKey can
-   contain either QgsProjectPropertyKey or QgsProjectPropertyValues, thus describing an
-   hierarchy.  QgsProjectPropertyValues are always graph leaves.
-
-   @note
-
-   This is really a hidden QgsProject implementation class.  It was getting
-   too large and unwieldy, so it's broken out here into separate files.
-
+ *
+ * Each sub-class is either a QgsProjectPropertyKey or QgsProjectPropertyValue.  QgsProjectPropertyKey can
+ * contain either QgsProjectPropertyKey or QgsProjectPropertyValues, thus describing an
+ * hierarchy.  QgsProjectPropertyValues are always graph leaves.
+ *
+ * @note This class is used internally by QgsProject. It's generally recommended that the methods in
+ * QgsProject are used to modify project properties rather than using these low-level classes.
+ * @note added in QGIS 3.0
 */
 class CORE_EXPORT QgsProjectProperty
 {
@@ -50,21 +50,31 @@ class CORE_EXPORT QgsProjectProperty
     QgsProjectProperty();
     virtual ~QgsProjectProperty() = default;
 
-    /** Dumps out the keys and values
+    /**
+     * Dumps out the keys and values
      *
      * @param tabs is number of tabs to print; used for pretty-printing hierarchy
      */
     virtual void dump( int tabs = 0 ) const = 0;
 
-    //! Returns true if is a QgsProjectPropertyKey
+    /**
+     * Returns true if the property is a QgsProjectPropertyKey.
+     * @see isValue()
+     * @see isLeaf()
+     */
     virtual bool isKey() const = 0;
 
-    //! Returns true if is a QgsProjectPropertyValue
+    /**
+     * Returns true if the property is a QgsProjectPropertyValue.
+     * @see isKey()
+     * @see isLeaf()
+     */
     virtual bool isValue() const = 0;
 
-    /** Returns true if a leaf node
+    /**
+     * Returns true if property is a leaf node.
      *
-     * A leaf node is a key node that has either no value or a single value.
+     * A leaf node is a key node that has either no value or only a single value.
      * A non-leaf node would be a key node with key sub-nodes.
      *
      * This is used for entryList() and subkeyList() implementation.
@@ -72,14 +82,14 @@ class CORE_EXPORT QgsProjectProperty
     virtual bool isLeaf() const = 0;
 
     /**
-     * restores property hierarchy to given Dom node
+     * Restores the property hierarchy from a specified DOM node.
      *
-     *  Used for restoring properties from project file
+     * Used for restoring properties from project file
      */
-    virtual bool readXml( QDomNode & keyNode ) = 0;
+    virtual bool readXml( const QDomNode& keyNode ) = 0;
 
     /**
-     * adds property hierarchy to given Dom element
+     * Writes the property hierarchy to a specified DOM element.
      *
      * Used for saving properties to project file.
      *
@@ -87,11 +97,12 @@ class CORE_EXPORT QgsProjectProperty
      * @param element the parent (or encompassing) property element
      * @param document the overall project file Dom document
      */
-    virtual bool writeXml( const QString & nodeName,
-                           QDomElement   & element,
-                           QDomDocument  & document ) = 0;
+    virtual bool writeXml( const QString& nodeName,
+                           QDomElement& element,
+                           QDomDocument& document ) = 0;
 
-    /** Return the node's value
+    /**
+     * Returns the node's value.
      *
      * For QgsProjectPropertyValue nodes, this is straightforward -- just return the
      * embedded QVariant, _value.  For QgsProjectPropertyKey, this means returning
@@ -105,73 +116,66 @@ class CORE_EXPORT QgsProjectProperty
 };
 
 
-/** \ingroup core
- * QgsProjectPropertyValue node
-
-Contains a QgsProjectPropertyKey's value
+/**
+ * \class QgsProjectPropertyValue
+ * \ingroup core
+ * Project property value node, contains a QgsProjectPropertyKey's value.
+ * \note added in QGIS 3.0
 */
 class CORE_EXPORT QgsProjectPropertyValue : public QgsProjectProperty
 {
   public:
+
+    //! Constructor for QgsProjectPropertyValue.
     QgsProjectPropertyValue() = default;
 
+    /**
+     * Constructor for QgsProjectPropertyValue, initialized to a specified value.
+     */
     QgsProjectPropertyValue( const QVariant &value )
         : mValue( value )
     {}
 
     virtual bool isKey() const override { return false; }
     virtual bool isValue() const override { return true; }
-
     QVariant value() const override { return mValue; }
 
-    /** Returns true if is a leaf node
-     *
-     * @note I suppose, in a way, value nodes can also be qualified as leaf
-     * nodes even though we're only counting key nodes.
-     */
+    //value nodes can also be qualified as leaf nodes even though we only count key nodes.
     bool isLeaf() const override { return true; }
 
     void dump( int tabs = 0 ) const override;
-
-    bool readXml( QDomNode & keyNode ) override;
-
-    bool writeXml( const QString & nodeName,
-                   QDomElement   & element,
-                   QDomDocument  & document ) override;
-
-    int count() const { return 0; }
-
-    /** Return keys that do not contain other keys
-     * Since QgsProjectPropertyValue isn't a key, don't do anything.
-     */
-    void entryList( QStringList & keyName, QStringList & entries ) const
-    { Q_UNUSED( keyName ); Q_UNUSED( entries ); /* NOP */ }
+    bool readXml( const QDomNode& keyNode ) override;
+    bool writeXml( const QString& nodeName,
+                   QDomElement& element,
+                   QDomDocument& document ) override;
 
   private:
 
-    /** We use QVariant as it's very handy to keep multiple types and provides
-     * type conversions
-     */
+    // We use QVariant as it's very handy to keep multiple types and provides type conversions
     QVariant mValue;
 
 };
 
 
-/** \ingroup core
-   QgsProjectPropertyKey node
-
-   Can, itself, contain QgsProjectPropertyKey and QgsProjectPropertyValues.
-
-   The internal QHash, mProperties, maps key names to their respective
-   QgsProjectPropertyValue or next QgsProjectPropertyKey in the key name sequence.  The key with
-   the current name should contain its QgsProjectPropertyValue.
-
-   E.g., given the key sequence "/foo/bar", "foo" will have a corresponding
-   QgsProjectPropertyKey with a name "foo".  It will contain an element in its
-   mProperties that maps to "bar", which is another QgsProjectPropertyKey.  The "bar"
-   QgsProjectPropertyKey will, in turn, have an element that maps to itself, i.e. "bar",
-   that will contain a QgsProjectPropertyValue.
-
+/**
+ * \class QgsProjectPropertyKey
+ * \ingroup core
+ *
+ * Project property key node.
+ *
+ * Can, itself, contain QgsProjectPropertyKey and QgsProjectPropertyValues.
+ *
+ * The internal QHash, mProperties, maps key names to their respective
+ * QgsProjectPropertyValue or next QgsProjectPropertyKey in the key name sequence.  The key with
+ * the current name should contain its QgsProjectPropertyValue.
+ *
+ * E.g., given the key sequence "/foo/bar", "foo" will have a corresponding
+ * QgsProjectPropertyKey with a name "foo".  It will contain an element in its
+ * mProperties that maps to "bar", which is another QgsProjectPropertyKey.  The "bar"
+ * QgsProjectPropertyKey will, in turn, have an element that maps to itself, i.e. "bar",
+ * that will contain a QgsProjectPropertyValue.
+ *
+ * \note added in QGIS 3.0
 */
 class CORE_EXPORT QgsProjectPropertyKey : public QgsProjectProperty
 {
@@ -185,6 +189,7 @@ class CORE_EXPORT QgsProjectPropertyKey : public QgsProjectProperty
 
     /**
      * The name of the property is used as identifier.
+     * @see setName()
      */
     QString name() const { return mName; }
 
@@ -192,6 +197,7 @@ class CORE_EXPORT QgsProjectPropertyKey : public QgsProjectProperty
      * The name of the property is used as identifier.
      *
      * @note Added in QGIS 3.0
+     * @see name()
      */
     void setName( const QString& name );
 
@@ -201,34 +207,43 @@ class CORE_EXPORT QgsProjectPropertyKey : public QgsProjectProperty
      */
     QVariant value() const override;
 
-
-    /// add the given property key
-    QgsProjectPropertyKey *addKey( const QString & keyName )
+    /**
+     * Adds the specified property key as a sub-key.
+     */
+    QgsProjectPropertyKey* addKey( const QString& keyName )
     {
-      delete mProperties.take( keyName );
-      mProperties.insert( keyName, new QgsProjectPropertyKey( keyName ) );
+      if ( mProperties.contains( keyName ) )
+        delete mProperties.take( keyName );
 
-      return dynamic_cast<QgsProjectPropertyKey*>( mProperties.value( keyName ) );
+      QgsProjectPropertyKey* p = new QgsProjectPropertyKey( keyName );
+      mProperties.insert( keyName, p );
+
+      return p;
     }
 
-
-    /// remove the given key
+    /**
+     * Removes the specified key.
+     */
     void removeKey( const QString & keyName )
     {
       delete mProperties.take( keyName );
     }
 
-    /** Set the value associated with this key
+    /**
+     * Sets the value associated with this key.
      * @param name is the key name
      * @param value is the value to set
      * @return pointer to property value
      */
-    QgsProjectPropertyValue * setValue( const QString & name, const QVariant & value )
+    QgsProjectPropertyValue* setValue( const QString & name, const QVariant & value )
     {
-      delete mProperties.take( name );
-      mProperties.insert( name, new QgsProjectPropertyValue( value ) );
+      if ( mProperties.contains( name ) )
+        delete mProperties.take( name );
 
-      return dynamic_cast<QgsProjectPropertyValue*>( mProperties.value( name ) );
+      QgsProjectPropertyValue* p = new QgsProjectPropertyValue( value );
+      mProperties.insert( name, p );
+
+      return p;
     }
 
     /** Set the value associated with this key
@@ -242,57 +257,67 @@ class CORE_EXPORT QgsProjectPropertyKey : public QgsProjectProperty
     }
 
     void dump( int tabs = 0 ) const override;
-
-    bool readXml( QDomNode & keyNode ) override;
-
+    bool readXml( const QDomNode& keyNode ) override;
     bool writeXml( const QString &nodeName, QDomElement & element, QDomDocument & document ) override;
 
-    /// how many elements are contained within this one?
+    /**
+     * Returns the number of sub-keys contained by this property.
+     */
     int count() const { return mProperties.count(); }
 
-    /// Does this property not have any subkeys or values?
-    /* virtual */ bool isEmpty() const { return mProperties.isEmpty(); }
+    /**
+     * Returns true if this property contains no sub-keys.
+     */
+    bool isEmpty() const { return mProperties.isEmpty(); }
 
     virtual bool isKey() const override { return true; }
     virtual bool isValue() const override { return false; }
-
-    /// return keys that do not contain other keys
-    void entryList( QStringList & entries ) const;
-
-    /// return keys that contain other keys
-    void subkeyList( QStringList & entries ) const;
-
-    /** Returns true if a leaf node
-     * A leaf node is a key node that has either no value or a single value.
-     * A non-leaf node would be a key node with key sub-nodes.
-     */
     bool isLeaf() const override;
 
-    /// reset the QgsProperty key to prestine state
+    /**
+     * Returns any sub-keys contained by this property that do not contain other keys.
+     * @see subkeyList()
+     */
+    void entryList( QStringList & entries ) const;
+
+    /**
+     * Return any sub-keys contained by this property which themselves contain other keys.
+     * @see entryList()
+     */
+    void subkeyList( QStringList & entries ) const;
+
+    /**
+     * Resets the property to a default, empty state.
+     */
     virtual void clear()
     {
-      mName = QLatin1String( "" );
+      mName.clear();
       clearKeys();
     }
 
-    /// delete any sub-nodes
+    /**
+     * Deletes any sub-nodes from the property.
+     */
     virtual void clearKeys()
     {
       qDeleteAll( mProperties );
       mProperties.clear();
     }
 
-    QgsProjectProperty * find( QString & propertyName )
+    /**
+     * Attempts to find a property with a matching sub-key name.
+     */
+    QgsProjectProperty* find( const QString& propertyName ) const
     {
       return mProperties.value( propertyName );
     }
 
   private:
 
-    /// every key has a name
+    //! Name of the key
     QString mName;
 
-    /// sub-keys
+    //! Sub-keys
     QHash < QString, QgsProjectProperty* > mProperties;
 
 };


### PR DESCRIPTION
...and QgsPropertyKey/Value to QgsProjectPropertyKey/Value

The QgsProperty names are too generic to be used in this context.