### PR TITLE
[BUGFIX][Server] Add short names in restricted layer list

### DIFF
--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -1189,6 +1189,27 @@ QSet<QString> QgsServerProjectParser::findRestrictedLayers() const
       }
     }
   }
+  // Add short name in restricted layers
+  else
+  {
+    QDomNodeList layerNodeList = mXMLDoc->elementsByTagName( "maplayer" );
+    for ( int i = 0; i < layerNodeList.size(); ++i )
+    {
+      QDomElement layerElem = layerNodeList.at( i ).toElement();
+      // get name
+      QString lName = layerName( layerElem );
+      if ( restrictedLayerSet.contains( lName ) )
+      {
+        // get short name
+        lName = layerShortName( layerElem );
+        if ( !lName.isEmpty() )
+        {
+          // add short name
+          restrictedLayerSet.insert( lName );
+        }
+      }
+    }
+  }
   return restrictedLayerSet;
 }
 


### PR DESCRIPTION
The restricted layer list contains layer names and layer ids if layer ids are used as service layer name.
This code adds layer  short name to the restricted layer list if layer ids are not used as service layer name.