### PR TITLE
change style file extension from QML to QLP

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1762,13 +1762,9 @@ void QgsRasterLayerProperties::loadStyle_clicked()
                        this,
                        tr( "Load layer properties from style file" ),
                        lastUsedDir,
-                       tr( "QGIS Layer Style File" ) + " (*.qml)" );
+                       tr( "QGIS Layer Properties File" ) + " (*.qlp);;" + tr( "QGIS Layer Style File" ) + " (*.qml)" );
   if ( fileName.isEmpty() )
     return;
-
-  // ensure the user never omits the extension from the file name
-  if ( !fileName.endsWith( QLatin1String( ".qml" ), Qt::CaseInsensitive ) )
-    fileName += QLatin1String( ".qml" );
 
   mOldStyle = mRasterLayer->styleManager()->style( mRasterLayer->styleManager()->currentStyle() );
 
@@ -1781,7 +1777,7 @@ void QgsRasterLayerProperties::loadStyle_clicked()
   }
   else
   {
-    QMessageBox::information( this, tr( "Saved Style" ), message );
+    QMessageBox::information( this, tr( "Load Style" ), message );
   }
 }
 
@@ -1795,13 +1791,13 @@ void QgsRasterLayerProperties::saveStyleAs_clicked()
                              this,
                              tr( "Save layer properties as style file" ),
                              lastUsedDir,
-                             tr( "QGIS Layer Style File" ) + " (*.qml)" );
+                             tr( "QGIS Layer Properties File" ) + " (*.qlp)" );
   if ( outputFileName.isEmpty() )
     return;
 
   // ensure the user never omits the extension from the file name
-  if ( !outputFileName.endsWith( QLatin1String( ".qml" ), Qt::CaseInsensitive ) )
-    outputFileName += QLatin1String( ".qml" );
+  if ( !outputFileName.endsWith( QLatin1String( ".qlp" ), Qt::CaseInsensitive ) )
+    outputFileName += QLatin1String( ".qlp" );
 
   apply(); // make sure the style to save is uptodate
 

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1762,7 +1762,7 @@ void QgsRasterLayerProperties::loadStyle_clicked()
                        this,
                        tr( "Load layer properties from style file" ),
                        lastUsedDir,
-                       tr( "QGIS Layer Properties File" ) + " (*.qlp);;" + tr( "QGIS Layer Style File" ) + " (*.qml)" );
+                       tr( "QGIS Layer Properties File" ) + " (*.qlp);;" + tr( "QGIS 2.x Layer Style File" ) + " (*.qml)" );
   if ( fileName.isEmpty() )
     return;
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -802,7 +802,7 @@ void QgsVectorLayerProperties::loadStyle_clicked()
 
   QString myFileName = QFileDialog::getOpenFileName( this, tr( "Load layer properties from style file" ), myLastUsedDir,
                        tr( "QGIS Layer Properties File" ) + " (*.qlp);;" +
-                       tr( "QGIS Layer Style File" ) + " (*.qml);;" +
+                       tr( "QGIS 2.x Layer Style File" ) + " (*.qml);;" +
                        tr( "SLD File" ) + " (*.sld)" );
   if ( myFileName.isNull() )
   {

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -801,7 +801,9 @@ void QgsVectorLayerProperties::loadStyle_clicked()
   QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
 
   QString myFileName = QFileDialog::getOpenFileName( this, tr( "Load layer properties from style file" ), myLastUsedDir,
-                       tr( "QGIS Layer Style File" ) + " (*.qml);;" + tr( "SLD File" ) + " (*.sld)" );
+                       tr( "QGIS Layer Properties File" ) + " (*.qlp);;" +
+                       tr( "QGIS Layer Style File" ) + " (*.qml);;" +
+                       tr( "SLD File" ) + " (*.sld)" );
   if ( myFileName.isNull() )
   {
     return;
@@ -907,8 +909,8 @@ void QgsVectorLayerProperties::saveStyleAs( StyleType styleType )
     }
     else
     {
-      format = tr( "QGIS Layer Style File" ) + " (*.qml)";
-      extension = QStringLiteral( ".qml" );
+      format = tr( "QGIS Layer Properties File" ) + " (*.qlp)";
+      extension = QStringLiteral( ".qlp" );
     }
 
     QString myOutputFileName = QFileDialog::getSaveFileName( this, tr( "Save layer properties as style file" ),

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -1439,7 +1439,7 @@ QgsDataItem* QgsZipItem::itemFromPath( QgsDataItem* parent, const QString& fileP
       {
         QgsDataItem *item = nullptr;
         // try first with normal path (Passthru)
-        // this is to simplify .qml handling, and without this some tests will fail
+        // this is to simplify .qlp handling, and without this some tests will fail
         // (e.g. testZipItemVectorTransparency(), second test)
         if (( sProviderNames.at( i ) == QLatin1String( "ogr" ) ) ||
             ( sProviderNames.at( i ) == QLatin1String( "gdal" ) && zipFileCount == 1 ) )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -429,7 +429,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     static QString capitalizeLayerName( const QString& name );
 
     /** Retrieve the style URI for this layer
-     * (either as a .qml file on disk or as a
+     * (either as a .qlp file on disk or as a
      * record in the users style table in their personal qgis.db)
      * @return a QString with the style file name
      * @see also loadNamedStyle () and saveNamedStyle ();
@@ -437,7 +437,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual QString styleURI() const;
 
     /** Retrieve the default style for this layer if one
-     * exists (either as a .qml file on disk or as a
+     * exists (either as a .qlp file on disk or as a
      * record in the users style table in their personal qgis.db)
      * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to load the default style.
@@ -447,7 +447,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual QString loadDefaultStyle( bool & resultFlag );
 
     /** Retrieve a named style for this layer if one
-     * exists (either as a .qml file on disk or as a
+     * exists (either as a .qlp file on disk or as a
      * record in the users style table in their personal qgis.db)
      * @param uri - the file name or other URI for the
      * style file. First an attempt will be made to see if this
@@ -464,10 +464,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** Retrieve a named style for this layer from a sqlite database.
      * @param db path to sqlite database
      * @param uri uri for table
-     * @param qml will be set to QML style content from database
+     * @param qlp will be set to QLP style content from database
      * @returns true if style was successfully loaded
      */
-    virtual bool loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qml );
+    virtual bool loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qlp );
 
     /**
      * Import the properties of this layer from a QDomDocument
@@ -497,7 +497,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual void exportSldStyle( QDomDocument &doc, QString &errorMsg ) const;
 
     /** Save the properties of this layer as the default style
-     * (either as a .qml file on disk or as a
+     * (either as a .qlp file on disk or as a
      * record in the users style table in their personal qgis.db)
      * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to save the default style.
@@ -507,7 +507,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual QString saveDefaultStyle( bool & resultFlag );
 
     /** Save the properties of this layer as a named style
-     * (either as a .qml file on disk or as a
+     * (either as a .qlp file on disk or as a
      * record in the users style table in their personal qgis.db)
      * @param uri the file name or other URI for the
      * style file. First an attempt will be made to see if this

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -167,7 +167,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      *
      * The main tasks carried out by the constructor are:
      *
-     * -Load the rasters default style (.qml) file if it exists
+     * -Load the rasters default style (.qlp) file if it exists
      *
      * -Populate the RasterStatsVector with initial values for each band.
      *

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -300,7 +300,7 @@ void QgsMapLayerStyleManagerWidget::loadStyle()
 
   QString myFileName = QFileDialog::getOpenFileName( this, tr( "Load layer properties from style file" ), myLastUsedDir,
                        tr( "QGIS Layer Properties File" ) + " (*.qlp);;" +
-                       tr( "QGIS Layer Style File" ) + " (*.qml);;" +
+                       tr( "QGIS 2.x Layer Style File" ) + " (*.qml);;" +
                        tr( "SLD File" ) + " (*.sld)" );
   if ( myFileName.isNull() )
   {

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -299,7 +299,9 @@ void QgsMapLayerStyleManagerWidget::loadStyle()
   QString myLastUsedDir = myQSettings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
 
   QString myFileName = QFileDialog::getOpenFileName( this, tr( "Load layer properties from style file" ), myLastUsedDir,
-                       tr( "QGIS Layer Style File" ) + " (*.qml);;" + tr( "SLD File" ) + " (*.sld)" );
+                       tr( "QGIS Layer Properties File" ) + " (*.qlp);;" +
+                       tr( "QGIS Layer Style File" ) + " (*.qml);;" +
+                       tr( "SLD File" ) + " (*.sld)" );
   if ( myFileName.isNull() )
   {
     return;


### PR DESCRIPTION
This fixes overlap with QtQuick/QtQML files and also reflects that this is more than just style, as now it contains labeling settings, widgets settings etc.

I only chaged corresponding strings and some variable names. Most of the variables and names of the fields in the databases left unchanged (e.g. when saving style to database). Not sure if we should change them too.