### PR TITLE
 Tweaks on symbols edit dialogs

### DIFF
--- a/src/ui/symbollayer/qgsarrowsymbollayerwidgetbase.ui
+++ b/src/ui/symbollayer/qgsarrowsymbollayerwidgetbase.ui
@@ -88,7 +88,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mHeadThicknessUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mHeadThicknessUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -205,7 +209,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mArrowWidthUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mArrowWidthUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -265,7 +273,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mHeadLengthUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mHeadLengthUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -330,7 +342,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mArrowStartWidthUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mArrowStartWidthUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -371,8 +387,27 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mHeadTypeCombo</tabstop>
+  <tabstop>mHeadTypeDDBtn</tabstop>
+  <tabstop>mArrowTypeCombo</tabstop>
+  <tabstop>mArrowTypeDDBtn</tabstop>
+  <tabstop>mArrowWidthSpin</tabstop>
+  <tabstop>mArrowWidthUnitWidget</tabstop>
+  <tabstop>mArrowWidthDDBtn</tabstop>
+  <tabstop>mArrowStartWidthSpin</tabstop>
+  <tabstop>mArrowStartWidthUnitWidget</tabstop>
+  <tabstop>mArrowStartWidthDDBtn</tabstop>
+  <tabstop>mHeadLengthSpin</tabstop>
+  <tabstop>mHeadLengthUnitWidget</tabstop>
+  <tabstop>mHeadWidthDDBtn</tabstop>
+  <tabstop>mHeadThicknessSpin</tabstop>
+  <tabstop>mHeadThicknessUnitWidget</tabstop>
+  <tabstop>mHeadHeightDDBtn</tabstop>
   <tabstop>mOffsetSpin</tabstop>
   <tabstop>mOffsetUnitWidget</tabstop>
+  <tabstop>mOffsetDDBtn</tabstop>
+  <tabstop>mCurvedArrowChck</tabstop>
+  <tabstop>mRepeatArrowChck</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_ellipse.ui
+++ b/src/ui/symbollayer/widget_ellipse.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>334</width>
+    <width>328</width>
     <height>680</height>
    </rect>
   </property>
@@ -46,16 +46,15 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
    <item row="5" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
-     </item>
-    </layout>
+    <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_3">
@@ -74,32 +73,28 @@
     </widget>
    </item>
    <item row="9" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_13">
+    <widget class="QComboBox" name="mVerticalAnchorComboBox">
      <item>
-      <widget class="QComboBox" name="mVerticalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Top</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>VCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Bottom</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Top</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>VCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </item>
+    </widget>
    </item>
    <item row="8" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
      <property name="buddy">
       <cstring>spinOffsetX</cstring>
@@ -128,14 +123,14 @@
    </item>
    <item row="8" column="1">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="1" rowspan="2">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="rightMargin">
-        <number>0</number>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>x</string>
        </property>
-      </layout>
+      </widget>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetX">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -157,7 +152,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="2" column="2" rowspan="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -165,9 +160,19 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetY">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -208,11 +213,7 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_8">
-     <item>
-      <widget class="QgsPenStyleComboBox" name="mStrokeStyleComboBox"/>
-     </item>
-    </layout>
+    <widget class="QgsPenStyleComboBox" name="mStrokeStyleComboBox"/>
    </item>
    <item row="6" column="0">
     <widget class="QLabel" name="mStrokeWidthLabel">
@@ -225,102 +226,90 @@
     </widget>
    </item>
    <item row="7" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_10">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
    </item>
    <item row="11" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <item>
-      <widget class="QListWidget" name="mShapeListWidget">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>1</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="dragDropMode">
-        <enum>QAbstractItemView::NoDragDrop</enum>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="movement">
-        <enum>QListView::Static</enum>
-       </property>
-       <property name="flow">
-        <enum>QListView::LeftToRight</enum>
-       </property>
-       <property name="resizeMode">
-        <enum>QListView::Adjust</enum>
-       </property>
-       <property name="spacing">
-        <number>4</number>
-       </property>
-       <property name="gridSize">
-        <size>
-         <width>30</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="viewMode">
-        <enum>QListView::IconMode</enum>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="selectionRectVisible">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QListWidget" name="mShapeListWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::NoDragDrop</enum>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="movement">
+      <enum>QListView::Static</enum>
+     </property>
+     <property name="flow">
+      <enum>QListView::LeftToRight</enum>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::Adjust</enum>
+     </property>
+     <property name="spacing">
+      <number>4</number>
+     </property>
+     <property name="gridSize">
+      <size>
+       <width>30</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="viewMode">
+      <enum>QListView::IconMode</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="selectionRectVisible">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item row="10" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_14">
+    <widget class="QComboBox" name="mHorizontalAnchorComboBox">
      <item>
-      <widget class="QComboBox" name="mHorizontalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Left</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>HCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Right</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Left</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>HCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Right</string>
+      </property>
+     </item>
+    </widget>
    </item>
-   <item row="9" column="0">
+   <item row="9" column="0" rowspan="2">
     <widget class="QLabel" name="mAnchorPointLabel">
      <property name="text">
       <string>Anchor point</string>
@@ -341,36 +330,29 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <property name="topMargin">
-      <number>0</number>
+    <widget class="QgsColorButton" name="btnChangeColorFill">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <item>
-      <widget class="QgsColorButton" name="btnChangeColorFill">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="mSymbolWidthLabel">
@@ -417,41 +399,37 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
    <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_12">
-     <property name="topMargin">
-      <number>0</number>
+    <widget class="QgsColorButton" name="btnChangeColorStroke">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <item>
-      <widget class="QgsColorButton" name="btnChangeColorStroke">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item row="4" column="0">
     <widget class="QLabel" name="mStrokeStyleLabel">
@@ -587,6 +565,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
@@ -596,11 +579,6 @@
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPenJoinStyleComboBox</class>
@@ -620,15 +598,34 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>btnChangeColorFill</tabstop>
+  <tabstop>mFillColorDDBtn</tabstop>
+  <tabstop>btnChangeColorStroke</tabstop>
+  <tabstop>mStrokeColorDDBtn</tabstop>
   <tabstop>mWidthSpinBox</tabstop>
+  <tabstop>mSymbolWidthUnitWidget</tabstop>
+  <tabstop>mSymbolWidthDDBtn</tabstop>
   <tabstop>mHeightSpinBox</tabstop>
+  <tabstop>mSymbolHeightDDBtn</tabstop>
   <tabstop>mStrokeStyleComboBox</tabstop>
+  <tabstop>mStrokeStyleDDBtn</tabstop>
   <tabstop>cboJoinStyle</tabstop>
+  <tabstop>mJoinStyleDDBtn</tabstop>
   <tabstop>mStrokeWidthSpinBox</tabstop>
+  <tabstop>mStrokeWidthUnitWidget</tabstop>
+  <tabstop>mStrokeWidthDDBtn</tabstop>
   <tabstop>mRotationSpinBox</tabstop>
+  <tabstop>mRotationDDBtn</tabstop>
   <tabstop>spinOffsetX</tabstop>
+  <tabstop>spinOffsetY</tabstop>
+  <tabstop>mOffsetUnitWidget</tabstop>
+  <tabstop>mOffsetDDBtn</tabstop>
   <tabstop>mVerticalAnchorComboBox</tabstop>
+  <tabstop>mVerticalAnchorDDBtn</tabstop>
+  <tabstop>mHorizontalAnchorComboBox</tabstop>
+  <tabstop>mHorizontalAnchorDDBtn</tabstop>
   <tabstop>mShapeListWidget</tabstop>
+  <tabstop>mShapeDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_filledmarker.ui
+++ b/src/ui/symbollayer/widget_filledmarker.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>450</width>
+    <width>341</width>
     <height>312</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
    <item row="0" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinSize">
@@ -63,7 +63,7 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="3">
     <widget class="QgsPropertyOverrideButton" name="mSizeDDBtn">
      <property name="text">
       <string>…</string>
@@ -77,7 +77,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="2">
     <widget class="QgsDoubleSpinBox" name="spinAngle">
      <property name="wrapping">
       <bool>true</bool>
@@ -99,78 +99,85 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mAngleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="2" column="0" rowspan="2">
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1" rowspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QgsDoubleSpinBox" name="spinOffsetY">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>1</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-99999999.989999994635582</double>
-         </property>
-         <property name="maximum">
-          <double>99999999.989999994635582</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QgsDoubleSpinBox" name="spinOffsetX">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>1</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-99999999.989999994635582</double>
-         </property>
-         <property name="maximum">
-          <double>99999999.989999994635582</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
+   <item row="2" column="2">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>y</string>
        </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinOffsetY">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-99999999.989999994635582</double>
+       </property>
+       <property name="maximum">
+        <double>99999999.989999994635582</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinOffsetX">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-99999999.989999994635582</double>
+       </property>
+       <property name="maximum">
+        <double>99999999.989999994635582</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2" rowspan="2">
+      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>
@@ -178,21 +185,24 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="2">
+   <item row="2" column="3">
     <widget class="QgsPropertyOverrideButton" name="mOffsetDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0" rowspan="2">
     <widget class="QLabel" name="mAnchorPointLabel">
      <property name="text">
       <string>Anchor point</string>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="6" column="2">
     <widget class="QComboBox" name="mHorizontalAnchorComboBox">
      <item>
       <property name="text">
@@ -211,14 +221,14 @@
      </item>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="6" column="3">
     <widget class="QgsPropertyOverrideButton" name="mHorizontalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="5" column="2">
     <widget class="QComboBox" name="mVerticalAnchorComboBox">
      <item>
       <property name="text">
@@ -237,14 +247,14 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="5" column="3">
     <widget class="QgsPropertyOverrideButton" name="mVerticalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="8" column="0" colspan="3">
     <widget class="QListWidget" name="lstNames">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -287,7 +297,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
+   <item row="8" column="3">
     <widget class="QgsPropertyOverrideButton" name="mNameDDBtn">
      <property name="text">
       <string>…</string>
@@ -298,14 +308,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -317,13 +327,19 @@
  <tabstops>
   <tabstop>spinSize</tabstop>
   <tabstop>mSizeUnitWidget</tabstop>
+  <tabstop>mSizeDDBtn</tabstop>
   <tabstop>spinAngle</tabstop>
+  <tabstop>mAngleDDBtn</tabstop>
   <tabstop>spinOffsetX</tabstop>
   <tabstop>spinOffsetY</tabstop>
   <tabstop>mOffsetUnitWidget</tabstop>
-  <tabstop>mHorizontalAnchorComboBox</tabstop>
+  <tabstop>mOffsetDDBtn</tabstop>
   <tabstop>mVerticalAnchorComboBox</tabstop>
+  <tabstop>mVerticalAnchorDDBtn</tabstop>
+  <tabstop>mHorizontalAnchorComboBox</tabstop>
+  <tabstop>mHorizontalAnchorDDBtn</tabstop>
   <tabstop>lstNames</tabstop>
+  <tabstop>mNameDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>488</width>
+    <width>487</width>
     <height>639</height>
    </rect>
   </property>
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="5" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QgsDoubleSpinBox" name="mStrokeWidthSpinBox">
@@ -59,20 +59,30 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="8" column="0">
+   <item row="8" column="0" rowspan="3">
     <widget class="QLabel" name="mAnchorPointLabel">
      <property name="text">
       <string>Anchor point</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="7" column="2">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetX">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -94,7 +104,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" rowspan="2">
+     <item row="0" column="2" rowspan="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
@@ -102,6 +112,13 @@
       </widget>
      </item>
      <item row="1" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetY">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -132,28 +149,24 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
+   <item row="8" column="2">
+    <widget class="QComboBox" name="mVerticalAnchorComboBox">
      <item>
-      <widget class="QComboBox" name="mVerticalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Top</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>VCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Bottom</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Top</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>VCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </item>
+    </widget>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="mStrokeWidthLabel">
@@ -162,35 +175,31 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="3">
     <widget class="QgsPropertyOverrideButton" name="mStrokeColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
+   <item row="9" column="2">
+    <widget class="QComboBox" name="mHorizontalAnchorComboBox">
      <item>
-      <widget class="QComboBox" name="mHorizontalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Left</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>HCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Right</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Left</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>HCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Right</string>
+      </property>
+     </item>
+    </widget>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_9">
@@ -205,7 +214,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="3" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinSize">
@@ -233,18 +242,22 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="5" column="3">
     <widget class="QgsPropertyOverrideButton" name="mStrokeWidthDDBtn">
      <property name="text">
       <string>…</string>
@@ -258,44 +271,40 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="4" column="3">
     <widget class="QgsPropertyOverrideButton" name="mJoinStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <widget class="QFontComboBox" name="cboFont"/>
    </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QgsColorButton" name="btnColor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="2">
+    <widget class="QgsColorButton" name="btnColor">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item row="4" column="0">
     <widget class="QLabel" name="label_8">
@@ -307,43 +316,39 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="3" column="3">
     <widget class="QgsPropertyOverrideButton" name="mSizeDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_8">
-     <item>
-      <widget class="QgsColorButton" name="btnStrokeColor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="2" column="2">
+    <widget class="QgsColorButton" name="btnStrokeColor">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="11" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0" rowspan="2">
       <widget class="QgsScrollArea" name="scrollArea">
@@ -374,14 +379,10 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
-     </item>
-    </layout>
+   <item row="4" column="2">
+    <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mColorDDBtn">
      <property name="text">
       <string>…</string>
@@ -395,61 +396,57 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="spinAngle">
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="decimals">
-        <number>2</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="6" column="2">
+    <widget class="QgsDoubleSpinBox" name="spinAngle">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="decimals">
+      <number>2</number>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
     <widget class="QgsPropertyOverrideButton" name="mRotationDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
+   <item row="7" column="3">
     <widget class="QgsPropertyOverrideButton" name="mOffsetDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="2">
+   <item row="9" column="3">
     <widget class="QgsPropertyOverrideButton" name="mHorizontalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="2">
+   <item row="8" column="3">
     <widget class="QgsPropertyOverrideButton" name="mVerticalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="2">
+   <item row="11" column="3">
     <widget class="QgsPropertyOverrideButton" name="mCharDDBtn">
      <property name="text">
       <string>…</string>
@@ -476,6 +473,12 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsPenJoinStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
@@ -486,29 +489,33 @@
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>cboFont</tabstop>
   <tabstop>btnColor</tabstop>
+  <tabstop>mColorDDBtn</tabstop>
   <tabstop>btnStrokeColor</tabstop>
+  <tabstop>mStrokeColorDDBtn</tabstop>
   <tabstop>spinSize</tabstop>
   <tabstop>mSizeUnitWidget</tabstop>
+  <tabstop>mSizeDDBtn</tabstop>
   <tabstop>cboJoinStyle</tabstop>
+  <tabstop>mJoinStyleDDBtn</tabstop>
   <tabstop>mStrokeWidthSpinBox</tabstop>
   <tabstop>mStrokeWidthUnitWidget</tabstop>
+  <tabstop>mStrokeWidthDDBtn</tabstop>
   <tabstop>spinAngle</tabstop>
+  <tabstop>mRotationDDBtn</tabstop>
   <tabstop>spinOffsetX</tabstop>
   <tabstop>spinOffsetY</tabstop>
   <tabstop>mOffsetUnitWidget</tabstop>
-  <tabstop>mHorizontalAnchorComboBox</tabstop>
+  <tabstop>mOffsetDDBtn</tabstop>
   <tabstop>mVerticalAnchorComboBox</tabstop>
+  <tabstop>mVerticalAnchorDDBtn</tabstop>
+  <tabstop>mHorizontalAnchorComboBox</tabstop>
+  <tabstop>mHorizontalAnchorDDBtn</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mCharDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_gradientfill.ui
+++ b/src/ui/symbollayer/widget_gradientfill.ui
@@ -6,15 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>364</width>
-    <height>664</height>
+    <width>358</width>
+    <height>602</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="8" column="1" rowspan="2">
+   <item row="8" column="2" rowspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_11">
      <item>
       <widget class="QLabel" name="label_7">
@@ -41,7 +41,7 @@
      </item>
     </layout>
    </item>
-   <item row="6" column="1" rowspan="2">
+   <item row="6" column="2" rowspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <item>
       <widget class="QLabel" name="label_5">
@@ -71,14 +71,14 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="2">
+   <item row="5" column="3">
     <widget class="QgsPropertyOverrideButton" name="mSpreadDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="2">
     <widget class="QgsColorButton" name="btnChangeColor2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -113,27 +113,23 @@
    <item row="18" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+   <item row="4" column="2">
+    <widget class="QComboBox" name="cboCoordinateMode">
      <item>
-      <widget class="QComboBox" name="cboCoordinateMode">
-       <item>
-        <property name="text">
-         <string>Object</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Viewport</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Object</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>Viewport</string>
+      </property>
+     </item>
+    </widget>
    </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_2">
@@ -147,9 +143,12 @@
      <property name="text">
       <string>Reference Point 2</string>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="2" column="2">
     <widget class="QgsColorRampButton" name="btnColorRamp">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -171,37 +170,33 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="2" rowspan="2">
+   <item row="8" column="3" rowspan="2">
     <widget class="QgsPropertyOverrideButton" name="mRefPoint1YDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
+   <item row="3" column="2">
+    <widget class="QComboBox" name="cboGradientType">
      <item>
-      <widget class="QComboBox" name="cboGradientType">
-       <item>
-        <property name="text">
-         <string>Linear</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Radial</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Conical</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Linear</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>Radial</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Conical</string>
+      </property>
+     </item>
+    </widget>
    </item>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <widget class="QgsColorButton" name="btnChangeColor">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -226,7 +221,7 @@
      </property>
     </widget>
    </item>
-   <item row="13" column="1" rowspan="2">
+   <item row="13" column="2" rowspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_12">
      <item>
       <widget class="QLabel" name="label_10">
@@ -256,14 +251,14 @@
      </item>
     </layout>
    </item>
-   <item row="17" column="2">
+   <item row="17" column="3">
     <widget class="QgsPropertyOverrideButton" name="mAngleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="4" column="3">
     <widget class="QgsPropertyOverrideButton" name="mCoordinateModeDDBtn">
      <property name="text">
       <string>…</string>
@@ -277,67 +272,70 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
+   <item row="5" column="2">
+    <widget class="QComboBox" name="cboGradientSpread">
      <item>
-      <widget class="QComboBox" name="cboGradientSpread">
-       <item>
-        <property name="text">
-         <string>Pad</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Repeat</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Reflect</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Pad</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>Repeat</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Reflect</string>
+      </property>
+     </item>
+    </widget>
    </item>
-   <item row="3" column="2">
+   <item row="3" column="3">
     <widget class="QgsPropertyOverrideButton" name="mGradientTypeDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="10" column="2">
     <widget class="QCheckBox" name="checkRefPoint1Centroid">
      <property name="text">
       <string>Centroid</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="3">
     <widget class="QgsPropertyOverrideButton" name="mStartColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="2" rowspan="2">
+   <item row="13" column="3" rowspan="2">
     <widget class="QgsPropertyOverrideButton" name="mRefPoint2YDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="2">
+   <item row="15" column="3">
     <widget class="QgsPropertyOverrideButton" name="mRefPoint2CentroidDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="18" column="1">
+   <item row="18" column="2">
     <layout class="QGridLayout" name="gridLayout_4">
      <item row="1" column="0">
+      <widget class="QLabel" name="label_13">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetY">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -360,6 +358,13 @@
       </widget>
      </item>
      <item row="0" column="0">
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetX">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -381,7 +386,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="0" column="2" rowspan="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -400,30 +405,26 @@
      </property>
     </widget>
    </item>
-   <item row="17" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="mSpinAngle">
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="17" column="2">
+    <widget class="QgsDoubleSpinBox" name="mSpinAngle">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
    </item>
-   <item row="15" column="1">
+   <item row="15" column="2">
     <widget class="QCheckBox" name="checkRefPoint2Centroid">
      <property name="text">
       <string>Centroid</string>
@@ -437,14 +438,14 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="2">
+   <item row="10" column="3">
     <widget class="QgsPropertyOverrideButton" name="mRefPoint1CentroidDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mEndColorDDBtn">
      <property name="text">
       <string>…</string>
@@ -456,9 +457,12 @@
      <property name="text">
       <string>Reference Point 1</string>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
-   <item row="12" column="1">
+   <item row="12" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_7">
      <item>
       <widget class="QLabel" name="label_9">
@@ -488,7 +492,7 @@
      </item>
     </layout>
    </item>
-   <item row="6" column="2" rowspan="2">
+   <item row="6" column="3" rowspan="2">
     <widget class="QgsPropertyOverrideButton" name="mRefPoint1XDDBtn">
      <property name="text">
       <string>…</string>
@@ -502,14 +506,14 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="2">
+   <item row="12" column="3">
     <widget class="QgsPropertyOverrideButton" name="mRefPoint2XDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="19" column="0" colspan="3">
+   <item row="19" column="0" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -549,6 +553,11 @@
   <zorder>mRefPoint1XDDBtn</zorder>
   <zorder>mRefPoint1YDDBtn</zorder>
   <zorder>mRefPoint2CentroidDDBtn</zorder>
+  <zorder>cboGradientType</zorder>
+  <zorder>mSpinAngle</zorder>
+  <zorder>cboGradientSpread</zorder>
+  <zorder>cboCoordinateMode</zorder>
+  <zorder>verticalSpacer</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -583,19 +592,31 @@
  <tabstops>
   <tabstop>radioTwoColor</tabstop>
   <tabstop>btnChangeColor</tabstop>
+  <tabstop>mStartColorDDBtn</tabstop>
   <tabstop>btnChangeColor2</tabstop>
+  <tabstop>mEndColorDDBtn</tabstop>
   <tabstop>radioColorRamp</tabstop>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>cboGradientType</tabstop>
+  <tabstop>mGradientTypeDDBtn</tabstop>
   <tabstop>cboCoordinateMode</tabstop>
+  <tabstop>mCoordinateModeDDBtn</tabstop>
   <tabstop>cboGradientSpread</tabstop>
+  <tabstop>mSpreadDDBtn</tabstop>
   <tabstop>spinRefPoint1X</tabstop>
+  <tabstop>mRefPoint1XDDBtn</tabstop>
   <tabstop>spinRefPoint1Y</tabstop>
+  <tabstop>mRefPoint1YDDBtn</tabstop>
   <tabstop>checkRefPoint1Centroid</tabstop>
+  <tabstop>mRefPoint1CentroidDDBtn</tabstop>
   <tabstop>spinRefPoint2X</tabstop>
+  <tabstop>mRefPoint2XDDBtn</tabstop>
   <tabstop>spinRefPoint2Y</tabstop>
+  <tabstop>mRefPoint2YDDBtn</tabstop>
   <tabstop>checkRefPoint2Centroid</tabstop>
+  <tabstop>mRefPoint2CentroidDDBtn</tabstop>
   <tabstop>mSpinAngle</tabstop>
+  <tabstop>mAngleDDBtn</tabstop>
   <tabstop>spinOffsetX</tabstop>
   <tabstop>spinOffsetY</tabstop>
  </tabstops>

--- a/src/ui/symbollayer/widget_linepatternfill.ui
+++ b/src/ui/symbollayer/widget_linepatternfill.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,0">
    <item row="0" column="0">
     <widget class="QLabel" name="mRotationLabel">
      <property name="text">
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="3">
     <widget class="QgsPropertyOverrideButton" name="mAngleDDBtn">
      <property name="text">
       <string>…</string>
@@ -35,7 +35,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QgsDoubleSpinBox" name="mDistanceSpinBox">
@@ -67,6 +67,9 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
@@ -78,7 +81,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="2" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QgsDoubleSpinBox" name="mOffsetSpinBox">
@@ -106,44 +109,44 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mDistanceDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="mAngleSpinBox">
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-       <property name="showClearButton" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="0" column="2">
+    <widget class="QgsDoubleSpinBox" name="mAngleSpinBox">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+     <property name="showClearButton" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="1">
+   <item row="3" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -160,14 +163,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -180,8 +183,10 @@
   <tabstop>mAngleSpinBox</tabstop>
   <tabstop>mAngleDDBtn</tabstop>
   <tabstop>mDistanceSpinBox</tabstop>
+  <tabstop>mDistanceUnitWidget</tabstop>
   <tabstop>mDistanceDDBtn</tabstop>
   <tabstop>mOffsetSpinBox</tabstop>
+  <tabstop>mOffsetUnitWidget</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_pointpatternfill.ui
+++ b/src/ui/symbollayer/widget_pointpatternfill.ui
@@ -67,7 +67,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mVerticalDistanceUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mVerticalDistanceUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -116,6 +120,9 @@
          <width>0</width>
          <height>0</height>
         </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
       </widget>
      </item>
@@ -167,6 +174,9 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
@@ -210,6 +220,9 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
@@ -238,14 +251,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -254,6 +267,20 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mHorizontalDistanceSpinBox</tabstop>
+  <tabstop>mHorizontalDistanceUnitWidget</tabstop>
+  <tabstop>mHorizontalDistanceDDBtn</tabstop>
+  <tabstop>mVerticalDistanceSpinBox</tabstop>
+  <tabstop>mVerticalDistanceUnitWidget</tabstop>
+  <tabstop>mVerticalDistanceDDBtn</tabstop>
+  <tabstop>mHorizontalDisplacementSpinBox</tabstop>
+  <tabstop>mHorizontalDisplacementUnitWidget</tabstop>
+  <tabstop>mHorizontalDisplacementDDBtn</tabstop>
+  <tabstop>mVerticalDisplacementSpinBox</tabstop>
+  <tabstop>mVerticalDisplacementUnitWidget</tabstop>
+  <tabstop>mVerticalDisplacementDDBtn</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/symbollayer/widget_rasterfill.ui
+++ b/src/ui/symbollayer/widget_rasterfill.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>310</width>
-    <height>429</height>
+    <width>338</width>
+    <height>419</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="2" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QgsDoubleSpinBox" name="mWidthSpinBox">
@@ -56,47 +56,46 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mFilenameDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="3" column="2">
+    <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
    </item>
-   <item row="5" column="2">
+   <item row="5" column="3">
     <widget class="QgsPropertyOverrideButton" name="mOpacityDDBtn">
      <property name="text">
       <string>…</string>
@@ -113,7 +112,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="3">
+   <item row="0" column="0" colspan="4">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="topMargin">
       <number>0</number>
@@ -167,16 +166,23 @@
    <item row="6" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
      <property name="buddy">
       <cstring>mSpinOffsetX</cstring>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="6" column="2">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QgsDoubleSpinBox" name="mSpinOffsetX">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -198,7 +204,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" rowspan="2">
+     <item row="0" column="2" rowspan="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -206,9 +212,19 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
      <item row="1" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="mSpinOffsetY">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -249,7 +265,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLineEdit" name="mImageLineEdit"/>
@@ -263,7 +279,7 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="1">
+   <item row="4" column="2">
     <widget class="QComboBox" name="cboCoordinateMode">
      <item>
       <property name="text">
@@ -277,14 +293,14 @@
      </item>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="3">
     <widget class="QgsPropertyOverrideButton" name="mWidthDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="3" column="3">
     <widget class="QgsPropertyOverrideButton" name="mRotationDDBtn">
      <property name="text">
       <string>…</string>
@@ -304,7 +320,7 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="1">
+   <item row="5" column="2">
     <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
@@ -342,14 +358,15 @@
   <tabstop>mBrowseToolButton</tabstop>
   <tabstop>mFilenameDDBtn</tabstop>
   <tabstop>mWidthSpinBox</tabstop>
+  <tabstop>mWidthUnitWidget</tabstop>
   <tabstop>mWidthDDBtn</tabstop>
   <tabstop>mRotationSpinBox</tabstop>
   <tabstop>mRotationDDBtn</tabstop>
   <tabstop>cboCoordinateMode</tabstop>
-  <tabstop>mOpacityWidget</tabstop>
   <tabstop>mOpacityDDBtn</tabstop>
   <tabstop>mSpinOffsetX</tabstop>
   <tabstop>mSpinOffsetY</tabstop>
+  <tabstop>mOffsetUnitWidget</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_shapeburstfill.ui
+++ b/src/ui/symbollayer/widget_shapeburstfill.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>429</height>
+    <width>411</width>
+    <height>427</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -172,6 +172,9 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
@@ -179,7 +182,7 @@
    <item row="10" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
     </widget>
    </item>
@@ -288,6 +291,13 @@
    <item row="10" column="1" colspan="3">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetX">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -309,10 +319,21 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" rowspan="2">
-      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true"/>
+     <item row="0" column="2" rowspan="2">
+      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
      <item row="1" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetY">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -387,6 +408,7 @@
     </spacer>
    </item>
   </layout>
+  <zorder>btnColorRamp</zorder>
   <zorder>label</zorder>
   <zorder>label_6</zorder>
   <zorder>label_2</zorder>
@@ -404,6 +426,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
@@ -420,12 +448,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
@@ -434,15 +456,26 @@
  </customwidgets>
  <tabstops>
   <tabstop>radioTwoColor</tabstop>
+  <tabstop>btnChangeColor</tabstop>
+  <tabstop>mStartColorDDBtn</tabstop>
+  <tabstop>btnChangeColor2</tabstop>
+  <tabstop>mEndColorDDBtn</tabstop>
   <tabstop>radioColorRamp</tabstop>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>mRadioUseWholeShape</tabstop>
+  <tabstop>mShadeWholeShapeDDBtn</tabstop>
   <tabstop>mRadioUseMaxDistance</tabstop>
   <tabstop>mSpinMaxDistance</tabstop>
+  <tabstop>mDistanceUnitWidget</tabstop>
+  <tabstop>mShadeDistanceDDBtn</tabstop>
   <tabstop>mIgnoreRingsCheckBox</tabstop>
+  <tabstop>mIgnoreRingsDDBtn</tabstop>
   <tabstop>mBlurSlider</tabstop>
   <tabstop>mSpinBlurRadius</tabstop>
+  <tabstop>mBlurRadiusDDBtn</tabstop>
   <tabstop>spinOffsetX</tabstop>
+  <tabstop>mOffsetUnitWidget</tabstop>
+  <tabstop>spinOffsetY</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/symbollayer/widget_simplefill.ui
+++ b/src/ui/symbollayer/widget_simplefill.ui
@@ -6,22 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>269</width>
-    <height>322</height>
+    <width>332</width>
+    <height>319</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
-     </item>
-    </layout>
+   <item row="5" column="3">
+    <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Stroke style</string>
@@ -31,7 +27,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Stroke width</string>
@@ -57,44 +53,59 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="3" column="4">
     <widget class="QgsPropertyOverrideButton" name="mFillStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="4">
     <widget class="QgsPropertyOverrideButton" name="mFillColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="6" column="4">
     <widget class="QgsPropertyOverrideButton" name="mStrokeWidthDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QgsPenStyleComboBox" name="cboStrokeStyle"/>
-     </item>
-    </layout>
+   <item row="4" column="3">
+    <widget class="QgsPenStyleComboBox" name="cboStrokeStyle"/>
    </item>
-   <item row="6" column="1">
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="2">
+   <item row="7" column="3">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0" rowminimumheight="0,0">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <item row="0" column="2" rowspan="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>
       </widget>
      </item>
      <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetX">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -117,6 +128,13 @@
       </widget>
      </item>
      <item row="1" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetY">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -140,17 +158,17 @@
      </item>
     </layout>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="3">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinStrokeWidth">
@@ -192,36 +210,32 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QgsColorButton" name="btnChangeStrokeColor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="2" column="3">
+    <widget class="QgsColorButton" name="btnChangeStrokeColor">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>Join style</string>
@@ -231,50 +245,46 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="2" column="4">
     <widget class="QgsPropertyOverrideButton" name="mStrokeColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="5" column="4">
     <widget class="QgsPropertyOverrideButton" name="mJoinStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QgsColorButton" name="btnChangeColor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="0" column="3">
+    <widget class="QgsColorButton" name="btnChangeColor">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Fill style</string>
@@ -284,14 +294,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="4" column="4">
     <widget class="QgsPropertyOverrideButton" name="mStrokeStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label_3">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -307,14 +317,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QgsBrushStyleComboBox" name="cboFillStyle"/>
-     </item>
-    </layout>
+   <item row="3" column="3">
+    <widget class="QgsBrushStyleComboBox" name="cboFillStyle"/>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="3">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -370,13 +376,20 @@
  </customwidgets>
  <tabstops>
   <tabstop>btnChangeColor</tabstop>
+  <tabstop>mFillColorDDBtn</tabstop>
   <tabstop>btnChangeStrokeColor</tabstop>
+  <tabstop>mStrokeColorDDBtn</tabstop>
   <tabstop>cboFillStyle</tabstop>
+  <tabstop>mFillStyleDDBtn</tabstop>
   <tabstop>cboStrokeStyle</tabstop>
+  <tabstop>mStrokeStyleDDBtn</tabstop>
   <tabstop>cboJoinStyle</tabstop>
+  <tabstop>mJoinStyleDDBtn</tabstop>
   <tabstop>spinStrokeWidth</tabstop>
   <tabstop>mStrokeWidthUnitWidget</tabstop>
+  <tabstop>mStrokeWidthDDBtn</tabstop>
   <tabstop>spinOffsetX</tabstop>
+  <tabstop>spinOffsetY</tabstop>
   <tabstop>mOffsetUnitWidget</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/symbollayer/widget_simpleline.ui
+++ b/src/ui/symbollayer/widget_simpleline.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>276</width>
+    <width>290</width>
     <height>384</height>
    </rect>
   </property>
@@ -14,7 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
+   <item row="1" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinWidth">
@@ -52,23 +52,22 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="4" column="2">
+   <item row="4" column="3">
     <widget class="QgsPropertyOverrideButton" name="mJoinStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_10">
-     <item>
-      <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
-     </item>
-    </layout>
+   <item row="4" column="2">
+    <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_6">
@@ -97,36 +96,32 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <item>
-      <widget class="QgsColorButton" name="btnChangeColor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="0" column="2">
+    <widget class="QgsColorButton" name="btnChangeColor">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="8" column="0" colspan="3">
     <widget class="QCheckBox" name="mDrawInsideCheckBox">
      <property name="text">
       <string>Draw line only inside polygon</string>
@@ -140,7 +135,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="7" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_12">
      <item>
       <widget class="QPushButton" name="mChangePatternButton">
@@ -156,23 +151,19 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mDashPatternUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mDashPatternUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QgsPenStyleComboBox" name="cboPenStyle"/>
-     </item>
-    </layout>
+   <item row="3" column="2">
+    <widget class="QgsPenStyleComboBox" name="cboPenStyle"/>
    </item>
-   <item row="5" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <item>
-      <widget class="QgsPenCapStyleComboBox" name="cboCapStyle"/>
-     </item>
-    </layout>
+   <item row="5" column="2">
+    <widget class="QgsPenCapStyleComboBox" name="cboCapStyle"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
@@ -188,7 +179,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
+   <item row="7" column="3">
     <widget class="QgsPropertyOverrideButton" name="mDashPatternDDBtn">
      <property name="text">
       <string>…</string>
@@ -202,7 +193,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="2" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinOffset">
@@ -237,46 +228,49 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="5" column="2">
+   <item row="5" column="3">
     <widget class="QgsPropertyOverrideButton" name="mCapStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="3">
     <widget class="QgsPropertyOverrideButton" name="mColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mPenWidthDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="3" column="3">
     <widget class="QgsPropertyOverrideButton" name="mPenStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="3">
     <widget class="QgsPropertyOverrideButton" name="mOffsetDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="6" column="0" colspan="3">
     <widget class="QCheckBox" name="mCustomCheckBox">
      <property name="text">
       <string>Use custom dash pattern</string>
@@ -292,6 +286,12 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
@@ -300,12 +300,6 @@
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -326,12 +320,23 @@
  </customwidgets>
  <tabstops>
   <tabstop>btnChangeColor</tabstop>
+  <tabstop>mColorDDBtn</tabstop>
   <tabstop>spinWidth</tabstop>
+  <tabstop>mPenWidthUnitWidget</tabstop>
+  <tabstop>mPenWidthDDBtn</tabstop>
   <tabstop>spinOffset</tabstop>
+  <tabstop>mOffsetUnitWidget</tabstop>
+  <tabstop>mOffsetDDBtn</tabstop>
   <tabstop>cboPenStyle</tabstop>
+  <tabstop>mPenStyleDDBtn</tabstop>
   <tabstop>cboJoinStyle</tabstop>
+  <tabstop>mJoinStyleDDBtn</tabstop>
   <tabstop>cboCapStyle</tabstop>
+  <tabstop>mCapStyleDDBtn</tabstop>
+  <tabstop>mCustomCheckBox</tabstop>
   <tabstop>mChangePatternButton</tabstop>
+  <tabstop>mDashPatternUnitWidget</tabstop>
+  <tabstop>mDashPatternDDBtn</tabstop>
   <tabstop>mDrawInsideCheckBox</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/symbollayer/widget_simplemarker.ui
+++ b/src/ui/symbollayer/widget_simplemarker.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>318</width>
+    <width>333</width>
     <height>637</height>
    </rect>
   </property>
@@ -14,7 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -27,123 +27,85 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="13" column="0" rowspan="3">
     <widget class="QLabel" name="mAnchorPointLabel">
      <property name="text">
       <string>Anchor point</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="mStrokeStyleLabel">
      <property name="text">
       <string>Stroke style</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="topMargin">
-      <number>0</number>
+   <item row="0" column="2">
+    <widget class="QgsColorButton" name="btnChangeColorFill">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <item>
-      <widget class="QgsColorButton" name="btnChangeColorFill">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Size</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
-     </item>
-    </layout>
+   <item row="7" column="2">
+    <widget class="QgsPenJoinStyleComboBox" name="cboJoinStyle"/>
    </item>
-   <item row="6" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Rotation</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <item>
-      <widget class="QComboBox" name="mHorizontalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Left</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>HCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Right</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
+   <item row="10" column="2">
+    <widget class="QgsDoubleSpinBox" name="spinAngle">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="decimals">
+      <number>2</number>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
    </item>
-   <item row="6" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="spinAngle">
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="decimals">
-        <number>2</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>Join style</string>
@@ -166,81 +128,91 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="mStrokeWidthLabel">
      <property name="text">
       <string>Stroke width</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
+   <item row="10" column="4">
     <widget class="QgsPropertyOverrideButton" name="mAngleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="3" column="4">
     <widget class="QgsPropertyOverrideButton" name="mSizeDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="topMargin">
-        <number>0</number>
+   <item row="11" column="2">
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>x</string>
        </property>
-       <item>
-        <widget class="QgsDoubleSpinBox" name="spinOffsetX">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>1</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-99999999.989999994635582</double>
-         </property>
-         <property name="maximum">
-          <double>99999999.989999994635582</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QgsDoubleSpinBox" name="spinOffsetY">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>1</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>-99999999.989999994635582</double>
-         </property>
-         <property name="maximum">
-          <double>99999999.989999994635582</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      </widget>
      </item>
-     <item>
+     <item row="0" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinOffsetX">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-99999999.989999994635582</double>
+       </property>
+       <property name="maximum">
+        <double>99999999.989999994635582</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinOffsetY">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-99999999.989999994635582</double>
+       </property>
+       <property name="maximum">
+        <double>99999999.989999994635582</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2" rowspan="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -255,7 +227,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinSize">
@@ -297,30 +269,26 @@
      </item>
     </layout>
    </item>
-   <item row="8" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
+   <item row="13" column="2">
+    <widget class="QComboBox" name="mVerticalAnchorComboBox">
      <item>
-      <widget class="QComboBox" name="mVerticalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Top</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>VCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Bottom</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Top</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>VCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </item>
+    </widget>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="16" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
       <widget class="QListWidget" name="lstNames">
@@ -367,156 +335,160 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_10">
-     <item>
-      <widget class="QgsPenStyleComboBox" name="mStrokeStyleComboBox"/>
-     </item>
-    </layout>
+   <item row="5" column="2">
+    <widget class="QgsPenStyleComboBox" name="mStrokeStyleComboBox"/>
    </item>
-   <item row="4" column="2">
+   <item row="7" column="4">
     <widget class="QgsPropertyOverrideButton" name="mJoinStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="5" column="4">
     <widget class="QgsPropertyOverrideButton" name="mStrokeStyleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0" rowspan="2" colspan="2">
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <item>
-        <widget class="QgsDoubleSpinBox" name="mStrokeWidthSpinBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>1</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="specialValueText">
-          <string>Hairline</string>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="maximum">
-          <double>999999999.999999046325684</double>
-         </property>
-         <property name="singleStep">
-          <double>0.200000000000000</double>
-         </property>
-         <property name="showClearButton" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QgsUnitSelectionWidget" name="mStrokeWidthUnitWidget" native="true">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
+   <item row="8" column="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QgsDoubleSpinBox" name="mStrokeWidthSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="specialValueText">
+        <string>Hairline</string>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>999999999.999999046325684</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="showClearButton" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsUnitSelectionWidget" name="mStrokeWidthUnitWidget" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
+   <item row="11" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Offset X,Y</string>
+      <string>Offset</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="8" column="4">
     <widget class="QgsPropertyOverrideButton" name="mStrokeWidthDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="2">
+   <item row="13" column="4">
     <widget class="QgsPropertyOverrideButton" name="mVerticalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mHorizontalAnchorDDBtn">
-     <property name="text">
-      <string>…</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="2">
+   <item row="16" column="4">
     <widget class="QgsPropertyOverrideButton" name="mNameDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
+   <item row="11" column="4">
     <widget class="QgsPropertyOverrideButton" name="mOffsetDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="topMargin">
-      <number>0</number>
+   <item row="2" column="2">
+    <widget class="QgsColorButton" name="btnChangeColorStroke">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <item>
-      <widget class="QgsColorButton" name="btnChangeColorStroke">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
-   <item row="1" column="2">
+   <item row="2" column="4">
     <widget class="QgsPropertyOverrideButton" name="mStrokeColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="4">
     <widget class="QgsPropertyOverrideButton" name="mFillColorDDBtn">
+     <property name="text">
+      <string>…</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="2">
+    <widget class="QComboBox" name="mHorizontalAnchorComboBox">
+     <item>
+      <property name="text">
+       <string>Left</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>HCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Right</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="14" column="4">
+    <widget class="QgsPropertyOverrideButton" name="mHorizontalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
@@ -526,25 +498,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPenJoinStyleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspenstylecombobox.h</header>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -553,19 +514,49 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPenJoinStyleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspenstylecombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsPenStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>btnChangeColorFill</tabstop>
+  <tabstop>mFillColorDDBtn</tabstop>
+  <tabstop>btnChangeColorStroke</tabstop>
+  <tabstop>mStrokeColorDDBtn</tabstop>
   <tabstop>spinSize</tabstop>
+  <tabstop>mSizeUnitWidget</tabstop>
+  <tabstop>mSizeDDBtn</tabstop>
   <tabstop>mStrokeStyleComboBox</tabstop>
+  <tabstop>mStrokeStyleDDBtn</tabstop>
   <tabstop>cboJoinStyle</tabstop>
+  <tabstop>mJoinStyleDDBtn</tabstop>
   <tabstop>mStrokeWidthSpinBox</tabstop>
+  <tabstop>mStrokeWidthUnitWidget</tabstop>
+  <tabstop>mStrokeWidthDDBtn</tabstop>
   <tabstop>spinAngle</tabstop>
+  <tabstop>mAngleDDBtn</tabstop>
+  <tabstop>spinOffsetX</tabstop>
+  <tabstop>spinOffsetY</tabstop>
   <tabstop>mOffsetUnitWidget</tabstop>
+  <tabstop>mOffsetDDBtn</tabstop>
+  <tabstop>mVerticalAnchorComboBox</tabstop>
+  <tabstop>mVerticalAnchorDDBtn</tabstop>
+  <tabstop>mHorizontalAnchorComboBox</tabstop>
+  <tabstop>mHorizontalAnchorDDBtn</tabstop>
   <tabstop>lstNames</tabstop>
+  <tabstop>mNameDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_svgfill.ui
+++ b/src/ui/symbollayer/widget_svgfill.ui
@@ -6,38 +6,34 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>322</width>
-    <height>509</height>
+    <width>319</width>
+    <height>497</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="2">
+    <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="mStrokeColorLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -50,43 +46,39 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QgsColorButton" name="mChangeStrokeColorButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="5" column="2">
+    <widget class="QgsColorButton" name="mChangeStrokeColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
-   <item row="4" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="mStrokeWidthLabel">
      <property name="text">
       <string>Stroke width</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="8" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLineEdit" name="mSVGLineEdit"/>
@@ -100,7 +92,7 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="1">
+   <item row="6" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QgsDoubleSpinBox" name="mStrokeWidthSpinBox">
@@ -128,38 +120,38 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mSvgStrokeWidthUnitWidget" native="true"/>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QgsColorButton" name="mChangeColorButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
+      <widget class="QgsUnitSelectionWidget" name="mSvgStrokeWidthUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="3" column="2">
+    <widget class="QgsColorButton" name="mChangeColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="mRotationLabel">
@@ -168,7 +160,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QgsDoubleSpinBox" name="mTextureWidthSpinBox">
@@ -193,11 +185,15 @@
       </widget>
      </item>
      <item>
-      <widget class="QgsUnitSelectionWidget" name="mTextureWidthUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mTextureWidthUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -217,42 +213,42 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="3">
     <widget class="QgsPropertyOverrideButton" name="mTextureWidthDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mRotationDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="3" column="3">
     <widget class="QgsPropertyOverrideButton" name="mFilColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="5" column="3">
     <widget class="QgsPropertyOverrideButton" name="mStrokeColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="6" column="3">
     <widget class="QgsPropertyOverrideButton" name="mStrokeWidthDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="3">
+   <item row="7" column="0" colspan="4">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
       <widget class="QLabel" name="mSymbolGroupLabel">
@@ -323,7 +319,7 @@
      </item>
     </layout>
    </item>
-   <item row="6" column="2">
+   <item row="8" column="3">
     <widget class="QgsPropertyOverrideButton" name="mSVGDDBtn">
      <property name="text">
       <string>…</string>
@@ -358,14 +354,22 @@
  </customwidgets>
  <tabstops>
   <tabstop>mTextureWidthSpinBox</tabstop>
+  <tabstop>mTextureWidthUnitWidget</tabstop>
+  <tabstop>mTextureWidthDDBtn</tabstop>
   <tabstop>mRotationSpinBox</tabstop>
+  <tabstop>mRotationDDBtn</tabstop>
   <tabstop>mChangeColorButton</tabstop>
+  <tabstop>mFilColorDDBtn</tabstop>
   <tabstop>mChangeStrokeColorButton</tabstop>
+  <tabstop>mStrokeColorDDBtn</tabstop>
   <tabstop>mStrokeWidthSpinBox</tabstop>
+  <tabstop>mSvgStrokeWidthUnitWidget</tabstop>
+  <tabstop>mStrokeWidthDDBtn</tabstop>
   <tabstop>mSvgTreeView</tabstop>
   <tabstop>mSvgListView</tabstop>
   <tabstop>mSVGLineEdit</tabstop>
   <tabstop>mBrowseToolButton</tabstop>
+  <tabstop>mSVGDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_svgmarker.ui
+++ b/src/ui/symbollayer/widget_svgmarker.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0">
+  <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
    <item row="1" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -21,24 +21,24 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
+   <item row="8" column="3">
     <widget class="QgsPropertyOverrideButton" name="mVerticalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="8" column="0" rowspan="2">
     <widget class="QLabel" name="mAnchorPointLabel">
      <property name="text">
       <string>Anchor point</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_6">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -48,7 +48,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinSize">
@@ -83,44 +83,43 @@
          <height>0</height>
         </size>
        </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="spinAngle">
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="decimals">
-        <number>2</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="4" column="0">
+   <item row="1" column="2">
+    <widget class="QgsDoubleSpinBox" name="spinAngle">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
+     <property name="suffix">
+      <string> °</string>
+     </property>
+     <property name="decimals">
+      <number>2</number>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <widget class="QLabel" name="mStrokeWidthLabel">
      <property name="text">
       <string>Stroke width</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="mStrokeColorLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -133,7 +132,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="3">
+   <item row="10" column="0" colspan="4">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -224,14 +223,14 @@
      </widget>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="6" column="3">
     <widget class="QgsPropertyOverrideButton" name="mStrokeWidthDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="7" column="3">
     <widget class="QgsPropertyOverrideButton" name="mOffsetDDBtn">
      <property name="text">
       <string>…</string>
@@ -241,7 +240,7 @@
    <item row="0" column="0">
     <widget class="QLabel" name="label_2">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -251,23 +250,30 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QgsPropertyOverrideButton" name="mAngleDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="3" column="3">
     <widget class="QgsPropertyOverrideButton" name="mFillColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="7" column="2">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>x</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetX">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -276,7 +282,7 @@
         </sizepolicy>
        </property>
        <property name="prefix">
-        <string>x </string>
+        <string/>
        </property>
        <property name="decimals">
         <number>6</number>
@@ -293,6 +299,13 @@
       </widget>
      </item>
      <item row="1" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="spinOffsetY">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -301,7 +314,7 @@
         </sizepolicy>
        </property>
        <property name="prefix">
-        <string>y </string>
+        <string/>
        </property>
        <property name="decimals">
         <number>6</number>
@@ -317,141 +330,124 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" rowspan="2">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
-   <item row="6" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QComboBox" name="mVerticalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Top</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>VCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Bottom</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QgsColorButton" name="mChangeColorButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+     <item row="0" column="2" rowspan="2">
+      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
        <property name="minimumSize">
         <size>
-         <width>120</width>
+         <width>0</width>
          <height>0</height>
         </size>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="7" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
+   <item row="8" column="2">
+    <widget class="QComboBox" name="mVerticalAnchorComboBox">
      <item>
-      <widget class="QComboBox" name="mHorizontalAnchorComboBox">
-       <item>
-        <property name="text">
-         <string>Left</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>HCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Right</string>
-        </property>
-       </item>
-      </widget>
+      <property name="text">
+       <string>Top</string>
+      </property>
      </item>
-    </layout>
+     <item>
+      <property name="text">
+       <string>VCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </item>
+    </widget>
    </item>
-   <item row="7" column="2">
+   <item row="3" column="2">
+    <widget class="QgsColorButton" name="mChangeColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="2">
+    <widget class="QComboBox" name="mHorizontalAnchorComboBox">
+     <item>
+      <property name="text">
+       <string>Left</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>HCenter</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Right</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="9" column="3">
     <widget class="QgsPropertyOverrideButton" name="mHorizontalAnchorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_8">
-     <item>
-      <widget class="QgsColorButton" name="mChangeStrokeColorButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="5" column="2">
+    <widget class="QgsColorButton" name="mChangeStrokeColorButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <property name="text">
-      <string>Offset X,Y</string>
+      <string/>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Offset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QgsDoubleSpinBox" name="mStrokeWidthSpinBox">
@@ -489,25 +485,28 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="3" column="2">
+   <item row="5" column="3">
     <widget class="QgsPropertyOverrideButton" name="mStrokeColorDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="3">
     <widget class="QgsPropertyOverrideButton" name="mSizeDDBtn">
      <property name="text">
       <string>…</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="11" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLineEdit" name="mFileLineEdit"/>
@@ -521,7 +520,7 @@
      </item>
     </layout>
    </item>
-   <item row="9" column="2">
+   <item row="11" column="3">
     <widget class="QgsPropertyOverrideButton" name="mFilenameDDBtn">
      <property name="text">
       <string>…</string>
@@ -556,16 +555,25 @@
  </customwidgets>
  <tabstops>
   <tabstop>spinSize</tabstop>
-  <tabstop>spinAngle</tabstop>
-  <tabstop>mChangeColorButton</tabstop>
-  <tabstop>mChangeStrokeColorButton</tabstop>
+  <tabstop>mSizeUnitWidget</tabstop>
+  <tabstop>mSizeDDBtn</tabstop>
+  <tabstop>mAngleDDBtn</tabstop>
+  <tabstop>mFillColorDDBtn</tabstop>
+  <tabstop>mStrokeColorDDBtn</tabstop>
   <tabstop>mStrokeWidthSpinBox</tabstop>
-  <tabstop>mHorizontalAnchorComboBox</tabstop>
-  <tabstop>mVerticalAnchorComboBox</tabstop>
+  <tabstop>mStrokeWidthUnitWidget</tabstop>
+  <tabstop>mStrokeWidthDDBtn</tabstop>
+  <tabstop>spinOffsetX</tabstop>
+  <tabstop>spinOffsetY</tabstop>
+  <tabstop>mOffsetUnitWidget</tabstop>
+  <tabstop>mOffsetDDBtn</tabstop>
+  <tabstop>mVerticalAnchorDDBtn</tabstop>
+  <tabstop>mHorizontalAnchorDDBtn</tabstop>
   <tabstop>viewGroups</tabstop>
   <tabstop>viewImages</tabstop>
   <tabstop>mFileLineEdit</tabstop>
   <tabstop>mFileToolButton</tabstop>
+  <tabstop>mFilenameDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -434,6 +434,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
@@ -443,11 +448,6 @@
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -465,6 +465,12 @@
  <tabstops>
   <tabstop>mOpacityWidget</tabstop>
   <tabstop>btnColor</tabstop>
+  <tabstop>spinSize</tabstop>
+  <tabstop>mSizeDDBtn</tabstop>
+  <tabstop>spinAngle</tabstop>
+  <tabstop>mRotationDDBtn</tabstop>
+  <tabstop>spinWidth</tabstop>
+  <tabstop>mWidthDDBtn</tabstop>
   <tabstop>groupsCombo</tabstop>
   <tabstop>openStyleManagerButton</tabstop>
   <tabstop>viewSymbols</tabstop>

--- a/src/ui/symbollayer/widget_vectorfield.ui
+++ b/src/ui/symbollayer/widget_vectorfield.ui
@@ -135,7 +135,11 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QgsUnitSelectionWidget" name="mDistanceUnitWidget" native="true"/>
+      <widget class="QgsUnitSelectionWidget" name="mDistanceUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -250,6 +254,7 @@
  <tabstops>
   <tabstop>mXAttributeComboBox</tabstop>
   <tabstop>mYAttributeComboBox</tabstop>
+  <tabstop>mDistanceUnitWidget</tabstop>
   <tabstop>mScaleSpinBox</tabstop>
   <tabstop>mCartesianRadioButton</tabstop>
   <tabstop>mPolarRadioButton</tabstop>


### PR DESCRIPTION
Refs https://github.com/qgis/qgis3_UIX_discussion/issues/13
Add more consistency to the dialogs to edit layer symbology
* vertical center alignment for "Offset X,Y" label with its comboboxes and unit widget
* added x, y prefixes within offset comboboxes
* vertical center alignment for "Anchor point" label with its comboboxes
* consistency in the order of Anchor options (vertical alignment first)
* remove unnecessary group boxes (with single widget) in the dialog
* Tab ordering

Some screenies (don't pay attention to the join style)
before (left) vs after (right)
![image](https://cloud.githubusercontent.com/assets/7983394/21758108/72000550-d638-11e6-8671-7065b4c60ece.png)

![image](https://cloud.githubusercontent.com/assets/7983394/21758939/92033f18-d640-11e6-991e-ae413214c434.png)

![image](https://cloud.githubusercontent.com/assets/7983394/21758886/17f07e66-d640-11e6-8609-2f6628f93190.png)
