### PR TITLE
[Processing] Fix wrapping unicoded error messages

### DIFF
--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -214,7 +214,7 @@ class GeoAlgorithm:
             lines.append(traceback.format_exc())
             ProcessingLog.addToLog(ProcessingLog.LOG_ERROR, lines)
             raise GeoAlgorithmExecutionException(
-                unicode(e) + self.tr('\nSee log for more details'))
+                unicode(e.message, errors='ignore') + self.tr(u'\nSee log for more details'))
 
     def _checkParameterValuesBeforeExecuting(self):
         for param in self.parameters:

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -214,7 +214,7 @@ class GeoAlgorithm:
             lines.append(traceback.format_exc())
             ProcessingLog.addToLog(ProcessingLog.LOG_ERROR, lines)
             raise GeoAlgorithmExecutionException(
-                unicode(e.message, errors='ignore') + self.tr(u'\nSee log for more details'))
+                unicode(e.message, errors='replace') + self.tr(u'\nSee log for more details'))
 
     def _checkParameterValuesBeforeExecuting(self):
         for param in self.parameters:


### PR DESCRIPTION
Currently, Processing fails to display unicoded error mesages (e.g. localized postgres errors from psycopg2): 

```UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 1: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/share/qgis/python/plugins/processing/gui/AlgorithmDialog.py", line 223, in accept
    if runalg(self.alg, self):
  File "/usr/share/qgis/python/plugins/processing/gui/AlgorithmExecutor.py", line 51, in runalg
    alg.execute(progress)
  File "/usr/share/qgis/python/plugins/processing/core/GeoAlgorithm.py", line 218, in execute
    unicode(e) + self.tr(u'\nSee log for more details'))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 1: ordinal not in range(128)
```

This PR solves the problem by using the `errors='replace'` mode. Please note that mode requires the first parameter to be a string type, so the `Exception.message` must be used instead of the usual `Exception.__unicode__()`. 

In my case also encoding='utf8' parameter is helpful (otherwise non-ascii characters are blank), however I didn't want to not risk introducing a regression.