### PR TITLE
[composer] Restore legend customisation from composer templates (Fix #2738)

### DIFF
--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -55,12 +55,23 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     //! Find group node with specified name. Searches recursively the whole sub-tree.
     QgsLayerTreeGroup* findGroup( const QString& name );
 
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error)
-    static QgsLayerTreeGroup* readXML( QDomElement& element ) /Factory/;
+    /**
+     * Read group (tree) from XML element <layer-tree-group> and return the newly
+     * created group (or null on error). If the looseMatch
+     * parameter is true then child legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    static QgsLayerTreeGroup* readXML( QDomElement& element, bool looseMatch = false ) /Factory/;
+
     //! Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
     virtual void writeXML( QDomElement& parentElement );
-    //! Read children from XML and append them to the group.
-    void readChildrenFromXML( QDomElement& element );
+
+    /**
+     * Read children from XML and append them to the group. If the looseMatch
+     * parameter is true then legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    void readChildrenFromXML( QDomElement& element, bool looseMatch = false );
 
     //! Return text representation of the tree. For debugging purposes only.
     virtual QString dump() const;

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -21,17 +21,29 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
 %TypeHeaderCode
 #include <qgslayertreelayer.h>
 %End
+  public:
+
+    //! Parameters for loose layer matching
+    struct LayerMatchParams
+    {
+      //! Layer public source
+      QString source;
+      //! Layer name
+      QString name;
+      //! Provider
+      QString providerKey;
+    };
 
   public:
     explicit QgsLayerTreeLayer( QgsMapLayer* layer );
 
     /**
-     * Creates a layer node which will attach to a layer with a matching
-     * QgsMapLayer::publicSource(). This can be used for "looser" layer matching,
+     * Creates a layer node which will attach to a layer with matching
+     * parameters. This can be used for "looser" layer matching,
      * avoiding the usual layer id check in favour of attaching to any layer
-     * with an equal source.
+     * with an equal source/name/provider.
      */
-    static QgsLayerTreeLayer* createLayerFromSource( const QString& source ) /Factory/;
+    static QgsLayerTreeLayer* createLayerFromParams( const LayerMatchParams& source ) /Factory/;
 
     explicit QgsLayerTreeLayer( const QString& layerId, const QString& name = QString() );
 
@@ -52,7 +64,7 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
      * avoiding the usual layer id check in favour of attaching to any layer
      * with an equal source.
      */
-    void attachToSource( const QString& source );
+    void attachToSource( const LayerMatchParams &source );
 
     QString layerName() const;
     void setLayerName( const QString& n );

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -25,6 +25,14 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
   public:
     explicit QgsLayerTreeLayer( QgsMapLayer* layer );
 
+    /**
+     * Creates a layer node which will attach to a layer with a matching
+     * QgsMapLayer::publicSource(). This can be used for "looser" layer matching,
+     * avoiding the usual layer id check in favour of attaching to any layer
+     * with an equal source.
+     */
+    static QgsLayerTreeLayer* createLayerFromSource( const QString& source ) /Factory/;
+
     explicit QgsLayerTreeLayer( const QString& layerId, const QString& name = QString() );
 
     QString layerId() const;
@@ -38,13 +46,27 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
     //! @note added in 2.18.1
     void setName( const QString& n );
 
+    /**
+     * Attempts to attach this layer node to a layer with a matching
+     * QgsMapLayer::publicSource(). This can be used for "looser" layer matching,
+     * avoiding the usual layer id check in favour of attaching to any layer
+     * with an equal source.
+     */
+    void attachToSource( const QString& source );
+
     QString layerName() const;
     void setLayerName( const QString& n );
 
     Qt::CheckState isVisible() const;
     void setVisible( Qt::CheckState visible );
 
-    static QgsLayerTreeLayer* readXML( QDomElement& element ) /Factory/;
+    /**
+     * Creates a new layer from an XML definition. If the looseMatch
+     * parameter is true then legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    static QgsLayerTreeLayer* readXML( QDomElement& element, bool looseMatch = false ) /Factory/;
+
     virtual void writeXML( QDomElement& parentElement );
 
     virtual QString dump() const;

--- a/python/core/layertree/qgslayertreenode.sip
+++ b/python/core/layertree/qgslayertreenode.sip
@@ -83,8 +83,13 @@ class QgsLayerTreeNode : QObject
     //! @note added in 2.18.1
     virtual void setName( const QString& name ) = 0;
 
-    //! Read layer tree from XML. Returns new instance
-    static QgsLayerTreeNode *readXML( QDomElement &element );
+    /**
+     * Read layer tree from XML. Returns new instance. If the looseMatch
+     * parameter is true then child legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    static QgsLayerTreeNode *readXML( QDomElement &element, bool looseMatch = false ) /Factory/;
+
     //! Write layer tree to XML
     virtual void writeXML( QDomElement &parentElement ) = 0;
 

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -535,7 +535,7 @@ bool QgsComposerLegend::readXML( const QDomElement& itemElem, const QDomDocument
   {
     // QGIS >= 2.6
     QDomElement layerTreeElem = itemElem.firstChildElement( "layer-tree-group" );
-    setCustomLayerTree( QgsLayerTreeGroup::readXML( layerTreeElem ) );
+    setCustomLayerTree( QgsLayerTreeGroup::readXML( layerTreeElem, true ) );
   }
 
   //restore general composer item properties

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -254,7 +254,7 @@ QgsLayerTreeGroup* QgsLayerTreeGroup::findGroup( const QString& name )
   return nullptr;
 }
 
-QgsLayerTreeGroup* QgsLayerTreeGroup::readXML( QDomElement& element )
+QgsLayerTreeGroup* QgsLayerTreeGroup::readXML( QDomElement& element, bool looseMatch )
 {
   if ( element.tagName() != "layer-tree-group" )
     return nullptr;
@@ -270,7 +270,7 @@ QgsLayerTreeGroup* QgsLayerTreeGroup::readXML( QDomElement& element )
 
   groupNode->readCommonXML( element );
 
-  groupNode->readChildrenFromXML( element );
+  groupNode->readChildrenFromXML( element, looseMatch );
 
   groupNode->setIsMutuallyExclusive( isMutuallyExclusive, mutuallyExclusiveChildIndex );
 
@@ -298,13 +298,13 @@ void QgsLayerTreeGroup::writeXML( QDomElement& parentElement )
   parentElement.appendChild( elem );
 }
 
-void QgsLayerTreeGroup::readChildrenFromXML( QDomElement& element )
+void QgsLayerTreeGroup::readChildrenFromXML( QDomElement& element, bool looseMatch )
 {
   QList<QgsLayerTreeNode*> nodes;
   QDomElement childElem = element.firstChildElement();
   while ( !childElem.isNull() )
   {
-    QgsLayerTreeNode* newNode = QgsLayerTreeNode::readXML( childElem );
+    QgsLayerTreeNode* newNode = QgsLayerTreeNode::readXML( childElem, looseMatch );
     if ( newNode )
       nodes << newNode;
 

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -76,12 +76,22 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     //! Find group node with specified name. Searches recursively the whole sub-tree.
     QgsLayerTreeGroup* findGroup( const QString& name );
 
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error)
-    static QgsLayerTreeGroup* readXML( QDomElement& element );
+    /**
+     * Read group (tree) from XML element <layer-tree-group> and return the newly
+     * created group (or null on error). If the looseMatch
+     * parameter is true then child legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    static QgsLayerTreeGroup* readXML( QDomElement& element, bool looseMatch = false );
+
     //! Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
     virtual void writeXML( QDomElement& parentElement ) override;
-    //! Read children from XML and append them to the group.
-    void readChildrenFromXML( QDomElement& element );
+    /**
+     * Read children from XML and append them to the group. If the looseMatch
+     * parameter is true then legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    void readChildrenFromXML( QDomElement& element, bool looseMatch = false );
 
     //! Return text representation of the tree. For debugging purposes only.
     virtual QString dump() const override;

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -45,6 +45,14 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     explicit QgsLayerTreeLayer( QgsMapLayer* layer );
     QgsLayerTreeLayer( const QgsLayerTreeLayer& other );
 
+    /**
+     * Creates a layer node which will attach to a layer with a matching
+     * QgsMapLayer::publicSource(). This can be used for "looser" layer matching,
+     * avoiding the usual layer id check in favour of attaching to any layer
+     * with an equal source.
+     */
+    static QgsLayerTreeLayer* createLayerFromSource( const QString& source );
+
     explicit QgsLayerTreeLayer( const QString& layerId, const QString& name = QString() );
 
     QString layerId() const { return mLayerId; }
@@ -58,13 +66,27 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     //! @note added in 2.18.1
     void setName( const QString& n ) override;
 
+    /**
+     * Attempts to attach this layer node to a layer with a matching
+     * QgsMapLayer::publicSource(). This can be used for "looser" layer matching,
+     * avoiding the usual layer id check in favour of attaching to any layer
+     * with an equal source.
+     */
+    void attachToSource( const QString& source );
+
     QString layerName() const;
     void setLayerName( const QString& n );
 
     Qt::CheckState isVisible() const { return mVisible; }
     void setVisible( Qt::CheckState visible );
 
-    static QgsLayerTreeLayer* readXML( QDomElement& element );
+    /**
+     * Creates a new layer from an XML definition. If the looseMatch
+     * parameter is true then legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    static QgsLayerTreeLayer* readXML( QDomElement& element, bool looseMatch = false );
+
     virtual void writeXML( QDomElement& parentElement ) override;
 
     virtual QString dump() const override;
@@ -90,6 +112,9 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     QString mLayerId;
     QString mLayerName; // only used if layer does not exist
+    //! Only used when loosely matching to layers - eg when creating a composer legend from template
+    //! If set this will attach to the first matching layer with an equal source
+    QString mLayerSource;
     QgsMapLayer* mLayer; // not owned! may be null
     Qt::CheckState mVisible;
 };

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -42,16 +42,28 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 {
     Q_OBJECT
   public:
+
+    //! Parameters for loose layer matching
+    struct LayerMatchParams
+    {
+      //! Layer public source
+      QString source;
+      //! Layer name
+      QString name;
+      //! Provider
+      QString providerKey;
+    };
+
     explicit QgsLayerTreeLayer( QgsMapLayer* layer );
     QgsLayerTreeLayer( const QgsLayerTreeLayer& other );
 
     /**
-     * Creates a layer node which will attach to a layer with a matching
-     * QgsMapLayer::publicSource(). This can be used for "looser" layer matching,
+     * Creates a layer node which will attach to a layer with matching
+     * parameters. This can be used for "looser" layer matching,
      * avoiding the usual layer id check in favour of attaching to any layer
-     * with an equal source.
+     * with an equal source/name/provider.
      */
-    static QgsLayerTreeLayer* createLayerFromSource( const QString& source );
+    static QgsLayerTreeLayer* createLayerFromParams( const LayerMatchParams& source );
 
     explicit QgsLayerTreeLayer( const QString& layerId, const QString& name = QString() );
 
@@ -72,7 +84,7 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
      * avoiding the usual layer id check in favour of attaching to any layer
      * with an equal source.
      */
-    void attachToSource( const QString& source );
+    void attachToSource( const LayerMatchParams &source );
 
     QString layerName() const;
     void setLayerName( const QString& n );
@@ -112,11 +124,17 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     QString mLayerId;
     QString mLayerName; // only used if layer does not exist
+
     //! Only used when loosely matching to layers - eg when creating a composer legend from template
-    //! If set this will attach to the first matching layer with an equal source
-    QString mLayerSource;
+    //! If set this will attach to the first matching layer with equal parameters
+    LayerMatchParams mLooseMatchParams;
+
     QgsMapLayer* mLayer; // not owned! may be null
     Qt::CheckState mVisible;
+
+  private:
+
+    bool layerMatchesSource( QgsMapLayer *layer, const LayerMatchParams& params ) const;
 };
 
 

--- a/src/core/layertree/qgslayertreenode.cpp
+++ b/src/core/layertree/qgslayertreenode.cpp
@@ -47,13 +47,13 @@ QgsLayerTreeNode::~QgsLayerTreeNode()
   qDeleteAll( mChildren );
 }
 
-QgsLayerTreeNode* QgsLayerTreeNode::readXML( QDomElement& element )
+QgsLayerTreeNode* QgsLayerTreeNode::readXML( QDomElement& element, bool looseMatch )
 {
   QgsLayerTreeNode* node = nullptr;
   if ( element.tagName() == "layer-tree-group" )
-    node = QgsLayerTreeGroup::readXML( element );
+    node = QgsLayerTreeGroup::readXML( element, looseMatch );
   else if ( element.tagName() == "layer-tree-layer" )
-    node = QgsLayerTreeLayer::readXML( element );
+    node = QgsLayerTreeLayer::readXML( element, looseMatch );
 
   return node;
 }

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -90,8 +90,13 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     //! @note added in 2.18.1
     virtual void setName( const QString& name ) = 0;
 
-    //! Read layer tree from XML. Returns new instance
-    static QgsLayerTreeNode *readXML( QDomElement &element );
+    /**
+     * Read layer tree from XML. Returns new instance. If the looseMatch
+     * parameter is true then child legend layers will use looser matching criteria,
+     * eg testing layer source instead of layer IDs.
+     */
+    static QgsLayerTreeNode *readXML( QDomElement &element, bool looseMatch = false );
+
     //! Write layer tree to XML
     virtual void writeXML( QDomElement &parentElement ) = 0;
 


### PR DESCRIPTION
This change allows customised legends within composer templates to be correctly restored when creating a new composition from the template in a different project.

The legend layers will be attached to any loaded layers with a matching data source as the layer from the original template composition.

A high level description of this fix is available at https://github.com/qgis/QGIS-Enhancement-Proposals/issues/87

This should NOT be merged yet - unit tests are required, and I believe there's a few additional corner cases I need to catch. But I'm after feedback that this approach is an acceptable fix for this issue first.

(Sponsored by ENEL, on behalf of Faunalia)