### PR TITLE
Add willBeDeleted() signal to QgsMapLayer

### DIFF
--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -743,6 +743,14 @@ class QgsMapLayer : QObject
      */
     void dependenciesChanged();
 
+    /**
+     * Emitted in the destructor when the layer is about to be deleted,
+     * but it is still in a perfectly valid state: the last chance for
+     * other pieces of code for some cleanup if they use the layer.
+     * @note added in QGIS 3.0
+     */
+    void willBeDeleted();
+
   protected:
     /** Set the extent */
     virtual void setExtent( const QgsRectangle &rect );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -778,6 +778,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void dependenciesChanged();
 
+    /**
+     * Emitted in the destructor when the layer is about to be deleted,
+     * but it is still in a perfectly valid state: the last chance for
+     * other pieces of code for some cleanup if they use the layer.
+     * @note added in QGIS 3.0
+     */
+    void willBeDeleted();
+
   protected:
     //! Set the extent
     virtual void setExtent( const QgsRectangle &rect );

--- a/src/core/qgspluginlayer.cpp
+++ b/src/core/qgspluginlayer.cpp
@@ -24,6 +24,13 @@ QgsPluginLayer::QgsPluginLayer( const QString& layerType, const QString& layerNa
   setLegend( QgsMapLayerLegend::defaultPluginLegend( this ) );
 }
 
+QgsPluginLayer::~QgsPluginLayer()
+{
+  // TODO: shall we move the responsibility of emitting the signal to plugin
+  // layer implementations before they start doing their part of cleanup...?
+  emit willBeDeleted();
+}
+
 QString QgsPluginLayer::pluginLayerType()
 {
   return mPluginLayerType;

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -34,6 +34,7 @@ class CORE_EXPORT QgsPluginLayer : public QgsMapLayer
 
   public:
     QgsPluginLayer( const QString& layerType, const QString& layerName = QString() );
+    ~QgsPluginLayer();
 
     //! Return plugin layer type (the same as used in QgsPluginLayerRegistry)
     QString pluginLayerType();

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -172,6 +172,7 @@ QgsVectorLayer::QgsVectorLayer( const QString& vectorLayerPath,
 
 QgsVectorLayer::~QgsVectorLayer()
 {
+  emit willBeDeleted();
 
   mValid = false;
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -170,6 +170,8 @@ QgsRasterLayer::QgsRasterLayer( const QString & uri,
 
 QgsRasterLayer::~QgsRasterLayer()
 {
+  emit willBeDeleted();
+
   mValid = false;
   // Note: provider and other interfaces are owned and deleted by pipe
 }


### PR DESCRIPTION
This allows pieces of code that depend on map layers to listen directly
to the layer's notification rather than having to listen to project's
layersWillBeRemoved signal (and cycle through the whole list)