### PR TITLE
enforce utf-8 when generating INSTALL* files

### DIFF
--- a/doc/build.sh
+++ b/doc/build.sh
@@ -14,8 +14,8 @@
 #                                                                         #
 ###########################################################################
 
-txt2tags -o ../INSTALL -t txt INSTALL.t2t 
-txt2tags -o INSTALL.html -t html INSTALL.t2t
-txt2tags -o INSTALL.tex -t tex INSTALL.t2t
+txt2tags --encoding=utf-8 -o ../INSTALL -t txt INSTALL.t2t
+txt2tags --encoding=utf-8 -o INSTALL.html -t html INSTALL.t2t
+txt2tags --encoding=utf-8 -o INSTALL.tex -t tex INSTALL.t2t
 pdflatex INSTALL.tex
 mv INSTALL.pdf ..


### PR DESCRIPTION
Is there a reason not to ensure the output is in utf-8?

On my machine it generated using other encoding and when I set it up in the ``~/.txt2tagsrc`` it didn't work as planned.