### PR TITLE
skip if the SAGA folder is not defined

### DIFF
--- a/python/plugins/processing/algs/saga/SagaUtils.py
+++ b/python/plugins/processing/algs/saga/SagaUtils.py
@@ -72,7 +72,7 @@ def findSagaFolder():
 
 def sagaPath():
     folder = ProcessingConfig.getSetting(SAGA_FOLDER)
-    if not os.path.isdir(folder):
+    if folder and not os.path.isdir(folder):
         folder = None
         ProcessingLog.addToLog(ProcessingLog.LOG_WARNING,
                                'Specified SAGA folder does not exist. Will try to find built-in binaries.')


### PR DESCRIPTION
On my machine the SAGA folder was empty.
`os.path.isdir` was complaining to test a None value.

CC : @volaya @alexbruy 
