### PR TITLE
Bridge map canvas layers to composer map layers

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -660,7 +660,10 @@ to use the QgsProperty framework objects.
 QgsComposition        {#qgis_api_break_3_0_QgsComposition}
 --------------
 
-- constructor requires QgsProject instance as the second argument
+- The constructor no longer takes a reference to a QgsMapSettings object. This is no longer
+used by compositions. To set the layers to show in composer maps, the QgsComposerMap::setLayers()
+method should be used instead.
+- constructor requires QgsProject instance
 - addItemsFromXML() has been renamed to addItemsFromXml()
 - Constructor with QgsMapRenderer parameter has been removed. Use the variant with QgsMapSettings parameter.
 - mapRenderer() has been removed. Use mapSettings() instead.
@@ -674,6 +677,7 @@ were removed. Use setSnapTolerance() and snapTolerance() instead.
 - worldFileMap() and setWorldFileMap() have been renamed to referenceMap() and setReferenceMap()
 - dataDefinedProperty() and setDataDefinedProperty() now use the QgsProperty framework instead
 of QgsDataDefined objects.
+- mapSettings() was removed. Use QgsComposerMap::mapSettings() instead.
 
 
 QgsCoordinateReferenceSystem        {#qgis_api_break_3_0_QgsCoordinateReferenceSystem}

--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -40,7 +40,7 @@ class QgsComposition : QGraphicsScene, QgsExpressionContextGenerator
       Landscape
     };
 
-    explicit QgsComposition( const QgsMapSettings& mapSettings, QgsProject* project );
+    explicit QgsComposition( QgsProject* project );
 
     /** Composition atlas modes*/
     enum AtlasMode
@@ -365,10 +365,6 @@ class QgsComposition : QGraphicsScene, QgsExpressionContextGenerator
     bool useAdvancedEffects() const;
     /** Used to enable or disable advanced effects such as blend modes in a composition */
     void setUseAdvancedEffects( const bool effectsEnabled );
-
-    //! Return setting of QGIS map canvas
-    //! @note added in 2.4
-    const QgsMapSettings& mapSettings() const;
 
     QgsComposition::PlotStyle plotStyle() const;
     void setPlotStyle( const QgsComposition::PlotStyle style );

--- a/python/gui/layertree/qgslayertreemapcanvasbridge.sip
+++ b/python/gui/layertree/qgslayertreemapcanvasbridge.sip
@@ -63,6 +63,7 @@ class QgsLayerTreeMapCanvasBridge : QObject
   signals:
     void hasCustomLayerOrderChanged( bool );
     void customLayerOrderChanged( const QStringList& order );
+    void canvasLayersChanged( const QList< QgsMapLayer* >& layers );
 
   protected:
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -934,6 +934,23 @@ bool QgsComposer::loadFromTemplate( const QDomDocument& templateDoc, bool clearE
   return result;
 }
 
+void QgsComposer::onCanvasLayersChanged( const QList<QgsMapLayer*>& layers )
+{
+  if ( !mComposition )
+    return;
+
+  QList< QgsComposerMap* > maps;
+  mComposition->composerItems( maps );
+
+  Q_FOREACH ( QgsComposerMap* map, maps )
+  {
+    if ( map->keepLayerSet() )
+      continue;
+
+    map->setLayers( layers );
+  }
+}
+
 void QgsComposer::updateStatusCursorPos( QPointF cursorPosition )
 {
   if ( !mComposition )

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -547,7 +547,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   connect( mActionShowRulers, SIGNAL( triggered( bool ) ), this, SLOT( toggleRulers( bool ) ) );
 
   //init undo/redo buttons
-  mComposition = new QgsComposition( mQgis->mapCanvas()->mapSettings(), QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
 
   mActionUndo->setEnabled( false );
   mActionRedo->setEnabled( false );
@@ -3560,7 +3560,7 @@ void QgsComposer::readXml( const QDomElement& composerElem, const QDomDocument& 
   createComposerView();
 
   //read composition settings
-  mComposition = new QgsComposition( mQgis->mapCanvas()->mapSettings(), QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   QDomNodeList compositionNodeList = composerElem.elementsByTagName( QStringLiteral( "Composition" ) );
   if ( compositionNodeList.size() > 0 )
   {

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -114,6 +114,16 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
      */
     bool loadFromTemplate( const QDomDocument& templateDoc, bool clearExisting );
 
+  public slots:
+
+    /**
+     * Should be called whenever the app's canvas layers change (or layer order
+     * changes). Required to update composer maps which are synced to the canvas
+     * layer set with the new canvas layer set.
+     * @note added in QGIS 3.0
+     */
+    void onCanvasLayersChanged( const QList< QgsMapLayer* >& layers );
+
   protected:
     //! Move event
     virtual void moveEvent( QMoveEvent * ) override;

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -905,20 +905,20 @@ void QgsComposerMapWidget::on_mKeepLayerListCheckBox_stateChanged( int state )
     return;
   }
 
+  // update map
+  storeCurrentLayerSet();
+  mComposerMap->setKeepLayerSet( state == Qt::Checked );
+
+  // update gui
   if ( state == Qt::Checked )
   {
-    storeCurrentLayerSet();
-    mComposerMap->setKeepLayerSet( true );
-
     // mutually exclusive with following a preset
     mFollowVisibilityPresetCheckBox->setCheckState( Qt::Unchecked );
   }
   else
   {
-    mComposerMap->setLayers( QList<QgsMapLayer*>() );
-    mComposerMap->setKeepLayerSet( false );
-
     mKeepLayerStylesCheckBox->setChecked( Qt::Unchecked );
+    mComposerMap->updateCachedImage();
   }
 
   mKeepLayerStylesCheckBox->setEnabled( state == Qt::Checked );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6773,9 +6773,11 @@ QgsComposer* QgisApp::createNewComposer( QString title )
   mPrintComposersMenu->addAction( newComposerObject->windowAction() );
   newComposerObject->open();
   emit composerAdded( newComposerObject->view() );
-  connect( newComposerObject, SIGNAL( composerAdded( QgsComposerView* ) ), this, SIGNAL( composerAdded( QgsComposerView* ) ) );
-  connect( newComposerObject, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ), this, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ) );
-  connect( newComposerObject, SIGNAL( atlasPreviewFeatureChanged() ), this, SLOT( refreshMapCanvas() ) );
+  connect( newComposerObject, &QgsComposer::composerAdded, this, &QgisApp::composerAdded );
+  connect( newComposerObject, &QgsComposer::composerWillBeRemoved, this, &QgisApp::composerWillBeRemoved );
+  connect( newComposerObject, &QgsComposer::atlasPreviewFeatureChanged, this, &QgisApp::refreshMapCanvas );
+  connect( mLayerTreeCanvasBridge, &QgsLayerTreeMapCanvasBridge::canvasLayersChanged, newComposerObject, &QgsComposer::onCanvasLayersChanged );
+
   markDirty();
   return newComposerObject;
 }
@@ -6875,9 +6877,10 @@ bool QgisApp::loadComposersFromProject( const QDomDocument& doc )
       composerView->updateRulers();
     }
     emit composerAdded( composer->view() );
-    connect( composer, SIGNAL( composerAdded( QgsComposerView* ) ), this, SIGNAL( composerAdded( QgsComposerView* ) ) );
-    connect( composer, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ), this, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ) );
-    connect( composer, SIGNAL( atlasPreviewFeatureChanged() ), this, SLOT( refreshMapCanvas() ) );
+    connect( composer, &QgsComposer::composerAdded, this, &QgisApp::composerAdded );
+    connect( composer, &QgsComposer::composerWillBeRemoved, this, &QgisApp::composerWillBeRemoved );
+    connect( composer, &QgsComposer::atlasPreviewFeatureChanged, this, &QgisApp::refreshMapCanvas );
+    connect( mLayerTreeCanvasBridge, &QgsLayerTreeMapCanvasBridge::canvasLayersChanged, composer, &QgsComposer::onCanvasLayersChanged );
 
     QgsDebugMsg( QString( "Loaded composer %1: %2ms" ).arg( title ).arg( t.elapsed() ) );
   }

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -523,15 +523,11 @@ QList<QgsMapLayer*> QgsComposerMap::layersToRender( const QgsExpressionContext* 
     if ( mComposition->project()->mapThemeCollection()->hasMapTheme( presetName ) )
       renderLayers = mComposition->project()->mapThemeCollection()->mapThemeVisibleLayers( presetName );
     else  // fallback to using map canvas layers
-      renderLayers = mComposition->mapSettings().layers();
-  }
-  else if ( mKeepLayerSet )
-  {
-    renderLayers = layers();
+      renderLayers = layers();
   }
   else
   {
-    renderLayers = mComposition->mapSettings().layers();
+    renderLayers = layers();
   }
 
   bool ok = false;

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -202,14 +202,36 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     PreviewMode previewMode() const {return mPreviewMode;}
     void setPreviewMode( PreviewMode m );
 
-    //! Getter for flag that determines if the stored layer set should be used or the current layer set of the qgis mapcanvas
+    /**
+     * Getter for flag that determines if a stored layer set should be used
+     * or the current layer set of the QGIS map canvas.
+     * @see setKeepLayerSet()
+     * @see layers()
+     */
     bool keepLayerSet() const {return mKeepLayerSet;}
-    //! Setter for flag that determines if the stored layer set should be used or the current layer set of the qgis mapcanvas
+
+    /**
+     * Setter for flag that determines if the stored layer set should be used
+     * or the current layer set of the QGIS map canvas.
+     * @see keepLayerSet()
+     * @see layers()
+     */
     void setKeepLayerSet( bool enabled ) {mKeepLayerSet = enabled;}
 
-    //! Getter for stored layer set that is used if mKeepLayerSet is true
+    /**
+     * Getter for stored layer set. This will usually be synchronized with the main app canvas
+     * layer set (and layer order), unless the keepLayerSet() flag is true.
+     * @see setLayers()
+     * @see keepLayerSet()
+     */
     QList<QgsMapLayer*> layers() const;
-    //! Setter for stored layer set that is used if mKeepLayerSet is true
+
+    /**
+     * Setter for stored layer set.  This will usually be synchronized with the main app canvas
+     * layer set (and layer order), unless the keepLayerSet() flag is true.
+     * @see layers()
+     * @see keepLayerSet()
+     */
     void setLayers( const QList<QgsMapLayer*> layers );
 
     //! Getter for flag that determines if current styles of layers should be overridden by previously stored styles. @note added in 2.8

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -60,9 +60,8 @@
 #include "gdal.h"
 #include "cpl_conv.h"
 
-QgsComposition::QgsComposition( const QgsMapSettings& mapSettings, QgsProject* project )
+QgsComposition::QgsComposition( QgsProject* project )
     : QGraphicsScene( nullptr )
-    , mMapSettings( mapSettings )
     , mProject( project )
     , mAtlasComposition( this )
 {

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -104,8 +104,10 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene, public QgsExpressionCo
       Landscape
     };
 
-    //! Construct a composition, using given map settings and project
-    explicit QgsComposition( const QgsMapSettings& mapSettings, QgsProject* project );
+    /**
+     * Construct a new composition linked to the specified project.
+     */
+    explicit QgsComposition( QgsProject* project );
 
     //! Composition atlas modes
     enum AtlasMode
@@ -442,10 +444,6 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene, public QgsExpressionCo
     bool useAdvancedEffects() const {return mUseAdvancedEffects;}
     //! Used to enable or disable advanced effects such as blend modes in a composition
     void setUseAdvancedEffects( const bool effectsEnabled );
-
-    //! Return setting of QGIS map canvas
-    //! @note added in 2.4
-    const QgsMapSettings& mapSettings() const { return mMapSettings; }
 
     QgsComposition::PlotStyle plotStyle() const { return mPlotStyle; }
     void setPlotStyle( const QgsComposition::PlotStyle style ) { mPlotStyle = style; }
@@ -862,8 +860,6 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene, public QgsExpressionCo
 
 
   private:
-    //! Reference to map settings of QGIS main map
-    const QgsMapSettings& mMapSettings;
 
     //! Pointer to associated project (not null)
     QgsProject* mProject;

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -34,9 +34,9 @@ QgsLayerTreeMapCanvasBridge::QgsLayerTreeMapCanvasBridge( QgsLayerTreeGroup *roo
     , mAutoEnableCrsTransform( true )
     , mLastLayerCount( !root->findLayers().isEmpty() )
 {
-  connect( root, SIGNAL( addedChildren( QgsLayerTreeNode*, int, int ) ), this, SLOT( nodeAddedChildren( QgsLayerTreeNode*, int, int ) ) );
-  connect( root, SIGNAL( customPropertyChanged( QgsLayerTreeNode*, QString ) ), this, SLOT( nodeCustomPropertyChanged( QgsLayerTreeNode*, QString ) ) );
-  connect( root, SIGNAL( removedChildren( QgsLayerTreeNode*, int, int ) ), this, SLOT( nodeRemovedChildren() ) );
+  connect( root, &QgsLayerTreeGroup::addedChildren, this, &QgsLayerTreeMapCanvasBridge::nodeAddedChildren );
+  connect( root, &QgsLayerTreeGroup::customPropertyChanged, this, &QgsLayerTreeMapCanvasBridge::nodeCustomPropertyChanged );
+  connect( root, &QgsLayerTreeGroup::removedChildren, this, &QgsLayerTreeMapCanvasBridge::nodeRemovedChildren );
   connect( root, &QgsLayerTreeNode::visibilityChanged, this, &QgsLayerTreeMapCanvasBridge::nodeVisibilityChanged );
 
   setCanvasLayers();
@@ -205,6 +205,8 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
     mFirstCRS = QgsCoordinateReferenceSystem();
 
   mPendingCanvasUpdate = false;
+
+  emit canvasLayersChanged( canvasLayers );
 }
 
 void QgsLayerTreeMapCanvasBridge::readProject( const QDomDocument& doc )

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.h
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.h
@@ -92,6 +92,13 @@ class GUI_EXPORT QgsLayerTreeMapCanvasBridge : public QObject
     void hasCustomLayerOrderChanged( bool );
     void customLayerOrderChanged( const QStringList& order );
 
+    /**
+     * Emitted when the set of layers (or order of layers) visible in the
+     * canvas changes.
+     * @note added in QGIS 3.0
+     */
+    void canvasLayersChanged( const QList< QgsMapLayer* >& layers );
+
   protected:
 
     void defaultLayerOrder( QgsLayerTreeNode* node, QStringList& order ) const;

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -1522,7 +1522,7 @@ bool QgsGeorefPluginGui::writePDFMapFile( const QString& fileName, const QgsGeor
   double paperHeight = s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/HeightPDFMap" ), "420" ).toDouble();
 
   //create composition
-  QgsComposition* composition = new QgsComposition( mCanvas->mapSettings(), QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   if ( mapRatio >= 1 )
   {
     composition->setPaperSize( paperHeight, paperWidth );
@@ -1589,7 +1589,7 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString& fileName, const QgsG
   }
 
   //create composition A4 with 300 dpi
-  QgsComposition* composition = new QgsComposition( mCanvas->mapSettings(), QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   composition->setPaperSize( 210, 297 ); //A4
   composition->setPrintResolution( 300 );
   composition->setNumPages( 2 );

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -26,6 +26,7 @@
 #include "qgspallabeling.h"
 #include "qgsrenderer.h"
 #include "qgsvectorlayer.h"
+#include "qgsmapsettings.h"
 
 #include "qgscomposition.h"
 #include "qgscomposerarrow.h"
@@ -475,7 +476,7 @@ QgsComposition* QgsWmsProjectParser::initComposition( const QString& composerTem
     return nullptr;
   }
 
-  QgsComposition* composition = new QgsComposition( mapSettings, QgsProject::instance() ); //set resolution, paper size from composer element attributes
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() ); //set resolution, paper size from composer element attributes
   if ( !composition->readXml( compositionElem, *( mProjectParser->xmlDocument() ) ) )
   {
     delete composition;
@@ -503,6 +504,8 @@ QgsComposition* QgsWmsProjectParser::initComposition( const QString& composerTem
     QgsComposerMap* map = qobject_cast< QgsComposerMap *>( *itemIt );
     if ( map )
     {
+      if ( !map->keepLayerSet() )
+        map->setLayers( mapSettings.layers() );
       mapList.push_back( map );
       continue;
     }

--- a/tests/src/core/testqgs25drenderer.cpp
+++ b/tests/src/core/testqgs25drenderer.cpp
@@ -126,10 +126,11 @@ void TestQgs25DRenderer::render()
 
 void TestQgs25DRenderer::renderComposition()
 {
-  QgsComposition* composition = new QgsComposition( mMapSettings, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   composition->setPaperSize( 297, 210 ); //A4 landscape
   QgsComposerMap* map = new QgsComposerMap( composition, 20, 20, 200, 100 );
   map->setFrameEnabled( true );
+  map->setLayers( QList< QgsMapLayer* >() << mpPolysLayer );
   composition->addComposerMap( map );
 
   map->setNewExtent( mpPolysLayer->extent() );

--- a/tests/src/core/testqgsatlascomposition.cpp
+++ b/tests/src/core/testqgsatlascomposition.cpp
@@ -43,7 +43,6 @@ class TestQgsAtlasComposition : public QObject
         , mLabel2( 0 )
         , mAtlasMap( 0 )
         , mOverview( 0 )
-        , mMapSettings( 0 )
         , mVectorLayer( 0 )
         , mVectorLayer2( 0 )
         , mAtlas( 0 )
@@ -84,7 +83,6 @@ class TestQgsAtlasComposition : public QObject
     QgsComposerLabel* mLabel2;
     QgsComposerMap* mAtlasMap;
     QgsComposerMap* mOverview;
-    QgsMapSettings *mMapSettings;
     QgsVectorLayer* mVectorLayer;
     QgsVectorLayer* mVectorLayer2;
     QgsAtlasComposition* mAtlas;
@@ -95,8 +93,6 @@ void TestQgsAtlasComposition::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
-
-  mMapSettings = new QgsMapSettings();
 
   //create maplayers from testdata and add to layer registry
   QFileInfo vectorFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/france_parts.shp" );
@@ -115,9 +111,7 @@ void TestQgsAtlasComposition::initTestCase()
 }
 
 TestQgsAtlasComposition::~TestQgsAtlasComposition()
-{
-  delete mMapSettings;
-}
+{}
 
 
 void TestQgsAtlasComposition::cleanupTestCase()
@@ -139,15 +133,12 @@ void TestQgsAtlasComposition::cleanupTestCase()
 void TestQgsAtlasComposition::init()
 {
   //create composition with composer map
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mVectorLayer );
-  mMapSettings->setCrsTransformEnabled( true );
-  mMapSettings->setMapUnits( QgsUnitTypes::DistanceMeters );
 
   // select epsg:2154
   QgsCoordinateReferenceSystem crs;
   crs.createFromSrid( 2154 );
   QgsProject::instance()->setCrs( crs );
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   // fix the renderer, fill with green
@@ -163,6 +154,7 @@ void TestQgsAtlasComposition::init()
   // Make sure it doesn't try to render a map for caching onto a still 0-sized image
   mAtlasMap->setPreviewMode( QgsComposerMap::Rectangle );
   mComposition->addComposerMap( mAtlasMap, false );
+  mAtlasMap->setLayers( QList<QgsMapLayer*>() << mVectorLayer );
 
   mAtlas = &mComposition->atlasComposition();
   mAtlas->setCoverageLayer( mVectorLayer );
@@ -174,6 +166,7 @@ void TestQgsAtlasComposition::init()
   mOverview->setFrameEnabled( true );
   mOverview->overview()->setFrameMap( mAtlasMap->id() );
   mOverview->setPreviewMode( QgsComposerMap::Rectangle );
+  mOverview->setLayers( QList<QgsMapLayer*>() << mVectorLayer );
   mComposition->addComposerMap( mOverview, false );
   mOverview->setNewExtent( QgsRectangle( 49670.718, 6415139.086, 699672.519, 7065140.887 ) );
 

--- a/tests/src/core/testqgscomposerdd.cpp
+++ b/tests/src/core/testqgscomposerdd.cpp
@@ -38,7 +38,6 @@ class TestQgsComposerDD : public QObject
   public:
     TestQgsComposerDD()
         : mComposition( 0 )
-        , mMapSettings( 0 )
         , mVectorLayer( 0 )
         , mAtlasMap( 0 )
         , mAtlas( 0 )
@@ -54,7 +53,6 @@ class TestQgsComposerDD : public QObject
 
   private:
     QgsComposition *mComposition;
-    QgsMapSettings *mMapSettings;
     QgsVectorLayer* mVectorLayer;
     QgsComposerMap* mAtlasMap;
     QgsAtlasComposition* mAtlas;
@@ -65,8 +63,6 @@ void TestQgsComposerDD::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
-
-  mMapSettings = new QgsMapSettings();
 
   //create maplayers from testdata and add to layer registry
   QFileInfo vectorFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/france_parts.shp" );
@@ -79,15 +75,11 @@ void TestQgsComposerDD::initTestCase()
   mVectorLayer->setSimplifyMethod( simplifyMethod );
 
   //create composition with composer map
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mVectorLayer );
-  mMapSettings->setCrsTransformEnabled( true );
-  mMapSettings->setMapUnits( QgsUnitTypes::DistanceMeters );
 
   // select epsg:2154
   QgsCoordinateReferenceSystem crs;
   crs.createFromSrid( 2154 );
-  mMapSettings->setDestinationCrs( crs );
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   // fix the renderer, fill with green
@@ -114,7 +106,6 @@ void TestQgsComposerDD::initTestCase()
 void TestQgsComposerDD::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
   delete mVectorLayer;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";

--- a/tests/src/core/testqgscomposereffects.cpp
+++ b/tests/src/core/testqgscomposereffects.cpp
@@ -34,7 +34,6 @@ class TestQgsComposerEffects : public QObject
         : mComposition( 0 )
         , mComposerRect1( 0 )
         , mComposerRect2( 0 )
-        , mMapSettings( 0 )
     {}
 
   private slots:
@@ -49,7 +48,6 @@ class TestQgsComposerEffects : public QObject
     QgsComposition* mComposition;
     QgsComposerShape *mComposerRect1;
     QgsComposerShape *mComposerRect2;
-    QgsMapSettings *mMapSettings;
     QString mReport;
 };
 
@@ -58,11 +56,9 @@ void TestQgsComposerEffects::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   //create composition with two rectangles
 
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerRect1 = new QgsComposerShape( 20, 20, 150, 100, mComposition );
   mComposerRect1->setShapeType( QgsComposerShape::Rectangle );
@@ -79,7 +75,6 @@ void TestQgsComposerEffects::initTestCase()
 void TestQgsComposerEffects::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );

--- a/tests/src/core/testqgscomposergroup.cpp
+++ b/tests/src/core/testqgscomposergroup.cpp
@@ -81,7 +81,7 @@ void TestQgsComposerGroup::initTestCase()
   QgsApplication::initQgis();
 
   mMapSettings = new QgsMapSettings();
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   //create some items

--- a/tests/src/core/testqgscomposerhtml.cpp
+++ b/tests/src/core/testqgscomposerhtml.cpp
@@ -51,14 +51,12 @@ class TestQgsComposerHtml : public QObject
 
   private:
     QgsComposition *mComposition;
-    QgsMapSettings *mMapSettings;
     QString mReport;
     QFont mTestFont;
 };
 
 TestQgsComposerHtml::TestQgsComposerHtml()
     : mComposition( 0 )
-    , mMapSettings( 0 )
 {
 
 }
@@ -68,8 +66,7 @@ void TestQgsComposerHtml::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   mReport = QStringLiteral( "<h1>Composer HTML Tests</h1>\n" );
@@ -81,7 +78,6 @@ void TestQgsComposerHtml::initTestCase()
 void TestQgsComposerHtml::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );

--- a/tests/src/core/testqgscomposerlabel.cpp
+++ b/tests/src/core/testqgscomposerlabel.cpp
@@ -35,7 +35,6 @@ class TestQgsComposerLabel : public QObject
     TestQgsComposerLabel()
         : mComposition( 0 )
         , mComposerLabel( 0 )
-        , mMapSettings( 0 )
         , mVectorLayer( 0 )
     {}
 
@@ -59,7 +58,6 @@ class TestQgsComposerLabel : public QObject
   private:
     QgsComposition* mComposition;
     QgsComposerLabel* mComposerLabel;
-    QgsMapSettings *mMapSettings;
     QgsVectorLayer* mVectorLayer;
     QString mReport;
 };
@@ -69,8 +67,6 @@ void TestQgsComposerLabel::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   //create maplayers from testdata and add to layer registry
   QFileInfo vectorFileInfo( QStringLiteral( TEST_DATA_DIR ) + '/' +  "france_parts.shp" );
   mVectorLayer = new QgsVectorLayer( vectorFileInfo.filePath(),
@@ -78,9 +74,7 @@ void TestQgsComposerLabel::initTestCase()
                                      QStringLiteral( "ogr" ) );
 
   //create composition with composer map
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mVectorLayer );
-  mMapSettings->setCrsTransformEnabled( false );
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposition->atlasComposition().setCoverageLayer( mVectorLayer );
 
@@ -102,7 +96,6 @@ void TestQgsComposerLabel::cleanupTestCase()
   }
 
   delete mComposition;
-  delete mMapSettings;
   delete mVectorLayer;
 
   QgsApplication::exitQgis();

--- a/tests/src/core/testqgscomposermap.cpp
+++ b/tests/src/core/testqgscomposermap.cpp
@@ -38,7 +38,6 @@ class TestQgsComposerMap : public QObject
     TestQgsComposerMap()
         : mComposition( 0 )
         , mComposerMap( 0 )
-        , mMapSettings( 0 )
         , mRasterLayer( 0 )
         , mPointsLayer( 0 )
         , mPolysLayer( 0 )
@@ -60,7 +59,6 @@ class TestQgsComposerMap : public QObject
   private:
     QgsComposition *mComposition;
     QgsComposerMap *mComposerMap;
-    QgsMapSettings *mMapSettings;
     QgsRasterLayer* mRasterLayer;
     QgsVectorLayer* mPointsLayer;
     QgsVectorLayer* mPolysLayer;
@@ -112,15 +110,12 @@ void TestQgsComposerMap::cleanupTestCase()
 
 void TestQgsComposerMap::init()
 {
-  mMapSettings = new QgsMapSettings();
-
   //create composition with composer map
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
-  mMapSettings->setCrsTransformEnabled( false );
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerMap = new QgsComposerMap( mComposition, 20, 20, 200, 100 );
   mComposerMap->setFrameEnabled( true );
+  mComposerMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( mComposerMap );
 
   mReport = QStringLiteral( "<h1>Composer Map Tests</h1>\n" );
@@ -129,7 +124,6 @@ void TestQgsComposerMap::init()
 void TestQgsComposerMap::cleanup()
 {
   delete mComposition;
-  delete mMapSettings;
 }
 
 void TestQgsComposerMap::render()
@@ -262,7 +256,7 @@ void TestQgsComposerMap::dataDefinedLayers()
   ms.setLayers( QList<QgsMapLayer*>() << mRasterLayer << mPolysLayer << mPointsLayer << mLinesLayer );
   ms.setCrsTransformEnabled( true );
 
-  mComposition = new QgsComposition( ms, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerMap = new QgsComposerMap( mComposition, 20, 20, 200, 100 );
   mComposerMap->setFrameEnabled( true );
@@ -338,14 +332,14 @@ void TestQgsComposerMap::dataDefinedLayers()
 void TestQgsComposerMap::dataDefinedStyles()
 {
   delete mComposition;
-  QgsMapSettings ms;
-  ms.setLayers( QList<QgsMapLayer*>() << mRasterLayer << mPolysLayer << mPointsLayer << mLinesLayer );
-  ms.setCrsTransformEnabled( true );
 
-  mComposition = new QgsComposition( ms, QgsProject::instance() );
+  QList<QgsMapLayer*> layers = QList<QgsMapLayer*>() << mRasterLayer << mPolysLayer << mPointsLayer << mLinesLayer;
+
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerMap = new QgsComposerMap( mComposition, 20, 20, 200, 100 );
   mComposerMap->setFrameEnabled( true );
+  mComposerMap->setLayers( layers );
   mComposition->addComposerMap( mComposerMap );
 
   QgsMapThemeCollection::MapThemeRecord rec;
@@ -366,7 +360,7 @@ void TestQgsComposerMap::dataDefinedStyles()
   //test malformed style string
   mComposerMap->dataDefinedProperties().setProperty( QgsComposerObject::MapStylePreset, QgsProperty::fromExpression( QStringLiteral( "5" ) ) );
   result = mComposerMap->layersToRender().toSet();
-  QCOMPARE( result, ms.layers().toSet() );
+  QCOMPARE( result, layers.toSet() );
 
   //test valid preset
   mComposerMap->dataDefinedProperties().setProperty( QgsComposerObject::MapStylePreset, QgsProperty::fromExpression( QStringLiteral( "'test preset'" ) ) );
@@ -378,7 +372,7 @@ void TestQgsComposerMap::dataDefinedStyles()
   //test non-existent preset
   mComposerMap->dataDefinedProperties().setProperty( QgsComposerObject::MapStylePreset, QgsProperty::fromExpression( QStringLiteral( "'bad preset'" ) ) );
   result = mComposerMap->layersToRender().toSet();
-  QCOMPARE( result, ms.layers().toSet() );
+  QCOMPARE( result, layers.toSet() );
 
   //test that dd layer set overrides style layers
   mComposerMap->dataDefinedProperties().setProperty( QgsComposerObject::MapStylePreset, QgsProperty::fromExpression( QStringLiteral( "'test preset'" ) ) );

--- a/tests/src/core/testqgscomposermapgrid.cpp
+++ b/tests/src/core/testqgscomposermapgrid.cpp
@@ -101,7 +101,7 @@ void TestQgsComposerMapGrid::init()
   QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem( 32633 );
   mMapSettings->setDestinationCrs( crs );
   mMapSettings->setCrsTransformEnabled( false );
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerMap = new QgsComposerMap( mComposition, 20, 20, 200, 100 );
   mComposerMap->setFrameEnabled( true );

--- a/tests/src/core/testqgscomposermapoverview.cpp
+++ b/tests/src/core/testqgscomposermapoverview.cpp
@@ -36,7 +36,6 @@ class TestQgsComposerMapOverview : public QObject
     TestQgsComposerMapOverview()
         : mComposition( 0 )
         , mComposerMap( 0 )
-        , mMapSettings( 0 )
         , mRasterLayer( 0 )
     {}
 
@@ -55,7 +54,6 @@ class TestQgsComposerMapOverview : public QObject
   private:
     QgsComposition* mComposition;
     QgsComposerMap* mComposerMap;
-    QgsMapSettings *mMapSettings;
     QgsRasterLayer* mRasterLayer;
     QString mReport;
 };
@@ -65,8 +63,6 @@ void TestQgsComposerMapOverview::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   //create maplayers from testdata and add to layer registry
   QFileInfo rasterFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/rgb256x256.png" );
   mRasterLayer = new QgsRasterLayer( rasterFileInfo.filePath(),
@@ -75,12 +71,11 @@ void TestQgsComposerMapOverview::initTestCase()
   mRasterLayer->setRenderer( rasterRenderer );
 
   //create composition with composer map
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
-  mMapSettings->setCrsTransformEnabled( false );
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerMap = new QgsComposerMap( mComposition, 20, 20, 200, 100 );
   mComposerMap->setFrameEnabled( true );
+  mComposerMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( mComposerMap );
 
   mReport = QStringLiteral( "<h1>Composer Map Overview Tests</h1>\n" );
@@ -89,7 +84,6 @@ void TestQgsComposerMapOverview::initTestCase()
 void TestQgsComposerMapOverview::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
   delete mRasterLayer;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
@@ -116,6 +110,7 @@ void TestQgsComposerMapOverview::overviewMap()
 {
   QgsComposerMap* overviewMap =  new QgsComposerMap( mComposition, 20, 130, 70, 70 );
   overviewMap->setFrameEnabled( true );
+  overviewMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( overviewMap );
   mComposerMap->setNewExtent( QgsRectangle( 96, -152, 160, -120 ) ); //zoom in
   overviewMap->setNewExtent( QgsRectangle( 0, -256, 256, 0 ) );
@@ -132,6 +127,7 @@ void TestQgsComposerMapOverview::overviewMapRotated()
 {
   QgsComposerMap* overviewMap = new QgsComposerMap( mComposition, 20, 130, 70, 70 );
   overviewMap->setFrameEnabled( true );
+  overviewMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( overviewMap );
   mComposerMap->setNewExtent( QgsRectangle( 96, -144, 160, -112 ) ); //zoom in
   mComposerMap->setMapRotation( 30 );
@@ -150,6 +146,7 @@ void TestQgsComposerMapOverview::overviewMapRotated2()
 {
   QgsComposerMap* overviewMap = new QgsComposerMap( mComposition, 20, 130, 70, 70 );
   overviewMap->setFrameEnabled( true );
+  overviewMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( overviewMap );
   mComposerMap->setNewExtent( QgsRectangle( 96, -152, 160, -120 ) ); //zoom in
   overviewMap->setMapRotation( 30 );
@@ -167,6 +164,7 @@ void TestQgsComposerMapOverview::overviewMapBlending()
 {
   QgsComposerMap* overviewMapBlend = new QgsComposerMap( mComposition, 20, 130, 70, 70 );
   overviewMapBlend->setFrameEnabled( true );
+  overviewMapBlend->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( overviewMapBlend );
   mComposerMap->setNewExtent( QgsRectangle( 96, -152, 160, -120 ) ); //zoom in
   overviewMapBlend->setNewExtent( QgsRectangle( 0, -256, 256, 0 ) );
@@ -185,6 +183,7 @@ void TestQgsComposerMapOverview::overviewMapInvert()
 {
   QgsComposerMap* overviewMapInvert = new QgsComposerMap( mComposition, 20, 130, 70, 70 );
   overviewMapInvert->setFrameEnabled( true );
+  overviewMapInvert->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( overviewMapInvert );
   mComposerMap->setNewExtent( QgsRectangle( 96, -152, 160, -120 ) ); //zoom in
   overviewMapInvert->setNewExtent( QgsRectangle( 0, -256, 256, 0 ) );
@@ -203,6 +202,7 @@ void TestQgsComposerMapOverview::overviewMapCenter()
 {
   QgsComposerMap* overviewMapCenter = new QgsComposerMap( mComposition, 20, 130, 70, 70 );
   overviewMapCenter->setFrameEnabled( true );
+  overviewMapCenter->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
   mComposition->addComposerMap( overviewMapCenter );
   mComposerMap->setNewExtent( QgsRectangle( 192, -288, 320, -224 ) );
   overviewMapCenter->setNewExtent( QgsRectangle( 0, -256, 256, 0 ) );

--- a/tests/src/core/testqgscomposermodel.cpp
+++ b/tests/src/core/testqgscomposermodel.cpp
@@ -33,7 +33,6 @@ class TestQgsComposerModel : public QObject
   public:
     TestQgsComposerModel()
         : mComposition( 0 )
-        , mMapSettings( 0 )
         , mItem1( 0 )
         , mItem2( 0 )
         , mItem3( 0 )
@@ -66,7 +65,6 @@ class TestQgsComposerModel : public QObject
 
   private:
     QgsComposition *mComposition;
-    QgsMapSettings *mMapSettings;
     QgsComposerLabel *mItem1;
     QgsComposerLabel *mItem2;
     QgsComposerLabel *mItem3;
@@ -77,8 +75,7 @@ void TestQgsComposerModel::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
 
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 }
@@ -89,7 +86,6 @@ void TestQgsComposerModel::cleanupTestCase()
   delete mItem2;
   delete mItem3;
   delete mComposition;
-  delete mMapSettings;
   QgsApplication::exitQgis();
 }
 

--- a/tests/src/core/testqgscomposermultiframe.cpp
+++ b/tests/src/core/testqgscomposermultiframe.cpp
@@ -46,13 +46,11 @@ class TestQgsComposerMultiFrame : public QObject
 
   private:
     QgsComposition *mComposition;
-    QgsMapSettings *mMapSettings;
     QString mReport;
 };
 
 TestQgsComposerMultiFrame::TestQgsComposerMultiFrame()
     : mComposition( 0 )
-    , mMapSettings( 0 )
 {
 }
 
@@ -61,8 +59,7 @@ void TestQgsComposerMultiFrame::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   mReport = QStringLiteral( "<h1>Composer MultiFrame Tests</h1>\n" );
@@ -71,7 +68,6 @@ void TestQgsComposerMultiFrame::initTestCase()
 void TestQgsComposerMultiFrame::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );

--- a/tests/src/core/testqgscomposerobject.cpp
+++ b/tests/src/core/testqgscomposerobject.cpp
@@ -33,7 +33,6 @@ class TestQgsComposerObject : public QObject
   public:
     TestQgsComposerObject()
         : mComposition( 0 )
-        , mMapSettings( 0 )
     {
     }
 
@@ -52,7 +51,6 @@ class TestQgsComposerObject : public QObject
   private:
     bool renderCheck( const QString& testName, QImage &image, int mismatchCount = 0 );
     QgsComposition *mComposition;
-    QgsMapSettings *mMapSettings;
     QString mReport;
 
 };
@@ -62,8 +60,7 @@ void TestQgsComposerObject::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   mReport = QStringLiteral( "<h1>Composer Object Tests</h1>\n" );
@@ -72,7 +69,6 @@ void TestQgsComposerObject::initTestCase()
 void TestQgsComposerObject::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );

--- a/tests/src/core/testqgscomposerpaper.cpp
+++ b/tests/src/core/testqgscomposerpaper.cpp
@@ -37,7 +37,6 @@ class TestQgsComposerPaper : public QObject
   public:
     TestQgsComposerPaper()
         : mComposition( 0 )
-        , mMapSettings( 0 )
     {}
 
   private slots:
@@ -54,7 +53,6 @@ class TestQgsComposerPaper : public QObject
   private:
     QgsComposition* mComposition;
     QString mReport;
-    QgsMapSettings *mMapSettings;
     // QgsSingleSymbolRenderer* mSymbolRenderer;
 
 };
@@ -65,8 +63,7 @@ void TestQgsComposerPaper::initTestCase()
   QgsApplication::initQgis();
 
   //create empty composition
-  mMapSettings = new QgsMapSettings();
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   mReport = QStringLiteral( "<h1>Composer Paper Tests</h1>\n" );
@@ -75,7 +72,6 @@ void TestQgsComposerPaper::initTestCase()
 void TestQgsComposerPaper::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );

--- a/tests/src/core/testqgscomposerpicture.cpp
+++ b/tests/src/core/testqgscomposerpicture.cpp
@@ -67,7 +67,6 @@ class TestQgsComposerPicture : public QObject
   private:
     QgsComposition* mComposition;
     QgsComposerPicture* mComposerPicture;
-    QgsMapSettings *mMapSettings;
     QString mReport;
     QString mPngImage;
     QString mSvgImage;
@@ -77,7 +76,6 @@ class TestQgsComposerPicture : public QObject
 TestQgsComposerPicture::TestQgsComposerPicture()
     : mComposition( 0 )
     , mComposerPicture( 0 )
-    , mMapSettings( 0 )
 {
 
 }
@@ -87,13 +85,11 @@ void TestQgsComposerPicture::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   mPngImage = QStringLiteral( TEST_DATA_DIR ) + "/sample_image.png";
   mSvgImage = QStringLiteral( TEST_DATA_DIR ) + "/sample_svg.svg";
   mSvgParamsImage = QStringLiteral( TEST_DATA_DIR ) + "/svg_params.svg";
 
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   mComposerPicture = new QgsComposerPicture( mComposition );
@@ -108,7 +104,6 @@ void TestQgsComposerPicture::cleanupTestCase()
 {
   delete mComposerPicture;
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );

--- a/tests/src/core/testqgscomposerrotation.cpp
+++ b/tests/src/core/testqgscomposerrotation.cpp
@@ -41,7 +41,6 @@ class TestQgsComposerRotation : public QObject
         , mComposerRect( 0 )
         , mComposerLabel( 0 )
         , mComposerMap( 0 )
-        , mMapSettings( 0 )
         , mRasterLayer( 0 )
     {}
 
@@ -61,7 +60,6 @@ class TestQgsComposerRotation : public QObject
     QgsComposerShape* mComposerRect;
     QgsComposerLabel* mComposerLabel;
     QgsComposerMap* mComposerMap;
-    QgsMapSettings *mMapSettings;
     QgsRasterLayer* mRasterLayer;
     QString mReport;
 };
@@ -71,8 +69,6 @@ void TestQgsComposerRotation::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   //create maplayers from testdata and add to layer registry
   QFileInfo rasterFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/rgb256x256.png" );
   mRasterLayer = new QgsRasterLayer( rasterFileInfo.filePath(),
@@ -80,10 +76,7 @@ void TestQgsComposerRotation::initTestCase()
   QgsMultiBandColorRenderer* rasterRenderer = new QgsMultiBandColorRenderer( mRasterLayer->dataProvider(), 1, 2, 3 );
   mRasterLayer->setRenderer( rasterRenderer );
 
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
-  mMapSettings->setCrsTransformEnabled( false );
-
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   mComposerRect = new QgsComposerShape( 70, 70, 150, 100, mComposition );
@@ -112,7 +105,6 @@ void TestQgsComposerRotation::cleanupTestCase()
   delete mComposerLabel;
   delete mComposerRect;
   delete mComposition;
-  delete mMapSettings;
   delete mRasterLayer;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
@@ -173,6 +165,7 @@ void TestQgsComposerRotation::mapRotation()
   mComposition->addItem( mComposerMap );
   mComposerMap->setNewExtent( QgsRectangle( 0, -192, 256, -64 ) );
   mComposerMap->setMapRotation( 90 );
+  mComposerMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
 
   QgsCompositionChecker checker( QStringLiteral( "composerrotation_maprotation" ), mComposition );
   checker.setControlPathPrefix( QStringLiteral( "composer_items" ) );
@@ -191,6 +184,7 @@ void TestQgsComposerRotation::mapItemRotation()
   mComposition->addItem( mComposerMap );
   mComposerMap->setNewExtent( QgsRectangle( 0, -192, 256, -64 ) );
   mComposerMap->setItemRotation( 90, true );
+  mComposerMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
 
   QgsCompositionChecker checker( QStringLiteral( "composerrotation_mapitemrotation" ), mComposition );
   checker.setControlPathPrefix( QStringLiteral( "composer_items" ) );

--- a/tests/src/core/testqgscomposerscalebar.cpp
+++ b/tests/src/core/testqgscomposerscalebar.cpp
@@ -41,7 +41,6 @@ class TestQgsComposerScaleBar : public QObject
         , mComposerMap( 0 )
         , mComposerScaleBar( 0 )
         , mRasterLayer( 0 )
-        , mMapSettings( 0 )
     {}
 
   private slots:
@@ -61,7 +60,6 @@ class TestQgsComposerScaleBar : public QObject
     QgsComposerMap* mComposerMap;
     QgsComposerScaleBar* mComposerScaleBar;
     QgsRasterLayer* mRasterLayer;
-    QgsMapSettings *mMapSettings;
     QString mReport;
 };
 
@@ -82,8 +80,6 @@ void TestQgsComposerScaleBar::initTestCase()
   QgsProject::instance()->setCrs( destCRS );
   QgsProject::instance()->setEllipsoid( QStringLiteral( "WGS84" ) );
 
-  mMapSettings = new QgsMapSettings();
-
   //create maplayers from testdata and add to layer registry
   QFileInfo rasterFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/landsat.tif" );
   mRasterLayer = new QgsRasterLayer( rasterFileInfo.filePath(),
@@ -92,14 +88,14 @@ void TestQgsComposerScaleBar::initTestCase()
   mRasterLayer->setRenderer( rasterRenderer );
 
   //create composition with composer map
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
 
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerMap = new QgsComposerMap( mComposition, 20, 20, 150, 150 );
   mComposerMap->setFrameEnabled( true );
   mComposition->addComposerMap( mComposerMap );
   mComposerMap->setNewExtent( QgsRectangle( 17.923, 30.160, 18.023, 30.260 ) );
+  mComposerMap->setLayers( QList<QgsMapLayer*>() << mRasterLayer );
 
   mComposerScaleBar = new QgsComposerScaleBar( mComposition );
   mComposerScaleBar->setSceneRect( QRectF( 20, 180, 50, 20 ) );
@@ -121,7 +117,6 @@ void TestQgsComposerScaleBar::initTestCase()
 void TestQgsComposerScaleBar::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
   delete mRasterLayer;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";

--- a/tests/src/core/testqgscomposershapes.cpp
+++ b/tests/src/core/testqgscomposershapes.cpp
@@ -37,7 +37,6 @@ class TestQgsComposerShapes : public QObject
     TestQgsComposerShapes()
         : mComposition( 0 )
         , mComposerShape( 0 )
-        , mMapSettings( 0 )
     {}
 
   private slots:
@@ -54,7 +53,6 @@ class TestQgsComposerShapes : public QObject
   private:
     QgsComposition* mComposition;
     QgsComposerShape* mComposerShape;
-    QgsMapSettings *mMapSettings;
     QString mReport;
 };
 
@@ -63,10 +61,8 @@ void TestQgsComposerShapes::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   //create composition with two rectangles
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposerShape = new QgsComposerShape( 20, 20, 150, 100, mComposition );
   mComposerShape->setBackgroundColor( QColor::fromRgb( 255, 150, 0 ) );
@@ -78,7 +74,6 @@ void TestQgsComposerShapes::initTestCase()
 void TestQgsComposerShapes::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );

--- a/tests/src/core/testqgscomposertablev2.cpp
+++ b/tests/src/core/testqgscomposertablev2.cpp
@@ -40,7 +40,6 @@ class TestQgsComposerTableV2 : public QObject
   public:
     TestQgsComposerTableV2()
         : mComposition( 0 )
-        , mMapSettings( 0 )
         , mVectorLayer( 0 )
         , mComposerAttributeTable( 0 )
         , mFrame1( 0 )
@@ -79,7 +78,6 @@ class TestQgsComposerTableV2 : public QObject
 
   private:
     QgsComposition* mComposition;
-    QgsMapSettings *mMapSettings;
     QgsVectorLayer* mVectorLayer;
     QgsComposerAttributeTableV2* mComposerAttributeTable;
     QgsComposerFrame* mFrame1;
@@ -95,8 +93,6 @@ void TestQgsComposerTableV2::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   //create maplayers from testdata and add to layer registry
   QFileInfo vectorFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/points.shp" );
   mVectorLayer = new QgsVectorLayer( vectorFileInfo.filePath(),
@@ -104,16 +100,11 @@ void TestQgsComposerTableV2::initTestCase()
                                      QStringLiteral( "ogr" ) );
   QgsProject::instance()->addMapLayer( mVectorLayer );
 
-  mMapSettings->setLayers( QList<QgsMapLayer*>() << mVectorLayer );
-  mMapSettings->setCrsTransformEnabled( false );
-
   mReport = QStringLiteral( "<h1>Composer TableV2 Tests</h1>\n" );
 }
 
 void TestQgsComposerTableV2::cleanupTestCase()
 {
-  delete mMapSettings;
-
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );
   if ( myFile.open( QIODevice::WriteOnly | QIODevice::Append ) )
@@ -128,7 +119,7 @@ void TestQgsComposerTableV2::cleanupTestCase()
 void TestQgsComposerTableV2::init()
 {
   //create composition with composer map
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 portrait
 
   mComposerAttributeTable = new QgsComposerAttributeTableV2( mComposition, false );

--- a/tests/src/core/testqgscomposerutils.cpp
+++ b/tests/src/core/testqgscomposerutils.cpp
@@ -67,7 +67,6 @@ class TestQgsComposerUtils : public QObject
   private:
     bool renderCheck( const QString& testName, QImage &image, int mismatchCount = 0 );
     QgsComposition* mComposition;
-    QgsMapSettings *mMapSettings;
     QString mReport;
     QFont mTestFont;
 
@@ -75,7 +74,6 @@ class TestQgsComposerUtils : public QObject
 
 TestQgsComposerUtils::TestQgsComposerUtils()
     : mComposition( 0 )
-    , mMapSettings( 0 )
 {
 }
 
@@ -85,8 +83,7 @@ void TestQgsComposerUtils::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis(); //for access to test font
 
-  mMapSettings = new QgsMapSettings();
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
 
   mReport = QStringLiteral( "<h1>Composer Utils Tests</h1>\n" );
@@ -100,7 +97,6 @@ void TestQgsComposerUtils::initTestCase()
 void TestQgsComposerUtils::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QgsApplication::exitQgis();
 
@@ -660,9 +656,7 @@ void TestQgsComposerUtils::createRenderContext()
 
   //create composition with no reference map
   QgsRectangle extent( 2000, 2800, 2500, 2900 );
-  QgsMapSettings ms;
-  ms.setExtent( extent );
-  QgsComposition* composition = new QgsComposition( ms, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   rc = QgsComposerUtils::createRenderContext( composition, &p );
   QGSCOMPARENEAR( rc.scaleFactor(), 150 / 25.4, 0.001 );
   QCOMPARE( rc.painter(), &p );

--- a/tests/src/core/testqgscomposition.cpp
+++ b/tests/src/core/testqgscomposition.cpp
@@ -61,14 +61,12 @@ class TestQgsComposition : public QObject
 
   private:
     QgsComposition *mComposition;
-    QgsMapSettings *mMapSettings;
     QString mReport;
 
 };
 
 TestQgsComposition::TestQgsComposition()
     : mComposition( 0 )
-    , mMapSettings( 0 )
 {
 }
 
@@ -77,12 +75,8 @@ void TestQgsComposition::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
 
-  mMapSettings = new QgsMapSettings();
-
   //create composition
-  mMapSettings->setCrsTransformEnabled( true );
-  mMapSettings->setMapUnits( QgsUnitTypes::DistanceMeters );
-  mComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  mComposition = new QgsComposition( QgsProject::instance() );
   mComposition->setPaperSize( 297, 210 ); //A4 landscape
   mComposition->setNumPages( 3 );
 
@@ -93,7 +87,6 @@ void TestQgsComposition::initTestCase()
 void TestQgsComposition::cleanupTestCase()
 {
   delete mComposition;
-  delete mMapSettings;
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );
@@ -273,7 +266,7 @@ void TestQgsComposition::pageIsEmpty()
 
 void TestQgsComposition::customProperties()
 {
-  QgsComposition* composition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
 
   QCOMPARE( composition->customProperty( "noprop", "defaultval" ).toString(), QString( "defaultval" ) );
   QVERIFY( composition->customProperties().isEmpty() );
@@ -301,7 +294,7 @@ void TestQgsComposition::customProperties()
 
 void TestQgsComposition::writeRetrieveCustomProperties()
 {
-  QgsComposition* composition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   composition->setCustomProperty( QStringLiteral( "testprop" ), "testval" );
   composition->setCustomProperty( QStringLiteral( "testprop2" ), 5 );
 
@@ -320,7 +313,7 @@ void TestQgsComposition::writeRetrieveCustomProperties()
   QDomElement compositionElem = evalNodeList.at( 0 ).toElement();
 
   //test reading node containing custom properties
-  QgsComposition* readComposition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  QgsComposition* readComposition = new QgsComposition( QgsProject::instance() );
   QVERIFY( readComposition->readXml( compositionElem, doc ) );
 
   //test retrieved custom properties
@@ -337,7 +330,7 @@ void TestQgsComposition::writeRetrieveCustomProperties()
 void TestQgsComposition::bounds()
 {
   //add some items to a composition
-  QgsComposition* composition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   QgsComposerShape* shape1 = new QgsComposerShape( composition );
   shape1->setShapeType( QgsComposerShape::Rectangle );
   composition->addComposerShape( shape1 );
@@ -395,7 +388,7 @@ void TestQgsComposition::bounds()
 void TestQgsComposition::resizeToContents()
 {
   //add some items to a composition
-  QgsComposition* composition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   QgsSimpleFillSymbolLayer* simpleFill = new QgsSimpleFillSymbolLayer();
   QgsFillSymbol* fillSymbol = new QgsFillSymbol();
   fillSymbol->changeSymbolLayer( 0, simpleFill );
@@ -436,7 +429,7 @@ void TestQgsComposition::resizeToContentsMargin()
 {
   //resize to contents, with margin
 
-  QgsComposition* composition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   QgsSimpleFillSymbolLayer* simpleFill = new QgsSimpleFillSymbolLayer();
   QgsFillSymbol* fillSymbol = new QgsFillSymbol();
   fillSymbol->changeSymbolLayer( 0, simpleFill );
@@ -477,7 +470,7 @@ void TestQgsComposition::resizeToContentsMultiPage()
 {
   //resize to contents with multi-page composition, should result in a single page
 
-  QgsComposition* composition = new QgsComposition( *mMapSettings, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   QgsSimpleFillSymbolLayer* simpleFill = new QgsSimpleFillSymbolLayer();
   QgsFillSymbol* fillSymbol = new QgsFillSymbol();
   fillSymbol->changeSymbolLayer( 0, simpleFill );
@@ -521,9 +514,7 @@ void TestQgsComposition::resizeToContentsMultiPage()
 void TestQgsComposition::georeference()
 {
   QgsRectangle extent( 2000, 2800, 2500, 2900 );
-  QgsMapSettings ms;
-  ms.setExtent( extent );
-  QgsComposition* composition = new QgsComposition( ms, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
 
   // no map
   double* t = composition->computeGeoTransform( nullptr );
@@ -590,8 +581,7 @@ void TestQgsComposition::georeference()
 
 void TestQgsComposition::variablesEdited()
 {
-  QgsMapSettings ms;
-  QgsComposition c( ms, QgsProject::instance() );
+  QgsComposition c( QgsProject::instance() );
   QSignalSpy spyVariablesChanged( &c, SIGNAL( variablesChanged() ) );
 
   c.setCustomProperty( QStringLiteral( "not a variable" ), "1" );
@@ -605,9 +595,7 @@ void TestQgsComposition::variablesEdited()
 void TestQgsComposition::itemVariablesFunction()
 {
   QgsRectangle extent( 2000, 2800, 2500, 2900 );
-  QgsMapSettings ms;
-  ms.setExtent( extent );
-  QgsComposition* composition = new QgsComposition( ms, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
 
   QgsExpression e( "map_get( item_variables( 'map_id' ), 'map_scale' )" );
   // no map
@@ -644,9 +632,7 @@ void TestQgsComposition::itemVariablesFunction()
 void TestQgsComposition::referenceMap()
 {
   QgsRectangle extent( 2000, 2800, 2500, 2900 );
-  QgsMapSettings ms;
-  ms.setExtent( extent );
-  QgsComposition* composition = new QgsComposition( ms, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
 
   // no maps
   QVERIFY( !composition->referenceMap() );

--- a/tests/src/core/testqgspainteffect.cpp
+++ b/tests/src/core/testqgspainteffect.cpp
@@ -864,7 +864,6 @@ void TestQgsPaintEffect::composer()
   simplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::NoSimplification );
   lineLayer->setSimplifyMethod( simplifyMethod );
 
-  QgsMapSettings ms;
   QgsSimpleLineSymbolLayer* line = new QgsSimpleLineSymbolLayer;
   line->setColor( QColor( 255, 0, 0 ) );
   line->setWidth( 1.0 );
@@ -878,15 +877,14 @@ void TestQgsPaintEffect::composer()
   renderer->setPaintEffect( effect );
 
   lineLayer->setRenderer( renderer );
-  ms.setLayers( QList<QgsMapLayer*>() << lineLayer );
-  ms.setCrsTransformEnabled( false );
 
-  QgsComposition* composition = new QgsComposition( ms, QgsProject::instance() );
+  QgsComposition* composition = new QgsComposition( QgsProject::instance() );
   composition->setPaperSize( 50, 50 );
   QgsComposerMap* composerMap = new QgsComposerMap( composition, 1, 1, 48, 48 );
   composerMap->setFrameEnabled( true );
   composition->addComposerMap( composerMap );
   composerMap->setNewExtent( lineLayer->extent() );
+  composerMap->setLayers( QList<QgsMapLayer*>() << lineLayer );
 
   QImage outputImage( 591, 591, QImage::Format_RGB32 );
   composition->setPlotStyle( QgsComposition::Print );

--- a/tests/src/python/test_qgscomposereffects.py
+++ b/tests/src/python/test_qgscomposereffects.py
@@ -37,7 +37,7 @@ class TestQgsComposerEffects(unittest.TestCase):
 
         # create composition
         self.mMapSettings = QgsMapSettings()
-        self.mComposition = QgsComposition(self.mMapSettings, QgsProject.instance())
+        self.mComposition = QgsComposition(QgsProject.instance())
         self.mComposition.setPaperSize(297, 210)
 
         self.mComposerRect1 = QgsComposerShape(20, 20, 150, 100, self.mComposition)

--- a/tests/src/python/test_qgscomposerhtml.py
+++ b/tests/src/python/test_qgscomposerhtml.py
@@ -43,7 +43,7 @@ class TestQgsComposerHtml(unittest.TestCase):
         """Run before each test."""
         self.iface = get_iface()
         self.mapSettings = QgsMapSettings()
-        self.mComposition = QgsComposition(self.mapSettings, QgsProject.instance())
+        self.mComposition = QgsComposition(QgsProject.instance())
         self.mComposition.setPaperSize(297, 210)  # A4 landscape
 
     def tearDown(self):

--- a/tests/src/python/test_qgscomposeritem.py
+++ b/tests/src/python/test_qgscomposeritem.py
@@ -29,7 +29,7 @@ class TestQgsComposerItem(unittest.TestCase):
     def testDataDefinedFrameColor(self):
         mapSettings = QgsMapSettings()
 
-        composition = QgsComposition(mapSettings, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         item = QgsComposerLabel(composition)
@@ -47,7 +47,7 @@ class TestQgsComposerItem(unittest.TestCase):
     def testDataDefinedBackgroundColor(self):
         mapSettings = QgsMapSettings()
 
-        composition = QgsComposition(mapSettings, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         item = QgsComposerLabel(composition)

--- a/tests/src/python/test_qgscomposerlabel.py
+++ b/tests/src/python/test_qgscomposerlabel.py
@@ -38,7 +38,7 @@ class TestQgsComposerLabel(unittest.TestCase):
         mapSettings.setLayers([mVectorLayer])
         mapSettings.setCrsTransformEnabled(False)
 
-        mComposition = QgsComposition(mapSettings, QgsProject.instance())
+        mComposition = QgsComposition(QgsProject.instance())
         mComposition.setPaperSize(297, 210)
 
         mLabel = QgsComposerLabel(mComposition)

--- a/tests/src/python/test_qgscomposerlegend.py
+++ b/tests/src/python/test_qgscomposerlegend.py
@@ -55,11 +55,12 @@ class TestQgsComposerLegend(unittest.TestCase):
         s = QgsMapSettings()
         s.setLayers([point_layer])
         s.setCrsTransformEnabled(False)
-        composition = QgsComposition(s, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         composer_map = QgsComposerMap(composition, 20, 20, 80, 80)
         composer_map.setFrameEnabled(True)
+        composer_map.setLayers([point_layer])
         composition.addComposerMap(composer_map)
         composer_map.setNewExtent(point_layer.extent())
 
@@ -90,11 +91,12 @@ class TestQgsComposerLegend(unittest.TestCase):
         s = QgsMapSettings()
         s.setLayers([point_layer])
         s.setCrsTransformEnabled(False)
-        composition = QgsComposition(s, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         composer_map = QgsComposerMap(composition, 20, 20, 80, 80)
         composer_map.setFrameEnabled(True)
+        composer_map.setLayers([point_layer])
         composition.addComposerMap(composer_map)
         composer_map.setNewExtent(point_layer.extent())
 
@@ -128,11 +130,12 @@ class TestQgsComposerLegend(unittest.TestCase):
         s = QgsMapSettings()
         s.setLayers([point_layer])
         s.setCrsTransformEnabled(False)
-        composition = QgsComposition(s, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         composer_map = QgsComposerMap(composition, 20, 20, 80, 80)
         composer_map.setFrameEnabled(True)
+        composer_map.setLayers([point_layer])
         composition.addComposerMap(composer_map)
         composer_map.setNewExtent(point_layer.extent())
 
@@ -170,11 +173,12 @@ class TestQgsComposerLegend(unittest.TestCase):
         s = QgsMapSettings()
         s.setLayers([point_layer])
         s.setCrsTransformEnabled(False)
-        composition = QgsComposition(s, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         composer_map = QgsComposerMap(composition, 20, 20, 80, 80)
         composer_map.setFrameEnabled(True)
+        composer_map.setLayers([point_layer])
         composition.addComposerMap(composer_map)
         composer_map.setNewExtent(point_layer.extent())
 
@@ -205,7 +209,7 @@ class TestQgsComposerLegend(unittest.TestCase):
     def testDataDefinedTitle(self):
         mapSettings = QgsMapSettings()
 
-        composition = QgsComposition(mapSettings, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         legend = QgsComposerLegend(composition)
@@ -223,7 +227,7 @@ class TestQgsComposerLegend(unittest.TestCase):
     def testDataDefinedColumnCount(self):
         mapSettings = QgsMapSettings()
 
-        composition = QgsComposition(mapSettings, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         legend = QgsComposerLegend(composition)

--- a/tests/src/python/test_qgscomposermap.py
+++ b/tests/src/python/test_qgscomposermap.py
@@ -63,18 +63,17 @@ class TestQgsComposerMap(unittest.TestCase):
         QgsProject.instance().addMapLayers([self.raster_layer, self.vector_layer])
 
         # create composition with composer map
-        self.mMapSettings = QgsMapSettings()
-        self.mMapSettings.setLayers([self.raster_layer])
-        self.mMapSettings.setCrsTransformEnabled(False)
-        self.mComposition = QgsComposition(self.mMapSettings, QgsProject.instance())
+        self.mComposition = QgsComposition(QgsProject.instance())
         self.mComposition.setPaperSize(297, 210)
         self.mComposerMap = QgsComposerMap(self.mComposition, 20, 20, 200, 100)
         self.mComposerMap.setFrameEnabled(True)
+        self.mComposerMap.setLayers([self.raster_layer])
         self.mComposition.addComposerMap(self.mComposerMap)
 
     def testOverviewMap(self):
         overviewMap = QgsComposerMap(self.mComposition, 20, 130, 70, 70)
         overviewMap.setFrameEnabled(True)
+        overviewMap.setLayers([self.raster_layer])
         self.mComposition.addComposerMap(overviewMap)
         # zoom in
         myRectangle = QgsRectangle(96, -152, 160, -120)
@@ -91,6 +90,7 @@ class TestQgsComposerMap(unittest.TestCase):
     def testOverviewMapBlend(self):
         overviewMap = QgsComposerMap(self.mComposition, 20, 130, 70, 70)
         overviewMap.setFrameEnabled(True)
+        overviewMap.setLayers([self.raster_layer])
         self.mComposition.addComposerMap(overviewMap)
         # zoom in
         myRectangle = QgsRectangle(96, -152, 160, -120)
@@ -108,6 +108,7 @@ class TestQgsComposerMap(unittest.TestCase):
     def testOverviewMapInvert(self):
         overviewMap = QgsComposerMap(self.mComposition, 20, 130, 70, 70)
         overviewMap.setFrameEnabled(True)
+        overviewMap.setLayers([self.raster_layer])
         self.mComposition.addComposerMap(overviewMap)
         # zoom in
         myRectangle = QgsRectangle(96, -152, 160, -120)
@@ -125,6 +126,7 @@ class TestQgsComposerMap(unittest.TestCase):
     def testOverviewMapCenter(self):
         overviewMap = QgsComposerMap(self.mComposition, 20, 130, 70, 70)
         overviewMap.setFrameEnabled(True)
+        overviewMap.setLayers([self.raster_layer])
         self.mComposition.addComposerMap(overviewMap)
         # zoom in
         myRectangle = QgsRectangle(192, -288, 320, -224)
@@ -144,7 +146,7 @@ class TestQgsComposerMap(unittest.TestCase):
         # create composition with composer map
         map_settings = QgsMapSettings()
         map_settings.setLayers([self.vector_layer])
-        composition = QgsComposition(map_settings, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
         composition.setPaperSize(297, 210)
 
         # check that new maps inherit project CRS
@@ -153,6 +155,7 @@ class TestQgsComposerMap(unittest.TestCase):
         map.setFrameEnabled(True)
         rectangle = QgsRectangle(-13838977, 2369660, -8672298, 6250909)
         map.setNewExtent(rectangle)
+        map.setLayers([self.vector_layer])
         composition.addComposerMap(map)
 
         self.assertEqual(map.crs().authid(), 'EPSG:4326')

--- a/tests/src/python/test_qgscomposermapgrid.py
+++ b/tests/src/python/test_qgscomposermapgrid.py
@@ -44,7 +44,7 @@ class TestQgsComposerMap(unittest.TestCase):
         crs = QgsCoordinateReferenceSystem(32633)
         self.mMapSettings.setDestinationCrs(crs)
         self.mMapSettings.setCrsTransformEnabled(False)
-        self.mComposition = QgsComposition(self.mMapSettings, QgsProject.instance())
+        self.mComposition = QgsComposition(QgsProject.instance())
         self.mComposition.setPaperSize(297, 210)
         self.mComposerMap = QgsComposerMap(self.mComposition, 20, 20, 200, 100)
         self.mComposerMap.setFrameEnabled(True)

--- a/tests/src/python/test_qgscomposerpicture.py
+++ b/tests/src/python/test_qgscomposerpicture.py
@@ -59,8 +59,7 @@ class TestQgsComposerPicture(unittest.TestCase):
         self.pngImage = TEST_DATA_DIR + "/sample_image.png"
 
         # create composition
-        self.mapSettings = QgsMapSettings()
-        self.composition = QgsComposition(self.mapSettings, QgsProject.instance())
+        self.composition = QgsComposition(QgsProject.instance())
         self.composition.setPaperSize(297, 210)
 
         self.composerPicture = QgsComposerPicture(self.composition)
@@ -94,8 +93,7 @@ class TestQgsComposerPicture(unittest.TestCase):
     def testGridNorth(self):
         """Test syncing picture to grid north"""
 
-        mapSettings = QgsMapSettings()
-        composition = QgsComposition(mapSettings, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
 
         composerMap = QgsComposerMap(composition)
         composerMap.setNewExtent(QgsRectangle(0, -256, 256, 0))
@@ -118,8 +116,7 @@ class TestQgsComposerPicture(unittest.TestCase):
     def testTrueNorth(self):
         """Test syncing picture to true north"""
 
-        mapSettings = QgsMapSettings()
-        composition = QgsComposition(mapSettings, QgsProject.instance())
+        composition = QgsComposition(QgsProject.instance())
 
         composerMap = QgsComposerMap(composition)
         composerMap.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(3575))

--- a/tests/src/python/test_qgscomposerpolygon.py
+++ b/tests/src/python/test_qgscomposerpolygon.py
@@ -41,10 +41,8 @@ class TestQgsComposerPolygon(unittest.TestCase):
         """Run once on class initialization."""
         unittest.TestCase.__init__(self, methodName)
 
-        self.mapSettings = QgsMapSettings()
-
         # create composition
-        self.mComposition = QgsComposition(self.mapSettings, QgsProject.instance())
+        self.mComposition = QgsComposition(QgsProject.instance())
         self.mComposition.setPaperSize(297, 210)
 
         # create

--- a/tests/src/python/test_qgscomposerpolyline.py
+++ b/tests/src/python/test_qgscomposerpolyline.py
@@ -41,10 +41,8 @@ class TestQgsComposerPolyline(unittest.TestCase):
         """Run once on class initialization."""
         unittest.TestCase.__init__(self, methodName)
 
-        self.mapSettings = QgsMapSettings()
-
         # create composition
-        self.mComposition = QgsComposition(self.mapSettings, QgsProject.instance())
+        self.mComposition = QgsComposition(QgsProject.instance())
         self.mComposition.setPaperSize(297, 210)
 
         # create

--- a/tests/src/python/test_qgscomposershapes.py
+++ b/tests/src/python/test_qgscomposershapes.py
@@ -35,10 +35,8 @@ class TestQgsComposerShapes(unittest.TestCase):
         """Run once on class initialization."""
         unittest.TestCase.__init__(self, methodName)
 
-        self.mapSettings = QgsMapSettings()
-
         # create composition
-        self.mComposition = QgsComposition(self.mapSettings, QgsProject.instance())
+        self.mComposition = QgsComposition(QgsProject.instance())
         self.mComposition.setPaperSize(297, 210)
 
         self.mComposerShape = QgsComposerShape(20, 20, 150, 100, self.mComposition)

--- a/tests/src/python/test_qgscomposition.py
+++ b/tests/src/python/test_qgscomposition.py
@@ -57,7 +57,7 @@ class TestQgsComposition(unittest.TestCase):
         myText = 'Latitude: %s, Longitude: %s' % (myLatitude, myLongitude)
 
         # Load the composition with the substitutions
-        myComposition = QgsComposition(self.iface.mapCanvas().mapSettings(), QgsProject.instance())
+        myComposition = QgsComposition(QgsProject.instance())
         mySubstitutionMap = {'replace-me': myText}
         myFile = os.path.join(TEST_DATA_DIR, 'template-for-substitution.qpt')
         with open(myFile) as f:
@@ -73,7 +73,7 @@ class TestQgsComposition(unittest.TestCase):
 
     def testNoSubstitutionMap(self):
         """Test that we can get a map if we use no text substitutions."""
-        myComposition = QgsComposition(self.iface.mapCanvas().mapSettings(), QgsProject.instance())
+        myComposition = QgsComposition(QgsProject.instance())
         myFile = os.path.join(TEST_DATA_DIR, 'template-for-substitution.qpt')
         with open(myFile) as f:
             myTemplateContent = f.read()
@@ -101,11 +101,7 @@ class TestQgsComposition(unittest.TestCase):
 
         QgsProject.instance().addMapLayers([myRasterLayer])
 
-        myMapSettings = QgsMapSettings()
-        myMapSettings.setLayers([myRasterLayer])
-        myMapSettings.setCrsTransformEnabled(False)
-
-        myComposition = QgsComposition(myMapSettings, QgsProject.instance())
+        myComposition = QgsComposition(QgsProject.instance())
         myFile = os.path.join(TEST_DATA_DIR, 'template-for-substitution.qpt')
         with open(myFile) as f:
             myTemplateContent = f.read()
@@ -120,6 +116,7 @@ class TestQgsComposition(unittest.TestCase):
 
         myExtent = myRasterLayer.extent()
         myMap.setNewExtent(myExtent)
+        myMap.setLayers([myRasterLayer])
 
         myImagePath = os.path.join(str(QDir.tempPath()),
                                    'template_map_render_python.png')

--- a/tests/src/python/test_qgspallabeling_composer.py
+++ b/tests/src/python/test_qgspallabeling_composer.py
@@ -102,7 +102,7 @@ class TestComposerBase(TestQgsPalLabeling):
 
     def _set_up_composition(self, width, height, dpi):
         # set up composition and add map
-        self._c = QgsComposition(self._TestMapSettings, QgsProject.instance())
+        self._c = QgsComposition(QgsProject.instance())
         """:type: QgsComposition"""
         # self._c.setUseAdvancedEffects(False)
         self._c.setPrintResolution(dpi)
@@ -119,6 +119,7 @@ class TestComposerBase(TestQgsPalLabeling):
         """:type: QgsComposerMap"""
         self._cmap.setPreviewMode(QgsComposerMap.Render)
         self._cmap.setFrameEnabled(False)
+        self._cmap.setLayers(self._TestMapSettings.layers())
         self._c.addComposerMap(self._cmap)
         # now expand map to fill page and set its extent
         self._cmap.setSceneRect(QRectF(0, 0, paperw, paperw))


### PR DESCRIPTION
...and remove the horrible link between canvas and compositions via the QgsMapSettings reference.

I don't consider the bridging to be an ideal approach, it's just moving a hack sideways. But at this stage I really need the mapsettings gone in order to fully separate compositions from app and eventually be able to fix this in a nicer way.

Refs https://github.com/qgis/qgis3.0_api/issues/4