### PR TITLE
[FEATURE] Change of ergonomy of the visibility of layers inside groups

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -687,6 +687,13 @@ QgsCptCitySelectionItem        {#qgis_api_break_3_0_QgsCptCitySelectionItem}
 
 - parseXML() has been renamed to parseXml()
 
+
+QgsCustomLayerOrderWidget        {#qgis_api_break_3_0_QgsCustomLayerOrderWidget}
+-------------------------
+
+- the signature of the visibilityChanged() signal is changed to visibilityChanged( QgsLayerTreeNode *node )
+
+
 QgsCRSCache        {#qgis_api_break_3_0_QgsCRSCache}
 -----------
 
@@ -1059,12 +1066,16 @@ QgsLayerTreeGroup        {#qgis_api_break_3_0_QgsLayerTreeGroup}
 -----------------
 
 - readChildrenFromXML() has been renamed to readChildrenFromXml()
-
+- isVisible() is moved to QgsLayerTreeNode
+- setVisible() is replaced by QgsLayerTreeNode::setItemVisibilityChecked()
+- protected methods updateVisibilityFromChildren() and updateChildVisibility() removed
 
 QgsLayerTreeLayer        {#qgis_api_break_3_0_QgsLayerTreeLayer}
 -----------------
 
 - setLayerName(), layerName() were renamed to setName(), name()
+- isVisible() is moved to QgsLayerTreeNode
+- setVisible() is replaced by QgsLayerTreeNode::setItemVisibilityChecked()
 
 
 QgsLayerTreeModel        {#qgis_api_break_3_0_QgsLayerTreeMode}
@@ -1090,7 +1101,7 @@ QgsLayerTreeNode        {#qgis_api_break_3_0_QgsLayerTreeNode}
 
 - readCommonXML() has been renamed to readCommonXml()
 - writeCommonXML() has been renamed to writeCommonXml()
-
+- the signature of the visibilityChanged() signal is changed to visibilityChanged( QgsLayerTreeNode *node )
 
 QgsLimitedRandomColorRampDialog        {#qgis_api_break_3_0_QgsLimitedRandomRampDialog}
 -------------------------------

--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -71,11 +71,6 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     //! Return a clone of the group. The children are cloned too.
     virtual QgsLayerTreeGroup* clone() const /Factory/;
 
-    //! Return the check state of the group node
-    Qt::CheckState isVisible() const;
-    //! Set check state of the group node - will also update children
-    void setVisible( Qt::CheckState state );
-
     //! Return whether the group is mutually exclusive (only one child can be checked at a time)
     //! @note added in 2.12
     bool isMutuallyExclusive() const;
@@ -86,14 +81,10 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     void setIsMutuallyExclusive( bool enabled, int initialChildIndex = -1 );
 
   protected slots:
-    void layerDestroyed();
     void nodeVisibilityChanged( QgsLayerTreeNode* node );
 
   protected:
-    //! Set check state of this group from its children
-    void updateVisibilityFromChildren();
-    //! Set check state of children (when this group's check state changes) - if not mutually exclusive
-    void updateChildVisibility();
+
     //! Set check state of children - if mutually exclusive
     void updateChildVisibilityMutuallyExclusive();
 

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -38,9 +38,6 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
     //! @note added in 3.0
     void setName( const QString& n );
 
-    Qt::CheckState isVisible() const;
-    void setVisible( Qt::CheckState visible );
-
     static QgsLayerTreeLayer* readXml( QDomElement& element ) /Factory/;
     virtual void writeXml( QDomElement& parentElement );
 

--- a/python/core/layertree/qgslayertreemodel.sip
+++ b/python/core/layertree/qgslayertreemodel.sip
@@ -61,6 +61,7 @@ class QgsLayerTreeModel : QAbstractItemModel
       AllowNodeRename,            //!< Allow renaming of groups and layers
       AllowNodeChangeVisibility,  //!< Allow user to set node visibility with a check box
       AllowLegendChangeState,     //!< Allow check boxes for legend nodes (if supported by layer's legend)
+      ActionHierarchical,         //!< Check/uncheck action has consequences on children (or parents for leaf node)
     };
     typedef QFlags<QgsLayerTreeModel::Flag> Flags;
 

--- a/python/core/layertree/qgslayertreenode.sip
+++ b/python/core/layertree/qgslayertreenode.sip
@@ -94,6 +94,34 @@ class QgsLayerTreeNode : QObject
     //! Create a copy of the node. Returns new instance
     virtual QgsLayerTreeNode *clone() const = 0 /Factory/;
 
+    //! Returns whether a node is really visible (ie checked and all its ancestors checked as well)
+    //! @note added in 3.0
+    bool isVisible() const;
+
+    //! Returns whether a node is checked (independantly of its ancestors or children)
+    //! @note added in 3.0
+    bool itemVisibilityChecked() const;
+
+    //! Check or uncheck a node (independantly of its ancestors or children)
+    //! @note added in 3.0
+    void setItemVisibilityChecked( bool checked );
+
+    //! Check or uncheck a node and all its children (taking into account exclusion rules)
+    //! @note added in 3.0
+    virtual void setItemVisibilityCheckedRecursive( bool checked );
+
+    //! Check or uncheck a node and all its parents
+    //! @note added in 3.0
+    void setItemVisibilityCheckedParentRecursive( bool checked );
+
+    //! Return whether this node is checked and all its children.
+    //! @note added in 3.0
+    bool isItemVisibilityCheckedRecursive() const;
+
+    //! Return whether this node is unchecked and all its children.
+    //! @note added in 3.0
+    bool isItemVisibilityUncheckedRecursive() const;
+
     //! Return whether the node should be shown as expanded or collapsed in GUI
     bool isExpanded() const;
     //! Set whether the node should be shown as expanded or collapsed in GUI
@@ -121,7 +149,7 @@ class QgsLayerTreeNode : QObject
     //! Emitted when one or more nodes has been removed from a node within the tree
     void removedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
     //! Emitted when check state of a node within the tree has been changed
-    void visibilityChanged( QgsLayerTreeNode *node, Qt::CheckState state );
+    void visibilityChanged( QgsLayerTreeNode *node );
     //! Emitted when a custom property of a node within the tree has been changed or removed
     void customPropertyChanged( QgsLayerTreeNode *node, const QString& key );
     //! Emitted when the collapsed/expanded state of a node within the tree has been changed

--- a/python/gui/layertree/qgscustomlayerorderwidget.sip
+++ b/python/gui/layertree/qgscustomlayerorderwidget.sip
@@ -20,7 +20,8 @@ class QgsCustomLayerOrderWidget : QWidget
   protected slots:
     void bridgeHasCustomLayerOrderChanged( bool state );
     void bridgeCustomLayerOrderChanged( const QStringList& order );
-    void nodeVisibilityChanged( QgsLayerTreeNode* node, Qt::CheckState state );
+    //! Slot triggered when the ivsibility of a node changes
+    void nodeVisibilityChanged( QgsLayerTreeNode* node );
 
     void modelUpdated();
 };

--- a/python/gui/layertree/qgslayertreeviewdefaultactions.sip
+++ b/python/gui/layertree/qgslayertreeviewdefaultactions.sip
@@ -20,6 +20,15 @@ class QgsLayerTreeViewDefaultActions : QObject
     QAction* actionRenameGroupOrLayer( QObject* parent = 0 ) /Factory/;
     QAction* actionShowFeatureCount( QObject* parent = 0 ) /Factory/;
 
+    //! Action to check a group and all its children
+    QAction* actionCheckAndAllChildren( QObject* parent = nullptr );
+
+    //! Action to uncheck a group and all its children
+    QAction* actionUncheckAndAllChildren( QObject* parent = nullptr );
+
+    //! Action to check a group and all its parents
+    QAction* actionCheckAndAllParents( QObject* parent = nullptr );
+
     QAction* actionZoomToLayer( QgsMapCanvas* canvas, QObject* parent = 0 ) /Factory/;
     QAction* actionZoomToGroup( QgsMapCanvas* canvas, QObject* parent = 0 ) /Factory/;
     // TODO: zoom to selected

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -422,7 +422,7 @@ void QgsDwgImportDialog::createGroup( QgsLayerTreeGroup *group, QString name, QS
   if ( !layerGroup->children().isEmpty() )
   {
     layerGroup->setExpanded( false );
-    layerGroup->setVisible( visible ? Qt::Checked : Qt::Unchecked );
+    layerGroup->setItemVisibilityChecked( visible );
   }
   else
   {

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -80,6 +80,10 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addAction( actions->actionMutuallyExclusiveGroup( menu ) );
 
+      menu->addAction( actions->actionCheckAndAllChildren( menu ) );
+
+      menu->addAction( actions->actionUncheckAndAllChildren( menu ) );
+
       if ( mView->selectedNodes( true ).count() >= 2 )
         menu->addAction( actions->actionGroupSelected( menu ) );
 
@@ -124,6 +128,8 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         if ( !layer->isInScaleRange( mCanvas->scale() ) )
           menu->addAction( tr( "Zoom to &Visible Scale" ), QgisApp::instance(), SLOT( zoomToLayerScale() ) );
+
+        menu->addAction( actions->actionCheckAndAllParents( menu ) );
 
         // set layer crs
         menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionSetCRS.png" ) ), tr( "Set Layer CRS" ), QgisApp::instance(), SLOT( setLayerCrs() ) );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -309,7 +309,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   // use visibility as selection
   mLayersDependenciesTreeModel->setFlag( QgsLayerTreeModel::AllowNodeChangeVisibility );
 
-  mLayersDependenciesTreeGroup->setVisible( Qt::Unchecked );
+  mLayersDependenciesTreeGroup->setItemVisibilityChecked( false );
 
   QSet<QString> dependencySources;
   Q_FOREACH ( const QgsMapLayerDependency& dep, mLayer->dependencies() )
@@ -318,7 +318,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   }
   Q_FOREACH ( QgsLayerTreeLayer* layer, mLayersDependenciesTreeGroup->findLayers() )
   {
-    layer->setVisible( dependencySources.contains( layer->layerId() ) ? Qt::Checked : Qt::Unchecked );
+    layer->setItemVisibilityChecked( dependencySources.contains( layer->layerId() ) );
   }
 
   mLayersDependenciesTreeView->setModel( mLayersDependenciesTreeModel.data() );

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -32,7 +32,8 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 {
     Q_OBJECT
   public:
-    QgsLayerTreeGroup( const QString& name = QString(), Qt::CheckState checked = Qt::Checked );
+    //! Constructor
+    QgsLayerTreeGroup( const QString& name = QString(), bool checked = true );
     QgsLayerTreeGroup( const QgsLayerTreeGroup& other );
 
     //! Get group's name
@@ -92,10 +93,8 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     //! Return a clone of the group. The children are cloned too.
     virtual QgsLayerTreeGroup* clone() const override;
 
-    //! Return the check state of the group node
-    Qt::CheckState isVisible() const { return mChecked; }
-    //! Set check state of the group node - will also update children
-    void setVisible( Qt::CheckState state );
+    //! Check or uncheck a node and all its children (taking into account exclusion rules)
+    virtual void setItemVisibilityCheckedRecursive( bool checked ) override;
 
     //! Return whether the group is mutually exclusive (only one child can be checked at a time)
     //! @note added in 2.12
@@ -107,20 +106,15 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     void setIsMutuallyExclusive( bool enabled, int initialChildIndex = -1 );
 
   protected slots:
-    void layerDestroyed();
     void nodeVisibilityChanged( QgsLayerTreeNode* node );
 
   protected:
-    //! Set check state of this group from its children
-    void updateVisibilityFromChildren();
-    //! Set check state of children (when this group's check state changes) - if not mutually exclusive
-    void updateChildVisibility();
+
     //! Set check state of children - if mutually exclusive
     void updateChildVisibilityMutuallyExclusive();
 
   protected:
     QString mName;
-    Qt::CheckState mChecked;
 
     bool mChangingChildVisibility;
 

--- a/src/core/layertree/qgslayertreelayer.cpp
+++ b/src/core/layertree/qgslayertreelayer.cpp
@@ -21,21 +21,19 @@
 
 
 QgsLayerTreeLayer::QgsLayerTreeLayer( QgsMapLayer *layer )
-    : QgsLayerTreeNode( NodeLayer )
+    : QgsLayerTreeNode( NodeLayer, true )
     , mLayerId( layer->id() )
     , mLayer( nullptr )
-    , mVisible( Qt::Checked )
 {
   Q_ASSERT( QgsProject::instance()->mapLayer( mLayerId ) == layer );
   attachToLayer();
 }
 
 QgsLayerTreeLayer::QgsLayerTreeLayer( const QString& layerId, const QString& name )
-    : QgsLayerTreeNode( NodeLayer )
+    : QgsLayerTreeNode( NodeLayer, true )
     , mLayerId( layerId )
     , mLayerName( name )
     , mLayer( nullptr )
-    , mVisible( Qt::Checked )
 {
   attachToLayer();
 }
@@ -45,7 +43,6 @@ QgsLayerTreeLayer::QgsLayerTreeLayer( const QgsLayerTreeLayer& other )
     , mLayerId( other.mLayerId )
     , mLayerName( other.mLayerName )
     , mLayer( nullptr )
-    , mVisible( other.mVisible )
 {
   attachToLayer();
 }
@@ -94,15 +91,6 @@ void QgsLayerTreeLayer::setName( const QString& n )
   }
 }
 
-void QgsLayerTreeLayer::setVisible( Qt::CheckState state )
-{
-  if ( mVisible == state )
-    return;
-
-  mVisible = state;
-  emit visibilityChanged( this, state );
-}
-
 QgsLayerTreeLayer* QgsLayerTreeLayer::readXml( QDomElement& element )
 {
   if ( element.tagName() != QLatin1String( "layer-tree-layer" ) )
@@ -124,7 +112,7 @@ QgsLayerTreeLayer* QgsLayerTreeLayer::readXml( QDomElement& element )
 
   nodeLayer->readCommonXml( element );
 
-  nodeLayer->setVisible( checked );
+  nodeLayer->setItemVisibilityChecked( checked != Qt::Unchecked );
   nodeLayer->setExpanded( isExpanded );
   return nodeLayer;
 }
@@ -135,7 +123,7 @@ void QgsLayerTreeLayer::writeXml( QDomElement& parentElement )
   QDomElement elem = doc.createElement( QStringLiteral( "layer-tree-layer" ) );
   elem.setAttribute( QStringLiteral( "id" ), mLayerId );
   elem.setAttribute( QStringLiteral( "name" ), name() );
-  elem.setAttribute( QStringLiteral( "checked" ), QgsLayerTreeUtils::checkStateToXml( mVisible ) );
+  elem.setAttribute( QStringLiteral( "checked" ), mChecked ? QStringLiteral( "Qt::Checked" ) : QStringLiteral( "Qt::Unchecked" ) );
   elem.setAttribute( QStringLiteral( "expanded" ), mExpanded ? "1" : "0" );
 
   writeCommonXml( elem );
@@ -145,7 +133,7 @@ void QgsLayerTreeLayer::writeXml( QDomElement& parentElement )
 
 QString QgsLayerTreeLayer::dump() const
 {
-  return QStringLiteral( "LAYER: %1 visible=%2 expanded=%3 id=%4\n" ).arg( name() ).arg( mVisible ).arg( mExpanded ).arg( layerId() );
+  return QStringLiteral( "LAYER: %1 checked=%2 expanded=%3 id=%4\n" ).arg( name() ).arg( mChecked ).arg( mExpanded ).arg( layerId() );
 }
 
 QgsLayerTreeLayer* QgsLayerTreeLayer::clone() const

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -58,9 +58,6 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     //! @note added in 3.0
     void setName( const QString& n ) override;
 
-    Qt::CheckState isVisible() const { return mVisible; }
-    void setVisible( Qt::CheckState visible );
-
     static QgsLayerTreeLayer* readXml( QDomElement& element );
     virtual void writeXml( QDomElement& parentElement ) override;
 
@@ -88,7 +85,6 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     QString mLayerId;
     QString mLayerName; // only used if layer does not exist
     QgsMapLayer* mLayer; // not owned! may be null
-    Qt::CheckState mVisible;
 };
 
 

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -394,7 +394,11 @@ bool QgsLayerTreeModel::setData( const QModelIndex& index, const QVariant& value
       return false;
 
     bool checked = static_cast< Qt::CheckState >( value.toInt() ) == Qt::Checked;
-    if ( testFlag( ActionHierarchical ) )
+    if ( checked &&  node->children().isEmpty() )
+    {
+      node->setItemVisibilityCheckedParentRecursive( checked );
+    }
+    else if ( testFlag( ActionHierarchical ) )
     {
       if ( node->children().isEmpty() )
         node->setItemVisibilityCheckedParentRecursive( checked );

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -87,6 +87,7 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
       AllowNodeRename            = 0x2000,  //!< Allow renaming of groups and layers
       AllowNodeChangeVisibility  = 0x4000,  //!< Allow user to set node visibility with a check box
       AllowLegendChangeState     = 0x8000,  //!< Allow check boxes for legend nodes (if supported by layer's legend)
+      ActionHierarchical         = 0x10000, //!< Check/uncheck action has consequences on children (or parents for leaf node)
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -82,6 +82,8 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     QgsLayerTreeNode *parent() { return mParent; }
     //! Get list of children of the node. Children are owned by the parent
     QList<QgsLayerTreeNode*> children() { return mChildren; }
+    //! Get list of children of the node. Children are owned by the parent
+    const QList<QgsLayerTreeNode*>& children() const { return mChildren; }
 
     //! Return name of the node
     //! @note added in 3.0
@@ -100,6 +102,34 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
 
     //! Create a copy of the node. Returns new instance
     virtual QgsLayerTreeNode *clone() const = 0;
+
+    //! Returns whether a node is really visible (ie checked and all its ancestors checked as well)
+    //! @note added in 3.0
+    bool isVisible() const;
+
+    //! Returns whether a node is checked (independantly of its ancestors or children)
+    //! @note added in 3.0
+    bool itemVisibilityChecked() const { return mChecked; }
+
+    //! Check or uncheck a node (independantly of its ancestors or children)
+    //! @note added in 3.0
+    void setItemVisibilityChecked( bool checked );
+
+    //! Check or uncheck a node and all its children (taking into account exclusion rules)
+    //! @note added in 3.0
+    virtual void setItemVisibilityCheckedRecursive( bool checked );
+
+    //! Check or uncheck a node and all its parents
+    //! @note added in 3.0
+    void setItemVisibilityCheckedParentRecursive( bool checked );
+
+    //! Return whether this node is checked and all its children.
+    //! @note added in 3.0
+    bool isItemVisibilityCheckedRecursive() const;
+
+    //! Return whether this node is unchecked and all its children.
+    //! @note added in 3.0
+    bool isItemVisibilityUncheckedRecursive() const;
 
     //! Return whether the node should be shown as expanded or collapsed in GUI
     bool isExpanded() const;
@@ -128,7 +158,7 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     //! Emitted when one or more nodes has been removed from a node within the tree
     void removedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
     //! Emitted when check state of a node within the tree has been changed
-    void visibilityChanged( QgsLayerTreeNode *node, Qt::CheckState state );
+    void visibilityChanged( QgsLayerTreeNode *node );
     //! Emitted when a custom property of a node within the tree has been changed or removed
     void customPropertyChanged( QgsLayerTreeNode *node, const QString& key );
     //! Emitted when the collapsed/expanded state of a node within the tree has been changed
@@ -139,12 +169,15 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
 
   protected:
 
-    QgsLayerTreeNode( NodeType t );
+    //! Constructor
+    QgsLayerTreeNode( NodeType t, bool checked = true );
     QgsLayerTreeNode( const QgsLayerTreeNode &other );
 
     // low-level utility functions
 
+    //! Read common XML elements.
     void readCommonXml( QDomElement &element );
+    //! Write common XML elements.
     void writeCommonXml( QDomElement &element );
 
     //! Low-level insertion of children to the node. The children must not have any parent yet!
@@ -155,6 +188,7 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
   protected:
     //! type of the node - determines which subclass is used
     NodeType mNodeType;
+    bool mChecked;
     //! pointer to the parent node - null in case of root node
     QgsLayerTreeNode *mParent;
     //! list of children - node is responsible for their deletion

--- a/src/core/layertree/qgslayertreeregistrybridge.cpp
+++ b/src/core/layertree/qgslayertreeregistrybridge.cpp
@@ -52,7 +52,7 @@ void QgsLayerTreeRegistryBridge::layersAdded( const QList<QgsMapLayer*>& layers 
   Q_FOREACH ( QgsMapLayer* layer, layers )
   {
     QgsLayerTreeLayer* nodeLayer = new QgsLayerTreeLayer( layer );
-    nodeLayer->setVisible( mNewLayersVisible ? Qt::Checked : Qt::Unchecked );
+    nodeLayer->setItemVisibilityChecked( mNewLayersVisible );
 
     nodes << nodeLayer;
 

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -112,7 +112,7 @@ static QDomElement _writeOldLegendLayer( QDomDocument& doc, QgsLayerTreeLayer* n
   QDomElement layerElem = doc.createElement( QStringLiteral( "legendlayer" ) );
   layerElem.setAttribute( QStringLiteral( "drawingOrder" ), drawingOrder );
   layerElem.setAttribute( QStringLiteral( "open" ), nodeLayer->isExpanded() ? "true" : "false" );
-  layerElem.setAttribute( QStringLiteral( "checked" ), QgsLayerTreeUtils::checkStateToXml( nodeLayer->isVisible() ) );
+  layerElem.setAttribute( QStringLiteral( "checked" ), QgsLayerTreeUtils::checkStateToXml( nodeLayer->itemVisibilityChecked() ? Qt::Checked : Qt::Unchecked ) );
   layerElem.setAttribute( QStringLiteral( "name" ), nodeLayer->name() );
   layerElem.setAttribute( QStringLiteral( "showFeatureCount" ), nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ) ).toInt() );
 
@@ -123,7 +123,7 @@ static QDomElement _writeOldLegendLayer( QDomDocument& doc, QgsLayerTreeLayer* n
   QDomElement layerFileElem = doc.createElement( QStringLiteral( "legendlayerfile" ) );
   layerFileElem.setAttribute( QStringLiteral( "isInOverview" ), nodeLayer->customProperty( QStringLiteral( "overview" ) ).toInt() );
   layerFileElem.setAttribute( QStringLiteral( "layerid" ), nodeLayer->layerId() );
-  layerFileElem.setAttribute( QStringLiteral( "visible" ), nodeLayer->isVisible() == Qt::Checked ? 1 : 0 );
+  layerFileElem.setAttribute( QStringLiteral( "visible" ), nodeLayer->isVisible() ? 1 : 0 );
 
   layerElem.appendChild( fileGroupElem );
   fileGroupElem.appendChild( layerFileElem );
@@ -138,7 +138,7 @@ static QDomElement _writeOldLegendGroup( QDomDocument& doc, QgsLayerTreeGroup* n
   QDomElement groupElem = doc.createElement( QStringLiteral( "legendgroup" ) );
   groupElem.setAttribute( QStringLiteral( "open" ), nodeGroup->isExpanded() ? "true" : "false" );
   groupElem.setAttribute( QStringLiteral( "name" ), nodeGroup->name() );
-  groupElem.setAttribute( QStringLiteral( "checked" ), QgsLayerTreeUtils::checkStateToXml( nodeGroup->isVisible() ) );
+  groupElem.setAttribute( QStringLiteral( "checked" ), QgsLayerTreeUtils::checkStateToXml( nodeGroup->itemVisibilityChecked() ? Qt::Checked : Qt::Unchecked ) );
 
   if ( nodeGroup->customProperty( QStringLiteral( "embedded" ) ).toInt() )
   {
@@ -210,7 +210,7 @@ static void _readOldLegendGroup( const QDomElement& groupElem, QgsLayerTreeGroup
 
   QgsLayerTreeGroup* groupNode = new QgsLayerTreeGroup( groupElem.attribute( QStringLiteral( "name" ) ) );
 
-  groupNode->setVisible( QgsLayerTreeUtils::checkStateFromXml( groupElem.attribute( QStringLiteral( "checked" ) ) ) );
+  groupNode->setItemVisibilityChecked( QgsLayerTreeUtils::checkStateFromXml( groupElem.attribute( QStringLiteral( "checked" ) ) ) != Qt::Unchecked );
   groupNode->setExpanded( groupElem.attribute( QStringLiteral( "open" ) ) == QLatin1String( "true" ) );
 
   if ( groupElem.attribute( QStringLiteral( "embedded" ) ) == QLatin1String( "1" ) )
@@ -241,7 +241,7 @@ static void _readOldLegendLayer( const QDomElement& layerElem, QgsLayerTreeGroup
   QString layerId = layerFileElem.attribute( QStringLiteral( "layerid" ) );
   QgsLayerTreeLayer* layerNode = new QgsLayerTreeLayer( layerId, layerElem.attribute( QStringLiteral( "name" ) ) );
 
-  layerNode->setVisible( QgsLayerTreeUtils::checkStateFromXml( layerElem.attribute( QStringLiteral( "checked" ) ) ) );
+  layerNode->setItemVisibilityChecked( QgsLayerTreeUtils::checkStateFromXml( layerElem.attribute( QStringLiteral( "checked" ) ) ) != Qt::Unchecked );
   layerNode->setExpanded( layerElem.attribute( QStringLiteral( "open" ) ) == QLatin1String( "true" ) );
 
   if ( layerFileElem.attribute( QStringLiteral( "isInOverview" ) ) == QLatin1String( "1" ) )

--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -103,7 +103,7 @@ void QgsMapThemeCollection::applyThemeToLayer( QgsLayerTreeLayer* nodeLayer, Qgs
   MapThemeLayerRecord layerRec;
   bool isVisible = findRecordForLayer( nodeLayer->layer(), rec, layerRec );
 
-  nodeLayer->setVisible( isVisible ? Qt::Checked : Qt::Unchecked );
+  nodeLayer->setItemVisibilityChecked( isVisible );
 
   if ( !isVisible )
     return;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2016,7 +2016,7 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
     QgsLayerTreeLayer *layer = newGroup->findLayer( layerId );
     if ( layer )
     {
-      layer->setVisible( invisibleLayers.contains( layerId ) ? Qt::Unchecked : Qt::Checked );
+      layer->setItemVisibilityChecked( invisibleLayers.contains( layerId ) );
     }
   }
 

--- a/src/gui/layertree/qgscustomlayerorderwidget.cpp
+++ b/src/gui/layertree/qgscustomlayerorderwidget.cpp
@@ -54,7 +54,7 @@ QgsCustomLayerOrderWidget::QgsCustomLayerOrderWidget( QgsLayerTreeMapCanvasBridg
   connect( mModel, SIGNAL( rowsInserted( QModelIndex, int, int ) ), this, SLOT( modelUpdated() ) );
   connect( mModel, SIGNAL( rowsRemoved( QModelIndex, int, int ) ), this, SLOT( modelUpdated() ) );
 
-  connect( bridge->rootGroup(), SIGNAL( visibilityChanged( QgsLayerTreeNode*, Qt::CheckState ) ), this, SLOT( nodeVisibilityChanged( QgsLayerTreeNode*, Qt::CheckState ) ) );
+  connect( bridge->rootGroup(), &QgsLayerTreeNode::visibilityChanged, this, &QgsCustomLayerOrderWidget::nodeVisibilityChanged );
 
   QVBoxLayout* l = new QVBoxLayout;
   l->setMargin( 0 );
@@ -76,9 +76,8 @@ void QgsCustomLayerOrderWidget::bridgeCustomLayerOrderChanged( const QStringList
   mModel->refreshModel( mBridge->hasCustomLayerOrder() ? mBridge->customLayerOrder() : mBridge->defaultLayerOrder() );
 }
 
-void QgsCustomLayerOrderWidget::nodeVisibilityChanged( QgsLayerTreeNode* node, Qt::CheckState state )
+void QgsCustomLayerOrderWidget::nodeVisibilityChanged( QgsLayerTreeNode* node )
 {
-  Q_UNUSED( state );
   if ( QgsLayerTree::isLayer( node ) )
   {
     mModel->updateLayerVisibility( QgsLayerTree::toLayer( node )->layerId() );
@@ -141,7 +140,7 @@ bool CustomLayerOrderModel::setData( const QModelIndex& index, const QVariant& v
     QgsLayerTreeLayer* nodeLayer = mBridge->rootGroup()->findLayer( id );
     if ( nodeLayer )
     {
-      nodeLayer->setVisible( static_cast< Qt::CheckState >( value.toInt() ) );
+      nodeLayer->setItemVisibilityChecked( static_cast< Qt::CheckState >( value.toInt() ) == Qt::Checked );
       return true;
     }
   }

--- a/src/gui/layertree/qgscustomlayerorderwidget.h
+++ b/src/gui/layertree/qgscustomlayerorderwidget.h
@@ -48,7 +48,8 @@ class GUI_EXPORT QgsCustomLayerOrderWidget : public QWidget
   protected slots:
     void bridgeHasCustomLayerOrderChanged( bool state );
     void bridgeCustomLayerOrderChanged( const QStringList& order );
-    void nodeVisibilityChanged( QgsLayerTreeNode* node, Qt::CheckState state );
+    //! Slot triggered when the ivsibility of a node changes
+    void nodeVisibilityChanged( QgsLayerTreeNode* node );
 
     void modelUpdated();
 

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -37,7 +37,7 @@ QgsLayerTreeMapCanvasBridge::QgsLayerTreeMapCanvasBridge( QgsLayerTreeGroup *roo
   connect( root, SIGNAL( addedChildren( QgsLayerTreeNode*, int, int ) ), this, SLOT( nodeAddedChildren( QgsLayerTreeNode*, int, int ) ) );
   connect( root, SIGNAL( customPropertyChanged( QgsLayerTreeNode*, QString ) ), this, SLOT( nodeCustomPropertyChanged( QgsLayerTreeNode*, QString ) ) );
   connect( root, SIGNAL( removedChildren( QgsLayerTreeNode*, int, int ) ), this, SLOT( nodeRemovedChildren() ) );
-  connect( root, SIGNAL( visibilityChanged( QgsLayerTreeNode*, Qt::CheckState ) ), this, SLOT( nodeVisibilityChanged() ) );
+  connect( root, &QgsLayerTreeNode::visibilityChanged, this, &QgsLayerTreeMapCanvasBridge::nodeVisibilityChanged );
 
   setCanvasLayers();
 }
@@ -127,7 +127,7 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
       QgsLayerTreeLayer* nodeLayer = mRoot->findLayer( layerId );
       if ( nodeLayer )
       {
-        if ( nodeLayer->isVisible() == Qt::Checked )
+        if ( nodeLayer->isVisible() )
           canvasLayers << nodeLayer->layer();
         if ( nodeLayer->customProperty( QStringLiteral( "overview" ), 0 ).toInt() )
           overviewLayers << nodeLayer->layer();
@@ -262,7 +262,7 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers( QgsLayerTreeNode *node, QList
   if ( QgsLayerTree::isLayer( node ) )
   {
     QgsLayerTreeLayer* nodeLayer = QgsLayerTree::toLayer( node );
-    if ( nodeLayer->isVisible() == Qt::Checked )
+    if ( nodeLayer->isVisible() )
       canvasLayers << nodeLayer->layer();
     if ( nodeLayer->customProperty( QStringLiteral( "overview" ), 0 ).toInt() )
       overviewLayers << nodeLayer->layer();

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -382,3 +382,25 @@ void QgsLayerTreeView::collapseAllNodes()
   _expandAllNodes( layerTreeModel()->rootGroup(), false, layerTreeModel() );
   collapseAll();
 }
+
+void QgsLayerTreeView::mouseReleaseEvent( QMouseEvent *event )
+{
+  const QgsLayerTreeModel::Flags oldFlags = layerTreeModel()->flags();
+  if ( event->modifiers() & Qt::ControlModifier )
+    layerTreeModel()->setFlags( oldFlags | QgsLayerTreeModel::ActionHierarchical );
+  else
+    layerTreeModel()->setFlags( oldFlags & ~QgsLayerTreeModel::ActionHierarchical );
+  QTreeView::mouseReleaseEvent( event );
+  layerTreeModel()->setFlags( oldFlags );
+}
+
+void QgsLayerTreeView::keyPressEvent( QKeyEvent *event )
+{
+  const QgsLayerTreeModel::Flags oldFlags = layerTreeModel()->flags();
+  if ( event->modifiers() & Qt::ControlModifier )
+    layerTreeModel()->setFlags( oldFlags | QgsLayerTreeModel::ActionHierarchical );
+  else
+    layerTreeModel()->setFlags( oldFlags & ~QgsLayerTreeModel::ActionHierarchical );
+  QTreeView::keyPressEvent( event );
+  layerTreeModel()->setFlags( oldFlags );
+}

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -111,6 +111,9 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
 
     QgsMapLayer* layerForIndex( const QModelIndex& index ) const;
 
+    void mouseReleaseEvent( QMouseEvent *event ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
+
   protected slots:
 
     void modelRowsInserted( const QModelIndex& index, int start, int end );

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -123,6 +123,60 @@ QAction* QgsLayerTreeViewDefaultActions::actionMutuallyExclusiveGroup( QObject* 
   return a;
 }
 
+QAction* QgsLayerTreeViewDefaultActions::actionCheckAndAllChildren( QObject* parent )
+{
+  QgsLayerTreeNode* node = mView->currentNode();
+  if ( !node || !QgsLayerTree::isGroup( node ) || node->isItemVisibilityCheckedRecursive() )
+    return nullptr;
+  QAction* a = new QAction( tr( "Check and all its children (Ctrl-click)" ), parent );
+  connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::checkAndAllChildren );
+  return a;
+}
+
+QAction* QgsLayerTreeViewDefaultActions::actionUncheckAndAllChildren( QObject* parent )
+{
+  QgsLayerTreeNode* node = mView->currentNode();
+  if ( !node || !QgsLayerTree::isGroup( node ) || node->isItemVisibilityUncheckedRecursive() )
+    return nullptr;
+  QAction* a = new QAction( tr( "Uncheck and all its children (Ctrl-click)" ), parent );
+  connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::uncheckAndAllChildren );
+  return a;
+}
+
+QAction* QgsLayerTreeViewDefaultActions::actionCheckAndAllParents( QObject* parent )
+{
+  QgsLayerTreeNode* node = mView->currentNode();
+  if ( !node || !QgsLayerTree::isLayer( node ) || node->isVisible() )
+    return nullptr;
+  QAction* a = new QAction( tr( "Check and all its parents (Ctrl-click)" ), parent );
+  connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::checkAndAllParents );
+  return a;
+}
+
+void QgsLayerTreeViewDefaultActions::checkAndAllChildren()
+{
+  QgsLayerTreeNode* node = mView->currentNode();
+  if ( !node )
+    return;
+  node->setItemVisibilityCheckedRecursive( true );
+}
+
+void QgsLayerTreeViewDefaultActions::uncheckAndAllChildren()
+{
+  QgsLayerTreeNode* node = mView->currentNode();
+  if ( !node )
+    return;
+  node->setItemVisibilityCheckedRecursive( false );
+}
+
+void QgsLayerTreeViewDefaultActions::checkAndAllParents()
+{
+  QgsLayerTreeNode* node = mView->currentNode();
+  if ( !node )
+    return;
+  node->setItemVisibilityCheckedParentRecursive( true );
+}
+
 void QgsLayerTreeViewDefaultActions::addGroup()
 {
   QgsLayerTreeGroup* group = mView->currentGroupNode();

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -148,7 +148,7 @@ QAction* QgsLayerTreeViewDefaultActions::actionCheckAndAllParents( QObject* pare
   QgsLayerTreeNode* node = mView->currentNode();
   if ( !node || !QgsLayerTree::isLayer( node ) || node->isVisible() )
     return nullptr;
-  QAction* a = new QAction( tr( "Check and all its parents (Ctrl-click)" ), parent );
+  QAction* a = new QAction( tr( "Check and all its parents" ), parent );
   connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::checkAndAllParents );
   return a;
 }

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -46,6 +46,15 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     QAction* actionRenameGroupOrLayer( QObject* parent = nullptr );
     QAction* actionShowFeatureCount( QObject* parent = nullptr );
 
+    //! Action to check a group and all its children
+    QAction* actionCheckAndAllChildren( QObject* parent = nullptr );
+
+    //! Action to uncheck a group and all its children
+    QAction* actionUncheckAndAllChildren( QObject* parent = nullptr );
+
+    //! Action to check a group and all its parents
+    QAction* actionCheckAndAllParents( QObject* parent = nullptr );
+
     QAction* actionZoomToLayer( QgsMapCanvas* canvas, QObject* parent = nullptr );
     QAction* actionZoomToGroup( QgsMapCanvas* canvas, QObject* parent = nullptr );
     // TODO: zoom to selected
@@ -74,6 +83,11 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     //! Slot to enable/disable mutually exclusive group flag
     //! @note added in 2.12
     void mutuallyExclusiveGroup();
+
+  private slots:
+    void checkAndAllChildren();
+    void uncheckAndAllChildren();
+    void checkAndAllParents();
 
   protected:
     void zoomToLayers( QgsMapCanvas* canvas, const QList<QgsMapLayer*>& layers );

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -180,12 +180,12 @@ void QgsOfflineEditingPluginGui::restoreState()
 void QgsOfflineEditingPluginGui::selectAll()
 {
   Q_FOREACH ( QgsLayerTreeLayer* nodeLayer, mLayerTree->layerTreeModel()->rootGroup()->findLayers() )
-    nodeLayer->setVisible( Qt::Checked );
+    nodeLayer->setItemVisibilityChecked( true );
 }
 
 
 void QgsOfflineEditingPluginGui::unSelectAll()
 {
   Q_FOREACH ( QgsLayerTreeLayer* nodeLayer, mLayerTree->layerTreeModel()->rootGroup()->findLayers() )
-    nodeLayer->setVisible( Qt::Unchecked );
+    nodeLayer->setItemVisibilityChecked( false );
 }


### PR DESCRIPTION
See https://github.com/qgis/QGIS-Enhancement-Proposals/issues/86

- Checking/unchecking a group doesn't change the check state of its children.
A node is visible if and only if it is checked and all its parents too.
- There is no more a semi-checked state for a group
- Ctrl-clic on a unchecked group will check the group and all its descendants.
- Ctrl-clic on a unchecked layer will check the lager and all its parents.
- Ctrl-clic on a checked group will uncheck the group and all its descendants.
- Ctrl-clic on a checked layer will uncheck the layer and all its parents.
- Those actions are available in contextual menu items in the tree view.
- Invisible layers because they or their parent(s) is unchecked are greyed out.