### PR TITLE
[FEATURE] Holding shift while using map zoom tools inverts the zoom

### DIFF
--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -290,7 +290,7 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
 
     case Zoom:
     {
-      if ( !( e->modifiers() & Qt::ShiftModifier ) )
+      if ( !( e->modifiers() & Qt::AltModifier ) )
       {
         //zoom in action
         startMarqueeZoom( scenePoint );
@@ -1706,7 +1706,7 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
     {
       //both control and space pressed
       //set cursor to zoom in/out depending on shift key status
-      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::ShiftModifier ) ? zoom_out : zoom_in ) );
+      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::AltModifier ) ? zoom_out : zoom_in ) );
       QCursor zoomCursor = QCursor( myZoomQPixmap, 7, 7 );
       viewport()->setCursor( zoomCursor );
     }
@@ -1740,8 +1740,8 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
       mTemporaryZoomStatus = QgsComposerView::Active;
       mPreviousTool = mCurrentTool;
       setCurrentTool( Zoom );
-      //set cursor to zoom in/out depending on shift key status
-      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::ShiftModifier ) ? zoom_out : zoom_in ) );
+      //set cursor to zoom in/out depending on alt key status
+      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::AltModifier ) ? zoom_out : zoom_in ) );
       QCursor zoomCursor = QCursor( myZoomQPixmap, 7, 7 );
       viewport()->setCursor( zoomCursor );
       return;
@@ -1750,10 +1750,10 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
 
   if ( mCurrentTool == QgsComposerView::Zoom )
   {
-    //using the zoom tool, respond to changes in shift key status and update mouse cursor accordingly
+    //using the zoom tool, respond to changes in alt key status and update mouse cursor accordingly
     if ( ! e->isAutoRepeat() )
     {
-      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::ShiftModifier ) ? zoom_out : zoom_in ) );
+      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::AltModifier ) ? zoom_out : zoom_in ) );
       QCursor zoomCursor = QCursor( myZoomQPixmap, 7, 7 );
       viewport()->setCursor( zoomCursor );
     }
@@ -1939,10 +1939,10 @@ void QgsComposerView::keyReleaseEvent( QKeyEvent * e )
   }
   else if ( mCurrentTool == QgsComposerView::Zoom )
   {
-    //if zoom tool is active, respond to changes in the shift key status and update cursor accordingly
+    //if zoom tool is active, respond to changes in the alt key status and update cursor accordingly
     if ( ! e->isAutoRepeat() )
     {
-      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::ShiftModifier ) ? zoom_out : zoom_in ) );
+      QPixmap myZoomQPixmap = QPixmap(( const char ** )(( e->modifiers() & Qt::AltModifier ) ? zoom_out : zoom_in ) );
       QCursor zoomCursor = QCursor( myZoomQPixmap, 7, 7 );
       viewport()->setCursor( zoomCursor );
     }

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -83,6 +83,10 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent* e )
   if ( e->button() != Qt::LeftButton )
     return;
 
+  bool zoomOut = mZoomOut;
+  if ( e->modifiers() & Qt::ShiftModifier )
+    zoomOut = !zoomOut;
+
   // We are not really dragging in this case. This is sometimes caused by
   // a pen based computer reporting a press, move, and release, all the
   // one point.
@@ -117,14 +121,14 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent* e )
     const QgsMapToPixel* m2p = mCanvas->getCoordinateTransform();
     QgsPoint c = m2p->toMapCoordinates( mZoomRect.center() );
 
-    mCanvas->zoomByFactor( mZoomOut ? 1.0 / sf : sf, &c );
+    mCanvas->zoomByFactor( zoomOut ? 1.0 / sf : sf, &c );
 
     mCanvas->refresh();
   }
   else // not dragging
   {
     // change to zoom in/out by the default multiple
-    mCanvas->zoomWithCenter( e->x(), e->y(), !mZoomOut );
+    mCanvas->zoomWithCenter( e->x(), e->y(), !zoomOut );
   }
 }
 

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -84,7 +84,7 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent* e )
     return;
 
   bool zoomOut = mZoomOut;
-  if ( e->modifiers() & Qt::ShiftModifier )
+  if ( e->modifiers() & Qt::AltModifier )
     zoomOut = !zoomOut;
 
   // We are not really dragging in this case. This is sometimes caused by


### PR DESCRIPTION
Eg hold shift and click with zoom in tool = zoom out

I used shift to match composer behaviour. But maybe alt is a better choice for both. Shift feels a bit odd to me...

@nirvn? @DelazJ ?