### PR TITLE
Enable visibility of icons in Evis dialogs

### DIFF
--- a/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
+++ b/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
@@ -180,13 +180,6 @@ bool eVisGenericEventBrowserGui::initBrowser()
 
   chkboxUseOnlyFilename->setChecked( false );
 
-  QString myThemePath = QgsApplication::activeThemePath();
-  pbtnResetEventImagePathData->setIcon( QIcon( QPixmap( myThemePath + "/mActionDraw.svg" ) ) );
-  pbtnResetCompassBearingData->setIcon( QIcon( QPixmap( myThemePath + "/mActionDraw.svg" ) ) );
-  pbtnResetCompassOffsetData->setIcon( QIcon( QPixmap( myThemePath + "/mActionDraw.svg" ) ) );
-  pbtnResetBasePathData->setIcon( QIcon( QPixmap( myThemePath + "/mActionDraw.svg" ) ) );
-  pbtnResetUseOnlyFilenameData->setIcon( QIcon( QPixmap( myThemePath + "/mActionDraw.svg" ) ) );
-  pbtnResetApplyPathRulesToDocs->setIcon( QIcon( QPixmap( myThemePath + "/mActionDraw.svg" ) ) );
 
   chkboxSaveEventImagePathData->setChecked( false );
   chkboxSaveCompassBearingData->setChecked( false );
@@ -194,9 +187,6 @@ bool eVisGenericEventBrowserGui::initBrowser()
   chkboxSaveBasePathData->setChecked( false );
   chkboxSaveUseOnlyFilenameData->setChecked( false );
 
-  //Set up Configure External Application buttons
-  pbtnAddFileType->setIcon( QIcon( QPixmap( myThemePath + "/mActionNewAttribute.svg" ) ) );
-  pbtnDeleteFileType->setIcon( QIcon( QPixmap( myThemePath + "/mActionDeleteAttribute.svg" ) ) );
 
   //Check to for interface, not null when launched from plugin toolbar, otherwise expect map canvas
   if ( mInterface )

--- a/src/plugins/evis/eventbrowser/evisimagedisplaywidget.cpp
+++ b/src/plugins/evis/eventbrowser/evisimagedisplaywidget.cpp
@@ -52,7 +52,7 @@ eVisImageDisplayWidget::eVisImageDisplayWidget( QWidget* parent, Qt::WindowFlags
   pbtnZoomIn->setEnabled( false );
   pbtnZoomOut->setEnabled( false );
   pbtnZoomFull->setEnabled( false );
-  QString myThemePath = QgsApplication::activeThemePath();
+  QString myThemePath = QgsApplication::defaultThemePath();
   pbtnZoomIn->setToolTip( tr( "Zoom in" ) );
   pbtnZoomIn->setWhatsThis( tr( "Zoom in to see more detail." ) );
   pbtnZoomOut->setToolTip( tr( "Zoom out" ) );

--- a/src/plugins/evis/ui/evisdatabaseconnectionguibase.ui
+++ b/src/plugins/evis/ui/evisdatabaseconnectionguibase.ui
@@ -72,7 +72,7 @@
          </property>
          <property name="icon" >
           <iconset>
-           <normaloff>../../../images/themes/default/mActionFolder.svg</normaloff>../../../images/themes/default/mActionFolder.svg</iconset>
+           <normaloff>:/images/themes/default/mActionFolder.svg</normaloff>:/images/themes/default/mActionFolder.svg</iconset>
          </property>
         </widget>
        </item>
@@ -331,7 +331,7 @@ p, li { white-space: pre-wrap; }
          </property>
          <property name="icon" >
           <iconset>
-           <normaloff>../../../images/themes/default/mActionFolder.svg</normaloff>../../../images/themes/default/mActionFolder.svg</iconset>
+           <normaloff>:/images/themes/default/mActionFolder.svg</normaloff>:/images/themes/default/mActionFolder.svg</iconset>
          </property>
         </widget>
        </item>
@@ -506,6 +506,7 @@ p, li { white-space: pre-wrap; }
  </tabstops>
  <resources>
   <include location="../resources/evis.qrc" />
+  <include location="../../../../images/images.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/plugins/evis/ui/evisgenericeventbrowserguibase.ui
+++ b/src/plugins/evis/ui/evisgenericeventbrowserguibase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>766</width>
+    <width>801</width>
     <height>654</height>
    </rect>
   </property>
@@ -14,11 +14,20 @@
    <string/>
   </property>
   <property name="windowIcon">
-   <iconset resource="../resources/evis.qrc">
+   <iconset>
     <normaloff>:/evis/eVisEventBrowser.png</normaloff>:/evis/eVisEventBrowser.png</iconset>
   </property>
   <layout class="QVBoxLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
     <number>2</number>
    </property>
    <item>
@@ -34,121 +43,7 @@
        <string>Display</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0" rowspan="2" colspan="2">
-        <widget class="QLabel" name="labelCompassOffsetWarning">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>351</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="2" rowspan="2">
-        <widget class="QPushButton" name="pbtnPrevious">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string>Use the Previous button to display the previous photo when more than one photo is available for display.</string>
-         </property>
-         <property name="text">
-          <string>Previous</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3" rowspan="2">
-        <widget class="QPushButton" name="pbtnNext">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string>Use the Next button to display the next photo when more than one photo is available for display.</string>
-         </property>
-         <property name="text">
-          <string>Next</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0" colspan="4">
-        <widget class="QTreeWidget" name="treeEventData">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>125</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>125</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string>All of the attribute information for the point associated with the photo being viewed is displayed here. If the file type being referenced in the displayed record is not an image but is of a file type defined in the “Configure External Applications” tab then when you double-click on the value of the field containing the path to the file the application to open the file will be launched to view or hear the contents of the file. If the file extension is recognized the attribute data will be displayed in green.</string>
-         </property>
-         <column>
-          <property name="text">
-           <string>1</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="4">
-        <widget class="eVisImageDisplayWidget" name="imageDisplayArea" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Image display area</string>
-         </property>
-         <property name="whatsThis">
-          <string>Display area for the image.</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0" colspan="3">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>628</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="3">
+       <item row="4" column="1">
         <widget class="QDialogButtonBox" name="buttonBox">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -157,6 +52,124 @@
           <set>QDialogButtonBox::Close</set>
          </property>
         </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <layout class="QGridLayout" name="gridLayout_1">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="1" column="0" colspan="3">
+          <widget class="QTreeWidget" name="treeEventData">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>125</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>125</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>All of the attribute information for the point associated with the photo being viewed is displayed here. If the file type being referenced in the displayed record is not an image but is of a file type defined in the “Configure External Applications” tab then when you double-click on the value of the field containing the path to the file the application to open the file will be launched to view or hear the contents of the file. If the file extension is recognized the attribute data will be displayed in green.</string>
+           </property>
+           <column>
+            <property name="text">
+             <string>1</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="pbtnNext">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>Use the Next button to display the next photo when more than one photo is available for display.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../../images/images.qrc">
+             <normaloff>:/images/themes/default/mActionArrowRight.svg</normaloff>:/images/themes/default/mActionArrowRight.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="labelCompassOffsetWarning">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QPushButton" name="pbtnPrevious">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>Use the Previous button to display the previous photo when more than one photo is available for display.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../../images/images.qrc">
+             <normaloff>:/images/themes/default/mActionArrowLeft.svg</normaloff>:/images/themes/default/mActionArrowLeft.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="3">
+          <widget class="eVisImageDisplayWidget" name="imageDisplayArea" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Image display area</string>
+           </property>
+           <property name="whatsThis">
+            <string>Display area for the image.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -178,28 +191,6 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QComboBox" name="cboxEventImagePathField">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>150</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>Use the drop-down list to select the field containing a directory path to the image. This can be an absolute or relative path.</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="3" colspan="3">
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
@@ -212,48 +203,6 @@
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="chkboxEventImagePathRelative">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>If checked the path to the image will be defined appending the attribute in the field selected from the “Attribute Containing Path to Image” drop-down list to the “Base Path” defined below.</string>
-            </property>
-            <property name="text">
-             <string>Path is relative</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="3">
-           <spacer>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>251</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="4">
-           <widget class="QCheckBox" name="chkboxSaveEventImagePathData">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>If checked, the relative path values will be saved for the next session.</string>
-            </property>
-            <property name="layoutDirection">
-             <enum>Qt::LeftToRight</enum>
-            </property>
-            <property name="text">
-             <string>Remember this</string>
-            </property>
-           </widget>
           </item>
           <item row="1" column="5">
            <widget class="QPushButton" name="pbtnResetEventImagePathData">
@@ -276,8 +225,8 @@
              <string>Reset</string>
             </property>
             <property name="icon">
-             <iconset>
-              <normaloff>../../../images/themes/default/mActionDraw.svg</normaloff>../../../images/themes/default/mActionDraw.svg</iconset>
+             <iconset resource="../../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionDraw.svg</normaloff>:/images/themes/default/mActionDraw.svg</iconset>
             </property>
             <property name="iconSize">
              <size>
@@ -286,6 +235,70 @@
              </size>
             </property>
            </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QComboBox" name="cboxEventImagePathField">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>150</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the drop-down list to select the field containing a directory path to the image. This can be an absolute or relative path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="whatsThis">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="chkboxEventImagePathRelative">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked the path to the image will be defined appending the attribute in the field selected from the “Attribute Containing Path to Image” drop-down list to the “Base Path” defined below.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Path is relative</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QCheckBox" name="chkboxSaveEventImagePathData">
+            <property name="toolTip">
+             <string>If checked, the relative path values will be saved for the next session.</string>
+            </property>
+            <property name="whatsThis">
+             <string notr="true"/>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Remember this</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="3">
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>251</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -296,13 +309,6 @@
           <string>Compass bearing</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Attribute containing compass bearing</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QComboBox" name="cboxCompassBearingField">
             <property name="sizePolicy">
@@ -318,36 +324,10 @@
              </size>
             </property>
             <property name="toolTip">
-             <string/>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the drop-down list to select the field containing the compass bearing for the image.&lt;/p&gt;&lt;p&gt;This bearing usually references the direction the camera was pointing when the image was acquired. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="whatsThis">
-             <string>Use the drop-down list to select the field containing the compass bearing for the image. This bearing usually references the direction the camera was pointing when the image was acquired. </string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="3">
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>268</width>
-              <height>24</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="chkboxDisplayCompassBearing">
-            <property name="toolTip">
              <string/>
-            </property>
-            <property name="whatsThis">
-             <string>If checked an arrow pointing in the direction defined by the attribute in the field selected from the drop-down list to the right will be displayed in the QGIS window on top of the point for this image.</string>
-            </property>
-            <property name="text">
-             <string>Display compass bearing</string>
             </property>
            </widget>
           </item>
@@ -363,22 +343,6 @@
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="1" column="3">
-           <widget class="QCheckBox" name="chkboxSaveCompassBearingData">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>If checked, the Display Compass Bearing values will be saved for the next session.</string>
-            </property>
-            <property name="layoutDirection">
-             <enum>Qt::LeftToRight</enum>
-            </property>
-            <property name="text">
-             <string>Remember this</string>
-            </property>
-           </widget>
           </item>
           <item row="1" column="4">
            <widget class="QPushButton" name="pbtnResetCompassBearingData">
@@ -398,8 +362,8 @@
              <string>Reset</string>
             </property>
             <property name="icon">
-             <iconset>
-              <normaloff>../../../images/themes/default/mActionDraw.svg</normaloff>../../../images/themes/default/mActionDraw.svg</iconset>
+             <iconset resource="../../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionDraw.svg</normaloff>:/images/themes/default/mActionDraw.svg</iconset>
             </property>
             <property name="iconSize">
              <size>
@@ -408,6 +372,55 @@
              </size>
             </property>
            </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Attribute containing compass bearing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="chkboxDisplayCompassBearing">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked an arrow pointing in the direction defined by the attribute in the field selected from the drop-down list&lt;/p&gt;&lt;p&gt;to the right will be displayed in the QGIS window on top of the point for this image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Display compass bearing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QCheckBox" name="chkboxSaveCompassBearingData">
+            <property name="toolTip">
+             <string>If checked, the Display Compass Bearing values will be saved for the next session.</string>
+            </property>
+            <property name="whatsThis">
+             <string notr="true"/>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Remember this</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2" colspan="3">
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>268</width>
+              <height>24</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -418,92 +431,61 @@
           <string>Compass offset</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_4">
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="rbtnManualCompassOffset">
+          <item row="2" column="4">
+           <widget class="QCheckBox" name="chkboxSaveCompassOffsetData">
             <property name="toolTip">
-             <string/>
+             <string>If checked, the compass offset values will be saved for the next session.</string>
             </property>
             <property name="whatsThis">
-             <string>Define the compass offset manually.</string>
+             <string notr="true"/>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
             </property>
             <property name="text">
-             <string>Manual</string>
+             <string>Remember this</string>
             </property>
            </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="dsboxCompassOffset">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>A value to be added to the compass bearing. This allows you to compensate for declination (adjust bearings collected using magnetic bearings to true north bearings). East declinations should be entered using positive values and west declinations should use negative values. </string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>-180.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>180.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="4">
-           <spacer name="horizontalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>430</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item row="1" column="0">
            <widget class="QRadioButton" name="rbtnAttributeCompassOffset">
             <property name="toolTip">
-             <string/>
+             <string>Define the compass offset using a field from the vector layer attribute table.</string>
             </property>
             <property name="whatsThis">
-             <string>Define the compass offset using a field from the vector layer attribute table.</string>
+             <string notr="true"/>
             </property>
             <property name="text">
              <string> From Attribute</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QComboBox" name="cboxCompassOffsetField">
+          <item row="2" column="5">
+           <widget class="QPushButton" name="pbtnResetCompassOffsetData">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>150</width>
-              <height>0</height>
-             </size>
-            </property>
             <property name="toolTip">
-             <string/>
+             <string>Reset to default</string>
             </property>
             <property name="whatsThis">
-             <string>Use the drop-down list to select the field containing the compass bearing offset. This allows you to compensate for declination (adjust bearings collected using magnetic bearings to true north bearings). East declinations should be entered using positive values and west declinations should use negative values. </string>
+             <string>Resets the compass offset values to the default settings.</string>
+            </property>
+            <property name="text">
+             <string>Reset</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionDraw.svg</normaloff>:/images/themes/default/mActionDraw.svg</iconset>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
             </property>
            </widget>
           </item>
@@ -533,50 +515,81 @@
             </property>
            </spacer>
           </item>
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="chkboxSaveCompassOffsetData">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>If checked, the compass offset values will be saved for the next session.</string>
-            </property>
-            <property name="layoutDirection">
-             <enum>Qt::LeftToRight</enum>
-            </property>
-            <property name="text">
-             <string>Remember this</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="5">
-           <widget class="QPushButton" name="pbtnResetCompassOffsetData">
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="dsboxCompassOffset">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset to default</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A value to be added to the compass bearing.&lt;/p&gt;&lt;p&gt;This allows you to compensate for declination (adjust bearings collected using magnetic bearings to true north bearings). East declinations should be entered using positive values and west declinations should use negative values. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="whatsThis">
-             <string>Resets the compass offset values to the default settings.</string>
+             <string/>
             </property>
-            <property name="text">
-             <string>Reset</string>
+            <property name="decimals">
+             <number>1</number>
             </property>
-            <property name="icon">
-             <iconset>
-              <normaloff>../../../images/themes/default/mActionDraw.svg</normaloff>../../../images/themes/default/mActionDraw.svg</iconset>
+            <property name="minimum">
+             <double>-180.000000000000000</double>
             </property>
-            <property name="iconSize">
-             <size>
-              <width>16</width>
-              <height>16</height>
-             </size>
+            <property name="maximum">
+             <double>180.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>1.000000000000000</double>
             </property>
            </widget>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="QComboBox" name="cboxCompassOffsetField">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>150</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the drop-down list to select the field containing the compass bearing offset.&lt;/p&gt;&lt;p&gt;This allows you to compensate for declination (adjust bearings collected using magnetic bearings to true north bearings). East declinations should be entered using positive values and west declinations should use negative values. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="rbtnManualCompassOffset">
+            <property name="toolTip">
+             <string>Define the compass offset manually.</string>
+            </property>
+            <property name="whatsThis">
+             <string notr="true"/>
+            </property>
+            <property name="text">
+             <string>Manual</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2" colspan="4">
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>430</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -623,20 +636,20 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Base Path</string>
+             <string>The Base Path onto which the relative path defined above will be appended.</string>
             </property>
             <property name="whatsThis">
-             <string>The Base Path onto which the relative path defined above will be appended.</string>
+             <string/>
             </property>
            </widget>
           </item>
           <item row="1" column="2" colspan="2">
            <widget class="QCheckBox" name="chkboxSaveBasePathData">
             <property name="toolTip">
-             <string/>
+             <string>If checked, the Base Path will be saved for the next session.</string>
             </property>
             <property name="whatsThis">
-             <string>If checked, the Base Path will be saved for the next session.</string>
+             <string notr="true"/>
             </property>
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>
@@ -664,8 +677,8 @@
              <string>Reset</string>
             </property>
             <property name="icon">
-             <iconset>
-              <normaloff>../../../images/themes/default/mActionDraw.svg</normaloff>../../../images/themes/default/mActionDraw.svg</iconset>
+             <iconset resource="../../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionDraw.svg</normaloff>:/images/themes/default/mActionDraw.svg</iconset>
             </property>
             <property name="iconSize">
              <size>
@@ -684,10 +697,10 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string/>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the Base Path will append only the file name instead of the entire relative path (defined above) to create the full directory path to the file. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="whatsThis">
-             <string>If checked, the Base Path will append only the file name instead of the entire relative path (defined above) to create the full directory path to the file. </string>
+             <string notr="true"/>
             </property>
             <property name="text">
              <string>Replace entire path/url stored in image path attribute with user defined
@@ -698,10 +711,10 @@ Base Path (i.e. keep only filename from attribute)</string>
           <item row="2" column="2" colspan="2">
            <widget class="QCheckBox" name="chkboxSaveUseOnlyFilenameData">
             <property name="toolTip">
-             <string/>
+             <string>If checked, the current check-box setting will be saved for the next session.</string>
             </property>
             <property name="whatsThis">
-             <string>If checked, the current check-box setting will be saved for the next session.</string>
+             <string notr="true"/>
             </property>
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>
@@ -729,8 +742,8 @@ Base Path (i.e. keep only filename from attribute)</string>
              <string>Reset</string>
             </property>
             <property name="icon">
-             <iconset>
-              <normaloff>../../../images/themes/default/mActionDraw.svg</normaloff>../../../images/themes/default/mActionDraw.svg</iconset>
+             <iconset resource="../../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionDraw.svg</normaloff>:/images/themes/default/mActionDraw.svg</iconset>
             </property>
             <property name="iconSize">
              <size>
@@ -749,10 +762,10 @@ Base Path (i.e. keep only filename from attribute)</string>
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string/>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the same path rules that are defined for images will be used for non-image documents such as movies, text documents, and sound files.&lt;/p&gt;&lt;p&gt;If not checked the path rules will only apply to images and other documents will ignore the Base Path parameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="whatsThis">
-             <string>If checked, the same path rules that are defined for images will be used for non-image documents such as movies, text documents, and sound files. If not checked the path rules will only apply to images and other documents will ignore the Base Path parameter.</string>
+             <string notr="true"/>
             </property>
             <property name="text">
              <string>Apply Path to Image rules when loading docs in external applications</string>
@@ -762,10 +775,10 @@ Base Path (i.e. keep only filename from attribute)</string>
           <item row="3" column="2" colspan="2">
            <widget class="QCheckBox" name="chkboxSaveApplyPathRulesToDocs">
             <property name="toolTip">
-             <string/>
+             <string>If checked, the current check-box setting will be saved for the next session.</string>
             </property>
             <property name="whatsThis">
-             <string>If checked, the current check-box setting will be saved for the next session.</string>
+             <string notr="true"/>
             </property>
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>
@@ -793,8 +806,8 @@ Base Path (i.e. keep only filename from attribute)</string>
              <string>Reset</string>
             </property>
             <property name="icon">
-             <iconset>
-              <normaloff>../../../images/themes/default/mActionDraw.svg</normaloff>../../../images/themes/default/mActionDraw.svg</iconset>
+             <iconset resource="../../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionDraw.svg</normaloff>:/images/themes/default/mActionDraw.svg</iconset>
             </property>
             <property name="iconSize">
              <size>
@@ -817,10 +830,10 @@ Base Path (i.e. keep only filename from attribute)</string>
        <item row="5" column="0">
         <widget class="QDialogButtonBox" name="buttonboxOptions">
          <property name="toolTip">
-          <string/>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clicking on Save will save the settings without closing the Options pane.&lt;/p&gt;&lt;p&gt;Clicking on Restore Defaults will reset all of the fields to their default settings.&lt;/p&gt;&lt;p&gt;It has the same effect as clicking all of the “Reset to default” buttons. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="whatsThis">
-          <string>Clicking on Save will save the settings without closing the Options pane. Clicking on Restore Defaults will reset all of the fields to their default settings. It has the same effect as clicking all of the “Reset to default” buttons. </string>
+          <string notr="true"/>
          </property>
          <property name="standardButtons">
           <set>QDialogButtonBox::RestoreDefaults|QDialogButtonBox::Save</set>
@@ -905,8 +918,8 @@ Base Path (i.e. keep only filename from attribute)</string>
             <string/>
            </property>
            <property name="icon">
-            <iconset>
-             <normaloff>../../../images/themes/default/mActionNewAttribute.svg</normaloff>../../../images/themes/default/mActionNewAttribute.svg</iconset>
+            <iconset resource="../../../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
            </property>
           </widget>
          </item>
@@ -922,8 +935,8 @@ Base Path (i.e. keep only filename from attribute)</string>
             <string/>
            </property>
            <property name="icon">
-            <iconset>
-             <normaloff>../../../images/themes/default/mActionDeleteAttribute.svg</normaloff>../../../images/themes/default/mActionDeleteAttribute.svg</iconset>
+            <iconset resource="../../../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
            </property>
           </widget>
          </item>
@@ -956,10 +969,6 @@ Base Path (i.e. keep only filename from attribute)</string>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>pbtnPrevious</tabstop>
-  <tabstop>pbtnNext</tabstop>
-  <tabstop>treeEventData</tabstop>
-  <tabstop>buttonBox</tabstop>
   <tabstop>cboxEventImagePathField</tabstop>
   <tabstop>chkboxEventImagePathRelative</tabstop>
   <tabstop>chkboxSaveEventImagePathData</tabstop>
@@ -971,6 +980,7 @@ Base Path (i.e. keep only filename from attribute)</string>
   <tabstop>rbtnManualCompassOffset</tabstop>
   <tabstop>dsboxCompassOffset</tabstop>
   <tabstop>rbtnAttributeCompassOffset</tabstop>
+  <tabstop>cboxCompassOffsetField</tabstop>
   <tabstop>chkboxSaveCompassOffsetData</tabstop>
   <tabstop>pbtnResetCompassOffsetData</tabstop>
   <tabstop>leBasePath</tabstop>
@@ -985,12 +995,10 @@ Base Path (i.e. keep only filename from attribute)</string>
   <tabstop>tableFileTypeAssociations</tabstop>
   <tabstop>pbtnAddFileType</tabstop>
   <tabstop>pbtnDeleteFileType</tabstop>
-  <tabstop>cboxCompassOffsetField</tabstop>
   <tabstop>displayArea</tabstop>
-  <tabstop>buttonboxOptions</tabstop>
  </tabstops>
  <resources>
-  <include location="../resources/evis.qrc"/>
+  <include location="../../../../images/images.qrc"/>
  </resources>
  <connections>
   <connection>


### PR DESCRIPTION
Currently, icons are not displayed in Evis dialogs. Also:
* add next and previous icons instead of text - before (bottom) vs after (top)
![image](https://cloud.githubusercontent.com/assets/7983394/22043910/3648e0e6-dd12-11e6-978b-a67c7ec610d4.png)

* add + and - buttons insted of attributes related icons  - before (bottom) vs after (top)
![image](https://cloud.githubusercontent.com/assets/7983394/22044240/f3563cb4-dd13-11e6-99dd-fe264f297b27.png)
* move some "what's this" comments to "tooltip" (they were not readable on my ubuntu xenial and not sure we keep using "what's this" feature)
* organize widgets within a group box

The event browser dialog still needs some love (see https://github.com/qgis/qgis3_UIX_discussion/issues/29)