### PR TITLE
Remove rasterScaleFactor/setRasterScaleFactor from QgsRenderContext

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1532,6 +1532,7 @@ QgsRenderContext        {#qgis_api_break_3_0_QgsRenderContext}
 - coordinateTransform() now returns a QgsCoordinateTransform object, not a pointer. An invalid QgsCoordinateTransform will
 be returned instead of a null pointer if no transformation is required.
 - setCoordinateTransform() now takes a QgsCoordinateTransform reference, not a pointer. An invalid QgsCoordinateTransform should be used instead of a null pointer if no transformation is required.
+- rasterScaleFactor() and setRasterScaleFactor() were removed. In QGIS 3.0 QPainter destinations should always be constructed so that 1 painter unit = 1 pixel.
 
 QgsRendererRangeLabelFormat        {#qgis_api_break_3_0_QgsRendererRangeLabelFormat}
 ---------------------------

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1533,6 +1533,8 @@ QgsRenderContext        {#qgis_api_break_3_0_QgsRenderContext}
 be returned instead of a null pointer if no transformation is required.
 - setCoordinateTransform() now takes a QgsCoordinateTransform reference, not a pointer. An invalid QgsCoordinateTransform should be used instead of a null pointer if no transformation is required.
 - rasterScaleFactor() and setRasterScaleFactor() were removed. In QGIS 3.0 QPainter destinations should always be constructed so that 1 painter unit = 1 pixel.
+- The constPainter() getter was removed. Const QPainters cannot be painted to or modified, so this
+method was of little use.
 
 QgsRendererRangeLabelFormat        {#qgis_api_break_3_0_QgsRendererRangeLabelFormat}
 ---------------------------

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1632,6 +1632,12 @@ QgsSvgCache        {#qgis_api_break_3_0_QgsSvgCache}
 
 - This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::svgCache() to access an application-wide cache.
 - containsParamsV2() was removed. Use containsParamsV3() instead.
+- The rasterScaleFactor parameter was removed from all methods
+
+QgsSvgCacheEntry       {#qgis_api_break_3_0_QgsSvgCacheEntry}
+----------------
+
+- The rasterScaleFactor member was removed.
 
 QgsStyle (renamed from QgsStyleV2)        {#qgis_api_break_3_0_QgsStyle}
 ----------------------------------

--- a/python/core/qgsmapunitscale.sip
+++ b/python/core/qgsmapunitscale.sip
@@ -18,7 +18,7 @@ class QgsMapUnitScale
      * @param minScale minimum allowed scale, or 0.0 if no minimum scale set
      * @param maxScale maximum allowed scale, or 0.0 if no maximum scale set
      */
-    QgsMapUnitScale( double minScale = 0.0, double maxScale = 0.0 );
+    explicit QgsMapUnitScale( double minScale = 0.0, double maxScale = 0.0 );
 
     /** The minimum scale, or 0.0 if unset */
     double minScale;

--- a/python/core/qgsrendercontext.sip
+++ b/python/core/qgsrendercontext.sip
@@ -75,8 +75,6 @@ class QgsRenderContext
 
     double scaleFactor() const;
 
-    double rasterScaleFactor() const;
-
     bool renderingStopped() const;
 
     bool forceVectorOutput() const;
@@ -119,7 +117,6 @@ class QgsRenderContext
 
     void setRenderingStopped( bool stopped );
     void setScaleFactor( double factor );
-    void setRasterScaleFactor( double factor );
     void setRendererScale( double scale );
     void setPainter( QPainter* p );
 

--- a/python/core/qgsrendercontext.sip
+++ b/python/core/qgsrendercontext.sip
@@ -62,7 +62,6 @@ class QgsRenderContext
     //getters
 
     QPainter* painter();
-    const QPainter* constPainter() const;
 
     /** Returns the current coordinate transform for the context, or an invalid
      * transform is no coordinate transformation is required.

--- a/python/core/qgstextrenderer.sip
+++ b/python/core/qgstextrenderer.sip
@@ -1049,21 +1049,19 @@ class QgsTextRenderer
      * @param size size to convert
      * @param c rendercontext
      * @param unit size units
-     * @param rasterfactor whether to consider oversampling
      * @param mapUnitScale a mapUnitScale clamper
      * @return font pixel size
      */
-    static int sizeToPixel( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, bool rasterfactor = false, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
+    static int sizeToPixel( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
 
     /** Calculates size (considering output size should be in pixel or map units, scale factors and optionally oversampling)
      * @param size size to convert
      * @param c rendercontext
      * @param unit size units
-     * @param rasterfactor whether to consider oversampling
      * @param mapUnitScale a mapUnitScale clamper
      * @return size that will render, as double
      */
-    static double scaleToPixelContext( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, bool rasterfactor = false, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
+    static double scaleToPixelContext( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
 
     /** Draws text within a rectangle using the specified settings.
      * @param rect destination rectangle for text

--- a/python/core/symbology-ng/qgssvgcache.sip
+++ b/python/core/symbology-ng/qgssvgcache.sip
@@ -16,7 +16,7 @@ class QgsSvgCacheEntry
      * @param outline color of outline
      * @param lookupKey the key string used in QgsSvgCache for quick lookup of this entry (relative or absolute path)
      */
-    QgsSvgCacheEntry( const QString& file, double size, double outlineWidth, double widthScaleFactor, double rasterScaleFactor, const QColor& fill, const QColor& outline, const QString& lookupKey = QString() );
+    QgsSvgCacheEntry( const QString& file, double size, double outlineWidth, double widthScaleFactor, const QColor& fill, const QColor& outline, const QString& lookupKey = QString() );
     ~QgsSvgCacheEntry();
 
     //! Absolute path to SVG file
@@ -26,7 +26,6 @@ class QgsSvgCacheEntry
     double size; //size in pixels (cast to int for QImage)
     double outlineWidth;
     double widthScaleFactor;
-    double rasterScaleFactor;
 
     /** SVG viewbox size.
      * @note added in QGIS 2.14
@@ -80,7 +79,7 @@ class QgsSvgCache : QObject
      * @param fitsInCache
      */
     QImage svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                              double widthScaleFactor, double rasterScaleFactor, bool& fitsInCache );
+                              double widthScaleFactor, bool& fitsInCache );
     /** Get SVG  as QPicture&.
      * @param file Absolute or relative path to SVG file.
      * @param size size of cached image
@@ -92,7 +91,7 @@ class QgsSvgCache : QObject
      * @param forceVectorOutput
      */
     QPicture svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                  double widthScaleFactor, double rasterScaleFactor, bool forceVectorOutput = false );
+                                  double widthScaleFactor, bool forceVectorOutput = false );
 
     /** Calculates the viewbox size of a (possibly cached) SVG file.
      * @param file Absolute or relative path to SVG file.
@@ -106,7 +105,7 @@ class QgsSvgCache : QObject
      * @note added in QGIS 2.14
      */
     QSizeF svgViewboxSize( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                           double widthScaleFactor, double rasterScaleFactor );
+                           double widthScaleFactor );
 
     /** Tests if an svg file contains parameters for fill, outline color, outline width. If yes, possible default values are returned. If there are several
       default values in the svg file, only the first one is considered*/
@@ -145,7 +144,7 @@ class QgsSvgCache : QObject
 
     /** Get SVG content*/
     QByteArray svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                  double widthScaleFactor, double rasterScaleFactor );
+                                  double widthScaleFactor );
 
   signals:
     /** Emit a signal to be caught by qgisapp and display a msg on status bar */
@@ -164,14 +163,14 @@ class QgsSvgCache : QObject
      * @param rasterScaleFactor raster scale factor
      */
     QgsSvgCacheEntry* insertSVG( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                 double widthScaleFactor, double rasterScaleFactor );
+                                 double widthScaleFactor );
 
     void replaceParamsAndCacheSvg( QgsSvgCacheEntry* entry );
     void cacheImage( QgsSvgCacheEntry* entry );
     void cachePicture( QgsSvgCacheEntry* entry, bool forceVectorOutput = false );
     /** Returns entry from cache or creates a new entry if it does not exist already*/
     QgsSvgCacheEntry* cacheEntry( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                  double widthScaleFactor, double rasterScaleFactor );
+                                  double widthScaleFactor );
 
     /** Removes the least used items until the maximum size is under the limit*/
     void trimToMaximumSize();

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -434,7 +434,7 @@ QIcon QgsComposerPictureWidget::svgToIcon( const QString& filePath ) const
     outlineWidth = 0.6;
 
   bool fitsInCache; // should always fit in cache at these sizes (i.e. under 559 px ^ 2, or half cache size)
-  const QImage& img = QgsApplication::svgCache()->svgAsImage( filePath, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, 1.0, fitsInCache );
+  const QImage& img = QgsApplication::svgCache()->svgAsImage( filePath, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, fitsInCache );
 
   return QIcon( QPixmap::fromImage( img ) );
 }

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -242,7 +242,7 @@ QFont QgsMapToolLabel::currentLabelFont()
       if ( sizeIndx != -1 )
       {
         font.setPixelSize( QgsTextRenderer::sizeToPixel( f.attribute( sizeIndx ).toDouble(),
-                           context, labelSettings.format().sizeUnit(), true,
+                           context, labelSettings.format().sizeUnit(),
                            labelSettings.format().sizeMapUnitScale() ) );
       }
 

--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -256,7 +256,7 @@ void QgsComposerArrow::drawSVGMarker( QPainter* p, MarkerType type, const QStrin
 
   QSvgRenderer r;
   const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( svgFileName, mArrowHeadWidth, mArrowHeadFillColor, mArrowHeadOutlineColor, mArrowHeadOutlineWidth,
-                                 1.0, 1.0 );
+                                 1.0 );
   r.load( svgContent );
 
   p->save();

--- a/src/core/composer/qgscomposerpicture.cpp
+++ b/src/core/composer/qgscomposerpicture.cpp
@@ -373,7 +373,7 @@ void QgsComposerPicture::loadLocalPicture( const QString &path )
     {
       //try to open svg
       const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( pic.fileName(), rect().width(), mSvgFillColor, mSvgBorderColor, mSvgBorderWidth,
-                                     1.0, 1.0 );
+                                     1.0 );
       mSVG.load( svgContent );
       if ( mSVG.isValid() )
       {

--- a/src/core/qgsmapunitscale.h
+++ b/src/core/qgsmapunitscale.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsMapUnitScale
      * @param minScale minimum allowed scale, or 0.0 if no minimum scale set
      * @param maxScale maximum allowed scale, or 0.0 if no maximum scale set
      */
-    QgsMapUnitScale( double minScale = 0.0, double maxScale = 0.0 )
+    explicit QgsMapUnitScale( double minScale = 0.0, double maxScale = 0.0 )
         : minScale( minScale )
         , maxScale( maxScale )
         , minSizeMMEnabled( false )

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1409,7 +1409,6 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
   double labelHeight = fm->ascent() + fm->descent(); // ignore +1 for baseline
 
   h += fm->height() + static_cast< double >(( lines - 1 ) * labelHeight * multilineH );
-  h /= context->rasterScaleFactor();
 
   for ( int i = 0; i < lines; ++i )
   {
@@ -1419,7 +1418,6 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
       w = width;
     }
   }
-  w /= context->rasterScaleFactor();
 
 #if 0 // XXX strk
   QgsPoint ptSize = xform->toMapCoordinatesF( w, h );
@@ -1567,7 +1565,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, QgsRenderContext &cont
     return;
   }
 
-  int fontPixelSize = QgsTextRenderer::sizeToPixel( fontSize, context, fontunits, true, mFormat.sizeMapUnitScale() );
+  int fontPixelSize = QgsTextRenderer::sizeToPixel( fontSize, context, fontunits, mFormat.sizeMapUnitScale() );
   // don't try to show font sizes less than 1 pixel (Qt complains)
   if ( fontPixelSize < 1 )
   {
@@ -2224,7 +2222,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, QgsRenderContext &cont
   double topMargin = qMax( 0.25 * labelFontMetrics->ascent(), 0.0 );
   double bottomMargin = 1.0 + labelFontMetrics->descent();
   QgsLabelFeature::VisualMargin vm( topMargin, 0.0, bottomMargin, 0.0 );
-  vm *= xform->mapUnitsPerPixel() / context.rasterScaleFactor();
+  vm *= xform->mapUnitsPerPixel();
   ( *labelFeature )->setVisualMargin( vm );
 
   // store the label's calculated font for later use during painting
@@ -2234,7 +2232,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, QgsRenderContext &cont
   // TODO: only for placement which needs character info
   // account for any data defined font metrics adjustments
   lf->calculateInfo( placement == QgsPalLayerSettings::Curved || placement == QgsPalLayerSettings::PerimeterCurved,
-                     labelFontMetrics.data(), xform, context.rasterScaleFactor(), maxcharanglein, maxcharangleout );
+                     labelFontMetrics.data(), xform, 1.0, maxcharanglein, maxcharangleout );
   // for labelFeature the LabelInfo is passed to feat when it is registered
 
   // TODO: allow layer-wide feature dist in PAL...?
@@ -2706,7 +2704,7 @@ void QgsPalLayerSettings::parseTextStyle( QFont& labelFont,
       wordspace = wspacing;
     }
   }
-  labelFont.setWordSpacing( QgsTextRenderer::scaleToPixelContext( wordspace, context, fontunits, false, mFormat.sizeMapUnitScale() ) );
+  labelFont.setWordSpacing( QgsTextRenderer::scaleToPixelContext( wordspace, context, fontunits, mFormat.sizeMapUnitScale() ) );
 
   // data defined letter spacing?
   double letterspace = labelFont.letterSpacing();
@@ -2720,7 +2718,7 @@ void QgsPalLayerSettings::parseTextStyle( QFont& labelFont,
       letterspace = lspacing;
     }
   }
-  labelFont.setLetterSpacing( QFont::AbsoluteSpacing, QgsTextRenderer::scaleToPixelContext( letterspace, context, fontunits, false, mFormat.sizeMapUnitScale() ) );
+  labelFont.setLetterSpacing( QFont::AbsoluteSpacing, QgsTextRenderer::scaleToPixelContext( letterspace, context, fontunits, mFormat.sizeMapUnitScale() ) );
 
   // data defined strikeout font style?
   if ( dataDefinedEvaluate( QgsPalLayerSettings::Strikeout, exprVal, &context.expressionContext(), labelFont.strikeOut() ) )

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2232,7 +2232,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, QgsRenderContext &cont
   // TODO: only for placement which needs character info
   // account for any data defined font metrics adjustments
   lf->calculateInfo( placement == QgsPalLayerSettings::Curved || placement == QgsPalLayerSettings::PerimeterCurved,
-                     labelFontMetrics.data(), xform, 1.0, maxcharanglein, maxcharangleout );
+                     labelFontMetrics.data(), xform, maxcharanglein, maxcharangleout );
   // for labelFeature the LabelInfo is passed to feat when it is registered
 
   // TODO: allow layer-wide feature dist in PAL...?

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -25,15 +25,6 @@
 
 QgsRenderContext::QgsRenderContext()
     : mFlags( DrawEditingInfo | UseAdvancedEffects | DrawSelection | UseRenderingOptimization )
-    , mPainter( nullptr )
-    , mRenderingStopped( false )
-    , mScaleFactor( 1.0 )
-    , mRendererScale( 1.0 )
-    , mLabelingEngine( nullptr )
-    , mGeometry( nullptr )
-    , mFeatureFilterProvider( nullptr )
-    , mSegmentationTolerance( M_PI_2 / 90 )
-    , mSegmentationToleranceType( QgsAbstractGeometry::MaximumAngle )
 {
   mVectorSimplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::NoSimplification );
 }
@@ -73,16 +64,10 @@ QgsRenderContext&QgsRenderContext::operator=( const QgsRenderContext & rh )
   mVectorSimplifyMethod = rh.mVectorSimplifyMethod;
   mExpressionContext = rh.mExpressionContext;
   mGeometry = rh.mGeometry;
-  mFeatureFilterProvider = rh.mFeatureFilterProvider ? rh.mFeatureFilterProvider->clone() : nullptr;
+  mFeatureFilterProvider.reset( rh.mFeatureFilterProvider ? rh.mFeatureFilterProvider->clone() : nullptr );
   mSegmentationTolerance = rh.mSegmentationTolerance;
   mSegmentationToleranceType = rh.mSegmentationToleranceType;
   return *this;
-}
-
-QgsRenderContext::~QgsRenderContext()
-{
-  delete mFeatureFilterProvider;
-  mFeatureFilterProvider = nullptr;
 }
 
 QgsRenderContext QgsRenderContext::fromQPainter( QPainter* painter )
@@ -209,11 +194,17 @@ void QgsRenderContext::setUseRenderingOptimization( bool enabled )
 
 void QgsRenderContext::setFeatureFilterProvider( const QgsFeatureFilterProvider* ffp )
 {
-  delete mFeatureFilterProvider;
-  mFeatureFilterProvider = nullptr;
-
   if ( ffp )
   {
-    mFeatureFilterProvider = ffp->clone();
+    mFeatureFilterProvider.reset( ffp->clone() );
   }
+  else
+  {
+    mFeatureFilterProvider.reset( nullptr );
+  }
+}
+
+const QgsFeatureFilterProvider* QgsRenderContext::featureFilterProvider() const
+{
+  return mFeatureFilterProvider.data();
 }

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -28,7 +28,6 @@ QgsRenderContext::QgsRenderContext()
     , mPainter( nullptr )
     , mRenderingStopped( false )
     , mScaleFactor( 1.0 )
-    , mRasterScaleFactor( 1.0 )
     , mRendererScale( 1.0 )
     , mLabelingEngine( nullptr )
     , mGeometry( nullptr )
@@ -47,7 +46,6 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext& rh )
     , mMapToPixel( rh.mMapToPixel )
     , mRenderingStopped( rh.mRenderingStopped )
     , mScaleFactor( rh.mScaleFactor )
-    , mRasterScaleFactor( rh.mRasterScaleFactor )
     , mRendererScale( rh.mRendererScale )
     , mLabelingEngine( rh.mLabelingEngine )
     , mSelectionColor( rh.mSelectionColor )
@@ -69,7 +67,6 @@ QgsRenderContext&QgsRenderContext::operator=( const QgsRenderContext & rh )
   mMapToPixel = rh.mMapToPixel;
   mRenderingStopped = rh.mRenderingStopped;
   mScaleFactor = rh.mScaleFactor;
-  mRasterScaleFactor = rh.mRasterScaleFactor;
   mRendererScale = rh.mRendererScale;
   mLabelingEngine = rh.mLabelingEngine;
   mSelectionColor = rh.mSelectionColor;
@@ -92,7 +89,6 @@ QgsRenderContext QgsRenderContext::fromQPainter( QPainter* painter )
 {
   QgsRenderContext context;
   context.setPainter( painter );
-  context.setRasterScaleFactor( 1.0 );
   if ( painter && painter->device() )
   {
     context.setScaleFactor( painter->device()->logicalDpiX() / 25.4 );
@@ -143,7 +139,6 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings& mapSet
   ctx.setFlag( RenderMapTile, mapSettings.testFlag( QgsMapSettings::RenderMapTile ) );
   ctx.setFlag( Antialiasing, mapSettings.testFlag( QgsMapSettings::Antialiasing ) );
   ctx.setFlag( RenderPartialOutput, mapSettings.testFlag( QgsMapSettings::RenderPartialOutput ) );
-  ctx.setRasterScaleFactor( 1.0 );
   ctx.setScaleFactor( mapSettings.outputDpi() / 25.4 ); // = pixels per mm
   ctx.setRendererScale( mapSettings.scale() );
   ctx.setExpressionContext( mapSettings.expressionContext() );

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -117,8 +117,6 @@ class CORE_EXPORT QgsRenderContext
 
     double scaleFactor() const {return mScaleFactor;}
 
-    double rasterScaleFactor() const {return mRasterScaleFactor;}
-
     bool renderingStopped() const {return mRenderingStopped;}
 
     bool forceVectorOutput() const;
@@ -160,7 +158,6 @@ class CORE_EXPORT QgsRenderContext
 
     void setRenderingStopped( bool stopped ) {mRenderingStopped = stopped;}
     void setScaleFactor( double factor ) {mScaleFactor = factor;}
-    void setRasterScaleFactor( double factor ) {mRasterScaleFactor = factor;}
     void setRendererScale( double scale ) {mRendererScale = scale;}
     void setPainter( QPainter* p ) {mPainter = p;}
 
@@ -261,9 +258,6 @@ class CORE_EXPORT QgsRenderContext
 
     //! Factor to scale line widths and point marker sizes
     double mScaleFactor;
-
-    //! Factor to scale rasters
-    double mRasterScaleFactor;
 
     //! Map scale
     double mRendererScale;

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -105,7 +105,6 @@ class CORE_EXPORT QgsRenderContext
      * @see setPainter()
     */
     QPainter* painter() {return mPainter;}
-    const QPainter* constPainter() const { return mPainter; }
 
     /** Returns the current coordinate transform for the context, or an invalid
      * transform is no coordinate transformation is required.

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -27,13 +27,12 @@
 #include "qgsrectangle.h"
 #include "qgsvectorsimplifymethod.h"
 #include "qgsexpressioncontext.h"
+#include "qgsfeaturefilterprovider.h"
 
 class QPainter;
-
 class QgsAbstractGeometry;
 class QgsLabelingEngine;
 class QgsMapSettings;
-class QgsFeatureFilterProvider;
 
 
 /** \ingroup core
@@ -49,8 +48,6 @@ class CORE_EXPORT QgsRenderContext
 
     QgsRenderContext( const QgsRenderContext& rh );
     QgsRenderContext& operator=( const QgsRenderContext& rh );
-
-    ~QgsRenderContext();
 
     /** Enumeration of flags that affect rendering operations.
      * @note added in QGIS 2.14
@@ -103,6 +100,10 @@ class CORE_EXPORT QgsRenderContext
 
     //getters
 
+    /**
+     * Returns the destination QPainter for the render operation.
+     * @see setPainter()
+    */
     QPainter* painter() {return mPainter;}
     const QPainter* constPainter() const { return mPainter; }
 
@@ -115,6 +116,12 @@ class CORE_EXPORT QgsRenderContext
 
     const QgsMapToPixel& mapToPixel() const {return mMapToPixel;}
 
+    /**
+     * Returns the scaling factor for the render to convert painter units
+     * to physical sizes. This is usually equal to the number of pixels
+     * per millimeter.
+     * @see setScaleFactor()
+     */
     double scaleFactor() const {return mScaleFactor;}
 
     bool renderingStopped() const {return mRenderingStopped;}
@@ -131,6 +138,11 @@ class CORE_EXPORT QgsRenderContext
 
     bool drawEditingInformation() const;
 
+    /**
+     * Returns the renderer map scale. This will match the desired scale denominator
+     * for the rendered map, eg 1000.0 for a 1:1000 map render.
+     * @see setRendererScale()
+     */
     double rendererScale() const {return mRendererScale;}
 
     //! Get access to new labeling engine (may be nullptr)
@@ -157,8 +169,28 @@ class CORE_EXPORT QgsRenderContext
     void setDrawEditingInformation( bool b );
 
     void setRenderingStopped( bool stopped ) {mRenderingStopped = stopped;}
+
+    /**
+     * Sets the scaling factor for the render to convert painter units
+     * to physical sizes. This should usually be equal to the number of pixels
+     * per millimeter.
+     * @see scaleFactor()
+     */
     void setScaleFactor( double factor ) {mScaleFactor = factor;}
+
+    /**
+     * Sets the renderer map scale. This should match the desired scale denominator
+     * for the rendered map, eg 1000.0 for a 1:1000 map render.
+     * @see rendererScale()
+     */
     void setRendererScale( double scale ) {mRendererScale = scale;}
+
+    /**
+     * Sets the destination QPainter for the render operation. Ownership of the painter
+     * is not transferred and the QPainter destination must stay alive for the duration
+     * of any rendering operations.
+     * @see painter()
+     */
     void setPainter( QPainter* p ) {mPainter = p;}
 
     void setForceVectorOutput( bool force );
@@ -225,7 +257,7 @@ class CORE_EXPORT QgsRenderContext
      * @note added in QGIS 2.14
      * @see setFeatureFilterProvider()
      */
-    const QgsFeatureFilterProvider* featureFilterProvider() const { return mFeatureFilterProvider; }
+    const QgsFeatureFilterProvider* featureFilterProvider() const;
 
     /** Sets the segmentation tolerance applied when rendering curved geometries
     @param tolerance the segmentation tolerance*/
@@ -244,7 +276,7 @@ class CORE_EXPORT QgsRenderContext
     Flags mFlags;
 
     //! Painter for rendering operations
-    QPainter* mPainter;
+    QPainter* mPainter = nullptr;
 
     //! For transformation between coordinate systems. Can be invalid if on-the-fly reprojection is not used
     QgsCoordinateTransform mCoordTransform;
@@ -254,16 +286,16 @@ class CORE_EXPORT QgsRenderContext
     QgsMapToPixel mMapToPixel;
 
     //! True if the rendering has been canceled
-    bool mRenderingStopped;
+    bool mRenderingStopped = false;
 
     //! Factor to scale line widths and point marker sizes
-    double mScaleFactor;
+    double mScaleFactor = 1.0;
 
     //! Map scale
-    double mRendererScale;
+    double mRendererScale = 1.0;
 
     //! Newer labeling engine implementation (can be nullptr)
-    QgsLabelingEngine* mLabelingEngine;
+    QgsLabelingEngine* mLabelingEngine = nullptr;
 
     //! Color used for features that are marked as selected
     QColor mSelectionColor;
@@ -275,14 +307,14 @@ class CORE_EXPORT QgsRenderContext
     QgsExpressionContext mExpressionContext;
 
     //! Pointer to the (unsegmentized) geometry
-    const QgsAbstractGeometry* mGeometry;
+    const QgsAbstractGeometry* mGeometry = nullptr;
 
     //! The feature filter provider
-    const QgsFeatureFilterProvider* mFeatureFilterProvider;
+    QScopedPointer< QgsFeatureFilterProvider > mFeatureFilterProvider;
 
-    double mSegmentationTolerance;
+    double mSegmentationTolerance = M_PI_2 / 90;
 
-    QgsAbstractGeometry::SegmentationToleranceType mSegmentationToleranceType;
+    QgsAbstractGeometry::SegmentationToleranceType mSegmentationToleranceType = QgsAbstractGeometry::MaximumAngle;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsRenderContext::Flags )

--- a/src/core/qgstextlabelfeature.cpp
+++ b/src/core/qgstextlabelfeature.cpp
@@ -43,7 +43,7 @@ QString QgsTextLabelFeature::text( int partId ) const
 }
 
 
-void QgsTextLabelFeature::calculateInfo( bool curvedLabeling, QFontMetricsF* fm, const QgsMapToPixel* xform, double fontScale, double maxinangle, double maxoutangle )
+void QgsTextLabelFeature::calculateInfo( bool curvedLabeling, QFontMetricsF* fm, const QgsMapToPixel* xform, double maxinangle, double maxoutangle )
 {
   if ( mInfo )
     return;
@@ -65,7 +65,7 @@ void QgsTextLabelFeature::calculateInfo( bool curvedLabeling, QFontMetricsF* fm,
 
   // create label info!
   double mapScale = xform->mapUnitsPerPixel();
-  double labelHeight = mapScale * fm->height() / fontScale;
+  double labelHeight = mapScale * fm->height();
 
   // mLetterSpacing/mWordSpacing = 0.0 is default for non-curved labels
   // (non-curved spacings handled by Qt in QgsPalLayerSettings/QgsPalLabeling)
@@ -102,7 +102,7 @@ void QgsTextLabelFeature::calculateInfo( bool curvedLabeling, QFontMetricsF* fm,
       charWidth = fm->width( QString( mClusters[i] ) ) + wordSpaceFix;
     }
 
-    double labelWidth = mapScale * charWidth / fontScale;
+    double labelWidth = mapScale * charWidth;
     mInfo->char_info[i].width = labelWidth;
   }
 }

--- a/src/core/qgstextlabelfeature.h
+++ b/src/core/qgstextlabelfeature.h
@@ -39,7 +39,7 @@ class QgsTextLabelFeature : public QgsLabelFeature
     QString text( int partId ) const;
 
     //! calculate data for info(). setDefinedFont() must have been called already.
-    void calculateInfo( bool curvedLabeling, QFontMetricsF* fm, const QgsMapToPixel* xform, double fontScale, double maxinangle, double maxoutangle );
+    void calculateInfo( bool curvedLabeling, QFontMetricsF* fm, const QgsMapToPixel* xform, double maxinangle, double maxoutangle );
 
     //! Get data-defined values
     const QMap< QgsPalLayerSettings::DataDefinedProperties, QVariant >& dataDefinedValues() const { return mDataDefinedValues; }

--- a/src/core/qgstextrenderer.h
+++ b/src/core/qgstextrenderer.h
@@ -1130,21 +1130,19 @@ class CORE_EXPORT QgsTextRenderer
      * @param size size to convert
      * @param c rendercontext
      * @param unit size units
-     * @param rasterfactor whether to consider oversampling
      * @param mapUnitScale a mapUnitScale clamper
      * @return font pixel size
      */
-    static int sizeToPixel( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, bool rasterfactor = false, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
+    static int sizeToPixel( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
 
     /** Calculates size (considering output size should be in pixel or map units, scale factors and optionally oversampling)
      * @param size size to convert
      * @param c rendercontext
      * @param unit size units
-     * @param rasterfactor whether to consider oversampling
      * @param mapUnitScale a mapUnitScale clamper
      * @return size that will render, as double
      */
-    static double scaleToPixelContext( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, bool rasterfactor = false, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
+    static double scaleToPixelContext( double size, const QgsRenderContext& c, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
 
     /** Draws text within a rectangle using the specified settings.
      * @param rect destination rectangle for text

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -552,8 +552,8 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition* label, Q
     component.center = centerPt;
 
     // convert label size to render units
-    double labelWidthPx = QgsTextRenderer::scaleToPixelContext( label->getWidth(), context, QgsUnitTypes::RenderMapUnits, true );
-    double labelHeightPx = QgsTextRenderer::scaleToPixelContext( label->getHeight(), context, QgsUnitTypes::RenderMapUnits, true );
+    double labelWidthPx = QgsTextRenderer::scaleToPixelContext( label->getWidth(), context, QgsUnitTypes::RenderMapUnits, QgsMapUnitScale() );
+    double labelHeightPx = QgsTextRenderer::scaleToPixelContext( label->getHeight(), context, QgsUnitTypes::RenderMapUnits, QgsMapUnitScale() );
 
     component.size = QSizeF( labelWidthPx, labelHeightPx );
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -172,7 +172,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer* layer, QgsRender
   // TODO R->mLastViewPort = *mRasterViewPort;
 
   // TODO: is it necessary? Probably WMS only?
-  layer->dataProvider()->setDpi( rendererContext.rasterScaleFactor() * 25.4 * rendererContext.scaleFactor() );
+  layer->dataProvider()->setDpi( 25.4 * rendererContext.scaleFactor() );
 
 
   // copy the whole raster pipe!

--- a/src/core/symbology-ng/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayer.cpp
@@ -676,8 +676,6 @@ QRectF QgsEllipseSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext& con
   double angle = 0;
   calculateOffsetAndRotation( context, size.width(), size.height(), hasDataDefinedRotation, offset, angle );
 
-  double pixelSize = 1.0 / context.renderContext().rasterScaleFactor();
-
   QMatrix transform;
 
   // move to the desired position
@@ -707,8 +705,8 @@ QRectF QgsEllipseSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext& con
     }
   }
 
-  //antialiasing
-  penWidth += pixelSize;
+  //antialiasing, add 1 pixel
+  penWidth += 1;
 
   QRectF symbolBounds = transform.mapRect( QRectF( -size.width() / 2.0,
                         -size.height() / 2.0,

--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -1951,11 +1951,11 @@ void QgsSVGFillSymbolLayer::applyPattern( QBrush& brush, const QString& svgFileP
     bool fitsInCache = true;
     double outlineWidth = QgsSymbolLayerUtils::convertToPainterUnits( context.renderContext(), svgOutlineWidth, svgOutlineWidthUnit, svgOutlineWidthMapUnitScale );
     const QImage& patternImage = QgsApplication::svgCache()->svgAsImage( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
-                                 context.renderContext().scaleFactor(), 1.0, fitsInCache );
+                                 context.renderContext().scaleFactor(), fitsInCache );
     if ( !fitsInCache )
     {
       const QPicture& patternPict = QgsApplication::svgCache()->svgAsPicture( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
-                                    context.renderContext().scaleFactor(), 1.0 );
+                                    context.renderContext().scaleFactor() );
       double hwRatio = 1.0;
       if ( patternPict.width() > 0 )
       {

--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -235,13 +235,6 @@ void QgsSimpleFillSymbolLayer::startRender( QgsSymbolRenderContext& context )
   fillColor.setAlphaF( context.alpha() * mColor.alphaF() );
   mBrush = QBrush( fillColor, mBrushStyle );
 
-  // scale brush content for printout
-  double rasterScaleFactor = context.renderContext().rasterScaleFactor();
-  if ( rasterScaleFactor != 1.0 )
-  {
-    mBrush.setMatrix( QMatrix().scale( 1.0 / rasterScaleFactor, 1.0 / rasterScaleFactor ) );
-  }
-
   QColor selColor = context.renderContext().selectionColor();
   QColor selPenColor = selColor == mColor ? selColor : mBorderColor;
   if ( ! SELECTION_IS_OPAQUE ) selColor.setAlphaF( context.alpha() );
@@ -1210,8 +1203,8 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF& points, QList
   //create a QImage to draw shapeburst in
   double imWidth = points.boundingRect().width() + ( sideBuffer * 2 );
   double imHeight = points.boundingRect().height() + ( sideBuffer * 2 );
-  QImage * fillImage = new QImage( imWidth * context.renderContext().rasterScaleFactor(),
-                                   imHeight * context.renderContext().rasterScaleFactor(), QImage::Format_ARGB32_Premultiplied );
+  QImage * fillImage = new QImage( imWidth,
+                                   imHeight, QImage::Format_ARGB32_Premultiplied );
   //Fill this image with black. Initially the distance transform is drawn in greyscale, where black pixels have zero distance from the
   //polygon boundary. Since we don't care about pixels which fall outside the polygon, we start with a black image and then draw over it the
   //polygon in white. The distance transform function then fills in the correct distance values for the white pixels.
@@ -1229,7 +1222,6 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF& points, QList
   imgPainter.setBrush( QBrush( Qt::white ) );
   imgPainter.setPen( QPen( Qt::black ) );
   imgPainter.translate( -points.boundingRect().left() + sideBuffer, - points.boundingRect().top() + sideBuffer );
-  imgPainter.scale( context.renderContext().rasterScaleFactor(), context.renderContext().rasterScaleFactor() );
   _renderPolygon( &imgPainter, points, rings, context );
   imgPainter.end();
 
@@ -1248,7 +1240,6 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF& points, QList
     imgPainter.setBrush( QBrush( Qt::white ) );
     imgPainter.setPen( QPen( Qt::black ) );
     imgPainter.translate( -points.boundingRect().left() + sideBuffer, - points.boundingRect().top() + sideBuffer );
-    imgPainter.scale( context.renderContext().rasterScaleFactor(), context.renderContext().rasterScaleFactor() );
     _renderPolygon( &imgPainter, points, nullptr, context );
   }
   imgPainter.end();
@@ -1292,7 +1283,6 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF& points, QList
     p->translate( offset );
   }
 
-  p->scale( 1 / context.renderContext().rasterScaleFactor(), 1 / context.renderContext().rasterScaleFactor() );
   p->drawImage( points.boundingRect().left() - sideBuffer, points.boundingRect().top() - sideBuffer, *fillImage );
 
   delete fillImage;
@@ -1961,7 +1951,7 @@ void QgsSVGFillSymbolLayer::applyPattern( QBrush& brush, const QString& svgFileP
     bool fitsInCache = true;
     double outlineWidth = QgsSymbolLayerUtils::convertToPainterUnits( context.renderContext(), svgOutlineWidth, svgOutlineWidthUnit, svgOutlineWidthMapUnitScale );
     const QImage& patternImage = QgsApplication::svgCache()->svgAsImage( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
-                                 context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), fitsInCache );
+                                 context.renderContext().scaleFactor(), 1.0, fitsInCache );
     if ( !fitsInCache )
     {
       const QPicture& patternPict = QgsApplication::svgCache()->svgAsPicture( svgFilePath, size, svgFillColor, svgOutlineColor, outlineWidth,
@@ -1979,7 +1969,6 @@ void QgsSVGFillSymbolLayer::applyPattern( QBrush& brush, const QString& svgFileP
     }
 
     QTransform brushTransform;
-    brushTransform.scale( 1.0 / context.renderContext().rasterScaleFactor(), 1.0 / context.renderContext().rasterScaleFactor() );
     if ( !qgsDoubleNear( context.alpha(), 1.0 ) )
     {
       QImage transparentImage = fitsInCache ? patternImage.copy() : mSvgPattern->copy();
@@ -2778,9 +2767,8 @@ void QgsLinePatternFillSymbolLayer::applyPattern( const QgsSymbolRenderContext& 
   // line rendering needs context for drawing on patternImage
   QgsRenderContext lineRenderContext;
   lineRenderContext.setPainter( &p );
-  lineRenderContext.setRasterScaleFactor( 1.0 );
-  lineRenderContext.setScaleFactor( context.renderContext().scaleFactor() * context.renderContext().rasterScaleFactor() );
-  QgsMapToPixel mtp( context.renderContext().mapToPixel().mapUnitsPerPixel() / context.renderContext().rasterScaleFactor() );
+  lineRenderContext.setScaleFactor( context.renderContext().scaleFactor() );
+  QgsMapToPixel mtp( context.renderContext().mapToPixel().mapUnitsPerPixel() );
   lineRenderContext.setMapToPixel( mtp );
   lineRenderContext.setForceVectorOutput( false );
   lineRenderContext.setExpressionContext( context.renderContext().expressionContext() );
@@ -2819,7 +2807,6 @@ void QgsLinePatternFillSymbolLayer::applyPattern( const QgsSymbolRenderContext& 
   }
 
   QTransform brushTransform;
-  brushTransform.scale( 1.0 / context.renderContext().rasterScaleFactor(), 1.0 / context.renderContext().rasterScaleFactor() );
   brush.setTransform( brushTransform );
 
   delete fillLineSymbol;
@@ -3207,9 +3194,8 @@ void QgsPointPatternFillSymbolLayer::applyPattern( const QgsSymbolRenderContext&
     QgsRenderContext pointRenderContext;
     pointRenderContext.setRendererScale( context.renderContext().rendererScale() );
     pointRenderContext.setPainter( &p );
-    pointRenderContext.setRasterScaleFactor( 1.0 );
-    pointRenderContext.setScaleFactor( context.renderContext().scaleFactor() * context.renderContext().rasterScaleFactor() );
-    QgsMapToPixel mtp( context.renderContext().mapToPixel().mapUnitsPerPixel() / context.renderContext().rasterScaleFactor() );
+    pointRenderContext.setScaleFactor( context.renderContext().scaleFactor() );
+    QgsMapToPixel mtp( context.renderContext().mapToPixel().mapUnitsPerPixel() );
     pointRenderContext.setMapToPixel( mtp );
     pointRenderContext.setForceVectorOutput( false );
     pointRenderContext.setExpressionContext( context.renderContext().expressionContext() );
@@ -3245,7 +3231,6 @@ void QgsPointPatternFillSymbolLayer::applyPattern( const QgsSymbolRenderContext&
     brush.setTextureImage( patternImage );
   }
   QTransform brushTransform;
-  brushTransform.scale( 1.0 / context.renderContext().rasterScaleFactor(), 1.0 / context.renderContext().rasterScaleFactor() );
   brush.setTransform( brushTransform );
 }
 

--- a/src/core/symbology-ng/qgslinesymbollayer.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayer.cpp
@@ -203,7 +203,7 @@ void QgsSimpleLineSymbolLayer::startRender( QgsSymbolRenderContext& context )
     QStringList versionSplit = QString( qVersion() ).split( '.' );
     if ( versionSplit.size() > 1
          && versionSplit.at( 1 ).toInt() >= 8
-         && ( scaledWidth * context.renderContext().rasterScaleFactor() ) < 1.0 )
+         && scaledWidth < 1.0 )
     {
       dashWidthDiv = 1.0;
     }
@@ -522,7 +522,7 @@ void QgsSimpleLineSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
     QStringList versionSplit = QString( qVersion() ).split( '.' );
     if ( versionSplit.size() > 1
          && versionSplit.at( 1 ).toInt() >= 8
-         && ( scaledWidth * context.renderContext().rasterScaleFactor() ) < 1.0 )
+         && scaledWidth < 1.0 )
     {
       dashWidthDiv = 1.0;
     }

--- a/src/core/symbology-ng/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayer.cpp
@@ -1973,7 +1973,7 @@ void QgsSvgMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext
   {
     usePict = false;
     const QImage& img = QgsApplication::svgCache()->svgAsImage( path, size, fillColor, outlineColor, outlineWidth,
-                        context.renderContext().scaleFactor(), 1.0, fitsInCache );
+                        context.renderContext().scaleFactor(), fitsInCache );
     if ( fitsInCache && img.width() > 1 )
     {
       //consider transparency
@@ -1996,7 +1996,7 @@ void QgsSvgMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext
   {
     p->setOpacity( context.alpha() );
     const QPicture& pct = QgsApplication::svgCache()->svgAsPicture( path, size, fillColor, outlineColor, outlineWidth,
-                          context.renderContext().scaleFactor(), 1.0, context.renderContext().forceVectorOutput() );
+                          context.renderContext().scaleFactor(), context.renderContext().forceVectorOutput() );
 
     if ( pct.width() > 1 )
     {
@@ -2348,8 +2348,7 @@ bool QgsSvgMarkerSymbolLayer::writeDxf( QgsDxfExport& e, double mmMapUnitScaleFa
   }
 
   const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( path, size, fillColor, outlineColor, outlineWidth,
-                                 context.renderContext().scaleFactor(),
-                                 1.0 );
+                                 context.renderContext().scaleFactor() );
 
   //if current entry image is 0: cache image for entry
   // checks to see if image will fit into cache
@@ -2431,8 +2430,7 @@ QRectF QgsSvgMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext& c
   }
 
   QSizeF svgViewbox = QgsApplication::svgCache()->svgViewboxSize( path, scaledSize, fillColor, outlineColor, outlineWidth,
-                      context.renderContext().scaleFactor(),
-                      1.0 );
+                      context.renderContext().scaleFactor() );
 
   double scaledHeight = svgViewbox.isValid() ? scaledSize * svgViewbox.height() / svgViewbox.width() : scaledSize;
 

--- a/src/core/symbology-ng/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayer.cpp
@@ -842,16 +842,6 @@ void QgsSimpleMarkerSymbolLayer::startRender( QgsSymbolRenderContext& context )
 
   if ( mUsingCache )
   {
-    if ( !qgsDoubleNear( context.renderContext().rasterScaleFactor(), 1.0 ) )
-    {
-      QTransform transform;
-      transform.scale( context.renderContext().rasterScaleFactor(), context.renderContext().rasterScaleFactor() );
-      if ( !mPolygon.isEmpty() )
-        mPolygon = transform.map( mPolygon );
-      else
-        mPath = transform.map( mPath );
-    }
-
     if ( !prepareCache( context ) )
     {
       mUsingCache = false;
@@ -1017,7 +1007,7 @@ void QgsSimpleMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderCont
   if ( mUsingCache )
   {
     QImage &img = context.selected() ? mSelCache : mCache;
-    double s = img.width() / context.renderContext().rasterScaleFactor();
+    double s = img.width();
 
     bool hasDataDefinedSize = false;
     double scaledSize = calculateSize( context, hasDataDefinedSize );
@@ -1456,7 +1446,6 @@ QRectF QgsSimpleMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext
   QRectF symbolBounds = QgsSimpleMarkerSymbolLayerBase::bounds( point, context );
 
   // need to account for outline width
-  double pixelSize = 1.0 / context.renderContext().rasterScaleFactor();
   double penWidth = 0.0;
   bool ok = true;
   if ( hasDataDefinedProperty( QgsSymbolLayer::EXPR_OUTLINE_WIDTH ) )
@@ -1477,8 +1466,8 @@ QRectF QgsSimpleMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext
       penWidth = 0.0;
     }
   }
-  //antialiasing
-  penWidth += pixelSize;
+  //antialiasing, add 1 pixel
+  penWidth += 1;
 
   //extend bounds by pen width / 2.0
   symbolBounds.adjust( -penWidth / 2.0, -penWidth / 2.0,
@@ -1984,7 +1973,7 @@ void QgsSvgMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext
   {
     usePict = false;
     const QImage& img = QgsApplication::svgCache()->svgAsImage( path, size, fillColor, outlineColor, outlineWidth,
-                        context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), fitsInCache );
+                        context.renderContext().scaleFactor(), 1.0, fitsInCache );
     if ( fitsInCache && img.width() > 1 )
     {
       //consider transparency
@@ -2007,7 +1996,7 @@ void QgsSvgMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext
   {
     p->setOpacity( context.alpha() );
     const QPicture& pct = QgsApplication::svgCache()->svgAsPicture( path, size, fillColor, outlineColor, outlineWidth,
-                          context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), context.renderContext().forceVectorOutput() );
+                          context.renderContext().scaleFactor(), 1.0, context.renderContext().forceVectorOutput() );
 
     if ( pct.width() > 1 )
     {
@@ -2360,7 +2349,7 @@ bool QgsSvgMarkerSymbolLayer::writeDxf( QgsDxfExport& e, double mmMapUnitScaleFa
 
   const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( path, size, fillColor, outlineColor, outlineWidth,
                                  context.renderContext().scaleFactor(),
-                                 context.renderContext().rasterScaleFactor() );
+                                 1.0 );
 
   //if current entry image is 0: cache image for entry
   // checks to see if image will fit into cache
@@ -2443,10 +2432,9 @@ QRectF QgsSvgMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext& c
 
   QSizeF svgViewbox = QgsApplication::svgCache()->svgViewboxSize( path, scaledSize, fillColor, outlineColor, outlineWidth,
                       context.renderContext().scaleFactor(),
-                      context.renderContext().rasterScaleFactor() );
+                      1.0 );
 
   double scaledHeight = svgViewbox.isValid() ? scaledSize * svgViewbox.height() / svgViewbox.width() : scaledSize;
-  double pixelSize = 1.0 / context.renderContext().rasterScaleFactor();
 
   QMatrix transform;
 
@@ -2457,7 +2445,7 @@ QRectF QgsSvgMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext& c
     transform.rotate( angle );
 
   //antialiasing
-  outlineWidth += pixelSize / 2.0;
+  outlineWidth += 1.0 / 2.0;
 
   QRectF symbolBounds = transform.mapRect( QRectF( -scaledSize / 2.0,
                         -scaledHeight / 2.0,

--- a/src/core/symbology-ng/qgspointdistancerenderer.cpp
+++ b/src/core/symbology-ng/qgspointdistancerenderer.cpp
@@ -397,7 +397,7 @@ void QgsPointDistanceRenderer::drawLabels( QPointF centerPoint, QgsSymbolRenderC
   QFont pixelSizeFont = mLabelFont;
   pixelSizeFont.setPixelSize( context.outputLineWidth( mLabelFont.pointSizeF() * 0.3527 ) );
   QFont scaledFont = pixelSizeFont;
-  scaledFont.setPixelSize( pixelSizeFont.pixelSize() * context.renderContext().rasterScaleFactor() );
+  scaledFont.setPixelSize( pixelSizeFont.pixelSize() );
   p->setFont( scaledFont );
 
   QFontMetricsF fontMetrics( pixelSizeFont );
@@ -421,7 +421,6 @@ void QgsPointDistanceRenderer::drawLabels( QPointF centerPoint, QgsSymbolRenderC
     QPointF drawingPoint( centerPoint + currentLabelShift );
     p->save();
     p->translate( drawingPoint.x(), drawingPoint.y() );
-    p->scale( 1.0 / context.renderContext().rasterScaleFactor(), 1.0 / context.renderContext().rasterScaleFactor() );
     p->drawText( QPointF( 0, 0 ), groupIt->label );
     p->restore();
   }

--- a/src/core/symbology-ng/qgssvgcache.h
+++ b/src/core/symbology-ng/qgssvgcache.h
@@ -46,12 +46,11 @@ class CORE_EXPORT QgsSvgCacheEntry
      * @param size
      * @param outlineWidth width of outline
      * @param widthScaleFactor width scale factor
-     * @param rasterScaleFactor raster scale factor
      * @param fill color of fill
      * @param outline color of outline
      * @param lookupKey the key string used in QgsSvgCache for quick lookup of this entry (relative or absolute path)
      */
-    QgsSvgCacheEntry( const QString& file, double size, double outlineWidth, double widthScaleFactor, double rasterScaleFactor, const QColor& fill, const QColor& outline, const QString& lookupKey = QString() );
+    QgsSvgCacheEntry( const QString& file, double size, double outlineWidth, double widthScaleFactor, const QColor& fill, const QColor& outline, const QString& lookupKey = QString() );
     ~QgsSvgCacheEntry();
 
     //! QgsSvgCacheEntry cannot be copied.
@@ -66,7 +65,6 @@ class CORE_EXPORT QgsSvgCacheEntry
     double size; //size in pixels (cast to int for QImage)
     double outlineWidth;
     double widthScaleFactor;
-    double rasterScaleFactor;
 
     /** SVG viewbox size.
      * @note added in QGIS 2.14
@@ -119,11 +117,10 @@ class CORE_EXPORT QgsSvgCache : public QObject
      * @param outline color of outline
      * @param outlineWidth width of outline
      * @param widthScaleFactor width scale factor
-     * @param rasterScaleFactor raster scale factor
      * @param fitsInCache
      */
     QImage svgAsImage( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                       double widthScaleFactor, double rasterScaleFactor, bool& fitsInCache );
+                       double widthScaleFactor, bool& fitsInCache );
 
     /** Get SVG  as QPicture&.
      * @param file Absolute or relative path to SVG file.
@@ -132,11 +129,10 @@ class CORE_EXPORT QgsSvgCache : public QObject
      * @param outline color of outline
      * @param outlineWidth width of outline
      * @param widthScaleFactor width scale factor
-     * @param rasterScaleFactor raster scale factor
      * @param forceVectorOutput
      */
     QPicture svgAsPicture( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                           double widthScaleFactor, double rasterScaleFactor, bool forceVectorOutput = false );
+                           double widthScaleFactor, bool forceVectorOutput = false );
 
     /** Calculates the viewbox size of a (possibly cached) SVG file.
      * @param file Absolute or relative path to SVG file.
@@ -145,12 +141,11 @@ class CORE_EXPORT QgsSvgCache : public QObject
      * @param outline color of outline
      * @param outlineWidth width of outline
      * @param widthScaleFactor width scale factor
-     * @param rasterScaleFactor raster scale factor
      * @returns viewbox size set in SVG file
      * @note added in QGIS 2.14
      */
     QSizeF svgViewboxSize( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                           double widthScaleFactor, double rasterScaleFactor );
+                           double widthScaleFactor );
 
     /** Tests if an svg file contains parameters for fill, outline color, outline width. If yes, possible default values are returned. If there are several
       default values in the svg file, only the first one is considered*/
@@ -189,7 +184,7 @@ class CORE_EXPORT QgsSvgCache : public QObject
 
     //! Get SVG content
     QByteArray svgContent( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                           double widthScaleFactor, double rasterScaleFactor );
+                           double widthScaleFactor );
 
   signals:
     //! Emit a signal to be caught by qgisapp and display a msg on status bar
@@ -205,17 +200,16 @@ class CORE_EXPORT QgsSvgCache : public QObject
      * @param outline color of outline
      * @param outlineWidth width of outline
      * @param widthScaleFactor width scale factor
-     * @param rasterScaleFactor raster scale factor
      */
     QgsSvgCacheEntry* insertSVG( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                 double widthScaleFactor, double rasterScaleFactor );
+                                 double widthScaleFactor );
 
     void replaceParamsAndCacheSvg( QgsSvgCacheEntry* entry );
     void cacheImage( QgsSvgCacheEntry* entry );
     void cachePicture( QgsSvgCacheEntry* entry, bool forceVectorOutput = false );
     //! Returns entry from cache or creates a new entry if it does not exist already
     QgsSvgCacheEntry* cacheEntry( const QString& file, double size, const QColor& fill, const QColor& outline, double outlineWidth,
-                                  double widthScaleFactor, double rasterScaleFactor );
+                                  double widthScaleFactor );
 
     //! Removes the least used items until the maximum size is under the limit
     void trimToMaximumSize();

--- a/src/core/symbology-ng/qgssymbollayerutils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerutils.cpp
@@ -3305,7 +3305,8 @@ double QgsSymbolLayerUtils::lineWidthScaleFactor( const QgsRenderContext& c, Qgs
       }
     }
     case QgsUnitTypes::RenderPixels:
-      return 1.0 / c.rasterScaleFactor();
+      return 1.0;
+
     case QgsUnitTypes::RenderUnknownUnit:
     case QgsUnitTypes::RenderPercentage:
       //no sensible value
@@ -3343,7 +3344,7 @@ double QgsSymbolLayerUtils::convertToMapUnits( const QgsRenderContext &c, double
       double minSizeMU = -DBL_MAX;
       if ( scale.minSizeMMEnabled )
       {
-        minSizeMU = scale.minSizeMM * c.scaleFactor() * c.rasterScaleFactor() * mup;
+        minSizeMU = scale.minSizeMM * c.scaleFactor() * mup;
       }
       if ( !qgsDoubleNear( scale.minScale, 0.0 ) )
       {
@@ -3354,7 +3355,7 @@ double QgsSymbolLayerUtils::convertToMapUnits( const QgsRenderContext &c, double
       double maxSizeMU = DBL_MAX;
       if ( scale.maxSizeMMEnabled )
       {
-        maxSizeMU = scale.maxSizeMM * c.scaleFactor() * c.rasterScaleFactor() * mup;
+        maxSizeMU = scale.maxSizeMM * c.scaleFactor() * mup;
       }
       if ( !qgsDoubleNear( scale.maxScale, 0.0 ) )
       {
@@ -3366,11 +3367,11 @@ double QgsSymbolLayerUtils::convertToMapUnits( const QgsRenderContext &c, double
     }
     case QgsUnitTypes::RenderMillimeters:
     {
-      return size * c.scaleFactor() * c.rasterScaleFactor() * mup;
+      return size * c.scaleFactor() * mup;
     }
     case QgsUnitTypes::RenderPoints:
     {
-      return size * c.scaleFactor() * c.rasterScaleFactor() * mup / POINTS_TO_MM;
+      return size * c.scaleFactor() * mup / POINTS_TO_MM;
     }
     case QgsUnitTypes::RenderPixels:
     {
@@ -3397,11 +3398,11 @@ double QgsSymbolLayerUtils::convertFromMapUnits( const QgsRenderContext& context
     }
     case QgsUnitTypes::RenderMillimeters:
     {
-      return sizeInMapUnits / ( context.scaleFactor() * context.rasterScaleFactor() * mup );
+      return sizeInMapUnits / ( context.scaleFactor() * mup );
     }
     case QgsUnitTypes::RenderPoints:
     {
-      return sizeInMapUnits / ( context.scaleFactor() * context.rasterScaleFactor() * mup / POINTS_TO_MM );
+      return sizeInMapUnits / ( context.scaleFactor() * mup / POINTS_TO_MM );
     }
     case QgsUnitTypes::RenderPixels:
     {
@@ -3421,15 +3422,15 @@ double QgsSymbolLayerUtils::pixelSizeScaleFactor( const QgsRenderContext& c, Qgs
   switch ( u )
   {
     case QgsUnitTypes::RenderMillimeters:
-      return ( c.scaleFactor() * c.rasterScaleFactor() );
+      return c.scaleFactor();
     case QgsUnitTypes::RenderPoints:
-      return ( c.scaleFactor() * c.rasterScaleFactor() ) * POINTS_TO_MM;
+      return c.scaleFactor() * POINTS_TO_MM;
     case QgsUnitTypes::RenderMapUnits:
     {
       double mup = scale.computeMapUnitsPerPixel( c );
       if ( mup > 0 )
       {
-        return c.rasterScaleFactor() / mup;
+        return 1.0 / mup;
       }
       else
       {
@@ -3451,9 +3452,9 @@ double QgsSymbolLayerUtils::mapUnitScaleFactor( const QgsRenderContext &c, QgsUn
   switch ( u )
   {
     case QgsUnitTypes::RenderMillimeters:
-      return scale.computeMapUnitsPerPixel( c ) * c.scaleFactor() * c.rasterScaleFactor();
+      return scale.computeMapUnitsPerPixel( c ) * c.scaleFactor();
     case QgsUnitTypes::RenderPoints:
-      return scale.computeMapUnitsPerPixel( c ) * c.scaleFactor() * c.rasterScaleFactor() * POINTS_TO_MM;
+      return scale.computeMapUnitsPerPixel( c ) * c.scaleFactor() * POINTS_TO_MM;
     case QgsUnitTypes::RenderMapUnits:
     {
       return 1.0;

--- a/src/gui/qgsmapcanvasitem.cpp
+++ b/src/gui/qgsmapcanvasitem.cpp
@@ -128,7 +128,6 @@ bool QgsMapCanvasItem::setRenderContextVariables( QPainter* p, QgsRenderContext&
   context.setPainter( p );
   context.setRendererScale( mMapCanvas->scale() );
   context.setScaleFactor( ms.outputDpi() / 25.4 );
-  context.setRasterScaleFactor( 1.0 );
 
   context.setForceVectorOutput( true );
   return true;

--- a/src/gui/qgstextpreview.cpp
+++ b/src/gui/qgstextpreview.cpp
@@ -42,16 +42,16 @@ void QgsTextPreview::paintEvent( QPaintEvent *e )
   // slightly inset text
   double xtrans = 0;
   if ( mFormat.buffer().enabled() )
-    xtrans = QgsTextRenderer::scaleToPixelContext( mFormat.buffer().size(), mContext, mFormat.buffer().sizeUnit(), false, mFormat.buffer().sizeMapUnitScale() );
+    xtrans = QgsTextRenderer::scaleToPixelContext( mFormat.buffer().size(), mContext, mFormat.buffer().sizeUnit(), mFormat.buffer().sizeMapUnitScale() );
   if ( mFormat.background().enabled() && mFormat.background().sizeType() != QgsTextBackgroundSettings::SizeFixed )
-    xtrans = qMax( xtrans, QgsTextRenderer::scaleToPixelContext( mFormat.background().size().width(), mContext, mFormat.background().sizeUnit(), false, mFormat.background().sizeMapUnitScale() ) );
+    xtrans = qMax( xtrans, QgsTextRenderer::scaleToPixelContext( mFormat.background().size().width(), mContext, mFormat.background().sizeUnit(), mFormat.background().sizeMapUnitScale() ) );
   xtrans += 4;
 
   double ytrans = 0.0;
   if ( mFormat.buffer().enabled() )
-    ytrans = qMax( ytrans, QgsTextRenderer::scaleToPixelContext( mFormat.buffer().size(), mContext, mFormat.buffer().sizeUnit(), false, mFormat.buffer().sizeMapUnitScale() ) );
+    ytrans = qMax( ytrans, QgsTextRenderer::scaleToPixelContext( mFormat.buffer().size(), mContext, mFormat.buffer().sizeUnit(), mFormat.buffer().sizeMapUnitScale() ) );
   if ( mFormat.background().enabled() )
-    ytrans = qMax( ytrans, QgsTextRenderer::scaleToPixelContext( mFormat.background().size().height(), mContext, mFormat.background().sizeUnit(), false, mFormat.background().sizeMapUnitScale() ) );
+    ytrans = qMax( ytrans, QgsTextRenderer::scaleToPixelContext( mFormat.background().size().height(), mContext, mFormat.background().sizeUnit(), mFormat.background().sizeMapUnitScale() ) );
   ytrans += 4;
 
   QRectF textRect = rect();

--- a/src/gui/symbology-ng/qgssvgselectorwidget.cpp
+++ b/src/gui/symbology-ng/qgssvgselectorwidget.cpp
@@ -259,7 +259,7 @@ QPixmap QgsSvgSelectorListModel::createPreview( const QString& entry ) const
     outlineWidth = 0.2;
 
   bool fitsInCache; // should always fit in cache at these sizes (i.e. under 559 px ^ 2, or half cache size)
-  const QImage& img = QgsApplication::svgCache()->svgAsImage( entry, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, 1.0, fitsInCache );
+  const QImage& img = QgsApplication::svgCache()->svgAsImage( entry, 30.0, fill, outline, outlineWidth, 3.5 /*appr. 88 dpi*/, fitsInCache );
   return QPixmap::fromImage( img );
 }
 


### PR DESCRIPTION
These were not being used by QGIS code (always left at default 1.0 value), and removing them from the api allows us to simplify lots of code. It also makes QgsRenderContext scaling much less confusing.