### PR TITLE
[composer] Some possibly controversial changes

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -399,7 +399,8 @@ QgsAdvancedDigitizingDockWidget        {#qgis_api_break_3_0_QgsAdvancedDigitizin
 QgsAtlasComposition        {#qgis_api_break_3_0_QgsAtlasComposition}
 -------------------
 
-- readXMLMapSettings() has been renamed to readXmlMapSettings()
+- readXMLMapSettings() was removed. QGIS no longer supports upgrading pre 2.2 compositions and if this is a
+requirement the projects should first be upgraded by opening and saving in 2.18.
 - composerMap() and setComposerMap() were removed. Use QgsComposerMap::atlasDriven() and setAtlasDriven()
 instead
 - fixedScale() and setFixedScale() were removed. Use QgsComposerMap::atlasScalingMode() and setAtlasScalingMode()

--- a/python/core/composer/qgsatlascomposition.sip
+++ b/python/core/composer/qgsatlascomposition.sip
@@ -189,15 +189,6 @@ public:
      */
     void readXml( const QDomElement& elem, const QDomDocument& doc );
 
-    /** Reads old (pre 2.2) map related atlas settings from xml
-     * @param elem a QDomElement holding the atlas map properties.
-     * @param doc QDomDocument for the source xml.
-     * @see readXMLMapSettings
-     * @note This method should be called after restoring composer item properties
-     * @note added in version 2.5
-     */
-    void readXmlMapSettings( const QDomElement& elem, const QDomDocument& doc );
-
     QgsComposition* composition();
 
     /** Requeries the current atlas coverage layer and applies filtering and sorting. Returns

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3931,7 +3931,7 @@ void QgsComposer::cleanupAfterTemplateRead()
         double currentHeight = mapItem->rect().height();
         if ( currentWidth - 0 > 0.0 ) //don't divide through zero
         {
-          QgsRectangle canvasExtent = mComposition->mapSettings().visibleExtent();
+          QgsRectangle canvasExtent = mQgis->mapCanvas()->mapSettings().visibleExtent();
           //adapt min y of extent such that the size of the map item stays the same
           double newCanvasExtentHeight = currentHeight / currentWidth * canvasExtent.width();
           canvasExtent.setYMinimum( canvasExtent.yMaximum() - newCanvasExtentHeight );

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3588,10 +3588,6 @@ void QgsComposer::readXml( const QDomElement& composerElem, const QDomDocument& 
   delete oldAtlasWidget;
   mAtlasDock->setWidget( new QgsAtlasCompositionWidget( mAtlasDock, mComposition ) );
 
-  //read atlas map parameters (for pre 2.2 templates)
-  //this part must be done after adding items
-  mComposition->atlasComposition().readXmlMapSettings( atlasElem, doc );
-
   //set state of atlas controls
   QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
   toggleAtlasControls( atlasMap->enabled() );

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -469,7 +469,7 @@ void QgsComposerMapWidget::on_mSetToMapCanvasExtentButton_clicked()
     return;
   }
 
-  QgsRectangle newExtent = mComposerMap->composition()->mapSettings().visibleExtent();
+  QgsRectangle newExtent = QgisApp::instance()->mapCanvas()->mapSettings().visibleExtent();
 
   mComposerMap->beginCommand( tr( "Map extent changed" ) );
   mComposerMap->zoomToExtent( newExtent );

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -661,40 +661,6 @@ void QgsAtlasComposition::readXml( const QDomElement& atlasElem, const QDomDocum
   emit parameterChanged();
 }
 
-void QgsAtlasComposition::readXmlMapSettings( const QDomElement &elem, const QDomDocument &doc )
-{
-  Q_UNUSED( doc );
-  //look for stored composer map, to upgrade pre 2.1 projects
-  int composerMapNo = elem.attribute( QStringLiteral( "composerMap" ), QStringLiteral( "-1" ) ).toInt();
-  QgsComposerMap * composerMap = nullptr;
-  if ( composerMapNo != -1 )
-  {
-    QList<QgsComposerMap*> maps;
-    mComposition->composerItems( maps );
-    for ( QList<QgsComposerMap*>::iterator it = maps.begin(); it != maps.end(); ++it )
-    {
-      if (( *it )->id() == composerMapNo )
-      {
-        composerMap = ( *it );
-        composerMap->setAtlasDriven( true );
-        break;
-      }
-    }
-  }
-
-  //upgrade pre 2.1 projects
-  double margin = elem.attribute( QStringLiteral( "margin" ), QStringLiteral( "0.0" ) ).toDouble();
-  if ( composerMap && !qgsDoubleNear( margin, 0.0 ) )
-  {
-    composerMap->setAtlasMargin( margin );
-  }
-  bool fixedScale = elem.attribute( QStringLiteral( "fixedScale" ), QStringLiteral( "false" ) ) == QLatin1String( "true" ) ? true : false;
-  if ( composerMap && fixedScale )
-  {
-    composerMap->setAtlasScalingMode( QgsComposerMap::Fixed );
-  }
-}
-
 void QgsAtlasComposition::setHideCoverage( bool hide )
 {
   mHideCoverage = hide;

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -220,15 +220,6 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
      */
     void readXml( const QDomElement& elem, const QDomDocument& doc );
 
-    /** Reads old (pre 2.2) map related atlas settings from xml
-     * @param elem a QDomElement holding the atlas map properties.
-     * @param doc QDomDocument for the source xml.
-     * @see readXMLMapSettings
-     * @note This method should be called after restoring composer item properties
-     * @note added in version 2.5
-     */
-    void readXmlMapSettings( const QDomElement& elem, const QDomDocument& doc );
-
     QgsComposition* composition() { return mComposition; }
 
     /** Requeries the current atlas coverage layer and applies filtering and sorting. Returns

--- a/src/core/composer/qgscomposerattributetablev2.cpp
+++ b/src/core/composer/qgscomposerattributetablev2.cpp
@@ -419,7 +419,7 @@ bool QgsComposerAttributeTableV2::getTableContents( QgsComposerTableContents &co
   if ( mComposerMap && mShowOnlyVisibleFeatures )
   {
     selectionRect = *mComposerMap->currentMapExtent();
-    if ( layer && mComposition->mapSettings().hasCrsTransformEnabled() )
+    if ( layer )
     {
       //transform back to layer CRS
       QgsCoordinateTransform coordTransform( layer->crs(), mComposition->mapSettings().destinationCrs() );

--- a/src/core/composer/qgscomposerhtml.cpp
+++ b/src/core/composer/qgscomposerhtml.cpp
@@ -546,7 +546,7 @@ void QgsComposerHtml::setExpressionContext( const QgsFeature &feature, QgsVector
   }
   if ( mComposition )
   {
-    mDistanceArea->setEllipsoidalMode( mComposition->mapSettings().hasCrsTransformEnabled() );
+    mDistanceArea->setEllipsoidalMode( true );
     mDistanceArea->setEllipsoid( mComposition->project()->ellipsoid() );
   }
 

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -264,7 +264,7 @@ void QgsComposerLabel::refreshExpressionContext()
     //set to composition's mapsettings' crs
     mDistanceArea->setSourceCrs( mComposition->mapSettings().destinationCrs().srsid() );
   }
-  mDistanceArea->setEllipsoidalMode( mComposition->mapSettings().hasCrsTransformEnabled() );
+  mDistanceArea->setEllipsoidalMode( true );
   mDistanceArea->setEllipsoid( mComposition->project()->ellipsoid() );
   contentChanged();
 

--- a/src/core/composer/qgscomposerscalebar.cpp
+++ b/src/core/composer/qgscomposerscalebar.cpp
@@ -302,7 +302,7 @@ double QgsComposerScaleBar::mapWidth() const
   else
   {
     QgsDistanceArea da;
-    da.setEllipsoidalMode( mComposition->mapSettings().hasCrsTransformEnabled() );
+    da.setEllipsoidalMode( true );
     da.setSourceCrs( mComposition->mapSettings().destinationCrs().srsid() );
     da.setEllipsoid( mComposition->project()->ellipsoid() );
 

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1084,12 +1084,6 @@ bool QgsComposition::loadFromTemplate( const QDomDocument& doc, QMap<QString, QS
   //addItemsFromXML
   addItemsFromXml( importDoc.documentElement(), importDoc, nullptr, addUndoCommands, nullptr );
 
-  //read atlas map parameters (for pre 2.2 templates)
-  //this can only be done after items have been added
-  if ( clearComposition )
-  {
-    atlasComposition().readXmlMapSettings( atlasElem, importDoc );
-  }
   return true;
 }
 


### PR DESCRIPTION
1. Remove support for upgrading pre 2.2 project atlas maps. Users must open the project in a recent 2.x release and resave to upgrade the project. I think 2.2 is old enough that almost everyone will be using 2.8 or >=2.14 instead, and no one will notice this dropped support. It's being done to clean up the API and simply upcoming work.

2. Don't use canvas OTF reprojection setting in composition calculations. Previously composer was using the canvas OTF reprojection setting to calculate distances and when calculating whether features are
visible in a composer map. Now, just always reproject when performing these calculations in composer. I don't believe that this setting should affect how a composition is exported and should only relate to the canvas appearance. This is also being motivated by the desire to separate compositions from the canvas map settings for a much cleaner design and to allow things like composer map with different CRS to each other.