### PR TITLE
[FEATURE] Support secondary geometry columns in PostGIS layers

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -165,6 +165,7 @@ void QgsApplication::init( QString customConfigPath )
   }
 
   qRegisterMetaType<QgsGeometry::Error>( "QgsGeometry::Error" );
+  qRegisterMetaType<QgsGeometry>( "QgsGeometry" );
 
   QString prefixPath( getenv( "QGIS_PREFIX_PATH" ) ? getenv( "QGIS_PREFIX_PATH" ) : applicationDirPath() );
   // QgsDebugMsg( QString( "prefixPath(): %1" ).arg( prefixPath ) );

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -18,6 +18,7 @@
 #include "qgsfield_p.h"
 #include "qgis.h"
 #include "qgsapplication.h"
+#include "qgsgeometry.h"
 
 #include <QSettings>
 #include <QDataStream>
@@ -206,8 +207,14 @@ QString QgsField::displayString( const QVariant& v ) const
 {
   if ( v.isNull() )
   {
-    QSettings settings;
     return QgsApplication::nullRepresentation();
+  }
+
+  if ( v.userType() == QMetaType::type( "QgsGeometry" ) )
+  {
+    QgsGeometry g = qvariant_cast<QgsGeometry>( v );
+    return g.isEmpty() ? QgsApplication::nullRepresentation()
+           : QgsWkbTypes::displayString( g.wkbType() );
   }
 
   if ( d->type == QVariant::Double && d->precision > 0 )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgspostgresconn.h"
+#include "qgspostgresprovider.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
 #include "qgsdatasourceuri.h"
@@ -39,7 +40,6 @@
 #else
 #include <netinet/in.h>
 #endif
-
 
 QgsPostgresResult::~QgsPostgresResult()
 {
@@ -1343,9 +1343,10 @@ QString QgsPostgresConn::fieldExpression( const QgsField &fld, QString expr )
   }
   else if ( type == QLatin1String( "geometry" ) )
   {
-    return QStringLiteral( "%1(%2)" )
-           .arg( majorVersion() < 2 ? "asewkt" : "st_asewkt",
-                 expr );
+    return QStringLiteral( "%1(%2,'%3')" )
+           .arg( mPostgisVersionMajor < 2 ? "asbinary" : "st_asbinary",
+                 expr,
+                 QgsPostgresProvider::endianString() );
   }
   else if ( type == QLatin1String( "geography" ) )
   {

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -779,8 +779,15 @@ void QgsPostgresFeatureIterator::getFeatureAttribute( int idx, QgsPostgresResult
     return;
 
   const QgsField fld = mSource->mFields.at( idx );
-  QVariant v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ) );
-  feature.setAttribute( idx, v );
+
+  if ( fld.type() == static_cast< QVariant::Type >( QMetaType::type( "QgsGeometry" ) ) )
+  {
+    feature.setAttribute( idx, QVariant::fromValue( getGeometry( queryResult, row, col ) ) );
+  }
+  else
+  {
+    feature.setAttribute( idx, QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ) ) );
+  }
 
   col++;
 }

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -89,6 +89,7 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
 
     QString whereClauseRect();
     bool getFeature( QgsPostgresResult &queryResult, int row, QgsFeature &feature );
+    QgsGeometry getGeometry( QgsPostgresResult& queryResult, int row, int col ) const;
     void getFeatureAttribute( int idx, QgsPostgresResult& queryResult, int row, int& col, QgsFeature& feature );
     bool declareCursor( const QString& whereClause, long limit = -1, bool closeOnFail = true , const QString& orderBy = QString() );
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -897,9 +897,13 @@ bool QgsPostgresProvider::loadFields()
         fieldType = QVariant::DateTime;
         fieldSize = -1;
       }
+      else if ( fieldTypeName == QLatin1String( "geometry" ) )
+      {
+        fieldType = static_cast< QVariant::Type >( QMetaType::type( "QgsGeometry" ) );
+        fieldSize = -1;
+      }
       else if ( fieldTypeName == QLatin1String( "text" ) ||
                 fieldTypeName == QLatin1String( "bool" ) ||
-                fieldTypeName == QLatin1String( "geometry" ) ||
                 fieldTypeName == QLatin1String( "inet" ) ||
                 fieldTypeName == QLatin1String( "money" ) ||
                 fieldTypeName == QLatin1String( "ltree" ) ||


### PR DESCRIPTION
Before, any additional geometry columns would have their values converted to an ewkt string and stored in a string field type.

This was not ideal, as it has some significant issues:
- complex geometries convert to a very long string, causing the attribute table to suffer lengthy hangs while trying to show the ewkt representation
- there is no easy way to convert a ewkt string back to a real geometry value (ie, no expression function or similar), making these additional geometry columns effectively unusable

Now, any additional geometry columns will have their values stored as QgsGeometrys. This allows easy use of these values within expressions (just reference the field and use with all the existing geometry functions, eg area("secondary_geom") ), field calculator (update the main geometry based on the
attributes of a secondary geometry!), and also a super-cool bonus is that these geometries can now easily be used within geometry generator symbol layers (eg draw the line strings stored in a secondary line geometry column in addition to the main point geometry*)

* Will be even more useful when we get labelling geometry generators!

Questions:
- is this the best approach? Could we somehow avoid the metatype requirements (maybe via https://github.com/qgis/qgis3.0_api/issues/49)? Or is this an acceptable requirement for handling non-default qt field types?
- how best to handle secondary geometries with a different CRS to the main geometry...
- why didn't I add unit tests? (answer:I'm still kind of on holidays, so I will, I just want feedback first!)
- who can raise their hand to fund labeling geometry generators? (contact me!!)


