### PR TITLE
Store URLs in QSettings

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9299,10 +9299,14 @@ void QgisApp::adjustBrightnessContrast( int delta, bool updateBrightness )
   }
 }
 
+
 void QgisApp::helpContents()
 {
+  QSettings settings;
+  QString helpUrl = settings.value( QStringLiteral( "Qgis/docsUserManualUrl" ),
+                                    QStringLiteral( "https://docs.qgis.org/%1.%2/%3/docs/user_manual/" ) ).toString();
   // We should really ship the HTML version of the docs local too.
-  openURL( QStringLiteral( "https://docs.qgis.org/%1.%2/%3/docs/user_manual/" )
+  openURL( helpUrl
            .arg( Qgis::QGIS_VERSION_INT / 10000 )
            .arg( Qgis::QGIS_VERSION_INT / 100 % 100 )
            .arg( tr( "en", "documentation language" ) ),
@@ -9317,22 +9321,35 @@ void QgisApp::apiDocumentation()
   }
   else
   {
-    openURL( QStringLiteral( "https://qgis.org/api/" ), false );
+    QSettings settings;
+    QString QgisApiUrl = settings.value( QStringLiteral( "Qgis/QgisApiUrl" ),
+                                         QStringLiteral( "https://qgis.org/api/" ) ).toString();
+    openURL( QgisApiUrl, false );
   }
 }
 
 void QgisApp::reportaBug()
 {
-  openURL( tr( "https://qgis.org/en/site/getinvolved/development/bugreporting.html" ), false );
+  QSettings settings;
+  QString reportaBugUrl = settings.value( QStringLiteral( "Qgis/reportaBugUrl" ),
+                                          tr( "https://qgis.org/en/site/getinvolved/development/bugreporting.html" ) ).toString();
+  openURL( reportaBugUrl, false );
 }
+
 void QgisApp::supportProviders()
 {
-  openURL( tr( "https://qgis.org/en/site/forusers/commercial_support.html" ), false );
+  QSettings settings;
+  QString supportProvidersUrl = settings.value( QStringLiteral( "Qgis/supportProvidersUrl" ),
+                                tr( "https://qgis.org/en/site/forusers/commercial_support.html" ) ).toString();
+  openURL( supportProvidersUrl , false );
 }
 
 void QgisApp::helpQgisHomePage()
 {
-  openURL( QStringLiteral( "https://qgis.org" ), false );
+  QSettings settings;
+  QString  helpQgisHomePageUrl = settings.value( QStringLiteral( "Qgis/helpQgisHomePageUrl" ),
+                                 QStringLiteral( "https://qgis.org" ) ).toString();
+  openURL( helpQgisHomePageUrl, false );
 }
 
 void QgisApp::openURL( QString url, bool useQgisDocDirectory )


### PR DESCRIPTION
Make URLs overrideable through QSettings.
The idea is to eventually make all hardcoded URLs
and paths user-overrideable through a QSettings entry.