### PR TITLE
Use native QGIS raster API instead of GDAL API in zonal statistics

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2014,6 +2014,9 @@ Triangulation        {#qgis_api_break_3_0_Triangulation}
 
 - forcedCrossBehaviour enum and its setter and getter have been renamed to ForcedCrossBehavior. Its members have been renamed: SnappingType_VERTICE: SnappingTypeVertex, DELETE_FIRST: DeleteFirst, INSERT_VERTEX: InsertVertex. <!--#spellok-->
 
+QgsZonalStatistics        {#qgis_api_break_3_0_QgsZonalStatistics}
+------------------
+- QgsZonalStatistics() сonstructor now accepts pointer to the QgsRasterLayer instance instead of path to the raster file
 
 
 QGIS 2.6        {#qgis_api_break_2_6}

--- a/python/analysis/vector/qgszonalstatistics.sip
+++ b/python/analysis/vector/qgszonalstatistics.sip
@@ -30,7 +30,7 @@ class QgsZonalStatistics
 
     typedef QFlags<QgsZonalStatistics::Statistic> Statistics;
 
-    QgsZonalStatistics( QgsVectorLayer* polygonLayer, const QString& rasterFile, const QString& attributePrefix = "", int rasterBand = 1,
+    QgsZonalStatistics( QgsVectorLayer* polygonLayer, QgsRasterLayer* rasterLayer, const QString& attributePrefix = "", int rasterBand = 1,
                         QgsZonalStatistics::Statistics stats = QgsZonalStatistics::Statistics( QgsZonalStatistics::Count | QgsZonalStatistics::Sum | QgsZonalStatistics::Mean) );
 
     /** Starts the calculation

--- a/python/plugins/processing/algs/qgis/ZonalStatisticsQgis.py
+++ b/python/plugins/processing/algs/qgis/ZonalStatisticsQgis.py
@@ -100,6 +100,7 @@ class ZonalStatisticsQgis(GeoAlgorithm):
         st = self.getParameterValue(self.STATISTICS)
 
         vectorLayer = dataobjects.getObjectFromUri(vectorPath)
+        rasterLayer = dataobjects.getObjectFromUri(rasterPath)
 
         keys = list(self.STATS.keys())
         selectedStats = 0
@@ -107,7 +108,7 @@ class ZonalStatisticsQgis(GeoAlgorithm):
             selectedStats |= self.STATS[keys[i]]
 
         zs = QgsZonalStatistics(vectorLayer,
-                                rasterPath,
+                                rasterLayer,
                                 columnPrefix,
                                 bandNumber,
                                 selectedStats)

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -26,6 +26,8 @@
 
 class QgsGeometry;
 class QgsVectorLayer;
+class QgsRasterLayer;
+class QgsRasterDataProvider;
 class QProgressDialog;
 class QgsRectangle;
 class QgsField;
@@ -57,7 +59,7 @@ class ANALYSIS_EXPORT QgsZonalStatistics
     /**
      * Constructor for QgsZonalStatistics.
      */
-    QgsZonalStatistics( QgsVectorLayer* polygonLayer, const QString& rasterFile, const QString& attributePrefix = "", int rasterBand = 1,
+    QgsZonalStatistics( QgsVectorLayer* polygonLayer, QgsRasterLayer* rasterLayer, const QString& attributePrefix = "", int rasterBand = 1,
                         Statistics stats = Statistics( Count | Sum | Mean ) );
 
     /** Starts the calculation
@@ -114,11 +116,11 @@ class ANALYSIS_EXPORT QgsZonalStatistics
                          int& offsetX, int& offsetY, int& nCellsX, int& nCellsY ) const;
 
     //! Returns statistics by considering the pixels where the center point is within the polygon (fast)
-    void statisticsFromMiddlePointTest( void* band, const QgsGeometry& poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY,
+    void statisticsFromMiddlePointTest( const QgsGeometry& poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY,
                                         double cellSizeX, double cellSizeY, const QgsRectangle& rasterBBox, FeatureStats& stats );
 
     //! Returns statistics with precise pixel - polygon intersection test (slow)
-    void statisticsFromPreciseIntersection( void* band, const QgsGeometry& poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY,
+    void statisticsFromPreciseIntersection( const QgsGeometry& poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY,
                                             double cellSizeX, double cellSizeY, const QgsRectangle& rasterBBox, FeatureStats& stats );
 
     //! Tests whether a pixel's value should be included in the result
@@ -126,7 +128,8 @@ class ANALYSIS_EXPORT QgsZonalStatistics
 
     QString getUniqueFieldName( const QString& fieldName, const QList<QgsField>& newFields );
 
-    QString mRasterFilePath;
+    QgsRasterLayer* mRasterLayer;
+    QgsRasterDataProvider* mRasterProvider;
     //! Raster band to calculate statistics from (defaults to 1)
     int mRasterBand;
     QgsVectorLayer* mPolygonLayer;

--- a/tests/src/analysis/testqgszonalstatistics.cpp
+++ b/tests/src/analysis/testqgszonalstatistics.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgsfeatureiterator.h"
 #include "qgsvectorlayer.h"
+#include "qgsrasterlayer.h"
 #include "qgszonalstatistics.h"
 #include "qgsproject.h"
 
@@ -42,7 +43,7 @@ class TestQgsZonalStatistics : public QObject
 
   private:
     QgsVectorLayer* mVectorLayer;
-    QString mRasterPath;
+    QgsRasterLayer* mRasterLayer;
 };
 
 TestQgsZonalStatistics::TestQgsZonalStatistics()
@@ -71,10 +72,9 @@ void TestQgsZonalStatistics::initTestCase()
   }
 
   mVectorLayer = new QgsVectorLayer( myTempPath + "polys.shp", QStringLiteral( "poly" ), QStringLiteral( "ogr" ) );
+  mRasterLayer = new QgsRasterLayer( myTempPath + "edge_problem.asc", QStringLiteral( "raster" ), QStringLiteral( "gdal" ) );
   QgsProject::instance()->addMapLayers(
-    QList<QgsMapLayer *>() << mVectorLayer );
-
-  mRasterPath = myTempPath + "edge_problem.asc";
+    QList<QgsMapLayer *>() << mVectorLayer << mRasterLayer );
 }
 
 void TestQgsZonalStatistics::cleanupTestCase()
@@ -84,7 +84,7 @@ void TestQgsZonalStatistics::cleanupTestCase()
 
 void TestQgsZonalStatistics::testStatistics()
 {
-  QgsZonalStatistics zs( mVectorLayer, mRasterPath, QLatin1String( "" ), 1, QgsZonalStatistics::All );
+  QgsZonalStatistics zs( mVectorLayer, mRasterLayer, QLatin1String( "" ), 1, QgsZonalStatistics::All );
   zs.calculateStatistics( nullptr );
 
   QgsFeature f;
@@ -135,7 +135,7 @@ void TestQgsZonalStatistics::testStatistics()
   QCOMPARE( f.attribute( "variety" ).toDouble(), 2.0 );
 
   // same with long prefix to ensure that field name truncation handled correctly
-  QgsZonalStatistics zsl( mVectorLayer, mRasterPath, QStringLiteral( "myqgis2_" ), 1, QgsZonalStatistics::All );
+  QgsZonalStatistics zsl( mVectorLayer, mRasterLayer, QStringLiteral( "myqgis2_" ), 1, QgsZonalStatistics::All );
   zsl.calculateStatistics( nullptr );
 
   request.setFilterFid( 0 );

--- a/tests/src/python/test_qgszonalstatistics.py
+++ b/tests/src/python/test_qgszonalstatistics.py
@@ -15,7 +15,7 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 from qgis.PyQt.QtCore import QDir, QFile
-from qgis.core import QgsVectorLayer, QgsFeature, QgsFeatureRequest
+from qgis.core import QgsVectorLayer, QgsRasterLayer, QgsFeature, QgsFeatureRequest
 from qgis.analysis import QgsZonalStatistics
 
 from qgis.testing import start_app, unittest
@@ -38,8 +38,8 @@ class TestQgsZonalStatistics(unittest.TestCase):
             QFile.copy(TEST_DATA_DIR + f, myTempPath + f)
 
         myVector = QgsVectorLayer(myTempPath + "polys.shp", "poly", "ogr")
-        myRasterPath = myTempPath + "edge_problem.asc"
-        zs = QgsZonalStatistics(myVector, myRasterPath, "", 1, QgsZonalStatistics.All)
+        myRaster = QgsRasterLayer(myTempPath + "edge_problem.asc", "raster", "gdal")
+        zs = QgsZonalStatistics(myVector, myRaster, "", 1, QgsZonalStatistics.All)
         zs.calculateStatistics(None)
 
         feat = QgsFeature()


### PR DESCRIPTION
This should allow users to use zonal statistics with rasters which come not only from GDAL provider but also from other providers, e.g. WCS. Related issue https://hub.qgis.org/issues/8736