### PR TITLE
Don't return const references to implicitly shared Qt classes

### DIFF
--- a/python/analysis/raster/qgsrelief.sip
+++ b/python/analysis/raster/qgsrelief.sip
@@ -26,7 +26,7 @@ class QgsRelief
 
     void clearReliefColors();
     void addReliefColorClass( const QgsRelief::ReliefColor& color );
-    const QList< QgsRelief::ReliefColor >& reliefColors() const;
+    QList< QgsRelief::ReliefColor > reliefColors() const;
     void setReliefColors( const QList< QgsRelief::ReliefColor >& c );
 
     /** Calculates class breaks according with the method of Buenzli (2011) using an iterative algorithm for segmented regression

--- a/python/core/composer/qgsatlascomposition.sip
+++ b/python/core/composer/qgsatlascomposition.sip
@@ -145,7 +145,7 @@ public:
      * @see setPredefinedScales
      * @see QgsComposerMap::atlasScalingMode
      */
-    const QVector<qreal>& predefinedScales() const;
+    QVector<qreal> predefinedScales() const;
 
     /** Sets the list of predefined scales for the atlas. This is used
      * for maps which are set to the predefined atlas scaling mode.

--- a/python/core/composer/qgscomposerhtml.sip
+++ b/python/core/composer/qgscomposerhtml.sip
@@ -51,7 +51,7 @@ class QgsComposerHtml: QgsComposerMultiFrame
      * @see setUrl
      * @see contentMode
      */
-    const QUrl& url() const;
+    QUrl url() const;
 
     /** Sets the HTML to display in the item when the item is using
      * the QgsComposerHtml::ManualHtml mode. Setting the HTML using this function

--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -235,7 +235,7 @@ class QgsComposition : QGraphicsScene, QgsExpressionContextGenerator
     double snapGridOffsetY() const;
 
     void setGridPen( const QPen& p );
-    const QPen& gridPen() const;
+    QPen gridPen() const;
 
     void setGridStyle( const GridStyle s );
     GridStyle gridStyle() const;

--- a/python/core/layertree/qgslayertreemodel.sip
+++ b/python/core/layertree/qgslayertreemodel.sip
@@ -228,7 +228,7 @@ class QgsLayerTreeModel : QAbstractItemModel
      */
     void refreshScaleBasedLayers( const QModelIndex& index = QModelIndex() );
 
-    static const QIcon& iconGroup();
+    static QIcon iconGroup();
 
     //! Filter nodes from QgsMapLayerLegend according to the current filtering rules
     QList<QgsLayerTreeModelLegendNode*> filterLegendNodes( const QList<QgsLayerTreeModelLegendNode*>& nodes );

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -308,12 +308,12 @@ class QgsLayerItem : QgsDataItem
     virtual QString comments() const;
 
   public:
-    static const QIcon &iconPoint();
-    static const QIcon &iconLine();
-    static const QIcon &iconPolygon();
-    static const QIcon &iconTable();
-    static const QIcon &iconRaster();
-    static const QIcon &iconDefault();
+    static QIcon iconPoint();
+    static QIcon iconLine();
+    static QIcon iconPolygon();
+    static QIcon iconTable();
+    static QIcon iconRaster();
+    static QIcon iconDefault();
 
     virtual QString layerName() const;
 };
@@ -331,8 +331,8 @@ class QgsDataCollectionItem : QgsDataItem
 
     void addChild( QgsDataItem *item /Transfer/ );
 
-    static const QIcon &iconDir(); // shared icon: open/closed directory
-    static const QIcon &iconDataCollection(); // default icon for data collection
+    static QIcon iconDir(); // shared icon: open/closed directory
+    static QIcon iconDataCollection(); // default icon for data collection
 };
 
 /** A directory: contains subdirectories and layers */
@@ -477,7 +477,7 @@ class QgsFavoritesItem : QgsDataCollectionItem
     void removeDirectory( QgsDirectoryItem *item );
 
     //! Icon for favorites group
-    static const QIcon &iconFavorites();
+    static QIcon iconFavorites();
 };
 
 /** A zip file: contains layers, using GDAL/OGR VSIFILE mechanism */
@@ -492,7 +492,7 @@ class QgsZipItem : QgsDataCollectionItem
     ~QgsZipItem();
 
     QVector<QgsDataItem*> createChildren();
-    const QStringList & getZipFileList();
+    QStringList getZipFileList();
 
     //! @note not available via python bindings
     // static QVector<dataItem_t *> mDataItemPtr;
@@ -504,6 +504,6 @@ class QgsZipItem : QgsDataCollectionItem
     //! @note available in python as itemFromFilePath
     static QgsDataItem* itemFromPath( QgsDataItem* parent, const QString& filePath, const QString& name, const QString& path ) /Factory,PyName=itemFromFilePath/;
 
-    static const QIcon &iconZip();
+    static QIcon iconZip();
 
 };

--- a/python/core/qgsexpressionfieldbuffer.sip
+++ b/python/core/qgsexpressionfieldbuffer.sip
@@ -64,5 +64,5 @@ class QgsExpressionFieldBuffer
      */
     void updateFields( QgsFields& flds );
 
-    const QList<QgsExpressionFieldBuffer::ExpressionField>& expressions() const;
+    QList<QgsExpressionFieldBuffer::ExpressionField> expressions() const;
 };

--- a/python/core/qgsnetworkaccessmanager.sip
+++ b/python/core/qgsnetworkaccessmanager.sip
@@ -46,7 +46,7 @@ class QgsNetworkAccessManager : QNetworkAccessManager
     const QNetworkProxy &fallbackProxy() const;
 
     //! retrieve exclude list (urls shouldn't use the fallback proxy)
-    const QStringList &excludeList() const;
+    QStringList excludeList() const;
 
     //! set fallback proxy and URL that shouldn't use it.
     void setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes );

--- a/python/core/qgsproviderregistry.sip
+++ b/python/core/qgsproviderregistry.sip
@@ -29,7 +29,7 @@ class QgsProviderRegistry
     QString pluginList( bool asHtml = false ) const;
 
     /** Return library directory where plugins are found */
-    const QDir & libraryDirectory() const;
+    QDir libraryDirectory() const;
 
     /** Set library directory where to search for plugins */
     void setLibraryDirectory( const QDir & path );

--- a/python/core/qgsrelationmanager.sip
+++ b/python/core/qgsrelationmanager.sip
@@ -25,7 +25,7 @@ class QgsRelationManager : QObject
      *
      * @return A QMap where the key is the relation id, the value the relation object.
      */
-    const QMap<QString, QgsRelation>& relations() const;
+    QMap<QString, QgsRelation> relations() const;
 
     /**
      * Add a relation.

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -375,7 +375,7 @@ class QgsVectorDataProvider : QgsDataProvider
     /**
      * Returns the names of the supported types
      */
-    const QList< QgsVectorDataProvider::NativeType > &nativeTypes() const;
+    QList< QgsVectorDataProvider::NativeType > nativeTypes() const;
 
     /**
      * Returns true if the provider is strict about the type of inserted features

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1111,10 +1111,10 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
 
     const QMap< QString, QString >& attributeAliases() const;
 
-    const QSet<QString>& excludeAttributesWms() const;
+    QSet<QString> excludeAttributesWms() const;
     void setExcludeAttributesWms( const QSet<QString>& att );
 
-    const QSet<QString>& excludeAttributesWfs() const;
+    QSet<QString> excludeAttributesWfs() const;
     void setExcludeAttributesWfs( const QSet<QString>& att );
 
     /** Delete an attribute field (but does not commit it) */

--- a/python/core/symbology-ng/qgssvgcache.sip
+++ b/python/core/symbology-ng/qgssvgcache.sip
@@ -79,7 +79,7 @@ class QgsSvgCache : QObject
      * @param rasterScaleFactor raster scale factor
      * @param fitsInCache
      */
-    const QImage& svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+    QImage svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
                               double widthScaleFactor, double rasterScaleFactor, bool& fitsInCache );
     /** Get SVG  as QPicture&.
      * @param file Absolute or relative path to SVG file.
@@ -91,7 +91,7 @@ class QgsSvgCache : QObject
      * @param rasterScaleFactor raster scale factor
      * @param forceVectorOutput
      */
-    const QPicture& svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+    QPicture svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
                                   double widthScaleFactor, double rasterScaleFactor, bool forceVectorOutput = false );
 
     /** Calculates the viewbox size of a (possibly cached) SVG file.
@@ -144,7 +144,7 @@ class QgsSvgCache : QObject
     QByteArray getImageData( const QString &path ) const;
 
     /** Get SVG content*/
-    const QByteArray& svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+    QByteArray svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
                                   double widthScaleFactor, double rasterScaleFactor );
 
   signals:

--- a/python/gui/editorwidgets/core/qgseditorwidgetregistry.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetregistry.sip
@@ -110,7 +110,7 @@ class QgsEditorWidgetRegistry : QObject
      *
      * @return All ids and factories
      */
-    const QMap<QString, QgsEditorWidgetFactory*>& factories();
+    QMap<QString, QgsEditorWidgetFactory*> factories();
 
     /**
      * Get a factory for the given widget type id.

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -269,7 +269,7 @@ class QgsAdvancedDigitizingDockWidget : QDockWidget
     /**
      * Snapped to a segment
      */
-    const QList<QgsPoint>& snappedSegment() const;
+    QList<QgsPoint> snappedSegment() const;
 
     //! return the action used to enable/disable the tools
     QAction* enableAction();

--- a/python/server/qgsserverprojectparser.sip
+++ b/python/server/qgsserverprojectparser.sip
@@ -60,9 +60,9 @@ class QgsServerProjectParser
 
     QStringList supportedOutputCrsList() const;
 
-    const QList<QDomElement>& projectLayerElements() const;
+    QList<QDomElement> projectLayerElements() const;
 
-    const QList<QDomElement>& legendGroupElements() const;
+    QList<QDomElement> legendGroupElements() const;
 
     QString projectTitle() const;
 
@@ -73,8 +73,8 @@ class QgsServerProjectParser
     const QSet<QString>& restrictedLayers() const;
     bool useLayerIds() const;
 
-    const QHash< QString, QDomElement >& projectLayerElementsByName() const;
-    const QHash< QString, QDomElement >& projectLayerElementsById() const;
+    QHash< QString, QDomElement > projectLayerElementsByName() const;
+    QHash< QString, QDomElement > projectLayerElementsById() const;
 
     // SIP doesn't like QMap:
     // void layerFromLegendLayer( const QDomElement& legendLayerElem, QMap< int, QgsMapLayer*>& layers, bool useCache = true ) const;

--- a/python/server/qgswmsconfigparser.sip
+++ b/python/server/qgswmsconfigparser.sip
@@ -88,8 +88,8 @@ class QgsWmsConfigParser
     virtual double legendIconLabelSpace() const = 0;
     virtual double legendSymbolWidth() const = 0;
     virtual double legendSymbolHeight() const = 0;
-    virtual const QFont& legendLayerFont() const = 0;
-    virtual const QFont& legendItemFont() const = 0;
+    virtual QFont legendLayerFont() const = 0;
+    virtual QFont legendItemFont() const = 0;
 
     virtual double maxWidth() const = 0;
     virtual double maxHeight() const = 0;

--- a/python/server/qgswmsprojectparser.sip
+++ b/python/server/qgswmsprojectparser.sip
@@ -46,8 +46,8 @@ class QgsWmsProjectParser : public QgsWmsConfigParser
     double legendIconLabelSpace() const  /*override*/ ;
     double legendSymbolWidth() const  /*override*/ ;
     double legendSymbolHeight() const  /*override*/ ;
-    const QFont& legendLayerFont() const  /*override*/ ;
-    const QFont& legendItemFont() const  /*override*/ ;
+    QFont legendLayerFont() const  /*override*/ ;
+    QFont legendItemFont() const  /*override*/ ;
 
     double maxWidth() const  /*override*/ ;
     double maxHeight() const  /*override*/ ;

--- a/src/analysis/interpolation/qgsinterpolator.h
+++ b/src/analysis/interpolation/qgsinterpolator.h
@@ -67,7 +67,7 @@ class ANALYSIS_EXPORT QgsInterpolator
     virtual int interpolatePoint( double x, double y, double& result ) = 0;
 
     //! @note not available in Python bindings
-    const QList<LayerData>& layerData() const { return mLayerData; }
+    QList<LayerData> layerData() const { return mLayerData; }
 
   protected:
 

--- a/src/analysis/raster/qgsrelief.h
+++ b/src/analysis/raster/qgsrelief.h
@@ -61,7 +61,7 @@ class ANALYSIS_EXPORT QgsRelief
 
     void clearReliefColors();
     void addReliefColorClass( const ReliefColor& color );
-    const QList< ReliefColor >& reliefColors() const { return mReliefColors; }
+    QList< ReliefColor > reliefColors() const { return mReliefColors; }
     void setReliefColors( const QList< ReliefColor >& c ) { mReliefColors = c; }
 
     /** Calculates class breaks according with the method of Buenzli (2011) using an iterative algorithm for segmented regression

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -104,7 +104,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     QAction* windowAction() {return mWindowAction;}
 
-    const QString& title() const {return mTitle;}
+    QString title() const {return mTitle;}
     void setTitle( const QString& title );
 
     /** Loads the contents of a template document into the composer's composition.

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -65,7 +65,7 @@ QgsMeasureTool::~QgsMeasureTool()
 }
 
 
-const QList<QgsPoint>& QgsMeasureTool::points()
+QList<QgsPoint> QgsMeasureTool::points()
 {
   return mPoints;
 }

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -52,7 +52,7 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
     void addPoint( const QgsPoint &point );
 
     //! Returns reference to array of the points
-    const QList<QgsPoint>& points();
+    QList<QgsPoint> points();
 
     // Inherited from QgsMapTool
 

--- a/src/core/auth/qgsauthmethodregistry.cpp
+++ b/src/core/auth/qgsauthmethodregistry.cpp
@@ -246,7 +246,7 @@ QString QgsAuthMethodRegistry::pluginList( bool asHtml ) const
   return list;
 }
 
-const QDir &QgsAuthMethodRegistry::libraryDirectory() const
+QDir QgsAuthMethodRegistry::libraryDirectory() const
 {
   return mLibraryDirectory;
 }

--- a/src/core/auth/qgsauthmethodregistry.h
+++ b/src/core/auth/qgsauthmethodregistry.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsAuthMethodRegistry
     QString pluginList( bool asHtml = false ) const;
 
     //! Return library directory where plugins are found
-    const QDir & libraryDirectory() const;
+    QDir libraryDirectory() const;
 
     //! Set library directory where to search for plugins
     void setLibraryDirectory( const QDir & path );

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -176,7 +176,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
      * @see setPredefinedScales
      * @see QgsComposerMap::atlasScalingMode
      */
-    const QVector<qreal>& predefinedScales() const { return mPredefinedScales; }
+    QVector<qreal> predefinedScales() const { return mPredefinedScales; }
 
     /** Sets the list of predefined scales for the atlas. This is used
      * for maps which are set to the predefined atlas scaling mode.

--- a/src/core/composer/qgscomposerhtml.h
+++ b/src/core/composer/qgscomposerhtml.h
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsComposerHtml: public QgsComposerMultiFrame
      * @see setUrl
      * @see contentMode
      */
-    const QUrl& url() const { return mUrl; }
+    QUrl url() const { return mUrl; }
 
     /** Sets the HTML to display in the item when the item is using
      * the QgsComposerHtml::ManualHtml mode. Setting the HTML using this function

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -301,7 +301,7 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene, public QgsExpressionCo
     double snapGridOffsetY() const {return mSnapGridOffsetY;}
 
     void setGridPen( const QPen& p );
-    const QPen& gridPen() const {return mGridPen;}
+    QPen gridPen() const {return mGridPen;}
 
     void setGridStyle( const GridStyle s );
     GridStyle gridStyle() const {return mGridStyle;}

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1109,14 +1109,9 @@ bool QgsLayerTreeModel::testFlag( QgsLayerTreeModel::Flag f ) const
   return mFlags.testFlag( f );
 }
 
-const QIcon& QgsLayerTreeModel::iconGroup()
+QIcon QgsLayerTreeModel::iconGroup()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mActionFolder.svg" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mActionFolder.svg" ) );
 }
 
 QList<QgsLayerTreeModelLegendNode*> QgsLayerTreeModel::filterLegendNodes( const QList<QgsLayerTreeModelLegendNode*>& nodes )

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -255,7 +255,7 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
      */
     void refreshScaleBasedLayers( const QModelIndex& index = QModelIndex() );
 
-    static const QIcon& iconGroup();
+    static QIcon iconGroup();
 
     //! Filter nodes from QgsMapLayerLegend according to the current filtering rules
     QList<QgsLayerTreeModelLegendNode*> filterLegendNodes( const QList<QgsLayerTreeModelLegendNode*>& nodes );

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -585,7 +585,7 @@ QgsWmsLegendNode::QgsWmsLegendNode( QgsLayerTreeLayer* nodeLayer, QObject* paren
 {
 }
 
-const QImage& QgsWmsLegendNode::getLegendGraphic() const
+QImage QgsWmsLegendNode::getLegendGraphic() const
 {
   if ( ! mValid && ! mFetcher )
   {

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -334,7 +334,7 @@ class CORE_EXPORT QgsWmsLegendNode : public QgsLayerTreeModelLegendNode
   private:
 
     // Lazily initializes mImage
-    const QImage& getLegendGraphic() const;
+    QImage getLegendGraphic() const;
 
     QImage renderMessage( const QString& msg ) const;
 

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -84,7 +84,7 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     //! Get list of children of the node. Children are owned by the parent
     QList<QgsLayerTreeNode*> children() { return mChildren; }
     //! Get list of children of the node. Children are owned by the parent
-    const QList<QgsLayerTreeNode*>& children() const { return mChildren; }
+    QList<QgsLayerTreeNode*> children() const { return mChildren; }
 
     //! Return name of the node
     //! @note added in 3.0

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -96,77 +96,42 @@ void QgsAnimatedIcon::disconnectFrameChanged( const QObject * receiver, const ch
 }
 
 // shared icons
-const QIcon &QgsLayerItem::iconPoint()
+QIcon QgsLayerItem::iconPoint()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) );
 }
 
-const QIcon &QgsLayerItem::iconLine()
+QIcon QgsLayerItem::iconLine()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) );
 }
 
-const QIcon &QgsLayerItem::iconPolygon()
+QIcon QgsLayerItem::iconPolygon()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) );
 }
 
-const QIcon &QgsLayerItem::iconTable()
+QIcon QgsLayerItem::iconTable()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) );
 }
 
-const QIcon &QgsLayerItem::iconRaster()
+QIcon QgsLayerItem::iconRaster()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconRaster.svg" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconRaster.svg" ) );
 }
 
-const QIcon &QgsLayerItem::iconDefault()
+QIcon QgsLayerItem::iconDefault()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconLayer.png" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconLayer.png" ) );
 }
 
-const QIcon &QgsDataCollectionItem::iconDataCollection()
+QIcon QgsDataCollectionItem::iconDataCollection()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconDbSchema.png" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconDbSchema.png" ) );
 }
 
-const QIcon &QgsDataCollectionItem::iconDir()
+QIcon QgsDataCollectionItem::iconDir()
 {
   static QIcon icon;
 
@@ -182,25 +147,15 @@ const QIcon &QgsDataCollectionItem::iconDir()
   return icon;
 }
 
-const QIcon &QgsFavoritesItem::iconFavorites()
+QIcon QgsFavoritesItem::iconFavorites()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconFavourites.png" ) );
-
-  return icon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFavourites.png" ) );
 }
 
-const QIcon &QgsZipItem::iconZip()
+QIcon QgsZipItem::iconZip()
 {
-  static QIcon icon;
-
-  if ( icon.isNull() )
-    icon = QgsApplication::getThemeIcon( QStringLiteral( "/mIconZip.png" ) );
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconZip.png" ) );
 // icon from http://www.softicons.com/free-icons/application-icons/mega-pack-icons-1-by-nikolay-verin/winzip-folder-icon
-
-  return icon;
 }
 
 QgsAnimatedIcon * QgsDataItem::mPopulatingIcon = nullptr;
@@ -1501,7 +1456,7 @@ QgsDataItem* QgsZipItem::itemFromPath( QgsDataItem* parent, const QString& fileP
   return nullptr;
 }
 
-const QStringList &QgsZipItem::getZipFileList()
+QStringList QgsZipItem::getZipFileList()
 {
   if ( ! mZipFileList.isEmpty() )
     return mZipFileList;

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -387,12 +387,12 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
     QStringList mSupportFormats;
 
   public:
-    static const QIcon &iconPoint();
-    static const QIcon &iconLine();
-    static const QIcon &iconPolygon();
-    static const QIcon &iconTable();
-    static const QIcon &iconRaster();
-    static const QIcon &iconDefault();
+    static QIcon iconPoint();
+    static QIcon iconLine();
+    static QIcon iconPolygon();
+    static QIcon iconTable();
+    static QIcon iconRaster();
+    static QIcon iconDefault();
 
     //! @return the layer name
     virtual QString layerName() const { return name(); }
@@ -411,8 +411,8 @@ class CORE_EXPORT QgsDataCollectionItem : public QgsDataItem
 
     void addChild( QgsDataItem *item ) { mChildren.append( item ); }
 
-    static const QIcon &iconDir(); // shared icon: open/closed directory
-    static const QIcon &iconDataCollection(); // default icon for data collection
+    static QIcon iconDir(); // shared icon: open/closed directory
+    static QIcon iconDataCollection(); // default icon for data collection
 };
 
 /** \ingroup core
@@ -549,7 +549,7 @@ class CORE_EXPORT QgsFavoritesItem : public QgsDataCollectionItem
     void removeDirectory( QgsDirectoryItem *item );
 
     //! Icon for favorites group
-    static const QIcon &iconFavorites();
+    static QIcon iconFavorites();
 
   private:
     QVector<QgsDataItem*> createChildren( const QString& favDir );
@@ -572,7 +572,7 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
     QgsZipItem( QgsDataItem* parent, const QString& name, const QString& filePath, const QString& path );
 
     QVector<QgsDataItem*> createChildren() override;
-    const QStringList & getZipFileList();
+    QStringList getZipFileList();
 
     //! @note not available via python bindings
     static QVector<dataItem_t *> mDataItemPtr;
@@ -591,7 +591,7 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
     */
     static QgsDataItem* itemFromPath( QgsDataItem* parent, const QString& filePath, const QString& name, const QString& path );
 
-    static const QIcon &iconZip();
+    static QIcon iconZip();
 
   private:
     void init();

--- a/src/core/qgsexpressionfieldbuffer.h
+++ b/src/core/qgsexpressionfieldbuffer.h
@@ -99,7 +99,7 @@ class CORE_EXPORT QgsExpressionFieldBuffer
      */
     void updateFields( QgsFields& flds );
 
-    const QList<ExpressionField>& expressions() const { return mExpressions; }
+    QList<ExpressionField> expressions() const { return mExpressions; }
 
   private:
     QList<ExpressionField> mExpressions;

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsGmlStreamingParser
     int getEPSGCode() const { return mEpsg; }
 
     //! Return the value of the srsName attribute
-    const QString& srsName() const { return mSrsName; }
+    QString srsName() const { return mSrsName; }
 
     //! Return layer bounding box
     const QgsRectangle& layerExtent() const { return mLayerExtent; }
@@ -130,7 +130,7 @@ class CORE_EXPORT QgsGmlStreamingParser
     bool isException() const { return mIsException; }
 
     //! Return the exception text.
-    const QString& exceptionText() const { return mExceptionText; }
+    QString exceptionText() const { return mExceptionText; }
 
     //! Return whether a "truncatedResponse" element is found
     bool isTruncatedResponse() const { return mTruncatedResponse; }

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -136,7 +136,7 @@ const QList<QNetworkProxyFactory *> QgsNetworkAccessManager::proxyFactories() co
   return mProxyFactories;
 }
 
-const QStringList &QgsNetworkAccessManager::excludeList() const
+QStringList QgsNetworkAccessManager::excludeList() const
 {
   return mExcludedURLs;
 }

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -67,7 +67,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     const QNetworkProxy &fallbackProxy() const;
 
     //! retrieve exclude list (urls shouldn't use the fallback proxy)
-    const QStringList &excludeList() const;
+    QStringList excludeList() const;
 
     //! set fallback proxy and URL that shouldn't use it.
     void setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes );

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -313,7 +313,7 @@ class QgsOgcUtilsExprToFilter
     bool GMLNamespaceUsed() const { return mGMLUsed; }
 
     //! Return the error message.
-    const QString& errorMessage() const { return mErrorMessage; }
+    QString errorMessage() const { return mErrorMessage; }
 
   private:
     QDomDocument& mDoc;
@@ -359,7 +359,7 @@ class QgsOgcUtilsSQLStatementToFilter
     bool GMLNamespaceUsed() const { return mGMLUsed; }
 
     //! Return the error message.
-    const QString& errorMessage() const { return mErrorMessage; }
+    QString errorMessage() const { return mErrorMessage; }
 
   private:
     QDomDocument& mDoc;

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -328,7 +328,7 @@ void QgsProviderRegistry::setLibraryDirectory( QDir const & path )
   init();
 }
 
-QDir const & QgsProviderRegistry::libraryDirectory() const
+QDir QgsProviderRegistry::libraryDirectory() const
 {
   return mLibraryDirectory;
 }

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsProviderRegistry
     QString pluginList( bool asHtml = false ) const;
 
     //! Return library directory where plugins are found
-    const QDir & libraryDirectory() const;
+    QDir libraryDirectory() const;
 
     //! Set library directory where to search for plugins
     void setLibraryDirectory( const QDir & path );

--- a/src/core/qgsrelationmanager.cpp
+++ b/src/core/qgsrelationmanager.cpp
@@ -40,7 +40,7 @@ void QgsRelationManager::setRelations( const QList<QgsRelation>& relations )
   emit changed();
 }
 
-const QMap<QString, QgsRelation>& QgsRelationManager::relations() const
+QMap<QString, QgsRelation> QgsRelationManager::relations() const
 {
   return mRelations;
 }

--- a/src/core/qgsrelationmanager.h
+++ b/src/core/qgsrelationmanager.h
@@ -53,7 +53,7 @@ class CORE_EXPORT QgsRelationManager : public QObject
      *
      * @return A QMap where the key is the relation id, the value the relation object.
      */
-    const QMap<QString, QgsRelation>& relations() const;
+    QMap<QString, QgsRelation> relations() const;
 
     /**
      * Add a relation.

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -318,7 +318,7 @@ QgsAttributeList QgsVectorDataProvider::pkAttributeIndexes() const
   return QgsAttributeList();
 }
 
-const QList< QgsVectorDataProvider::NativeType > &QgsVectorDataProvider::nativeTypes() const
+QList<QgsVectorDataProvider::NativeType> QgsVectorDataProvider::nativeTypes() const
 {
   return mNativeTypes;
 }

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -438,7 +438,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /**
      * Returns the names of the supported types
      */
-    const QList< NativeType > &nativeTypes() const;
+    QList< NativeType > nativeTypes() const;
 
     /**
      * Returns true if the provider is strict about the type of inserted features

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1245,7 +1245,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * A set of attributes that are not advertised in WMS requests with QGIS server.
      */
-    const QSet<QString>& excludeAttributesWms() const { return mExcludeAttributesWMS; }
+    QSet<QString> excludeAttributesWms() const { return mExcludeAttributesWMS; }
 
     /**
      * A set of attributes that are not advertised in WMS requests with QGIS server.
@@ -1255,7 +1255,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * A set of attributes that are not advertised in WFS requests with QGIS server.
      */
-    const QSet<QString>& excludeAttributesWfs() const { return mExcludeAttributesWFS; }
+    QSet<QString> excludeAttributesWfs() const { return mExcludeAttributesWFS; }
 
     /**
      * A set of attributes that are not advertised in WFS requests with QGIS server.

--- a/src/core/symbology-ng/qgssvgcache.cpp
+++ b/src/core/symbology-ng/qgssvgcache.cpp
@@ -109,8 +109,8 @@ QgsSvgCache::~QgsSvgCache()
 }
 
 
-const QImage& QgsSvgCache::svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                       double widthScaleFactor, double rasterScaleFactor, bool& fitsInCache )
+QImage QgsSvgCache::svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+                                double widthScaleFactor, double rasterScaleFactor, bool& fitsInCache )
 {
   QMutexLocker locker( &mMutex );
 
@@ -154,8 +154,8 @@ const QImage& QgsSvgCache::svgAsImage( const QString& file, double size, const Q
   return *( currentEntry->image );
 }
 
-const QPicture& QgsSvgCache::svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-    double widthScaleFactor, double rasterScaleFactor, bool forceVectorOutput )
+QPicture QgsSvgCache::svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+                                    double widthScaleFactor, double rasterScaleFactor, bool forceVectorOutput )
 {
   QMutexLocker locker( &mMutex );
 
@@ -172,8 +172,8 @@ const QPicture& QgsSvgCache::svgAsPicture( const QString& file, double size, con
   return *( currentEntry->picture );
 }
 
-const QByteArray& QgsSvgCache::svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-    double widthScaleFactor, double rasterScaleFactor )
+QByteArray QgsSvgCache::svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+                                    double widthScaleFactor, double rasterScaleFactor )
 {
   QMutexLocker locker( &mMutex );
 

--- a/src/core/symbology-ng/qgssvgcache.h
+++ b/src/core/symbology-ng/qgssvgcache.h
@@ -122,8 +122,8 @@ class CORE_EXPORT QgsSvgCache : public QObject
      * @param rasterScaleFactor raster scale factor
      * @param fitsInCache
      */
-    const QImage& svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                              double widthScaleFactor, double rasterScaleFactor, bool& fitsInCache );
+    QImage svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+                       double widthScaleFactor, double rasterScaleFactor, bool& fitsInCache );
 
     /** Get SVG  as QPicture&.
      * @param file Absolute or relative path to SVG file.
@@ -135,8 +135,8 @@ class CORE_EXPORT QgsSvgCache : public QObject
      * @param rasterScaleFactor raster scale factor
      * @param forceVectorOutput
      */
-    const QPicture& svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                  double widthScaleFactor, double rasterScaleFactor, bool forceVectorOutput = false );
+    QPicture svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+                           double widthScaleFactor, double rasterScaleFactor, bool forceVectorOutput = false );
 
     /** Calculates the viewbox size of a (possibly cached) SVG file.
      * @param file Absolute or relative path to SVG file.
@@ -188,8 +188,8 @@ class CORE_EXPORT QgsSvgCache : public QObject
     QByteArray getImageData( const QString &path ) const;
 
     //! Get SVG content
-    const QByteArray& svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                  double widthScaleFactor, double rasterScaleFactor );
+    QByteArray svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
+                           double widthScaleFactor, double rasterScaleFactor );
 
   signals:
     //! Emit a signal to be caught by qgisapp and display a msg on status bar

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -179,7 +179,7 @@ QString QgsEditorWidgetRegistry::name( const QString& widgetId )
   return QString();
 }
 
-const QMap<QString, QgsEditorWidgetFactory*>& QgsEditorWidgetRegistry::factories()
+QMap<QString, QgsEditorWidgetFactory*> QgsEditorWidgetRegistry::factories()
 {
   return mWidgetFactories;
 }

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
@@ -152,7 +152,7 @@ class GUI_EXPORT QgsEditorWidgetRegistry : public QObject
      *
      * @return All ids and factories
      */
-    const QMap<QString, QgsEditorWidgetFactory*>& factories();
+    QMap<QString, QgsEditorWidgetFactory*> factories();
 
     /**
      * Get a factory for the given widget type id.

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -315,7 +315,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
      * Snapped to a segment
      */
-    const QList<QgsPoint>& snappedSegment() const { return mSnappedSegment; }
+    QList<QgsPoint> snappedSegment() const { return mSnappedSegment; }
 
     //! return the action used to enable/disable the tools
     QAction* enableAction() { return mEnableAction; }

--- a/src/gui/qgscolorschemelist.cpp
+++ b/src/gui/qgscolorschemelist.cpp
@@ -724,7 +724,7 @@ void QgsColorSwatchDelegate::paint( QPainter *painter, const QStyleOptionViewIte
   painter->restore();
 }
 
-const QPixmap& QgsColorSwatchDelegate::transparentBackground() const
+QPixmap QgsColorSwatchDelegate::transparentBackground() const
 {
   static QPixmap transpBkgrd;
 

--- a/src/gui/qgscolorschemelist.h
+++ b/src/gui/qgscolorschemelist.h
@@ -51,7 +51,7 @@ class GUI_EXPORT QgsColorSwatchDelegate : public QAbstractItemDelegate
     /** Generates a checkboard pattern for transparent color backgrounds
      * @returns checkboard pixmap
      */
-    const QPixmap &transparentBackground() const;
+    QPixmap transparentBackground() const;
 };
 
 

--- a/src/gui/qgscolorswatchgrid.cpp
+++ b/src/gui/qgscolorswatchgrid.cpp
@@ -320,7 +320,7 @@ void QgsColorSwatchGrid::draw( QPainter &painter )
   }
 }
 
-const QPixmap& QgsColorSwatchGrid::transparentBackground()
+QPixmap QgsColorSwatchGrid::transparentBackground()
 {
   static QPixmap transpBkgrd;
 

--- a/src/gui/qgscolorswatchgrid.h
+++ b/src/gui/qgscolorswatchgrid.h
@@ -143,7 +143,7 @@ class GUI_EXPORT QgsColorSwatchGrid : public QWidget
     /** Generates a checkboard pattern for transparent color backgrounds
      * @returns checkboard pixmap
      */
-    const QPixmap &transparentBackground();
+    QPixmap transparentBackground();
 };
 
 

--- a/src/gui/qgsgradientstopeditor.cpp
+++ b/src/gui/qgsgradientstopeditor.cpp
@@ -376,7 +376,7 @@ void QgsGradientStopEditor::keyPressEvent( QKeyEvent *e )
   QWidget::keyPressEvent( e );
 }
 
-const QPixmap& QgsGradientStopEditor::transparentBackground()
+QPixmap QgsGradientStopEditor::transparentBackground()
 {
   static QPixmap transpBkgrd;
 

--- a/src/gui/qgsgradientstopeditor.h
+++ b/src/gui/qgsgradientstopeditor.h
@@ -139,7 +139,7 @@ class GUI_EXPORT QgsGradientStopEditor : public QWidget
     /** Generates a checkboard pattern pixmap for use as a background to transparent colors
      * @returns checkerboard pixmap
      */
-    const QPixmap& transparentBackground();
+    QPixmap transparentBackground();
 
     /** Draws a stop marker on the specified painter.
      * @param painter destination painter

--- a/src/plugins/geometry_checker/checks/qgsgeometryanglecheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryanglecheck.cpp
@@ -145,7 +145,7 @@ void QgsGeometryAngleCheck::fixError( QgsGeometryCheckError* error, int method, 
   }
 }
 
-const QStringList& QgsGeometryAngleCheck::getResolutionMethods() const
+QStringList QgsGeometryAngleCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList() << tr( "Delete node with small angle" ) << tr( "No action" );
   return methods;

--- a/src/plugins/geometry_checker/checks/qgsgeometryanglecheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometryanglecheck.h
@@ -29,7 +29,7 @@ class QgsGeometryAngleCheck : public QgsGeometryCheck
     {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList& messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Minimal angle" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryAngleCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometryareacheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryareacheck.cpp
@@ -217,7 +217,7 @@ bool QgsGeometryAreaCheck::mergeWithNeighbor( QgsFeature& feature, int partIdx, 
   return true;
 }
 
-const QStringList& QgsGeometryAreaCheck::getResolutionMethods() const
+QStringList QgsGeometryAreaCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList()
                                << tr( "Merge with neighboring polygon with longest shared edge" )

--- a/src/plugins/geometry_checker/checks/qgsgeometryareacheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometryareacheck.h
@@ -31,7 +31,7 @@ class QgsGeometryAreaCheck : public QgsGeometryCheck
     {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList& messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Minimal area" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryAreaCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometrycheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometrycheck.h
@@ -77,7 +77,7 @@ class QgsGeometryCheck : public QObject
     {}
     virtual void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList& messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const = 0;
     virtual void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const = 0;
-    virtual const QStringList& getResolutionMethods() const = 0;
+    virtual QStringList getResolutionMethods() const = 0;
     virtual QString errorDescription() const = 0;
     virtual QString errorName() const = 0;
     CheckType getCheckType() const { return mCheckType; }
@@ -115,11 +115,11 @@ class QgsGeometryCheckError
     virtual QgsRectangle affectedAreaBBox() { return geometry() ? geometry()->boundingBox() : QgsRectangle(); }
     virtual QString description() const { return mCheck->errorDescription(); }
     const QgsPointV2& location() const { return mErrorLocation; }
-    const QVariant& value() const { return mValue; }
+    QVariant value() const { return mValue; }
     ValueType valueType() const { return mValueType; }
     QgsVertexId vidx() const { return mVidx; }
     Status status() const { return mStatus; }
-    const QString& resolutionMessage() const { return mResolutionMessage; }
+    QString resolutionMessage() const { return mResolutionMessage; }
     void setFixed( int method )
     {
       mStatus = StatusFixed;

--- a/src/plugins/geometry_checker/checks/qgsgeometrycontainedcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrycontainedcheck.cpp
@@ -101,7 +101,7 @@ void QgsGeometryContainedCheck::fixError( QgsGeometryCheckError* error, int meth
   }
 }
 
-const QStringList& QgsGeometryContainedCheck::getResolutionMethods() const
+QStringList QgsGeometryContainedCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList()
                                << tr( "Delete feature" )

--- a/src/plugins/geometry_checker/checks/qgsgeometrycontainedcheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometrycontainedcheck.h
@@ -52,7 +52,7 @@ class QgsGeometryContainedCheck : public QgsGeometryCheck
     explicit QgsGeometryContainedCheck( QgsFeaturePool* featurePool ) : QgsGeometryCheck( FeatureCheck, featurePool ) {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList& messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Within" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryContainedCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometrydegeneratepolygoncheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrydegeneratepolygoncheck.cpp
@@ -84,7 +84,7 @@ void QgsGeometryDegeneratePolygonCheck::fixError( QgsGeometryCheckError* error, 
   }
 }
 
-const QStringList& QgsGeometryDegeneratePolygonCheck::getResolutionMethods() const
+QStringList QgsGeometryDegeneratePolygonCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList() << tr( "Delete feature" ) << tr( "No action" );
   return methods;

--- a/src/plugins/geometry_checker/checks/qgsgeometrydegeneratepolygoncheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometrydegeneratepolygoncheck.h
@@ -27,7 +27,7 @@ class QgsGeometryDegeneratePolygonCheck : public QgsGeometryCheck
         : QgsGeometryCheck( FeatureNodeCheck, featurePool ) {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Polygon with less than three nodes" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryDegeneratePolygonCheck" ); }
 

--- a/src/plugins/geometry_checker/checks/qgsgeometryduplicatecheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryduplicatecheck.cpp
@@ -112,7 +112,7 @@ void QgsGeometryDuplicateCheck::fixError( QgsGeometryCheckError* error, int meth
   }
 }
 
-const QStringList& QgsGeometryDuplicateCheck::getResolutionMethods() const
+QStringList QgsGeometryDuplicateCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList()
                                << tr( "No action" )

--- a/src/plugins/geometry_checker/checks/qgsgeometryduplicatecheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometryduplicatecheck.h
@@ -28,7 +28,7 @@ class QgsGeometryDuplicateCheckError : public QgsGeometryCheckError
         : QgsGeometryCheckError( check, featureId, errorLocation, QgsVertexId(), duplicatesString( duplicates ) )
         , mDuplicates( duplicates )
     { }
-    const QList<QgsFeatureId>& duplicates() const { return mDuplicates; }
+    QList<QgsFeatureId> duplicates() const { return mDuplicates; }
 
     bool isEqual( QgsGeometryCheckError* other ) const override
     {
@@ -61,7 +61,7 @@ class QgsGeometryDuplicateCheck : public QgsGeometryCheck
         : QgsGeometryCheck( FeatureCheck, featurePool ) {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Duplicate" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryDuplicateCheck" ); }
 

--- a/src/plugins/geometry_checker/checks/qgsgeometryduplicatenodescheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryduplicatenodescheck.cpp
@@ -110,7 +110,7 @@ void QgsGeometryDuplicateNodesCheck::fixError( QgsGeometryCheckError* error, int
   }
 }
 
-const QStringList& QgsGeometryDuplicateNodesCheck::getResolutionMethods() const
+QStringList QgsGeometryDuplicateNodesCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList() << tr( "Delete duplicate node" ) << tr( "No action" );
   return methods;

--- a/src/plugins/geometry_checker/checks/qgsgeometryduplicatenodescheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometryduplicatenodescheck.h
@@ -27,7 +27,7 @@ class QgsGeometryDuplicateNodesCheck : public QgsGeometryCheck
         : QgsGeometryCheck( FeatureNodeCheck, featurePool ) {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Duplicate node" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryDuplicateNodesCheck" ); }
 

--- a/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.cpp
@@ -213,7 +213,7 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( QgsGeometryGapCheckError* err, Chan
 }
 
 
-const QStringList& QgsGeometryGapCheck::getResolutionMethods() const
+QStringList QgsGeometryGapCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList() << tr( "Add gap area to neighboring polygon with longest shared edge" ) << tr( "No action" );
   return methods;

--- a/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.h
@@ -91,7 +91,7 @@ class QgsGeometryGapCheck : public QgsGeometryCheck
     {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Gap" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryGapCheck" ); }
 

--- a/src/plugins/geometry_checker/checks/qgsgeometryholecheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryholecheck.cpp
@@ -76,7 +76,7 @@ void QgsGeometryHoleCheck::fixError( QgsGeometryCheckError* error, int method, i
   }
 }
 
-const QStringList& QgsGeometryHoleCheck::getResolutionMethods() const
+QStringList QgsGeometryHoleCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList() << tr( "Remove hole" ) << tr( "No action" );
   return methods;

--- a/src/plugins/geometry_checker/checks/qgsgeometryholecheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometryholecheck.h
@@ -27,7 +27,7 @@ class QgsGeometryHoleCheck : public QgsGeometryCheck
         : QgsGeometryCheck( FeatureCheck, featurePool ) {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Polygon with hole" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryHoleCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometrymultipartcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrymultipartcheck.cpp
@@ -80,7 +80,7 @@ void QgsGeometryMultipartCheck::fixError( QgsGeometryCheckError* error, int meth
   }
 }
 
-const QStringList& QgsGeometryMultipartCheck::getResolutionMethods() const
+QStringList QgsGeometryMultipartCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList()
                                << tr( "Convert to single part feature" )

--- a/src/plugins/geometry_checker/checks/qgsgeometrymultipartcheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometrymultipartcheck.h
@@ -27,7 +27,7 @@ class QgsGeometryMultipartCheck : public QgsGeometryCheck
         : QgsGeometryCheck( FeatureCheck, featurePool ) {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Multipart object with only one feature" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryMultipartCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometryoverlapcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryoverlapcheck.cpp
@@ -194,7 +194,7 @@ void QgsGeometryOverlapCheck::fixError( QgsGeometryCheckError* error, int method
   delete interGeom;
 }
 
-const QStringList& QgsGeometryOverlapCheck::getResolutionMethods() const
+QStringList QgsGeometryOverlapCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList()
                                << tr( "Remove overlapping area from neighboring polygon with shortest shared edge" )

--- a/src/plugins/geometry_checker/checks/qgsgeometryoverlapcheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometryoverlapcheck.h
@@ -64,7 +64,7 @@ class QgsGeometryOverlapCheck : public QgsGeometryCheck
     {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Overlap" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryOverlapCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometrysegmentlengthcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrysegmentlengthcheck.cpp
@@ -99,7 +99,7 @@ void QgsGeometrySegmentLengthCheck::fixError( QgsGeometryCheckError* error, int 
   }
 }
 
-const QStringList& QgsGeometrySegmentLengthCheck::getResolutionMethods() const
+QStringList QgsGeometrySegmentLengthCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList() << tr( "No action" );
   return methods;

--- a/src/plugins/geometry_checker/checks/qgsgeometrysegmentlengthcheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometrysegmentlengthcheck.h
@@ -29,7 +29,7 @@ class QgsGeometrySegmentLengthCheck : public QgsGeometryCheck
     {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Minimal segment length" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometrySegmentLengthCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.cpp
@@ -324,7 +324,7 @@ void QgsGeometrySelfIntersectionCheck::fixError( QgsGeometryCheckError* error, i
   }
 }
 
-const QStringList& QgsGeometrySelfIntersectionCheck::getResolutionMethods() const
+QStringList QgsGeometrySelfIntersectionCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList()
                                << tr( "Split feature into a multi-object feature" )

--- a/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.h
@@ -54,7 +54,7 @@ class QgsGeometrySelfIntersectionCheck : public QgsGeometryCheck
         : QgsGeometryCheck( FeatureNodeCheck, featurePool ) {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Self intersection" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometrySelfIntersectionCheck" ); }
   private:

--- a/src/plugins/geometry_checker/checks/qgsgeometrytypecheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrytypecheck.cpp
@@ -155,7 +155,7 @@ void QgsGeometryTypeCheck::fixError( QgsGeometryCheckError* error, int method, i
   }
 }
 
-const QStringList& QgsGeometryTypeCheck::getResolutionMethods() const
+QStringList QgsGeometryTypeCheck::getResolutionMethods() const
 {
   static QStringList methods = QStringList()
                                << tr( "Convert to corresponding multi or single type if possible, otherwise delete feature" )

--- a/src/plugins/geometry_checker/checks/qgsgeometrytypecheck.h
+++ b/src/plugins/geometry_checker/checks/qgsgeometrytypecheck.h
@@ -53,7 +53,7 @@ class QgsGeometryTypeCheck : public QgsGeometryCheck
     {}
     void collectErrors( QList<QgsGeometryCheckError*>& errors, QStringList &messages, QAtomicInt* progressCounter = nullptr, const QgsFeatureIds& ids = QgsFeatureIds() ) const override;
     void fixError( QgsGeometryCheckError* error, int method, int mergeAttributeIndex, Changes& changes ) const override;
-    const QStringList& getResolutionMethods() const override;
+    QStringList getResolutionMethods() const override;
     QString errorDescription() const override { return tr( "Geometry type" ); }
     QString errorName() const override { return QStringLiteral( "QgsGeometryTypeCheck" ); }
   private:

--- a/src/plugins/geometry_checker/qgsgeometrychecker.h
+++ b/src/plugins/geometry_checker/qgsgeometrychecker.h
@@ -41,7 +41,7 @@ class QgsGeometryChecker : public QObject
     bool fixError( QgsGeometryCheckError *error, int method );
     QgsMapLayer* getLayer() const;
     const QList<QgsGeometryCheck*> getChecks() const { return mChecks; }
-    const QStringList& getMessages() const { return mMessages; }
+    QStringList getMessages() const { return mMessages; }
 
   public slots:
     void setMergeAttributeIndex( int mergeAttributeIndex ) { mMergeAttributeIndex = mergeAttributeIndex; }

--- a/src/plugins/gps_importer/qgsbabelformat.cpp
+++ b/src/plugins/gps_importer/qgsbabelformat.cpp
@@ -33,7 +33,7 @@ QgsBabelFormat::QgsBabelFormat( const QString& name )
 }
 
 
-const QString& QgsBabelFormat::name() const
+QString QgsBabelFormat::name() const
 {
   return mName;
 }

--- a/src/plugins/gps_importer/qgsbabelformat.h
+++ b/src/plugins/gps_importer/qgsbabelformat.h
@@ -29,7 +29,7 @@ class QgsBabelFormat
     explicit QgsBabelFormat( const QString& name = "" );
     virtual ~QgsBabelFormat() { }
 
-    const QString& name() const;
+    QString name() const;
     virtual QStringList importCommand( const QString& babel,
                                        const QString& featuretype,
                                        const QString& input,

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -32,7 +32,7 @@ class QgsAmsLegendFetcher : public QgsImageFetcher
     QgsAmsLegendFetcher( QgsAmsProvider* provider );
     void start() override;
     bool haveImage() const { return mLegendImage.isNull(); }
-    const QImage& getImage() const { return mLegendImage; }
+    QImage getImage() const { return mLegendImage; }
     const QString& errorTitle() const { return mErrorTitle; }
     const QString& errorMessage() const { return mError; }
 

--- a/src/providers/wfs/qgswfsrequest.h
+++ b/src/providers/wfs/qgswfsrequest.h
@@ -49,10 +49,10 @@ class QgsWfsRequest : public QObject
     ErrorCode errorCode() const { return mErrorCode; }
 
     //! \brief Return error message (after download/post)
-    const QString& errorMessage() const { return mErrorMessage; }
+    QString errorMessage() const { return mErrorMessage; }
 
     //! \brief Return server response (after download/post)
-    const QByteArray& response() const { return mResponse; }
+    QByteArray response() const { return mResponse; }
 
   public slots:
     //! Abort network request immediately

--- a/src/server/qgsbufferserverresponse.h
+++ b/src/server/qgsbufferserverresponse.h
@@ -63,12 +63,12 @@ class QgsBufferServerResponse: public QgsServerResponse
     /**
      * Return body
      */
-    const QByteArray& body() const { return mBody; }
+    QByteArray body() const { return mBody; }
 
     /**
      * Return header's map
      */
-    const QMap<QString, QString>& headers() const { return mHeaders; }
+    QMap<QString, QString> headers() const { return mHeaders; }
 
     /**
      * Return the status code

--- a/src/server/qgsserverprojectparser.h
+++ b/src/server/qgsserverprojectparser.h
@@ -74,9 +74,9 @@ class SERVER_EXPORT QgsServerProjectParser
 
     QStringList supportedOutputCrsList() const;
 
-    const QList<QDomElement>& projectLayerElements() const { return mProjectLayerElements; }
+    QList<QDomElement> projectLayerElements() const { return mProjectLayerElements; }
 
-    const QList<QDomElement>& legendGroupElements() const { return mLegendGroupElements; }
+    QList<QDomElement> legendGroupElements() const { return mLegendGroupElements; }
 
     QString projectTitle() const;
 
@@ -84,11 +84,11 @@ class SERVER_EXPORT QgsServerProjectParser
 
     QDomElement propertiesElem() const;
 
-    const QSet<QString>& restrictedLayers() const { return mRestrictedLayers; }
+    QSet<QString> restrictedLayers() const { return mRestrictedLayers; }
     bool useLayerIds() const { return mUseLayerIDs; }
 
-    const QHash< QString, QDomElement >& projectLayerElementsByName() const { return mProjectLayerElementsByName; }
-    const QHash< QString, QDomElement >& projectLayerElementsById() const { return mProjectLayerElementsById; }
+    QHash< QString, QDomElement > projectLayerElementsByName() const { return mProjectLayerElementsByName; }
+    QHash< QString, QDomElement > projectLayerElementsById() const { return mProjectLayerElementsById; }
 
     void layerFromLegendLayer( const QDomElement& legendLayerElem, QMap< int, QgsMapLayer*>& layers, bool useCache = true ) const;
 

--- a/src/server/qgssldconfigparser.cpp
+++ b/src/server/qgssldconfigparser.cpp
@@ -655,7 +655,7 @@ double QgsSLDConfigParser::legendSymbolHeight() const
   return 0;
 }
 
-const QFont& QgsSLDConfigParser::legendLayerFont() const
+QFont QgsSLDConfigParser::legendLayerFont() const
 {
   if ( mFallbackParser )
   {
@@ -664,7 +664,7 @@ const QFont& QgsSLDConfigParser::legendLayerFont() const
   return mLegendLayerFont;
 }
 
-const QFont& QgsSLDConfigParser::legendItemFont() const
+QFont QgsSLDConfigParser::legendItemFont() const
 {
   if ( mFallbackParser )
   {

--- a/src/server/qgssldconfigparser.h
+++ b/src/server/qgssldconfigparser.h
@@ -100,8 +100,8 @@ class SERVER_EXPORT QgsSLDConfigParser : public QgsWmsConfigParser
     double legendIconLabelSpace() const override;
     double legendSymbolWidth() const override;
     double legendSymbolHeight() const override;
-    const QFont& legendLayerFont() const override;
-    const QFont& legendItemFont() const override;
+    QFont legendLayerFont() const override;
+    QFont legendItemFont() const override;
 
     double maxWidth() const override;
     double maxHeight() const override;

--- a/src/server/qgswmsconfigparser.h
+++ b/src/server/qgswmsconfigparser.h
@@ -105,8 +105,8 @@ class SERVER_EXPORT QgsWmsConfigParser
     virtual double legendIconLabelSpace() const = 0;
     virtual double legendSymbolWidth() const = 0;
     virtual double legendSymbolHeight() const = 0;
-    virtual const QFont& legendLayerFont() const = 0;
-    virtual const QFont& legendItemFont() const = 0;
+    virtual QFont legendLayerFont() const = 0;
+    virtual QFont legendItemFont() const = 0;
 
     virtual double maxWidth() const = 0;
     virtual double maxHeight() const = 0;

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -379,12 +379,12 @@ double QgsWmsProjectParser::legendSymbolHeight() const
   return legendElem.isNull() ? 4.0 : legendElem.attribute( QStringLiteral( "symbolHeight" ) ).toDouble();
 }
 
-const QFont& QgsWmsProjectParser::legendLayerFont() const
+QFont QgsWmsProjectParser::legendLayerFont() const
 {
   return mLegendLayerFont;
 }
 
-const QFont& QgsWmsProjectParser::legendItemFont() const
+QFont QgsWmsProjectParser::legendItemFont() const
 {
   return mLegendItemFont;
 }

--- a/src/server/qgswmsprojectparser.h
+++ b/src/server/qgswmsprojectparser.h
@@ -62,8 +62,8 @@ class SERVER_EXPORT QgsWmsProjectParser : public QgsWmsConfigParser
     double legendIconLabelSpace() const override;
     double legendSymbolWidth() const override;
     double legendSymbolHeight() const override;
-    const QFont& legendLayerFont() const override;
-    const QFont& legendItemFont() const override;
+    QFont legendLayerFont() const override;
+    QFont legendItemFont() const override;
 
     double maxWidth() const override;
     double maxHeight() const override;


### PR DESCRIPTION
Instead return the inexpensive copies. Should provide extra safety against issues like #14822 while adding almost no overhead due to the implicitly shared nature of these classes.