### PR TITLE
fix setRelationId description

### DIFF
--- a/python/core/qgsrelation.sip
+++ b/python/core/qgsrelation.sip
@@ -43,7 +43,7 @@ class QgsRelation
     void writeXml( QDomNode& node, QDomDocument& doc ) const;
 
     /**
-     * Set a name for this relation
+     * Set an id for this relation
      *
      * @param id
      */

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -86,7 +86,7 @@ class CORE_EXPORT QgsRelation
     void writeXml( QDomNode& node, QDomDocument& doc ) const;
 
     /**
-     * Set a name for this relation
+     * Set an id for this relation
      *
      * @param id
      */


### PR DESCRIPTION
setRelationId sets the relation id while setRelationName sets the name.

Should be backported.