### PR TITLE
Remove duplicate QgsFeature::setFeatureId method

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -907,6 +907,7 @@ None will need to be modified, as the method will return an empty geometry if th
 - The temporary constGeometry() method has been removed. Use geometry() instead.
 - setFields( const QgsFields*, bool ) has been removed, use setFields( const QgsFields&, bool ) instead.
 - fields() no longer returns a pointer, but instead a QgsFields value.
+- The duplicate method setFeatureId() was removed. Use setId() instead.
 
 
 QgsFeatureRendererV2        {#qgis_api_break_3_0_QgsFeatureRendererV2}

--- a/python/core/qgsfeature.sip
+++ b/python/core/qgsfeature.sip
@@ -245,12 +245,6 @@ class QgsFeature
      * @param id feature id
      * @see id
      */
-    void setFeatureId( QgsFeatureId id );
-
-    /** Sets the feature ID for this feature.
-     * @param id feature id
-     * @see id
-     */
     void setId( QgsFeatureId id );
 
     /** Returns the feature's attributes.

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -121,21 +121,6 @@ QgsGeometry QgsFeature::geometry() const
  * See details in QEP #17
  ****************************************************************************/
 
-void QgsFeature::setFeatureId( QgsFeatureId id )
-{
-  if ( id == d->fid )
-    return;
-
-  d.detach();
-  d->fid = id;
-}
-
-/***************************************************************************
- * This class is considered CRITICAL and any change MUST be accompanied with
- * full unit tests in testqgsfeature.cpp.
- * See details in QEP #17
- ****************************************************************************/
-
 void QgsFeature::setId( QgsFeatureId id )
 {
   if ( id == d->fid )
@@ -324,7 +309,7 @@ QDataStream& operator>>( QDataStream& in, QgsFeature& feature )
   bool valid;
   QgsAttributes attr;
   in >> id >> attr >> geometry >> valid;
-  feature.setFeatureId( id );
+  feature.setId( id );
   feature.setGeometry( geometry );
   feature.setAttributes( attr );
   feature.setValid( valid );

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -172,21 +172,13 @@ class CORE_EXPORT QgsFeature
      */
     bool operator!=( const QgsFeature& other ) const;
 
-
-
     virtual ~QgsFeature();
 
     /** Get the feature ID for this feature.
      * @returns feature ID
-     * @see setFeatureId
+     * @see setId()
      */
     QgsFeatureId id() const;
-
-    /** Sets the feature ID for this feature.
-     * @param id feature id
-     * @see id
-     */
-    void setFeatureId( QgsFeatureId id );
 
     /** Sets the feature ID for this feature.
      * @param id feature id

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -40,7 +40,7 @@ QgsFeature QgsOgrUtils::readOgrFeature( OGRFeatureH ogrFet, const QgsFields& fie
     return feature;
   }
 
-  feature.setFeatureId( OGR_F_GetFID( ogrFet ) );
+  feature.setId( OGR_F_GetFID( ogrFet ) );
   feature.setValid( true );
 
   if ( !readOgrFeatureGeometry( ogrFet, feature ) )

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -129,7 +129,7 @@ void QgsVectorLayerDiagramProvider::drawLabel( QgsRenderContext& context, pal::L
   QgsFeature feature;
   feature.setFields( mFields );
   feature.setValid( true );
-  feature.setFeatureId( label->getFeaturePart()->featureId() );
+  feature.setId( label->getFeaturePart()->featureId() );
   feature.setAttributes( dlf->attributes() );
 
   //calculate top-left point for diagram

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -376,7 +376,7 @@ bool QgsVectorLayerFeatureIterator::fetchNextAddedFeature( QgsFeature& f )
 
 void QgsVectorLayerFeatureIterator::useAddedFeature( const QgsFeature& src, QgsFeature& f )
 {
-  f.setFeatureId( src.id() );
+  f.setId( src.id() );
   f.setValid( true );
   f.setFields( mSource->mFields );
 
@@ -450,7 +450,7 @@ bool QgsVectorLayerFeatureIterator::fetchNextChangedAttributeFeature( QgsFeature
 
 void QgsVectorLayerFeatureIterator::useChangedAttributeFeature( QgsFeatureId fid, const QgsGeometry& geom, QgsFeature& f )
 {
-  f.setFeatureId( fid );
+  f.setId( fid );
   f.setValid( true );
   f.setFields( mSource->mFields );
 

--- a/src/core/qgsvectorlayerundocommand.cpp
+++ b/src/core/qgsvectorlayerundocommand.cpp
@@ -38,7 +38,7 @@ QgsVectorLayerUndoCommandAddFeature::QgsVectorLayerUndoCommandAddFeature( QgsVec
   // Force a feature ID (to keep other functions in QGIS happy,
   // providers will use their own new feature ID when we commit the new feature)
   // and add to the known added features.
-  f.setFeatureId( addedIdLowWaterMark );
+  f.setId( addedIdLowWaterMark );
 
   mFeature = f;
 }

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -53,7 +53,7 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
     mFeatureRequest.setFlags( QgsFeatureRequest::NoGeometry );
   }
 
-  mFeat.setFeatureId( std::numeric_limits<int>::min() );
+  mFeat.setId( std::numeric_limits<int>::min() );
 
   if ( !layer()->hasGeometryType() )
     mFeatureRequest.setFlags( QgsFeatureRequest::NoGeometry );
@@ -744,7 +744,7 @@ Qt::ItemFlags QgsAttributeTableModel::flags( const QModelIndex &index ) const
 
 void QgsAttributeTableModel::reload( const QModelIndex &index1, const QModelIndex &index2 )
 {
-  mFeat.setFeatureId( std::numeric_limits<int>::min() );
+  mFeat.setId( std::numeric_limits<int>::min() );
   emit dataChanged( index1, index2 );
 }
 
@@ -765,7 +765,7 @@ QgsFeature QgsAttributeTableModel::feature( const QModelIndex &idx ) const
 {
   QgsFeature f;
   f.initAttributes( mAttributes.size() );
-  f.setFeatureId( rowToId( idx.row() ) );
+  f.setId( rowToId( idx.row() ) );
   for ( int i = 0; i < mAttributes.size(); i++ )
   {
     f.setAttribute( mAttributes[i], data( index( idx.row(), i ), Qt::EditRole ) );

--- a/src/plugins/geometry_checker/utils/qgsfeaturepool.cpp
+++ b/src/plugins/geometry_checker/utils/qgsfeaturepool.cpp
@@ -89,7 +89,7 @@ void QgsFeaturePool::addFeature( QgsFeature& feature )
   features.append( feature );
   mLayerMutex.lock();
   mLayer->dataProvider()->addFeatures( features );
-  feature.setFeatureId( features.front().id() );
+  feature.setId( features.front().id() );
   if ( mSelectedOnly )
   {
     QgsFeatureIds selectedFeatureIds = mLayer->selectedFeatureIds();

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -223,7 +223,7 @@ bool QgsAfsProvider::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeome
     QgsFeature feature;
 
     // Set FID
-    feature.setFeatureId( startId + i );
+    feature.setId( startId + i );
 
     // Set attributes
     if ( !fetchAttribIdx.isEmpty() )

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -347,7 +347,7 @@ bool QgsDb2FeatureIterator::fetchFeature( QgsFeature& feature )
       }
     }
 //    QgsDebugMsg( QString( "Fid: %1; value: %2" ).arg( mSource->mFidColName ).arg( record.value( mSource->mFidColName ).toLongLong() ) );
-    feature.setFeatureId( mQuery->record().value( mSource->mFidColName ).toLongLong() );
+    feature.setId( mQuery->record().value( mSource->mFidColName ).toLongLong() );
 
     if ( mSource->isSpatial() )
     {

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1146,7 +1146,7 @@ bool QgsDb2Provider::addFeatures( QgsFeatureList & flist )
         return false;
       }
     }
-    it->setFeatureId( queryFid.value( 0 ).toLongLong() );
+    it->setId( queryFid.value( 0 ).toLongLong() );
     writeCount++;
 //    QgsDebugMsg( QString( "count: %1; featureId: %2" ).arg( writeCount ).arg( queryFid.value( 0 ).toLongLong() ) );
   }

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -331,7 +331,7 @@ bool QgsDelimitedTextFeatureIterator::nextFeatureInternal( QgsFeature& feature )
 
     feature.setValid( true );
     feature.setFields( mSource->mFields ); // allow name-based attribute lookups
-    feature.setFeatureId( fid );
+    feature.setId( fid );
     feature.initAttributes( mSource->mFields.count() );
     feature.setGeometry( geom );
 

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -473,7 +473,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
               if ( buildSpatialIndex )
               {
                 QgsFeature f;
-                f.setFeatureId( mFile->recordId() );
+                f.setId( mFile->recordId() );
                 f.setGeometry( geom );
                 mSpatialIndex->insertFeature( f );
               }
@@ -528,7 +528,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
           if ( buildSpatialIndex && qIsFinite( pt.x() ) && qIsFinite( pt.y() ) )
           {
             QgsFeature f;
-            f.setFeatureId( mFile->recordId() );
+            f.setId( mFile->recordId() );
             f.setGeometry( QgsGeometry::fromPoint( pt ) );
             mSpatialIndex->insertFeature( f );
           }

--- a/src/providers/gpx/qgsgpxfeatureiterator.cpp
+++ b/src/providers/gpx/qgsgpxfeatureiterator.cpp
@@ -191,7 +191,7 @@ bool QgsGPXFeatureIterator::readWaypoint( const QgsWaypoint& wpt, QgsFeature& fe
     feature.setGeometry( *g );
     delete g;
   }
-  feature.setFeatureId( wpt.id );
+  feature.setId( wpt.id );
   feature.setValid( true );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups
   feature.initAttributes( mSource->mFields.count() );
@@ -235,7 +235,7 @@ bool QgsGPXFeatureIterator::readRoute( const QgsRoute& rte, QgsFeature& feature 
   {
     delete theGeometry;
   }
-  feature.setFeatureId( rte.id );
+  feature.setId( rte.id );
   feature.setValid( true );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups
   feature.initAttributes( mSource->mFields.count() );
@@ -278,7 +278,7 @@ bool QgsGPXFeatureIterator::readTrack( const QgsTrack& trk, QgsFeature& feature 
   {
     delete theGeometry;
   }
-  feature.setFeatureId( trk.id );
+  feature.setId( trk.id );
   feature.setValid( true );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups
   feature.initAttributes( mSource->mFields.count() );

--- a/src/providers/grass/qgsgrassfeatureiterator.cpp
+++ b/src/providers/grass/qgsgrassfeatureiterator.cpp
@@ -485,7 +485,7 @@ bool QgsGrassFeatureIterator::fetchFeature( QgsFeature& feature )
   }
   QgsDebugMsgLevel( QString( "lid = %1 type = %2 cat = %3 featureId = %4" ).arg( lid ).arg( type ).arg( cat ).arg( featureId ), 3 );
 
-  feature.setFeatureId( featureId );
+  feature.setId( featureId );
   //feature.initAttributes( mSource->mFields.count() );
   QgsDebugMsgLevel( QString( "mSource->mFields.size() = %1" ).arg( mSource->mFields.size() ), 3 );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups

--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -301,7 +301,7 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList & flist )
   // TODO: sanity checks of fields and geometries
   for ( QgsFeatureList::iterator it = flist.begin(); it != flist.end(); ++it )
   {
-    it->setFeatureId( mNextFeatureId );
+    it->setId( mNextFeatureId );
     it->setValid( true );
 
     mFeatures.insert( mNextFeatureId, *it );

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -304,7 +304,7 @@ bool QgsMssqlFeatureIterator::fetchFeature( QgsFeature& feature )
       feature.setAttribute( mAttributesToFetch.at( i ), v );
     }
 
-    feature.setFeatureId( mQuery->record().value( mSource->mFidColName ).toLongLong() );
+    feature.setId( mQuery->record().value( mSource->mFidColName ).toLongLong() );
 
     if ( mSource->isSpatial() )
     {

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1003,7 +1003,7 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList & flist )
         return false;
       }
     }
-    it->setFeatureId( query.value( 0 ).toLongLong() );
+    it->setId( query.value( 0 ).toLongLong() );
   }
 
   return true;

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -294,7 +294,7 @@ void QgsOgrFeatureIterator::getFeatureAttribute( OGRFeatureH ogrFet, QgsFeature 
 
 bool QgsOgrFeatureIterator::readFeature( OGRFeatureH fet, QgsFeature& feature ) const
 {
-  feature.setFeatureId( OGR_F_GetFID( fet ) );
+  feature.setId( OGR_F_GetFID( fet ) );
   feature.initAttributes( mSource->mFields.count() );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1339,7 +1339,7 @@ bool QgsOgrProvider::addFeature( QgsFeature& f )
     QgsFeatureId id = static_cast<QgsFeatureId>( OGR_F_GetFID( feature ) );
     if ( id >= 0 )
     {
-      f.setFeatureId( id );
+      f.setId( id );
 
       if ( mFirstFieldIsFid && attrs.count() > 0 )
       {

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -361,7 +361,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature& feature )
         return false;
     }
 
-    feature.setFeatureId( fid );
+    feature.setId( fid );
     QgsDebugMsgLevel( QString( "fid=%1" ).arg( fid ), 5 );
 
     // iterate attributes

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1410,7 +1410,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
 
       if ( mPrimaryKeyType == pktRowId )
       {
-        features->setFeatureId( mShared->lookupFid( QList<QVariant>() << QVariant( ins.lastInsertId() ) ) );
+        features->setId( mShared->lookupFid( QList<QVariant>() << QVariant( ins.lastInsertId() ) ) );
         QgsDebugMsgLevel( QString( "new fid=%1" ).arg( features->id() ), 4 );
       }
       else if ( mPrimaryKeyType == pktInt || mPrimaryKeyType == pktFidMap )
@@ -1448,7 +1448,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
 
         if ( mPrimaryKeyType == pktInt )
         {
-          features->setFeatureId( STRING_TO_FID( attributevec[ mPrimaryKeyAttrs[0] ] ) );
+          features->setId( STRING_TO_FID( attributevec[ mPrimaryKeyAttrs[0] ] ) );
         }
         else
         {
@@ -1459,7 +1459,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
             primaryKeyVals << attributevec[ idx ];
           }
 
-          features->setFeatureId( mShared->lookupFid( QVariant( primaryKeyVals ) ) );
+          features->setId( mShared->lookupFid( QVariant( primaryKeyVals ) ) );
         }
         QgsDebugMsgLevel( QString( "new fid=%1" ).arg( features->id() ), 4 );
       }

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -755,7 +755,7 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
       return false;
   }
 
-  feature.setFeatureId( fid );
+  feature.setId( fid );
   QgsDebugMsgLevel( QString( "fid=%1" ).arg( fid ), 4 );
 
   // iterate attributes

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2146,7 +2146,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
 
       if ( mPrimaryKeyType == pktOid )
       {
-        features->setFeatureId( result.PQoidValue() );
+        features->setId( result.PQoidValue() );
         QgsDebugMsgLevel( QString( "new fid=%1" ).arg( features->id() ), 4 );
       }
     }
@@ -2160,11 +2160,11 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
 
         if ( mPrimaryKeyType == pktUint64 )
         {
-          features->setFeatureId( STRING_TO_FID( attrs.at( mPrimaryKeyAttrs.at( 0 ) ) ) );
+          features->setId( STRING_TO_FID( attrs.at( mPrimaryKeyAttrs.at( 0 ) ) ) );
         }
         else if ( mPrimaryKeyType == pktInt )
         {
-          features->setFeatureId( PKINT2FID( STRING_TO_FID( attrs.at( mPrimaryKeyAttrs.at( 0 ) ) ) ) );
+          features->setId( PKINT2FID( STRING_TO_FID( attrs.at( mPrimaryKeyAttrs.at( 0 ) ) ) ) );
         }
         else
         {
@@ -2175,7 +2175,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
             primaryKeyVals << attrs.at( idx );
           }
 
-          features->setFeatureId( mShared->lookupFid( primaryKeyVals ) );
+          features->setId( mShared->lookupFid( primaryKeyVals ) );
         }
         QgsDebugMsgLevel( QString( "new fid=%1" ).arg( features->id() ), 4 );
       }

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -479,13 +479,13 @@ bool QgsSpatiaLiteFeatureIterator::getFeature( sqlite3_stmt *stmt, QgsFeature &f
         // first column always contains the ROWID (or the primary key)
         QgsFeatureId fid = sqlite3_column_int64( stmt, ic );
         QgsDebugMsgLevel( QString( "fid=%1" ).arg( fid ), 3 );
-        feature.setFeatureId( fid );
+        feature.setId( fid );
       }
       else
       {
         // autoincrement a row number
         mRowNumber++;
-        feature.setFeatureId( mRowNumber );
+        feature.setId( mRowNumber );
       }
     }
     else if ( mFetchGeometry && ic == mGeomColIdx )

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3970,7 +3970,7 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList & flist )
         if ( ret == SQLITE_DONE || ret == SQLITE_ROW )
         {
           // update feature id
-          feature->setFeatureId( sqlite3_last_insert_rowid( mSqliteHandle ) );
+          feature->setId( sqlite3_last_insert_rowid( mSqliteHandle ) );
           mNumberFeatures++;
         }
         else

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -198,12 +198,12 @@ bool QgsVirtualLayerFeatureIterator::fetchFeature( QgsFeature& feature )
   if ( mDefinition.uid().isNull() )
   {
     // no id column => autoincrement
-    feature.setFeatureId( mFid++ );
+    feature.setId( mFid++ );
   }
   else
   {
     // first column: uid
-    feature.setFeatureId( mQuery->columnInt64( 0 ) );
+    feature.setId( mQuery->columnInt64( 0 ) );
   }
 
   int n = mQuery->columnCount();

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -1217,7 +1217,7 @@ void QgsWFSFeatureIterator::copyFeature( const QgsFeature& srcFeature, QgsFeatur
 
   //id and valid
   dstFeature.setValid( true );
-  dstFeature.setFeatureId( srcFeature.id() );
+  dstFeature.setId( srcFeature.id() );
   dstFeature.setFields( fields ); // allow name-based attribute lookups
 }
 

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -872,7 +872,7 @@ bool QgsWFSProvider::addFeatures( QgsFeatureList &flist )
     for ( ; idIt != idList.constEnd() && featureIt != flist.end(); ++idIt, ++featureIt )
     {
       if ( map.find( *idIt ) != map.end() )
-        featureIt->setFeatureId( map[*idIt] );
+        featureIt->setId( map[*idIt] );
     }
 
     return true;

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -931,9 +931,9 @@ void QgsWFSSharedData::serializeFeatures( QVector<QgsWFSFeatureGmlIdPair>& featu
     for ( int i = 0; i < updatedFeatureList.size(); i++ )
     {
       if ( cacheOk )
-        updatedFeatureList[i].first.setFeatureId( featureListToCache[i].id() );
+        updatedFeatureList[i].first.setId( featureListToCache[i].id() );
       else
-        updatedFeatureList[i].first.setFeatureId( mTotalFeaturesAttemptedToBeCached + i + 1 );
+        updatedFeatureList[i].first.setId( mTotalFeaturesAttemptedToBeCached + i + 1 );
     }
 
     {
@@ -1035,7 +1035,7 @@ void QgsWFSSharedData::endOfDownload( bool success, int featureCount,
     QgsFeature f;
     f.setGeometry( QgsGeometry::fromRect( mRect ) );
     QgsFeatureId id = mRegions.size();
-    f.setFeatureId( id );
+    f.setId( id );
     f.initAttributes( 1 );
     f.setAttribute( 0, QVariant( bDownloadLimit ) );
     mRegions.push_back( f );

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -173,7 +173,7 @@ void TestQgsFeature::copy()
   QVERIFY( copy.id() == original.id() );
   QCOMPARE( copy.attributes(), original.attributes() );
 
-  copy.setFeatureId( 1001LL );
+  copy.setId( 1001LL );
   QCOMPARE( original.id(), 1000LL );
   QVERIFY( copy.id() != original.id() );
 }
@@ -187,7 +187,7 @@ void TestQgsFeature::assignment()
   QCOMPARE( copy.id(), original.id() );
   QCOMPARE( copy.attributes(), original.attributes() );
 
-  copy.setFeatureId( 1001LL );
+  copy.setId( 1001LL );
   QCOMPARE( original.id(), 1000LL );
   QVERIFY( copy.id() != original.id() );
   QCOMPARE( copy.attributes(), original.attributes() );
@@ -196,7 +196,7 @@ void TestQgsFeature::assignment()
 void TestQgsFeature::gettersSetters()
 {
   QgsFeature feature;
-  feature.setFeatureId( 1000LL );
+  feature.setId( 1000LL );
   QCOMPARE( feature.id(), 1000LL );
 
   feature.setValid( true );
@@ -289,7 +289,7 @@ void TestQgsFeature::geometry()
   emptyGeomFeature.setGeometry( QgsGeometry() );
   QVERIFY( !emptyGeomFeature.hasGeometry() );
   copy = emptyGeomFeature;
-  copy.setFeatureId( 5 ); //force detach
+  copy.setId( 5 ); //force detach
 
   //setGeometry
   //always start with a copy so that we can test implicit sharing detachment is working

--- a/tests/src/providers/grass/testqgsgrassprovider.cpp
+++ b/tests/src/providers/grass/testqgsgrassprovider.cpp
@@ -928,7 +928,7 @@ QList< TestQgsGrassCommandGroup > TestQgsGrassProvider::createCommands()
   // Add point
   command = TestQgsGrassCommand( TestQgsGrassCommand::AddFeature );
   grassFeature = TestQgsGrassFeature( GV_POINT );
-  grassFeature.setFeatureId( 1 );
+  grassFeature.setId( 1 );
   geometry = new QgsGeometry( new QgsPointV2( QgsWkbTypes::Point, 10, 10, 0 ) );
   grassFeature.setGeometry( *geometry );
   delete geometry;
@@ -1018,7 +1018,7 @@ QList< TestQgsGrassCommandGroup > TestQgsGrassProvider::createCommands()
   // Add line feature with attributes
   command = TestQgsGrassCommand( TestQgsGrassCommand::AddFeature );
   grassFeature = TestQgsGrassFeature( GV_LINE );
-  grassFeature.setFeatureId( 1 );
+  grassFeature.setId( 1 );
   line = new QgsLineString();
   pointList.clear();
   pointList << QgsPointV2( QgsWkbTypes::Point, 0, 0, 0 );
@@ -1059,7 +1059,7 @@ QList< TestQgsGrassCommandGroup > TestQgsGrassProvider::createCommands()
   command = TestQgsGrassCommand( TestQgsGrassCommand::AddFeature );
   command.verify = false;
   grassFeature = TestQgsGrassFeature( GV_BOUNDARY );
-  grassFeature.setFeatureId( 1 );
+  grassFeature.setId( 1 );
   line = new QgsLineString();
   pointList.clear();
   pointList << QgsPointV2( QgsWkbTypes::Point, 0, 0, 0 );

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -126,7 +126,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.assertEqual(m.point(), QgsPoint(1, 0))
 
         f = QgsFeature(self.linesLayer.fields())
-        f.setFeatureId(1)
+        f.setId(1)
         geom = QgsGeometry.fromWkt("LINESTRING(0 0,1 1)")
         f.setGeometry(geom)
         self.linesLayer.startEditing()
@@ -144,7 +144,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.pointsLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())])
         # add another line
         f = QgsFeature(self.linesLayer.fields())
-        f.setFeatureId(2)
+        f.setId(2)
         geom = QgsGeometry.fromWkt("LINESTRING(0 0,0.5 0.5)")
         f.setGeometry(geom)
         self.linesLayer.startEditing()
@@ -166,7 +166,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.pointsLayer2.setDependencies([QgsMapLayerDependency(self.pointsLayer.id())])
         # add another line
         f = QgsFeature(self.linesLayer.fields())
-        f.setFeatureId(3)
+        f.setId(3)
         geom = QgsGeometry.fromWkt("LINESTRING(0 0.2,0.5 0.8)")
         f.setGeometry(geom)
         self.linesLayer.startEditing()
@@ -247,7 +247,7 @@ class TestLayerDependencies(unittest.TestCase):
         u.setConfig(cfg)
         # add another line
         f = QgsFeature(self.linesLayer.fields())
-        f.setFeatureId(4)
+        f.setId(4)
         geom = QgsGeometry.fromWkt("LINESTRING(0.5 0.2,0.6 0)")
         f.setGeometry(geom)
         self.linesLayer.startEditing()

--- a/tests/src/python/test_qgsspatialindex.py
+++ b/tests/src/python/test_qgsspatialindex.py
@@ -33,7 +33,7 @@ class TestQgsSpatialIndex(unittest.TestCase):
         for y in range(5, 15, 5):
             for x in range(5, 25, 5):
                 ft = QgsFeature()
-                ft.setFeatureId(fid)
+                ft.setId(fid)
                 ft.setGeometry(QgsGeometry.fromPoint(QgsPoint(x, y)))
                 idx.insertFeature(ft)
                 fid += 1


### PR DESCRIPTION
Both QgsFeature::setFeatureId and QgsFeature::setId do the exact same thing.

This PR removes setFeatureId, leaving just setId and documents the api break