### PR TITLE
[processing] fix modeler output values in case algorithm(s) execution modifies those (fixes #16021)

### DIFF
--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -507,6 +507,15 @@ class ModelerAlgorithm(GeoAlgorithm):
                             t0 = time.time()
                             alg.algorithm.execute(progress, self)
                             dt = time.time() - t0
+
+                            # copy algorithm output value(s) back to model in case the algorithm modified those
+                            for out in alg.algorithm.outputs:
+                                if not out.hidden:
+                                    if out.name in alg.outputs:
+                                        modelOut = self.getOutputFromName(self.getSafeNameForOutput(alg.name, out.name))
+                                        if modelOut:
+                                            modelOut.value = out.value
+
                             executed.append(alg.name)
                             progress.setDebugInfo(
                                 self.tr('OK. Execution took %0.3f ms (%i outputs).', 'ModelerAlgorithm') % (dt, len(alg.algorithm.outputs)))


### PR DESCRIPTION
@alexbruy , @volaya , @nyalldawson , a number of algorithms, such as gdal's build virtual raster, modifies the output value upon execution for various reasons (for e.g. in the  above mentioned gdal algorithm, it insures the output filename extension is .VRT). If those algorithms are executed within a model, the output values are desynchronized, and results in brokenness (such as failure to add output to project, etc.)

This PR fixes that by copying algorithm's output(s)' value back to the model after execution.