### PR TITLE
[FEATURE] expression engine's is_layer_visible()

### DIFF
--- a/resources/function_help/json/is_layer_visible
+++ b/resources/function_help/json/is_layer_visible
@@ -1,0 +1,11 @@
+{
+  "name": "is_layer_visible",
+  "type": "function",
+  "description": "Returns true if a specified layer is visible.",
+  "arguments": [
+	{"arg":"layer", "description":"a string, representing either a layer name or layer ID"}
+  ],
+  "examples": [
+	{ "expression":"is_layer_visible('baseraster')", "returns":"True"}
+  ]
+}

--- a/src/core/qgsmaplayerlistutils.h
+++ b/src/core/qgsmaplayerlistutils.h
@@ -51,6 +51,48 @@ inline QStringList _qgis_listQPointerToIDs( const QList< QPointer<QgsMapLayer> >
   return lst;
 }
 
+inline static QgsMapLayer* _qgis_findLayer( const QList< QgsMapLayer*> layers, const QString& identifier )
+{
+  QgsMapLayer* matchId = nullptr;
+  QgsMapLayer* matchName = nullptr;
+  QgsMapLayer* matchNameInsensitive = nullptr;
+
+  // Look for match against layer IDs
+  Q_FOREACH ( QgsMapLayer* layer, layers )
+  {
+    if ( !matchId && layer->id() == identifier )
+    {
+      matchId = layer;
+      break;
+    }
+    if ( !matchName && layer->name() == identifier )
+    {
+      matchName = layer;
+    }
+    if ( !matchNameInsensitive && QString::compare( layer->name(), identifier, Qt::CaseInsensitive ) == 0 )
+    {
+      matchNameInsensitive = layer;
+    }
+  }
+
+  if ( matchId )
+  {
+    return matchId;
+  }
+  else if ( matchName )
+  {
+    return matchName;
+  }
+  else if ( matchNameInsensitive )
+  {
+    return matchNameInsensitive;
+  }
+  else
+  {
+    return nullptr;
+  }
+}
+
 ///@endcond
 
 #endif // QGSMAPLAYERLISTUTILS_H

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -18,6 +18,8 @@
 #include <math.h>
 
 //header for class being tested
+#include "qgsexpression.h"
+#include "qgsexpressioncontext.h"
 #include "qgsrectangle.h"
 #include "qgsmapsettings.h"
 #include "qgspoint.h"
@@ -34,6 +36,7 @@ class TestQgsMapSettings: public QObject
     void visibleExtent();
     void mapUnitsPerPixel();
     void visiblePolygon();
+    void testIsLayerVisible();
     void testMapLayerListUtils();
   private:
     QString toString( const QPolygonF& p, int decimalPlaces = 2 ) const;
@@ -149,6 +152,38 @@ void TestQgsMapSettings::visiblePolygon()
             QString( "32.32 28.03,103.03 -42.67,67.67 -78.03,-3.03 -7.32" ) );
 }
 
+void TestQgsMapSettings::testIsLayerVisible()
+{
+  QgsVectorLayer* vlA = new QgsVectorLayer( "Point", "a", "memory" );
+  QgsVectorLayer* vlB = new QgsVectorLayer( "Point", "b", "memory" );
+
+  QList<QgsMapLayer*> layers;
+  layers << vlA << vlB;
+
+  QgsMapSettings ms;
+  ms.setLayers( layers );
+  QgsExpressionContext context;
+  context << QgsExpressionContextUtils::mapSettingsScope( ms );
+
+  // test checking for visible layer by id
+  QgsExpression e( QString( "is_layer_visible( '%1' )" ).arg( vlA-> id() ) );
+  QVariant r = e.evaluate( &context );
+  QCOMPARE( r.toBool(), true );
+
+  // test checking for visible layer by name
+  QgsExpression e2( QString( "is_layer_visible( '%1' )" ).arg( vlB-> name() ) );
+  r = e2.evaluate( &context );
+  QCOMPARE( r.toBool(), true );
+
+  // test checking for non-existant layer
+  QgsExpression e3( QString( "is_layer_visible( 'non matching name' )" ) );
+  r = e3.evaluate( &context );
+  QCOMPARE( r.toBool(), false );
+
+  delete vlA;
+  delete vlB;
+}
+
 void TestQgsMapSettings::testMapLayerListUtils()
 {
   QgsVectorLayer* vlA = new QgsVectorLayer( "Point", "a", "memory" );
@@ -156,6 +191,12 @@ void TestQgsMapSettings::testMapLayerListUtils()
 
   QList<QgsMapLayer*> listRawSource;
   listRawSource << vlA << vlB;
+
+  QgsMapLayer* l = _qgis_findLayer( listRawSource, QStringLiteral( "a" ) );
+  QCOMPARE( l, vlA );
+
+  l = _qgis_findLayer( listRawSource, QStringLiteral( "z" ) );
+  QCOMPARE( !l, true );
 
   QList< QPointer<QgsMapLayer> > listQPointer = _qgis_listRawToQPointer( listRawSource );
 


### PR DESCRIPTION
It can be useful to know whether a given layer is visible when rendering. This PR adds that functionality to the expression engine to allow for data-defined styling of symbols and labels.

For e.g., in the GIF below, I'm switching village labels between black and white depending on whether a google imagery basemap layer is visible or not:
![socool2](https://cloud.githubusercontent.com/assets/1728657/22237966/7361b0f0-e241-11e6-9c6a-ec2615afa112.gif)

Edit: this PR adds a qgsmaplayerlistutil.h's function which returns a QgsMapLayer* when matched against a given string. The function first tries to produce a match using the following order:
- layer id
- layer name (case sensitive)
- layer name (case insensitive)