### PR TITLE
Show warning when adding more than 1 part to single geometry layers

### DIFF
--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -65,6 +65,10 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
     return;
   }
 
+  bool isGeometryEmpty = false;
+  if ( vlayer->selectedFeatures()[0].geometry().isEmpty() )
+    isGeometryEmpty = true;
+
   if ( !checkSelection() )
   {
     stopCapturing();
@@ -194,6 +198,12 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       vlayer->endEditCommand();
 
       vlayer->triggerRepaint();
+
+      if (( !isGeometryEmpty ) && QgsWkbTypes::isSingleType( vlayer->wkbType() ) )
+      {
+        emit messageEmitted( tr( "Add part: Feature geom is single part and you've added more than one" ), QgsMessageBar::WARNING );
+      }
+
       return;
     }
 


### PR DESCRIPTION
Hello,

Sometimes you can add a part to a single geometry layer that already has a geom turning it into a multipart.
No error or warning is provided until you save and you have to redo steps if you haven't tried to save immediately and get the provider error.

This provides a warning message so that the user has some feedback before he tries to save so that he can undo changes before saving. 

I thought about the cases when the user can save the multi-geometry into a new  layer or the ones where the geometry is reworked database side and I think the message is more helpful than it is disturbing for these cases.

I am a little bit unsure about this, what do you think?
Thanks!