### PR TITLE
Check fields by default when exporting to .kml

### DIFF
--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -345,12 +345,7 @@ void QgsVectorLayerSaveAsDialog::on_mFormatComboBox_currentIndexChanged( int idx
   bool fieldsAsDisplayedValues = false;
 
   const QString sFormat( format() );
-  if ( sFormat == QLatin1String( "KML" ) )
-  {
-    mAttributesSelection->setEnabled( true );
-    selectAllFields = false;
-  }
-  else if ( sFormat == QLatin1String( "DXF" ) )
+  if ( sFormat == QLatin1String( "DXF" ) )
   {
     mAttributesSelection->setEnabled( false );
     selectAllFields = false;


### PR DESCRIPTION
Unlike other formats, saving files into kml format didn't have the fields automatically selected; people could end with a file without attributes.