### PR TITLE
[FEATURE] Zoom in/out and fit items to view actions for the modeler

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -32,8 +32,8 @@ import os
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt, QRectF, QMimeData, QPoint, QPointF, QSettings, QByteArray, QSize, QSizeF, pyqtSignal
-from qgis.PyQt.QtWidgets import QGraphicsView, QTreeWidget, QMessageBox, QFileDialog, QTreeWidgetItem, QSizePolicy, QMainWindow
-from qgis.PyQt.QtGui import QIcon, QImage, QPainter
+from qgis.PyQt.QtWidgets import QGraphicsView, QTreeWidget, QMessageBox, QFileDialog, QTreeWidgetItem, QSizePolicy, QMainWindow, QShortcut
+from qgis.PyQt.QtGui import QIcon, QImage, QPainter, QKeySequence
 from qgis.PyQt.QtSvg import QSvgGenerator
 from qgis.PyQt.QtPrintSupport import QPrinter
 from qgis.core import QgsApplication
@@ -209,11 +209,19 @@ class ModelerDialog(BASE, WIDGET):
         self.searchBox.textChanged.connect(self.fillAlgorithmTree)
         self.algorithmTree.doubleClicked.connect(self.addAlgorithm)
 
+        # Ctrl+= should also trigger a zoom in action
+        ctrlEquals = QShortcut(QKeySequence("Ctrl+="), self)
+        ctrlEquals.activated.connect(self.zoomIn)
+
         iconSize = settings.value("iconsize", 24)
         self.mToolbar.setIconSize(QSize(iconSize, iconSize))
         self.mActionOpen.triggered.connect(self.openModel)
         self.mActionSave.triggered.connect(self.save)
         self.mActionSaveAs.triggered.connect(self.saveAs)
+        self.mActionZoomIn.triggered.connect(self.zoomIn)
+        self.mActionZoomOut.triggered.connect(self.zoomOut)
+        self.mActionZoomActual.triggered.connect(self.zoomActual)
+        self.mActionZoomToItems.triggered.connect(self.zoomToItems)
         self.mActionExportImage.triggered.connect(self.exportAsImage)
         self.mActionExportPdf.triggered.connect(self.exportAsPdf)
         self.mActionExportSvg.triggered.connect(self.exportAsSvg)
@@ -289,6 +297,39 @@ class ModelerDialog(BASE, WIDGET):
 
     def saveAs(self):
         self.saveModel(True)
+
+    def zoomIn(self):
+        self.view.setTransformationAnchor(QGraphicsView.NoAnchor)
+        point = self.view.mapToScene(QPoint(self.view.viewport().width() / 2, self.view.viewport().height() / 2))
+
+        settings = QSettings()
+        factor = settings.value('/qgis/zoom_favor', 2.0)
+
+        self.view.scale(factor, factor)
+        self.view.centerOn(point)
+        self.repaintModel()
+
+    def zoomOut(self):
+        self.view.setTransformationAnchor(QGraphicsView.NoAnchor)
+        point = self.view.mapToScene(QPoint(self.view.viewport().width() / 2, self.view.viewport().height() / 2))
+
+        settings = QSettings()
+        factor = settings.value('/qgis/zoom_favor', 2.0)
+        factor = 1 / factor
+
+        self.view.scale(factor, factor)
+        self.view.centerOn(point)
+        self.repaintModel()
+
+    def zoomActual(self):
+        point = self.view.mapToScene(QPoint(self.view.viewport().width() / 2, self.view.viewport().height() / 2))
+        self.view.resetTransform()
+        self.view.centerOn(point)
+
+    def zoomToItems(self):
+        totalRect = self.scene.itemsBoundingRect()
+        totalRect.adjust(-10, -10, 10, 10)
+        self.view.fitInView(totalRect, Qt.KeepAspectRatio)
 
     def exportAsImage(self):
         self.repaintModel(controls=False)

--- a/python/plugins/processing/ui/DlgModeler.ui
+++ b/python/plugins/processing/ui/DlgModeler.ui
@@ -309,6 +309,11 @@
    <addaction name="mActionSave"/>
    <addaction name="mActionSaveAs"/>
    <addaction name="separator"/>
+   <addaction name="mActionZoomIn"/>
+   <addaction name="mActionZoomOut"/>
+   <addaction name="mActionZoomActual"/>
+   <addaction name="mActionZoomToItems"/>
+   <addaction name="separator"/>
    <addaction name="mActionExportImage"/>
    <addaction name="mActionExportPdf"/>
    <addaction name="mActionExportSvg"/>
@@ -363,6 +368,51 @@
     <string>Ctrl+Shift+S</string>
    </property>
   </action>
+  <action name="mActionZoomActual">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomActual.svg</normaloff>:/images/themes/default/mActionZoomActual.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom to &amp;100%</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom to &amp;100%</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+1</string>
+   </property>
+  </action>
+  <action name="mActionZoomIn">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomIn.svg</normaloff>:/images/themes/default/mActionZoomIn.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom in</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom in</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl++</string>
+   </property>
+  </action>
+  <action name="mActionZoomOut">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomOut.svg</normaloff>:/images/themes/default/mActionZoomOut.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom out</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom out</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+-</string>
+   </property>
+  </action>
   <action name="mActionExportImage">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -373,6 +423,21 @@
    </property>
    <property name="toolTip">
     <string>Export as image</string>
+   </property>
+  </action>
+  <action name="mActionZoomToItems">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomFullExtent.svg</normaloff>:/images/themes/default/mActionZoomFullExtent.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom full</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom full</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+0</string>
    </property>
   </action>
   <action name="mActionExportPdf">


### PR DESCRIPTION
Feature in action:
![peek 2017-01-03 11-25](https://cloud.githubusercontent.com/assets/1728657/21600062/e6ab7ffe-d1a8-11e6-94f5-cd11930024d9.gif)

With large models, a zoom to full items' extent is quite useful.