### PR TITLE
Attribute form warn on uncommitted changes

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -655,48 +655,14 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
      * @note Called by QgsMapLayer::writeXml().
      */
     virtual bool writeXml( QDomNode & layer_node, QDomDocument & doc ) const;
-
-    /**
-     * Save named and sld style of the layer to the style table in the db.
-     * @param name
-     * @param description
-     * @param useAsDefault
-     * @param uiFileContent
-     * @param msgError (out)
-     */
-    virtual void saveStyleToDatabase( const QString& name, const QString& description,
+    void saveStyleToDatabase( const QString& name, const QString& description,
                                       bool useAsDefault, const QString& uiFileContent,
                                       QString &msgError /Out/ );
-
-    /**
-     * Lists all the style in db split into related to the layer and not related to
-     * @param ids the list in which will be stored the style db ids
-     * @param names the list in which will be stored the style names
-     * @param descriptions the list in which will be stored the style descriptions
-     * @param msgError
-     * @return the number of styles related to current layer
-     */
-    virtual int listStylesInDatabase( QStringList &ids /Out/, QStringList &names /Out/,
+    int listStylesInDatabase( QStringList &ids /Out/, QStringList &names /Out/,
                                       QStringList &descriptions /Out/, QString &msgError /Out/ );
-
-    /**
-     * Will return the named style corresponding to style id provided
-     */
-    virtual QString getStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
-
-    /**
-     * Load a named style from file/local db/datasource db
-     * @param theURI the URI of the style or the URI of the layer
-     * @param theResultFlag will be set to true if a named style is correctly loaded
-     * @param loadFromLocalDb if true forces to load from local db instead of datasource one
-     */
-    virtual QString loadNamedStyle( const QString &theURI, bool &theResultFlag /Out/, bool loadFromLocalDb );
-
-    /**
-     * Calls loadNamedStyle( theURI, theResultFlag, false );
-     * Retained for backward compatibility
-     */
-    virtual QString loadNamedStyle( const QString &theURI, bool &theResultFlag /Out/ );
+    QString getStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
+    QString loadNamedStyle( const QString &theURI, bool &theResultFlag /Out/, bool loadFromLocalDb );
+    QString loadNamedStyle( const QString &theURI, bool &theResultFlag /Out/ );
 
     /** Read the symbology for the current layer from the Dom node supplied.
      * @param node node that will contain the symbology definition for this layer.
@@ -756,21 +722,8 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
      * @return true if calculated, false if failed or was canceled by user
      */
     bool countSymbolFeatures( bool showProgress = true );
-
-    /**
-     * Set the string (typically sql) used to define a subset of the layer
-     * @param subset The subset string. This may be the where clause of a sql statement
-     *               or other defintion string specific to the underlying dataprovider
-     *               and data store.
-     * @return true, when setting the subset string was successful, false otherwise
-     */
-    virtual bool setSubsetString( const QString& subset );
-
-    /**
-     * Get the string (typically sql) used to define a subset of the layer
-     * @return The subset string or QString::null if not implemented by the provider
-     */
-    virtual QString subsetString() const;
+    bool setSubsetString( const QString& subset );
+    QString subsetString() const;
 
     /**
      * Query the layer for features specified in request.
@@ -967,9 +920,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     virtual bool isEditable() const;
 
     virtual bool isSpatial() const;
-
-    /** Returns true if the provider has been modified since the last commit */
-    virtual bool isModified() const;
+    bool isModified() const;
 
     /** Snaps a point to the closest vertex if there is one within the snapping tolerance
      *  @param point       The point which is set to the position of a vertex if there is one within the snapping tolerance.
@@ -1533,11 +1484,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
      * @see selectByIds()
      */
     void removeSelection();
-
-    /** Update the extents for the layer. This is necessary if features are
-     *  added/deleted or the layer has been subsetted.
-     */
-    virtual void updateExtents();
+    void updateExtents();
 
     /** Check if there is a join with a layer that will be removed */
     void checkJoinLayerRemove( const QString& theLayerId );

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -920,7 +920,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     virtual bool isEditable() const;
 
     virtual bool isSpatial() const;
-    bool isModified() const;
+    bool isModified( bool checkForPendingChanges = false ) const;
 
     /** Snaps a point to the closest vertex if there is one within the snapping tolerance
      *  @param point       The point which is set to the position of a vertex if there is one within the snapping tolerance.

--- a/python/gui/qgsattributeform.sip
+++ b/python/gui/qgsattributeform.sip
@@ -122,7 +122,7 @@ class QgsAttributeForm : QWidget
      * @note added in QGIS 2.16
      */
     void setMessageBar( QgsMessageBar* messageBar );
-
+    bool isChanged() const;
   signals:
     /**
      * Notifies about changes of attributes

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8002,7 +8002,7 @@ bool QgisApp::toggleEditing( QgsMapLayer *layer, bool allowCancel )
   bool isModified = false;
 
   // Assume changes if: a) the layer reports modifications or b) its transaction group was modified
-  if ( vlayer->isModified() || ( tg && tg->layers().contains( vlayer ) && tg->modified() ) )
+  if ( vlayer->isModified( true ) || ( tg && tg->layers().contains( vlayer ) && tg->modified() ) )
     isModified  = true;
 
   if ( !vlayer->isEditable() && !vlayer->readOnly() )
@@ -8112,7 +8112,7 @@ void QgisApp::saveActiveLayerEdits()
 void QgisApp::saveEdits( QgsMapLayer *layer, bool leaveEditable, bool triggerRepaint )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( !vlayer || !vlayer->isEditable() || !vlayer->isModified() )
+  if ( !vlayer || !vlayer->isEditable() || !vlayer->isModified( true ) )
     return;
 
   if ( vlayer == activeLayer() )
@@ -8300,14 +8300,8 @@ QList<QgsMapLayer *> QgisApp::editableLayers( bool modified ) const
   // use legend layers (instead of registry) so QList mirrors its order
   Q_FOREACH ( QgsLayerTreeLayer* nodeLayer, mLayerTreeView->layerTreeModel()->rootGroup()->findLayers() )
   {
-    if ( !nodeLayer->layer() )
-      continue;
-
-    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer*>( nodeLayer->layer() );
-    if ( !vl )
-      continue;
-
-    if ( vl->isEditable() && ( !modified || vl->isModified() ) )
+    QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( nodeLayer->layer() );
+    if ( vl && vl->isEditable() && ( !modified || vl->isModified() ) )
       editLayers << vl;
   }
   return editLayers;

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -78,7 +78,7 @@ bool QgsGuiVectorLayerTools::saveEdits( QgsVectorLayer* layer ) const
 {
   bool res = true;
 
-  if ( layer->isModified() )
+  if ( layer->isModified( true ) )
   {
     if ( !layer->commitChanges() )
     {
@@ -101,7 +101,7 @@ bool QgsGuiVectorLayerTools::stopEditing( QgsVectorLayer* layer, bool allowCance
 {
   bool res = true;
 
-  if ( layer->isModified() )
+  if ( layer->isModified( true ) )
   {
     QMessageBox::StandardButtons buttons = QMessageBox::Save | QMessageBox::Discard;
     if ( allowCancel )

--- a/src/core/qgstransactiongroup.cpp
+++ b/src/core/qgstransactiongroup.cpp
@@ -64,7 +64,7 @@ bool QgsTransactionGroup::modified() const
 {
   Q_FOREACH ( QgsVectorLayer* layer, mLayers )
   {
-    if ( layer->isModified() )
+    if ( layer->isModified( true ) )
       return true;
   }
   return false;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2832,9 +2832,11 @@ bool QgsVectorLayer::setReadOnly( bool readonly )
   return true;
 }
 
-bool QgsVectorLayer::isModified() const
+bool QgsVectorLayer::isModified( bool checkForPendingChanges ) const
 {
-  emit beforeModifiedCheck();
+  if ( checkForPendingChanges )
+    emit beforeModifiedCheck();
+
   return mEditBuffer && mEditBuffer->isModified();
 }
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -403,8 +403,6 @@ protected:
  * \subsection grass Grass data provider (grass)
  *
  * Provider to display vector data in a GRASS GIS layer.
- *
- * TODO QGIS3: Remove virtual from non-inherited methods (like isModified)
  * @see QgsVectorLayerUtils()
  */
 
@@ -765,9 +763,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * @param uiFileContent
      * @param msgError
      */
-    virtual void saveStyleToDatabase( const QString& name, const QString& description,
-                                      bool useAsDefault, const QString& uiFileContent,
-                                      QString &msgError );
+    void saveStyleToDatabase( const QString& name, const QString& description,
+                              bool useAsDefault, const QString& uiFileContent,
+                              QString &msgError );
 
     /**
      * Lists all the style in db split into related to the layer and not related to
@@ -777,13 +775,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * @param msgError
      * @return the number of styles related to current layer
      */
-    virtual int listStylesInDatabase( QStringList &ids, QStringList &names,
-                                      QStringList &descriptions, QString &msgError );
+    int listStylesInDatabase( QStringList &ids, QStringList &names,
+                              QStringList &descriptions, QString &msgError );
 
     /**
      * Will return the named style corresponding to style id provided
      */
-    virtual QString getStyleFromDatabase( const QString& styleId, QString &msgError );
+    QString getStyleFromDatabase( const QString& styleId, QString &msgError );
 
     /**
      * Load a named style from file/local db/datasource db
@@ -791,7 +789,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * @param theResultFlag will be set to true if a named style is correctly loaded
      * @param loadFromLocalDb if true forces to load from local db instead of datasource one
      */
-    virtual QString loadNamedStyle( const QString &theURI, bool &theResultFlag, bool loadFromLocalDb );
+    QString loadNamedStyle( const QString &theURI, bool &theResultFlag, bool loadFromLocalDb );
 
     /**
      * Calls loadNamedStyle( theURI, theResultFlag, false );
@@ -874,13 +872,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *               and data store.
      * @return true, when setting the subset string was successful, false otherwise
      */
-    virtual bool setSubsetString( const QString& subset );
+    bool setSubsetString( const QString& subset );
 
     /**
      * Get the string (typically sql) used to define a subset of the layer
      * @return The subset string or QString::null if not implemented by the provider
      */
-    virtual QString subsetString() const;
+    QString subsetString() const;
 
     /**
      * Query the layer for features specified in request.
@@ -1099,7 +1097,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     virtual bool isSpatial() const override;
 
     //! Returns true if the provider has been modified since the last commit
-    virtual bool isModified() const;
+    bool isModified() const;
 
     /** Snaps a point to the closest vertex if there is one within the snapping tolerance
      *  @param point       The point which is set to the position of a vertex if there is one within the snapping tolerance.
@@ -1697,7 +1695,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /** Update the extents for the layer. This is necessary if features are
      *  added/deleted or the layer has been subsetted.
      */
-    virtual void updateExtents();
+    void updateExtents();
 
     //! Check if there is a join with a layer that will be removed
     void checkJoinLayerRemove( const QString& theLayerId );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1096,8 +1096,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     virtual bool isSpatial() const override;
 
-    //! Returns true if the provider has been modified since the last commit
-    bool isModified() const;
+    /**
+     * Returns true if the provider has been modified since the last commit.
+     *
+     * If the checkForPendingChanges flag is specified, the beforeModifiedCheck()
+     * signal is emitted to let components like open attribute forms push in last
+     * minute changes.
+     */
+    bool isModified( bool checkForPendingChanges = false ) const;
 
     /** Snaps a point to the closest vertex if there is one within the snapping tolerance
      *  @param point       The point which is set to the position of a vertex if there is one within the snapping tolerance.
@@ -1301,6 +1307,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * so if a stage fails, it's difficult to roll back cleanly.
      * Therefore any error message also includes which stage failed so
      * that the user has some chance of repairing the damage cleanly.
+     *
+     * You may want to call isModified( true ) before calling commitChanges()
+     * if you want to include pending changes from attribute forms.
+     *
      * @see commitErrors()
      */
     bool commitChanges();

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -66,7 +66,6 @@ class CORE_EXPORT QgsVectorLayerUtils
                                      const QgsGeometry& geometry = QgsGeometry(),
                                      const QgsAttributeMap& attributes = QgsAttributeMap(),
                                      QgsExpressionContext* context = nullptr );
-
 };
 
 #endif // QGSVECTORLAYERUTILS_H

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -110,6 +110,9 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog
     //! Show the dialog non-blocking. Reparents this dialog to be a child of the dialog form
     void show();
 
+  private slots:
+    void onLayerModifiedCheck();
+
   private:
     void init( QgsVectorLayer* layer, QgsFeature* feature, const QgsAttributeEditorContext& context, bool showDialogButtons );
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1905,6 +1905,33 @@ void QgsAttributeForm::setMessageBar( QgsMessageBar* messageBar )
   mMessageBar = messageBar;
 }
 
+bool QgsAttributeForm::isChanged() const
+{
+  Q_FOREACH ( QgsWidgetWrapper* ww, mWidgets )
+  {
+    QgsEditorWidgetWrapper* eww = qobject_cast<QgsEditorWidgetWrapper*>( ww );
+    if ( eww )
+    {
+      int fieldIdx = eww->fieldIdx();
+
+      QVariant dstVar = mFeature.attribute( fieldIdx );
+      QVariant srcVar = eww->value();
+
+      // need to check dstVar.isNull() != srcVar.isNull()
+      // otherwise if dstVar=NULL and scrVar=0, then dstVar = srcVar
+      // be careful- sometimes two null qvariants will be reported as not equal!! (e.g., different types)
+      bool changed = ( dstVar != srcVar && !dstVar.isNull() && !srcVar.isNull() )
+                     || ( dstVar.isNull() != srcVar.isNull() );
+      if ( changed && srcVar.isValid()
+           && !mLayer->editFormConfig().readOnly( eww->fieldIdx() ) )
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 int QgsAttributeForm::messageTimeout()
 {
   QSettings settings;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -150,6 +150,14 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void setMessageBar( QgsMessageBar* messageBar );
 
+    /**
+     * Check if there are pending attribute changes that have not been
+     * saved to the edit buffer yet.
+     *
+     * @note Added in QGIS 3.0
+     */
+    bool isChanged() const;
+
   signals:
 
     /**


### PR DESCRIPTION
When a user wants to commit changes and has an unconfirmed attribute editor open, he will be asked if he wants to accept or dismiss these changes before the commit.

The old behavior was to keep the changed values visible in the form but disabling the form which was very misleading.