### PR TITLE
Fix 'bytes can only contain ASCII' error on python3

### DIFF
--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -619,11 +619,11 @@ QString QgsPythonUtilsImpl::homePythonPath()
   QString settingsDir = QgsApplication::qgisSettingsDirPath();
   if ( QDir::cleanPath( settingsDir ) == QDir::homePath() + QStringLiteral( "/.qgis3" ) )
   {
-    return QStringLiteral( "b\"%1/.qgis3/python\".decode('utf-8')" ).arg( QDir::homePath() );
+    return QStringLiteral( "\"%1/.qgis3/python\"" ).arg( QDir::homePath() );
   }
   else
   {
-    return "b\"" + settingsDir.replace( '\\', QLatin1String( "\\\\" ) ) + "python\".decode('utf-8')";
+    return "\"" + settingsDir.replace( '\\', QLatin1String( "\\\\" ) ) + "python\"";
   }
 }
 


### PR DESCRIPTION
In https://dash.orfeo-toolbox.org/testDetails.php?test=51211997&build=258264 I'm seeing an error:

"<font color=\"red\">An error occurred during execution of following code:<br><tt>sys.path = [\"/home/travis/build/qgis/QGIS/build/output/python\",b\"/tmp/tmp4o_r4n/test_configé€/python\".decode('utf-8'),b\"/tmp/tmp4o_r4n/test_configé€/python\".decode('utf-8') + \"/plugins\",\"/home/travis/build/qgis/QGIS/build/output/python/plugins\"] + sys.path</tt></font><br><pre><br>&nbsp; File \"<string>\", line 1<br>SyntaxError: bytes can only contain ASCII literal characters.<br><br></pre>Python version:<br>3.3.5 (default, Feb&nbsp; 5 2015, 16:01:18) <br>[GCC 4.6.3]<br><br>QGIS version:<br>2.99.0-Master 'Master', 6bff30a<br><br>Python path:<br>['/home/travis/build/qgis/QGIS/build/output/python', '/home/travis/build/qgis/QGIS/build/output/python/plugins', '/home/travis/build/qgis/QGIS/tests/src/python', '/home/travis/osgeo4travis/lib/python3.3/site-packages', '/home/travis/virtualenv/python3.3.5/lib/python33.zip', '/home/travis/virtualenv/python3.3.5/lib/python3.3', '/home/travis/virtualenv/python3.3.5/lib/python3.3/plat-linux', '/home/travis/virtualenv/python3.3.5/lib/python3.3/lib-dynload', '/opt/python/3.3.5/lib/python3.3', '/opt/python/3.3.5/lib/python3.3/plat-linux', '/home/travis/virtualenv/python3.3.5/lib/python3.3/site-packages']"


This is an attempt to fix it...