### PR TITLE
Fix compoundcurve area

### DIFF
--- a/python/core/geometry/qgscurvev2.sip
+++ b/python/core/geometry/qgscurvev2.sip
@@ -52,8 +52,7 @@ class QgsCurveV2: public QgsAbstractGeometryV2
      */
     virtual int numPoints() const = 0;
 
-    /** Calculates the area of the curve. Derived classes should override this
-     * to return the correct area of the curve.
+    /** Sums up the area of the curve by iterating over the vertices (shoelace formula).
      */
     virtual void sumUpArea( double& sum ) const = 0;
 

--- a/src/core/geometry/qgscurvepolygonv2.cpp
+++ b/src/core/geometry/qgscurvepolygonv2.cpp
@@ -365,7 +365,7 @@ double QgsCurvePolygonV2::area() const
 
   double totalArea = 0.0;
 
-  if ( mExteriorRing->isClosed() )
+  if ( mExteriorRing->isRing() )
   {
     double area = 0.0;
     mExteriorRing->sumUpArea( area );
@@ -376,7 +376,7 @@ double QgsCurvePolygonV2::area() const
   for ( ; ringIt != mInteriorRings.constEnd(); ++ringIt )
   {
     double area = 0.0;
-    if (( *ringIt )->isClosed() )
+    if (( *ringIt )->isRing() )
     {
       ( *ringIt )->sumUpArea( area );
       totalArea -= qAbs( area );

--- a/src/core/geometry/qgscurvev2.h
+++ b/src/core/geometry/qgscurvev2.h
@@ -80,8 +80,7 @@ class CORE_EXPORT QgsCurveV2: public QgsAbstractGeometryV2
      */
     virtual int numPoints() const = 0;
 
-    /** Calculates the area of the curve. Derived classes should override this
-     * to return the correct area of the curve.
+    /** Sums up the area of the curve by iterating over the vertices (shoelace formula).
      */
     virtual void sumUpArea( double& sum ) const = 0;
 

--- a/src/core/geometry/qgslinestringv2.cpp
+++ b/src/core/geometry/qgslinestringv2.cpp
@@ -837,9 +837,6 @@ QgsPointV2 QgsLineStringV2::centroid() const
 void QgsLineStringV2::sumUpArea( double& sum ) const
 {
   int maxIndex = numPoints() - 1;
-  if ( maxIndex == 1 )
-    return; //no area, just a single line
-
   for ( int i = 0; i < maxIndex; ++i )
   {
     sum += 0.5 * ( mX.at( i ) * mY.at( i + 1 ) - mY.at( i ) * mX.at( i + 1 ) );

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -2051,13 +2051,13 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( area, 1.0 );
   l36.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 10 ) );
   l36.sumUpArea( area );
-  QCOMPARE( area, 1.0 );
+  QVERIFY( qgsDoubleNear( area, -24 ) );
   l36.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 2, 0 ) << QgsPointV2( 2, 2 ) );
   l36.sumUpArea( area );
-  QVERIFY( qgsDoubleNear( area, 3.0 ) );
+  QVERIFY( qgsDoubleNear( area, -22 ) );
   l36.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 2, 0 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 0, 2 ) );
   l36.sumUpArea( area );
-  QVERIFY( qgsDoubleNear( area, 7.0 ) );
+  QVERIFY( qgsDoubleNear( area, -18 ) );
 
   //boundingBox - test that bounding box is updated after every modification to the line string
   QgsLineStringV2 l37;
@@ -2144,27 +2144,27 @@ void TestQgsGeometry::lineStringV2()
 
 void TestQgsGeometry::compoundCurveV2()
 {
-    //test that area of a compound curve ring is equal to a closed linestring with the same vertices
-    QgsCompoundCurveV2 cc;
-    QgsLineStringV2* l1 = new QgsLineStringV2();
-    l1->setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 2 ) );
-    cc.addCurve( l1 );
-    QgsLineStringV2* l2 = new QgsLineStringV2();
-    l2->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 2 ) << QgsPointV2( -1, 0 ) << QgsPointV2( 0, -1 ) );
-    cc.addCurve( l2 );
-    QgsLineStringV2* l3 = new QgsLineStringV2();
-    l3->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, -1 ) << QgsPointV2( 1, 1 ) );
-    cc.addCurve( l3 );
+  //test that area of a compound curve ring is equal to a closed linestring with the same vertices
+  QgsCompoundCurveV2 cc;
+  QgsLineStringV2* l1 = new QgsLineStringV2();
+  l1->setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 2 ) );
+  cc.addCurve( l1 );
+  QgsLineStringV2* l2 = new QgsLineStringV2();
+  l2->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 2 ) << QgsPointV2( -1, 0 ) << QgsPointV2( 0, -1 ) );
+  cc.addCurve( l2 );
+  QgsLineStringV2* l3 = new QgsLineStringV2();
+  l3->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, -1 ) << QgsPointV2( 1, 1 ) );
+  cc.addCurve( l3 );
 
-    double ccArea = 0.0;
-    cc.sumUpArea( ccArea );
+  double ccArea = 0.0;
+  cc.sumUpArea( ccArea );
 
-    QgsLineStringV2 ls;
-    ls.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 2 ) <<  QgsPointV2( -1, 0 ) << QgsPointV2( 0, -1 )
-                  << QgsPointV2( 1, 1 ) );
-    double lsArea = 0.0;
-    ls.sumUpArea( lsArea );
-    QVERIFY( qgsDoubleNear( ccArea, lsArea ) );
+  QgsLineStringV2 ls;
+  ls.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 2 ) <<  QgsPointV2( -1, 0 ) << QgsPointV2( 0, -1 )
+                << QgsPointV2( 1, 1 ) );
+  double lsArea = 0.0;
+  ls.sumUpArea( lsArea );
+  QVERIFY( qgsDoubleNear( ccArea, lsArea ) );
 }
 
 void TestQgsGeometry::polygonV2()

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -27,6 +27,7 @@
 
 //qgis includes...
 #include <qgsapplication.h>
+#include "qgscompoundcurvev2.h"
 #include <qgsgeometry.h>
 #include "qgsgeometryutils.h"
 #include <qgspoint.h>
@@ -60,6 +61,7 @@ class TestQgsGeometry : public QObject
     void isEmpty();
     void pointV2(); //test QgsPointV2
     void lineStringV2(); //test QgsLineStringV2
+    void compoundCurveV2(); //test QgsCompoundCurveV2
     void polygonV2(); //test QgsPolygonV2
 
     void fromQgsPoint();
@@ -2138,6 +2140,31 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( l39.numPoints() == 2 );
   l39.deleteVertex( QgsVertexId( 0, 0, 1 ) );
   QVERIFY( l39.numPoints() == 0 );
+}
+
+void TestQgsGeometry::compoundCurveV2()
+{
+    //test that area of a compound curve ring is equal to a closed linestring with the same vertices
+    QgsCompoundCurveV2 cc;
+    QgsLineStringV2* l1 = new QgsLineStringV2();
+    l1->setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 2 ) );
+    cc.addCurve( l1 );
+    QgsLineStringV2* l2 = new QgsLineStringV2();
+    l2->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 2 ) << QgsPointV2( -1, 0 ) << QgsPointV2( 0, -1 ) );
+    cc.addCurve( l2 );
+    QgsLineStringV2* l3 = new QgsLineStringV2();
+    l3->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, -1 ) << QgsPointV2( 1, 1 ) );
+    cc.addCurve( l3 );
+
+    double ccArea = 0.0;
+    cc.sumUpArea( ccArea );
+
+    QgsLineStringV2 ls;
+    ls.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 2 ) <<  QgsPointV2( -1, 0 ) << QgsPointV2( 0, -1 )
+                  << QgsPointV2( 1, 1 ) );
+    double lsArea = 0.0;
+    ls.sumUpArea( lsArea );
+    QVERIFY( qgsDoubleNear( ccArea, lsArea ) );
 }
 
 void TestQgsGeometry::polygonV2()


### PR DESCRIPTION
QgsLineStringV2::sumUpArea does not add to the area if the linestring has only two vertices. This is a bug, because the sumUpArea methods are meant to be used for the shoelance formula (https://en.wikipedia.org/wiki/Shoelace_formula). It is often the case that linestrings with only two vertices are part of compound curve rings. In such cases, the area is completely wrong if the two-vertice linestring is not considered.

The unit test for sumUpArea is adapted. Additionally, there is a unit test which makes sure that the area within a closed compound curve is the same to that of a closed linestring with the same vertices.