### PR TITLE
Don't use canvas mapSettings when composer maps respond to layer changes

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -570,6 +570,7 @@ instead.
 - atlasFixedScale() and setAtlasFixedScale() were removed. Use atlasScalingMode()
 and setAtlasScalingMode() instead.
 - storeCurrentLayerSet() was removed. Use setLayers() instead.
+- The layersChanged() slot was removed.
 
 QgsComposerMapGrid        {#qgis_api_break_3_0_QgsComposerMapGrid}
 ------------------

--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -387,12 +387,4 @@ class QgsComposerMap : QgsComposerItem
 
     virtual void refreshDataDefinedProperty( const QgsComposerObject::DataDefinedProperty property = QgsComposerObject::AllProperties, const QgsExpressionContext* context = 0 );
 
-  protected slots:
-
-    /** Called when layers are added or removed from the layer registry. Updates the maps
-     * layer set and redraws the map if required.
-     * @note added in QGIS 2.9
-     */
-    void layersChanged();
-
 };

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -458,13 +458,8 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
 
     virtual void refreshDataDefinedProperty( const QgsComposerObject::DataDefinedProperty property = QgsComposerObject::AllProperties, const QgsExpressionContext* context = nullptr ) override;
 
-  protected slots:
-
-    /** Called when layers are added or removed from the layer registry. Updates the maps
-     * layer set and redraws the map if required.
-     * @note added in QGIS 2.9
-     */
-    void layersChanged();
+  private slots:
+    void layersAboutToBeRemoved( QList<QgsMapLayer*> layers );
 
   private:
 


### PR DESCRIPTION
Also fixes refreshing maps when set to render mode and a layer is removed.