### PR TITLE
Make application icon great on GNOME using the theme

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -800,7 +800,7 @@ int main( int argc, char *argv[] )
 
   QgsApplication myApp( argc, argv, myUseGuiFlag, configpath );
 
-  myApp.setWindowIcon( QIcon( QgsApplication::appIconPath() ) );
+  myApp.setWindowIcon( QIcon::fromTheme( "qgis", QIcon( QgsApplication::appIconPath() ) ) );
 
   //
   // Set up the QSettings environment must be done after qapp is created


### PR DESCRIPTION

The application icon is currently set to the 60x60 png which looks blurry when scaled up on the GNOME window switcher and applications overview.

This patch looks for the application icon first in the theme, which picks a better size. If an icon is not found in the theme it falls back to the previous behaviour.

I believe this only works for X11 - that is why there is code already in QgsApplication e.g. getThemeIcon() but it is not used for setWindowIcon?
Maybe these Mac and Windows issues are related:
http://hub.qgis.org/issues/14434
http://hub.qgis.org/issues/9298


Don't know if there is an alternative to hardocding the icon name?

Supported by placing qgis.png files in `/usr/share/icons/hicolor/<size>/apps`.
(As done by debian/rules and rpm/qgis.spec.template)

Tested with Qt 4.8.6 on top of QGIS 2.18.2.
