### PR TITLE
Fix for alphaBand and opacity loss upon renderer switch (style dock & properties window)

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -540,6 +540,16 @@ void QgsRasterLayerProperties::setRendererWidget( const QString& rendererName )
 {
   QgsDebugMsg( "rendererName = " + rendererName );
   QgsRasterRendererWidget* oldWidget = mRendererWidget;
+  QgsRasterRenderer* oldRenderer = mRasterLayer->renderer();
+
+  int alphaBand = -1;
+  double opacity = 1;
+  if ( oldRenderer )
+  {
+    // Retain alpha band and opacity when switching renderer
+    alphaBand = oldRenderer->alphaBand();
+    opacity = oldRenderer->opacity();
+  }
 
   QgsRasterRendererRegistryEntry rendererEntry;
   if ( QgsApplication::rasterRendererRegistry()->rendererData( rendererName, rendererEntry ) )
@@ -562,6 +572,8 @@ void QgsRasterLayerProperties::setRendererWidget( const QString& rendererName )
           whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
         }
       }
+      mRasterLayer->renderer()->setAlphaBand( alphaBand );
+      mRasterLayer->renderer()->setOpacity( opacity );
       mRendererWidget = rendererEntry.widgetCreateFunction( mRasterLayer, myExtent );
       mRendererWidget->setMapCanvas( mMapCanvas );
       mRendererStackedWidget->addWidget( mRendererWidget );

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1258,7 +1258,11 @@ QDateTime QgsRasterLayer::timestamp() const
 void QgsRasterLayer::setRenderer( QgsRasterRenderer* theRenderer )
 {
   QgsDebugMsgLevel( "Entered", 4 );
-  if ( !theRenderer ) { return; }
+  if ( !theRenderer )
+  {
+    return;
+  }
+
   mPipe.set( theRenderer );
   emit rendererChanged();
   emit styleChanged();


### PR DESCRIPTION
This fixes a regression which made its way into QGIS master whereas switching the renderer type of a raster layer resets the opacity to 100% (not too bad) and sets the alphaBand to -1 (real bad).

The PR fixes hub issue 16044 (http://hub.qgis.org/issues/16044) filed by @pcav .