### PR TITLE
Fix tab focus order in dialogs

### DIFF
--- a/src/ui/composer/qgscomposerattributetablewidgetbase.ui
+++ b/src/ui/composer/qgscomposerattributetablewidgetbase.ui
@@ -17,16 +17,7 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -840,6 +831,8 @@
   <tabstop>mShowGridGroupCheckBox</tabstop>
   <tabstop>mGridStrokeWidthSpinBox</tabstop>
   <tabstop>mGridColorButton</tabstop>
+  <tabstop>mDrawHorizontalGrid</tabstop>
+  <tabstop>mDrawVerticalGrid</tabstop>
   <tabstop>groupBox_3</tabstop>
   <tabstop>mHeaderFontPushButton</tabstop>
   <tabstop>mHeaderFontColorButton</tabstop>

--- a/src/ui/composer/qgscomposermapgridwidgetbase.ui
+++ b/src/ui/composer/qgscomposermapgridwidgetbase.ui
@@ -777,6 +777,7 @@
   <tabstop>mGridLineStyleButton</tabstop>
   <tabstop>mGridMarkerStyleButton</tabstop>
   <tabstop>mGridBlendComboBox</tabstop>
+  <tabstop>mGridFrameGroupBox</tabstop>
   <tabstop>mFrameStyleComboBox</tabstop>
   <tabstop>mFrameWidthSpinBox</tabstop>
   <tabstop>mGridFramePenSizeSpinBox</tabstop>
@@ -791,6 +792,7 @@
   <tabstop>mCheckGridRightSide</tabstop>
   <tabstop>mCheckGridTopSide</tabstop>
   <tabstop>mCheckGridBottomSide</tabstop>
+  <tabstop>mDrawAnnotationGroupBox</tabstop>
   <tabstop>mAnnotationFormatComboBox</tabstop>
   <tabstop>mAnnotationFormatButton</tabstop>
   <tabstop>mAnnotationDisplayLeftComboBox</tabstop>
@@ -806,6 +808,7 @@
   <tabstop>mAnnotationPositionBottomComboBox</tabstop>
   <tabstop>mAnnotationDirectionComboBoxBottom</tabstop>
   <tabstop>mAnnotationFontButton</tabstop>
+  <tabstop>mAnnotationFontColorButton</tabstop>
   <tabstop>mDistanceToMapFrameSpinBox</tabstop>
   <tabstop>mCoordinatePrecisionSpinBox</tabstop>
  </tabstops>

--- a/src/ui/composer/qgscomposermapwidgetbase.ui
+++ b/src/ui/composer/qgscomposermapwidgetbase.ui
@@ -23,16 +23,7 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -827,8 +818,8 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>groupBox</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>mPreviewModeComboBox</tabstop>
   <tabstop>mUpdatePreviewButton</tabstop>
   <tabstop>mScaleLineEdit</tabstop>
@@ -867,6 +858,8 @@
   <tabstop>mGridUpButton</tabstop>
   <tabstop>mGridDownButton</tabstop>
   <tabstop>mGridListWidget</tabstop>
+  <tabstop>mDrawGridCheckBox</tabstop>
+  <tabstop>mGridPropertiesButton</tabstop>
   <tabstop>mOverviewsGroupBox</tabstop>
   <tabstop>mAddOverviewPushButton</tabstop>
   <tabstop>mRemoveOverviewPushButton</tabstop>

--- a/src/ui/composer/qgscomposerpolygonwidgetbase.ui
+++ b/src/ui/composer/qgscomposerpolygonwidgetbase.ui
@@ -104,8 +104,8 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>groupBox</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>mPolygonStyleButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/composer/qgscomposerpolylinewidgetbase.ui
+++ b/src/ui/composer/qgscomposerpolylinewidgetbase.ui
@@ -92,6 +92,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>mLineStyleButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -242,12 +242,26 @@
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mFieldFormatComboBox</tabstop>
+  <tabstop>mFieldFormatEdit</tabstop>
+  <tabstop>mFieldHelpToolButton</tabstop>
+  <tabstop>mDisplayFormatComboBox</tabstop>
+  <tabstop>mDisplayFormatEdit</tabstop>
+  <tabstop>mDisplayHelpToolButton</tabstop>
+  <tabstop>mCalendarPopupCheckBox</tabstop>
+  <tabstop>mAllowNullCheckBox</tabstop>
+  <tabstop>mHelpScrollArea</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
+++ b/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
@@ -45,7 +45,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-210</y>
+        <y>0</y>
         <width>465</width>
         <height>621</height>
        </rect>

--- a/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
@@ -227,13 +227,14 @@
  </customwidgets>
  <tabstops>
   <tabstop>rangeWidget</tabstop>
-  <tabstop>minimumDoubleSpinBox</tabstop>
-  <tabstop>maximumDoubleSpinBox</tabstop>
-  <tabstop>stepDoubleSpinBox</tabstop>
   <tabstop>minimumSpinBox</tabstop>
   <tabstop>maximumSpinBox</tabstop>
   <tabstop>stepSpinBox</tabstop>
+  <tabstop>minimumDoubleSpinBox</tabstop>
+  <tabstop>maximumDoubleSpinBox</tabstop>
+  <tabstop>stepDoubleSpinBox</tabstop>
   <tabstop>allowNullCheckBox</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>suffixLineEdit</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -40,6 +40,10 @@
    </item>
    <item row="0" column="1">
     <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true"/>
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_2">
@@ -100,7 +104,7 @@
          <string>...</string>
         </property>
         <property name="icon">
-         <iconset resource="../../../images/images.qrc">
+         <iconset>
           <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
         </property>
        </widget>
@@ -172,12 +176,14 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mExpressionWidget</tabstop>
   <tabstop>mComboRelation</tabstop>
   <tabstop>mCbxAllowNull</tabstop>
   <tabstop>mCbxOrderByValue</tabstop>
   <tabstop>mCbxShowForm</tabstop>
   <tabstop>mCbxMapIdentification</tabstop>
   <tabstop>mCbxReadOnly</tabstop>
+  <tabstop>mCbxAllowAddFeatures</tabstop>
   <tabstop>mFilterGroupBox</tabstop>
   <tabstop>mAvailableFieldsList</tabstop>
   <tabstop>mAddFilterButton</tabstop>

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -39,7 +39,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true"/>
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::TabFocus</enum>
      </property>

--- a/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
@@ -94,6 +94,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>loadFromLayerButton</tabstop>
+  <tabstop>loadFromCSVButton</tabstop>
+  <tabstop>tableWidget</tabstop>
+  <tabstop>addNullButton</tabstop>
+  <tabstop>removeSelectedButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsaddattrdialogbase.ui
+++ b/src/ui/qgsaddattrdialogbase.ui
@@ -128,7 +128,6 @@
   <tabstop>mTypeBox</tabstop>
   <tabstop>mLength</tabstop>
   <tabstop>mPrec</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsaddtaborgroupbase.ui
+++ b/src/ui/qgsaddtaborgroupbase.ui
@@ -115,7 +115,7 @@
   <tabstop>mTabButton</tabstop>
   <tabstop>mGroupButton</tabstop>
   <tabstop>mTabList</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>mColumnCountSpinBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsalignrasterdialog.ui
+++ b/src/ui/qgsalignrasterdialog.ui
@@ -237,6 +237,7 @@
   <tabstop>mViewLayers</tabstop>
   <tabstop>mCboReferenceLayer</tabstop>
   <tabstop>mChkCustomCRS</tabstop>
+  <tabstop>mCrsSelector</tabstop>
   <tabstop>mChkCustomCellSize</tabstop>
   <tabstop>mSpinCellSizeX</tabstop>
   <tabstop>mSpinCellSizeY</tabstop>

--- a/src/ui/qgsattributeactiondialogbase.ui
+++ b/src/ui/qgsattributeactiondialogbase.ui
@@ -255,11 +255,15 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mAttributeActionTable</tabstop>
+  <tabstop>groupBoxActionList</tabstop>
   <tabstop>mMoveUpButton</tabstop>
   <tabstop>mMoveDownButton</tabstop>
   <tabstop>mRemoveButton</tabstop>
+  <tabstop>mAddButton</tabstop>
   <tabstop>mAddDefaultActionsButton</tabstop>
+  <tabstop>mShowInAttributeTable</tabstop>
+  <tabstop>mAttributeTableWidgetType</tabstop>
+  <tabstop>mAttributeActionTable</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsattributeactionpropertiesdialogbase.ui
+++ b/src/ui/qgsattributeactionpropertiesdialogbase.ui
@@ -136,7 +136,11 @@
       <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QgsFieldExpressionWidget" name="mFieldExpression"/>
+         <widget class="QgsFieldExpressionWidget" name="mFieldExpression">
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="mInsertFieldOrExpression">
@@ -252,6 +256,9 @@
    </item>
    <item row="4" column="0" colspan="3">
     <widget class="QGroupBox" name="mActionScopesGroupBox">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="title">
       <string>Action Scopes</string>
      </property>
@@ -281,7 +288,9 @@
   <tabstop>mShortTitle</tabstop>
   <tabstop>mActionIcon</tabstop>
   <tabstop>mChooseIconButton</tabstop>
+  <tabstop>mActionScopesGroupBox</tabstop>
   <tabstop>mBrowseButton</tabstop>
+  <tabstop>mFieldExpression</tabstop>
   <tabstop>mInsertFieldOrExpression</tabstop>
  </tabstops>
  <resources>

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -240,6 +240,9 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
        </widget>
       </item>
       <item>
@@ -651,6 +654,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>mFieldCombo</tabstop>
+  <tabstop>mUpdateExpressionText</tabstop>
   <tabstop>mRunFieldCalc</tabstop>
   <tabstop>mRunFieldCalcSelected</tabstop>
   <tabstop>mFilterButton</tabstop>

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -16,6 +16,9 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="1">
     <widget class="QgsCollapsibleGroupBox" name="groupBox">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
      <property name="title">
       <string>Constraints</string>
      </property>
@@ -210,6 +213,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>selectionListWidget</tabstop>
   <tabstop>isFieldEditableCheckBox</tabstop>
   <tabstop>labelOnTopCheckBox</tabstop>
   <tabstop>mExpressionWidget</tabstop>
@@ -221,7 +225,6 @@
   <tabstop>constraintExpressionWidget</tabstop>
   <tabstop>leConstraintExpressionDescription</tabstop>
   <tabstop>mCheckBoxEnforceExpression</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -32,6 +32,9 @@
        <height>16777215</height>
       </size>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
     </widget>
    </item>
    <item row="1" column="0">
@@ -200,12 +203,6 @@
   <zorder>label_10</zorder>
   <zorder>mExpressionWidget</zorder>
   <zorder>label_3</zorder>
-  <zorder>viewCategories</zorder>
-  <zorder>btnChangeCategorizedSymbol</zorder>
-  <zorder>label_9</zorder>
-  <zorder>label_10</zorder>
-  <zorder>mExpressionWidget</zorder>
-  <zorder>label_3</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -222,11 +219,15 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mExpressionWidget</tabstop>
+  <tabstop>btnChangeCategorizedSymbol</tabstop>
+  <tabstop>btnColorRamp</tabstop>
   <tabstop>btnAddCategories</tabstop>
   <tabstop>btnAddCategory</tabstop>
   <tabstop>btnDeleteCategories</tabstop>
   <tabstop>btnDeleteAllCategories</tabstop>
   <tabstop>btnAdvanced</tabstop>
+  <tabstop>viewCategories</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscompoundcolorwidget.ui
+++ b/src/ui/qgscompoundcolorwidget.ui
@@ -964,6 +964,38 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mTabWidget</tabstop>
+  <tabstop>mSchemeComboBox</tabstop>
+  <tabstop>mSchemeToolButton</tabstop>
+  <tabstop>mAddColorToSchemeButton</tabstop>
+  <tabstop>mRemoveColorsFromSchemeButton</tabstop>
+  <tabstop>mSpinBoxRadius</tabstop>
+  <tabstop>mSampleButton</tabstop>
+  <tabstop>mHueRadio</tabstop>
+  <tabstop>mSaturationRadio</tabstop>
+  <tabstop>mValueRadio</tabstop>
+  <tabstop>mRedRadio</tabstop>
+  <tabstop>mGreenRadio</tabstop>
+  <tabstop>mBlueRadio</tabstop>
+  <tabstop>mAddCustomColorButton</tabstop>
+  <tabstop>mSwatchButton1</tabstop>
+  <tabstop>mSwatchButton9</tabstop>
+  <tabstop>mSwatchButton2</tabstop>
+  <tabstop>mSwatchButton10</tabstop>
+  <tabstop>mSwatchButton3</tabstop>
+  <tabstop>mSwatchButton11</tabstop>
+  <tabstop>mSwatchButton4</tabstop>
+  <tabstop>mSwatchButton12</tabstop>
+  <tabstop>mSwatchButton5</tabstop>
+  <tabstop>mSwatchButton13</tabstop>
+  <tabstop>mSwatchButton6</tabstop>
+  <tabstop>mSwatchButton14</tabstop>
+  <tabstop>mSwatchButton7</tabstop>
+  <tabstop>mSwatchButton15</tabstop>
+  <tabstop>mSwatchButton8</tabstop>
+  <tabstop>mSwatchButton16</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsconfigureshortcutsdialog.ui
+++ b/src/ui/qgsconfigureshortcutsdialog.ui
@@ -46,7 +46,7 @@
      <item>
       <widget class="QPushButton" name="btnChangeShortcut">
        <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
+        <enum>Qt::StrongFocus</enum>
        </property>
        <property name="text">
         <string>Change</string>
@@ -125,12 +125,13 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mLeFilter</tabstop>
   <tabstop>treeActions</tabstop>
+  <tabstop>btnChangeShortcut</tabstop>
   <tabstop>btnSetNoShortcut</tabstop>
   <tabstop>btnResetShortcut</tabstop>
   <tabstop>btnLoadShortcuts</tabstop>
   <tabstop>btnSaveShortcuts</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgscustomprojectiondialogbase.ui
+++ b/src/ui/qgscustomprojectiondialogbase.ui
@@ -31,6 +31,9 @@
    </item>
    <item row="0" column="0">
     <widget class="QScrollArea" name="scrollArea">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -314,17 +317,17 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>scrollArea</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>leNameList</tabstop>
   <tabstop>pbnAdd</tabstop>
   <tabstop>pbnRemove</tabstop>
   <tabstop>pbnCopyCRS</tabstop>
   <tabstop>leName</tabstop>
   <tabstop>teParameters</tabstop>
+  <tabstop>groupBox_2</tabstop>
   <tabstop>northWGS84</tabstop>
   <tabstop>eastWGS84</tabstop>
   <tabstop>pbnCalculate</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsdb2newconnectionbase.ui
+++ b/src/ui/qgsdb2newconnectionbase.ui
@@ -190,6 +190,8 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>txtName</tabstop>
+  <tabstop>txtService</tabstop>
   <tabstop>txtDriver</tabstop>
   <tabstop>txtHost</tabstop>
   <tabstop>txtPort</tabstop>
@@ -199,7 +201,7 @@
   <tabstop>chkStoreUsername</tabstop>
   <tabstop>txtPassword</tabstop>
   <tabstop>chkStorePassword</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>btnConnect</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -768,7 +768,7 @@
      <item row="1" column="1">
       <widget class="QStackedWidget" name="swFileFormat">
        <property name="currentIndex">
-        <number>2</number>
+        <number>1</number>
        </property>
        <widget class="QWidget" name="swpCSVOptions">
         <layout class="QVBoxLayout" name="verticalLayout_4"/>
@@ -1112,6 +1112,14 @@
   <tabstop>delimiterChars</tabstop>
   <tabstop>delimiterRegexp</tabstop>
   <tabstop>txtDelimiterRegexp</tabstop>
+  <tabstop>cbxDelimComma</tabstop>
+  <tabstop>cbxDelimTab</tabstop>
+  <tabstop>cbxDelimSpace</tabstop>
+  <tabstop>cbxDelimColon</tabstop>
+  <tabstop>cbxDelimSemicolon</tabstop>
+  <tabstop>txtDelimiterOther</tabstop>
+  <tabstop>txtQuoteChars</tabstop>
+  <tabstop>txtEscapeChars</tabstop>
   <tabstop>rowCounter</tabstop>
   <tabstop>cbxUseHeader</tabstop>
   <tabstop>cbxTrimFields</tabstop>
@@ -1123,21 +1131,12 @@
   <tabstop>cmbXField</tabstop>
   <tabstop>cmbYField</tabstop>
   <tabstop>cbxXyDms</tabstop>
+  <tabstop>cmbWktField</tabstop>
+  <tabstop>cmbGeometryType</tabstop>
   <tabstop>cbxSpatialIndex</tabstop>
   <tabstop>cbxSubsetIndex</tabstop>
   <tabstop>cbxWatchFile</tabstop>
   <tabstop>tblSample</tabstop>
-  <tabstop>buttonBox</tabstop>
-  <tabstop>cbxDelimTab</tabstop>
-  <tabstop>cbxDelimSpace</tabstop>
-  <tabstop>cbxDelimColon</tabstop>
-  <tabstop>cmbWktField</tabstop>
-  <tabstop>cmbGeometryType</tabstop>
-  <tabstop>cbxDelimSemicolon</tabstop>
-  <tabstop>txtDelimiterOther</tabstop>
-  <tabstop>txtQuoteChars</tabstop>
-  <tabstop>txtEscapeChars</tabstop>
-  <tabstop>cbxDelimComma</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -246,12 +246,13 @@
   <tabstop>leDrawing</tabstop>
   <tabstop>pbImportDrawing</tabstop>
   <tabstop>pbBrowseDrawing</tabstop>
+  <tabstop>cbExpandInserts</tabstop>
+  <tabstop>cbUseCurves</tabstop>
   <tabstop>leLayerGroup</tabstop>
   <tabstop>mLayers</tabstop>
   <tabstop>cbMergeLayers</tabstop>
   <tabstop>pbDeselectAll</tabstop>
   <tabstop>pbSelectAll</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -73,6 +73,9 @@
    </item>
    <item row="2" column="1" colspan="2">
     <widget class="QgsScaleWidget" name="mScaleWidget">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="showCurrentScaleButton">
       <bool>true</bool>
      </property>
@@ -194,14 +197,15 @@
   <tabstop>mFileLineEdit</tabstop>
   <tabstop>mFileSelectionButton</tabstop>
   <tabstop>mSymbologyModeComboBox</tabstop>
+  <tabstop>mScaleWidget</tabstop>
   <tabstop>mEncoding</tabstop>
   <tabstop>mVisibilityPresets</tabstop>
+  <tabstop>mCrsSelector</tabstop>
   <tabstop>mTreeView</tabstop>
   <tabstop>mSelectAllButton</tabstop>
   <tabstop>mDeselectAllButton</tabstop>
   <tabstop>mLayerTitleAsName</tabstop>
   <tabstop>mMapExtentCheckBox</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsexpressionselectiondialogbase.ui
+++ b/src/ui/qgsexpressionselectiondialogbase.ui
@@ -90,6 +90,11 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mButtonZoomToFeatures</tabstop>
+  <tabstop>mButtonSelect</tabstop>
+  <tabstop>mPbnClose</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsfieldspropertiesbase.ui
+++ b/src/ui/qgsfieldspropertiesbase.ui
@@ -619,6 +619,9 @@ Reference in function name: my_form_open
   <tabstop>mInitFunctionLineEdit</tabstop>
   <tabstop>mInitFilePathLineEdit</tabstop>
   <tabstop>pbtnSelectInitFilePath</tabstop>
+  <tabstop>mEditFormLineEdit</tabstop>
+  <tabstop>pbnSelectEditForm</tabstop>
+  <tabstop>mFieldsGroupBox</tabstop>
   <tabstop>mAddAttributeButton</tabstop>
   <tabstop>mDeleteAttributeButton</tabstop>
   <tabstop>mToggleEditingButton</tabstop>
@@ -628,9 +631,9 @@ Reference in function name: my_form_open
   <tabstop>mAddItemButton</tabstop>
   <tabstop>mMoveUpItem</tabstop>
   <tabstop>mMoveDownItem</tabstop>
+  <tabstop>mRelationsFrame</tabstop>
+  <tabstop>mPythonInitCodeGroupBox</tabstop>
   <tabstop>mFormSuppressCmbBx</tabstop>
-  <tabstop>pbnSelectEditForm</tabstop>
-  <tabstop>mEditFormLineEdit</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -1208,6 +1208,12 @@ gray = no data
   <tabstop>mTxtStatus</tabstop>
   <tabstop>mTxtSatellitesUsed</tabstop>
   <tabstop>mBtnRefreshDevices</tabstop>
+  <tabstop>mGPSPlainTextEdit</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>mRadAutodetect</tabstop>
+  <tabstop>mRadInternal</tabstop>
+  <tabstop>mRadUserPath</tabstop>
+  <tabstop>mCboDevices</tabstop>
   <tabstop>mRadGpsd</tabstop>
   <tabstop>mGpsdHost</tabstop>
   <tabstop>mGpsdPort</tabstop>
@@ -1225,12 +1231,6 @@ gray = no data
   <tabstop>mLogFileGroupBox</tabstop>
   <tabstop>mTxtLogFile</tabstop>
   <tabstop>mBtnLogFile</tabstop>
-  <tabstop>mGPSPlainTextEdit</tabstop>
-  <tabstop>mRadUserPath</tabstop>
-  <tabstop>mCboDevices</tabstop>
-  <tabstop>mRadAutodetect</tabstop>
-  <tabstop>scrollArea</tabstop>
-  <tabstop>mRadInternal</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsgradientcolorrampdialogbase.ui
+++ b/src/ui/qgsgradientcolorrampdialogbase.ui
@@ -331,14 +331,26 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QwtPlot</class>
+   <extends>QFrame</extends>
+   <header>qwt_plot.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -353,28 +365,23 @@
    <header>qgscompoundcolorwidget.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QwtPlot</class>
-   <extends>QFrame</extends>
-   <header>qwt_plot.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>btnColor1</tabstop>
   <tabstop>btnColor2</tabstop>
   <tabstop>cboType</tabstop>
   <tabstop>mStopEditor</tabstop>
+  <tabstop>groupBox_2</tabstop>
   <tabstop>mPositionSpinBox</tabstop>
   <tabstop>mDeleteStopButton</tabstop>
   <tabstop>mColorWidget</tabstop>
+  <tabstop>mPlotGroupBox</tabstop>
+  <tabstop>mPlotHueCheckbox</tabstop>
+  <tabstop>mPlotSaturationCheckbox</tabstop>
+  <tabstop>mPlotLightnessCheckbox</tabstop>
+  <tabstop>mPlotAlphaCheckbox</tabstop>
   <tabstop>btnInformation</tabstop>
+  <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -148,120 +148,116 @@ Negative rounds to powers of 10</string>
      </property>
     </widget>
    </item>
-       
-       <item row="4" column="0">
-        <widget class="QLabel" name="lblColorRamp">
-         <property name="text">
-          <string>Color ramp</string>
-         </property>
-         <property name="buddy">
-          <cstring>btnColorRamp</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QgsColorRampButton" name="btnColorRamp">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>120</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       
-       <item row="5" column="0">
-        <widget class="QLabel" name="lblSize">
-         <property name="text">
-          <string>Size from </string>
-         </property>
-         <property name="buddy">
-          <cstring>minSizeSpinBox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <layout class="QHBoxLayout" name="layoutSize">
-         <item>
-          <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
-           <property name="decimals">
-            <number>6</number>
-           </property>
-           <property name="maximum">
-            <double>999999999.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.200000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="showClearButton" stdset="0">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item> 
-         <item>
-          <widget class="QLabel" name="lblSizeTo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>to</string>
-           </property>
-          </widget>
-         </item>  
-         <item>
-          <widget class="QgsDoubleSpinBox" name="maxSizeSpinBox">
-           <property name="decimals">
-            <number>6</number>
-           </property>
-           <property name="maximum">
-            <double>999999999.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.200000000000000</double>
-           </property>
-           <property name="value">
-            <double>10.000000000000000</double>
-           </property>
-           <property name="showClearButton" stdset="0">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="6" column="1">
-        <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
-         <property name="minimumSize">
-          <size>
-           <width>14</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
-         </property>
-        </widget>
-       </item>
-       
-       
+   <item row="4" column="0">
+    <widget class="QLabel" name="lblColorRamp">
+     <property name="text">
+      <string>Color ramp</string>
+     </property>
+     <property name="buddy">
+      <cstring>btnColorRamp</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QgsColorRampButton" name="btnColorRamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="lblSize">
+     <property name="text">
+      <string>Size from </string>
+     </property>
+     <property name="buddy">
+      <cstring>minSizeSpinBox</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <layout class="QHBoxLayout" name="layoutSize">
+     <item>
+      <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>999999999.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="showClearButton">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblSizeTo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>to</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsDoubleSpinBox" name="maxSizeSpinBox">
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>999999999.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+       <property name="showClearButton">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="1">
+    <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>14</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
    <item row="7" column="0" colspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -483,26 +479,26 @@ Negative rounds to powers of 10</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
-   <header location="global">qgsfieldexpressionwidget.h</header>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -513,18 +509,26 @@ Negative rounds to powers of 10</string>
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mExpressionWidget</tabstop>
+  <tabstop>btnChangeGraduatedSymbol</tabstop>
+  <tabstop>txtLegendFormat</tabstop>
+  <tabstop>spinPrecision</tabstop>
+  <tabstop>cbxTrimTrailingZeroes</tabstop>
+  <tabstop>methodComboBox</tabstop>
   <tabstop>btnColorRamp</tabstop>
+  <tabstop>minSizeSpinBox</tabstop>
+  <tabstop>maxSizeSpinBox</tabstop>
+  <tabstop>mSizeUnitWidget</tabstop>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>viewGraduated</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
   <tabstop>spinGraduatedClasses</tabstop>
   <tabstop>btnGraduatedClassify</tabstop>
-  <tabstop>viewGraduated</tabstop>
   <tabstop>btnGraduatedAdd</tabstop>
   <tabstop>btnGraduatedDelete</tabstop>
   <tabstop>btnDeleteAllClasses</tabstop>
-  <tabstop>cbxLinkBoundaries</tabstop>
-  <tabstop>mSizeUnitWidget</tabstop>
   <tabstop>btnAdvanced</tabstop>
-  <tabstop>minSizeSpinBox</tabstop>
+  <tabstop>cbxLinkBoundaries</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgslabelingrulepropswidget.ui
+++ b/src/ui/qgslabelingrulepropswidget.ui
@@ -92,8 +92,8 @@
               </sizepolicy>
              </property>
              <property name="icon">
-              <iconset resource="../../images/images.qrc">
-               <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>/images/themes/default/mIconExpression.svg</iconset>
+              <iconset>
+               <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
              </property>
             </widget>
            </item>
@@ -163,10 +163,13 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>scrollArea</tabstop>
   <tabstop>editDescription</tabstop>
   <tabstop>editFilter</tabstop>
   <tabstop>btnExpressionBuilder</tabstop>
   <tabstop>btnTestFilter</tabstop>
+  <tabstop>groupScale</tabstop>
+  <tabstop>groupSettings</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgslabelpropertydialogbase.ui
+++ b/src/ui/qgslabelpropertydialogbase.ui
@@ -37,9 +37,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-319</y>
-        <width>415</width>
-        <height>619</height>
+        <y>0</y>
+        <width>431</width>
+        <height>622</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mLabelPropertiesLayout">
@@ -624,6 +624,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
@@ -639,19 +645,16 @@
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
   </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mLabelTextLineEdit</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>mDisplayGroupBox</tabstop>
   <tabstop>mShowLabelChkbx</tabstop>
   <tabstop>mMinScaleSpinBox</tabstop>
   <tabstop>mMaxScaleSpinBox</tabstop>
   <tabstop>mAlwaysShowChkbx</tabstop>
+  <tabstop>mFontGroupBox</tabstop>
   <tabstop>mFontFamilyCmbBx</tabstop>
   <tabstop>mFontStyleCmbBx</tabstop>
   <tabstop>mFontUnderlineBtn</tabstop>
@@ -660,15 +663,16 @@
   <tabstop>mFontItalicBtn</tabstop>
   <tabstop>mFontSizeSpinBox</tabstop>
   <tabstop>mFontColorButton</tabstop>
+  <tabstop>mBufferGroupBox</tabstop>
   <tabstop>mBufferSizeSpinBox</tabstop>
   <tabstop>mBufferColorButton</tabstop>
+  <tabstop>mPositionGroupBlox</tabstop>
   <tabstop>mLabelDistanceSpinBox</tabstop>
   <tabstop>mXCoordSpinBox</tabstop>
   <tabstop>mYCoordSpinBox</tabstop>
   <tabstop>mHaliComboBox</tabstop>
   <tabstop>mValiComboBox</tabstop>
   <tabstop>mRotationSpinBox</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsmapstylingwidgetbase.ui
+++ b/src/ui/qgsmapstylingwidgetbase.ui
@@ -224,6 +224,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mLayerCombo</tabstop>
+  <tabstop>mOptionsListWidget</tabstop>
+  <tabstop>mUndoButton</tabstop>
+  <tabstop>mRedoButton</tabstop>
+  <tabstop>mLiveApplyCheck</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsnewgeopackagelayerdialogbase.ui
+++ b/src/ui/qgsnewgeopackagelayerdialogbase.ui
@@ -444,6 +444,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>scrollArea</tabstop>
   <tabstop>mDatabaseEdit</tabstop>
   <tabstop>mSelectDatabaseButton</tabstop>
   <tabstop>mTableNameEdit</tabstop>
@@ -460,8 +461,6 @@
   <tabstop>mAddAttributeButton</tabstop>
   <tabstop>mAttributeView</tabstop>
   <tabstop>mRemoveAttributeButton</tabstop>
-  <tabstop>buttonBox</tabstop>
-  <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -265,16 +265,18 @@
  <tabstops>
   <tabstop>txtName</tabstop>
   <tabstop>txtUrl</tabstop>
+  <tabstop>tabAuth</tabstop>
   <tabstop>txtUserName</tabstop>
   <tabstop>txtPassword</tabstop>
   <tabstop>txtReferer</tabstop>
   <tabstop>cmbDpiMode</tabstop>
+  <tabstop>cmbVersion</tabstop>
+  <tabstop>txtMaxNumFeatures</tabstop>
   <tabstop>cbxIgnoreGetMapURI</tabstop>
   <tabstop>cbxIgnoreGetFeatureInfoURI</tabstop>
   <tabstop>cbxIgnoreAxisOrientation</tabstop>
   <tabstop>cbxInvertAxisOrientation</tabstop>
   <tabstop>cbxSmoothPixmapTransform</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2771,7 +2771,11 @@
                    </widget>
                   </item>
                   <item row="0" column="0" rowspan="8">
-                   <widget class="QgsColorSchemeList" name="mTreeCustomColors" native="true"/>
+                   <widget class="QgsColorSchemeList" name="mTreeCustomColors" native="true">
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -5466,6 +5470,7 @@
  <tabstops>
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>mOptionsScrollArea_01</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>cmbStyle</tabstop>
   <tabstop>cmbUITheme</tabstop>
   <tabstop>cmbIconSize</tabstop>
@@ -5476,9 +5481,11 @@
   <tabstop>mMessageTimeoutSpnBx</tabstop>
   <tabstop>cbxHideSplash</tabstop>
   <tabstop>cbxShowTips</tabstop>
+  <tabstop>cbxCheckVersion</tabstop>
   <tabstop>mCustomGroupBoxChkBx</tabstop>
   <tabstop>mNativeColorDialogsChkBx</tabstop>
   <tabstop>mLiveColorDialogsChkBx</tabstop>
+  <tabstop>groupBox_11</tabstop>
   <tabstop>mProjectOnLaunchCmbBx</tabstop>
   <tabstop>mProjectOnLaunchLineEdit</tabstop>
   <tabstop>mProjectOnLaunchPushBtn</tabstop>
@@ -5493,26 +5500,39 @@
   <tabstop>chbWarnOldProjectVersion</tabstop>
   <tabstop>cmbEnableMacros</tabstop>
   <tabstop>mOptionsScrollArea_03</tabstop>
+  <tabstop>groupBox_2</tabstop>
   <tabstop>mBtnAddSVGPath</tabstop>
   <tabstop>mBtnRemoveSVGPath</tabstop>
   <tabstop>mListSVGPaths</tabstop>
+  <tabstop>groupBox_4</tabstop>
   <tabstop>mBtnAddPluginPath</tabstop>
   <tabstop>mBtnRemovePluginPath</tabstop>
   <tabstop>mListPluginPaths</tabstop>
+  <tabstop>groupBox_29</tabstop>
+  <tabstop>mBtnAddHelpPath</tabstop>
+  <tabstop>mBtnRemoveHelpPath</tabstop>
+  <tabstop>mBtnMoveHelpUp</tabstop>
+  <tabstop>mBtnMoveHelpDown</tabstop>
+  <tabstop>mHelpPathTreeWidget</tabstop>
+  <tabstop>mQSettingsGrpBx</tabstop>
   <tabstop>mRestoreDefaultWindowStateBtn</tabstop>
+  <tabstop>mEnvironmentGrpBx</tabstop>
   <tabstop>mCustomVariablesChkBx</tabstop>
   <tabstop>mAddCustomVarBtn</tabstop>
   <tabstop>mRemoveCustomVarBtn</tabstop>
   <tabstop>mCustomVariablesTable</tabstop>
+  <tabstop>mCurrentVariablesGrpBx</tabstop>
   <tabstop>mCurrentVariablesTable</tabstop>
-  <tabstop>mComboCopyFeatureFormat</tabstop>
   <tabstop>mCurrentVariablesQGISChxBx</tabstop>
   <tabstop>mOptionsScrollArea_11</tabstop>
+  <tabstop>groupBox_18</tabstop>
   <tabstop>cbxAttributeTableDocked</tabstop>
+  <tabstop>mComboCopyFeatureFormat</tabstop>
   <tabstop>cmbAttrTableBehavior</tabstop>
   <tabstop>mAttrTableViewComboBox</tabstop>
   <tabstop>spinBoxAttrTableRowCache</tabstop>
   <tabstop>leNullValue</tabstop>
+  <tabstop>groupBox_19</tabstop>
   <tabstop>cmbScanItemsInBrowser</tabstop>
   <tabstop>cmbScanZipInBrowser</tabstop>
   <tabstop>cmbPromptRasterSublayers</tabstop>
@@ -5520,9 +5540,11 @@
   <tabstop>cbxAddPostgisDC</tabstop>
   <tabstop>cbxAddOracleDC</tabstop>
   <tabstop>cbxCompileExpressions</tabstop>
+  <tabstop>groupBox_28</tabstop>
   <tabstop>mBtnRemoveHiddenPath</tabstop>
   <tabstop>mListHiddenBrowserPaths</tabstop>
   <tabstop>mOptionsScrollArea_04</tabstop>
+  <tabstop>groupBox_5</tabstop>
   <tabstop>chkAddedVisibility</tabstop>
   <tabstop>chkUseRenderCaching</tabstop>
   <tabstop>chkParallelRendering</tabstop>
@@ -5534,25 +5556,41 @@
   <tabstop>mSimplifyAlgorithmComboBox</tabstop>
   <tabstop>mSimplifyDrawingAtProvider</tabstop>
   <tabstop>mSimplifyMaximumScaleComboBox</tabstop>
+  <tabstop>doubleSpinBoxMagnifierDefault</tabstop>
+  <tabstop>groupBox_8</tabstop>
   <tabstop>chkAntiAliasing</tabstop>
+  <tabstop>mSegmentationGroupBox</tabstop>
+  <tabstop>mSegmentationToleranceSpinBox</tabstop>
+  <tabstop>mToleranceTypeComboBox</tabstop>
+  <tabstop>groupBox_14</tabstop>
   <tabstop>spnRed</tabstop>
   <tabstop>spnGreen</tabstop>
   <tabstop>spnBlue</tabstop>
   <tabstop>cboxContrastEnhancementAlgorithmSingleBand</tabstop>
+  <tabstop>cboxContrastEnhancementLimitsSingleBand</tabstop>
+  <tabstop>cboxContrastEnhancementAlgorithmMultiBandSingleByte</tabstop>
+  <tabstop>cboxContrastEnhancementLimitsMultiBandSingleByte</tabstop>
+  <tabstop>cboxContrastEnhancementAlgorithmMultiBandMultiByte</tabstop>
+  <tabstop>cboxContrastEnhancementLimitsMultiBandMultiByte</tabstop>
   <tabstop>mRasterCumulativeCutLowerDoubleSpinBox</tabstop>
   <tabstop>mRasterCumulativeCutUpperDoubleSpinBox</tabstop>
   <tabstop>spnThreeBandStdDev</tabstop>
+  <tabstop>groupBox_22</tabstop>
   <tabstop>mLogCanvasRefreshChkBx</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>groupBox_7</tabstop>
   <tabstop>mButtonAddColor</tabstop>
   <tabstop>mButtonRemoveColor</tabstop>
   <tabstop>mButtonCopyColors</tabstop>
   <tabstop>mButtonPasteColors</tabstop>
   <tabstop>mButtonImportColors</tabstop>
   <tabstop>mButtonExportColors</tabstop>
+  <tabstop>mTreeCustomColors</tabstop>
   <tabstop>mOptionsScrollArea_06</tabstop>
+  <tabstop>groupBox_9</tabstop>
   <tabstop>pbnSelectionColor</tabstop>
   <tabstop>pbnCanvasColor</tabstop>
+  <tabstop>mLegendGrpBx</tabstop>
   <tabstop>cmbLegendDoubleClickAction</tabstop>
   <tabstop>capitalizeCheckBox</tabstop>
   <tabstop>mLegendLayersBoldChkBx</tabstop>
@@ -5561,17 +5599,21 @@
   <tabstop>cbxCreateRasterLegendIcons</tabstop>
   <tabstop>mLegendGraphicResolutionSpinBox</tabstop>
   <tabstop>mOptionsScrollArea_05</tabstop>
+  <tabstop>mIdentifyGroupBox</tabstop>
   <tabstop>spinBoxIdentifyValue</tabstop>
   <tabstop>mIdentifyHighlightColorButton</tabstop>
   <tabstop>mIdentifyHighlightBufferSpinBox</tabstop>
   <tabstop>mIdentifyHighlightMinWidthSpinBox</tabstop>
+  <tabstop>groupBox_6</tabstop>
   <tabstop>pbnMeasureColor</tabstop>
   <tabstop>mDecimalPlacesSpinBox</tabstop>
   <tabstop>mKeepBaseUnitCheckBox</tabstop>
   <tabstop>mDistanceUnitsComboBox</tabstop>
   <tabstop>mAreaUnitsComboBox</tabstop>
   <tabstop>mAngleUnitsComboBox</tabstop>
+  <tabstop>groupBox_10</tabstop>
   <tabstop>spinZoomFactor</tabstop>
+  <tabstop>groupBox_15</tabstop>
   <tabstop>mListGlobalScales</tabstop>
   <tabstop>pbnAddScale</tabstop>
   <tabstop>pbnRemoveScale</tabstop>
@@ -5579,32 +5621,43 @@
   <tabstop>pbnImportScales</tabstop>
   <tabstop>pbnExportScales</tabstop>
   <tabstop>mOptionsScrollArea_12</tabstop>
+  <tabstop>groupBox_3</tabstop>
   <tabstop>mComposerFontComboBox</tabstop>
+  <tabstop>groupBox_23</tabstop>
   <tabstop>mGridStyleComboBox</tabstop>
   <tabstop>mGridColorButton</tabstop>
+  <tabstop>groupBox_24</tabstop>
   <tabstop>mGridResolutionSpinBox</tabstop>
   <tabstop>mOffsetXSpinBox</tabstop>
   <tabstop>mOffsetYSpinBox</tabstop>
   <tabstop>mSnapToleranceSpinBox</tabstop>
+  <tabstop>groupBox_27</tabstop>
   <tabstop>mBtnAddTemplatePath</tabstop>
   <tabstop>mBtnRemoveTemplatePath</tabstop>
   <tabstop>mListComposerTemplatePaths</tabstop>
   <tabstop>mOptionsScrollArea_07</tabstop>
+  <tabstop>mEnterAttributeValuesGroupBox</tabstop>
   <tabstop>chkDisableAttributeValuesDlg</tabstop>
   <tabstop>chkReuseLastValues</tabstop>
   <tabstop>mValidateGeometries</tabstop>
+  <tabstop>mRubberBandGroupBox</tabstop>
   <tabstop>mLineWidthSpinBox</tabstop>
   <tabstop>mLineColorToolButton</tabstop>
   <tabstop>mFillColorToolButton</tabstop>
   <tabstop>mLineGhostCheckBox</tabstop>
+  <tabstop>mSnappingGroupBox</tabstop>
+  <tabstop>mSnappingEnabledDefault</tabstop>
   <tabstop>mDefaultSnapModeComboBox</tabstop>
   <tabstop>mDefaultSnappingToleranceSpinBox</tabstop>
   <tabstop>mDefaultSnappingToleranceComboBox</tabstop>
   <tabstop>mSearchRadiusVertexEditSpinBox</tabstop>
   <tabstop>mSearchRadiusVertexEditComboBox</tabstop>
+  <tabstop>mSnappingMainDialogComboBox</tabstop>
+  <tabstop>mVertexMarkerGroupBox</tabstop>
   <tabstop>mMarkersOnlyForSelectedCheckBox</tabstop>
   <tabstop>mMarkerStyleComboBox</tabstop>
   <tabstop>mMarkerSizeSpinBox</tabstop>
+  <tabstop>groupBox_21</tabstop>
   <tabstop>mOffsetJoinStyleComboBox</tabstop>
   <tabstop>mOffsetQuadSegSpinBox</tabstop>
   <tabstop>mCurveOffsetMiterLimitComboBox</tabstop>
@@ -5614,6 +5667,7 @@
   <tabstop>pbnEditPyramidsOptions</tabstop>
   <tabstop>lstGdalDrivers</tabstop>
   <tabstop>mOptionsScrollArea_08</tabstop>
+  <tabstop>grpOtfTransform</tabstop>
   <tabstop>radOtfNone</tabstop>
   <tabstop>radOtfAuto</tabstop>
   <tabstop>radOtfTransform</tabstop>
@@ -5622,6 +5676,7 @@
   <tabstop>radUseProjectProjection</tabstop>
   <tabstop>radUseGlobalProjection</tabstop>
   <tabstop>leLayerGlobalCrs</tabstop>
+  <tabstop>mDefaultDatumTransformGroupBox</tabstop>
   <tabstop>chkShowDatumTransformDialog</tabstop>
   <tabstop>mAddDefaultTransformButton</tabstop>
   <tabstop>mRemoveDefaultTransformButton</tabstop>
@@ -5630,6 +5685,7 @@
   <tabstop>grpLocale</tabstop>
   <tabstop>cboLocale</tabstop>
   <tabstop>mAuthConfigsGrpBx</tabstop>
+  <tabstop>mOptionsScrollArea_10</tabstop>
   <tabstop>leWmsSearch</tabstop>
   <tabstop>mNetworkTimeoutSpinBox</tabstop>
   <tabstop>mDefaultCapabilitiesExpirySpinBox</tabstop>
@@ -5646,12 +5702,11 @@
   <tabstop>leProxyPort</tabstop>
   <tabstop>leProxyUser</tabstop>
   <tabstop>leProxyPassword</tabstop>
-  <tabstop>mRemoveUrlPushButton</tabstop>
-  <tabstop>mAdvancedSettingsEnableButton</tabstop>
-  <tabstop>cbxCheckVersion</tabstop>
-  <tabstop>mOptionsScrollArea_10</tabstop>
   <tabstop>mAddUrlPushButton</tabstop>
+  <tabstop>mRemoveUrlPushButton</tabstop>
   <tabstop>mExcludeUrlListWidget</tabstop>
+  <tabstop>mAdvancedSettingsEnableButton</tabstop>
+  <tabstop>grpProjectionBehavior</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsorganizetablecolumnsdialog.ui
+++ b/src/ui/qgsorganizetablecolumnsdialog.ui
@@ -63,6 +63,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mFieldsList</tabstop>
+  <tabstop>mShowAllButton</tabstop>
+  <tabstop>mHideAllButton</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -2583,15 +2583,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsProjectionSelector</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselector.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2601,15 +2601,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorSchemeList</class>
-   <extends>QTreeView</extends>
-   <header>qgscolorschemelist.h</header>
+   <class>QgsProjectionSelector</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselector.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
+   <class>QgsColorSchemeList</class>
+   <extends>QWidget</extends>
+   <header location="global">qgscolorschemelist.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2622,32 +2622,36 @@
  <tabstops>
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>scrollArea_2</tabstop>
+  <tabstop>titleBox</tabstop>
   <tabstop>mProjectFileLineEdit</tabstop>
   <tabstop>titleEdit</tabstop>
   <tabstop>pbnSelectionColor</tabstop>
   <tabstop>pbnCanvasColor</tabstop>
   <tabstop>cbxAbsolutePath</tabstop>
   <tabstop>mMapTileRenderingCheckBox</tabstop>
+  <tabstop>btnGrpMeasureEllipsoid</tabstop>
   <tabstop>cmbEllipsoid</tabstop>
   <tabstop>leSemiMajor</tabstop>
   <tabstop>leSemiMinor</tabstop>
   <tabstop>mDistanceUnitsCombo</tabstop>
   <tabstop>mAreaUnitsCombo</tabstop>
+  <tabstop>mCoordinateDisplayGroup</tabstop>
   <tabstop>mCoordinateDisplayComboBox</tabstop>
   <tabstop>radAutomatic</tabstop>
   <tabstop>radManual</tabstop>
   <tabstop>spinBoxDP</tabstop>
   <tabstop>grpProjectScales</tabstop>
-  <tabstop>lstScales</tabstop>
   <tabstop>pbnAddScale</tabstop>
   <tabstop>pbnRemoveScale</tabstop>
   <tabstop>pbnImportScales</tabstop>
   <tabstop>pbnExportScales</tabstop>
+  <tabstop>lstScales</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>cbxProjectionEnabled</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>twIdentifyLayers</tabstop>
   <tabstop>scrollArea_4</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>cboStyleMarker</tabstop>
   <tabstop>pbtnStyleMarker</tabstop>
   <tabstop>cboStyleLine</tabstop>
@@ -2656,10 +2660,12 @@
   <tabstop>pbtnStyleFill</tabstop>
   <tabstop>cboStyleColorRamp</tabstop>
   <tabstop>pbtnStyleColorRamp</tabstop>
+  <tabstop>groupBox_2</tabstop>
   <tabstop>mTransparencySlider</tabstop>
   <tabstop>mTransparencySpinBox</tabstop>
   <tabstop>cbxStyleRandomColors</tabstop>
   <tabstop>pbtnStyleManager</tabstop>
+  <tabstop>groupBox_7</tabstop>
   <tabstop>mButtonAddColor</tabstop>
   <tabstop>mButtonRemoveColor</tabstop>
   <tabstop>mButtonCopyColors</tabstop>
@@ -2668,17 +2674,19 @@
   <tabstop>mButtonExportColors</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>grpOWSServiceCapabilities</tabstop>
+  <tabstop>mWMSName</tabstop>
   <tabstop>mWMSTitle</tabstop>
   <tabstop>mWMSContactOrganization</tabstop>
   <tabstop>mWMSOnlineResourceLineEdit</tabstop>
   <tabstop>mWMSContactPerson</tabstop>
+  <tabstop>mWMSContactPositionCb</tabstop>
   <tabstop>mWMSContactMail</tabstop>
   <tabstop>mWMSContactPhone</tabstop>
-  <tabstop>mWMSContactPositionCb</tabstop>
   <tabstop>mWMSAbstract</tabstop>
   <tabstop>mWMSFeesCb</tabstop>
   <tabstop>mWMSAccessConstraintsCb</tabstop>
   <tabstop>mWMSKeywordList</tabstop>
+  <tabstop>grpWMSCapabilities</tabstop>
   <tabstop>grpWMSExt</tabstop>
   <tabstop>mWMSExtMinX</tabstop>
   <tabstop>mWMSExtMinY</tabstop>
@@ -2698,34 +2706,38 @@
   <tabstop>mLayerRestrictionsListWidget</tabstop>
   <tabstop>mAddLayerRestrictionButton</tabstop>
   <tabstop>mRemoveLayerRestrictionButton</tabstop>
+  <tabstop>mWMSInspire</tabstop>
+  <tabstop>mWMSInspireLanguage</tabstop>
+  <tabstop>mWMSInspireScenario1</tabstop>
+  <tabstop>mWMSInspireMetadataUrl</tabstop>
+  <tabstop>mWMSInspireMetadataUrlType</tabstop>
+  <tabstop>mWMSInspireScenario2</tabstop>
+  <tabstop>mWMSInspireTemporalReference</tabstop>
+  <tabstop>mWMSInspireMetadataDate</tabstop>
   <tabstop>mWmsUseLayerIDs</tabstop>
   <tabstop>mAddWktGeometryCheckBox</tabstop>
+  <tabstop>mAllowRequestDefinedDataSourcesBox</tabstop>
+  <tabstop>mSegmentizeFeatureInfoGeometryCheckBox</tabstop>
   <tabstop>mWMSPrecisionSpinBox</tabstop>
   <tabstop>mWMSUrlLineEdit</tabstop>
   <tabstop>mMaxWidthLineEdit</tabstop>
   <tabstop>mMaxHeightLineEdit</tabstop>
   <tabstop>mWMSImageQualitySpinBox</tabstop>
+  <tabstop>grpWFSCapabilities</tabstop>
   <tabstop>twWFSLayers</tabstop>
   <tabstop>pbnWFSLayersSelectAll</tabstop>
   <tabstop>pbnWFSLayersDeselectAll</tabstop>
   <tabstop>mWFSUrlLineEdit</tabstop>
+  <tabstop>grpWCSCapabilities</tabstop>
   <tabstop>twWCSLayers</tabstop>
   <tabstop>pbnWCSLayersSelectAll</tabstop>
   <tabstop>pbnWCSLayersDeselectAll</tabstop>
   <tabstop>mWCSUrlLineEdit</tabstop>
-  <tabstop>grpPythonMacros</tabstop>
-  <tabstop>scrollArea_6</tabstop>
-  <tabstop>mWMSName</tabstop>
-  <tabstop>mWMSInspire</tabstop>
-  <tabstop>mWMSInspireLanguage</tabstop>
-  <tabstop>mWMSInspireScenario2</tabstop>
-  <tabstop>mWMSInspireTemporalReference</tabstop>
-  <tabstop>mWMSInspireMetadataDate</tabstop>
-  <tabstop>mWMSInspireScenario1</tabstop>
-  <tabstop>mWMSInspireMetadataUrl</tabstop>
-  <tabstop>mWMSInspireMetadataUrlType</tabstop>
+  <tabstop>mOWSCheckerGroupBox</tabstop>
   <tabstop>pbnLaunchOWSChecker</tabstop>
   <tabstop>teOWSChecker</tabstop>
+  <tabstop>scrollArea_6</tabstop>
+  <tabstop>grpPythonMacros</tabstop>
   <tabstop>mAutoTransaction</tabstop>
   <tabstop>mEvaluateDefaultValues</tabstop>
  </tabstops>

--- a/src/ui/qgsquerybuilderbase.ui
+++ b/src/ui/qgsquerybuilderbase.ui
@@ -327,6 +327,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>btnSampleValues</tabstop>
   <tabstop>btnGetAllValues</tabstop>
   <tabstop>mUseUnfilteredLayer</tabstop>
+  <tabstop>groupBox4</tabstop>
   <tabstop>btnEqual</tabstop>
   <tabstop>btnLessThan</tabstop>
   <tabstop>btnGreaterThan</tabstop>
@@ -341,7 +342,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>btnAnd</tabstop>
   <tabstop>btnOr</tabstop>
   <tabstop>btnNot</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -541,6 +541,7 @@
   <tabstop>mNRowsSpinBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mAddResultToProjectCheckBox</tabstop>
+  <tabstop>mOperatorsGroupBox</tabstop>
   <tabstop>mPlusPushButton</tabstop>
   <tabstop>mMultiplyPushButton</tabstop>
   <tabstop>mSqrtButton</tabstop>

--- a/src/ui/qgsrasterhistogramwidgetbase.ui
+++ b/src/ui/qgsrasterhistogramwidgetbase.ui
@@ -345,6 +345,16 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>btnHistoActions</tabstop>
+  <tabstop>mSaveAsImageButton</tabstop>
+  <tabstop>cboHistoBand</tabstop>
+  <tabstop>leHistoMin</tabstop>
+  <tabstop>btnHistoMin</tabstop>
+  <tabstop>leHistoMax</tabstop>
+  <tabstop>btnHistoMax</tabstop>
+  <tabstop>btnHistoCompute</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -2195,20 +2195,15 @@ p, li { white-space: pre-wrap; }
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsBlendModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2223,6 +2218,11 @@ p, li { white-space: pre-wrap; }
    <header>qgsscalerangewidget.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>
    <extends>QWidget</extends>
    <header>qgslayertreeembeddedconfigwidget.h</header>
@@ -2232,13 +2232,17 @@ p, li { white-space: pre-wrap; }
  <tabstops>
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>scrollArea_3</tabstop>
+  <tabstop>mLayerInfoGrpBx</tabstop>
   <tabstop>mLayerOrigNameLineEd</tabstop>
   <tabstop>leDisplayName</tabstop>
   <tabstop>leLayerSource</tabstop>
+  <tabstop>grpSRS</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>chkUseScaleDependentRendering</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mBandRenderingGrpBx</tabstop>
   <tabstop>mRenderTypeComboBox</tabstop>
+  <tabstop>mColorRenderingGrpBox</tabstop>
   <tabstop>mBlendModeComboBox</tabstop>
   <tabstop>mResetColorRenderingBtn</tabstop>
   <tabstop>mSliderBrightness</tabstop>
@@ -2256,17 +2260,20 @@ p, li { white-space: pre-wrap; }
   <tabstop>mZoomedOutResamplingComboBox</tabstop>
   <tabstop>mMaximumOversamplingSpinBox</tabstop>
   <tabstop>scrollArea_2</tabstop>
+  <tabstop>gboxGlobalTransp</tabstop>
   <tabstop>sliderTransparency</tabstop>
+  <tabstop>gboxNoDataValue</tabstop>
   <tabstop>mSrcNoDataValueCheckBox</tabstop>
   <tabstop>leNoDataValue</tabstop>
+  <tabstop>gboxCustomTransparency</tabstop>
   <tabstop>cboxTransparencyBand</tabstop>
-  <tabstop>tableTransparency</tabstop>
   <tabstop>pbnAddValuesManually</tabstop>
   <tabstop>pbnAddValuesFromDisplay</tabstop>
   <tabstop>pbnRemoveSelectedRow</tabstop>
   <tabstop>pbnDefaultValues</tabstop>
   <tabstop>pbnImportTransparentPixelValues</tabstop>
   <tabstop>pbnExportTransparentPixelValues</tabstop>
+  <tabstop>tableTransparency</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>tePyramidDescription</tabstop>
   <tabstop>lbxPyramidResolutions</tabstop>
@@ -2275,19 +2282,24 @@ p, li { white-space: pre-wrap; }
   <tabstop>buttonBuildPyramids</tabstop>
   <tabstop>scrollArea_6</tabstop>
   <tabstop>scrollArea_4</tabstop>
+  <tabstop>mMetaDescriptionGrpBx</tabstop>
   <tabstop>mLayerShortNameLineEdit</tabstop>
   <tabstop>mLayerTitleLineEdit</tabstop>
   <tabstop>mLayerAbstractTextEdit</tabstop>
   <tabstop>mLayerKeywordListLineEdit</tabstop>
   <tabstop>mLayerDataUrlLineEdit</tabstop>
   <tabstop>mLayerDataUrlFormatComboBox</tabstop>
+  <tabstop>mMetaAttributionGrpBx</tabstop>
   <tabstop>mLayerAttributionLineEdit</tabstop>
   <tabstop>mLayerAttributionUrlLineEdit</tabstop>
+  <tabstop>mMetaMetaUrlGrpBx</tabstop>
   <tabstop>mLayerMetadataUrlLineEdit</tabstop>
   <tabstop>mLayerMetadataUrlTypeComboBox</tabstop>
   <tabstop>mLayerMetadataUrlFormatComboBox</tabstop>
+  <tabstop>mMetaLegendGrpBx</tabstop>
   <tabstop>mLayerLegendUrlLineEdit</tabstop>
   <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
+  <tabstop>mMetaPropertiesGrpBx</tabstop>
   <tabstop>txtbMetadata</tabstop>
  </tabstops>
  <resources>

--- a/src/ui/qgsrasterlayersaveasdialogbase.ui
+++ b/src/ui/qgsrasterlayersaveasdialogbase.ui
@@ -188,7 +188,7 @@ datasets with maximum width and height specified below.</string>
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-207</y>
+        <y>0</y>
         <width>541</width>
         <height>583</height>
        </rect>
@@ -653,21 +653,21 @@ datasets with maximum width and height specified below.</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsExtentGroupBox</class>
-   <extends>QGroupBox</extends>
+   <extends>QgsCollapsibleGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -423,19 +423,19 @@
      </layout>
     </widget>
    </item>
-           <item row="7">
-            <spacer name="verticalSpacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -451,6 +451,25 @@
    <header>qgsblendmodecombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>cboRenderers</tabstop>
+  <tabstop>mBlendModeComboBox</tabstop>
+  <tabstop>mSliderBrightness</tabstop>
+  <tabstop>mBrightnessSpinBox</tabstop>
+  <tabstop>sliderSaturation</tabstop>
+  <tabstop>spinBoxSaturation</tabstop>
+  <tabstop>mSliderContrast</tabstop>
+  <tabstop>mContrastSpinBox</tabstop>
+  <tabstop>comboGrayscale</tabstop>
+  <tabstop>mColorizeCheck</tabstop>
+  <tabstop>btnColorizeColor</tabstop>
+  <tabstop>sliderColorizeStrength</tabstop>
+  <tabstop>spinColorizeStrength</tabstop>
+  <tabstop>mResetColorRenderingBtn</tabstop>
+  <tabstop>mZoomedInResamplingComboBox</tabstop>
+  <tabstop>mZoomedOutResamplingComboBox</tabstop>
+  <tabstop>mMaximumOversamplingSpinBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgsrendererrulepropsdialogbase.ui
+++ b/src/ui/qgsrendererrulepropsdialogbase.ui
@@ -125,6 +125,15 @@
    <header>qgsscalerangewidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>editLabel</tabstop>
+  <tabstop>editFilter</tabstop>
+  <tabstop>btnExpressionBuilder</tabstop>
+  <tabstop>btnTestFilter</tabstop>
+  <tabstop>editDescription</tabstop>
+  <tabstop>groupScale</tabstop>
+  <tabstop>groupSymbol</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -317,6 +317,24 @@ suffix</string>
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mBandComboBox</tabstop>
+  <tabstop>mMinLineEdit</tabstop>
+  <tabstop>mMaxLineEdit</tabstop>
+  <tabstop>mColorInterpolationComboBox</tabstop>
+  <tabstop>btnColorRamp</tabstop>
+  <tabstop>mUnitLineEdit</tabstop>
+  <tabstop>mColormapTreeWidget</tabstop>
+  <tabstop>mClassificationModeComboBox</tabstop>
+  <tabstop>mNumberOfEntriesSpinBox</tabstop>
+  <tabstop>mClassifyButton</tabstop>
+  <tabstop>mAddEntryButton</tabstop>
+  <tabstop>mDeleteEntryButton</tabstop>
+  <tabstop>mLoadFromBandButton</tabstop>
+  <tabstop>mLoadFromFileButton</tabstop>
+  <tabstop>mExportToFileButton</tabstop>
+  <tabstop>mClipCheckBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/src/ui/qgssourceselectdialogbase.ui
+++ b/src/ui/qgssourceselectdialogbase.ui
@@ -24,11 +24,11 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QPushButton" name="btnConnect">
-          <property name="toolTip">
-           <string>Connect to selected database</string>
-          </property>
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Connect to selected database</string>
           </property>
           <property name="text">
            <string>C&amp;onnect</string>
@@ -47,11 +47,11 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnEdit">
-          <property name="toolTip">
-           <string>Edit selected database connection</string>
-          </property>
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Edit selected database connection</string>
           </property>
           <property name="text">
            <string>Edit</string>
@@ -60,11 +60,11 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnDelete">
-          <property name="toolTip">
-           <string>Remove connection to selected database</string>
-          </property>
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Remove connection to selected database</string>
           </property>
           <property name="text">
            <string>Remove</string>
@@ -263,8 +263,8 @@
   <tabstop>lineFilter</tabstop>
   <tabstop>treeView</tabstop>
   <tabstop>cbxUseTitleLayerName</tabstop>
+  <tabstop>cbxFeatureCurrentViewExtent</tabstop>
   <tabstop>btnChangeSpatialRefSys</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsstyleexportimportdialogbase.ui
+++ b/src/ui/qgsstyleexportimportdialogbase.ui
@@ -154,8 +154,10 @@
   <tabstop>importTypeCombo</tabstop>
   <tabstop>locationLineEdit</tabstop>
   <tabstop>btnBrowse</tabstop>
+  <tabstop>mFavorite</tabstop>
+  <tabstop>mIgnoreXMLTags</tabstop>
+  <tabstop>mSymbolTags</tabstop>
   <tabstop>listItems</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -98,11 +98,11 @@
        </item>
        <item row="3" column="0">
         <widget class="QPushButton" name="btnManageGroups">
-         <property name="text">
-          <string>Modify group</string>
-         </property>
          <property name="toolTip">
           <string>Modify selected tag or smart group</string>
+         </property>
+         <property name="text">
+          <string>Modify group</string>
          </property>
          <property name="autoDefault">
           <bool>false</bool>
@@ -496,9 +496,9 @@
  </customwidgets>
  <tabstops>
   <tabstop>groupTree</tabstop>
-  <tabstop>btnManageGroups</tabstop>
   <tabstop>btnAddTag</tabstop>
   <tabstop>btnAddSmartgroup</tabstop>
+  <tabstop>btnManageGroups</tabstop>
   <tabstop>btnShare</tabstop>
   <tabstop>tabItemType</tabstop>
   <tabstop>listItems</tabstop>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -1076,7 +1076,11 @@ font-style: italic;</string>
                           </widget>
                          </item>
                          <item row="6" column="1">
-                          <widget class="QgsUnitSelectionWidget" name="mFontSizeUnitWidget" native="true"/>
+                          <widget class="QgsUnitSelectionWidget" name="mFontSizeUnitWidget" native="true">
+                           <property name="focusPolicy">
+                            <enum>Qt::StrongFocus</enum>
+                           </property>
+                          </widget>
                          </item>
                          <item row="9" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontCaseDDBtn">
@@ -2387,7 +2391,11 @@ font-style: italic;</string>
                             </widget>
                            </item>
                            <item row="1" column="1">
-                            <widget class="QgsUnitSelectionWidget" name="mBufferUnitWidget" native="true"/>
+                            <widget class="QgsUnitSelectionWidget" name="mBufferUnitWidget" native="true">
+                             <property name="focusPolicy">
+                              <enum>Qt::StrongFocus</enum>
+                             </property>
+                            </widget>
                            </item>
                           </layout>
                          </widget>
@@ -2456,8 +2464,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>454</width>
-                       <height>720</height>
+                       <width>448</width>
+                       <height>731</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3057,7 +3065,11 @@ font-style: italic;</string>
                            <item row="20" column="1">
                             <layout class="QHBoxLayout" name="horizontalLayout_43">
                              <item>
-                              <widget class="QgsUnitSelectionWidget" name="mShapeBorderWidthUnitWidget" native="true"/>
+                              <widget class="QgsUnitSelectionWidget" name="mShapeBorderWidthUnitWidget" native="true">
+                               <property name="focusPolicy">
+                                <enum>Qt::StrongFocus</enum>
+                               </property>
+                              </widget>
                              </item>
                              <item>
                               <widget class="QLabel" name="mShapeSVGUnitsLabel">
@@ -3210,13 +3222,25 @@ font-style: italic;</string>
                             </widget>
                            </item>
                            <item row="5" column="1">
-                            <widget class="QgsUnitSelectionWidget" name="mShapeSizeUnitWidget" native="true"/>
+                            <widget class="QgsUnitSelectionWidget" name="mShapeSizeUnitWidget" native="true">
+                             <property name="focusPolicy">
+                              <enum>Qt::StrongFocus</enum>
+                             </property>
+                            </widget>
                            </item>
                            <item row="11" column="1">
-                            <widget class="QgsUnitSelectionWidget" name="mShapeOffsetUnitWidget" native="true"/>
+                            <widget class="QgsUnitSelectionWidget" name="mShapeOffsetUnitWidget" native="true">
+                             <property name="focusPolicy">
+                              <enum>Qt::StrongFocus</enum>
+                             </property>
+                            </widget>
                            </item>
                            <item row="13" column="1">
-                            <widget class="QgsUnitSelectionWidget" name="mShapeRadiusUnitWidget" native="true"/>
+                            <widget class="QgsUnitSelectionWidget" name="mShapeRadiusUnitWidget" native="true">
+                             <property name="focusPolicy">
+                              <enum>Qt::StrongFocus</enum>
+                             </property>
+                            </widget>
                            </item>
                           </layout>
                          </widget>
@@ -3697,10 +3721,18 @@ font-style: italic;</string>
                             </widget>
                            </item>
                            <item row="3" column="1">
-                            <widget class="QgsUnitSelectionWidget" name="mShadowOffsetUnitWidget" native="true"/>
+                            <widget class="QgsUnitSelectionWidget" name="mShadowOffsetUnitWidget" native="true">
+                             <property name="focusPolicy">
+                              <enum>Qt::StrongFocus</enum>
+                             </property>
+                            </widget>
                            </item>
                            <item row="6" column="1">
-                            <widget class="QgsUnitSelectionWidget" name="mShadowRadiusUnitWidget" native="true"/>
+                            <widget class="QgsUnitSelectionWidget" name="mShadowRadiusUnitWidget" native="true">
+                             <property name="focusPolicy">
+                              <enum>Qt::StrongFocus</enum>
+                             </property>
+                            </widget>
                            </item>
                           </layout>
                          </widget>
@@ -3826,7 +3858,7 @@ font-style: italic;</string>
                             <enum>QFrame::Sunken</enum>
                            </property>
                            <property name="currentIndex">
-                            <number>2</number>
+                            <number>1</number>
                            </property>
                            <widget class="QWidget" name="pagePoint">
                             <layout class="QGridLayout" name="gridLayout_13" columnstretch="0,0,0,0">
@@ -4283,7 +4315,11 @@ font-style: italic;</string>
                           </widget>
                          </item>
                          <item row="1" column="1">
-                          <widget class="QgsUnitSelectionWidget" name="mLineDistanceUnitWidget" native="true"/>
+                          <widget class="QgsUnitSelectionWidget" name="mLineDistanceUnitWidget" native="true">
+                           <property name="focusPolicy">
+                            <enum>Qt::StrongFocus</enum>
+                           </property>
+                          </widget>
                          </item>
                         </layout>
                        </widget>
@@ -4813,7 +4849,11 @@ font-style: italic;</string>
                           </widget>
                          </item>
                          <item row="1" column="1" colspan="2">
-                          <widget class="QgsUnitSelectionWidget" name="mPointOffsetUnitWidget" native="true"/>
+                          <widget class="QgsUnitSelectionWidget" name="mPointOffsetUnitWidget" native="true">
+                           <property name="focusPolicy">
+                            <enum>Qt::StrongFocus</enum>
+                           </property>
+                          </widget>
                          </item>
                         </layout>
                        </widget>
@@ -4951,7 +4991,11 @@ font-style: italic;</string>
                           </widget>
                          </item>
                          <item row="1" column="1">
-                          <widget class="QgsUnitSelectionWidget" name="mRepeatDistanceUnitWidget" native="true"/>
+                          <widget class="QgsUnitSelectionWidget" name="mRepeatDistanceUnitWidget" native="true">
+                           <property name="focusPolicy">
+                            <enum>Qt::StrongFocus</enum>
+                           </property>
+                          </widget>
                          </item>
                          <item row="1" column="2">
                           <widget class="QgsDataDefinedButton" name="mRepeatDistanceUnitDDBtn">
@@ -6355,6 +6399,9 @@ font-style: italic;</string>
           <height>16777215</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
        </widget>
       </item>
       <item>
@@ -6409,6 +6456,11 @@ font-style: italic;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
@@ -6434,23 +6486,15 @@ font-style: italic;</string>
    <extends>QLabel</extends>
    <header>qgstextpreview.h</header>
   </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsPanelWidget</class>
-   <extends>QWidget</extends>
-   <header>qgspanelwidget.h</header>
-   <container>1</container>
-  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>scrollArea_mPreview</tabstop>
+  <tabstop>mFieldExpressionWidget</tabstop>
+  <tabstop>groupBox_mPreview</tabstop>
   <tabstop>mPreviewTextEdit</tabstop>
   <tabstop>mPreviewTextBtn</tabstop>
+  <tabstop>mPreviewScaleComboBox</tabstop>
   <tabstop>mPreviewBackgroundBtn</tabstop>
+  <tabstop>mOptionsTab</tabstop>
   <tabstop>mLabelingOptionsListWidget</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>mFontFamilyCmbBx</tabstop>
@@ -6464,8 +6508,10 @@ font-style: italic;</string>
   <tabstop>mFontBoldBtn</tabstop>
   <tabstop>mFontBoldDDBtn</tabstop>
   <tabstop>mFontItalicBtn</tabstop>
+  <tabstop>mFontItalicDDBtn</tabstop>
   <tabstop>mFontSizeSpinBox</tabstop>
   <tabstop>mFontSizeDDBtn</tabstop>
+  <tabstop>mFontSizeUnitWidget</tabstop>
   <tabstop>mFontUnitsDDBtn</tabstop>
   <tabstop>btnTextColor</tabstop>
   <tabstop>mFontColorDDBtn</tabstop>
@@ -6475,9 +6521,13 @@ font-style: italic;</string>
   <tabstop>mFontCapitalsComboBox</tabstop>
   <tabstop>mFontCaseDDBtn</tabstop>
   <tabstop>mFontLetterSpacingSpinBox</tabstop>
+  <tabstop>mFontLetterSpacingDDBtn</tabstop>
   <tabstop>mFontWordSpacingSpinBox</tabstop>
+  <tabstop>mFontWordSpacingDDBtn</tabstop>
   <tabstop>comboBlendMode</tabstop>
   <tabstop>mFontBlendModeDDBtn</tabstop>
+  <tabstop>mCheckBoxSubstituteText</tabstop>
+  <tabstop>mToolButtonConfigureSubstitutes</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>wrapCharacterEdit</tabstop>
   <tabstop>mWrapCharDDBtn</tabstop>
@@ -6510,6 +6560,7 @@ font-style: italic;</string>
   <tabstop>mBufferDrawDDBtn</tabstop>
   <tabstop>spinBufferSize</tabstop>
   <tabstop>mBufferSizeDDBtn</tabstop>
+  <tabstop>mBufferUnitWidget</tabstop>
   <tabstop>mBufferUnitsDDBtn</tabstop>
   <tabstop>btnBufferColor</tabstop>
   <tabstop>mBufferColorDDBtn</tabstop>
@@ -6535,6 +6586,7 @@ font-style: italic;</string>
   <tabstop>mShapeSizeXDDBtn</tabstop>
   <tabstop>mShapeSizeYSpnBx</tabstop>
   <tabstop>mShapeSizeYDDBtn</tabstop>
+  <tabstop>mShapeSizeUnitWidget</tabstop>
   <tabstop>mShapeSizeUnitsDDBtn</tabstop>
   <tabstop>mShapeRotationCmbBx</tabstop>
   <tabstop>mShapeRotationTypeDDBtn</tabstop>
@@ -6543,10 +6595,12 @@ font-style: italic;</string>
   <tabstop>mShapeOffsetXSpnBx</tabstop>
   <tabstop>mShapeOffsetYSpnBx</tabstop>
   <tabstop>mShapeOffsetDDBtn</tabstop>
+  <tabstop>mShapeOffsetUnitWidget</tabstop>
   <tabstop>mShapeOffsetUnitsDDBtn</tabstop>
   <tabstop>mShapeRadiusXDbSpnBx</tabstop>
   <tabstop>mShapeRadiusYDbSpnBx</tabstop>
   <tabstop>mShapeRadiusDDBtn</tabstop>
+  <tabstop>mShapeRadiusUnitWidget</tabstop>
   <tabstop>mShapeRadiusUnitsDDBtn</tabstop>
   <tabstop>mShapeTranspSlider</tabstop>
   <tabstop>mShapeTranspSpinBox</tabstop>
@@ -6560,6 +6614,7 @@ font-style: italic;</string>
   <tabstop>mShapeBorderColorDDBtn</tabstop>
   <tabstop>mShapeBorderWidthSpnBx</tabstop>
   <tabstop>mShapeBorderWidthDDBtn</tabstop>
+  <tabstop>mShapeBorderWidthUnitWidget</tabstop>
   <tabstop>mShapeBorderUnitsDDBtn</tabstop>
   <tabstop>mShapePenStyleCmbBx</tabstop>
   <tabstop>mShapePenStyleDDBtn</tabstop>
@@ -6573,10 +6628,12 @@ font-style: italic;</string>
   <tabstop>mShadowOffsetAngleDDBtn</tabstop>
   <tabstop>mShadowOffsetSpnBx</tabstop>
   <tabstop>mShadowOffsetDDBtn</tabstop>
+  <tabstop>mShadowOffsetUnitWidget</tabstop>
   <tabstop>mShadowOffsetUnitsDDBtn</tabstop>
   <tabstop>mShadowOffsetGlobalChkBx</tabstop>
   <tabstop>mShadowRadiusDblSpnBx</tabstop>
   <tabstop>mShadowRadiusDDBtn</tabstop>
+  <tabstop>mShadowRadiusUnitWidget</tabstop>
   <tabstop>mShadowRadiusUnitsDDBtn</tabstop>
   <tabstop>mShadowRadiusAlphaChkBx</tabstop>
   <tabstop>mShadowTranspSlider</tabstop>
@@ -6589,18 +6646,18 @@ font-style: italic;</string>
   <tabstop>mShadowBlendCmbBx</tabstop>
   <tabstop>mShadowBlendDDBtn</tabstop>
   <tabstop>scrollArea_3</tabstop>
-  <tabstop>radLineParallel</tabstop>
-  <tabstop>radLineCurved</tabstop>
-  <tabstop>radLineHorizontal</tabstop>
+  <tabstop>radOverCentroid</tabstop>
+  <tabstop>radPolygonHorizontal</tabstop>
+  <tabstop>radAroundCentroid</tabstop>
+  <tabstop>radPolygonFree</tabstop>
+  <tabstop>radPolygonPerimeter</tabstop>
+  <tabstop>radPolygonPerimeterCurved</tabstop>
   <tabstop>radPredefinedOrder</tabstop>
   <tabstop>radAroundPoint</tabstop>
   <tabstop>radOverPoint</tabstop>
-  <tabstop>radOverCentroid</tabstop>
-  <tabstop>radAroundCentroid</tabstop>
-  <tabstop>radPolygonPerimeter</tabstop>
-  <tabstop>radPolygonPerimeterCurved</tabstop>
-  <tabstop>radPolygonHorizontal</tabstop>
-  <tabstop>radPolygonFree</tabstop>
+  <tabstop>radLineParallel</tabstop>
+  <tabstop>radLineCurved</tabstop>
+  <tabstop>radLineHorizontal</tabstop>
   <tabstop>chkLineAbove</tabstop>
   <tabstop>chkLineOn</tabstop>
   <tabstop>chkLineBelow</tabstop>
@@ -6611,6 +6668,7 @@ font-style: italic;</string>
   <tabstop>mCentroidInsideCheckBox</tabstop>
   <tabstop>mLineDistanceSpnBx</tabstop>
   <tabstop>mLineDistanceDDBtn</tabstop>
+  <tabstop>mLineDistanceUnitWidget</tabstop>
   <tabstop>mLineDistanceUnitDDBtn</tabstop>
   <tabstop>mOffsetTypeComboBox</tabstop>
   <tabstop>mPointOffsetAboveLeft</tabstop>
@@ -6627,24 +6685,29 @@ font-style: italic;</string>
   <tabstop>mPointOffsetXSpinBox</tabstop>
   <tabstop>mPointOffsetYSpinBox</tabstop>
   <tabstop>mPointOffsetDDBtn</tabstop>
+  <tabstop>mPointOffsetUnitWidget</tabstop>
   <tabstop>mPointOffsetUnitsDDBtn</tabstop>
   <tabstop>mPointAngleSpinBox</tabstop>
   <tabstop>mPointAngleDDBtn</tabstop>
   <tabstop>mRepeatDistanceSpinBox</tabstop>
   <tabstop>mRepeatDistanceDDBtn</tabstop>
+  <tabstop>mRepeatDistanceUnitWidget</tabstop>
   <tabstop>mRepeatDistanceUnitDDBtn</tabstop>
   <tabstop>mMaxCharAngleInDSpinBox</tabstop>
   <tabstop>mMaxCharAngleOutDSpinBox</tabstop>
   <tabstop>mMaxCharAngleDDBtn</tabstop>
+  <tabstop>mPlacementDDGroupBox</tabstop>
   <tabstop>mCoordXDDBtn</tabstop>
   <tabstop>mCoordYDDBtn</tabstop>
   <tabstop>mCoordAlignmentHDDBtn</tabstop>
   <tabstop>mCoordAlignmentVDDBtn</tabstop>
   <tabstop>mCoordRotationDDBtn</tabstop>
   <tabstop>chkPreserveRotation</tabstop>
+  <tabstop>mPriorityGrpBx</tabstop>
   <tabstop>mPrioritySlider</tabstop>
   <tabstop>mPriorityDDBtn</tabstop>
   <tabstop>scrollArea_4</tabstop>
+  <tabstop>mRenderingLabelGrpBx</tabstop>
   <tabstop>mScaleBasedVisibilityChkBx</tabstop>
   <tabstop>mScaleBasedVisibilityDDBtn</tabstop>
   <tabstop>mScaleBasedVisibilityMinSpnBx</tabstop>
@@ -6665,18 +6728,20 @@ font-style: italic;</string>
   <tabstop>mUpsidedownRadioOff</tabstop>
   <tabstop>mUpsidedownRadioDefined</tabstop>
   <tabstop>mUpsidedownRadioAll</tabstop>
+  <tabstop>mRenderingFeaturesGrpBx</tabstop>
   <tabstop>chkLabelPerFeaturePart</tabstop>
   <tabstop>chkMergeLines</tabstop>
   <tabstop>mLimitLabelChkBox</tabstop>
   <tabstop>mLimitLabelSpinBox</tabstop>
   <tabstop>mMinSizeSpinBox</tabstop>
   <tabstop>mFitInsidePolygonCheckBox</tabstop>
+  <tabstop>mObstaclesGroupBox</tabstop>
   <tabstop>mChkNoObstacle</tabstop>
   <tabstop>mIsObstacleDDBtn</tabstop>
   <tabstop>mObstacleFactorSlider</tabstop>
   <tabstop>mObstacleFactorDDBtn</tabstop>
   <tabstop>mObstacleTypeComboBox</tabstop>
-  <tabstop>mOptionsTab</tabstop>
+  <tabstop>scrollArea_mPreview</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -431,6 +431,9 @@
                </item>
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="indexGroupBox">
+                 <property name="focusPolicy">
+                  <enum>Qt::StrongFocus</enum>
+                 </property>
                  <property name="title">
                   <string>Coordinate reference system</string>
                  </property>
@@ -502,7 +505,11 @@
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
                   <item row="0" column="0">
-                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true"/>
+                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -943,7 +950,11 @@
                </widget>
               </item>
               <item row="0" column="1">
-               <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget"/>
+               <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget">
+                <property name="focusPolicy">
+                 <enum>Qt::StrongFocus</enum>
+                </property>
+               </widget>
               </item>
               <item row="1" column="0" colspan="2">
                <widget class="QGroupBox" name="groupBox_2">
@@ -991,6 +1002,9 @@
                  </item>
                  <item row="1" column="0" colspan="2">
                   <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget">
+                   <property name="focusPolicy">
+                    <enum>Qt::StrongFocus</enum>
+                   </property>
                    <property name="toolTip">
                     <string>The valid attribute names for this layer</string>
                    </property>
@@ -1814,6 +1828,12 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
@@ -1825,31 +1845,26 @@
    <header>qgsscalerangewidget.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsScaleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsscalecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsVariableEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">qgsvariableeditorwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsLayerTreeEmbeddedConfigWidget</class>
-   <extends>QWidget</extends>
-   <header>qgslayertreeembeddedconfigwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsFieldExpressionWidget</class>
+   <class>QgsScaleComboBox</class>
    <extends>QComboBox</extends>
-   <header>qgsfieldexpressionwidget.h</header>
+   <header>qgsscalecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLayerTreeView</class>
    <extends>QTreeView</extends>
    <header>qgslayertreeview.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsLayerTreeEmbeddedConfigWidget</class>
+   <extends>QWidget</extends>
+   <header>qgslayertreeembeddedconfigwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1861,16 +1876,19 @@
  <tabstops>
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>groupBox</tabstop>
   <tabstop>mLayerOrigNameLineEdit</tabstop>
   <tabstop>txtDisplayName</tabstop>
   <tabstop>txtLayerSource</tabstop>
   <tabstop>cboProviderEncoding</tabstop>
+  <tabstop>indexGroupBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>pbnIndex</tabstop>
   <tabstop>pbnUpdateExtents</tabstop>
   <tabstop>mScaleVisibilityGroupBox</tabstop>
+  <tabstop>mScaleRangeWidget</tabstop>
+  <tabstop>mSubsetGroupBox</tabstop>
   <tabstop>txtSubsetSQL</tabstop>
-  <tabstop>pbnQueryBuilder</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>scrollArea_19</tabstop>
@@ -1880,28 +1898,37 @@
   <tabstop>mSimplifyDrawingAtProvider</tabstop>
   <tabstop>mSimplifyMaximumScaleComboBox</tabstop>
   <tabstop>mForceRasterCheckBox</tabstop>
-  <tabstop>scrollArea_10</tabstop>
+  <tabstop>mDisplayExpressionWidget</tabstop>
+  <tabstop>mMapTipExpressionFieldWidget</tabstop>
+  <tabstop>mInsertExpressionButton</tabstop>
   <tabstop>scrollArea_6</tabstop>
-  <tabstop>mJoinTreeWidget</tabstop>
   <tabstop>scrollArea_7</tabstop>
   <tabstop>mButtonAddJoin</tabstop>
   <tabstop>mButtonRemoveJoin</tabstop>
   <tabstop>mButtonEditJoin</tabstop>
+  <tabstop>mJoinTreeWidget</tabstop>
   <tabstop>scrollArea_2</tabstop>
+  <tabstop>mMetaDescriptionGrpBx</tabstop>
   <tabstop>mLayerShortNameLineEdit</tabstop>
   <tabstop>mLayerTitleLineEdit</tabstop>
   <tabstop>mLayerAbstractTextEdit</tabstop>
   <tabstop>mLayerKeywordListLineEdit</tabstop>
   <tabstop>mLayerDataUrlLineEdit</tabstop>
   <tabstop>mLayerDataUrlFormatComboBox</tabstop>
+  <tabstop>mMetaAttributionGrpBx</tabstop>
   <tabstop>mLayerAttributionLineEdit</tabstop>
   <tabstop>mLayerAttributionUrlLineEdit</tabstop>
+  <tabstop>mMetaMetaUrlGrpBx</tabstop>
   <tabstop>mLayerMetadataUrlLineEdit</tabstop>
   <tabstop>mLayerMetadataUrlTypeComboBox</tabstop>
   <tabstop>mLayerMetadataUrlFormatComboBox</tabstop>
+  <tabstop>mMetaLegendGrpBx</tabstop>
   <tabstop>mLayerLegendUrlLineEdit</tabstop>
   <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
+  <tabstop>mMetaPropertiesGrpBx</tabstop>
   <tabstop>teMetadata</tabstop>
+  <tabstop>mLayersDependenciesTreeView</tabstop>
+  <tabstop>pbnQueryBuilder</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -456,18 +456,19 @@
   <tabstop>scrollArea</tabstop>
   <tabstop>mEncodingComboBox</tabstop>
   <tabstop>mSelectedOnly</tabstop>
-  <tabstop>mAttributesSelection</tabstop>
-  <tabstop>mAttributeTable</tabstop>
   <tabstop>mSelectAllAttributes</tabstop>
   <tabstop>mDeselectAllAttributes</tabstop>
   <tabstop>mAddToCanvas</tabstop>
   <tabstop>mSymbologyExportComboBox</tabstop>
   <tabstop>mScaleSpinBox</tabstop>
+  <tabstop>mGeometryGroupBox</tabstop>
   <tabstop>mGeometryTypeComboBox</tabstop>
   <tabstop>mForceMultiCheckBox</tabstop>
   <tabstop>mIncludeZCheckBox</tabstop>
-  <tabstop>mOgrDatasourceOptions</tabstop>
-  <tabstop>mOgrLayerOptions</tabstop>
+  <tabstop>mExtentGroupBox</tabstop>
+  <tabstop>mDatasourceOptionsGroupBox</tabstop>
+  <tabstop>mLayerOptionsGroupBox</tabstop>
+  <tabstop>mOgrOptionsGroupBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/raster/qgshillshaderendererwidget.ui
+++ b/src/ui/raster/qgshillshaderendererwidget.ui
@@ -161,6 +161,14 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mBandsCombo</tabstop>
+  <tabstop>mLightAngle</tabstop>
+  <tabstop>mLightAzimuthDial</tabstop>
+  <tabstop>mLightAzimuth</tabstop>
+  <tabstop>mZFactor</tabstop>
+  <tabstop>mMultiDirection</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/raster/qgsrastertransparencywidget.ui
+++ b/src/ui/raster/qgsrastertransparencywidget.ui
@@ -394,6 +394,22 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>gboxGlobalTransp</tabstop>
+  <tabstop>sliderTransparency</tabstop>
+  <tabstop>gboxNoDataValue</tabstop>
+  <tabstop>mSrcNoDataValueCheckBox</tabstop>
+  <tabstop>leNoDataValue</tabstop>
+  <tabstop>gboxCustomTransparency</tabstop>
+  <tabstop>cboxTransparencyBand</tabstop>
+  <tabstop>pbnExportTransparentPixelValues</tabstop>
+  <tabstop>pbnImportTransparentPixelValues</tabstop>
+  <tabstop>pbnDefaultValues</tabstop>
+  <tabstop>pbnRemoveSelectedRow</tabstop>
+  <tabstop>pbnAddValuesFromDisplay</tabstop>
+  <tabstop>pbnAddValuesManually</tabstop>
+  <tabstop>tableTransparency</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>


### PR DESCRIPTION
This PR aims to fix order when moving from widget to widget with the TAB key. Refs https://github.com/qgis/qgis3_UIX_discussion/issues/13
Not sure I catch all the dialogs and given that I couldn't find a documentation on tabs use (which widget could be tabbed or not, whether scrollArea should be ...) I often keep/extends the current widgets that have a focus policy.
It'd be nice if someone can review the order in Vector layer properties --> Actions --> Add an action dialog.
Whatever, the situation should be better than before in most of the dialogs...