### PR TITLE
[processing] fix app freeze when closing options dialog (fixes #15550)

### DIFF
--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -289,16 +289,15 @@ class Setting(object):
         self.validator(value)
         self.value = value
 
-    def read(self):
-        qsettings = QSettings()
+    def read(self, qsettings=QSettings()):
         value = qsettings.value(self.qname, None)
         if value is not None:
             if isinstance(self.value, bool):
                 value = str(value).lower() == str(True).lower()
             self.value = value
 
-    def save(self):
-        QSettings().setValue(self.qname, self.value)
+    def save(self, qsettings=QSettings()):
+        qsettings.setValue(self.qname, self.value)
 
     def __str__(self):
         return self.name + '=' + str(self.value)

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -30,8 +30,7 @@ __revision__ = '$Format:%H$'
 import os
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import (Qt,
-                              QEvent)
+from qgis.PyQt.QtCore import Qt, QEvent, QSettings
 from qgis.PyQt.QtWidgets import (QFileDialog,
                                  QDialog,
                                  QStyle,
@@ -266,6 +265,7 @@ class ConfigDialog(BASE, WIDGET):
 
     def accept(self):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        qsettings = QSettings()
         for setting in list(self.items.keys()):
             if setting.group != menusSettingsGroup or self.saveMenus:
                 if isinstance(setting.value, bool):
@@ -277,7 +277,7 @@ class ConfigDialog(BASE, WIDGET):
                         QMessageBox.warning(self, self.tr('Wrong value'),
                                             self.tr('Wrong value for parameter "%s":\n\n%s' % (setting.description, str(e))))
                         return
-                setting.save()
+                setting.save(qsettings)
         Processing.updateAlgsList()
         settingsWatcher.settingsChanged.emit()
         QApplication.restoreOverrideCursor()


### PR DESCRIPTION
@alexbruy , @nyalldawson , this fixes the freeze (which under ubuntu can be >10sec) when closing processing's options dialog.