### PR TITLE
Fix wrapping unicoded error messages

### DIFF
--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -215,7 +215,8 @@ class GeoAlgorithm:
             lines = [self.tr('Uncaught error while executing algorithm')]
             lines.append(traceback.format_exc())
             ProcessingLog.addToLog(ProcessingLog.LOG_ERROR, lines)
-            raise GeoAlgorithmExecutionException(unicode(e) + self.tr('\nSee log for more details'), lines, e)
+            raise GeoAlgorithmExecutionException(
+                unicode(e.message, errors='replace') + self.tr('\nSee log for more details'), lines, e)
 
     def _checkParameterValuesBeforeExecuting(self):
         for param in self.parameters:


### PR DESCRIPTION
I forgot to do the same as f4ba082836e0a1 for the 2.18 branch.