### PR TITLE
Bump minimum GDAL version to 2.0, remove old version #ifdefs

### DIFF
--- a/cmake/FindGDAL.cmake
+++ b/cmake/FindGDAL.cmake
@@ -61,13 +61,9 @@ ELSE(WIN32)
           ENDIF (NOT GDAL_VERSION)
           STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GDAL_VERSION_MAJOR "${GDAL_VERSION}")
           STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GDAL_VERSION_MINOR "${GDAL_VERSION}")
-          IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-            MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
-          ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-
-          IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 11))
-            MESSAGE (WARNING "GDAL version is too old (${GDAL_VERSION}) to support GeoPackage. 1.11.0 or higher is recommended.")
-          ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 11))
+          IF (GDAL_VERSION_MAJOR LESS 2)
+            MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 2.0 or higher.")
+          ENDIF (GDAL_VERSION_MAJOR LESS 2)
 
         ENDIF (GDAL_LIBRARY)
         SET (CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK_save} CACHE STRING "" FORCE)
@@ -105,14 +101,10 @@ ELSE(WIN32)
   
         # check for gdal version
         # version 1.2.5 is known NOT to be supported (missing CPL_STDCALL macro)
-        # According to INSTALL, 1.4.0+ is required
-        IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-          MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
-        ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-
-        IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 11))
-          MESSAGE (WARNING "GDAL version is too old (${GDAL_VERSION}) to support GeoPackage. 1.11.0 or higher is recommended.")
-        ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 11))
+        # According to INSTALL, 2.0+ is required
+        IF (GDAL_VERSION_MAJOR LESS 2)
+          MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 2.0 or higher.")
+        ENDIF (GDAL_VERSION_MAJOR LESS 2)
 
         # set INCLUDE_DIR to prefix+include
         EXEC_PROGRAM(${GDAL_CONFIG}

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -23,8 +23,6 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-#define TO8F(x) (x).toUtf8().constData()
-
 QgsKernelDensityEstimation::QgsKernelDensityEstimation( const QgsKernelDensityEstimation::Parameters& parameters, const QString& outputFile, const QString& outputFormat )
     : mInputLayer( parameters.vectorLayer )
     , mOutputFile( outputFile )
@@ -95,7 +93,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
     return FileCreationError;
 
   // open the raster in GA_Update mode
-  mDatasetH = GDALOpen( TO8F( mOutputFile ), GA_Update );
+  mDatasetH = GDALOpen( mOutputFile.toUtf8().constData(), GA_Update );
   if ( !mDatasetH )
     return FileCreationError;
   mRasterBandH = GDALGetRasterBand( mDatasetH, 1 );

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -23,11 +23,7 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#endif
 
 QgsKernelDensityEstimation::QgsKernelDensityEstimation( const QgsKernelDensityEstimation::Parameters& parameters, const QString& outputFile, const QString& outputFormat )
     : mInputLayer( parameters.vectorLayer )

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -21,11 +21,7 @@
 #include <QProgressDialog>
 #include <QFile>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#endif
 
 QgsNineCellFilter::QgsNineCellFilter( const QString& inputFile, const QString& outputFile, const QString& outputFormat )
     : mInputFile( inputFile )

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -21,8 +21,6 @@
 #include <QProgressDialog>
 #include <QFile>
 
-#define TO8F(x) (x).toUtf8().constData()
-
 QgsNineCellFilter::QgsNineCellFilter( const QString& inputFile, const QString& outputFile, const QString& outputFormat )
     : mInputFile( inputFile )
     , mOutputFile( outputFile )
@@ -204,7 +202,7 @@ int QgsNineCellFilter::processRaster( QProgressDialog* p )
   if ( p && p->wasCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    GDALDeleteDataset( outputDriver, TO8F( mOutputFile ) );
+    GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
     return 7;
   }
   GDALClose( outputDataset );
@@ -214,7 +212,7 @@ int QgsNineCellFilter::processRaster( QProgressDialog* p )
 
 GDALDatasetH QgsNineCellFilter::openInputFile( int& nCellsX, int& nCellsY )
 {
-  GDALDatasetH inputDataset = GDALOpen( TO8F( mInputFile ), GA_ReadOnly );
+  GDALDatasetH inputDataset = GDALOpen( mInputFile.toUtf8().constData(), GA_ReadOnly );
   if ( inputDataset )
   {
     nCellsX = GDALGetRasterXSize( inputDataset );
@@ -263,7 +261,7 @@ GDALDatasetH QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALD
 
   //open output file
   char **papszOptions = nullptr;
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, TO8F( mOutputFile ), xSize, ySize, 1, GDT_Float32, papszOptions );
+  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 1, GDT_Float32, papszOptions );
   if ( !outputDataset )
   {
     return outputDataset;

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -29,13 +29,8 @@
 #include <cpl_string.h>
 #include <gdalwarper.h>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8(x)   (x).toUtf8().constData()
 #define TO8F(x)  (x).toUtf8().constData()
-#else
-#define TO8(x)   (x).toLocal8Bit().constData()
-#define TO8F(x)  QFile::encodeName( x ).constData()
-#endif
 
 QgsRasterCalculator::QgsRasterCalculator( const QString& formulaString, const QString& outputFile, const QString& outputFormat,
     const QgsRectangle& outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry>& rasterEntries )

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -29,9 +29,6 @@
 #include <cpl_string.h>
 #include <gdalwarper.h>
 
-#define TO8(x)   (x).toUtf8().constData()
-#define TO8F(x)  (x).toUtf8().constData()
-
 QgsRasterCalculator::QgsRasterCalculator( const QString& formulaString, const QString& outputFile, const QString& outputFormat,
     const QgsRectangle& outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry>& rasterEntries )
     : mFormulaString( formulaString )
@@ -175,7 +172,7 @@ int QgsRasterCalculator::processCalculation( QProgressDialog* p )
   if ( p && p->wasCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    GDALDeleteDataset( outputDriver, TO8F( mOutputFile ) );
+    GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
     return static_cast< int >( Cancelled );
   }
   GDALClose( outputDataset );
@@ -214,7 +211,7 @@ GDALDatasetH QgsRasterCalculator::openOutputFile( GDALDriverH outputDriver )
 {
   //open output file
   char **papszOptions = nullptr;
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, TO8F( mOutputFile ), mNumOutputColumns, mNumOutputRows, 1, GDT_Float32, papszOptions );
+  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), mNumOutputColumns, mNumOutputRows, 1, GDT_Float32, papszOptions );
   if ( !outputDataset )
   {
     return outputDataset;

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -28,11 +28,7 @@
 #include <QFile>
 #include <QTextStream>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#endif
 
 QgsRelief::QgsRelief( const QString& inputFile, const QString& outputFile, const QString& outputFormat )
     : mInputFile( inputFile )

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -28,8 +28,6 @@
 #include <QFile>
 #include <QTextStream>
 
-#define TO8F(x) (x).toUtf8().constData()
-
 QgsRelief::QgsRelief( const QString& inputFile, const QString& outputFile, const QString& outputFormat )
     : mInputFile( inputFile )
     , mOutputFile( outputFile )
@@ -288,7 +286,7 @@ int QgsRelief::processRaster( QProgressDialog* p )
   if ( p && p->wasCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    GDALDeleteDataset( outputDriver, TO8F( mOutputFile ) );
+    GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
     return 7;
   }
   GDALClose( outputDataset );
@@ -411,7 +409,7 @@ bool QgsRelief::setElevationColor( double elevation, int* red, int* green, int* 
 //duplicated from QgsNineCellFilter. Todo: make common base class
 GDALDatasetH QgsRelief::openInputFile( int& nCellsX, int& nCellsY )
 {
-  GDALDatasetH inputDataset = GDALOpen( TO8F( mInputFile ), GA_ReadOnly );
+  GDALDatasetH inputDataset = GDALOpen( mInputFile.toUtf8().constData(), GA_ReadOnly );
   if ( inputDataset )
   {
     nCellsX = GDALGetRasterXSize( inputDataset );
@@ -465,7 +463,7 @@ GDALDatasetH QgsRelief::openOutputFile( GDALDatasetH inputDataset, GDALDriverH o
   papszOptions = CSLSetNameValue( papszOptions, "COMPRESS", "PACKBITS" );
 
   //create three band raster (reg, green, blue)
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, TO8F( mOutputFile ), xSize, ySize, 3, GDT_Byte, papszOptions );
+  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 3, GDT_Byte, papszOptions );
   if ( !outputDataset )
   {
     return outputDataset;

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -28,11 +28,7 @@
 #include <QProgressDialog>
 #include <QFile>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#endif
 
 QgsZonalStatistics::QgsZonalStatistics( QgsVectorLayer* polygonLayer, const QString& rasterFile, const QString& attributePrefix, int rasterBand, Statistics stats )
     : mRasterFilePath( rasterFile )

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -28,8 +28,6 @@
 #include <QProgressDialog>
 #include <QFile>
 
-#define TO8F(x) (x).toUtf8().constData()
-
 QgsZonalStatistics::QgsZonalStatistics( QgsVectorLayer* polygonLayer, const QString& rasterFile, const QString& attributePrefix, int rasterBand, Statistics stats )
     : mRasterFilePath( rasterFile )
     , mRasterBand( rasterBand )
@@ -65,7 +63,7 @@ int QgsZonalStatistics::calculateStatistics( QProgressDialog* p )
 
   //open the raster layer and the raster band
   GDALAllRegister();
-  GDALDatasetH inputDataset = GDALOpen( TO8F( mRasterFilePath ), GA_ReadOnly );
+  GDALDatasetH inputDataset = GDALOpen( mRasterFilePath.toUtf8().constData(), GA_ReadOnly );
   if ( !inputDataset )
   {
     return 3;

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -69,11 +69,6 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
   cbMergeLayers->setChecked( s.value( "/DwgImport/lastMergeLayers", false ).toBool() );
   cbUseCurves->setChecked( s.value( "/DwgImport/lastUseCurves", true ).toBool() );
 
-#if !defined(GDAL_COMPUTE_VERSION) || GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(2,0,0)
-  cbUseCurves->setChecked( false );
-  cbUseCurves->setHidden( true );
-#endif
-
   leDrawing->setReadOnly( true );
   pbImportDrawing->setHidden( true );
   lblMessage->setHidden( true );

--- a/src/app/dwg/qgsdwgimporter.cpp
+++ b/src/app/dwg/qgsdwgimporter.cpp
@@ -140,7 +140,6 @@ void QgsDwgImporter::startTransaction()
 {
   Q_ASSERT( mDs );
 
-#if defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,0,0)
   mInTransaction = GDALDatasetStartTransaction( mDs, 0 ) == OGRERR_NONE;
   if ( !mInTransaction )
   {
@@ -148,14 +147,12 @@ void QgsDwgImporter::startTransaction()
          .arg( mDatabase )
          .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
   }
-#endif
 }
 
 void QgsDwgImporter::commitTransaction()
 {
   Q_ASSERT( mDs != nullptr );
 
-#if defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,0,0)
   if ( mInTransaction && GDALDatasetCommitTransaction( mDs ) != OGRERR_NONE )
   {
     LOG( QObject::tr( "Could not commit transaction\nDatabase:%1\nError:%2" )
@@ -163,7 +160,6 @@ void QgsDwgImporter::commitTransaction()
          .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
   }
   mInTransaction = false;
-#endif
 }
 
 QgsDwgImporter::~QgsDwgImporter()
@@ -186,13 +182,8 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
   OGRwkbGeometryType lineGeomType, hatchGeomType;
   if ( useCurves )
   {
-#if !defined(GDAL_COMPUTE_VERSION) || GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(2,0,0)
-    error = QObject::tr( "Curves only supported with GDAL2" );
-    return false;
-#else
     lineGeomType = wkbCompoundCurveZ;
     hatchGeomType = wkbCurvePolygonZ;
-#endif
   }
   else
   {

--- a/src/app/ogr/qgsnewogrconnection.cpp
+++ b/src/app/ogr/qgsnewogrconnection.cpp
@@ -26,11 +26,7 @@
 #include <ogr_api.h>
 #include <cpl_error.h>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#endif
 
 QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString& connType, const QString& connName, Qt::WindowFlags fl )
     : QDialog( parent, fl )

--- a/src/app/ogr/qgsnewogrconnection.cpp
+++ b/src/app/ogr/qgsnewogrconnection.cpp
@@ -26,8 +26,6 @@
 #include <ogr_api.h>
 #include <cpl_error.h>
 
-#define TO8F(x) (x).toUtf8().constData()
-
 QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString& connType, const QString& connName, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mOriginalConnName( connName )
@@ -85,7 +83,7 @@ void QgsNewOgrConnection::testConnection()
   OGRDataSourceH       poDS;
   OGRSFDriverH         pahDriver;
   CPLErrorReset();
-  poDS = OGROpen( TO8F( uri ), false, &pahDriver );
+  poDS = OGROpen( uri.toUtf8().constData(), false, &pahDriver );
   if ( !poDS )
   {
     QMessageBox::information( this, tr( "Test connection" ), tr( "Connection failed - Check settings and try again.\n\nExtended error information:\n%1" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -266,9 +266,7 @@
 #include <gdal_version.h>
 #include <proj_api.h>
 
-#if defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(1,11,0)
 #define SUPPORT_GEOPACKAGE
-#endif
 
 //
 // Other includes

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -266,8 +266,6 @@
 #include <gdal_version.h>
 #include <proj_api.h>
 
-#define SUPPORT_GEOPACKAGE
-
 //
 // Other includes
 //
@@ -1962,10 +1960,6 @@ void QgisApp::createMenus()
    */
 
   // Layer menu
-#ifndef SUPPORT_GEOPACKAGE
-  mProjectMenu->removeAction( mActionDwgImport );
-  mNewLayerMenu->removeAction( mActionNewGeoPackageLayer );
-#endif
 
   // Panel and Toolbar Submenus
   mPanelMenu = new QMenu( tr( "Panels" ), this );
@@ -2239,9 +2233,7 @@ void QgisApp::createToolBars()
   bt->setPopupMode( QToolButton::MenuButtonPopup );
   bt->addAction( mActionNewVectorLayer );
   bt->addAction( mActionNewSpatiaLiteLayer );
-#ifdef SUPPORT_GEOPACKAGE
   bt->addAction( mActionNewGeoPackageLayer );
-#endif
   bt->addAction( mActionNewMemoryLayer );
 
   QAction* defNewLayerAction = mActionNewVectorLayer;
@@ -2256,11 +2248,9 @@ void QgisApp::createToolBars()
     case 2:
       defNewLayerAction = mActionNewMemoryLayer;
       break;
-#ifdef SUPPORT_GEOPACKAGE
     case 3:
       defNewLayerAction = mActionNewGeoPackageLayer;
       break;
-#endif
   }
   bt->setDefaultAction( defNewLayerAction );
   QAction* newLayerAction = mLayerToolBar->addWidget( bt );

--- a/src/app/qgsalignrasterdialog.cpp
+++ b/src/app/qgsalignrasterdialog.cpp
@@ -393,13 +393,11 @@ QgsAlignRasterLayerConfigDialog::QgsAlignRasterLayerConfigDialog()
   cboResample->addItem( tr( "Lanczos (6x6 kernel)" ), QgsAlignRaster::RA_Lanczos );
   cboResample->addItem( tr( "Average" ), QgsAlignRaster::RA_Average );
   cboResample->addItem( tr( "Mode" ), QgsAlignRaster::RA_Mode );
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 2000000
   cboResample->addItem( tr( "Maximum" ), QgsAlignRaster::RA_Max );
   cboResample->addItem( tr( "Minimum" ), QgsAlignRaster::RA_Min );
   cboResample->addItem( tr( "Median" ), QgsAlignRaster::RA_Median );
   cboResample->addItem( tr( "First Quartile (Q1)" ), QgsAlignRaster::RA_Q1 );
   cboResample->addItem( tr( "Third Quartile (Q3)" ), QgsAlignRaster::RA_Q3 );
-#endif
 
   editOutput = new QLineEdit( this );
   btnBrowse = new QPushButton( tr( "Browse..." ), this );

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1852,12 +1852,8 @@ void QgsOptions::loadGdalDriverList()
 
     // in GDAL 2.0 vector and mixed drivers are returned by GDALGetDriver, so filter out non-raster drivers
     // TODO add same UI for vector drivers
-#ifdef GDAL_COMPUTE_VERSION
-#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,0,0)
     if ( QString( GDALGetMetadataItem( myGdalDriver, GDAL_DCAP_RASTER, nullptr ) ) != "YES" )
       continue;
-#endif
-#endif
 
     myGdalDriverDescription = GDALGetDescription( myGdalDriver );
     myDrivers << myGdalDriverDescription;

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -47,11 +47,7 @@ const int Qgis::QGIS_VERSION_INT = VERSION_INT;
 // Release name
 QString Qgis::QGIS_RELEASE_NAME( QStringLiteral( RELEASE_NAME ) );
 
-#if GDAL_VERSION_NUM >= 1800
 const QString GEOPROJ4 = QStringLiteral( "+proj=longlat +datum=WGS84 +no_defs" );
-#else
-const QString GEOPROJ4 = "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs";
-#endif
 
 const QString GEOWKT =
   "GEOGCS[\"WGS 84\", "

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -214,12 +214,10 @@ bool QgsCoordinateReferenceSystem::createFromUserInput( const QString &theDefini
   OGRSpatialReferenceH crs = OSRNewSpatialReference( nullptr );
 
   // make sure towgs84 parameter is loaded if using an ESRI definition and gdal >= 1.9
-#if GDAL_VERSION_NUM >= 1900
   if ( theDefinition.startsWith( QLatin1String( "ESRI::" ) ) )
   {
     setupESRIWktFix();
   }
-#endif
 
   if ( OSRSetFromUserInput( crs, theDefinition.toLocal8Bit().constData() ) == OGRERR_NONE )
   {
@@ -238,7 +236,6 @@ void QgsCoordinateReferenceSystem::setupESRIWktFix()
 {
   // make sure towgs84 parameter is loaded if gdal >= 1.9
   // this requires setting GDAL_FIX_ESRI_WKT=GEOGCS (see qgis bug #5598 and gdal bug #4673)
-#if GDAL_VERSION_NUM >= 1900
   const char* configOld = CPLGetConfigOption( "GDAL_FIX_ESRI_WKT", "" );
   const char* configNew = "GEOGCS";
   // only set if it was not set, to let user change the value if needed
@@ -254,7 +251,6 @@ void QgsCoordinateReferenceSystem::setupESRIWktFix()
   {
     QgsDebugMsg( QString( "GDAL_FIX_ESRI_WKT was already set : %1" ).arg( configNew ) );
   }
-#endif
 }
 
 bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString& theCrs )

--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -868,11 +868,7 @@ void QgsGmlStreamingParser::endElement( const XML_Char* el )
       {
         const int wkbSize = OGR_G_WkbSize( hGeom );
         unsigned char* pabyBuffer = new unsigned char[ wkbSize ];
-#if GDAL_VERSION_MAJOR >= 2
         OGR_G_ExportToIsoWkb( hGeom, wkbNDR, pabyBuffer );
-#else
-        OGR_G_ExportToWkb( hGeom, wkbNDR, pabyBuffer );
-#endif
         QgsGeometry g;
         g.fromWkb( pabyBuffer, wkbSize );
         if ( mInvertAxisOrientation )

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -21,10 +21,6 @@
 #include <QTextCodec>
 #include <QUuid>
 
-#define TO8(x)   (x).toUtf8().constData()
-#define TO8F(x)  (x).toUtf8().constData()
-#define FROM8(x) QString::fromUtf8(x)
-
 QgsFeature QgsOgrUtils::readOgrFeature( OGRFeatureH ogrFet, const QgsFields& fields, QTextCodec* encoding )
 {
   QgsFeature feature;
@@ -233,13 +229,13 @@ QgsFeatureList QgsOgrUtils::stringToFeatureList( const QString& string, const Qg
 
   // create memory file system object from string buffer
   QByteArray ba = string.toUtf8();
-  VSIFCloseL( VSIFileFromMemBuffer( TO8( randomFileName ), reinterpret_cast< GByte* >( ba.data() ),
+  VSIFCloseL( VSIFileFromMemBuffer( randomFileName.toUtf8().constData(), reinterpret_cast< GByte* >( ba.data() ),
                                     static_cast< vsi_l_offset >( ba.size() ), FALSE ) );
 
-  OGRDataSourceH hDS = OGROpen( TO8( randomFileName ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( randomFileName.toUtf8().constData(), false, nullptr );
   if ( !hDS )
   {
-    VSIUnlink( TO8( randomFileName ) );
+    VSIUnlink( randomFileName.toUtf8().constData() );
     return features;
   }
 
@@ -247,7 +243,7 @@ QgsFeatureList QgsOgrUtils::stringToFeatureList( const QString& string, const Qg
   if ( !ogrLayer )
   {
     OGR_DS_Destroy( hDS );
-    VSIUnlink( TO8( randomFileName ) );
+    VSIUnlink( randomFileName.toUtf8().constData() );
     return features;
   }
 
@@ -262,7 +258,7 @@ QgsFeatureList QgsOgrUtils::stringToFeatureList( const QString& string, const Qg
   }
 
   OGR_DS_Destroy( hDS );
-  VSIUnlink( TO8( randomFileName ) );
+  VSIUnlink( randomFileName.toUtf8().constData() );
 
   return features;
 }
@@ -277,13 +273,13 @@ QgsFields QgsOgrUtils::stringToFields( const QString& string, QTextCodec* encodi
 
   // create memory file system object from buffer
   QByteArray ba = string.toUtf8();
-  VSIFCloseL( VSIFileFromMemBuffer( TO8( randomFileName ), reinterpret_cast< GByte* >( ba.data() ),
+  VSIFCloseL( VSIFileFromMemBuffer( randomFileName.toUtf8().constData(), reinterpret_cast< GByte* >( ba.data() ),
                                     static_cast< vsi_l_offset >( ba.size() ), FALSE ) );
 
-  OGRDataSourceH hDS = OGROpen( TO8( randomFileName ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( randomFileName.toUtf8().constData(), false, nullptr );
   if ( !hDS )
   {
-    VSIUnlink( TO8( randomFileName ) );
+    VSIUnlink( randomFileName.toUtf8().constData() );
     return fields;
   }
 
@@ -291,7 +287,7 @@ QgsFields QgsOgrUtils::stringToFields( const QString& string, QTextCodec* encodi
   if ( !ogrLayer )
   {
     OGR_DS_Destroy( hDS );
-    VSIUnlink( TO8( randomFileName ) );
+    VSIUnlink( randomFileName.toUtf8().constData() );
     return fields;
   }
 
@@ -304,6 +300,6 @@ QgsFields QgsOgrUtils::stringToFields( const QString& string, QTextCodec* encodi
   }
 
   OGR_DS_Destroy( hDS );
-  VSIUnlink( TO8( randomFileName ) );
+  VSIUnlink( randomFileName.toUtf8().constData() );
   return fields;
 }

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -21,15 +21,9 @@
 #include <QTextCodec>
 #include <QUuid>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8(x)   (x).toUtf8().constData()
 #define TO8F(x)  (x).toUtf8().constData()
 #define FROM8(x) QString::fromUtf8(x)
-#else
-#define TO8(x)   (x).toLocal8Bit().constData()
-#define TO8F(x)  QFile::encodeName( x ).constData()
-#define FROM8(x) QString::fromLocal8Bit(x)
-#endif
 
 QgsFeature QgsOgrUtils::readOgrFeature( OGRFeatureH ogrFet, const QgsFields& fields, QTextCodec* encoding )
 {
@@ -80,15 +74,12 @@ QgsFields QgsOgrUtils::readOgrFields( OGRFeatureH ogrFet, QTextCodec* encoding )
       case OFTInteger:
         varType = QVariant::Int;
         break;
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 2000000
       case OFTInteger64:
         varType = QVariant::LongLong;
         break;
-#endif
       case OFTReal:
         varType = QVariant::Double;
         break;
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1400
       case OFTDate:
         varType = QVariant::Date;
         break;
@@ -99,7 +90,6 @@ QgsFields QgsOgrUtils::readOgrFields( OGRFeatureH ogrFet, QTextCodec* encoding )
         varType = QVariant::DateTime;
         break;
       case OFTString:
-#endif
       default:
         varType = QVariant::String; // other unsupported, leave it as a string
     }
@@ -148,11 +138,9 @@ QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField
       case QVariant::Int:
         value = QVariant( OGR_F_GetFieldAsInteger( ogrFet, attIndex ) );
         break;
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 2000000
       case QVariant::LongLong:
         value = QVariant( OGR_F_GetFieldAsInteger64( ogrFet, attIndex ) );
         break;
-#endif
       case QVariant::Double:
         value = QVariant( OGR_F_GetFieldAsDouble( ogrFet, attIndex ) );
         break;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -50,8 +50,6 @@
 #include <cpl_conv.h>
 #include <gdal.h>
 
-#define TO8F(x)  (x).toUtf8().constData()
-
 QgsVectorFileWriter::FieldValueConverter::FieldValueConverter()
 {
 }
@@ -275,9 +273,9 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
   // create the data source
   if ( action == CreateOrOverwriteFile )
-    mDS = OGR_Dr_CreateDataSource( poDriver, TO8F( vectorFileName ), options );
+    mDS = OGR_Dr_CreateDataSource( poDriver, vectorFileName.toUtf8().constData(), options );
   else
-    mDS = OGROpen( TO8F( vectorFileName ), TRUE, nullptr );
+    mDS = OGROpen( vectorFileName.toUtf8().constData(), TRUE, nullptr );
 
   if ( options )
   {
@@ -309,7 +307,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     for ( int i = 0; i < layer_count; i++ )
     {
       OGRLayerH hLayer = OGR_DS_GetLayer( mDS, i );
-      if ( EQUAL( OGR_L_GetName( hLayer ), TO8F( layerName ) ) )
+      if ( EQUAL( OGR_L_GetName( hLayer ), layerName.toUtf8().constData() ) )
       {
         if ( OGR_DS_DeleteLayer( mDS, i ) != OGRERR_NONE )
         {
@@ -377,9 +375,9 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   CPLSetConfigOption( "SHAPE_ENCODING", "" );
 
   if ( action == CreateOrOverwriteFile || action == CreateOrOverwriteLayer )
-    mLayer = OGR_DS_CreateLayer( mDS, TO8F( layerName ), mOgrRef, wkbType, options );
+    mLayer = OGR_DS_CreateLayer( mDS, layerName.toUtf8().constData(), mOgrRef, wkbType, options );
   else
-    mLayer = OGR_DS_GetLayerByName( mDS, TO8F( layerName ) );
+    mLayer = OGR_DS_GetLayerByName( mDS, layerName.toUtf8().constData() );
 
   if ( options )
   {
@@ -2609,11 +2607,11 @@ QMap<QString, QString> QgsVectorFileWriter::ogrDriverList()
           poDriver = OGRGetDriverByName( drvName.toLocal8Bit().constData() );
           if ( poDriver )
           {
-            OGRDataSourceH ds = OGR_Dr_CreateDataSource( poDriver, TO8F( QString( "/vsimem/spatialitetest.sqlite" ) ), options );
+            OGRDataSourceH ds = OGR_Dr_CreateDataSource( poDriver, QString( "/vsimem/spatialitetest.sqlite" ).toUtf8().constData(), options );
             if ( ds )
             {
               writableDrivers << QStringLiteral( "SpatiaLite" );
-              OGR_Dr_DeleteDataSource( poDriver, TO8F( QString( "/vsimem/spatialitetest.sqlite" ) ) );
+              OGR_Dr_DeleteDataSource( poDriver, QString( "/vsimem/spatialitetest.sqlite" ).toUtf8().constData() );
               OGR_DS_Destroy( ds );
             }
           }
@@ -3013,7 +3011,7 @@ QStringList QgsVectorFileWriter::concatenateOptions( const QMap<QString, QgsVect
 QgsVectorFileWriter::EditionCapabilities QgsVectorFileWriter::editionCapabilities( const QString& datasetName )
 {
   OGRSFDriverH hDriver = nullptr;
-  OGRDataSourceH hDS = OGROpen( TO8F( datasetName ), TRUE, &hDriver );
+  OGRDataSourceH hDS = OGROpen( datasetName.toUtf8().constData(), TRUE, &hDriver );
   if ( !hDS )
     return 0;
   QString drvName = OGR_Dr_GetName( hDriver );
@@ -3054,7 +3052,7 @@ bool QgsVectorFileWriter::targetLayerExists( const QString& datasetName,
     const QString& layerNameIn )
 {
   OGRSFDriverH hDriver = nullptr;
-  OGRDataSourceH hDS = OGROpen( TO8F( datasetName ), TRUE, &hDriver );
+  OGRDataSourceH hDS = OGROpen( datasetName.toUtf8().constData(), TRUE, &hDriver );
   if ( !hDS )
     return false;
 
@@ -3062,7 +3060,7 @@ bool QgsVectorFileWriter::targetLayerExists( const QString& datasetName,
   if ( layerName.isEmpty() )
     layerName = QFileInfo( datasetName ).baseName();
 
-  bool ret = OGR_DS_GetLayerByName( hDS, TO8F( layerName ) );
+  bool ret = OGR_DS_GetLayerByName( hDS, layerName.toUtf8().constData() );
   OGR_DS_Destroy( hDS );
   return ret;
 }
@@ -3074,10 +3072,10 @@ bool QgsVectorFileWriter::areThereNewFieldsToCreate( const QString& datasetName,
     const QgsAttributeList& attributes )
 {
   OGRSFDriverH hDriver = nullptr;
-  OGRDataSourceH hDS = OGROpen( TO8F( datasetName ), TRUE, &hDriver );
+  OGRDataSourceH hDS = OGROpen( datasetName.toUtf8().constData(), TRUE, &hDriver );
   if ( !hDS )
     return false;
-  OGRLayerH hLayer = OGR_DS_GetLayerByName( hDS, TO8F( layerName ) );
+  OGRLayerH hLayer = OGR_DS_GetLayerByName( hDS, layerName.toUtf8().constData() );
   if ( !hLayer )
   {
     OGR_DS_Destroy( hDS );
@@ -3088,7 +3086,7 @@ bool QgsVectorFileWriter::areThereNewFieldsToCreate( const QString& datasetName,
   Q_FOREACH ( int idx, attributes )
   {
     QgsField fld = layer->fields().at( idx );
-    if ( OGR_FD_GetFieldIndex( defn, TO8F( fld.name() ) ) < 0 )
+    if ( OGR_FD_GetFieldIndex( defn, fld.name().toUtf8().constData() ) < 0 )
     {
       ret = true;
       break;

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -540,9 +540,7 @@ class CORE_EXPORT QgsVectorFileWriter
 
     SymbologyExport mSymbologyExport;
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1700
     QMap< QgsSymbolLayer*, QString > mSymbolLayerTable;
-#endif
 
     //! Scale for symbology export (e.g. for symbols units in map units)
     double mSymbologyScaleDenominator;

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -42,14 +42,12 @@
 #include <cpl_error.h>
 #include <cpl_string.h>
 
-#if defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,0,0)
 #define SUPPORT_GEOMETRY_LESS
 #define SUPPORT_CURVE_GEOMETRIES
 #define SUPPORT_INTEGER64
 #define SUPPORT_SPATIAL_INDEX
 #define SUPPORT_IDENTIFIER_DESCRIPTION
 #define SUPPORT_FIELD_WIDTH
-#endif
 
 QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -42,13 +42,6 @@
 #include <cpl_error.h>
 #include <cpl_string.h>
 
-#define SUPPORT_GEOMETRY_LESS
-#define SUPPORT_CURVE_GEOMETRIES
-#define SUPPORT_INTEGER64
-#define SUPPORT_SPATIAL_INDEX
-#define SUPPORT_IDENTIFIER_DESCRIPTION
-#define SUPPORT_FIELD_WIDTH
-
 QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mOkButton( nullptr )
@@ -63,16 +56,14 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
 
-#ifdef SUPPORT_GEOMETRY_LESS
   mGeometryTypeBox->addItem( tr( "Non spatial" ), wkbNone );
-#endif
   mGeometryTypeBox->addItem( tr( "Point" ), wkbPoint );
   mGeometryTypeBox->addItem( tr( "Line" ), wkbLineString );
   mGeometryTypeBox->addItem( tr( "Polygon" ), wkbPolygon );
   mGeometryTypeBox->addItem( tr( "Multi point" ), wkbMultiPoint );
   mGeometryTypeBox->addItem( tr( "Multi line" ), wkbMultiLineString );
   mGeometryTypeBox->addItem( tr( "Multi polygon" ), wkbMultiPolygon );
-#ifdef SUPPORT_CURVE_GEOMETRIES
+
 #if 0
   // QGIS always create CompoundCurve and there's no real interest of having just CircularString. CompoundCurve are more useful
   mGeometryTypeBox->addItem( tr( "Circular string" ), wkbCircularString );
@@ -81,19 +72,14 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mGeometryTypeBox->addItem( tr( "Curve polygon" ), wkbCurvePolygon );
   mGeometryTypeBox->addItem( tr( "Multi curve" ), wkbMultiCurve );
   mGeometryTypeBox->addItem( tr( "Multi surface" ), wkbMultiSurface );
-#endif
 
-#ifdef SUPPORT_GEOMETRY_LESS
   mGeometryColumnEdit->setEnabled( false );
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
-#endif
 
   mFieldTypeBox->addItem( tr( "Text data" ), "text" );
   mFieldTypeBox->addItem( tr( "Whole number (integer)" ), "integer" );
-#ifdef SUPPORT_INTEGER64
   mFieldTypeBox->addItem( tr( "Whole number (integer 64 bit)" ), "integer64" );
-#endif
   mFieldTypeBox->addItem( tr( "Decimal number (real)" ), "real" );
   mFieldTypeBox->addItem( tr( "Date" ), "date" );
   mFieldTypeBox->addItem( tr( "Date&time" ), "datetime" );
@@ -114,24 +100,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mAddAttributeButton->setEnabled( false );
   mRemoveAttributeButton->setEnabled( false );
 
-#ifndef SUPPORT_SPATIAL_INDEX
-  mCheckBoxCreateSpatialIndex->hide();
-  mCheckBoxCreateSpatialIndex->setChecked( false );
-#else
   mCheckBoxCreateSpatialIndex->setChecked( true );
-#endif
-
-#ifndef SUPPORT_IDENTIFIER_DESCRIPTION
-  mLayerIdentifierLabel->hide();
-  mLayerIdentifierEdit->hide();
-  mLayerDescriptionLabel->hide();
-  mLayerDescriptionEdit->hide();
-#endif
-
-#ifndef SUPPORT_FIELD_WIDTH
-  mFieldLengthLabel->hide();
-  mFieldLengthEdit->hide();
-#endif
 }
 
 QgsNewGeoPackageLayerDialog::~QgsNewGeoPackageLayerDialog()
@@ -409,10 +378,8 @@ bool QgsNewGeoPackageLayerDialog::apply()
   if ( wkbType != wkbNone && !geometryColumn.isEmpty() )
     options = CSLSetNameValue( options, "GEOMETRY_COLUMN", geometryColumn.toUtf8().constData() );
 
-#ifdef SUPPORT_SPATIAL_INDEX
   if ( wkbType != wkbNone )
     options = CSLSetNameValue( options, "SPATIAL_INDEX", mCheckBoxCreateSpatialIndex->isChecked() ? "YES" : "NO" );
-#endif
 
   OGRLayerH hLayer = OGR_DS_CreateLayer( hDS, tableName.toUtf8().constData(), hSRS, wkbType, options );
   CSLDestroy( options );
@@ -439,10 +406,8 @@ bool QgsNewGeoPackageLayerDialog::apply()
       ogrType = OFTString;
     else if ( fieldType == QLatin1String( "integer" ) )
       ogrType = OFTInteger;
-#ifdef SUPPORT_INTEGER64
     else if ( fieldType == "integer64" )
       ogrType = OFTInteger64;
-#endif
     else if ( fieldType == QLatin1String( "real" ) )
       ogrType = OFTReal;
     else if ( fieldType == QLatin1String( "date" ) )

--- a/src/plugins/georeferencer/qgsimagewarper.cpp
+++ b/src/plugins/georeferencer/qgsimagewarper.cpp
@@ -29,11 +29,7 @@
 #include "qgsgeoreftransform.h"
 #include "qgslogger.h"
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#endif
 
 bool QgsImageWarper::mWarpCanceled = false;
 

--- a/src/plugins/georeferencer/qgsimagewarper.cpp
+++ b/src/plugins/georeferencer/qgsimagewarper.cpp
@@ -29,8 +29,6 @@
 #include "qgsgeoreftransform.h"
 #include "qgslogger.h"
 
-#define TO8F(x) (x).toUtf8().constData()
-
 bool QgsImageWarper::mWarpCanceled = false;
 
 QgsImageWarper::QgsImageWarper( QWidget *theParent )
@@ -44,7 +42,7 @@ bool QgsImageWarper::openSrcDSAndGetWarpOpt( const QString &input, ResamplingMet
 {
   // Open input file
   GDALAllRegister();
-  hSrcDS = GDALOpen( TO8F( input ), GA_ReadOnly );
+  hSrcDS = GDALOpen( input.toUtf8().constData(), GA_ReadOnly );
   if ( !hSrcDS )
     return false;
 
@@ -81,7 +79,7 @@ bool QgsImageWarper::createDestinationDataset( const QString &outputName, GDALDa
   char **papszOptions = nullptr;
   papszOptions = CSLSetNameValue( papszOptions, "COMPRESS", compression.toLatin1() );
   hDstDS = GDALCreate( driver,
-                       TO8F( outputName ), resX, resY,
+                       outputName.toUtf8().constData(), resX, resY,
                        GDALGetRasterCount( hSrcDS ),
                        GDALGetRasterDataType( GDALGetRasterBand( hSrcDS, 1 ) ),
                        papszOptions );

--- a/src/plugins/georeferencer/qgsrasterchangecoords.cpp
+++ b/src/plugins/georeferencer/qgsrasterchangecoords.cpp
@@ -20,8 +20,6 @@
 
 #include <QFile>
 
-#define TO8F(x) (x).toUtf8().constData()
-
 QgsRasterChangeCoords::QgsRasterChangeCoords()
     : mHasCrs( false )
     , mUL_X( 0. )
@@ -34,7 +32,7 @@ QgsRasterChangeCoords::QgsRasterChangeCoords()
 void QgsRasterChangeCoords::setRaster( const QString &fileRaster )
 {
   GDALAllRegister();
-  GDALDatasetH hDS = GDALOpen( TO8F( fileRaster ), GA_ReadOnly );
+  GDALDatasetH hDS = GDALOpen( fileRaster.toUtf8().constData(), GA_ReadOnly );
   double adfGeoTransform[6];
   if ( GDALGetProjectionRef( hDS ) && GDALGetGeoTransform( hDS, adfGeoTransform ) == CE_None )
     //if ( false )

--- a/src/plugins/georeferencer/qgsrasterchangecoords.cpp
+++ b/src/plugins/georeferencer/qgsrasterchangecoords.cpp
@@ -20,11 +20,7 @@
 
 #include <QFile>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#endif
 
 QgsRasterChangeCoords::QgsRasterChangeCoords()
     : mHasCrs( false )

--- a/src/plugins/grass/qgsgrassmoduleparam.cpp
+++ b/src/plugins/grass/qgsgrassmoduleparam.cpp
@@ -1024,29 +1024,7 @@ QStringList QgsGrassModuleGdalInput::options()
   if ( !mOgrLayerOption.isEmpty() && mOgrLayers[current].size() > 0 )
   {
     opt = mOgrLayerOption + "=";
-    // GDAL 1.4.0 supports schemas (r9998)
-#if GDAL_VERSION_NUM >= 1400
     opt += mOgrLayers[current];
-#else
-    // Handle older versions of gdal gracefully
-    // OGR does not support schemas !!!
-    if ( current >= 0 && current <  mUri.size() )
-    {
-      QStringList l = mOgrLayers[current].split( "." );
-      opt += l.at( 1 );
-
-      // Currently only PostGIS is using layer
-      //  -> layer -> PostGIS -> warning
-      if ( mOgrLayers[current].length() > 0 )
-      {
-        QMessageBox::warning( 0, tr( "Warning" ),
-                              tr( "PostGIS driver in OGR does not support schemas!<br>"
-                                  "Only the table name will be used.<br>"
-                                  "It can result in wrong input if more tables of the same name<br>"
-                                  "are present in the database." ) );
-      }
-    }
-#endif //GDAL_VERSION_NUM
     list.push_back( opt );
   }
 

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -40,7 +40,7 @@ QgsGdalLayerItem::QgsGdalLayerItem( QgsDataItem* parent,
     setState( Populated );
 
   GDALAllRegister();
-  GDALDatasetH hDS = GDALOpen( TO8F( mPath ), GA_Update );
+  GDALDatasetH hDS = GDALOpen( mPath.toUtf8().constData(), GA_Update );
 
   if ( hDS )
   {
@@ -51,7 +51,7 @@ QgsGdalLayerItem::QgsGdalLayerItem( QgsDataItem* parent,
 
 bool QgsGdalLayerItem::setCrs( const QgsCoordinateReferenceSystem &crs )
 {
-  GDALDatasetH hDS = GDALOpen( TO8F( mPath ), GA_Update );
+  GDALDatasetH hDS = GDALOpen( mPath.toUtf8().constData(), GA_Update );
   if ( !hDS )
     return false;
 
@@ -248,7 +248,7 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
       // do not print errors, but write to debug
       CPLPushErrorHandler( CPLQuietErrorHandler );
       CPLErrorReset();
-      if ( ! GDALIdentifyDriver( TO8F( thePath ), nullptr ) )
+      if ( ! GDALIdentifyDriver( thePath.toUtf8().constData(), nullptr ) )
       {
         QgsDebugMsgLevel( "Skipping VRT file because root is not a GDAL VRT", 2 );
         CPLPopErrorHandler();
@@ -269,7 +269,7 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
   // do not print errors, but write to debug
   CPLPushErrorHandler( CPLQuietErrorHandler );
   CPLErrorReset();
-  GDALDatasetH hDS = GDALOpen( TO8F( thePath ), GA_ReadOnly );
+  GDALDatasetH hDS = GDALOpen( thePath.toUtf8().constData(), GA_ReadOnly );
   CPLPopErrorHandler();
 
   if ( ! hDS )

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -165,7 +165,7 @@ QgsGdalProvider::QgsGdalProvider( const QString &uri, bool update )
   QString gdalUri = dataSourceUri();
 
   CPLErrorReset();
-  mGdalBaseDataset = gdalOpen( TO8F( gdalUri ), mUpdate ? GA_Update : GA_ReadOnly );
+  mGdalBaseDataset = gdalOpen( gdalUri.toUtf8().constData(), mUpdate ? GA_Update : GA_ReadOnly );
 
   if ( !mGdalBaseDataset )
   {
@@ -265,7 +265,7 @@ QString QgsGdalProvider::metadata()
   myMetadata += tr( "Dataset Description" );
   myMetadata += QLatin1String( "</p>\n" );
   myMetadata += QLatin1String( "<p>" );
-  myMetadata += FROM8( GDALGetDescription( mGdalDataset ) );
+  myMetadata += QString::fromUtf8( GDALGetDescription( mGdalDataset ) );
   myMetadata += QLatin1String( "</p>\n" );
 
 
@@ -1513,12 +1513,12 @@ QString QgsGdalProvider::buildPyramids( const QList<QgsRasterPyramid> & theRaste
       GDALClose( mGdalDataset );
       //mGdalBaseDataset = GDALOpen( QFile::encodeName( dataSourceUri() ).constData(), GA_Update );
 
-      mGdalBaseDataset = gdalOpen( TO8F( dataSourceUri() ), GA_Update );
+      mGdalBaseDataset = gdalOpen( dataSourceUri().toUtf8().constData(), GA_Update );
 
       // if the dataset couldn't be opened in read / write mode, tell the user
       if ( !mGdalBaseDataset )
       {
-        mGdalBaseDataset = gdalOpen( TO8F( dataSourceUri() ), GA_ReadOnly );
+        mGdalBaseDataset = gdalOpen( dataSourceUri().toUtf8().constData(), GA_ReadOnly );
         //Since we are not a virtual warped dataset, mGdalDataSet and mGdalBaseDataset are supposed to be the same
         mGdalDataset = mGdalBaseDataset;
         return QStringLiteral( "ERROR_WRITE_FORMAT" );
@@ -1618,7 +1618,7 @@ QString QgsGdalProvider::buildPyramids( const QList<QgsRasterPyramid> & theRaste
       //something bad happenend
       //QString myString = QString (CPLGetLastError());
       GDALClose( mGdalBaseDataset );
-      mGdalBaseDataset = gdalOpen( TO8F( dataSourceUri() ), mUpdate ? GA_Update : GA_ReadOnly );
+      mGdalBaseDataset = gdalOpen( dataSourceUri().toUtf8().constData(), mUpdate ? GA_Update : GA_ReadOnly );
       //Since we are not a virtual warped dataset, mGdalDataSet and mGdalBaseDataset are supposed to be the same
       mGdalDataset = mGdalBaseDataset;
 
@@ -1669,7 +1669,7 @@ QString QgsGdalProvider::buildPyramids( const QList<QgsRasterPyramid> & theRaste
     QgsDebugMsg( "Reopening dataset ..." );
     //close the gdal dataset and reopen it in read only mode
     GDALClose( mGdalBaseDataset );
-    mGdalBaseDataset = gdalOpen( TO8F( dataSourceUri() ), mUpdate ? GA_Update : GA_ReadOnly );
+    mGdalBaseDataset = gdalOpen( dataSourceUri().toUtf8().constData(), mUpdate ? GA_Update : GA_ReadOnly );
     //Since we are not a virtual warped dataset, mGdalDataSet and mGdalBaseDataset are supposed to be the same
     mGdalDataset = mGdalBaseDataset;
   }
@@ -2161,7 +2161,7 @@ QGISEXTERN bool isValidRasterFileName( QString const & theFileNameQString, QStri
 
   //open the file using gdal making sure we have handled locale properly
   //myDataset = GDALOpen( QFile::encodeName( theFileNameQString ).constData(), GA_ReadOnly );
-  myDataset = QgsGdalProviderBase::gdalOpen( TO8F( fileName ), GA_ReadOnly );
+  myDataset = QgsGdalProviderBase::gdalOpen( fileName.toUtf8().constData(), GA_ReadOnly );
   if ( !myDataset )
   {
     if ( CPLGetLastErrorNo() != CPLE_OpenFailed )
@@ -2718,7 +2718,7 @@ QGISEXTERN QgsGdalProvider * create(
   //create dataset
   CPLErrorReset();
   char **papszOptions = papszFromStringList( createOptions );
-  GDALDatasetH dataset = GDALCreate( driver, TO8F( uri ), width, height, nBands, ( GDALDataType )type, papszOptions );
+  GDALDatasetH dataset = GDALCreate( driver, uri.toUtf8().constData(), width, height, nBands, ( GDALDataType )type, papszOptions );
   CSLDestroy( papszOptions );
   if ( !dataset )
   {
@@ -2779,7 +2779,7 @@ bool QgsGdalProvider::remove()
     mGdalDataset = nullptr;
 
     CPLErrorReset();
-    CPLErr err = GDALDeleteDataset( driver, TO8F( dataSourceUri() ) );
+    CPLErr err = GDALDeleteDataset( driver, dataSourceUri().toUtf8().constData() );
     if ( err != CPLE_None )
     {
       QgsLogger::warning( "RasterIO error: " + QString::fromUtf8( CPLGetLastErrorMsg() ) );

--- a/src/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/providers/gdal/qgsgdalproviderbase.cpp
@@ -262,21 +262,7 @@ QgsRectangle QgsGdalProviderBase::extent( GDALDatasetH gdalDataset )const
 
 GDALDatasetH QgsGdalProviderBase::gdalOpen( const char *pszFilename, GDALAccess eAccess )
 {
-  // See http://hub.qgis.org/issues/8356 and http://trac.osgeo.org/gdal/ticket/5170
-#if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
-  char* pszOldVal = CPLStrdup( CPLGetConfigOption( "VSI_CACHE", "FALSE" ) );
-  CPLSetThreadLocalConfigOption( "VSI_CACHE", "FALSE" );
-  QgsDebugMsg( "Disabled VSI_CACHE" );
-#endif
-
   GDALDatasetH hDS = GDALOpen( pszFilename, eAccess );
-
-#if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
-  CPLSetThreadLocalConfigOption( "VSI_CACHE", pszOldVal );
-  CPLFree( pszOldVal );
-  QgsDebugMsg( "Reset VSI_CACHE" );
-#endif
-
   return hDS;
 }
 
@@ -292,14 +278,6 @@ int CPL_STDCALL _gdalProgressFnWithFeedback( double dfComplete, const char *pszM
 
 CPLErr QgsGdalProviderBase::gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize, int nYSize, void * pData, int nBufXSize, int nBufYSize, GDALDataType eBufType, int nPixelSpace, int nLineSpace, QgsRasterBlockFeedback* feedback )
 {
-  // See http://hub.qgis.org/issues/8356 and http://trac.osgeo.org/gdal/ticket/5170
-#if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
-  char* pszOldVal = CPLStrdup( CPLGetConfigOption( "VSI_CACHE", "FALSE" ) );
-  CPLSetThreadLocalConfigOption( "VSI_CACHE", "FALSE" );
-  QgsDebugMsg( "Disabled VSI_CACHE" );
-#endif
-
-#if GDAL_VERSION_MAJOR >= 2
   GDALRasterIOExtraArg extra;
   INIT_RASTERIO_EXTRA_ARG( extra );
   if ( 0 && feedback )  // disabled!
@@ -313,36 +291,12 @@ CPLErr QgsGdalProviderBase::gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWF
     extra.pProgressData = ( void* ) feedback;
   }
   CPLErr err = GDALRasterIOEx( hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, &extra );
-#else
-  Q_UNUSED( feedback );
-  CPLErr err = GDALRasterIO( hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace );
-#endif
-
-#if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
-  CPLSetThreadLocalConfigOption( "VSI_CACHE", pszOldVal );
-  CPLFree( pszOldVal );
-  QgsDebugMsg( "Reset VSI_CACHE" );
-#endif
 
   return err;
 }
 
 int QgsGdalProviderBase::gdalGetOverviewCount( GDALRasterBandH hBand )
 {
-  // See http://hub.qgis.org/issues/8356 and http://trac.osgeo.org/gdal/ticket/5170
-#if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
-  char* pszOldVal = CPLStrdup( CPLGetConfigOption( "VSI_CACHE", "FALSE" ) );
-  CPLSetThreadLocalConfigOption( "VSI_CACHE", "FALSE" );
-  QgsDebugMsg( "Disabled VSI_CACHE" );
-#endif
-
   int count = GDALGetOverviewCount( hBand );
-
-#if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
-  CPLSetThreadLocalConfigOption( "VSI_CACHE", pszOldVal );
-  CPLFree( pszOldVal );
-  QgsDebugMsg( "Reset VSI_CACHE" );
-#endif
-
   return count;
 }

--- a/src/providers/gdal/qgsgdalproviderbase.h
+++ b/src/providers/gdal/qgsgdalproviderbase.h
@@ -26,9 +26,6 @@
 #define CPL_SUPRESS_CPLUSPLUS
 #include <gdal.h>
 
-#define TO8F(x) (x).toUtf8().constData()
-#define FROM8(x) QString::fromUtf8(x)
-
 /**
   \brief Base clasee for GDAL and WCS providers.
 */

--- a/src/providers/gdal/qgsgdalproviderbase.h
+++ b/src/providers/gdal/qgsgdalproviderbase.h
@@ -26,13 +26,8 @@
 #define CPL_SUPRESS_CPLUSPLUS
 #include <gdal.h>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
 #define FROM8(x) QString::fromUtf8(x)
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#define FROM8(x) QString::fromLocal8Bit(x)
-#endif
 
 /**
   \brief Base clasee for GDAL and WCS providers.

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -40,7 +40,7 @@ QgsOgrLayerItem::QgsOgrLayerItem( QgsDataItem* parent,
 
   OGRRegisterAll();
   OGRSFDriverH hDriver;
-  OGRDataSourceH hDataSource = QgsOgrProviderUtils::OGROpenWrapper( TO8F( mPath ), true, &hDriver );
+  OGRDataSourceH hDataSource = QgsOgrProviderUtils::OGROpenWrapper( mPath.toUtf8().constData(), true, &hDriver );
 
   if ( hDataSource )
   {
@@ -160,7 +160,7 @@ static QgsOgrLayerItem* dataItemForLayer( QgsDataItem* parentItem, QString name,
   if ( name.isEmpty() )
   {
     // we are in a collection
-    name = FROM8( OGR_FD_GetName( hDef ) );
+    name = QString::fromUtf8( OGR_FD_GetName( hDef ) );
     QgsDebugMsg( "OGR layer name : " + name );
 
     layerUri += "|layerid=" + QString::number( layerId );
@@ -189,7 +189,7 @@ QVector<QgsDataItem*> QgsOgrDataCollectionItem::createChildren()
   QVector<QgsDataItem*> children;
 
   OGRSFDriverH hDriver;
-  OGRDataSourceH hDataSource = QgsOgrProviderUtils::OGROpenWrapper( TO8F( mPath ), false, &hDriver );
+  OGRDataSourceH hDataSource = QgsOgrProviderUtils::OGROpenWrapper( mPath.toUtf8().constData(), false, &hDriver );
   if ( !hDataSource )
     return children;
   int numLayers = OGR_DS_GetLayerCount( hDataSource );
@@ -357,7 +357,7 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
   // do not print errors, but write to debug
   CPLPushErrorHandler( CPLQuietErrorHandler );
   CPLErrorReset();
-  OGRDataSourceH hDataSource = QgsOgrProviderUtils::OGROpenWrapper( TO8F( thePath ), false, &hDriver );
+  OGRDataSourceH hDataSource = QgsOgrProviderUtils::OGROpenWrapper( thePath.toUtf8().constData(), false, &hDriver );
   CPLPopErrorHandler();
 
   if ( ! hDataSource )

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -58,7 +58,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource* source, bool 
   }
   else
   {
-    ogrLayer = OGR_DS_GetLayerByName( mConn->ds, TO8( mSource->mLayerName ) );
+    ogrLayer = OGR_DS_GetLayerByName( mConn->ds, mSource->mLayerName.toUtf8().constData() );
   }
   if ( !ogrLayer )
   {

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -32,15 +32,9 @@ class QgsOgrFeatureIterator;
 
 #include <ogr_api.h>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8(x)   (x).toUtf8().constData()
 #define TO8F(x)  (x).toUtf8().constData()
 #define FROM8(x) QString::fromUtf8(x)
-#else
-#define TO8(x)   (x).toLocal8Bit().constData()
-#define TO8F(x)  QFile::encodeName( x ).constData()
-#define FROM8(x) QString::fromLocal8Bit(x)
-#endif
 
 /**
   \class QgsOgrProvider

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -32,10 +32,6 @@ class QgsOgrFeatureIterator;
 
 #include <ogr_api.h>
 
-#define TO8(x)   (x).toUtf8().constData()
-#define TO8F(x)  (x).toUtf8().constData()
-#define FROM8(x) QString::fromUtf8(x)
-
 /**
   \class QgsOgrProvider
   \brief Data provider for ESRI shapefiles

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -49,9 +49,6 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
-#define TO8F(x) (x).toUtf8().constData()
-#define FROM8(x) QString::fromUtf8(x)
-
 #define ERR(message) QGS_ERROR_MESSAGE(message,"WCS provider")
 #define SRVERR(message) QGS_ERROR_MESSAGE(message,"WCS server")
 #define QGS_ERROR(message) QgsError(message,"WCS provider")
@@ -785,7 +782,7 @@ void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const & viewExtent, int
   }
 #endif
 
-  mCachedMemFile = VSIFileFromMemBuffer( TO8F( mCachedMemFilename ),
+  mCachedMemFile = VSIFileFromMemBuffer( mCachedMemFilename.toUtf8().constData(),
                                          ( GByte* )mCachedData.data(),
                                          ( vsi_l_offset )mCachedData.size(),
                                          FALSE );
@@ -799,7 +796,7 @@ void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const & viewExtent, int
   QgsDebugMsg( "Memory file created" );
 
   CPLErrorReset();
-  mCachedGdalDataset = GDALOpen( TO8F( mCachedMemFilename ), GA_ReadOnly );
+  mCachedGdalDataset = GDALOpen( mCachedMemFilename.toUtf8().constData(), GA_ReadOnly );
   if ( !mCachedGdalDataset )
   {
     QgsMessageLog::logMessage( QString::fromUtf8( CPLGetLastErrorMsg() ), tr( "WCS" ) );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -49,13 +49,8 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8F(x) (x).toUtf8().constData()
 #define FROM8(x) QString::fromUtf8(x)
-#else
-#define TO8F(x) QFile::encodeName( x ).constData()
-#define FROM8(x) QString::fromLocal8Bit(x)
-#endif
 
 #define ERR(message) QGS_ERROR_MESSAGE(message,"WCS provider")
 #define SRVERR(message) QGS_ERROR_MESSAGE(message,"WCS server")

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -348,11 +348,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     //! Name of memory file for cached data
     QString mCachedMemFilename;
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
     mutable VSILFILE * mCachedMemFile;
-#else
-    mutable FILE * mCachedMemFile;
-#endif
 
     //! Pointer to cached GDAL dataset
     mutable GDALDatasetH mCachedGdalDataset;

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -202,9 +202,7 @@ bool QgsWFSSharedData::computeFilter( QString& errorMsg )
 // The difference is that in the QGIS way we have to create the template database
 // on disk, which is a slightly bit slower. But due to later caching, this is
 // not so a big deal.
-#if GDAL_VERSION_MAJOR >= 2 || GDAL_VERSION_MINOR >= 11
 #define USE_OGR_FOR_DB_CREATION
-#endif
 
 static QString quotedIdentifier( QString id )
 {
@@ -248,16 +246,8 @@ bool QgsWFSSharedData::createCache()
   // but QgsVectorFileWriter will refuse anyway to create a ogc_fid, so we will
   // do it manually
   bool useReservedNames = cacheFields.lookupField( QStringLiteral( "ogc_fid" ) ) >= 0;
-#if GDAL_VERSION_MAJOR < 2
-  if ( cacheFields.lookupField( QStringLiteral( "geometry" ) ) >= 0 )
-    useReservedNames = true;
-#endif
   if ( !useReservedNames )
   {
-#if GDAL_VERSION_MAJOR < 2
-    fidName = QStringLiteral( "ogc_fid" );
-    geometryFieldname = QStringLiteral( "GEOMETRY" );
-#endif
     // Creating a spatialite database can be quite slow on some file systems
     // so we create a GDAL in-memory file, and then copy it on
     // the file system.
@@ -266,10 +256,8 @@ bool QgsWFSSharedData::createCache()
     QStringList layerOptions;
     datasourceOptions.push_back( QStringLiteral( "INIT_WITH_EPSG=NO" ) );
     layerOptions.push_back( QStringLiteral( "LAUNDER=NO" ) ); // to get exact matches for field names, especially regarding case
-#if GDAL_VERSION_MAJOR >= 2
     layerOptions.push_back( "FID=__ogc_fid" );
     layerOptions.push_back( "GEOMETRY_NAME=__spatialite_geometry" );
-#endif
     vsimemFilename.sprintf( "/vsimem/qgis_wfs_cache_template_%p/features.sqlite", this );
     mCacheTablename = CPLGetBasename( vsimemFilename.toStdString().c_str() );
     VSIUnlink( vsimemFilename.toStdString().c_str() );

--- a/src/server/qgssldconfigparser.cpp
+++ b/src/server/qgssldconfigparser.cpp
@@ -49,11 +49,7 @@
 
 #include <QTemporaryFile>
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8(x) (x).toUtf8().constData()
-#else
-#define TO8(x) (x).toLocal8Bit().constData()
-#endif
 
 QgsSLDConfigParser::QgsSLDConfigParser( QDomDocument* doc, const QMap<QString, QString>& parameters )
     : QgsWmsConfigParser()

--- a/src/server/qgssldconfigparser.cpp
+++ b/src/server/qgssldconfigparser.cpp
@@ -49,8 +49,6 @@
 
 #include <QTemporaryFile>
 
-#define TO8(x) (x).toUtf8().constData()
-
 QgsSLDConfigParser::QgsSLDConfigParser( QDomDocument* doc, const QMap<QString, QString>& parameters )
     : QgsWmsConfigParser()
     , mXMLDoc( doc )
@@ -1057,7 +1055,7 @@ QgsVectorLayer* QgsSLDConfigParser::contourLayerFromRaster( const QDomElement& u
 
   int /* b3D = FALSE, */ bNoDataSet = FALSE, bIgnoreNoData = FALSE;
 
-  hSrcDS = GDALOpen( TO8( rasterLayer->source() ), GA_ReadOnly );
+  hSrcDS = GDALOpen( rasterLayer->source().toUtf8().constData(), GA_ReadOnly );
   if ( !hSrcDS )
   {
     delete [] adfFixedLevels;
@@ -1101,7 +1099,7 @@ QgsVectorLayer* QgsSLDConfigParser::contourLayerFromRaster( const QDomElement& u
     throw QgsMapServiceException( QStringLiteral( "LayerNotDefined" ), QStringLiteral( "Operation request is for a file not available on the server." ) );
   }
 
-  hDS = OGR_Dr_CreateDataSource( hDriver, TO8( tmpFileName ), nullptr );
+  hDS = OGR_Dr_CreateDataSource( hDriver, tmpFileName.toUtf8().constData(), nullptr );
   if ( !hDS )
   {
     delete [] adfFixedLevels;
@@ -1124,7 +1122,7 @@ QgsVectorLayer* QgsSLDConfigParser::contourLayerFromRaster( const QDomElement& u
 
   if ( !propertyName.isEmpty() )
   {
-    hFld = OGR_Fld_Create( TO8( propertyName ), OFTReal );
+    hFld = OGR_Fld_Create( propertyName.toUtf8().constData(), OFTReal );
     OGR_Fld_SetWidth( hFld, 12 );
     OGR_Fld_SetPrecision( hFld, 3 );
     OGR_L_CreateField( hLayer, hFld, FALSE );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -102,13 +102,11 @@ void TestQgsCoordinateReferenceSystem::initTestCase()
   qDebug() << "PROJ.4 version:         " << PJ_VERSION;
 
   // if user set GDAL_FIX_ESRI_WKT print a warning
-#if GDAL_VERSION_NUM >= 1900
   if ( strcmp( CPLGetConfigOption( "GDAL_FIX_ESRI_WKT", "" ), "" ) != 0 )
   {
     qDebug() << "Warning! GDAL_FIX_ESRI_WKT =" << CPLGetConfigOption( "GDAL_FIX_ESRI_WKT", "" )
     << "this might generate errors!";
   }
-#endif
 
 }
 
@@ -361,14 +359,10 @@ void TestQgsCoordinateReferenceSystem::createFromESRIWkt()
   myWktStrings << QStringLiteral( "GEOGCS[\"GCS_South_American_1969\",DATUM[\"D_South_American_1969\",SPHEROID[\"GRS_1967_Truncated\",6378160.0,298.25]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]]" );
   myFiles << QLatin1String( "" );
   myGdalVersionOK << 1900;
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 2000000
+
   //proj definition for EPSG:4618 was updated in GDAL 2.0 - see https://github.com/OSGeo/proj.4/issues/241
   myProj4Strings << "+proj=longlat +ellps=aust_SA +towgs84=-66.87,4.37,-38.52,0,0,0,0 +no_defs";
   myTOWGS84Strings << "+towgs84=-66.87,4.37,-38.52,0,0,0,0";
-#else
-  myProj4Strings << QStringLiteral( "+proj=longlat +ellps=aust_SA +towgs84=-57,1,-41,0,0,0,0 +no_defs" );
-  myTOWGS84Strings << QStringLiteral( "+towgs84=-57,1,-41,0,0,0,0" );
-#endif
   myAuthIdStrings << QStringLiteral( "EPSG:4618" );
 
   // do test with WKT definitions
@@ -637,21 +631,12 @@ void TestQgsCoordinateReferenceSystem::toWkt()
   myCrs.createFromSrid( GEOSRID );
   QString myWkt = myCrs.toWkt();
   debugPrint( myCrs );
-#if GDAL_VERSION_NUM >= 1800
   //Note: this is not the same as GEOWKT as OGR strips off the TOWGS clause...
   QString myStrippedWkt( "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID"
                          "[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],"
                          "AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY"
                          "[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY"
                          "[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]" );
-#else
-  // for GDAL <1.8
-  QString myStrippedWkt( "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID"
-                         "[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],"
-                         "AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY"
-                         "[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY"
-                         "[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]" );
-#endif
   qDebug() << "wkt:      " << myWkt;
   qDebug() << "stripped: " << myStrippedWkt;
   QVERIFY( myWkt == myStrippedWkt );

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -29,15 +29,9 @@
 #include "qgsapplication.h"
 #include "qgspointv2.h"
 
-#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
 #define TO8(x)   (x).toUtf8().constData()
 #define TO8F(x)  (x).toUtf8().constData()
 #define FROM8(x) QString::fromUtf8(x)
-#else
-#define TO8(x)   (x).toLocal8Bit().constData()
-#define TO8F(x)  QFile::encodeName( x ).constData()
-#define FROM8(x) QString::fromLocal8Bit(x)
-#endif
 
 class TestQgsOgrUtils: public QObject
 {

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -29,10 +29,6 @@
 #include "qgsapplication.h"
 #include "qgspointv2.h"
 
-#define TO8(x)   (x).toUtf8().constData()
-#define TO8F(x)  (x).toUtf8().constData()
-#define FROM8(x) QString::fromUtf8(x)
-
 class TestQgsOgrUtils: public QObject
 {
     Q_OBJECT
@@ -90,7 +86,7 @@ void TestQgsOgrUtils::ogrGeometryToQgsGeometry()
   QVERIFY( QgsOgrUtils::ogrGeometryToQgsGeometry( nullptr ).isEmpty() );
 
   // get a geometry from line file, test
-  OGRDataSourceH hDS = OGROpen( TO8F( mTestFile ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( mTestFile.toUtf8().constData(), false, nullptr );
   QVERIFY( hDS );
   OGRLayerH ogrLayer = OGR_DS_GetLayer( hDS, 0 );
   QVERIFY( ogrLayer );
@@ -119,7 +115,7 @@ void TestQgsOgrUtils::readOgrFeatureGeometry()
 
   //real geometry
   // get a geometry from line file, test
-  OGRDataSourceH hDS = OGROpen( TO8F( mTestFile ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( mTestFile.toUtf8().constData(), false, nullptr );
   QVERIFY( hDS );
   OGRLayerH ogrLayer = OGR_DS_GetLayer( hDS, 0 );
   QVERIFY( ogrLayer );
@@ -149,7 +145,7 @@ void TestQgsOgrUtils::getOgrFeatureAttribute()
 
   //real feature
   //get a feature from line file, test
-  OGRDataSourceH hDS = OGROpen( TO8F( mTestFile ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( mTestFile.toUtf8().constData(), false, nullptr );
   QVERIFY( hDS );
   OGRLayerH ogrLayer = OGR_DS_GetLayer( hDS, 0 );
   QVERIFY( ogrLayer );
@@ -216,7 +212,7 @@ void TestQgsOgrUtils::readOgrFeatureAttributes()
 
   //real feature
   //get a feature from line file, test
-  OGRDataSourceH hDS = OGROpen( TO8F( mTestFile ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( mTestFile.toUtf8().constData(), false, nullptr );
   QVERIFY( hDS );
   OGRLayerH ogrLayer = OGR_DS_GetLayer( hDS, 0 );
   QVERIFY( ogrLayer );
@@ -253,7 +249,7 @@ void TestQgsOgrUtils::readOgrFeature()
 
   //real feature
   //get a feature from line file, test
-  OGRDataSourceH hDS = OGROpen( TO8F( mTestFile ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( mTestFile.toUtf8().constData(), false, nullptr );
   QVERIFY( hDS );
   OGRLayerH ogrLayer = OGR_DS_GetLayer( hDS, 0 );
   QVERIFY( ogrLayer );
@@ -293,7 +289,7 @@ void TestQgsOgrUtils::readOgrFields()
 
   //real feature
   //get a feature from line file, test
-  OGRDataSourceH hDS = OGROpen( TO8F( mTestFile ), false, nullptr );
+  OGRDataSourceH hDS = OGROpen( mTestFile.toUtf8().constData(), false, nullptr );
   QVERIFY( hDS );
   OGRLayerH ogrLayer = OGR_DS_GetLayer( hDS, 0 );
   QVERIFY( ogrLayer );

--- a/tests/src/core/testziplayer.cpp
+++ b/tests/src/core/testziplayer.cpp
@@ -314,9 +314,6 @@ void TestZipLayer::testPassthruVectorZip()
   QSettings settings;
   QString myFileName = mDataDir + "points2.zip";
   QgsDebugMsg( "GDAL: " + QString( GDAL_RELEASE_NAME ) );
-#if GDAL_VERSION_NUM < 1800
-  myFileName = "/vsizip/" + myFileName + "/points.shp";
-#endif
   QgsDebugMsg( "FILE: " + QString( myFileName ) );
   Q_FOREACH ( const QString& s, mScanZipSettings )
   {
@@ -328,9 +325,6 @@ void TestZipLayer::testPassthruVectorZip()
 
 void TestZipLayer::testPassthruVectorTar()
 {
-#if GDAL_VERSION_NUM < 1800
-  QSKIP( "This test requires GDAL >= 1.8", SkipSingle );
-#endif
   QSettings settings;
   QString myFileName = mDataDir + "points2.tar";
   Q_FOREACH ( const QString& s, mScanZipSettings )
@@ -343,9 +337,6 @@ void TestZipLayer::testPassthruVectorTar()
 
 void TestZipLayer::testPassthruVectorGzip()
 {
-#if GDAL_VERSION_NUM < 1700
-  QSKIP( "This test requires GDAL >= 1.7", SkipSingle );
-#endif
   QSettings settings;
   Q_FOREACH ( const QString& s, mScanZipSettings )
   {
@@ -368,9 +359,6 @@ void TestZipLayer::testPassthruRasterZip()
 
 void TestZipLayer::testPassthruRasterTar()
 {
-#if GDAL_VERSION_NUM < 1800
-  QSKIP( "This test requires GDAL >= 1.8", SkipSingle );
-#endif
   QSettings settings;
   Q_FOREACH ( const QString& s, mScanZipSettings )
   {
@@ -404,9 +392,6 @@ void TestZipLayer::testZipItemRaster()
 
 void TestZipLayer::testTarItemRaster()
 {
-#if GDAL_VERSION_NUM < 1800
-  QSKIP( "This test requires GDAL >= 1.8", SkipSingle );
-#endif
   QSettings settings;
   Q_FOREACH ( const QString& s, mScanZipSettings )
   {
@@ -429,9 +414,6 @@ void TestZipLayer::testZipItemVector()
 
 void TestZipLayer::testTarItemVector()
 {
-#if GDAL_VERSION_NUM < 1800
-  QSKIP( "This test requires GDAL >= 1.8", SkipSingle );
-#endif
   QSettings settings;
   Q_FOREACH ( const QString& s, mScanZipSettings )
   {
@@ -455,9 +437,6 @@ void TestZipLayer::testZipItemAll()
 
 void TestZipLayer::testTarItemAll()
 {
-#if GDAL_VERSION_NUM < 1800
-  QSKIP( "This test requires GDAL >= 1.8", SkipSingle );
-#endif
   QSettings settings;
   settings.setValue( mSettingsKey, "full" );
   QVERIFY( "full" == settings.value( mSettingsKey ).toString() );
@@ -497,9 +476,6 @@ void TestZipLayer::testZipItemRasterTransparency()
 
 void TestZipLayer::testTarItemRasterTransparency()
 {
-#if GDAL_VERSION_NUM < 1800
-  QSKIP( "This test requires GDAL >= 1.8", SkipSingle );
-#endif
   QVERIFY( testZipItemTransparency( mDataDir + "landsat_b1.tar", "gdal", 250 ) );
 }
 
@@ -521,9 +497,6 @@ void TestZipLayer::testZipItemSubfolder()
 
 void TestZipLayer::testTarItemSubfolder()
 {
-#if GDAL_VERSION_NUM < 1800
-  QSKIP( "This test requires GDAL >= 1.8", SkipSingle );
-#endif
   QSettings settings;
   Q_FOREACH ( const QString& s, mScanZipSettings )
   {
@@ -536,9 +509,6 @@ void TestZipLayer::testTarItemSubfolder()
 
 void TestZipLayer::testZipItemVRT()
 {
-#if GDAL_VERSION_NUM < 1700
-  QSKIP( "This test requires GDAL >= 1.7", SkipSingle );
-#endif
   QSettings settings;
   Q_FOREACH ( const QString& s, mScanZipSettings )
   {

--- a/tests/src/python/test_db_manager_gpkg.py
+++ b/tests/src/python/test_db_manager_gpkg.py
@@ -404,13 +404,11 @@ class TestPyQgsDBManagerGpkg(unittest.TestCase):
         ds.CreateLayer('testMultiLineString', geom_type=ogr.wkbMultiLineString)
         ds.CreateLayer('testMultiPolygon', geom_type=ogr.wkbMultiPolygon)
         ds.CreateLayer('testGeometryCollection', geom_type=ogr.wkbGeometryCollection)
-
-        if int(gdal.VersionInfo('VERSION_NUM')) >= GDAL_COMPUTE_VERSION(2, 0, 0):
-            ds.CreateLayer('testCircularString', geom_type=ogr.wkbCircularString)
-            ds.CreateLayer('testCompoundCurve', geom_type=ogr.wkbCompoundCurve)
-            ds.CreateLayer('testCurvePolygon', geom_type=ogr.wkbCurvePolygon)
-            ds.CreateLayer('testMultiCurve', geom_type=ogr.wkbMultiCurve)
-            ds.CreateLayer('testMultiSurface', geom_type=ogr.wkbMultiSurface)
+        ds.CreateLayer('testCircularString', geom_type=ogr.wkbCircularString)
+        ds.CreateLayer('testCompoundCurve', geom_type=ogr.wkbCompoundCurve)
+        ds.CreateLayer('testCurvePolygon', geom_type=ogr.wkbCurvePolygon)
+        ds.CreateLayer('testMultiCurve', geom_type=ogr.wkbMultiCurve)
+        ds.CreateLayer('testMultiSurface', geom_type=ogr.wkbMultiSurface)
         ds = None
 
         uri.setDatabase(test_gpkg)

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -99,7 +99,6 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertTrue(vl.isValid())
         self.assertEqual(vl.wkbType(), QgsWkbTypes.Point)
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     def testMixOfPolygonCurvePolygon(self):
 
         datasource = os.path.join(self.basetestpath, 'testMixOfPolygonCurvePolygon.csv')
@@ -115,7 +114,6 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(len(vl.dataProvider().subLayers()), 1)
         self.assertEqual(vl.dataProvider().subLayers()[0], '0:testMixOfPolygonCurvePolygon:4:CurvePolygon')
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     def testMixOfLineStringCompoundCurve(self):
 
         datasource = os.path.join(self.basetestpath, 'testMixOfLineStringCompoundCurve.csv')

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -76,7 +76,6 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         # The geometries must be binarily identical
         self.assertEqual(got_geom.exportToWkb(), reference.exportToWkb(), 'Expected {}, got {}'.format(reference.exportToWkt(), got_geom.exportToWkt()))
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     def testCurveGeometryType(self):
 
         tmpfile = os.path.join(self.basetestpath, 'testCurveGeometryType.gpkg')
@@ -146,18 +145,15 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         ds = None
         self.assertEqual(res, 'delete')
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     # We need GDAL 2.0 to issue PRAGMA journal_mode
     # Note: for that case, we don't strictly need turning on WAL
     def testBug15351_closeIter_commit_closeProvider(self):
         self.internalTestBug15351('closeIter_commit_closeProvider')
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     # We need GDAL 2.0 to issue PRAGMA journal_mode
     def testBug15351_commit_closeProvider_closeIter(self):
         self.internalTestBug15351('commit_closeProvider_closeIter')
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     # We need GDAL 2.0 to issue PRAGMA journal_mode
     def testBug15351_commit_closeIter_closeProvider(self):
         self.internalTestBug15351('commit_closeIter_closeProvider')

--- a/tests/src/python/test_provider_ogr_sqlite.py
+++ b/tests/src/python/test_provider_ogr_sqlite.py
@@ -130,7 +130,6 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
         got = [(f.attribute('fid'), f.attribute('intfield')) for f in vl.dataProvider().getFeatures(QgsFeatureRequest().setFilterExpression("fid = 12"))]
         self.assertEqual(got, [(12, 123)])
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     def testNotNullConstraint(self):
         """ test detection of not null constraint on OGR layer """
 
@@ -161,7 +160,6 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
         self.assertTrue(fields.at(2).constraints().constraints() & QgsFieldConstraints.ConstraintNotNull)
         self.assertEqual(fields.at(2).constraints().constraintOrigin(QgsFieldConstraints.ConstraintNotNull), QgsFieldConstraints.ConstraintOriginProvider)
 
-    @unittest.expectedFailure(int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     def testDefaultValues(self):
         """ test detection of defaults on OGR layer """
 

--- a/tests/src/python/test_provider_tabfile.py
+++ b/tests/src/python/test_provider_tabfile.py
@@ -68,8 +68,6 @@ class TestPyQgsTabfileProvider(unittest.TestCase):
         assert isinstance(f.attributes()[datetime_idx], QDateTime)
         self.assertEqual(f.attributes()[datetime_idx], QDateTime(QDate(2004, 5, 3), QTime(13, 41, 00)))
 
-    # This test fails with GDAL version < 2 because tab update is new in GDAL 2.0
-    @unittest.expectedFailure(int(osgeo.gdal.VersionInfo()[:1]) < 2)
     def testUpdateMode(self):
         """ Test that on-the-fly re-opening in update/read-only mode works """
 
@@ -90,7 +88,6 @@ class TestPyQgsTabfileProvider(unittest.TestCase):
         self.assertEqual(vl.dataProvider().property("_debug_open_mode"), "read-only")
         self.assertTrue(vl.dataProvider().isValid())
 
-    @unittest.expectedFailure(int(osgeo.gdal.VersionInfo()[:1]) < 2)
     def testInteger64WriteTabfile(self):
         """Check writing Integer64 fields to an MapInfo tabfile (which does not support that type)."""
 

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -225,10 +225,6 @@ class TestQgsServer(unittest.TestCase):
         response = re.sub(RE_STRIP_UNCHECKABLE, b'*****', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'*****', expected)
 
-        # for older GDAL versions (<2.0), id field will be integer type
-        if int(osgeo.gdal.VersionInfo()[:1]) < 2:
-            expected = expected.replace(b'typeName="Integer64" precision="0" length="10" editType="TextEdit" type="qlonglong"', b'typeName="Integer" precision="0" length="10" editType="TextEdit" type="int"')
-
         self.assertXMLEqual(response, expected, msg="request %s failed.\n Query: %s\n Expected:\n%s\n\n Response:\n%s" % (query_string, request, expected.decode('utf-8'), response.decode('utf-8')))
 
     def test_project_wms(self):
@@ -316,10 +312,6 @@ class TestQgsServer(unittest.TestCase):
         """
         response = re.sub(RE_STRIP_UNCHECKABLE, b'', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'', expected)
-
-        # for older GDAL versions (<2.0), id field will be integer type
-        if int(osgeo.gdal.VersionInfo()[:1]) < 2:
-            expected = expected.replace(b'<element type="long" name="id"/>', b'<element type="integer" name="id"/>')
 
         self.assertXMLEqual(response, expected, msg="request %s failed.\n Query: %s\n Expected:\n%s\n\n Response:\n%s" % (query_string, request, expected.decode('utf-8'), response.decode('utf-8')))
 

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -421,7 +421,6 @@ class TestQgsVectorLayer(unittest.TestCase):
         self.assertEqual(f['nonconv'], 1)
         self.assertEqual(f['conv_attr'], 'converted_val')
 
-    @unittest.expectedFailure(int(osgeo.gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 0, 0))
     def testInteger64WriteTabfile(self):
         """Check writing Integer64 fields to an MapInfo tabfile (which does not support that type)."""
         ml = QgsVectorLayer(


### PR DESCRIPTION
Based on https://github.com/qgis/QGIS/commit/6c5ec70f8782808fc5b35fc87ab1dac3825aa0e9#commitcomment-20335255 it seems there's consensus to bump the minimum GDAL version to 2.0 and drop distros which do not provide this (Ubuntu 16.04)

This PR implements this bump.