### PR TITLE
Labels: Disable "merge lines" option with "line direction symbol"

### DIFF
--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -853,6 +853,16 @@ void QgsLabelingGui::updateUi()
   syncDefinedCheckboxFrame( mFormatNumDDBtn, mFormatNumChkBx, mFormatNumFrame );
   syncDefinedCheckboxFrame( mScaleBasedVisibilityDDBtn, mScaleBasedVisibilityChkBx, mScaleBasedVisibilityFrame );
   syncDefinedCheckboxFrame( mFontLimitPixelDDBtn, mFontLimitPixelChkBox, mFontLimitPixelFrame );
+
+  chkMergeLines->setEnabled( !mDirectSymbChkBx->isChecked() );
+  if ( mDirectSymbChkBx->isChecked() )
+  {
+    chkMergeLines->setToolTip( tr( "This option is not compatible with line direction symbols." ) );
+  }
+  else
+  {
+    chkMergeLines->setToolTip( QString() );
+  }
 }
 
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -351,7 +351,7 @@ QgsPalLayerSettings& QgsPalLayerSettings::operator=( const QgsPalLayerSettings &
   upsidedownLabels = s.upsidedownLabels;
 
   labelPerPart = s.labelPerPart;
-  mergeLines = s.mergeLines;
+  mergeLines = s.mergeLines && !s.addDirectionSymbol;
   minFeatureSize = s.minFeatureSize;
   limitNumLabels = s.limitNumLabels;
   maxNumLabels = s.maxNumLabels;

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -83,11 +83,17 @@ void QgsVectorLayerLabelProvider::init()
   mPlacement = mSettings.placement;
   mLinePlacementFlags = mSettings.placementFlags;
   mFlags = Flags();
-  if ( mSettings.drawLabels ) mFlags |= DrawLabels;
-  if ( mSettings.displayAll ) mFlags |= DrawAllLabels;
-  if ( mSettings.mergeLines ) mFlags |= MergeConnectedLines;
-  if ( mSettings.centroidInside ) mFlags |= CentroidMustBeInside;
-  if ( mSettings.labelPerPart ) mFlags |= LabelPerFeaturePart;
+  if ( mSettings.drawLabels )
+    mFlags |= DrawLabels;
+  if ( mSettings.displayAll )
+    mFlags |= DrawAllLabels;
+  if ( mSettings.mergeLines && !mSettings.addDirectionSymbol )
+    mFlags |= MergeConnectedLines;
+  if ( mSettings.centroidInside )
+    mFlags |= CentroidMustBeInside;
+  if ( mSettings.labelPerPart )
+    mFlags |= LabelPerFeaturePart;
+
   mPriority = 1 - mSettings.priority / 10.0; // convert 0..10 --> 1..0
 
   if ( mLayerGeometryType == QgsWkbTypes::PointGeometry && mRenderer )


### PR DESCRIPTION
This sometimes produces reversed lines and therefore unreliable results.

@nyalldawson maybe we could also integrate an algorithm to make sure that lines are only merged when possible and if they are merged its done in the appropriate order?

For me, disabling with an informative text to prevent results like this one here is fine https://github.com/QGEP/QGEP/issues/272.