### PR TITLE
Fix working on constraints, labelontop, editable when list is sorted

### DIFF
--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -989,9 +989,9 @@ void QgsFieldsProperties::apply()
     QString name = mLayer->fields().at( idx ).name();
     FieldConfig cfg = configForRow( i );
 
-    editFormConfig.setReadOnly( i, !cfg.mEditable );
-    editFormConfig.setLabelOnTop( i, cfg.mLabelOnTop );
-    mLayer->setConstraintExpression( i, cfg.mConstraint, cfg.mConstraintDescription );
+    editFormConfig.setReadOnly( idx, !cfg.mEditable );
+    editFormConfig.setLabelOnTop( idx, cfg.mLabelOnTop );
+    mLayer->setConstraintExpression( idx, cfg.mConstraint, cfg.mConstraintDescription );
     mLayer->setEditorWidgetSetup( idx, QgsEditorWidgetSetup( cfg.mEditorWidgetType, cfg.mEditorWidgetConfig ) );
 
     if ( cfg.mConstraints & QgsFieldConstraints::ConstraintNotNull )

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -996,27 +996,27 @@ void QgsFieldsProperties::apply()
 
     if ( cfg.mConstraints & QgsFieldConstraints::ConstraintNotNull )
     {
-      mLayer->setFieldConstraint( i, QgsFieldConstraints::ConstraintNotNull, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard ) );
+      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard ) );
     }
     else
     {
-      mLayer->removeFieldConstraint( i, QgsFieldConstraints::ConstraintNotNull );
+      mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull );
     }
     if ( cfg.mConstraints & QgsFieldConstraints::ConstraintUnique )
     {
-      mLayer->setFieldConstraint( i, QgsFieldConstraints::ConstraintUnique, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintStrengthHard ) );
+      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintStrengthHard ) );
     }
     else
     {
-      mLayer->removeFieldConstraint( i, QgsFieldConstraints::ConstraintUnique );
+      mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique );
     }
     if ( cfg.mConstraints & QgsFieldConstraints::ConstraintExpression )
     {
-      mLayer->setFieldConstraint( i, QgsFieldConstraints::ConstraintExpression, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthHard ) );
+      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthHard ) );
     }
     else
     {
-      mLayer->removeFieldConstraint( i, QgsFieldConstraints::ConstraintExpression );
+      mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression );
     }
 
     if ( mFieldsList->item( i, AttrWMSCol )->checkState() == Qt::Unchecked )


### PR DESCRIPTION
Hello,

If the field list is sorted by name, the ``setLabelOnTop``, ``*FieldConstraint``, ``setReadOnly`` functions should take into consideration the sorted list IDs instead of the unsorted one.

This also needs backporting.
There's still an issue that I noticed while fixing this:

The changes made by the ``setReadOnly`` and ``setLabelOnTop`` functions work well after these commits but the changes don't get saved in the project. Any hints towards solving this?

Thanks a lot!
Tudor