### PR TITLE
Avoid "Failed to load file  "/style.qss"" startup error

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -533,11 +533,14 @@ void QgsApplication::setUITheme( const QString &themeName )
 {
   // Loop all style sheets, find matching name, load it.
   QHash<QString, QString> themes = QgsApplication::uiThemes();
-  QString themename = themeName;
-  if ( !themes.contains( themename ) )
-    themename = QStringLiteral( "default" );
+  if ( themeName == QStringLiteral( "default" ) || !themes.contains( themeName ) )
+  {
+    setThemeName( QStringLiteral( "default" ) );
+    qApp->setStyleSheet( QString() );
+    return;
+  }
 
-  QString path = themes[themename];
+  QString path = themes.value( themeName );
   QString stylesheetname = path + "/style.qss";
   QString autostylesheet = stylesheetname + ".auto";
 
@@ -554,7 +557,6 @@ void QgsApplication::setUITheme( const QString &themeName )
       return;
     }
 
-    QHash<QString, QString> variables;
     QString styledata = file.readAll();
     QTextStream in( &variablesfile );
     while ( !in.atEnd() )
@@ -580,7 +582,7 @@ void QgsApplication::setUITheme( const QString &themeName )
   QString styleSheet = QStringLiteral( "file:///" );
   styleSheet.append( stylesheetname );
   qApp->setStyleSheet( styleSheet );
-  setThemeName( themename );
+  setThemeName( themeName );
 }
 
 QHash<QString, QString> QgsApplication::uiThemes()


### PR DESCRIPTION
Avoids this error on startup:

```
Warning: QCss::Parser - Failed to load file  "/style.qss"
283: Stacktrace (piped through c++filt):
283: /home/nyall/dev/build-QGIS/output/bin/qgis[0x40917f]
283: /home/nyall/dev/build-QGIS/output/bin/qgis[0x4095f6]
283: /lib64/libQt5Core.so.5(+0x901fb)[0x7fb9f872f1fb]
283: /lib64/libQt5Core.so.5(qt_message_output(QtMsgType, QMessageLogContext const&, QString const&)+0x8)[0x7fb9f8731108]
283: /lib64/libQt5Core.so.5(QDebug::~QDebug()+0x90)[0x7fb9f881b3b0]
283: /lib64/libQt5Gui.so.5(QCss::Parser::init(QString const&, bool)+0x1eb)[0x7fb9fb6f793b]
283: /lib64/libQt5Widgets.so.5(+0x1f497f)[0x7fb9fbb6197f]
283: /lib64/libQt5Widgets.so.5(+0x1fa186)[0x7fb9fbb67186]
283: /lib64/libQt5Widgets.so.5(+0x1fb35a)[0x7fb9fbb6835a]
283: /lib64/libQt5Widgets.so.5(+0x1feae0)[0x7fb9fbb6bae0]
283: /lib64/libQt5Widgets.so.5(QWidgetPrivate::setStyle_helper(QStyle*, bool, bool)+0xdc)[0x7fb9fbaffcdc]
283: /lib64/libQt5Widgets.so.5(QWidgetPrivate::inheritStyle()+0x1e7)[0x7fb9fbb00127]
283: /lib64/libQt5Widgets.so.5(QApplication::setStyle(QStyle*)+0x235)[0x7fb9fbacb185]
283: /home/nyall/dev/build-QGIS/output/lib/libqgis_core.so.2.99.0(QgsApplication::setUITheme(QString const&)+0x524)[0x7fb9fe9701d6]
283: /home/nyall/dev/build-QGIS/output/lib/libqgis_app.so.2.99.0(QgisApp::setTheme(QString const&)+0x29)[0x7fba0101aaf1]
283: /home/nyall/dev/build-QGIS/output/lib/libqgis_app.so.2.99.0(QgisApp::readSettings()+0xd9)[0x7fba0100defd]
283: /home/nyall/dev/build-QGIS/output/lib/libqgis_app.so.2.99.0(QgisApp::functionProfile(void (QgisApp::*)(), QgisApp*, QString)+0x7c)[0x7fba010605d8]
283: /home/nyall/dev/build-QGIS/output/lib/libqgis_app.so.2.99.0(QgisApp::QgisApp(QSplashScreen*, bool, bool, QWidget*, QFlags<Qt::WindowType>)+0x1f5e)[0x7fba010077c2]
283: /home/nyall/dev/build-QGIS/output/bin/qgis[0x40daf5]
283: /lib64/libc.so.6(__libc_start_main+0xf1)[0x7fb9f7a51401]
```