### PR TITLE
Remove draw() method from QgsRasterDataProvider interface

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1495,6 +1495,7 @@ QgsRasterDataProvider        {#qgis_api_break_3_0_QgsRasterDataProvider}
 - useSrcNoDataValue() has been renamed to useSourceNoDataValue()
 - setUseSrcNoDataValue() has been renamed to setUseSourceNoDataValue()
 - srcNoDataValue() has been renamed to sourceNoDataValue()
+- draw() has been removed from the interface as it was not used anywhere.
 
 
 QgsRasterInterface        {#qgis_api_break_3_0_QgsRasterInterface}

--- a/python/core/raster/qgsrasterdataprovider.sip
+++ b/python/core/raster/qgsrasterdataprovider.sip
@@ -52,15 +52,6 @@ class QgsRasterDataProvider : QgsDataProvider, QgsRasterInterface
     /* It makes no sense to set input on provider */
     bool setInput( QgsRasterInterface* input );
 
-    /** \brief   Renders the layer as an image
-     * \note When render caching (/qgis/enable_render_caching) is on the wms
-     * provider doesn't wait for the reply of the getmap request or all
-     * tiles replies and can return incomplete images.
-     * Temporarily disable render caching if you require the complete
-     * wms image in the first call.
-     */
-    virtual QImage* draw( const QgsRectangle & viewExtent, int pixelWidth, int pixelHeight ) = 0;
-
     /** Get the extent of the data source.
      * @return QgsRectangle containing the extent of the layer
      */

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -91,15 +91,6 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
     /* It makes no sense to set input on provider */
     bool setInput( QgsRasterInterface* input ) override { Q_UNUSED( input ); return false; }
 
-    /** \brief   Renders the layer as an image
-     * \note When render caching (/qgis/enable_render_caching) is on the wms
-     * provider doesn't wait for the reply of the getmap request or all
-     * tiles replies and can return incomplete images.
-     * Temporarily disable render caching if you require the complete
-     * wms image in the first call.
-     */
-    virtual QImage* draw( const QgsRectangle & viewExtent, int pixelWidth, int pixelHeight ) = 0;
-
     virtual QgsRectangle extent() const override = 0;
 
     //! Returns data type for the band specified by number

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -238,11 +238,11 @@ QString QgsAmsProvider::metadata()
   return dumpVariantMap( mServiceInfo, tr( "Service Info" ) ) + dumpVariantMap( mLayerInfo, tr( "Layer Info" ) );
 }
 
-QImage* QgsAmsProvider::draw( const QgsRectangle & viewExtent, int pixelWidth, int pixelHeight )
+void QgsAmsProvider::draw( const QgsRectangle & viewExtent, int pixelWidth, int pixelHeight )
 {
   if ( !mCachedImage.isNull() && mCachedImageExtent == viewExtent )
   {
-    return &mCachedImage;
+    return;
   }
   QgsDataSourceUri dataSource( dataSourceUri() );
 
@@ -269,7 +269,7 @@ QImage* QgsAmsProvider::draw( const QgsRectangle & viewExtent, int pixelWidth, i
     {
       mCachedImage = QImage();
       mCachedImage.fill( Qt::transparent );
-      return &mCachedImage;
+      return;
     }
     int level = 0;
     double resolution = lodEntries.front().toMap()[QStringLiteral( "resolution" )].toDouble();
@@ -343,7 +343,7 @@ QImage* QgsAmsProvider::draw( const QgsRectangle & viewExtent, int pixelWidth, i
       mCachedImage = mCachedImage.convertToFormat( QImage::Format_ARGB32 );
     }
   }
-  return &mCachedImage;
+  return;
 }
 
 QImage QgsAmsProvider::getLegendGraphic( double /*scale*/, bool forceRefresh, const QgsRectangle * /*visibleExtent*/ )
@@ -442,12 +442,11 @@ void QgsAmsProvider::readBlock( int /*bandNo*/, const QgsRectangle & viewExtent,
   Q_UNUSED( feedback );  // TODO: make use of the feedback object
 
   // TODO: optimize to avoid writing to QImage
-  // returned image is actually mCachedImage, no need to delete
-  QImage *image = draw( viewExtent, width, height );
-  if ( image->width() != width || image->height() != height )
+  draw( viewExtent, width, height );
+  if ( mCachedImage.width() != width || mCachedImage.height() != height )
   {
     QgsDebugMsg( "Unexpected image size for block" );
     return;
   }
-  std::memcpy( data, image->bits(), image->bytesPerLine() * image->height() );
+  std::memcpy( data, mCachedImage.constBits(), mCachedImage.bytesPerLine() * mCachedImage.height() );
 }

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -80,7 +80,6 @@ class QgsAmsProvider : public QgsRasterDataProvider
     Qgis::DataType sourceDataType( int /*bandNo*/ ) const override { return Qgis::ARGB32; }
     QgsRasterInterface* clone() const override;
     QString metadata() override;
-    QImage* draw( const QgsRectangle & viewExtent, int pixelWidth, int pixelHeight ) override;
     bool supportsLegendGraphic() const override { return true; }
     QImage getLegendGraphic( double scale = 0, bool forceRefresh = false, const QgsRectangle * visibleExtent = 0 ) override;
     QgsImageFetcher* getLegendGraphicFetcher( const QgsMapSettings* mapSettings ) override;
@@ -88,6 +87,8 @@ class QgsAmsProvider : public QgsRasterDataProvider
 
   protected:
     void readBlock( int bandNo, const QgsRectangle & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
+
+    void draw( const QgsRectangle & viewExtent, int pixelWidth, int pixelHeight );
 
   private:
     bool mValid;

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -373,20 +373,6 @@ QString QgsGdalProvider::metadata()
 }
 
 
-// Not supported by GDAL
-QImage* QgsGdalProvider::draw( QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight )
-{
-  Q_UNUSED( viewExtent );
-  QgsDebugMsg( "pixelWidth = "  + QString::number( pixelWidth ) );
-  QgsDebugMsg( "pixelHeight = "  + QString::number( pixelHeight ) );
-  QgsDebugMsg( "viewExtent: " + viewExtent.toString() );
-
-  QImage *image = new QImage( pixelWidth, pixelHeight, QImage::Format_ARGB32 );
-  image->fill( QColor( Qt::gray ).rgb() );
-
-  return image;
-}
-
 QgsRasterBlock* QgsGdalProvider::block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight, QgsRasterBlockFeedback* feedback )
 {
   QgsRasterBlock *block = new QgsRasterBlock( dataType( theBandNo ), theWidth, theHeight );

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -76,7 +76,6 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
 
     QgsGdalProvider * clone() const override;
 
-    QImage* draw( QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight ) override;
     QString name() const override;
     QString description() const override;
     virtual QgsCoordinateReferenceSystem crs() const override;

--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -178,50 +178,6 @@ QgsRasterInterface * QgsGrassRasterProvider::clone() const
   return provider;
 }
 
-QImage* QgsGrassRasterProvider::draw( QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight )
-{
-  QgsDebugMsg( "pixelWidth = "  + QString::number( pixelWidth ) );
-  QgsDebugMsg( "pixelHeight = "  + QString::number( pixelHeight ) );
-  QgsDebugMsg( "viewExtent: " + viewExtent.toString() );
-  clearLastError();
-
-  QImage *image = new QImage( pixelWidth, pixelHeight, QImage::Format_ARGB32 );
-  image->fill( QColor( Qt::gray ).rgb() );
-
-  QStringList arguments;
-  arguments.append( "map=" +  mMapName + "@" + mMapset );
-
-  arguments.append(( QStringLiteral( "window=%1,%2,%3,%4,%5,%6" )
-                     .arg( QgsRasterBlock::printValue( viewExtent.xMinimum() ),
-                           QgsRasterBlock::printValue( viewExtent.yMinimum() ),
-                           QgsRasterBlock::printValue( viewExtent.xMaximum() ),
-                           QgsRasterBlock::printValue( viewExtent.yMaximum() ) )
-                     .arg( pixelWidth ).arg( pixelHeight ) ) );
-  QString cmd = QgsApplication::libexecPath() + "grass/modules/qgis.d.rast";
-  QByteArray data;
-  try
-  {
-    data = QgsGrass::runModule( mGisdbase, mLocation, mMapset, cmd, arguments );
-  }
-  catch ( QgsGrass::Exception &e )
-  {
-    QString error = tr( "Cannot draw raster" ) + " : " + e.what();
-    QgsDebugMsg( error );
-    appendError( error );
-    // We don't set mValid to false, because the raster can be recreated and work next time
-    return image;
-  }
-  QgsDebugMsg( QString( "%1 bytes read from modules stdout" ).arg( data.size() ) );
-  uchar * ptr = image->bits();
-  // byteCount() in Qt >= 4.6
-  //int size = image->byteCount() < data.size() ? image->byteCount() : data.size();
-  int size = pixelWidth * pixelHeight * 4 < data.size() ? pixelWidth * pixelHeight * 4 : data.size();
-  memcpy( ptr, data.data(), size );
-
-  return image;
-}
-
-
 void QgsGrassRasterProvider::readBlock( int bandNo, int xBlock, int yBlock, void *block )
 {
   Q_UNUSED( xBlock );

--- a/src/providers/grass/qgsgrassrasterprovider.h
+++ b/src/providers/grass/qgsgrassrasterprovider.h
@@ -106,10 +106,6 @@ class GRASS_LIB_EXPORT QgsGrassRasterProvider : public QgsRasterDataProvider
 
     QgsRasterInterface * clone() const override;
 
-    /** \brief   Renders the layer as an image
-     */
-    QImage* draw( QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight ) override;
-
     /** Return a provider name
      *
      * Essentially just returns the provider key.  Should be used to build file

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1598,21 +1598,6 @@ QMap<QString, QString> QgsWcsProvider::supportedMimes()
   return mimes;
 }
 
-// Not supported by WCS
-// TODO: remove from QgsRasterDataProvider?
-QImage* QgsWcsProvider::draw( QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight )
-{
-  Q_UNUSED( viewExtent );
-  QgsDebugMsg( "pixelWidth = "  + QString::number( pixelWidth ) );
-  QgsDebugMsg( "pixelHeight = "  + QString::number( pixelHeight ) );
-  QgsDebugMsg( "viewExtent: " + viewExtent.toString() );
-
-  QImage *image = new QImage( pixelWidth, pixelHeight, QImage::Format_ARGB32 );
-  image->fill( QColor( Qt::gray ).rgb() );
-
-  return image;
-}
-
 QGISEXTERN QgsWcsProvider * classFactory( const QString *uri )
 {
   return new QgsWcsProvider( *uri );

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -142,21 +142,6 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
 
     // TODO: Document this better.
 
-    /** \brief   Renders the layer as an image
-     *
-     *  \return  A QImage - if the attempt to retrieve data for the draw was unsuccessful, returns 0
-     *           and more information can be found in lastError() and lastErrorTitle()
-     *
-     *  \todo    Add pixel depth parameter (intended to match the display or printer device)
-     *
-     *  \note    Ownership of the returned QImage remains with this provider and its lifetime
-     *           is guaranteed only until the next call to draw() or destruction of this provider.
-     *
-     *  \warning A pointer to an QImage is used, as a plain QImage seems to have difficulty being
-     *           shared across library boundaries
-     */
-    QImage *draw( QgsRectangle const &  viewExtent, int pixelWidth, int pixelHeight ) override;
-
     void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     void readBlock( int theBandNo, int xBlock, int yBlock, void *block ) override;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -497,11 +497,6 @@ void QgsWmsProvider::setFormatQueryItem( QUrl &url )
     setQueryItem( url, QStringLiteral( "FORMAT" ), mSettings.mImageMimeType );
 }
 
-QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, int pixelHeight )
-{
-  return draw( viewExtent, pixelWidth, pixelHeight, nullptr );
-}
-
 
 static bool _fuzzyContainsRect( const QRectF& r1, const QRectF& r2 )
 {

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -145,8 +145,6 @@ class QgsWmsProvider : public QgsRasterDataProvider
      */
     void setConnectionName( QString const & connName );
 
-    QImage *draw( QgsRectangle const &  viewExtent, int pixelWidth, int pixelHeight ) override;
-
     void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
     //void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, QgsCoordinateReferenceSystem theSrcCRS, QgsCoordinateReferenceSystem theDestCRS, void *data );
 


### PR DESCRIPTION
It was redundant in the API - one always wants to use block() to get data