### PR TITLE
[Processing] Yet another fix for error message encoding errors. Fixes #16102

### DIFF
--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -217,12 +217,9 @@ class GeoAlgorithm:
             ProcessingLog.addToLog(ProcessingLog.LOG_ERROR, lines)
             try:
                 message = unicode(e)
-            except Exception:
-                # Encoding the error message failed. Try with the 'replace' mode.
-                try:
-                    message = unicode(e.message, 'utf-8', 'replace')
-                except Exception:
-                    message = self.tr('Unknown error')
+            except UnicodeDecodeError:
+                # Try with the 'replace' mode (requires e.message instead of e!)
+                message = unicode(e.message, 'utf-8', 'replace')
             raise GeoAlgorithmExecutionException(
                 message + self.tr(' \nSee log for more details'), lines, e)
 

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -215,8 +215,16 @@ class GeoAlgorithm:
             lines = [self.tr('Uncaught error while executing algorithm')]
             lines.append(traceback.format_exc())
             ProcessingLog.addToLog(ProcessingLog.LOG_ERROR, lines)
+            try:
+                message = unicode(e)
+            except Exception:
+                # Encoding the error message failed. Try with the 'replace' mode.
+                try:
+                    message = unicode(e.message, 'utf-8', 'replace')
+                except Exception:
+                    message = self.tr('Unknown error')
             raise GeoAlgorithmExecutionException(
-                unicode(e.message, errors='replace') + self.tr('\nSee log for more details'), lines, e)
+                message + self.tr(' \nSee log for more details'), lines, e)
 
     def _checkParameterValuesBeforeExecuting(self):
         for param in self.parameters:


### PR DESCRIPTION
My recent fix requires the exceptions classes to have the `message` field what is not always true. 
This PR first tries to use the normal `unicode(e)`, then tries the `replace` mode (what requires the message field) and finally gently fallbacks to an `Unknown error` message.

Fixes http://hub.qgis.org/issues/16102