### PR TITLE
[spellcheck] allow inwords checks and line skipping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
             - george-edison55-precise-backports # doxygen 1.8.3
-            # - laurent-boulard-devtools not whitelisted yet https://github.com/travis-ci/apt-source-whitelist/pull/345
+            # - laurent-boulard-devtools (for silver-search, not whitelisted yet https://github.com/travis-ci/apt-source-whitelist/pull/345)
           packages:
             - doxygen
             - bison
@@ -33,6 +33,7 @@ matrix:
             - libfcgi-dev
             - libfftw3-3	    
             - pkg-config
+            - perl  # lookahead regex in spell check script
             - poppler-utils
             - txt2tags
             - xvfb

--- a/NEWS
+++ b/NEWS
@@ -91,7 +91,7 @@ This release has following new features:
 - Layer Legend: New option to zoom to a layer's visible scale range
 - Map Composer: New tools for drawing polygons and polylines
 - Map Composer: Embed atlas features into composer HTML source as GeoJSON
-- Map Composer: Parameterized svg support for composer svg images
+- Map Composer: Parametrized svg support for composer svg images
 - Map Composer: Easier use of HTML in labels
 - Map Composer: Relative links in composer labels
 - Map Composer: Georeference outputs (eg PDF) from composer

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -205,7 +205,7 @@ Renamed Classes        {#qgis_api_break_3_0_renamed_classes}
 <tr><td>QgsApplication<td>userStyleV2Path<td>userStylePath
 <tr><td>QgsComposerShape<td>setUseSymbolV2<td>setUseSymbol
 <tr><td>QgsIFeatureSelectionManager<td>selectedFeaturesIds<td>selectedFeatureIds
-<tr><td>QgsMapLayer<td>capitaliseLayerName<td>capitalizeLayerName
+<tr><td>QgsMapLayer<td>capitaliseLayerName<td>capitalizeLayerName  <!--#spellok-->
 <tr><td>QgsSymbolLayerUtils<td>createSymbolLayerV2ListFromSld<td>createSymbolLayerListFromSld
 <tr><td>QgsVectorLayer<td>editorWidgetV2Config<td>editorWidgetConfig
 <tr><td>QgsVectorLayer<td>editorWidgetV2Text<td>editorWidgetText
@@ -582,6 +582,7 @@ QgsComposerNodesItem        {#qgis_api_break_3_0_QgsComposerNodesItem}
 
 - _readXMLStyle() has been renamed to _readXmlStyle()
 - _writeXMLStyle() has been renamed to _writeXMLStyle()
+- unselectNode() has been renamed to deselectNode() <!--#spellok-->
 
 
 QgsComposerPicture        {#qgis_api_break_3_0_QgsComposerPicture}
@@ -610,6 +611,11 @@ QgsComposerTableV2        {#qgis_api_break_3_0_QgsComposerTableV2}
 
 - rowsVisible(), rowRange(), drawHorizontalGridLines() and
  drawVerticalGridLines() were removed.
+ 
+ QgsComposerView        {#qgis_api_break_3_0_QgsComposerView}
+--------------------
+
+- unselectNode() has been renamed to deselectNode() <!--#spellok-->
 
 
 QgsComposition        {#qgis_api_break_3_0_QgsComposition}
@@ -625,6 +631,7 @@ were removed. Use setSnapTolerance() and snapTolerance() instead.
 - pixelFontSize(), pointFontSize(), relativeResizeRect(), relativePosition() were removed. Use the corresponding methods in QgsComposerUtils instead.
 - sortZList() was removed. Use refreshZList() instead.
 - addComposerTable(), composerTableAdded() were removed.
+- setAllUnselected() has been renamed to setAllDeselected. <!--#spellok-->
 
 
 QgsCoordinateReferenceSystem        {#qgis_api_break_3_0_QgsCoordinateReferenceSystem}
@@ -1189,7 +1196,7 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 - drawLabels() method was removed. It used old deprecated labeling. Replaced by labeling based on PAL library, see QgsLabelingEngine.
 - readLayerXML() was renamed to readLayerXml()
 - writeLayerXML() was renamed to writeLayerXml()
-- capitaliseLayerName() was renamed to capitalizeLayerName()
+- capitaliseLayerName() was renamed to capitalizeLayerName() <!--#spellok-->
 
 
 QgsMapLayerRegistry        {#qgis_api_break_3_0_QgsMapLayerRegistry}

--- a/doc/news.html
+++ b/doc/news.html
@@ -171,7 +171,7 @@ This release has following new features:
 <LI>Layer Legend: New option to zoom to a layer's visible scale range
 <LI>Map Composer: New tools for drawing polygons and polylines
 <LI>Map Composer: Embed atlas features into composer HTML source as GeoJSON
-<LI>Map Composer: Parameterized svg support for composer svg images
+<LI>Map Composer: Parametrized svg support for composer svg images
 <LI>Map Composer: Easier use of HTML in labels
 <LI>Map Composer: Relative links in composer labels
 <LI>Map Composer: Georeference outputs (e.g., PDF) from composer

--- a/doc/news.t2t
+++ b/doc/news.t2t
@@ -85,7 +85,7 @@ This release has following new features:
 - Layer Legend: New option to zoom to a layer's visible scale range
 - Map Composer: New tools for drawing polygons and polylines
 - Map Composer: Embed atlas features into composer HTML source as GeoJSON
-- Map Composer: Parameterized svg support for composer svg images
+- Map Composer: Parametrized svg support for composer svg images
 - Map Composer: Easier use of HTML in labels
 - Map Composer: Relative links in composer labels
 - Map Composer: Georeference outputs (eg PDF) from composer

--- a/doc/release-sponsors.html
+++ b/doc/release-sponsors.html
@@ -121,7 +121,7 @@
 <p>April 17, 2016 - April 17, 2017</p>
 <p>Bronze : 500 EUR or more</p>
 <p><img src="images/projects/thumbnails/e24951be1e5ff2d6fd591f9760871e38a684bed0.png.100x50_q85.png" /></p>
-<p><a href="http://www.gfi-gis.de/">GFI - Gesellschaft für Informationstechnologie mbH</a></p>
+<p><a href="http://www.gfi-gis.de/">GFI - Gesellschaft für Informationstechnologie mbH</a></p>  <!--#spellok-->
 <p>April 15, 2016 - April 15, 2017</p>
 <p>Bronze : 500 EUR or more</p>
 <p><img src="images/projects/thumbnails/44113fc21a8e2cd84d93459d0f00b3a64850095c.png.100x50_q85.jpg" /></p>

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -168,7 +168,7 @@ class Editor(QsciScintilla):
         self.newShortcutCS.activated.connect(self.autoCompleteKeyBinding)
         self.runScut = QShortcut(QKeySequence(Qt.CTRL + Qt.Key_E), self)
         self.runScut.setContext(Qt.WidgetShortcut)
-        self.runScut.activated.connect(self.runSelectedCode)
+        self.runScut.activated.connect(self.runSelectedCode)  #spellok
         self.runScriptScut = QShortcut(QKeySequence(Qt.SHIFT + Qt.CTRL + Qt.Key_E), self)
         self.runScriptScut.setContext(Qt.WidgetShortcut)
         self.runScriptScut.activated.connect(self.runScriptCode)
@@ -307,9 +307,9 @@ class Editor(QsciScintilla):
         syntaxCheck = menu.addAction(iconSyntaxCk,
                                      QCoreApplication.translate("PythonConsole", "Check Syntax"),
                                      self.syntaxCheck, 'Ctrl+4')
-        runSelected = menu.addAction(iconRun,
+        runSelected = menu.addAction(iconRun,  #spellok
                                      QCoreApplication.translate("PythonConsole", "Run Selected"),
-                                     self.runSelectedCode, 'Ctrl+E')
+                                     self.runSelectedCode, 'Ctrl+E')  #spellok
         menu.addAction(iconRunScript,
                        QCoreApplication.translate("PythonConsole", "Run Script"),
                        self.runScriptCode, 'Shift+Ctrl+E')
@@ -358,14 +358,14 @@ class Editor(QsciScintilla):
         pasteAction.setEnabled(False)
         codePadAction.setEnabled(False)
         cutAction.setEnabled(False)
-        runSelected.setEnabled(False)
+        runSelected.setEnabled(False)  #spellok
         copyAction.setEnabled(False)
         selectAllAction.setEnabled(False)
         undoAction.setEnabled(False)
         redoAction.setEnabled(False)
         showCodeInspection.setEnabled(False)
         if self.hasSelectedText():
-            runSelected.setEnabled(True)
+            runSelected.setEnabled(True)  #spellok
             copyAction.setEnabled(True)
             cutAction.setEnabled(True)
             codePadAction.setEnabled(True)
@@ -600,7 +600,7 @@ class Editor(QsciScintilla):
             self.parent.pc.shell.runCommand(u"exec(open(u'{0}'.encode('{1}')).read())"
                                             .format(filename.replace("\\", "/"), sys.getfilesystemencoding()))
 
-    def runSelectedCode(self):
+    def runSelectedCode(self):  #spellok
         cmd = self.selectedText()
         self.parent.pc.shell.insertFromDropPaste(cmd)
         self.parent.pc.shell.entered()

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -166,8 +166,8 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         if not self.is_cursor_on_last_line():
             self.move_cursor_to_end()
         line, pos = self.getCursorPosition()
-        selCmdLenght = len(self.text(line))
-        self.setSelection(line, 4, line, selCmdLenght)
+        selCmdLength = len(self.text(line))
+        self.setSelection(line, 4, line, selCmdLength)
         self.removeSelectedText()
         for cmd in commands:
             self.append(cmd)
@@ -348,8 +348,8 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
     def showPrevious(self):
         if self.historyIndex < len(self.history) and self.history:
             line, pos = self.getCursorPosition()
-            selCmdLenght = len(self.text(line))
-            self.setSelection(line, 4, line, selCmdLenght)
+            selCmdLength = len(self.text(line))
+            self.setSelection(line, 4, line, selCmdLength)
             self.removeSelectedText()
             self.historyIndex += 1
             if self.historyIndex == len(self.history):
@@ -363,8 +363,8 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
     def showNext(self):
         if self.historyIndex > 0 and self.history:
             line, pos = self.getCursorPosition()
-            selCmdLenght = len(self.text(line))
-            self.setSelection(line, 4, line, selCmdLenght)
+            selCmdLength = len(self.text(line))
+            self.setSelection(line, 4, line, selCmdLength)
             self.removeSelectedText()
             self.historyIndex -= 1
             if self.historyIndex == len(self.history):

--- a/python/core/auth/qgsauthcertutils.sip
+++ b/python/core/auth/qgsauthcertutils.sip
@@ -138,7 +138,7 @@ class QgsAuthCertUtils
     /** Get the general name for certificate trust */
     static QString getCertTrustName( QgsAuthCertUtils::CertTrustPolicy trust );
 
-    /** Get string with colon delimeters every 2 characters */
+    /** Get string with colon delimiters every 2 characters */
     static QString getColonDelimited( const QString& txt );
 
     /** Get the sha1 hash for certificate

--- a/python/core/composer/qgscomposernodesitem.sip
+++ b/python/core/composer/qgscomposernodesitem.sip
@@ -74,7 +74,7 @@ class QgsComposerNodesItem: QgsComposerItem
 
     /** Deselect a node.
      */
-    void unselectNode();
+    void deselectNode();
 
     /** Stores state in Dom element
      * @param elem is Dom element corresponding to 'Composer' tag

--- a/python/core/composer/qgscomposerpicture.sip
+++ b/python/core/composer/qgscomposerpicture.sip
@@ -172,51 +172,51 @@ class QgsComposerPicture: QgsComposerItem
      */
     ItemPositionMode pictureAnchor() const;
 
-    /** Returns the fill color used for parameterized SVG files.
+    /** Returns the fill color used for parametrized SVG files.
      * @see setSvgFillColor()
      * @see svgBorderColor()
      * @note added in QGIS 2.14.1
      */
     QColor svgFillColor() const;
 
-    /** Sets the fill color used for parameterized SVG files.
+    /** Sets the fill color used for parametrized SVG files.
      * @param color fill color.
-     * @note this setting only has an effect on parameterized SVG files, and is ignored for
-     * non-parameterized SVG files.
+     * @note this setting only has an effect on parametrized SVG files, and is ignored for
+     * non-parametrized SVG files.
      * @see svgFillColor()
      * @see setSvgBorderColor()
      * @note added in QGIS 2.14.1
      */
     void setSvgFillColor( const QColor& color );
 
-    /** Returns the border color used for parameterized SVG files.
+    /** Returns the border color used for parametrized SVG files.
      * @see setSvgBorderColor()
      * @see svgFillColor()
      * @note added in QGIS 2.14.1
      */
     QColor svgBorderColor() const;
 
-    /** Sets the border color used for parameterized SVG files.
+    /** Sets the border color used for parametrized SVG files.
      * @param color border color.
-     * @note this setting only has an effect on parameterized SVG files, and is ignored for
-     * non-parameterized SVG files.
+     * @note this setting only has an effect on parametrized SVG files, and is ignored for
+     * non-parametrized SVG files.
      * @see svgBorderlColor()
      * @see setSvgFillColor()
      * @note added in QGIS 2.14.1
      */
     void setSvgBorderColor( const QColor& color );
 
-    /** Returns the border width (in mm) used for parameterized SVG files.
+    /** Returns the border width (in mm) used for parametrized SVG files.
      * @see setSvgBorderWidth()
      * @see svgBorderColor()
      * @note added in QGIS 2.14.1
      */
     double svgBorderWidth() const;
 
-    /** Sets the border width used for parameterized SVG files.
+    /** Sets the border width used for parametrized SVG files.
      * @param width border width in mm
-     * @note this setting only has an effect on parameterized SVG files, and is ignored for
-     * non-parameterized SVG files.
+     * @note this setting only has an effect on parametrized SVG files, and is ignored for
+     * non-parametrized SVG files.
      * @see svgBorderWidth()
      * @see setSvgBorderColor()
      * @note added in QGIS 2.14.1

--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -768,7 +768,7 @@ class QgsComposition : QGraphicsScene, QgsExpressionContextGenerator
      * QGraphicsScene::clearSelection, as the latter does not correctly emit signals to allow
      * the composition's model to update.
      * @note added in version 2.5*/
-    void setAllUnselected();
+    void setAllDeselected();
 
     /** Refreshes a data defined property for the composition by reevaluating the property's value
      * and redrawing the composition with this new value.

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -2037,7 +2037,7 @@ template <TYPE>
 
 // Import the Chimera helper registration functions.
 void (*register_from_qvariant_converter)(FromQVariantConverterFn);
-register_from_qvariant_converter = (void (*)(FromQVariantConverterFn))sipImportSymbol("pyqt5_register_from_qvariant_converter");
+register_from_qvariant_converter = (void (*)(FromQVariantConverterFn))sipImportSymbol("pyqt5_register_from_qvariant_convertor");  //#spellok
 register_from_qvariant_converter(null_from_qvariant_converter);
 %End
 %End

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -2033,11 +2033,11 @@ template <TYPE>
 #include "qgissiphelper.h"
 %End
 
-%PostInitialisationCode
+%PostInitialisationCode  //#spellok
 
 // Import the Chimera helper registration functions.
-void (*register_from_qvariant_convertor)(FromQVariantConvertorFn);
-register_from_qvariant_convertor = (void (*)(FromQVariantConvertorFn))sipImportSymbol("pyqt5_register_from_qvariant_convertor");
-register_from_qvariant_convertor(null_from_qvariant_convertor);
+void (*register_from_qvariant_converter)(FromQVariantConverterFn);
+register_from_qvariant_converter = (void (*)(FromQVariantConverterFn))sipImportSymbol("pyqt5_register_from_qvariant_converter");
+register_from_qvariant_converter(null_from_qvariant_converter);
 %End
 %End

--- a/python/core/layertree/qgslayertreenode.sip
+++ b/python/core/layertree/qgslayertreenode.sip
@@ -98,11 +98,11 @@ class QgsLayerTreeNode : QObject
     //! @note added in 3.0
     bool isVisible() const;
 
-    //! Returns whether a node is checked (independantly of its ancestors or children)
+    //! Returns whether a node is checked (independently of its ancestors or children)
     //! @note added in 3.0
     bool itemVisibilityChecked() const;
 
-    //! Check or uncheck a node (independantly of its ancestors or children)
+    //! Check or uncheck a node (independently of its ancestors or children)
     //! @note added in 3.0
     void setItemVisibilityChecked( bool checked );
 

--- a/python/plugins/processing/algs/taudem/dropanalysis.py
+++ b/python/plugins/processing/algs/taudem/dropanalysis.py
@@ -55,9 +55,9 @@ class DropAnalysis(GeoAlgorithm):
     D8_FLOW_DIR_GRID = 'D8_FLOW_DIR_GRID'
     ACCUM_STREAM_SOURCE_GRID = 'ACCUM_STREAM_SOURCE_GRID'
     OUTLETS_SHAPE = 'OUTLETS_SHAPE'
-    MIN_TRESHOLD = 'MIN_TRESHOLD'
+    MIN_THRESHOLD = 'MIN_THRESHOLD'
     MAX_THRESHOLD = 'MAX_THRESHOLD'
-    TRESHOLD_NUM = 'TRESHOLD_NUM'
+    THRESHOLD_NUM = 'THRESHOLD_NUM'
     STEP_TYPE = 'STEP_TYPE'
 
     DROP_ANALYSIS_FILE = 'DROP_ANALYSIS_FILE'
@@ -81,11 +81,11 @@ class DropAnalysis(GeoAlgorithm):
         self.addParameter(ParameterVector(self.OUTLETS_SHAPE,
                                           self.tr('Outlets Shapefile'),
                                           [dataobjects.TYPE_VECTOR_POINT], False))
-        self.addParameter(ParameterNumber(self.MIN_TRESHOLD,
+        self.addParameter(ParameterNumber(self.MIN_THRESHOLD,
                                           self.tr('Minimum Threshold'), 0, None, 5))
         self.addParameter(ParameterNumber(self.MAX_THRESHOLD,
                                           self.tr('Maximum Threshold'), 0, None, 500))
-        self.addParameter(ParameterNumber(self.TRESHOLD_NUM,
+        self.addParameter(ParameterNumber(self.THRESHOLD_NUM,
                                           self.tr('Number of Threshold Values'), 0, None, 10))
         self.addParameter(ParameterBoolean(self.STEP_TYPE,
                                            self.tr('Use logarithmic spacing for threshold values'), True))
@@ -116,9 +116,9 @@ class DropAnalysis(GeoAlgorithm):
         commands.append('-o')
         commands.append(self.getParameterValue(self.OUTLETS_SHAPE))
         commands.append('-par')
-        commands.append(str(self.getParameterValue(self.MIN_TRESHOLD)))
+        commands.append(str(self.getParameterValue(self.MIN_THRESHOLD)))
         commands.append(str(self.getParameterValue(self.MAX_THRESHOLD)))
-        commands.append(str(self.getParameterValue(self.TRESHOLD_NUM)))
+        commands.append(str(self.getParameterValue(self.THRESHOLD_NUM)))
         commands.append(str(self.getParameterValue(self.STEP_TYPE)))
         commands.append('-drp')
         commands.append(self.getOutputValue(self.DROP_ANALYSIS_FILE))

--- a/python/plugins/processing/gui/ListMultiselectWidget.py
+++ b/python/plugins/processing/gui/ListMultiselectWidget.py
@@ -47,7 +47,7 @@ class ListMultiSelectWidget(QGroupBox):
         self.setTitle(title)
 
         self.selected_widget = None
-        self.unselected_widget = None
+        self.deselected_widget = None
         self._setupUI()
 
         # connect actions
@@ -56,7 +56,7 @@ class ListMultiSelectWidget(QGroupBox):
         self.select_btn.clicked.connect(self._select)
         self.deselect_btn.clicked.connect(self._deselect)
 
-        self.unselected_widget.itemDoubleClicked.connect(self._select)
+        self.deselected_widget.itemDoubleClicked.connect(self._select)
         self.selected_widget.itemDoubleClicked.connect(self._deselect)
 
     def get_selected_items(self):
@@ -65,11 +65,11 @@ class ListMultiSelectWidget(QGroupBox):
         """
         return self._get_items(self.selected_widget)
 
-    def get_unselected_items(self):
+    def get_deselected_items(self):
         """
-        :return list with all the unselected items text
+        :return list with all the deselected items text
         """
-        return self._get_items(self.unselected_widget)
+        return self._get_items(self.deselected_widget)
 
     def add_selected_items(self, items):
         """
@@ -77,11 +77,11 @@ class ListMultiSelectWidget(QGroupBox):
         """
         self._add_items(self.selected_widget, items)
 
-    def add_unselected_items(self, items):
+    def add_deselected_items(self, items):
         """
-        :param items list of strings to be added in the unselected list
+        :param items list of strings to be added in the deselected list
         """
-        self._add_items(self.unselected_widget, items)
+        self._add_items(self.deselected_widget, items)
 
     def set_selected_items(self, items):
         """
@@ -89,32 +89,32 @@ class ListMultiSelectWidget(QGroupBox):
         """
         self._set_items(self.selected_widget, items)
 
-    def set_unselected_items(self, items):
+    def set_deselected_items(self, items):
         """
-        :param items list of strings to be set as the unselected list
+        :param items list of strings to be set as the deselected list
         """
-        self._set_items(self.unselected_widget, items)
+        self._set_items(self.deselected_widget, items)
 
     def clear(self):
         """
-        removes all items from selected and unselected
+        removes all items from selected and deselected
         """
         self.set_selected_items([])
-        self.set_unselected_items([])
+        self.set_deselected_items([])
 
     def addItem(self, item):
         """
         This is for Processing
-        :param item: string to be added in the unselected list
+        :param item: string to be added in the deselected list
         """
-        self.add_unselected_items([item])
+        self.add_deselected_items([item])
 
     def addItems(self, items):
         """
         This is for Processing
-        :param items: list of strings to be added in the unselected list
+        :param items: list of strings to be added in the deselected list
         """
-        self.add_unselected_items(items)
+        self.add_deselected_items(items)
 
     def _get_items(self, widget):
         for i in range(widget.count()):
@@ -128,18 +128,18 @@ class ListMultiSelectWidget(QGroupBox):
         widget.addItems(items)
 
     def _select_all(self):
-        self.unselected_widget.selectAll()
-        self._do_move(self.unselected_widget, self.selected_widget)
+        self.deselected_widget.selectAll()
+        self._do_move(self.deselected_widget, self.selected_widget)
 
     def _deselect_all(self):
         self.selected_widget.selectAll()
-        self._do_move(self.selected_widget, self.unselected_widget)
+        self._do_move(self.selected_widget, self.deselected_widget)
 
     def _select(self):
-        self._do_move(self.unselected_widget, self.selected_widget)
+        self._do_move(self.deselected_widget, self.selected_widget)
 
     def _deselect(self):
-        self._do_move(self.selected_widget, self.unselected_widget)
+        self._do_move(self.selected_widget, self.deselected_widget)
 
     def _do_move(self, fromList, toList):
         for item in fromList.selectedItems():
@@ -159,16 +159,16 @@ class ListMultiSelectWidget(QGroupBox):
         italic_font = QFont()
         italic_font.setItalic(True)
 
-        # unselected widget
-        self.unselected_widget = QListWidget(self)
-        self._set_list_widget_defaults(self.unselected_widget)
-        unselected_label = QLabel()
-        unselected_label.setText('Unselected')
-        unselected_label.setAlignment(Qt.AlignCenter)
-        unselected_label.setFont(italic_font)
-        unselected_v_layout = QVBoxLayout()
-        unselected_v_layout.addWidget(unselected_label)
-        unselected_v_layout.addWidget(self.unselected_widget)
+        # deselected widget
+        self.deselected_widget = QListWidget(self)
+        self._set_list_widget_defaults(self.deselected_widget)
+        deselected_label = QLabel()
+        deselected_label.setText('Deselected')
+        deselected_label.setAlignment(Qt.AlignCenter)
+        deselected_label.setFont(italic_font)
+        deselected_v_layout = QVBoxLayout()
+        deselected_v_layout.addWidget(deselected_label)
+        deselected_v_layout.addWidget(self.deselected_widget)
 
         # selected widget
         self.selected_widget = QListWidget(self)
@@ -206,7 +206,7 @@ class ListMultiSelectWidget(QGroupBox):
         self.buttons_vertical_layout.addWidget(self.deselect_all_btn)
 
         # add sub widgets
-        self.main_horizontal_layout.addLayout(unselected_v_layout)
+        self.main_horizontal_layout.addLayout(deselected_v_layout)
         self.main_horizontal_layout.addLayout(self.buttons_vertical_layout)
         self.main_horizontal_layout.addLayout(selected_v_layout)
 

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -236,7 +236,7 @@ class ModelerParametersDialog(QDialog):
         reply.deleteLater()
         self.txtHelp.setHtml(html)
 
-    def getAvailableDependencies(self):
+    def getAvailableDependencies(self):  #spellok
         if self._algName is None:
             dependent = []
         else:
@@ -248,7 +248,7 @@ class ModelerParametersDialog(QDialog):
         return opts
 
     def getDependenciesPanel(self):
-        return MultipleInputPanel([alg.description for alg in self.getAvailableDependencies()])
+        return MultipleInputPanel([alg.description for alg in self.getAvailableDependencies()])    #spellok
 
     def showAdvancedParametersClicked(self):
         self.showAdvanced = not self.showAdvanced
@@ -318,7 +318,7 @@ class ModelerParametersDialog(QDialog):
                 self.valueItems[name].setText(out.description)
 
             selected = []
-            dependencies = self.getAvailableDependencies()
+            dependencies = self.getAvailableDependencies()    #spellok
             for idx, dependency in enumerate(dependencies):
                 if dependency.name in alg.dependencies:
                     selected.append(idx)
@@ -345,9 +345,9 @@ class ModelerParametersDialog(QDialog):
                     alg.outputs[output.name] = ModelerOutput(name)
 
         selectedOptions = self.dependenciesPanel.selectedoptions
-        availableDependencies = self.getAvailableDependencies()
+        availableDependencies = self.getAvailableDependencies()  #spellok
         for selected in selectedOptions:
-            alg.dependencies.append(availableDependencies[selected].name)
+            alg.dependencies.append(availableDependencies[selected].name)  #spellok
 
         self._alg.processBeforeAddingToModeler(alg, self.model)
         return alg

--- a/python/plugins/processing/script/ScriptSelector.py
+++ b/python/plugins/processing/script/ScriptSelector.py
@@ -67,7 +67,7 @@ class ScriptSelector(BASE, WIDGET):
         self.scriptsTree.expandAll()
 
         self.selectAllLabel.linkActivated.connect(lambda: self.checkScripts(True))
-        self.unselectAllLabel.linkActivated.connect(lambda: self.checkScripts(False))
+        self.deselectAllLabel.linkActivated.connect(lambda: self.checkScripts(False))
 
         self.folderButton.clicked.connect(self.selectFolder)
 

--- a/python/plugins/processing/ui/scriptselector.ui
+++ b/python/plugins/processing/ui/scriptselector.ui
@@ -48,7 +48,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="unselectAllLabel">
+          <widget class="QLabel" name="deselectAllLabel">
            <property name="text">
             <string>&lt;a href='#'&gt;None&lt;/a&gt;</string>
            </property>

--- a/python/sip_helpers/qgissiphelper.cpp
+++ b/python/sip_helpers/qgissiphelper.cpp
@@ -22,7 +22,7 @@
 #include <QVariant>
 #include <Python.h>
 
-bool null_from_qvariant_convertor( const QVariant *varp, PyObject **objp )
+bool null_from_qvariant_converter( const QVariant *varp, PyObject **objp )
 {
   static bool watchdog = false;
 

--- a/python/sip_helpers/qgissiphelper.h
+++ b/python/sip_helpers/qgissiphelper.h
@@ -19,6 +19,6 @@
 
 class QVariant;
 
-typedef bool ( *FromQVariantConvertorFn )( const QVariant *, PyObject ** );
+typedef bool ( *FromQVariantConverterFn )( const QVariant *, PyObject ** );
 
-bool null_from_qvariant_convertor( const QVariant *, PyObject ** );
+bool null_from_qvariant_converter( const QVariant *, PyObject ** );

--- a/resources/customization.xml
+++ b/resources/customization.xml
@@ -945,7 +945,7 @@
       <widget objectName="mCircleRadiusLabel" class="QLabel" label="Circle radius modification:"/>
       <widget objectName="mDistanceToleranceLabel" class="QLabel" label="Point distance tolerance:"/>
     </widget>
-    <widget objectName="mLabellingGroupBox" class="QGroupBox" label="">
+    <widget objectName="mLabelingGroupBox" class="QGroupBox" label="">
       <widget objectName="mLabelAttributeLabel" class="QLabel" label="Label attribute:"/>
       <widget objectName="mLabelFieldComboBox" class="QComboBox" label=""/>
       <widget objectName="mLabelFontButton" class="QPushButton" label="Label font..."/>

--- a/scripts/.agignore
+++ b/scripts/.agignore
@@ -33,7 +33,6 @@ src/server/qgis_wms.xmi
 resources/cpt-city-qgis-min/fme/metres/DESC.xml
 resources/cpt-city-qgis-min/selections/reds.xml
 resources/cpt-city-qgis-min/wkp/schwarzwald/COPYING.xml
-tests/src/python/test_qgsserver_accesscontrol.py
 tests/testdata/qgis_server/ets-wms13/project.qgs
 tests/testdata/qgis_server_accesscontrol/project.qgs
 tests/testdata/qgis_server_accesscontrol/Hello.qml

--- a/scripts/.agignore
+++ b/scripts/.agignore
@@ -23,11 +23,18 @@ src/plugins/grass/qtermwidget/
 
 #Specific files
 ChangeLog
+debian/qgis.desktop
+debian/qbrowser.desktop
 doc/contributors.json
 Exception_to_GPL_for_Qt.txt
 images/themes/default/svgbase/hammer.svg
 images/themes/default/propertyicons/general.svg
 LexerR.py
+python/plugins/processing/tests/testdata/expected/orthagonal_polys.gml
+python/plugins/processing/tests/testdata/expected/orthagonal_lines.gml
+python/plugins/processing/tests/testdata/expected/orthagonal_lines.gfs
+python/plugins/processing/tests/testdata/expected/orthagonal_polys.gfs
+python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
 spelling.dat
 src/server/qgis_wms.xmi
 resources/cpt-city-qgis-min/fme/metres/DESC.xml

--- a/scripts/.agignore
+++ b/scripts/.agignore
@@ -29,7 +29,9 @@ images/themes/default/svgbase/hammer.svg
 images/themes/default/propertyicons/general.svg
 LexerR.py
 spelling.dat
+src/server/qgis_wms.xmi
 resources/cpt-city-qgis-min/fme/metres/DESC.xml
+resources/cpt-city-qgis-min/selections/reds.xml
 resources/cpt-city-qgis-min/wkp/schwarzwald/COPYING.xml
 tests/src/python/test_qgsserver_accesscontrol.py
 tests/testdata/qgis_server/ets-wms13/project.qgs

--- a/scripts/chkspelling_ag.sh
+++ b/scripts/chkspelling_ag.sh
@@ -19,9 +19,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 AGIGNORE=${DIR}/.agignore
 
-WHOLEWORDS=$(sed '/\*/d' scripts/spelling.dat | cut -d: -f1 |  tr '\n' '\|' | sed -e 's/|$//')
-INWORDS=$(sed -n -e '/\*/p' scripts/spelling.dat | cut -d: -f1 |  tr '\n' '\|' | sed -e 's/|$//')
-
+# This will try to look for mispelling within larger words.
+# Condition is hard to explain in words.
+# You can test it here: https://regex101.com/r/7kznVA/9
+# extra words that should not be checked in longer words
+WHOLEWORDS=$(echo "("; perl -ne 'print if not /^(\w)(\w)\w{2,}(\w)(\w):(\2\2|\1(?:(?!\1)\w)|(?:(?!\1)\w)\2|(?:(?!\1)\w)(?:(?!\1)\w)|\2\1)\w*(\3\3|(?:(?!\4)\w)(?:(?!\3)\4)|\3(?:(?!\4).)|(?:(?!\4)\w)(?:(?!\4)\w)|\4\3)(?!:\*)$/' scripts/spelling.dat | cut -d: -f1 |  tr '\n' '\|' | sed -e 's/|$//'; echo ")")
+INWORDS=$(   echo "("; perl -ne 'print if     /^(\w)(\w)\w{2,}(\w)(\w):(\2\2|\1(?:(?!\1)\w)|(?:(?!\1)\w)\2|(?:(?!\1)\w)(?:(?!\1)\w)|\2\1)\w*(\3\3|(?:(?!\4)\w)(?:(?!\3)\4)|\3(?:(?!\4).)|(?:(?!\4)\w)(?:(?!\4)\w)|\4\3)(?!:\*)$/' scripts/spelling.dat | cut -d: -f1 |  tr '\n' '\|' | sed -e 's/|$//'; echo ")")
 
 if [ ! $# -eq 0 ]; then
   EXCLUDE=$(cat $AGIGNORE | sed -e 's/\s*#.*$//' -e '/^\s*$/d' | tr '\n' '|' | sed -e 's/|$//')
@@ -31,19 +34,23 @@ else
   FILES="."
 fi
 
+SPELLOK='(#spellok|<!--#spellok-->)$'
+
 
 exec 5>&1
 # "path-to-ignore" option differs on ag version: --path-to-ignore on fedora, --path-to-agignore on ubuntu 16.04: using short option
-OUTPUT=$(unbuffer ag --smart-case --all-text --nopager --numbers --word-regexp -p $AGIGNORE "$WHOLEWORDS"'(?!.*#spellok$)' $FILES | tee /dev/fd/5 ; \
-         unbuffer ag --smart-case --all-text --nopager --numbers               -p $AGIGNORE "$INWORDS"'(?!.*#spellok$)'    $FILES | tee /dev/fd/5)
+OUTPUT=$(unbuffer ag --smart-case --all-text --nopager --numbers --word-regexp -p $AGIGNORE "${WHOLEWORDS}"'(?!.*'"${SPELLOK}"')' $FILES | tee /dev/fd/5 ; \
+         unbuffer ag --smart-case --all-text --nopager --numbers               -p $AGIGNORE "${INWORDS}"'(?!.*'"${SPELLOK}"')'    $FILES | tee /dev/fd/5)
 
+
+ESCSPELLOK=$(echo $SPELLOK | sed 's/(/\\\\(/' | sed 's/)/\\\\)/' | sed 's/|/\\\\|/')
 
 if [[ !  -z  $OUTPUT  ]]; then
   echo "Spelling errors have been found"
   echo "****"
-  # < ---------- get files + error --------------------------------------------------------------------------->                                                             <-- generate sed command .... <------------------------------ get correction word ---------------------------------->    <------------------------------- match case ------------------------------------------->   <-----replace : by / and add word boundary------> ...finalize sed command>  remove duplicate line
-  ag --smart-case --only-matching --nogroup --nonumbers --all-text --word-regexp -p $AGIGNORE "$WHOLEWORDS"'(?!.*#spellok$)' $FILES | sed -e 's/\(\S*\):\([[:alnum:]]*\)$/  echo "sed -i \x27s\/"$( echo "\2:$(ag --nonumbers --ignore-case --word-regexp \2 scripts\/spelling.dat | cut -d: -f2)" | sed -r \x27s\/([A-Z]+):(.*)\/\\1:\\U\\2\/; s\/([A-Z][a-z]+):([a-z])\/\\1:\\U\\2\\L\/\x27  | sed -r \x27s\/(\\S\*):\/\\\\b\\1\\\\b\\\/\/\x27)"\/g\x27 \1" /e'  | sort -u
-  ag --smart-case --only-matching --nogroup --nonumbers --all-text -p $AGIGNORE "$INWORDS"'(?!.*#spellok$)' $FILES                  | sed -e 's/\(\S*\):\([[:alnum:]]*\)$/  echo "sed -i \x27s\/"$( echo "\2:$(ag --nonumbers --ignore-case --word-regexp \2 scripts\/spelling.dat | cut -d: -f2)" | sed -r \x27s\/([A-Z]+):(.*)\/\\1:\\U\\2\/; s\/([A-Z][a-z]+):([a-z])\/\\1:\\U\\2\\L\/\x27  | sed -r \x27s\/(\\S\*):\/\\1\\\/\/\x27)"\/g\x27 \1" /e'            | sort -u
+  # < ---------- get files + error --------------------------------------------------------------------------->                                                                     <-- generate sed command ....                          <------------------------------ get correction word ---------------------------------->    <------------------------------- match case ------------------------------------------->   <-----replace : by / and add word boundary------> ...finalize sed command> remove duplicate line
+  ag --smart-case --only-matching --nogroup --nonumbers --all-text --word-regexp -p $AGIGNORE "${WHOLEWORDS}"'(?!.*'"${SPELLOK}"')' $FILES | sed -e 's/\(\S*\):\([[:alnum:]]*\)$/  echo "sed -i \x27\/'"$ESCSPELLOK"'\/! s\/"$( echo "\2:$(ag --nonumbers --ignore-case --word-regexp \2 scripts\/spelling.dat | cut -d: -f2)" | sed -r \x27s\/([A-Z]+):(.*)\/\\1:\\U\\2\/; s\/([A-Z][a-z]+):([a-z])\/\\1:\\U\\2\\L\/\x27  | sed -r \x27s\/(\\S\*):\/\\\\b\\1\\\\b\\\/\/\x27)"\/g\x27 \1" /e'  | sort -u
+  ag --smart-case --only-matching --nogroup --nonumbers --all-text               -p $AGIGNORE "${INWORDS}"'(?!.*'"${SPELLOK}"')'    $FILES | sed -e 's/\(\S*\):\([[:alnum:]]*\)$/  echo "sed -i \x27\/'"$ESCSPELLOK"'\/! s\/"$( echo "\2:$(ag --nonumbers --ignore-case --word-regexp \2 scripts\/spelling.dat | cut -d: -f2)" | sed -r \x27s\/([A-Z]+):(.*)\/\\1:\\U\\2\/; s\/([A-Z][a-z]+):([a-z])\/\\1:\\U\\2\\L\/\x27  | sed -r \x27s\/(\\S\*):\/\\1\\\/\/\x27)"\/g\x27 \1" /e'            | sort -u
   echo "****"
   echo "Run above commands to fix spelling errors or add #spellok at the end of the line to discard spell check on this line."
   exit 1

--- a/scripts/spelling.dat
+++ b/scripts/spelling.dat
@@ -103,7 +103,7 @@ charcter:character
 chnages:changes
 choosen:chosen
 colorfull:colorful
-colour:color
+colour:color:*
 colours:colors
 comand:command
 comit:commit

--- a/scripts/spelling.dat
+++ b/scripts/spelling.dat
@@ -75,7 +75,7 @@ automatizes:automates
 auxilliary:auxiliary
 avaiable:available
 availabel:available
-availabled:available
+availabled:available:*
 availablity:availability
 availale:available
 availavility:availability
@@ -103,7 +103,7 @@ charcter:character
 chnages:changes
 choosen:chosen
 colorfull:colorful
-colour:color:*
+colour:color
 colours:colors
 comand:command
 comit:commit
@@ -272,7 +272,7 @@ libary:library
 libraris:libraries
 licenceing:licencing
 loggging:logging
-loggin:login
+loggin:login:*
 logile:logfile
 machinary:machinery
 maintainance:maintenance
@@ -318,7 +318,7 @@ occured:occurred
 occurence:occurrence
 occuring:occurring
 omitt:omit
-ommitted:omitted
+ommitted:omitted:*
 opps:oops
 optionnal:optional
 optmizations:optimizations
@@ -402,7 +402,7 @@ reenable:re-enable
 reenabled:re-enabled
 reencode:re-encode
 refence:reference
-registerd:registered
+registerd:registered:*
 registraration:registration
 regulamentations:regulations
 remoote:remote
@@ -420,7 +420,7 @@ rigth:right
 runnning:running
 safly:safely
 savable:saveable
-searchs:searches
+searchs:searches:*
 secific:specific
 secund:second
 separatly:separately
@@ -448,8 +448,8 @@ splitted:split
 staically:statically
 standart:standard
 staticly:statically
-statics:statistics
-stoped:stopped
+statics:statistics:*
+stoped:stopped:*
 subdirectoires:subdirectories
 succesful:successful
 succesfully:successfully
@@ -469,7 +469,7 @@ suppported:supported
 supress:suppress
 surpress:suppress
 suspicously:suspiciously
-swaped:swapped
+swaped:swapped:*
 symbo:symbol
 syle:style
 symetrical:symmetrical

--- a/scripts/spelling.dat
+++ b/scripts/spelling.dat
@@ -198,6 +198,7 @@ familar:familiar
 fatser:faster
 fetaures:features
 feture:feature
+flter:filter
 flavour:flavor
 flavours:flavors
 forse:force
@@ -256,6 +257,7 @@ intersecton:intersection
 intersectons:intersections
 interupted:interrupted
 intialised:initialized
+intreface:interface
 jave:java
 kilometre:kilometer
 kilometres:kilometers

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3435,7 +3435,7 @@ void QgsComposer::saveWindowState()
 
 void QgsComposer::restoreWindowState()
 {
-  // restore the toolbar and dock widgets postions using Qt4 settings API
+  // restore the toolbar and dock widgets positions using Qt4 settings API
   QSettings settings;
 
   if ( !restoreState( settings.value( QStringLiteral( "/ComposerUI/state" ), QByteArray::fromRawData(( char * )defaultComposerUIstate, sizeof defaultComposerUIstate ) ).toByteArray() ) )

--- a/src/app/nodetool/qgsmaptoolnodetool.h
+++ b/src/app/nodetool/qgsmaptoolnodetool.h
@@ -111,7 +111,7 @@ class QgsMapToolNodeTool: public QgsMapToolEdit
     void createTopologyRubberBands();
 
     /**
-     * Returns the index of first selected vertex, -1 when all unselected
+     * Returns the index of first selected vertex, -1 when all deselected
      */
     int firstSelectedVertex();
 

--- a/src/app/openstreetmap/qgsosmexportdialog.cpp
+++ b/src/app/openstreetmap/qgsosmexportdialog.cpp
@@ -42,7 +42,7 @@ QgsOSMExportDialog::QgsOSMExportDialog( QWidget *parent )
   connect( radPolygons, SIGNAL( clicked() ), this, SLOT( updateLayerName() ) );
   connect( btnLoadTags, SIGNAL( clicked() ), this, SLOT( onLoadTags() ) );
   connect( btnSelectAll, SIGNAL( clicked() ), this, SLOT( onSelectAll() ) );
-  connect( btnUnselectAll, SIGNAL( clicked() ), this, SLOT( onUnselectAll() ) );
+  connect( btnDeselectAll, SIGNAL( clicked() ), this, SLOT( onDeselectAll() ) );
 
   mTagsModel = new QStandardItemModel( this );
   mTagsModel->setHorizontalHeaderLabels( QStringList() << tr( "Tag" ) << tr( "Count" ) << tr( "Not null" ) );
@@ -205,7 +205,7 @@ void QgsOSMExportDialog::onSelectAll()
   }
 }
 
-void QgsOSMExportDialog::onUnselectAll()
+void QgsOSMExportDialog::onDeselectAll()
 {
   for ( int i = 0; i < mTagsModel->rowCount(); ++i )
   {

--- a/src/app/openstreetmap/qgsosmexportdialog.h
+++ b/src/app/openstreetmap/qgsosmexportdialog.h
@@ -39,7 +39,7 @@ class QgsOSMExportDialog : public QDialog, private Ui::QgsOSMExportDialog
     void updateLayerName();
     void onLoadTags();
     void onSelectAll();
-    void onUnselectAll();
+    void onDeselectAll();
 
     void onOK();
     void onClose();

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -58,7 +58,7 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     //! Load selected plugin
     void loadPlugin( const QString& id );
 
-    //! Unload unselected plugin
+    //! Unload deselected plugin
     void unloadPlugin( const QString& id );
 
     //! Save plugin enabled/disabled state to QSettings

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -407,7 +407,7 @@ void QgsVectorLayerAndAttributeModel::selectAll()
   emit dataChanged( QModelIndex(), QModelIndex() );
 }
 
-void QgsVectorLayerAndAttributeModel::unSelectAll()
+void QgsVectorLayerAndAttributeModel::deSelectAll()
 {
   mCheckedLeafs.clear();
 
@@ -438,7 +438,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   connect( mFileLineEdit, SIGNAL( textChanged( const QString& ) ), this, SLOT( setOkEnabled() ) );
   connect( this, SIGNAL( accepted() ), this, SLOT( saveSettings() ) );
   connect( mSelectAllButton, SIGNAL( clicked() ), this, SLOT( selectAll() ) );
-  connect( mUnSelectAllButton, SIGNAL( clicked() ), this, SLOT( unSelectAll() ) );
+  connect( mDeselectAllButton, SIGNAL( clicked() ), this, SLOT( deSelectAll() ) );
 
   mFileLineEdit->setFocus();
 
@@ -522,11 +522,11 @@ void QgsDxfExportDialog::selectAll()
   model->selectAll();
 }
 
-void QgsDxfExportDialog::unSelectAll()
+void QgsDxfExportDialog::deSelectAll()
 {
   QgsVectorLayerAndAttributeModel *model = dynamic_cast< QgsVectorLayerAndAttributeModel *>( mTreeView->model() );
   Q_ASSERT( model );
-  model->unSelectAll();
+  model->deSelectAll();
 }
 
 

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -62,7 +62,7 @@ class QgsVectorLayerAndAttributeModel : public QgsLayerTreeModel
     void applyVisibilityPreset( const QString &name );
 
     void selectAll();
-    void unSelectAll();
+    void deSelectAll();
 
   private:
     QHash<const QgsVectorLayer *, int> mAttributeIdx;
@@ -93,7 +93,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
   public slots:
     //! Change the selection of layers in the list
     void selectAll();
-    void unSelectAll();
+    void deSelectAll();
 
   private slots:
     void on_mFileSelectionButton_clicked();

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -35,7 +35,7 @@ QgsMapToolSelect::QgsMapToolSelect( QgsMapCanvas* canvas )
   mToolName = tr( "Select" );
   mCursor = Qt::ArrowCursor;
   mFillColor = QColor( 254, 178, 76, 63 );
-  mBorderColour = QColor( 254, 58, 29, 100 );
+  mBorderColor = QColor( 254, 58, 29, 100 );
 }
 
 void QgsMapToolSelect::canvasReleaseEvent( QgsMapMouseEvent* e )
@@ -46,7 +46,7 @@ void QgsMapToolSelect::canvasReleaseEvent( QgsMapMouseEvent* e )
 
   QgsRubberBand rubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
   rubberBand.setFillColor( mFillColor );
-  rubberBand.setBorderColor( mBorderColour );
+  rubberBand.setBorderColor( mBorderColor );
   QRect selectRect( 0, 0, 0, 0 );
   QgsMapToolSelectUtils::expandSelectRectangle( selectRect, vlayer, e->pos() );
   QgsMapToolSelectUtils::setRubberBand( mCanvas, selectRect, &rubberBand );

--- a/src/app/qgsmaptoolselect.h
+++ b/src/app/qgsmaptoolselect.h
@@ -33,7 +33,7 @@ class APP_EXPORT QgsMapToolSelect : public QgsMapTool
 
   private:
     QColor mFillColor;
-    QColor mBorderColour;
+    QColor mBorderColor;
 };
 
 #endif

--- a/src/app/qgsmaptoolselectfreehand.cpp
+++ b/src/app/qgsmaptoolselectfreehand.cpp
@@ -30,7 +30,7 @@ QgsMapToolSelectFreehand::QgsMapToolSelectFreehand( QgsMapCanvas* canvas )
   mRubberBand = nullptr;
   mCursor = Qt::ArrowCursor;
   mFillColor = QColor( 254, 178, 76, 63 );
-  mBorderColour = QColor( 254, 58, 29, 100 );
+  mBorderColor = QColor( 254, 58, 29, 100 );
 }
 
 QgsMapToolSelectFreehand::~QgsMapToolSelectFreehand()
@@ -47,7 +47,7 @@ void QgsMapToolSelectFreehand::canvasPressEvent( QgsMapMouseEvent* e )
   {
     mRubberBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
     mRubberBand->setFillColor( mFillColor );
-    mRubberBand->setBorderColor( mBorderColour );
+    mRubberBand->setBorderColor( mBorderColor );
   }
   mRubberBand->addPoint( toMapCoordinates( e->pos() ) );
   mDragging = true;

--- a/src/app/qgsmaptoolselectfreehand.h
+++ b/src/app/qgsmaptoolselectfreehand.h
@@ -48,7 +48,7 @@ class APP_EXPORT QgsMapToolSelectFreehand : public QgsMapTool
     bool mDragging;
 
     QColor mFillColor;
-    QColor mBorderColour;
+    QColor mBorderColor;
 };
 
 #endif

--- a/src/app/qgsmaptoolselectpolygon.cpp
+++ b/src/app/qgsmaptoolselectpolygon.cpp
@@ -29,7 +29,7 @@ QgsMapToolSelectPolygon::QgsMapToolSelectPolygon( QgsMapCanvas* canvas )
   mRubberBand = nullptr;
   mCursor = Qt::ArrowCursor;
   mFillColor = QColor( 254, 178, 76, 63 );
-  mBorderColour = QColor( 254, 58, 29, 100 );
+  mBorderColor = QColor( 254, 58, 29, 100 );
 }
 
 QgsMapToolSelectPolygon::~QgsMapToolSelectPolygon()
@@ -43,7 +43,7 @@ void QgsMapToolSelectPolygon::canvasPressEvent( QgsMapMouseEvent* e )
   {
     mRubberBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
     mRubberBand->setFillColor( mFillColor );
-    mRubberBand->setBorderColor( mBorderColour );
+    mRubberBand->setBorderColor( mBorderColor );
   }
   if ( e->button() == Qt::LeftButton )
   {

--- a/src/app/qgsmaptoolselectpolygon.h
+++ b/src/app/qgsmaptoolselectpolygon.h
@@ -44,7 +44,7 @@ class APP_EXPORT QgsMapToolSelectPolygon : public QgsMapTool
 
     QColor mFillColor;
 
-    QColor mBorderColour;
+    QColor mBorderColor;
 };
 
 #endif

--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -37,7 +37,7 @@ QgsMapToolSelectRadius::QgsMapToolSelectRadius( QgsMapCanvas* canvas )
   mRubberBand = nullptr;
   mCursor = Qt::ArrowCursor;
   mFillColor = QColor( 254, 178, 76, 63 );
-  mBorderColour = QColor( 254, 58, 29, 100 );
+  mBorderColor = QColor( 254, 58, 29, 100 );
 }
 
 QgsMapToolSelectRadius::~QgsMapToolSelectRadius()
@@ -65,7 +65,7 @@ void QgsMapToolSelectRadius::canvasMoveEvent( QgsMapMouseEvent* e )
     {
       mRubberBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
       mRubberBand->setFillColor( mFillColor );
-      mRubberBand->setBorderColor( mBorderColour );
+      mRubberBand->setBorderColor( mBorderColor );
     }
     mDragging = true;
   }
@@ -85,7 +85,7 @@ void QgsMapToolSelectRadius::canvasReleaseEvent( QgsMapMouseEvent* e )
     {
       mRubberBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
       mRubberBand->setFillColor( mFillColor );
-      mRubberBand->setBorderColor( mBorderColour );
+      mRubberBand->setBorderColor( mBorderColor );
     }
     mRadiusCenter = toMapCoordinates( e->pos() );
     QgsPoint radiusEdge = toMapCoordinates( QPoint( e->pos().x() + 1, e->pos().y() + 1 ) );

--- a/src/app/qgsmaptoolselectradius.h
+++ b/src/app/qgsmaptoolselectradius.h
@@ -58,7 +58,7 @@ class APP_EXPORT QgsMapToolSelectRadius : public QgsMapTool
 
     QColor mFillColor;
 
-    QColor mBorderColour;
+    QColor mBorderColor;
 };
 
 #endif

--- a/src/app/qgsmaptoolselectrectangle.cpp
+++ b/src/app/qgsmaptoolselectrectangle.cpp
@@ -38,7 +38,7 @@ QgsMapToolSelectFeatures::QgsMapToolSelectFeatures( QgsMapCanvas* canvas )
   mCursor = QCursor( mySelectQPixmap, 1, 1 );
   mRubberBand = nullptr;
   mFillColor = QColor( 254, 178, 76, 63 );
-  mBorderColour = QColor( 254, 58, 29, 100 );
+  mBorderColor = QColor( 254, 58, 29, 100 );
 }
 
 
@@ -49,7 +49,7 @@ void QgsMapToolSelectFeatures::canvasPressEvent( QgsMapMouseEvent* e )
   delete mRubberBand;
   mRubberBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
   mRubberBand->setFillColor( mFillColor );
-  mRubberBand->setBorderColor( mBorderColour );
+  mRubberBand->setBorderColor( mBorderColor );
 }
 
 

--- a/src/app/qgsmaptoolselectrectangle.h
+++ b/src/app/qgsmaptoolselectrectangle.h
@@ -56,7 +56,7 @@ class APP_EXPORT QgsMapToolSelectFeatures : public QgsMapTool
 
     QColor mFillColor;
 
-    QColor mBorderColour;
+    QColor mBorderColor;
 };
 
 #endif

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -63,7 +63,7 @@
 #include <sqlite3.h>
 #include "qgslogger.h"
 
-#define CPL_SUPRESS_CPLUSPLUS
+#define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <gdal.h>
 #include <geos_c.h>
 #include <cpl_conv.h> // for setting gdal options

--- a/src/app/qgsprojectlayergroupdialog.cpp
+++ b/src/app/qgsprojectlayergroupdialog.cpp
@@ -206,12 +206,12 @@ void QgsProjectLayerGroupDialog::onTreeViewSelectionChanged()
 {
   Q_FOREACH ( const QModelIndex& index, mTreeView->selectionModel()->selectedIndexes() )
   {
-    unselectChildren( index );
+    deselectChildren( index );
   }
 }
 
 
-void QgsProjectLayerGroupDialog::unselectChildren( const QModelIndex& index )
+void QgsProjectLayerGroupDialog::deselectChildren( const QModelIndex& index )
 {
   int childCount = mTreeView->model()->rowCount( index );
   for ( int i = 0; i < childCount; ++i )
@@ -220,7 +220,7 @@ void QgsProjectLayerGroupDialog::unselectChildren( const QModelIndex& index )
     if ( mTreeView->selectionModel()->isSelected( childIndex ) )
       mTreeView->selectionModel()->select( childIndex, QItemSelectionModel::Deselect );
 
-    unselectChildren( childIndex );
+    deselectChildren( childIndex );
   }
 }
 

--- a/src/app/qgsprojectlayergroupdialog.h
+++ b/src/app/qgsprojectlayergroupdialog.h
@@ -48,7 +48,7 @@ class APP_EXPORT QgsProjectLayerGroupDialog: public QDialog, private Ui::QgsProj
   private:
     void changeProjectFile();
     void removeEmbeddedNodes( QgsLayerTreeGroup* node );
-    void unselectChildren( const QModelIndex& index );
+    void deselectChildren( const QModelIndex& index );
     QString mProjectPath;
     bool mShowEmbeddedContent;
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -850,7 +850,7 @@ void QgsProjectProperties::apply()
     // If the user fields have changed, use them instead.
     if ( leSemiMajor->isModified() || leSemiMinor->isModified() )
     {
-      QgsDebugMsg( "Using paramteric major/minor" );
+      QgsDebugMsg( "Using parameteric major/minor" );
       major = QLocale::system().toDouble( leSemiMajor->text() );
       minor = QLocale::system().toDouble( leSemiMinor->text() );
     }
@@ -1504,7 +1504,7 @@ void QgsProjectProperties::on_mWMSInspireScenario2_toggled( bool on )
   mWMSInspireScenario1->blockSignals( false );
 }
 
-void QgsProjectProperties::on_pbnWFSLayersUnselectAll_clicked()
+void QgsProjectProperties::on_pbnWFSLayersDeselectAll_clicked()
 {
   for ( int i = 0; i < twWFSLayers->rowCount(); i++ )
   {
@@ -1522,7 +1522,7 @@ void QgsProjectProperties::on_pbnWCSLayersSelectAll_clicked()
   }
 }
 
-void QgsProjectProperties::on_pbnWCSLayersUnselectAll_clicked()
+void QgsProjectProperties::on_pbnWCSLayersDeselectAll_clicked()
 {
   for ( int i = 0; i < twWCSLayers->rowCount(); i++ )
   {

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -114,13 +114,13 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
      * Slots to select/deselect all the WFS layers
      */
     void on_pbnWFSLayersSelectAll_clicked();
-    void on_pbnWFSLayersUnselectAll_clicked();
+    void on_pbnWFSLayersDeselectAll_clicked();
 
     /*!
      * Slots to select/deselect all the WCS layers
      */
     void on_pbnWCSLayersSelectAll_clicked();
-    void on_pbnWCSLayersUnselectAll_clicked();
+    void on_pbnWCSLayersDeselectAll_clicked();
 
     /*!
      * Slots to launch OWS test

--- a/src/astyle/ASBeautifier.cpp
+++ b/src/astyle/ASBeautifier.cpp
@@ -255,7 +255,7 @@ ASBeautifier::~ASBeautifier()
  *
  * init() should be called every time a ABeautifier object is to start
  * beautifying a NEW source file.
- * init() recieves a pointer to a DYNAMICALLY CREATED ASSourceIterator object
+ * init() receives a pointer to a DYNAMICALLY CREATED ASSourceIterator object
  * that will be used to iterate through the source code. This object will be
  * deleted during the ASBeautifier's destruction, and thus should not be
  * deleted elsewhere.

--- a/src/core/auth/qgsauthcertutils.h
+++ b/src/core/auth/qgsauthcertutils.h
@@ -168,7 +168,7 @@ class CORE_EXPORT QgsAuthCertUtils
     //! Get the general name for certificate trust
     static QString getCertTrustName( QgsAuthCertUtils::CertTrustPolicy trust );
 
-    //! Get string with colon delimeters every 2 characters
+    //! Get string with colon delimiters every 2 characters
     static QString getColonDelimited( const QString& txt );
 
     /** Get the sha1 hash for certificate

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -638,7 +638,7 @@ void QgsComposerMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent* event
     {
       if (( *itemIter )->positionLock() || (( *itemIter )->flags() & QGraphicsItem::ItemIsSelectable ) == 0 )
       {
-        //don't resize locked items or unselectable items (e.g., items which make up an item group)
+        //don't resize locked items or deselectable items (e.g., items which make up an item group)
         continue;
       }
       QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *itemIter, QLatin1String( "" ), parentCommand );

--- a/src/core/composer/qgscomposernodesitem.h
+++ b/src/core/composer/qgscomposernodesitem.h
@@ -111,7 +111,7 @@ class CORE_EXPORT QgsComposerNodesItem: public QgsComposerItem
 
     /** Deselect a node.
      */
-    void unselectNode() { mSelectedNode = -1; }
+    void deselectNode() { mSelectedNode = -1; }
 
     /** Stores state in Dom element
      * @param elem is Dom element corresponding to 'Composer' tag

--- a/src/core/composer/qgscomposerpicture.h
+++ b/src/core/composer/qgscomposerpicture.h
@@ -195,51 +195,51 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
      */
     ItemPositionMode pictureAnchor() const { return mPictureAnchor; }
 
-    /** Returns the fill color used for parameterized SVG files.
+    /** Returns the fill color used for parametrized SVG files.
      * @see setSvgFillColor()
      * @see svgBorderColor()
      * @note added in QGIS 2.14.1
      */
     QColor svgFillColor() const { return mSvgFillColor; }
 
-    /** Sets the fill color used for parameterized SVG files.
+    /** Sets the fill color used for parametrized SVG files.
      * @param color fill color.
-     * @note this setting only has an effect on parameterized SVG files, and is ignored for
-     * non-parameterized SVG files.
+     * @note this setting only has an effect on parametrized SVG files, and is ignored for
+     * non-parametrized SVG files.
      * @see svgFillColor()
      * @see setSvgBorderColor()
      * @note added in QGIS 2.14.1
      */
     void setSvgFillColor( const QColor& color );
 
-    /** Returns the border color used for parameterized SVG files.
+    /** Returns the border color used for parametrized SVG files.
      * @see setSvgBorderColor()
      * @see svgFillColor()
      * @note added in QGIS 2.14.1
      */
     QColor svgBorderColor() const { return mSvgBorderColor; }
 
-    /** Sets the border color used for parameterized SVG files.
+    /** Sets the border color used for parametrized SVG files.
      * @param color border color.
-     * @note this setting only has an effect on parameterized SVG files, and is ignored for
-     * non-parameterized SVG files.
+     * @note this setting only has an effect on parametrized SVG files, and is ignored for
+     * non-parametrized SVG files.
      * @see svgBorderlColor()
      * @see setSvgFillColor()
      * @note added in QGIS 2.14.1
      */
     void setSvgBorderColor( const QColor& color );
 
-    /** Returns the border width (in mm) used for parameterized SVG files.
+    /** Returns the border width (in mm) used for parametrized SVG files.
      * @see setSvgBorderWidth()
      * @see svgBorderColor()
      * @note added in QGIS 2.14.1
      */
     double svgBorderWidth() const { return mSvgBorderWidth; }
 
-    /** Sets the border width used for parameterized SVG files.
+    /** Sets the border width used for parametrized SVG files.
      * @param width border width in mm
-     * @note this setting only has an effect on parameterized SVG files, and is ignored for
-     * non-parameterized SVG files.
+     * @note this setting only has an effect on parametrized SVG files, and is ignored for
+     * non-parametrized SVG files.
      * @see svgBorderWidth()
      * @see setSvgBorderColor()
      * @note added in QGIS 2.14.1

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -207,7 +207,7 @@ void QgsComposition::refreshItems()
 
 void QgsComposition::setSelectedItem( QgsComposerItem *item )
 {
-  setAllUnselected();
+  setAllDeselected();
   if ( item )
   {
     item->setSelected( true );
@@ -215,10 +215,10 @@ void QgsComposition::setSelectedItem( QgsComposerItem *item )
   }
 }
 
-void QgsComposition::setAllUnselected()
+void QgsComposition::setAllDeselected()
 {
   //we can't use QGraphicsScene::clearSelection, as that emits no signals
-  //and we don't know which items are being unselected
+  //and we don't know which items are being deselected
   //accordingly, we can't inform the composition model of selection changes
   //instead, do the clear selection manually...
   QList<QGraphicsItem *> selectedItemList = selectedItems();
@@ -1145,7 +1145,7 @@ void QgsComposition::addItemsFromXml( const QDomElement& elem, const QDomDocumen
     pasteShiftPos = *pos - minItemPos;
 
     //since we are pasting items, clear the existing selection
-    setAllUnselected();
+    setAllDeselected();
 
     if ( pasteInPlace )
     {
@@ -1604,7 +1604,7 @@ void QgsComposition::selectNextByZOrder( ZValueDirection direction )
   }
 
   //ok, found a good target item
-  setAllUnselected();
+  setAllDeselected();
   selectedItem->setSelected( true );
   emit selectedItemChanged( selectedItem );
 }
@@ -1878,7 +1878,7 @@ void QgsComposition::lockSelectedItems()
     subcommand->saveAfterState();
   }
 
-  setAllUnselected();
+  setAllDeselected();
   mUndoStack->push( parentCommand );
   mProject->setDirty( true );
 }
@@ -1890,7 +1890,7 @@ void QgsComposition::unlockAllItems()
   QUndoCommand* parentCommand = new QUndoCommand( tr( "Items unlocked" ) );
 
   //first, clear the selection
-  setAllUnselected();
+  setAllDeselected();
 
   QList<QGraphicsItem *> itemList = items();
   QList<QGraphicsItem *>::iterator itemIt = itemList.begin();

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -836,7 +836,7 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene, public QgsExpressionCo
      * QGraphicsScene::clearSelection, as the latter does not correctly emit signals to allow
      * the composition's model to update.
      * @note added in version 2.5*/
-    void setAllUnselected();
+    void setAllDeselected();
 
     /** Refreshes a data defined property for the composition by reevaluating the property's value
      * and redrawing the composition with this new value.

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -108,11 +108,11 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     //! @note added in 3.0
     bool isVisible() const;
 
-    //! Returns whether a node is checked (independantly of its ancestors or children)
+    //! Returns whether a node is checked (independently of its ancestors or children)
     //! @note added in 3.0
     bool itemVisibilityChecked() const { return mChecked; }
 
-    //! Check or uncheck a node (independantly of its ancestors or children)
+    //! Check or uncheck a node (independently of its ancestors or children)
     //! @note added in 3.0
     void setItemVisibilityChecked( bool checked );
 

--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -1,3 +1,4 @@
+
 /***************************************************************************
   qgslabelingengine.cpp
   --------------------------------------
@@ -102,7 +103,7 @@ void QgsLabelingEngine::removeProvider( QgsAbstractLabelProvider* provider )
   }
 }
 
-void QgsLabelingEngine::processProvider( QgsAbstractLabelProvider* provider, QgsRenderContext& context, pal::Pal& p )
+void QgsLabelingEngine::processProvider( QgsAbstractLabelProvider* provider, QgsRenderContext& context, pal::Pal& p ) //#spellok
 {
   QgsAbstractLabelProvider::Flags flags = provider->flags();
 
@@ -170,7 +171,7 @@ void QgsLabelingEngine::processProvider( QgsAbstractLabelProvider* provider, Qgs
   Q_FOREACH ( QgsAbstractLabelProvider* subProvider, provider->subProviders() )
   {
     mSubProviders << subProvider;
-    processProvider( subProvider, context, p );
+    processProvider( subProvider, context, p );  //#spellok
   }
 }
 
@@ -212,7 +213,7 @@ void QgsLabelingEngine::run( QgsRenderContext& context )
   // for each provider: get labels and register them in PAL
   Q_FOREACH ( QgsAbstractLabelProvider* provider, mProviders )
   {
-    processProvider( provider, context, p );
+    processProvider( provider, context, p );  //#spellok
   }
 
 

--- a/src/core/qgslabelingengine.h
+++ b/src/core/qgslabelingengine.h
@@ -226,7 +226,7 @@ class CORE_EXPORT QgsLabelingEngine
     void writeSettingsToProject();
 
   protected:
-    void processProvider( QgsAbstractLabelProvider* provider, QgsRenderContext& context, pal::Pal& p );
+    void processProvider( QgsAbstractLabelProvider* provider, QgsRenderContext& context, pal::Pal& p );  //#spellok
 
   protected:
     //! Associated map settings instance

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -59,8 +59,8 @@ QgsMapToPixel::QgsMapToPixel( double mapUnitsPerPixel )
 
 QgsMapToPixel QgsMapToPixel::fromScale( double scale, QgsUnitTypes::DistanceUnit mapUnits, double dpi )
 {
-  double metresPerPixel = 25.4 / dpi / 1000.0;
-  double mapUnitsPerPixel = metresPerPixel * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::DistanceMeters, mapUnits );
+  double metersPerPixel = 25.4 / dpi / 1000.0;
+  double mapUnitsPerPixel = metersPerPixel * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::DistanceMeters, mapUnits );
   return QgsMapToPixel( mapUnitsPerPixel / scale );
 }
 

--- a/src/core/qgsprojectproperty.h
+++ b/src/core/qgsprojectproperty.h
@@ -36,7 +36,7 @@ class QDomDocument;
 /**
  * \class QgsProjectProperty
  * \ingroup core
- * An Abstract Base Class for QGIS project property hierarchies.
+ * An Abstract Base Class for QGIS project property hierarchys.
  *
  * Each sub-class is either a QgsProjectPropertyKey or QgsProjectPropertyValue.  QgsProjectPropertyKey can
  * contain either QgsProjectPropertyKey or QgsProjectPropertyValues, thus describing an

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -101,7 +101,7 @@ void QgsComposerView::setCurrentTool( QgsComposerView::Tool t )
   mPolygonItem.reset();
   mPolylineItem.reset();
   displayNodes( false );
-  unselectNode();
+  deselectNode();
 
   switch ( t )
   {
@@ -264,7 +264,7 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
       if (( !selectedItem->selected() ) &&        //keep selection if an already selected item pressed
           !( e->modifiers() & Qt::ShiftModifier ) ) //keep selection if shift key pressed
       {
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
       }
 
       if (( e->modifiers() & Qt::ShiftModifier ) && ( selectedItem->selected() ) )
@@ -447,7 +447,7 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
         }
         newScaleBar->applyDefaultSize(); //4 segments, 1/5 of composer map width
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         newScaleBar->setSelected( true );
         emit selectedItemChanged( newScaleBar );
 
@@ -558,7 +558,7 @@ void QgsComposerView::addShape( Tool currentTool )
     composition()->addComposerShape( composerShape );
     removeRubberBand();
 
-    composition()->setAllUnselected();
+    composition()->setAllDeselected();
     composerShape->setSelected( true );
     emit selectedItemChanged( composerShape );
 
@@ -622,7 +622,7 @@ void QgsComposerView::endMarqueeSelect( QMouseEvent* e )
   else
   {
     //not adding to or removing from selection, so clear current selection
-    composition()->setAllUnselected();
+    composition()->setAllDeselected();
   }
 
   if ( !mRubberBandItem || ( mRubberBandItem->rect().width() < 0.1 && mRubberBandItem->rect().height() < 0.1 ) )
@@ -811,7 +811,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
             composition()->addComposerPolygon( composerPolygon );
 
             // select the polygon
-            composition()->setAllUnselected();
+            composition()->setAllDeselected();
             composerPolygon->setSelected( true );
             emit selectedItemChanged( composerPolygon );
 
@@ -844,7 +844,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
             composition()->addComposerPolyline( composerPolyline );
 
             // select the polygon
-            composition()->setAllUnselected();
+            composition()->setAllDeselected();
             composerPolyline->setSelected( true );
             emit selectedItemChanged( composerPolyline );
 
@@ -944,7 +944,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
         QgsComposerArrow* composerArrow = new QgsComposerArrow( mRubberBandLineItem->line().p1(), mRubberBandLineItem->line().p2(), composition() );
         composition()->addComposerArrow( composerArrow );
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         composerArrow->setSelected( true );
         emit selectedItemChanged( composerArrow );
 
@@ -999,7 +999,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
         QgsComposerMap* composerMap = new QgsComposerMap( composition(), mRubberBandItem->transform().dx(), mRubberBandItem->transform().dy(), mRubberBandItem->rect().width(), mRubberBandItem->rect().height() );
         composition()->addComposerMap( composerMap );
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         composerMap->setSelected( true );
         emit selectedItemChanged( composerMap );
 
@@ -1021,7 +1021,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
         newPicture->setSceneRect( QRectF( mRubberBandItem->transform().dx(), mRubberBandItem->transform().dy(), mRubberBandItem->rect().width(), mRubberBandItem->rect().height() ) );
         composition()->addComposerPicture( newPicture );
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         newPicture->setSelected( true );
         emit selectedItemChanged( newPicture );
 
@@ -1050,7 +1050,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
 
         composition()->addComposerLabel( newLabelItem );
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         newLabelItem->setSelected( true );
         emit selectedItemChanged( newLabelItem );
 
@@ -1078,7 +1078,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
         composition()->addComposerLegend( newLegend );
         newLegend->updateLegend();
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         newLegend->setSelected( true );
         emit selectedItemChanged( newLegend );
 
@@ -1112,7 +1112,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
         newTable->addFrame( frame );
         composition()->endMultiFrameCommand();
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         frame->setSelected( true );
         emit selectedItemChanged( frame );
 
@@ -1140,7 +1140,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
         composerHtml->addFrame( frame );
         composition()->endMultiFrameCommand();
 
-        composition()->setAllUnselected();
+        composition()->setAllDeselected();
         frame->setSelected( true );
         emit selectedItemChanged( frame );
 
@@ -1399,7 +1399,7 @@ void QgsComposerView::mouseDoubleClickEvent( QMouseEvent* e )
       {
         mNodesItem = nullptr;
         mNodesItemIndex = -1;
-        unselectNode();
+        deselectNode();
       }
 
       // search items in composer
@@ -1631,7 +1631,7 @@ void QgsComposerView::selectNone()
     return;
   }
 
-  composition()->setAllUnselected();
+  composition()->setAllDeselected();
 }
 
 void QgsComposerView::selectInvert()
@@ -2284,20 +2284,20 @@ void QgsComposerView::setSelectedNode( QgsComposerNodesItem *shape,
       emit selectedItemChanged(( *it ) );
     }
     else
-      ( *it )->unselectNode();
+      ( *it )->deselectNode();
   }
 
   scene()->update();
 }
 
-void QgsComposerView::unselectNode()
+void QgsComposerView::deselectNode()
 {
   QList<QgsComposerNodesItem*> nodesShapes;
   composition()->composerItems( nodesShapes );
 
   QList<QgsComposerNodesItem*>::iterator it = nodesShapes.begin();
   for ( ; it != nodesShapes.end(); ++it )
-    ( *it )->unselectNode();
+    ( *it )->deselectNode();
 
   scene()->update();
 }

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -226,7 +226,7 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     void movePolygonNode( QPointF scenePoint );
     void displayNodes( const bool display = true );
     void setSelectedNode( QgsComposerNodesItem *shape, const int index );
-    void unselectNode();
+    void deselectNode();
 
     float mMoveContentSearchRadius;
     QgsComposerNodesItem* mNodesItem;

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -35,7 +35,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     //! @note added in 2.4
     void setDatumTransformInfo( const QString& srcCRSauthId, const QString& destCRSauthId );
 
-    //! getter for selected datum tranformations
+    //! getter for selected datum transformations
     QList< int > selectedDatumTransform();
 
     //! dialog shall remember the selection

--- a/src/gui/qgsprevieweffect.cpp
+++ b/src/gui/qgsprevieweffect.cpp
@@ -105,7 +105,7 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb& originalColor, QgsPreviewEf
   int blue = qBlue( originalColor );
 
   //convert RGB to LMS color space
-  // (http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p245, equation 4)
+  // (http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p245, equation 4) #spellok
   double L = ( 17.8824 * red ) + ( 43.5161 * green ) + ( 4.11935 * blue );
   double M = ( 3.45565 * red ) + ( 27.1554 * green ) + ( 3.86714 * blue );
   double S = ( 0.0299566 * red ) + ( 0.184309 * green ) + ( 1.46709 * blue );
@@ -124,7 +124,7 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb& originalColor, QgsPreviewEf
   }
 
   //convert LMS back to RGB color space
-  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 6)
+  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 6) #spellok
   red = ( 0.080944 * L ) + ( -0.130504 * M ) + ( 0.116721 * S );
   green = ( -0.0102485 * L ) + ( 0.0540194 * M ) + ( -0.113615 * S );
   blue = ( -0.000365294 * L ) + ( -0.00412163 * M ) + ( 0.693513 * S );
@@ -140,13 +140,13 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb& originalColor, QgsPreviewEf
 void QgsPreviewEffect::simulateProtanopeLMS( double& L, double &M, double &S )
 {
   //adjust L component to simulate vision of Protanope
-  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5)
+  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5) #spellok
   L = ( 2.02344 * M ) + ( -2.52581 * S );
 }
 
 void QgsPreviewEffect::simulateDeuteranopeLMS( double& L, double &M, double &S )
 {
   //adjust M component to simulate vision of Deuteranope
-  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5)
+  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5) #spellok
   M = ( 0.494207 * L ) + ( 1.24827 * S );
 }

--- a/src/plugins/grass/qgsgrassmoduleinput.h
+++ b/src/plugins/grass/qgsgrassmoduleinput.h
@@ -245,7 +245,7 @@ class QgsGrassModuleInput : public QgsGrassModuleGroupBoxItem
 
     ~QgsGrassModuleInput();
 
-    //! Retruns list of options which will be passed to module
+    //! Returns list of options which will be passed to module
     virtual QStringList options() override;
 
     // ! Return vector of attribute fields of current vector

--- a/src/plugins/grass/qgsgrassmoduleparam.h
+++ b/src/plugins/grass/qgsgrassmoduleparam.h
@@ -99,7 +99,7 @@ class QgsGrassModuleParam
     //! Is the item hidden
     bool hidden();
 
-    //! Retruns list of options which will be passed to module
+    //! Returns list of options which will be passed to module
     virtual QStringList options();
 
     //! Item's key
@@ -262,7 +262,7 @@ class QgsGrassModuleOption : public QgsGrassModuleMultiParam
     //! Output type
     enum OutputType { None, Vector, Raster };
 
-    //! Retruns list of options which will be passed to module
+    //! Returns list of options which will be passed to module
     virtual QStringList options() override;
 
     //! True if this option is output
@@ -359,7 +359,7 @@ class QgsGrassModuleFlag : public QgsGrassModuleCheckBox, public QgsGrassModuleP
 
     ~QgsGrassModuleFlag();
 
-    //! Retruns list of options which will be passed to module
+    //! Returns list of options which will be passed to module
     virtual QStringList options() override;
 
 };
@@ -474,7 +474,7 @@ class QgsGrassModuleVectorField : public QgsGrassModuleMultiParam
 
     ~QgsGrassModuleVectorField();
 
-    //! Retruns list of options which will be passed to module
+    //! Returns list of options which will be passed to module
     virtual QStringList options() override;
 
     void setLayerInput( QgsGrassModuleInput * layerInput ) { mLayerInput = layerInput; }
@@ -539,7 +539,7 @@ class QgsGrassModuleSelection : public QgsGrassModuleGroupBoxItem
 
     ~QgsGrassModuleSelection();
 
-    //! Retruns list of options which will be passed to module
+    //! Returns list of options which will be passed to module
     virtual QStringList options() override;
 
   public slots:

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -81,7 +81,7 @@ QgsOfflineEditingPluginGui::QgsOfflineEditingPluginGui( QWidget* parent, Qt::Win
   mLayerTree->setModel( treeModel );
 
   connect( mSelectAllButton, SIGNAL( clicked() ), this, SLOT( selectAll() ) );
-  connect( mUnselectAllButton, SIGNAL( clicked() ), this, SLOT( unSelectAll() ) );
+  connect( mDeselectAllButton, SIGNAL( clicked() ), this, SLOT( deSelectAll() ) );
 }
 
 QgsOfflineEditingPluginGui::~QgsOfflineEditingPluginGui()
@@ -184,7 +184,7 @@ void QgsOfflineEditingPluginGui::selectAll()
 }
 
 
-void QgsOfflineEditingPluginGui::unSelectAll()
+void QgsOfflineEditingPluginGui::deSelectAll()
 {
   Q_FOREACH ( QgsLayerTreeLayer* nodeLayer, mLayerTree->layerTreeModel()->rootGroup()->findLayers() )
     nodeLayer->setItemVisibilityChecked( false );

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.h
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.h
@@ -52,7 +52,7 @@ class QgsOfflineEditingPluginGui : public QDialog, private Ui::QgsOfflineEditing
   public slots:
     //! Change the selection of layers in the list
     void selectAll();
-    void unSelectAll();
+    void deSelectAll();
 
   private:
     void saveState();

--- a/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
+++ b/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
@@ -82,7 +82,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QPushButton" name="mUnselectAllButton">
+        <widget class="QPushButton" name="mDeselectAllButton">
          <property name="text">
           <string>Deselect all</string>
          </property>

--- a/src/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/providers/gdal/qgsgdalproviderbase.cpp
@@ -15,7 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#define CPL_SUPRESS_CPLUSPLUS
+#define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include "cpl_conv.h"
 
 #include "qgsapplication.h"

--- a/src/providers/gdal/qgsgdalproviderbase.h
+++ b/src/providers/gdal/qgsgdalproviderbase.h
@@ -23,7 +23,7 @@
 
 #include <QList>
 
-#define CPL_SUPRESS_CPLUSPLUS
+#define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <gdal.h>
 
 /**

--- a/src/providers/grass/qgsgrassimport.h
+++ b/src/providers/grass/qgsgrassimport.h
@@ -89,7 +89,7 @@ class GRASS_LIB_EXPORT QgsGrassImport : public QObject
     // TODO: this is not completely kosher, because QgsGrassImport exist on the main thread
     // but import is running in another thread, to do it right, we should have an import object
     // created on another thread, send cancel signal to that object which regularly processes events
-    // and thus recieves the signal.
+    // and thus receives the signal.
     // Most probably however, it will work correctly, even if read/write the bool wasn't atomic
     void cancel();
     void frameChanged() {}

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -22,7 +22,7 @@ email                : sherman at mrcc.com
 #include "qgslocalec.h"
 #include "qgsfeedback.h"
 
-#define CPL_SUPRESS_CPLUSPLUS
+#define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <gdal.h>         // to collect version information
 #include <ogr_api.h>
 #include <ogr_srs_api.h>

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -149,7 +149,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     //! Clean shapefile from features which are marked as deleted
     void repack();
 
-    //! Invalidate extent and optionnaly force its low level recomputation
+    //! Invalidate extent and optionaly force its low level recomputation
     void invalidateCachedExtent( bool bForceRecomputeExtent );
 
     enum OpenMode

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -45,7 +45,7 @@ class QNetworkAccessManager;
 class QNetworkReply;
 class QNetworkRequest;
 
-#define CPL_SUPRESS_CPLUSPLUS
+#define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <gdal.h>
 #include "cpl_conv.h"
 

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -132,7 +132,7 @@ void QgsWfsCapabilities::capabilitiesReplyFinished()
 
   // WFS 2.0 implementation are supposed to implement resultType=hits, and some
   // implementations (GeoServer) might advertize it, whereas others (MapServer) do not.
-  // WFS 1.1 implementation too I think, but in the examples of the GetCapabilites
+  // WFS 1.1 implementation too I think, but in the examples of the GetCapabilities
   // response of the WFS 1.1 standard (and in common implementations), this is
   // explictly advertized
   if ( mCaps.version.startsWith( QLatin1String( "2.0" ) ) )

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -172,7 +172,7 @@ class QgsWFSProvider : public QgsVectorDataProvider
     bool transactionSuccess( const QDomDocument& serverResponse ) const;
     //! Returns the inserted ids
     QStringList insertedFeatureIds( const QDomDocument& serverResponse ) const;
-    //! Retrieve version and capabilities for this layer from GetCapabilities document (will be stored in mCapabilites)
+    //! Retrieve version and capabilities for this layer from GetCapabilities document (will be stored in mCapabilities)
     bool getCapabilities();
     //! Records provider error
     void handleException( const QDomDocument& serverResponse );

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -64,7 +64,7 @@ bool QgsWfsRequest::sendGET( const QUrl& url, bool synchronous, bool forceRefres
   QUrl modifiedUrl( url );
   if ( modifiedUrl.toString().contains( QLatin1String( "fake_qgis_http_endpoint" ) ) )
   {
-    // Just for testing with local files instead of http:// ressources
+    // Just for testing with local files instead of http:// resources
     QString modifiedUrlString = modifiedUrl.toString();
     // Qt5 does URL encoding from some reason (of the FILTER parameter for example)
     modifiedUrlString = QUrl::fromPercentEncoding( modifiedUrlString.toUtf8() );

--- a/src/server/qgsmslayercache.cpp
+++ b/src/server/qgsmslayercache.cpp
@@ -134,7 +134,7 @@ void QgsMSLayerCache::removeProjectFileLayers( const QString& project )
     {
       removeEntries.push_back( entryIt.key() );
       removeEntriesValues.push_back( entryIt.value() );
-      freeEntryRessources( entryIt.value() );
+      freeEntryResources( entryIt.value() );
     }
   }
 
@@ -183,11 +183,11 @@ void QgsMSLayerCache::removeLeastUsedEntry()
   }
 
   QgsMessageLog::logMessage( "Removing last accessed layer '" + lowest_it.value().layerPointer->name() + "' project file " + lowest_it.value().configFile + " from cache" , QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  freeEntryRessources( *lowest_it );
+  freeEntryResources( *lowest_it );
   mEntries.erase( lowest_it );
 }
 
-void QgsMSLayerCache::freeEntryRessources( QgsMSLayerCacheEntry& entry )
+void QgsMSLayerCache::freeEntryResources( QgsMSLayerCacheEntry& entry )
 {
   // remove layer from QgsProject before delete it
   if ( QgsProject::instance()->mapLayer( entry.layerPointer->id() ) )

--- a/src/server/qgsmslayercache.h
+++ b/src/server/qgsmslayercache.h
@@ -88,7 +88,7 @@ class QgsMSLayerCache: public QObject
     //! Removes the cash entry with the lowest 'lastUsedTime'
     void removeLeastUsedEntry();
     //! Frees memory and removes temporary files of an entry
-    void freeEntryRessources( QgsMSLayerCacheEntry& entry );
+    void freeEntryResources( QgsMSLayerCacheEntry& entry );
 
   private:
 

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -91,7 +91,7 @@
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QPushButton" name="mUnSelectAllButton">
+      <widget class="QPushButton" name="mDeselectAllButton">
        <property name="text">
         <string>Deselect all</string>
        </property>
@@ -198,7 +198,7 @@
   <tabstop>mVisibilityPresets</tabstop>
   <tabstop>mTreeView</tabstop>
   <tabstop>mSelectAllButton</tabstop>
-  <tabstop>mUnSelectAllButton</tabstop>
+  <tabstop>mDeselectAllButton</tabstop>
   <tabstop>mLayerTitleAsName</tabstop>
   <tabstop>mMapExtentCheckBox</tabstop>
   <tabstop>buttonBox</tabstop>

--- a/src/ui/qgsosmexportdialog.ui
+++ b/src/ui/qgsosmexportdialog.ui
@@ -114,7 +114,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btnUnselectAll">
+         <widget class="QPushButton" name="btnDeselectAll">
           <property name="text">
            <string>Deselect All</string>
           </property>
@@ -174,7 +174,7 @@
   <tabstop>editLayerName</tabstop>
   <tabstop>btnLoadTags</tabstop>
   <tabstop>btnSelectAll</tabstop>
-  <tabstop>btnUnselectAll</tabstop>
+  <tabstop>btnDeselectAll</tabstop>
   <tabstop>viewTags</tabstop>
   <tabstop>chkLoadWhenFinished</tabstop>
  </tabstops>

--- a/src/ui/qgspointdisplacementrendererwidgetbase.ui
+++ b/src/ui/qgspointdisplacementrendererwidgetbase.ui
@@ -34,7 +34,7 @@
     </widget>
    </item>
    <item row="9" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBoxBasic" name="mLabellingGroupBox">
+    <widget class="QgsCollapsibleGroupBoxBasic" name="mLabelingGroupBox">
      <property name="title">
       <string>Labels</string>
      </property>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -2169,7 +2169,7 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QPushButton" name="pbnWFSLayersUnselectAll">
+                   <widget class="QPushButton" name="pbnWFSLayersDeselectAll">
                     <property name="text">
                      <string>Deselect all</string>
                     </property>
@@ -2235,7 +2235,7 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QPushButton" name="pbnWCSLayersUnselectAll">
+                   <widget class="QPushButton" name="pbnWCSLayersDeselectAll">
                     <property name="text">
                      <string>Deselect all</string>
                     </property>
@@ -2617,11 +2617,11 @@
   <tabstop>mWMSImageQualitySpinBox</tabstop>
   <tabstop>twWFSLayers</tabstop>
   <tabstop>pbnWFSLayersSelectAll</tabstop>
-  <tabstop>pbnWFSLayersUnselectAll</tabstop>
+  <tabstop>pbnWFSLayersDeselectAll</tabstop>
   <tabstop>mWFSUrlLineEdit</tabstop>
   <tabstop>twWCSLayers</tabstop>
   <tabstop>pbnWCSLayersSelectAll</tabstop>
-  <tabstop>pbnWCSLayersUnselectAll</tabstop>
+  <tabstop>pbnWCSLayersDeselectAll</tabstop>
   <tabstop>mWCSUrlLineEdit</tabstop>
   <tabstop>grpPythonMacros</tabstop>
   <tabstop>scrollArea_6</tabstop>

--- a/tests/src/core/testqgsapplication.cpp
+++ b/tests/src/core/testqgsapplication.cpp
@@ -15,7 +15,7 @@ Email                : sherman at mrcc dot com
 #include "qgstest.h"
 #include <QPixmap>
 
-#define CPL_SUPRESS_CPLUSPLUS
+#define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <gdal.h>
 
 //header for class being tested

--- a/tests/src/python/acceptable_missing_doc.py
+++ b/tests/src/python/acceptable_missing_doc.py
@@ -192,7 +192,7 @@ ACCEPTABLE_MISSING_DOCS = {
     "QgsComposerGroupItem": ["QgsComposerGroupItem(const QString &text)"],
     "QgsGraphDirector": ["buildProgress(int, int) const ", "buildMessage(const QString &) const ", "addProperter(QgsArcProperter *prop)"],
     "QgsScaleComboBox": ["QgsScaleComboBox(QWidget *parent=nullptr)", "updateScales(const QStringList &scales=QStringList())"],
-    "QgsLabelingEngine": ["processProvider(QgsAbstractLabelProvider *provider, QgsRenderContext &context, pal::Pal &p)", "Flag"],
+    "QgsLabelingEngine": ["processProvider(QgsAbstractLabelProvider *provider, QgsRenderContext &context, pal::Pal &p)", "Flag"], #spellok
     "QgsSymbolSelectorDialog": ["moveLayerByOffset(int offset)", "QgsSymbolSelectorDialog(QgsSymbol *symbol, QgsStyle *style, const QgsVectorLayer *vl, QWidget *parent=nullptr, bool embedded=false)", "lockLayer()", "moveLayerUp()", "updateUi()", "addLayer()", "moveLayerDown()", "layerChanged()", "loadSymbol()", "setWidget(QWidget *widget)", "updateLayerPreview()", "symbolModified()", "updateLockButton()", "removeLayer()", "currentLayer()", "updatePreview()"],
     "QgsCacheIndexFeatureId": ["QgsCacheIndexFeatureId(QgsVectorLayerCache *)"],
     "QgsSymbolLayerWidget": ["registerDataDefinedButton(QgsDataDefinedButton *button, const QString &propertyName, QgsDataDefinedButton::DataType type, const QString &description)", "setSymbolLayer(QgsSymbolLayer *layer)=0", "updateDataDefinedProperty()", "QgsSymbolLayerWidget(QWidget *parent, const QgsVectorLayer *vl=nullptr)", "symbolLayer()=0"],

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -341,10 +341,10 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         shutil.rmtree(cls.basetestpath, True)
         cls.vl = None # so as to properly close the provider and remove any temporary file
 
-    def testInconsistantUri(self):
+    def testInconsistentUri(self):
         """Test a URI with a typename that doesn't match a type of the capabilities"""
 
-        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_testInconsistantUri'
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_testInconsistentUri'
         with open(sanitize(endpoint, '?SERVICE=WFS?REQUEST=GetCapabilities?ACCEPTVERSIONS=2.0.0,1.1.0,1.0.0'), 'wb') as f:
             f.write("""
 <wfs:WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://schemas.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">

--- a/tests/src/python/test_qgscomposerpolygon.py
+++ b/tests/src/python/test_qgscomposerpolygon.py
@@ -108,7 +108,7 @@ class TestQgsComposerPolygon(unittest.TestCase):
         assert myTestResult, myMessage
 
     def testSelectedNode(self):
-        """Test selectedNode and unselectNode methods"""
+        """Test selectedNode and deselectNode methods"""
 
         self.mComposerPolygon.setDisplayNodes(True)
 
@@ -119,7 +119,7 @@ class TestQgsComposerPolygon(unittest.TestCase):
         myTestResult, myMessage = checker.testComposition()
         assert myTestResult, myMessage
 
-        self.mComposerPolygon.unselectNode()
+        self.mComposerPolygon.deselectNode()
         self.mComposerPolygon.setDisplayNodes(False)
         checker = QgsCompositionChecker(
             'composerpolygon_defaultstyle', self.mComposition)

--- a/tests/src/python/test_qgscomposerpolyline.py
+++ b/tests/src/python/test_qgscomposerpolyline.py
@@ -106,7 +106,7 @@ class TestQgsComposerPolyline(unittest.TestCase):
         assert myTestResult, myMessage
 
     def testSelectedNode(self):
-        """Test selectedNode and unselectNode methods"""
+        """Test selectedNode and deselectNode methods"""
 
         self.mComposerPolyline.setDisplayNodes(True)
 
@@ -117,7 +117,7 @@ class TestQgsComposerPolyline(unittest.TestCase):
         myTestResult, myMessage = checker.testComposition()
         assert myTestResult, myMessage
 
-        self.mComposerPolyline.unselectNode()
+        self.mComposerPolyline.deselectNode()
         self.mComposerPolyline.setDisplayNodes(False)
         checker = QgsCompositionChecker(
             'composerpolyline_defaultstyle', self.mComposition)

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -60,7 +60,7 @@ from utilities import (
 )
 
 
-start_app(sys.platform != 'darwin') # No cleanup on mac os x, it crashes the pallabellingcanvas test on exit
+start_app(sys.platform != 'darwin') # No cleanup on mac os x, it crashes the pallabelingcanvas test on exit
 FONTSLOADED = loadTestFonts()
 
 PALREPORT = 'PAL_REPORT' in os.environ

--- a/tests/src/python/test_qgsserver_accesscontrol.py
+++ b/tests/src/python/test_qgsserver_accesscontrol.py
@@ -142,8 +142,8 @@ class RestrictedAccessControl(QgsAccessControlFilter):
         if not self._active:
             return super(RestrictedAccessControl, self).authorizedLayerAttributes(layer, attributes)
 
-        if "colour" in attributes:
-            attributes.remove("colour")
+        if "colour" in attributes:  #spellok
+            attributes.remove("colour")  #spellok
         return attributes
 
     def allowToEdit(self, layer, feature):
@@ -378,7 +378,7 @@ class TestQgsServerAccessControl(unittest.TestCase):
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
             "No result in GetFeatureInfo\n%s" % response)
         self.assertTrue(
-            str(response).find("<qgs:colour>red</qgs:colour>") != -1,
+            str(response).find("<qgs:colour>red</qgs:colour>") != -1,  #spellok
             "No color in result of GetFeatureInfo\n%s" % response)
 
         response, headers = self._get_restricted(query_string)
@@ -386,10 +386,10 @@ class TestQgsServerAccessControl(unittest.TestCase):
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
             "No result in GetFeatureInfo\n%s" % response)
         self.assertFalse(
-            str(response).find("<qgs:colour>red</qgs:colour>") != -1,
+            str(response).find("<qgs:colour>red</qgs:colour>") != -1,  #spellok
             "Unexpected color in result of GetFeatureInfo\n%s" % response)
         self.assertFalse(
-            str(response).find("<qgs:colour>NULL</qgs:colour>") != -1,
+            str(response).find("<qgs:colour>NULL</qgs:colour>") != -1,  #spellok
             "Unexpected color NULL in result of GetFeatureInfo\n%s" % response)
 
     def test_wms_getfeatureinfo_hello2(self):
@@ -530,7 +530,7 @@ class TestQgsServerAccessControl(unittest.TestCase):
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
             "No result in GetFeature\n%s" % response)
         self.assertTrue(
-            str(response).find("<qgs:colour>red</qgs:colour>") != -1,
+            str(response).find("<qgs:colour>red</qgs:colour>") != -1,  #spellok
             "No color in result of GetFeature\n%s" % response)
 
         response, headers = self._post_restricted(data)
@@ -538,10 +538,10 @@ class TestQgsServerAccessControl(unittest.TestCase):
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
             "No result in GetFeature\n%s" % response)
         self.assertFalse(
-            str(response).find("<qgs:colour>red</qgs:colour>") != -1,
+            str(response).find("<qgs:colour>red</qgs:colour>") != -1,  #spellok
             "Unexpected color in result of GetFeature\n%s" % response)
         self.assertFalse(
-            str(response).find("<qgs:colour>NULL</qgs:colour>") != -1,
+            str(response).find("<qgs:colour>NULL</qgs:colour>") != -1,  #spellok
             "Unexpected color NULL in result of GetFeature\n%s" % response)
 
     def test_wfs_getfeature_hello2(self):


### PR DESCRIPTION
spell checking is now performed within longer words by default (when some conditions are fulfilled)
see https://regex101.com/r/7kznVA/9
possibility to avoid in words checking by adding :* at the end in spelling.dat

@rouault this modifies the architecture of spelling.dat, is this ok for your proj4 spell check? Or can you adapt it...