### PR TITLE
API docs website: Constrain main nav to main column

### DIFF
--- a/doc/api_custom.css
+++ b/doc/api_custom.css
@@ -177,6 +177,12 @@ div.header {
 	width: 80%;
 }
 
+#main-nav {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 div.qindex, div.navpath {
     width: 80%;
     margin-left: auto;


### PR DESCRIPTION
On the API docs website, the main nav menu (the one with the search field in it) spills out of the main column to the full width of the browser. This should fix it.