### PR TITLE
Reading/saving labeling engine uses a particular QgsProject

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1448,6 +1448,8 @@ QgsPalLabeling        {#qgis_api_break_3_0_QgsPalLabeling}
 - labelsAtPosition() was removed. Use takeResults() and methods of QgsLabelingResults instead.
 - labelsWithinRect() was removed. Use takeResults() and methods of QgsLabelingResults instead.
 - isStoredWithProject() and setStoredWithProject() had no effect and were removed.
+- staticWillUseLayer(QString) was removed. Use the variant with QgsVectorLayer argument.
+- clearEngineSettings() was replaced by QgsLabelingEngine::clearSettingsInProject().
 
 
 QgsPalLayerSettings        {#qgis_api_break_3_0_QgsPalLayerSettings}

--- a/python/core/qgspallabeling.sip
+++ b/python/core/qgspallabeling.sip
@@ -552,7 +552,6 @@ class QgsPalLabeling
     //! called to find out whether the layer is used for labeling
     //! @note added in 2.4
     static bool staticWillUseLayer( QgsVectorLayer* layer );
-    static bool staticWillUseLayer( const QString& layerID );
 
     //! @note not available in python bindings
     // void drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* painter, const QgsMapToPixel* xform );
@@ -560,7 +559,6 @@ class QgsPalLabeling
     //! load/save engine settings to project file
     void loadEngineSettings();
     void saveEngineSettings();
-    void clearEngineSettings();
 
     /** Prepares a geometry for registration with PAL. Handles reprojection, rotation, clipping, etc.
      * @param geometry geometry to prepare

--- a/src/app/qgslabelengineconfigdialog.cpp
+++ b/src/app/qgslabelengineconfigdialog.cpp
@@ -15,6 +15,8 @@
 #include "qgslabelengineconfigdialog.h"
 
 #include "qgspallabeling.h"
+#include "qgslabelingengine.h"
+#include "qgsproject.h"
 #include <pal/pal.h>
 
 #include <QPushButton>
@@ -28,44 +30,44 @@ QgsLabelEngineConfigDialog::QgsLabelEngineConfigDialog( QWidget* parent )
   connect( buttonBox->button( QDialogButtonBox::RestoreDefaults ), SIGNAL( clicked() ),
            this, SLOT( setDefaults() ) );
 
-  QgsPalLabeling lbl;
-  lbl.loadEngineSettings();
+  QgsLabelingEngine engine;
+  engine.readSettingsFromProject( QgsProject::instance() );
 
   // search method
-  cboSearchMethod->setCurrentIndex( lbl.searchMethod() );
+  cboSearchMethod->setCurrentIndex( engine.searchMethod() );
 
   // candidate numbers
   int candPoint, candLine, candPolygon;
-  lbl.numCandidatePositions( candPoint, candLine, candPolygon );
+  engine.numCandidatePositions( candPoint, candLine, candPolygon );
   spinCandPoint->setValue( candPoint );
   spinCandLine->setValue( candLine );
   spinCandPolygon->setValue( candPolygon );
 
-  chkShowCandidates->setChecked( lbl.isShowingCandidates() );
-  chkShowAllLabels->setChecked( lbl.isShowingAllLabels() );
+  chkShowCandidates->setChecked( engine.testFlag( QgsLabelingEngine::DrawCandidates ) );
+  chkShowAllLabels->setChecked( engine.testFlag( QgsLabelingEngine::UseAllLabels ) );
 
-  chkShowPartialsLabels->setChecked( lbl.isShowingPartialsLabels() );
-  mDrawOutlinesChkBox->setChecked( lbl.isDrawingOutlineLabels() );
+  chkShowPartialsLabels->setChecked( engine.testFlag( QgsLabelingEngine::UsePartialCandidates ) );
+  mDrawOutlinesChkBox->setChecked( engine.testFlag( QgsLabelingEngine::RenderOutlineLabels ) );
 }
 
 
 void QgsLabelEngineConfigDialog::onOK()
 {
-  QgsPalLabeling lbl;
+  QgsLabelingEngine engine;
 
   // save
-  lbl.setSearchMethod(( QgsPalLabeling::Search ) cboSearchMethod->currentIndex() );
+  engine.setSearchMethod(( QgsPalLabeling::Search ) cboSearchMethod->currentIndex() );
 
-  lbl.setNumCandidatePositions( spinCandPoint->value(),
-                                spinCandLine->value(),
-                                spinCandPolygon->value() );
+  engine.setNumCandidatePositions( spinCandPoint->value(),
+                                   spinCandLine->value(),
+                                   spinCandPolygon->value() );
 
-  lbl.setShowingCandidates( chkShowCandidates->isChecked() );
-  lbl.setShowingAllLabels( chkShowAllLabels->isChecked() );
-  lbl.setShowingPartialsLabels( chkShowPartialsLabels->isChecked() );
-  lbl.setDrawingOutlineLabels( mDrawOutlinesChkBox->isChecked() );
+  engine.setFlag( QgsLabelingEngine::DrawCandidates, chkShowCandidates->isChecked() );
+  engine.setFlag( QgsLabelingEngine::UseAllLabels, chkShowAllLabels->isChecked() );
+  engine.setFlag( QgsLabelingEngine::UsePartialCandidates, chkShowPartialsLabels->isChecked() );
+  engine.setFlag( QgsLabelingEngine::RenderOutlineLabels, mDrawOutlinesChkBox->isChecked() );
 
-  lbl.saveEngineSettings();
+  engine.writeSettingsToProject( QgsProject::instance() );
 
   accept();
 }

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -30,6 +30,7 @@
 #include "qgsdxfpallabeling.h"
 #include "qgsvectordataprovider.h"
 #include "qgspoint.h"
+#include "qgsproject.h"
 #include "qgsrenderer.h"
 #include "qgssymbollayer.h"
 #include "qgsfillsymbollayer.h"
@@ -941,7 +942,7 @@ void QgsDxfExport::writeEntities()
 
   // label engine
   QgsLabelingEngine engine;
-  engine.readSettingsFromProject();
+  engine.readSettingsFromProject( QgsProject::instance() );
   engine.setMapSettings( mMapSettings );
 
   // iterate through the maplayers

--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -347,10 +347,9 @@ QgsLabelingResults* QgsLabelingEngine::takeResults()
 }
 
 
-void QgsLabelingEngine::readSettingsFromProject()
+void QgsLabelingEngine::readSettingsFromProject( QgsProject* prj )
 {
   bool saved = false;
-  QgsProject* prj = QgsProject::instance();
   mSearchMethod = static_cast< QgsPalLabeling::Search >( prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ), static_cast< int >( QgsPalLabeling::Chain ), &saved ) );
   mCandPoint = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ), 16, &saved );
   mCandLine = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ), 50, &saved );
@@ -364,18 +363,30 @@ void QgsLabelingEngine::readSettingsFromProject()
   if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), true, &saved ) ) mFlags |= RenderOutlineLabels;
 }
 
-void QgsLabelingEngine::writeSettingsToProject()
+void QgsLabelingEngine::writeSettingsToProject( QgsProject* project )
 {
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ), static_cast< int >( mSearchMethod ) );
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ), mCandPoint );
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ), mCandLine );
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ), mCandPolygon );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ), static_cast< int >( mSearchMethod ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ), mCandPoint );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ), mCandLine );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ), mCandPolygon );
 
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), mFlags.testFlag( DrawCandidates ) );
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), mFlags.testFlag( DrawLabelRectOnly ) );
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), mFlags.testFlag( UseAllLabels ) );
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), mFlags.testFlag( UsePartialCandidates ) );
-  QgsProject::instance()->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), mFlags.testFlag( RenderOutlineLabels ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), mFlags.testFlag( DrawCandidates ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), mFlags.testFlag( DrawLabelRectOnly ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), mFlags.testFlag( UseAllLabels ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), mFlags.testFlag( UsePartialCandidates ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), mFlags.testFlag( RenderOutlineLabels ) );
+}
+
+void QgsLabelingEngine::clearSettingsInProject( QgsProject* project )
+{
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ) );
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ) );
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ) );
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ) );
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ) );
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ) );
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ) );
+  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ) );
 }
 
 

--- a/src/core/qgslabelingengine.h
+++ b/src/core/qgslabelingengine.h
@@ -220,10 +220,12 @@ class CORE_EXPORT QgsLabelingEngine
     //! Which search method to use for removal collisions between labels
     QgsPalLabeling::Search searchMethod() const { return mSearchMethod; }
 
-    //! Read configuration of the labeling engine from the current project file
-    void readSettingsFromProject();
-    //! Write configuration of the labeling engine to the current project file
-    void writeSettingsToProject();
+    //! Read configuration of the labeling engine from a project
+    void readSettingsFromProject( QgsProject* project );
+    //! Write configuration of the labeling engine to a project
+    void writeSettingsToProject( QgsProject* project );
+    //! Clear configuration of the labeling engine in a project
+    static void clearSettingsInProject( QgsProject* project );
 
   protected:
     void processProvider( QgsAbstractLabelProvider* provider, QgsRenderContext& context, pal::Pal& p );  //#spellok

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -79,7 +79,7 @@ void QgsMapRendererCustomPainterJob::start()
   if ( mSettings.testFlag( QgsMapSettings::DrawLabeling ) )
   {
     mLabelingEngineV2 = new QgsLabelingEngine();
-    mLabelingEngineV2->readSettingsFromProject();
+    mLabelingEngineV2->readSettingsFromProject( QgsProject::instance() );
     mLabelingEngineV2->setMapSettings( mSettings );
   }
 

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -20,6 +20,7 @@
 #include "qgslogger.h"
 #include "qgsmaplayerrenderer.h"
 #include "qgspallabeling.h"
+#include "qgsproject.h"
 
 #include <QtConcurrentMap>
 
@@ -57,7 +58,7 @@ void QgsMapRendererParallelJob::start()
   if ( mSettings.testFlag( QgsMapSettings::DrawLabeling ) )
   {
     mLabelingEngineV2 = new QgsLabelingEngine();
-    mLabelingEngineV2->readSettingsFromProject();
+    mLabelingEngineV2->readSettingsFromProject( QgsProject::instance() );
     mLabelingEngineV2->setMapSettings( mSettings );
   }
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2740,15 +2740,6 @@ QgsPalLabeling::~QgsPalLabeling()
   mEngine = nullptr;
 }
 
-bool QgsPalLabeling::staticWillUseLayer( const QString& layerID )
-{
-  QgsVectorLayer* layer = qobject_cast<QgsVectorLayer*>( QgsProject::instance()->mapLayer( layerID ) );
-  if ( !layer )
-    return false;
-  return staticWillUseLayer( layer );
-}
-
-
 bool QgsPalLabeling::staticWillUseLayer( QgsVectorLayer* layer )
 {
   // don't do QgsPalLayerSettings::readFromLayer( layer ) if not needed
@@ -3485,26 +3476,16 @@ void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* p
     drawLabelCandidateRect( lp->getNextPart(), painter, xform, candidates );
 }
 
+// TODO: remove once not used in labeling tests
 void QgsPalLabeling::loadEngineSettings()
 {
-  mEngine->readSettingsFromProject();
+  mEngine->readSettingsFromProject( QgsProject::instance() );
 }
 
+// TODO: remove once not used in labeling tests
 void QgsPalLabeling::saveEngineSettings()
 {
-  mEngine->writeSettingsToProject();
-}
-
-void QgsPalLabeling::clearEngineSettings()
-{
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ) );
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ) );
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ) );
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ) );
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ) );
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ) );
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ) );
-  QgsProject::instance()->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ) );
+  mEngine->writeSettingsToProject( QgsProject::instance() );
 }
 
 QgsLabelingResults::QgsLabelingResults()

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -737,7 +737,6 @@ class CORE_EXPORT QgsPalLabeling
     //! called to find out whether the layer is used for labeling
     //! @note added in 2.4
     static bool staticWillUseLayer( QgsVectorLayer* layer );
-    static bool staticWillUseLayer( const QString& layerID );
 
     //! @note not available in python bindings
     static void drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* painter, const QgsMapToPixel* xform, QList<QgsLabelCandidate>* candidates = nullptr );
@@ -745,7 +744,6 @@ class CORE_EXPORT QgsPalLabeling
     //! load/save engine settings to project file
     void loadEngineSettings();
     void saveEngineSettings();
-    void clearEngineSettings();
 
     /** Prepares a geometry for registration with PAL. Handles reprojection, rotation, clipping, etc.
      * @param geometry geometry to prepare


### PR DESCRIPTION
... rather than using QgsProject::instance() internally

These are small cleanups to dig out some instance() uses and move them one level up...

At some point we should maybe make labeling engine configuration a part of QgsMapSettings and have default project labeling engine config accessible from QgsProject in a way similar to e.g. snapping configuration.