### PR TITLE
Move request logging to request object

### DIFF
--- a/src/server/qgsfcgiserverresponse.cpp
+++ b/src/server/qgsfcgiserverresponse.cpp
@@ -20,6 +20,7 @@
 #include "qgis.h"
 #include "qgsfcgiserverresponse.h"
 #include "qgslogger.h"
+#include "qgsserverlogger.h"
 #include "qgsmessagelog.h"
 #include <fcgi_stdio.h>
 
@@ -260,6 +261,13 @@ QgsFcgiServerRequest::QgsFcgiServerRequest()
 
   setUrl( url );
   setMethod( method );
+
+  // Output debug infos
+  QgsMessageLog::MessageLevel logLevel = QgsServerLogger::instance()->logLevel();
+  if ( logLevel <= QgsMessageLog::INFO )
+  {
+    printRequestInfos();
+  }
 }
 
 QgsFcgiServerRequest::~QgsFcgiServerRequest()
@@ -304,4 +312,54 @@ void QgsFcgiServerRequest::readData()
     QgsMessageLog::logMessage( "fcgi: No POST data" );
   }
 }
+
+void QgsFcgiServerRequest::printRequestInfos()
+{
+  QgsMessageLog::logMessage( QStringLiteral( "******************** New request ***************" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  if ( getenv( "REMOTE_ADDR" ) )
+  {
+    QgsMessageLog::logMessage( "REMOTE_ADDR: " + QString( getenv( "REMOTE_ADDR" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "REMOTE_HOST" ) )
+  {
+    QgsMessageLog::logMessage( "REMOTE_HOST: " + QString( getenv( "REMOTE_HOST" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "REMOTE_USER" ) )
+  {
+    QgsMessageLog::logMessage( "REMOTE_USER: " + QString( getenv( "REMOTE_USER" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "REMOTE_IDENT" ) )
+  {
+    QgsMessageLog::logMessage( "REMOTE_IDENT: " + QString( getenv( "REMOTE_IDENT" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "CONTENT_TYPE" ) )
+  {
+    QgsMessageLog::logMessage( "CONTENT_TYPE: " + QString( getenv( "CONTENT_TYPE" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "AUTH_TYPE" ) )
+  {
+    QgsMessageLog::logMessage( "AUTH_TYPE: " + QString( getenv( "AUTH_TYPE" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "HTTP_USER_AGENT" ) )
+  {
+    QgsMessageLog::logMessage( "HTTP_USER_AGENT: " + QString( getenv( "HTTP_USER_AGENT" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "HTTP_PROXY" ) )
+  {
+    QgsMessageLog::logMessage( "HTTP_PROXY: " + QString( getenv( "HTTP_PROXY" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "HTTPS_PROXY" ) )
+  {
+    QgsMessageLog::logMessage( "HTTPS_PROXY: " + QString( getenv( "HTTPS_PROXY" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "NO_PROXY" ) )
+  {
+    QgsMessageLog::logMessage( "NO_PROXY: " + QString( getenv( "NO_PROXY" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+  if ( getenv( "HTTP_AUTHORIZATION" ) )
+  {
+    QgsMessageLog::logMessage( "HTTP_AUTHORIZATION: " + QString( getenv( "HTTP_AUTHORIZATION" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  }
+}
+
 

--- a/src/server/qgsfcgiserverresponse.h
+++ b/src/server/qgsfcgiserverresponse.h
@@ -92,6 +92,11 @@ class QgsFcgiServerRequest: public QgsServerRequest
   private:
     void readData();
 
+    // Log request info: print debug infos
+    // about the request
+    void printRequestInfos();
+
+
     QByteArray mData;
     bool       mHasError;
 };

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -149,58 +149,6 @@ void QgsServer::printRequestParameters( const QMap< QString, QString>& parameter
 }
 
 /**
- * @brief QgsServer::printRequestInfos prints debug information about the request
- */
-void QgsServer::printRequestInfos()
-{
-  QgsMessageLog::logMessage( QStringLiteral( "******************** New request ***************" ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  if ( getenv( "REMOTE_ADDR" ) )
-  {
-    QgsMessageLog::logMessage( "REMOTE_ADDR: " + QString( getenv( "REMOTE_ADDR" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "REMOTE_HOST" ) )
-  {
-    QgsMessageLog::logMessage( "REMOTE_HOST: " + QString( getenv( "REMOTE_HOST" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "REMOTE_USER" ) )
-  {
-    QgsMessageLog::logMessage( "REMOTE_USER: " + QString( getenv( "REMOTE_USER" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "REMOTE_IDENT" ) )
-  {
-    QgsMessageLog::logMessage( "REMOTE_IDENT: " + QString( getenv( "REMOTE_IDENT" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "CONTENT_TYPE" ) )
-  {
-    QgsMessageLog::logMessage( "CONTENT_TYPE: " + QString( getenv( "CONTENT_TYPE" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "AUTH_TYPE" ) )
-  {
-    QgsMessageLog::logMessage( "AUTH_TYPE: " + QString( getenv( "AUTH_TYPE" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "HTTP_USER_AGENT" ) )
-  {
-    QgsMessageLog::logMessage( "HTTP_USER_AGENT: " + QString( getenv( "HTTP_USER_AGENT" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "HTTP_PROXY" ) )
-  {
-    QgsMessageLog::logMessage( "HTTP_PROXY: " + QString( getenv( "HTTP_PROXY" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "HTTPS_PROXY" ) )
-  {
-    QgsMessageLog::logMessage( "HTTPS_PROXY: " + QString( getenv( "HTTPS_PROXY" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "NO_PROXY" ) )
-  {
-    QgsMessageLog::logMessage( "NO_PROXY: " + QString( getenv( "NO_PROXY" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-  if ( getenv( "HTTP_AUTHORIZATION" ) )
-  {
-    QgsMessageLog::logMessage( "HTTP_AUTHORIZATION: " + QString( getenv( "HTTP_AUTHORIZATION" ) ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  }
-}
-
-/**
  * @brief QgsServer::configPath
  * @param defaultConfigPath
  * @param parameters
@@ -366,7 +314,6 @@ void QgsServer::handleRequest( QgsServerRequest& request, QgsServerResponse& res
   if ( logLevel == QgsMessageLog::INFO )
   {
     time.start();
-    printRequestInfos();
   }
 
   //Pass the filters to the requestHandler, this is needed for the following reasons:

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -100,10 +100,6 @@ class SERVER_EXPORT QgsServer
     // static methods of this class
     static QString configPath( const QString& defaultConfigPath,
                                const QMap<QString, QString>& parameters );
-    // Mainly for debug
-    static void dummyMessageHandler( QtMsgType type, const char *msg );
-    // Mainly for debug
-    static void printRequestInfos();
 
     /**
      * @brief QgsServer::printRequestParameters prints the request parameters


### PR DESCRIPTION
The printRequestInfos output fcgi debugging informations about the requests with: because QgsRequest is an abstract interface, request logging details should be delegated to implementation details. 
