### PR TITLE
Make layer tree implementation independent from QgsProject::instance()

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1194,6 +1194,7 @@ QgsLayerTreeGroup        {#qgis_api_break_3_0_QgsLayerTreeGroup}
 - isVisible() is moved to QgsLayerTreeNode
 - setVisible() is replaced by QgsLayerTreeNode::setItemVisibilityChecked()
 - protected methods updateVisibilityFromChildren() and updateChildVisibility() removed
+- readXml() and readChildrenFromXml() do not resolve layers from the layer IDs anymore. Call resolveReferences() or use readXml() override with QgsProject as the second argument.
 
 QgsLayerTreeLayer        {#qgis_api_break_3_0_QgsLayerTreeLayer}
 -----------------
@@ -1201,6 +1202,12 @@ QgsLayerTreeLayer        {#qgis_api_break_3_0_QgsLayerTreeLayer}
 - setLayerName(), layerName() were renamed to setName(), name()
 - isVisible() is moved to QgsLayerTreeNode
 - setVisible() is replaced by QgsLayerTreeNode::setItemVisibilityChecked()
+- readXml() does not resolve layer from the layer ID anymore. Call resolveReferences() or use readXml() override with QgsProject as the second argument.
+
+QgsLayerTreeNode        {#qgis_api_break_3_0_QgsLayerTreeNode}
+----------------
+
+- readXml() does not resolve layers from the layer IDs anymore. Call resolveReferences() or use readXml() override with QgsProject as the second argument.
 
 
 QgsLayerTreeModel        {#qgis_api_break_3_0_QgsLayerTreeMode}

--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -58,11 +58,18 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     //! Find group node with specified name. Searches recursively the whole sub-tree.
     QgsLayerTreeGroup* findGroup( const QString& name );
 
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error)
+    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
     static QgsLayerTreeGroup* readXml( QDomElement& element ) /Factory/;
+    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
+    //! @note added in 3.0
+    static QgsLayerTreeGroup* readXml( QDomElement& element, const QgsProject* project ) /Factory/;
+
     //! Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
     virtual void writeXml( QDomElement& parentElement );
     //! Read children from XML and append them to the group.
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
     void readChildrenFromXml( QDomElement& element );
 
     //! Return text representation of the tree. For debugging purposes only.
@@ -70,6 +77,10 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
 
     //! Return a clone of the group. The children are cloned too.
     virtual QgsLayerTreeGroup* clone() const /Factory/;
+
+    //! Calls resolveReferences() on child tree nodes
+    //! @note added in 3.0
+    virtual void resolveReferences( const QgsProject* project );
 
     //! Return whether the group is mutually exclusive (only one child can be checked at a time)
     //! @note added in 2.12

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -1,14 +1,10 @@
 /**
  * Layer tree node points to a map layer.
  *
- * When using with existing QgsMapLayer instance, it is expected that the layer
- * has been registered in QgsProject earlier.
- *
  * The node can exist also without a valid instance of a layer (just ID). That
  * means the referenced layer does not need to be loaded in order to use it
- * in layer tree. In such case, the node will start listening to map layer
- * registry updates in expectation that the layer (identified by its ID) will
- * be loaded later.
+ * in layer tree. In such case, resolveReferences() method can be called
+ * once the layer is loaded.
  *
  * A map layer is supposed to be present in one layer tree just once. It is
  * however possible that temporarily a layer exists in one tree more than just
@@ -38,19 +34,23 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
     //! @note added in 3.0
     void setName( const QString& n );
 
+    //! Read layer node from XML. Returns new instance.
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
     static QgsLayerTreeLayer* readXml( QDomElement& element ) /Factory/;
+    //! Read layer node from XML. Returns new instance.
+    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
+    //! @note added in 3.0
+    static QgsLayerTreeLayer* readXml( QDomElement& element, const QgsProject* project ) /Factory/;
+
     virtual void writeXml( QDomElement& parentElement );
 
     virtual QString dump() const;
 
     virtual QgsLayerTreeLayer* clone() const /Factory/;
 
-  protected slots:
-    void registryLayersAdded( const QList<QgsMapLayer*>& layers );
-    void registryLayersWillBeRemoved( const QStringList& layerIds );
-    //! Emits a nameChanged() signal if layer's name has changed
+    //! Resolves reference to layer from stored layer ID (if it has not been resolved already)
     //! @note added in 3.0
-    void layerNameChanged();
+    virtual void resolveReferences( const QgsProject* project );
 
   signals:
     //! emitted when a previously unavailable layer got loaded

--- a/python/core/layertree/qgslayertreenode.sip
+++ b/python/core/layertree/qgslayertreenode.sip
@@ -83,8 +83,14 @@ class QgsLayerTreeNode : QObject
     //! @note added in 3.0
     virtual void setName( const QString& name ) = 0;
 
-    //! Read layer tree from XML. Returns new instance
-    static QgsLayerTreeNode* readXml( QDomElement& element ) /Factory/;
+    //! Read layer tree from XML. Returns new instance.
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+    static QgsLayerTreeNode *readXml( QDomElement &element ) /Factory/;
+    //! Read layer tree from XML. Returns new instance.
+    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
+    //! @note added in 3.0
+    static QgsLayerTreeNode* readXml( QDomElement& element, const QgsProject* project ) /Factory/;
+
     //! Write layer tree to XML
     virtual void writeXml( QDomElement &parentElement ) = 0;
 
@@ -93,6 +99,11 @@ class QgsLayerTreeNode : QObject
 
     //! Create a copy of the node. Returns new instance
     virtual QgsLayerTreeNode *clone() const = 0 /Factory/;
+
+    //! Turn textual references to layers into map layer object from project.
+    //! This method should be called after readXml()
+    //! @note added in 3.0
+    virtual void resolveReferences( const QgsProject* project ) = 0;
 
     //! Returns whether a node is really visible (ie checked and all its ancestors checked as well)
     //! @note added in 3.0

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11573,7 +11573,7 @@ void QgisApp::writeProject( QDomDocument &doc )
 
   QgsLayerTreeNode* clonedRoot = QgsProject::instance()->layerTreeRoot()->clone();
   QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTree::toGroup( clonedRoot ) );
-  QgsLayerTreeUtils::updateEmbeddedGroupsProjectPath( QgsLayerTree::toGroup( clonedRoot ) ); // convert absolute paths to relative paths if required
+  QgsLayerTreeUtils::updateEmbeddedGroupsProjectPath( QgsLayerTree::toGroup( clonedRoot ), QgsProject::instance() ); // convert absolute paths to relative paths if required
   QDomElement oldLegendElem = QgsLayerTreeUtils::writeOldLegend( doc, QgsLayerTree::toGroup( clonedRoot ),
                               mLayerTreeCanvasBridge->hasCustomLayerOrder(), mLayerTreeCanvasBridge->customLayerOrder() );
   delete clonedRoot;

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -537,7 +537,7 @@ bool QgsComposerLegend::readXml( const QDomElement& itemElem, const QDomDocument
   {
     // QGIS >= 2.6
     QDomElement layerTreeElem = itemElem.firstChildElement( QStringLiteral( "layer-tree-group" ) );
-    setCustomLayerTree( QgsLayerTreeGroup::readXml( layerTreeElem ) );
+    setCustomLayerTree( QgsLayerTreeGroup::readXml( layerTreeElem, mComposition->project() ) );
   }
 
   //restore general composer item properties

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -18,7 +18,6 @@
 #include "qgslayertree.h"
 #include "qgslayertreeutils.h"
 #include "qgsmaplayer.h"
-#include "qgsproject.h"
 
 #include <QDomElement>
 #include <QStringList>
@@ -73,9 +72,9 @@ QgsLayerTreeGroup* QgsLayerTreeGroup::addGroup( const QString &name )
   return grp;
 }
 
-QgsLayerTreeLayer*QgsLayerTreeGroup::insertLayer( int index, QgsMapLayer* layer )
+QgsLayerTreeLayer* QgsLayerTreeGroup::insertLayer( int index, QgsMapLayer* layer )
 {
-  if ( !layer || QgsProject::instance()->mapLayer( layer->id() ) != layer )
+  if ( !layer )
     return nullptr;
 
   QgsLayerTreeLayer* ll = new QgsLayerTreeLayer( layer );
@@ -85,7 +84,7 @@ QgsLayerTreeLayer*QgsLayerTreeGroup::insertLayer( int index, QgsMapLayer* layer 
 
 QgsLayerTreeLayer* QgsLayerTreeGroup::addLayer( QgsMapLayer* layer )
 {
-  if ( !layer || QgsProject::instance()->mapLayer( layer->id() ) != layer )
+  if ( !layer )
     return nullptr;
 
   QgsLayerTreeLayer* ll = new QgsLayerTreeLayer( layer );
@@ -276,6 +275,14 @@ QgsLayerTreeGroup* QgsLayerTreeGroup::readXml( QDomElement& element )
   return groupNode;
 }
 
+QgsLayerTreeGroup* QgsLayerTreeGroup::readXml( QDomElement& element, const QgsProject* project )
+{
+  QgsLayerTreeGroup* node = readXml( element );
+  if ( node )
+    node->resolveReferences( project );
+  return node;
+}
+
 void QgsLayerTreeGroup::writeXml( QDomElement& parentElement )
 {
   QDomDocument doc = parentElement.ownerDocument();
@@ -327,6 +334,12 @@ QString QgsLayerTreeGroup::dump() const
 QgsLayerTreeGroup* QgsLayerTreeGroup::clone() const
 {
   return new QgsLayerTreeGroup( *this );
+}
+
+void QgsLayerTreeGroup::resolveReferences( const QgsProject* project )
+{
+  Q_FOREACH ( QgsLayerTreeNode* node, mChildren )
+    node->resolveReferences( project );
 }
 
 static bool _nodeIsChecked( QgsLayerTreeNode* node )

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -81,11 +81,18 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     //! Find group node with specified name. Searches recursively the whole sub-tree.
     QgsLayerTreeGroup* findGroup( const QString& name );
 
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error)
+    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
     static QgsLayerTreeGroup* readXml( QDomElement& element );
+    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
+    //! @note added in 3.0
+    static QgsLayerTreeGroup* readXml( QDomElement& element, const QgsProject* project );
+
     //! Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
     virtual void writeXml( QDomElement& parentElement ) override;
     //! Read children from XML and append them to the group.
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
     void readChildrenFromXml( QDomElement& element );
 
     //! Return text representation of the tree. For debugging purposes only.
@@ -93,6 +100,10 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 
     //! Return a clone of the group. The children are cloned too.
     virtual QgsLayerTreeGroup* clone() const override;
+
+    //! Calls resolveReferences() on child tree nodes
+    //! @note added in 3.0
+    virtual void resolveReferences( const QgsProject* project ) override;
 
     //! Check or uncheck a node and all its children (taking into account exclusion rules)
     virtual void setItemVisibilityCheckedRecursive( bool checked ) override;

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -18,20 +18,17 @@
 
 #include "qgis_core.h"
 #include "qgslayertreenode.h"
+#include "qgsmaplayerref.h"
 
 class QgsMapLayer;
 
 /** \ingroup core
  * Layer tree node points to a map layer.
  *
- * When using with existing QgsMapLayer instance, it is expected that the layer
- * has been registered in QgsProject earlier.
- *
  * The node can exist also without a valid instance of a layer (just ID). That
  * means the referenced layer does not need to be loaded in order to use it
- * in layer tree. In such case, the node will start listening to map layer
- * registry updates in expectation that the layer (identified by its ID) will
- * be loaded later.
+ * in layer tree. In such case, resolveReferences() method can be called
+ * once the layer is loaded.
  *
  * A map layer is supposed to be present in one layer tree just once. It is
  * however possible that temporarily a layer exists in one tree more than just
@@ -48,9 +45,9 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     explicit QgsLayerTreeLayer( const QString& layerId, const QString& name = QString() );
 
-    QString layerId() const { return mLayerId; }
+    QString layerId() const { return mRef.layerId; }
 
-    QgsMapLayer* layer() const { return mLayer; }
+    QgsMapLayer* layer() const { return mRef.layer.data(); }
 
     //! Get layer's name
     //! @note added in 3.0
@@ -59,19 +56,31 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     //! @note added in 3.0
     void setName( const QString& n ) override;
 
+    //! Read layer node from XML. Returns new instance.
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
     static QgsLayerTreeLayer* readXml( QDomElement& element );
+    //! Read layer node from XML. Returns new instance.
+    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
+    //! @note added in 3.0
+    static QgsLayerTreeLayer* readXml( QDomElement& element, const QgsProject* project );
+
     virtual void writeXml( QDomElement& parentElement ) override;
 
     virtual QString dump() const override;
 
     virtual QgsLayerTreeLayer* clone() const override;
 
-  protected slots:
-    void registryLayersAdded( const QList<QgsMapLayer*>& layers );
-    void registryLayersWillBeRemoved( const QStringList& layerIds );
+    //! Resolves reference to layer from stored layer ID (if it has not been resolved already)
+    //! @note added in 3.0
+    virtual void resolveReferences( const QgsProject* project ) override;
+
+  private slots:
     //! Emits a nameChanged() signal if layer's name has changed
     //! @note added in 3.0
     void layerNameChanged();
+    //! Handles the event of deletion of the referenced layer
+    //! @note added in 3.0
+    void layerWillBeDeleted();
 
   signals:
     //! emitted when a previously unavailable layer got loaded
@@ -83,9 +92,10 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
   protected:
     void attachToLayer();
 
-    QString mLayerId;
-    QString mLayerName; // only used if layer does not exist
-    QgsMapLayer* mLayer; // not owned! may be null
+    //! Weak reference to the layer (or just it's ID if the reference is not resolved yet)
+    QgsMapLayerRef mRef;
+    //! Layer name - only used if layer does not exist
+    QString mLayerName;
 };
 
 

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -18,6 +18,7 @@
 #include "qgslayertree.h"
 #include "qgslayertreeutils.h"
 #include "qgslayertreemodellegendnode.h"
+#include "qgsproject.h"
 
 #include <QMimeData>
 #include <QTextStream>
@@ -1057,7 +1058,7 @@ bool QgsLayerTreeModel::dropMimeData( const QMimeData* data, Qt::DropAction acti
   QDomElement elem = rootElem.firstChildElement();
   while ( !elem.isNull() )
   {
-    QgsLayerTreeNode* node = QgsLayerTreeNode::readXml( elem );
+    QgsLayerTreeNode* node = QgsLayerTreeNode::readXml( elem, QgsProject::instance() );
     if ( node )
       nodes << node;
 

--- a/src/core/layertree/qgslayertreenode.cpp
+++ b/src/core/layertree/qgslayertreenode.cpp
@@ -60,6 +60,14 @@ QgsLayerTreeNode* QgsLayerTreeNode::readXml( QDomElement& element )
   return node;
 }
 
+QgsLayerTreeNode* QgsLayerTreeNode::readXml( QDomElement& element, const QgsProject* project )
+{
+  QgsLayerTreeNode* node = readXml( element );
+  if ( node )
+    node->resolveReferences( project );
+  return node;
+}
+
 
 void QgsLayerTreeNode::setItemVisibilityChecked( bool checked )
 {

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -23,6 +23,8 @@
 
 class QDomElement;
 
+class QgsProject;
+
 /** \ingroup core
  * This class is a base class for nodes in a layer tree.
  * Layer tree is a hierarchical structure consisting of group and layer nodes:
@@ -93,8 +95,14 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     //! @note added in 3.0
     virtual void setName( const QString& name ) = 0;
 
-    //! Read layer tree from XML. Returns new instance
+    //! Read layer tree from XML. Returns new instance.
+    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
     static QgsLayerTreeNode *readXml( QDomElement &element );
+    //! Read layer tree from XML. Returns new instance.
+    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
+    //! @note added in 3.0
+    static QgsLayerTreeNode* readXml( QDomElement& element, const QgsProject* project );
+
     //! Write layer tree to XML
     virtual void writeXml( QDomElement &parentElement ) = 0;
 
@@ -103,6 +111,11 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
 
     //! Create a copy of the node. Returns new instance
     virtual QgsLayerTreeNode *clone() const = 0;
+
+    //! Turn textual references to layers into map layer object from project.
+    //! This method should be called after readXml()
+    //! @note added in 3.0
+    virtual void resolveReferences( const QgsProject* project ) = 0;
 
     //! Returns whether a node is really visible (ie checked and all its ancestors checked as well)
     //! @note added in 3.0

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -348,20 +348,20 @@ void QgsLayerTreeUtils::replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup* grou
 }
 
 
-void QgsLayerTreeUtils::updateEmbeddedGroupsProjectPath( QgsLayerTreeGroup* group )
+void QgsLayerTreeUtils::updateEmbeddedGroupsProjectPath( QgsLayerTreeGroup* group, const QgsProject* project )
 {
   Q_FOREACH ( QgsLayerTreeNode* node, group->children() )
   {
     if ( !node->customProperty( QStringLiteral( "embedded_project" ) ).toString().isEmpty() )
     {
       // may change from absolute path to relative path
-      QString newPath = QgsProject::instance()->writePath( node->customProperty( QStringLiteral( "embedded_project" ) ).toString() );
+      QString newPath = project->writePath( node->customProperty( QStringLiteral( "embedded_project" ) ).toString() );
       node->setCustomProperty( QStringLiteral( "embedded_project" ), newPath );
     }
 
     if ( QgsLayerTree::isGroup( node ) )
     {
-      updateEmbeddedGroupsProjectPath( QgsLayerTree::toGroup( node ) );
+      updateEmbeddedGroupsProjectPath( QgsLayerTree::toGroup( node ), project );
     }
   }
 }

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -29,6 +29,7 @@ class QgsLayerTreeNode;
 class QgsLayerTreeGroup;
 class QgsLayerTreeLayer;
 class QgsMapLayer;
+class QgsProject;
 
 /** \ingroup core
  * Assorted functions for dealing with layer trees.
@@ -63,7 +64,7 @@ class CORE_EXPORT QgsLayerTreeUtils
     static void replaceChildrenOfEmbeddedGroups( QgsLayerTreeGroup* group );
 
     //! @note not available in python bindings
-    static void updateEmbeddedGroupsProjectPath( QgsLayerTreeGroup* group );
+    static void updateEmbeddedGroupsProjectPath( QgsLayerTreeGroup* group, const QgsProject* project );
 
     //! get invisible layers
     static QStringList invisibleLayerList( QgsLayerTreeNode *node );

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -23,6 +23,7 @@
 #include "qgsvectorlayer.h"
 #include "qgslayertree.h"
 #include "qgslayerdefinition.h"
+#include "qgsproject.h"
 
 bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsLayerTreeGroup *rootGroup, QString &errorMessage )
 {
@@ -148,6 +149,8 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsLayerTreeGrou
       vlayer->updateFields();
     }
   }
+
+  root->resolveReferences( QgsProject::instance() );
 
   QList<QgsLayerTreeNode*> nodes = root->children();
   Q_FOREACH ( QgsLayerTreeNode *node, nodes )

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -1,0 +1,36 @@
+/***************************************************************************
+  qgsmaplayerref.h
+  --------------------------------------
+  Date                 : January 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPLAYERREF_H
+#define QGSMAPLAYERREF_H
+
+#include <QPointer>
+
+#include "qgsmaplayer.h"
+
+/** Internal structure to keep weak pointer to QgsMapLayer or layerId
+ *  if the layer is not available yet.
+ *  @note not available in python bindings
+ */
+struct QgsMapLayerRef
+{
+  QgsMapLayerRef( QgsMapLayer* l = nullptr ): layer( l ), layerId( l ? l->id() : QString() ) {}
+  QgsMapLayerRef( const QString& id ): layer(), layerId( id ) {}
+
+  QPointer<QgsMapLayer> layer;
+  QString layerId;
+};
+
+#endif // QGSMAPLAYERREF_H

--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -1253,6 +1253,7 @@ QList<QDomElement> QgsServerProjectParser::findLegendGroupElements() const
   QDomElement layerTreeElem = mXMLDoc->documentElement().firstChildElement( QStringLiteral( "layer-tree-group" ) );
   if ( !layerTreeElem.isNull() )
   {
+    // this is apparently only used to retrieve groups - layers do not need to be resolved
     rootLayerTreeGroup = QgsLayerTreeGroup::readXml( layerTreeElem );
   }
 

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -2362,7 +2362,7 @@ QgsLayerTreeGroup* QgsWmsProjectParser::projectLayerTreeGroup() const
     QgsLayerTreeUtils::readOldLegend( rootGroup, mProjectParser->legendElem() );
     return rootGroup;
   }
-  return QgsLayerTreeGroup::readXml( layerTreeElem );
+  return QgsLayerTreeGroup::readXml( layerTreeElem, QgsProject::instance() );
 }
 
 bool QgsWmsProjectParser::annotationPosition( const QDomElement& elem, double scaleFactor, double& xPos, double& yPos )

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -45,6 +45,7 @@ class TestQgsLayerTree : public QObject
     void testLegendSymbolCategorized();
     void testLegendSymbolGraduated();
     void testLegendSymbolRuleBased();
+    void testResolveReferences();
 
   private:
 
@@ -124,7 +125,9 @@ void TestQgsLayerTree::testLayerNameChanged()
   QCOMPARE( arguments.at( 0 ).value<QgsLayerTreeNode*>(), n );
   QCOMPARE( arguments.at( 1 ).toString(), QString( "changed 1" ) );
 
-  QgsProject::instance()->addMapLayers( QList<QgsMapLayer*>() << vl );
+  QgsProject project;
+  project.addMapLayer( vl );
+  n->resolveReferences( &project );
 
   // set name via map layer
   vl->setName( "changed 2" );
@@ -141,8 +144,6 @@ void TestQgsLayerTree::testLayerNameChanged()
   arguments = spy.takeFirst();
   QCOMPARE( arguments.at( 0 ).value<QgsLayerTreeNode*>(), n );
   QCOMPARE( arguments.at( 1 ).toString(), QString( "changed 3" ) );
-
-  QgsProject::instance()->removeMapLayers( QList<QgsMapLayer*>() << vl );
 
   mRoot->removeChildNode( n );
 }
@@ -286,7 +287,8 @@ void TestQgsLayerTree::testShowHideAllSymbolNodes()
   QgsVectorLayer* vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
   QVERIFY( vl->isValid() );
 
-  QgsProject::instance()->addMapLayers( QList<QgsMapLayer*>() << vl );
+  QgsProject project;
+  project.addMapLayer( vl );
 
   //create a categorized renderer for layer
   QgsCategorizedSymbolRenderer* renderer = new QgsCategorizedSymbolRenderer();
@@ -327,7 +329,6 @@ void TestQgsLayerTree::testShowHideAllSymbolNodes()
   //cleanup
   delete m;
   delete root;
-  QgsProject::instance()->removeMapLayers( QList<QgsMapLayer*>() << vl );
 }
 
 void TestQgsLayerTree::testFindLegendNode()
@@ -336,7 +337,8 @@ void TestQgsLayerTree::testFindLegendNode()
   QgsVectorLayer* vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
   QVERIFY( vl->isValid() );
 
-  QgsProject::instance()->addMapLayers( QList<QgsMapLayer*>() << vl );
+  QgsProject project;
+  project.addMapLayer( vl );
 
   //create a categorized renderer for layer
   QgsCategorizedSymbolRenderer* renderer = new QgsCategorizedSymbolRenderer();
@@ -369,7 +371,6 @@ void TestQgsLayerTree::testFindLegendNode()
   //cleanup
   delete m;
   delete root;
-  QgsProject::instance()->removeMapLayers( QList<QgsMapLayer*>() << vl );
 }
 
 void TestQgsLayerTree::testLegendSymbolCategorized()
@@ -419,6 +420,50 @@ void TestQgsLayerTree::testLegendSymbolRuleBased()
   testRendererLegend( renderer );
 }
 
+void TestQgsLayerTree::testResolveReferences()
+{
+  QgsVectorLayer* vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  QVERIFY( vl->isValid() );
+
+  QString n1id = vl->id();
+  QString n2id = "XYZ";
+
+  QgsMapLayer* nullLayer = nullptr; // QCOMPARE does not like nullptr directly
+
+  QgsLayerTreeGroup* root = new QgsLayerTreeGroup();
+  QgsLayerTreeLayer* n1 = new QgsLayerTreeLayer( n1id, vl->name() );
+  QgsLayerTreeLayer* n2 = new QgsLayerTreeLayer( n2id, "invalid layer" );
+  root->addChildNode( n1 );
+  root->addChildNode( n2 );
+
+  // layer object not yet accessible
+  QCOMPARE( n1->layer(), nullLayer );
+  QCOMPARE( n1->layerId(), n1id );
+  QCOMPARE( n2->layer(), nullLayer );
+  QCOMPARE( n2->layerId(), n2id );
+
+  QgsProject project;
+  project.addMapLayer( vl );
+
+  root->resolveReferences( &project );
+
+  // now the layer should be accessible
+  QCOMPARE( n1->layer(), vl );
+  QCOMPARE( n1->layerId(), n1id );
+  QCOMPARE( n2->layer(), nullLayer );
+  QCOMPARE( n2->layerId(), n2id );
+
+  project.removeMapLayer( vl ); // deletes the layer
+
+  // layer object not accessible anymore
+  QCOMPARE( n1->layer(), nullLayer );
+  QCOMPARE( n1->layerId(), n1id );
+  QCOMPARE( n2->layer(), nullLayer );
+  QCOMPARE( n2->layerId(), n2id );
+
+  delete root;
+}
+
 void TestQgsLayerTree::testRendererLegend( QgsFeatureRenderer* renderer )
 {
   // runs renderer legend through a bunch of legend symbol tests
@@ -430,7 +475,9 @@ void TestQgsLayerTree::testRendererLegend( QgsFeatureRenderer* renderer )
   QgsVectorLayer* vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
   QVERIFY( vl->isValid() );
 
-  QgsProject::instance()->addMapLayers( QList<QgsMapLayer*>() << vl );
+  QgsProject project;
+  project.addMapLayer( vl );
+
   vl->setRenderer( renderer );
 
   //create legend with symbology nodes for renderer
@@ -471,7 +518,6 @@ void TestQgsLayerTree::testRendererLegend( QgsFeatureRenderer* renderer )
   //cleanup
   delete m;
   delete root;
-  QgsProject::instance()->removeMapLayers( QList<QgsMapLayer*>() << vl );
 }
 
 


### PR DESCRIPTION
Another bit in the project refactoring work to get rid of dependencies
on QgsProject singleton.

Reading of layer trees from XML is now split into two phases:
1. read XML and keep layer IDs
2. resolve layer IDs to QgsMapLayer instances (using QgsProject)

There are convenience methods to do both phases in one go.