### PR TITLE
show field alias when presenting constraint msg

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -818,7 +818,7 @@ bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields,
     {
       if ( ! eww->isValidConstraint() )
       {
-        invalidFields.append( eww->field().name() );
+        invalidFields.append( eww->field().displayName() );
 
         descriptions.append( eww->constraintFailureReason() );
 


### PR DESCRIPTION
Before, when a field didn't passed the defined constraints
it showed a message in the form of "field name: Constraint defined message".

Now, if if a field alias is defined, the message is in the form of
"field alias: Constraint defined message"

I see it was already described at https://hub.qgis.org/issues/15455