### PR TITLE
show field alias when presenting constraint msg backport

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -833,7 +833,7 @@ bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields,
     {
       if ( ! eww->isValidConstraint() )
       {
-        invalidFields.append( eww->field().name() );
+        invalidFields.append( eww->field().displayName() );
 
         QString desc = eww->layer()->editFormConfig()->expressionDescription( eww->fieldIdx() );
         descriptions.append( desc );


### PR DESCRIPTION
Before, when a field didn't passed the defined constraints
it showed a message in the form of "field name: Constraint defined message".

Now, if if a field alias is defined, the message is in the form of
"field alias: Constraint defined message"

See #15455