### PR TITLE
Delete style from db provider postgis

### DIFF
--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -413,11 +413,6 @@ class QgsVectorDataProvider : QgsDataProvider
      */
     virtual bool isDeleteStyleFromDBSupported() const;
 
-    /**
-     * Deletes an existing style from the provider
-     */
-    virtual void deleteStyleById( const QString& uri, QString styleId, QString& errCause );
-
     static QVariant convertValue( QVariant::Type type, const QString& value );
 
     /**

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -408,10 +408,12 @@ class QgsVectorDataProvider : QgsDataProvider
     virtual bool isSaveAndLoadStyleToDBSupported() const;
 
     /**
-     * It returns false by default.
+     * Checks if the provider supports style removal
      * Must be implemented by providers that support delete styles from db returning true
+     * @note added in QGIS 3.0
+     * @return true if delete operation is supported by the provider
      */
-    virtual bool isDeleteStyleFromDBSupported() const;
+    virtual bool isDeleteStyleFromDbSupported() const;
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -407,6 +407,17 @@ class QgsVectorDataProvider : QgsDataProvider
      */
     virtual bool isSaveAndLoadStyleToDBSupported() const;
 
+    /**
+     * It returns false by default.
+     * Must be implemented by providers that support delete styles from db returning true
+     */
+    virtual bool isDeleteStyleFromDBSupported() const;
+
+    /**
+     * Deletes an existing style from the provider
+     */
+    virtual void deleteStyleById( const QString& uri, QString styleId, QString& errCause );
+
     static QVariant convertValue( QVariant::Type type, const QString& value );
 
     /**

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -685,6 +685,11 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     virtual QString getStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
 
     /**
+     * Will delete the named style corresponding to style id provided from the database
+     */
+    virtual void deleteStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
+
+    /**
      * Load a named style from file/local db/datasource db
      * @param theURI the URI of the style or the URI of the layer
      * @param theResultFlag will be set to true if a named style is correctly loaded

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -685,7 +685,11 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     virtual QString getStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
 
     /**
-     * Will delete the named style corresponding to style id provided from the database
+     * Delete a style from the database
+     * @note added in QGIS 3.0
+     * @param styleId the provider's layer_styles table id of the style to delete
+     * @param msgError reference to string that will be updated with any error messages
+     * @return true in case of success
      */
     virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
 

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -687,7 +687,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     /**
      * Will delete the named style corresponding to style id provided from the database
      */
-    virtual void deleteStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
+    virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
 
     /**
      * Load a named style from file/local db/datasource db

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -687,7 +687,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     /**
      * Will delete the named style corresponding to style id provided from the database
      */
-    virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError );
+    virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
 
     /**
      * Load a named style from file/local db/datasource db

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -687,7 +687,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
     /**
      * Will delete the named style corresponding to style id provided from the database
      */
-    virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError /Out/ );
+    virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError );
 
     /**
      * Load a named style from file/local db/datasource db

--- a/src/app/qgsloadstylefromdbdialog.cpp
+++ b/src/app/qgsloadstylefromdbdialog.cpp
@@ -25,10 +25,12 @@ QgsLoadStyleFromDBDialog::QgsLoadStyleFromDBDialog( QWidget *parent )
     , mSectionLimit( 0 )
 {
   setupUi( this );
-  setWindowTitle( QStringLiteral( "Load style from database" ) );
+  setWindowTitle( QStringLiteral( "Saved styles manager" ) );
   mSelectedStyleId = QLatin1String( "" );
+  mSelectedStyleName = QLatin1String( "" );
 
   mLoadButton->setDisabled( true );
+  mDeleteButton->setDisabled( true );
   mRelatedTable->setEditTriggers( QTableWidget::NoEditTriggers );
   mRelatedTable->horizontalHeader()->setStretchLastSection( true );
   mRelatedTable->setSelectionBehavior( QTableWidget::SelectRows );
@@ -39,16 +41,18 @@ QgsLoadStyleFromDBDialog::QgsLoadStyleFromDBDialog( QWidget *parent )
   mOthersTable->setSelectionBehavior( QTableWidget::SelectRows );
   mOthersTable->verticalHeader()->setVisible( false );
 
-  connect( mRelatedTable, SIGNAL( cellClicked( int, int ) ), this, SLOT( cellSelectedRelatedTable( int ) ) );
-  connect( mOthersTable, SIGNAL( cellClicked( int, int ) ), this, SLOT( cellSelectedOthersTable( int ) ) );
+  connect( mRelatedTable, SIGNAL( itemSelectionChanged() ), this, SLOT( relatedTableSelectionChanged() ) );
+  connect( mOthersTable, SIGNAL( itemSelectionChanged() ), this, SLOT( otherTableSelectionChanged() ) );
   connect( mRelatedTable, SIGNAL( doubleClicked( QModelIndex ) ), this, SLOT( accept() ) );
   connect( mOthersTable, SIGNAL( doubleClicked( QModelIndex ) ), this, SLOT( accept() ) );
   connect( mCancelButton, SIGNAL( clicked() ), this, SLOT( reject() ) );
+  connect( mDeleteButton, SIGNAL( clicked() ), this, SLOT( deleteStyleFromDB() ) );
   connect( mLoadButton, SIGNAL( clicked() ), this, SLOT( accept() ) );
 
   setTabOrder( mRelatedTable, mOthersTable );
   setTabOrder( mOthersTable, mCancelButton );
-  setTabOrder( mCancelButton, mLoadButton );
+  setTabOrder( mCancelButton, mDeleteButton );
+  setTabOrder( mDeleteButton, mLoadButton );
 
   QSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "/Windows/loadStyleFromDb/geometry" ) ).toByteArray() );
@@ -102,14 +106,96 @@ QString QgsLoadStyleFromDBDialog::getSelectedStyleId()
   return mSelectedStyleId;
 }
 
-void QgsLoadStyleFromDBDialog::cellSelectedRelatedTable( int r )
+void QgsLoadStyleFromDBDialog::setLayer( QgsVectorLayer *l )
 {
-  mLoadButton->setEnabled( true );
-  mSelectedStyleId = mRelatedTable->item( r, 0 )->data( Qt::UserRole ).toString();
+  mLayer = l;
+  if ( mLayer->dataProvider()->isDeleteStyleFromDBSupported() )
+  {
+    //QgsDebugMsg( "QgsLoadStyleFromDBDialog::setLayer → The dataProvider supports isDeleteStyleFromDBSupported" );
+    mDeleteButton->setVisible( true );
+  }
+  else
+  {
+    // QgsDebugMsg( "QgsLoadStyleFromDBDialog::setLayer → The dataProvider does not supports isDeleteStyleFromDBSupported" );
+    mDeleteButton->setVisible( false );
+  }
 }
 
-void QgsLoadStyleFromDBDialog::cellSelectedOthersTable( int r )
+void QgsLoadStyleFromDBDialog::relatedTableSelectionChanged()
 {
-  mLoadButton->setEnabled( true );
-  mSelectedStyleId = mOthersTable->item( r, 0 )->data( Qt::UserRole ).toString();
+  selectionChanged( mRelatedTable );
+  //deselect any other row on the other table widget
+  QTableWidgetSelectionRange range( 0, 0, mOthersTable->rowCount() - 1, mOthersTable->columnCount() - 1 );
+  mOthersTable->setRangeSelected( range, false );
+}
+
+void QgsLoadStyleFromDBDialog::otherTableSelectionChanged()
+{
+  selectionChanged( mOthersTable );
+  //deselect any other row on the other table widget
+  QTableWidgetSelectionRange range( 0, 0, mRelatedTable->rowCount() - 1, mRelatedTable->columnCount() - 1 );
+  mRelatedTable->setRangeSelected( range, false );
+
+}
+
+void QgsLoadStyleFromDBDialog::selectionChanged( QTableWidget *styleTable )
+{
+  QTableWidgetItem *item;
+  QList<QTableWidgetItem *> selected = styleTable->selectedItems();
+  //QgsDebugMsg( QString( "itemSelectionChanged(): count() = %1" ).arg( selected.count() )  );
+  if ( selected.count() > 0 )
+  {
+    item = selected.at( 0 );
+    mSelectedStyleName = item->text();
+    mSelectedStyleId = item->data( Qt::UserRole ).toString();
+    mLoadButton->setEnabled( true );
+    mDeleteButton->setEnabled( true );
+  }
+  else
+  {
+    mSelectedStyleName = "";
+    mSelectedStyleId = "";
+    mLoadButton->setEnabled( false );
+    mDeleteButton->setEnabled( false );
+  }
+}
+
+void QgsLoadStyleFromDBDialog::deleteStyleFromDB()
+{
+  QString uri, msgError;
+  QString infoWindowTitle = QObject::tr( "Delete style %1 from %2" ).arg( mSelectedStyleName, mLayer->providerType() );
+  //QgsDebugMsg( QString( "Delete style: %1 " ).arg( mSelectedStyleName ) );
+
+  if ( QMessageBox::question( nullptr, QObject::tr( "Delete style" ),
+                              QObject::tr( "Are you sure you want to delete the style %1?" ).arg( mSelectedStyleName ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
+  uri = mLayer->dataProvider()->dataSourceUri();
+  mLayer->dataProvider()->deleteStyleById( uri, mSelectedStyleId, msgError );
+
+  if ( !msgError.isNull() )
+  {
+    QMessageBox::warning( this, infoWindowTitle, msgError );
+  }
+  else
+  {
+    QMessageBox::information( this, infoWindowTitle, tr( "Style deleted" ) );
+
+    //Delete all rows from the UI table widgets
+    mRelatedTable->setRowCount( 0 );
+    mOthersTable->setRowCount( 0 );
+
+    //Fill UI widgets again from DB. Other users might have change the styles meanwhile.
+    QString errorMsg;
+    QStringList ids, names, descriptions;
+    //get the list of styles in the db
+    int sectionLimit = mLayer->listStylesInDatabase( ids, names, descriptions, errorMsg );
+    if ( !errorMsg.isNull() )
+    {
+      QMessageBox::warning( this, tr( "Error occurred retrieving styles from database" ), errorMsg );
+      return;
+    }
+    initializeLists( ids, names, descriptions, sectionLimit );
+  }
 }

--- a/src/app/qgsloadstylefromdbdialog.cpp
+++ b/src/app/qgsloadstylefromdbdialog.cpp
@@ -171,7 +171,8 @@ void QgsLoadStyleFromDBDialog::deleteStyleFromDB()
     return;
 
   uri = mLayer->dataProvider()->dataSourceUri();
-  mLayer->dataProvider()->deleteStyleById( uri, mSelectedStyleId, msgError );
+  //  mLayer->dataProvider()->deleteStyleById( uri, mSelectedStyleId, msgError );
+  mLayer->deleteStyleFromDatabase( mSelectedStyleId, msgError );
 
   if ( !msgError.isNull() )
   {

--- a/src/app/qgsloadstylefromdbdialog.h
+++ b/src/app/qgsloadstylefromdbdialog.h
@@ -27,7 +27,6 @@ class APP_EXPORT QgsLoadStyleFromDBDialog : public QDialog, private Ui::QgsLoadS
     QString mSelectedStyleId;
     QString mSelectedStyleName;
     int mSectionLimit;
-    QString qmlStyle;
     Q_OBJECT
   public:
     explicit QgsLoadStyleFromDBDialog( QWidget *parent = nullptr );
@@ -37,16 +36,15 @@ class APP_EXPORT QgsLoadStyleFromDBDialog : public QDialog, private Ui::QgsLoadS
     void initializeLists( const QStringList& ids, const QStringList& names, const QStringList& descriptions, int sectionLimit );
     QString getSelectedStyleId();
     void selectionChanged( QTableWidget *styleTable );
-
     void setLayer( QgsVectorLayer *l );
 
   public slots:
-    void relatedTableSelectionChanged();
-    void otherTableSelectionChanged();
+    void onRelatedTableSelectionChanged();
+    void onOthersTableSelectionChanged();
     void deleteStyleFromDB();
 
   private:
-    QgsVectorLayer *mLayer;
+    QgsVectorLayer *mLayer = nullptr;
 
 };
 

--- a/src/app/qgsloadstylefromdbdialog.h
+++ b/src/app/qgsloadstylefromdbdialog.h
@@ -19,10 +19,13 @@
 #include "ui_qgsloadstylefromdbdialog.h"
 #include "qgisgui.h"
 #include "qgis_app.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataprovider.h"
 
 class APP_EXPORT QgsLoadStyleFromDBDialog : public QDialog, private Ui::QgsLoadStyleFromDBDialogLayout
 {
     QString mSelectedStyleId;
+    QString mSelectedStyleName;
     int mSectionLimit;
     QString qmlStyle;
     Q_OBJECT
@@ -33,12 +36,17 @@ class APP_EXPORT QgsLoadStyleFromDBDialog : public QDialog, private Ui::QgsLoadS
 
     void initializeLists( const QStringList& ids, const QStringList& names, const QStringList& descriptions, int sectionLimit );
     QString getSelectedStyleId();
+    void selectionChanged( QTableWidget *styleTable );
+
+    void setLayer( QgsVectorLayer *l );
 
   public slots:
-    void cellSelectedRelatedTable( int r );
-    void cellSelectedOthersTable( int r );
+    void relatedTableSelectionChanged();
+    void otherTableSelectionChanged();
+    void deleteStyleFromDB();
 
   private:
+    QgsVectorLayer *mLayer;
 
 };
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -163,7 +163,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     //for loading
     mLoadStyleMenu = new QMenu( this );
     mLoadStyleMenu->addAction( tr( "Load from file..." ) );
-    mLoadStyleMenu->addAction( tr( "Saved styles manager" ) );
+    mLoadStyleMenu->addAction( tr( "Database styles manager" ) );
     //mActionLoadStyle->setContextMenuPolicy( Qt::PreventContextMenu );
     mActionLoadStyle->setMenu( mLoadStyleMenu );
 
@@ -883,11 +883,11 @@ void QgsVectorLayerProperties::saveStyleAs( StyleType styleType )
 
       if ( !msgError.isNull() )
       {
-        QMessageBox::warning( this, infoWindowTitle, msgError );
+        QgisApp::instance()->messageBar()->pushMessage( infoWindowTitle , msgError, QgsMessageBar::WARNING, QgisApp::instance()->messageTimeout() );
       }
       else
       {
-        QMessageBox::information( this, infoWindowTitle, tr( "Style saved" ) );
+        QgisApp::instance()->messageBar()->pushMessage( infoWindowTitle , tr( "Style saved" ), QgsMessageBar::INFO, QgisApp::instance()->messageTimeout() );
       }
 
     }

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -163,7 +163,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     //for loading
     mLoadStyleMenu = new QMenu( this );
     mLoadStyleMenu->addAction( tr( "Load from file..." ) );
-    mLoadStyleMenu->addAction( tr( "Load from database" ) );
+    mLoadStyleMenu->addAction( tr( "Saved styles manager" ) );
     //mActionLoadStyle->setContextMenuPolicy( Qt::PreventContextMenu );
     mActionLoadStyle->setMenu( mLoadStyleMenu );
 
@@ -1022,6 +1022,7 @@ void QgsVectorLayerProperties::showListOfStylesFromDatabase()
   }
 
   QgsLoadStyleFromDBDialog dialog;
+  dialog.setLayer( mLayer );
   dialog.initializeLists( ids, names, descriptions, sectionLimit );
 
   if ( dialog.exec() == QDialog::Accepted )

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -700,7 +700,7 @@ bool QgsVectorDataProvider::isDeleteStyleFromDBSupported() const
   return false;
 }
 
-void QgsVectorDataProvider::deleteStyleById( const QString& uri, QString styleId, QString& errCause )
+void QgsVectorDataProvider::deleteStyleById( const QString& uri, QString styleId, QString& errCause ) const
 {
   Q_UNUSED( uri );
   Q_UNUSED( styleId );

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -702,6 +702,9 @@ bool QgsVectorDataProvider::isDeleteStyleFromDBSupported() const
 
 void QgsVectorDataProvider::deleteStyleById( const QString& uri, QString styleId, QString& errCause )
 {
+  Q_UNUSED( uri );
+  Q_UNUSED( styleId );
+  Q_UNUSED( errCause );
   return;
 }
 

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -700,14 +700,6 @@ bool QgsVectorDataProvider::isDeleteStyleFromDBSupported() const
   return false;
 }
 
-void QgsVectorDataProvider::deleteStyleById( const QString& uri, QString styleId, QString& errCause ) const
-{
-  Q_UNUSED( uri );
-  Q_UNUSED( styleId );
-  Q_UNUSED( errCause );
-  return;
-}
-
 void QgsVectorDataProvider::pushError( const QString& msg ) const
 {
   QgsDebugMsg( msg );

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -695,7 +695,7 @@ bool QgsVectorDataProvider::isSaveAndLoadStyleToDBSupported() const
   return false;
 }
 
-bool QgsVectorDataProvider::isDeleteStyleFromDBSupported() const
+bool QgsVectorDataProvider::isDeleteStyleFromDbSupported() const
 {
   return false;
 }

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -695,6 +695,16 @@ bool QgsVectorDataProvider::isSaveAndLoadStyleToDBSupported() const
   return false;
 }
 
+bool QgsVectorDataProvider::isDeleteStyleFromDBSupported() const
+{
+  return false;
+}
+
+void QgsVectorDataProvider::deleteStyleById( const QString& uri, QString styleId, QString& errCause )
+{
+  return;
+}
+
 void QgsVectorDataProvider::pushError( const QString& msg ) const
 {
   QgsDebugMsg( msg );

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -474,7 +474,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * It returns false by default.
      * Must be implemented by providers that support delete styles from db returning true
      */
-    virtual bool isDeleteStyleFromDBSupported() const;
+    virtual bool isDeleteStyleFromDbSupported() const;
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -479,7 +479,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /**
      * Deletes an existing style from the provider
      */
-    virtual void deleteStyleById( const QString& uri, QString styleId, QString& errCause );
+    virtual void deleteStyleById( const QString& uri, QString styleId, QString& errCause ) const;
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -469,7 +469,16 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * Must be implemented by providers that support saving and loading styles to db returning true
      */
     virtual bool isSaveAndLoadStyleToDBSupported() const;
+
+    /**
+     * It returns false by default.
+     * Must be implemented by providers that support delete styles from db returning true
+     */
     virtual bool isDeleteStyleFromDBSupported() const;
+
+    /**
+     * Deletes an existing style from the provider
+     */
     virtual void deleteStyleById( const QString& uri, QString styleId, QString& errCause );
 
     static QVariant convertValue( QVariant::Type type, const QString& value );

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -469,6 +469,8 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * Must be implemented by providers that support saving and loading styles to db returning true
      */
     virtual bool isSaveAndLoadStyleToDBSupported() const;
+    virtual bool isDeleteStyleFromDBSupported() const;
+    virtual void deleteStyleById( const QString& uri, QString styleId, QString& errCause );
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -476,11 +476,6 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      */
     virtual bool isDeleteStyleFromDBSupported() const;
 
-    /**
-     * Deletes an existing style from the provider
-     */
-    virtual void deleteStyleById( const QString& uri, QString styleId, QString& errCause ) const;
-
     static QVariant convertValue( QVariant::Type type, const QString& value );
 
     /**

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -120,6 +120,12 @@ typedef QString getStyleById_t(
   QString& errCause
 );
 
+typedef void deleteStyleById_t(
+  const QString& uri,
+  QString styleID,
+  QString& errCause
+);
+
 QgsVectorLayer::QgsVectorLayer( const QString& vectorLayerPath,
                                 const QString& baseName,
                                 const QString& providerKey,
@@ -4333,6 +4339,27 @@ QString QgsVectorLayer::getStyleFromDatabase( const QString& styleId, QString &m
   }
 
   return getStyleByIdMethod( mDataSource, styleId, msgError );
+}
+
+void QgsVectorLayer::deleteStyleFromDatabase( const QString& styleId, QString &msgError )
+{
+  QgsProviderRegistry * pReg = QgsProviderRegistry::instance();
+  QLibrary *myLib = pReg->providerLibrary( mProviderKey );
+  if ( !myLib )
+  {
+    msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
+    return;
+  }
+  deleteStyleById_t* deleteStyleByIdMethod = reinterpret_cast< deleteStyleById_t * >( cast_to_fptr( myLib->resolve( "deleteStyleById" ) ) );
+
+  if ( !deleteStyleByIdMethod )
+  {
+    delete myLib;
+    msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "deleteStyleById" ) );
+    return;
+  }
+
+  return deleteStyleByIdMethod( mDataSource, styleId, msgError );
 }
 
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4343,22 +4343,19 @@ QString QgsVectorLayer::getStyleFromDatabase( const QString& styleId, QString &m
 
 bool QgsVectorLayer::deleteStyleFromDatabase( const QString& styleId, QString &msgError )
 {
-  QgsProviderRegistry * pReg = QgsProviderRegistry::instance();
-  QLibrary *myLib = pReg->providerLibrary( mProviderKey );
+  QLibrary *myLib = QgsProviderRegistry::instance()->providerLibrary( mProviderKey );
   if ( !myLib )
   {
     msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
     return false;
   }
   deleteStyleById_t* deleteStyleByIdMethod = reinterpret_cast< deleteStyleById_t * >( cast_to_fptr( myLib->resolve( "deleteStyleById" ) ) );
-
   if ( !deleteStyleByIdMethod )
   {
     delete myLib;
     msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "deleteStyleById" ) );
     return false;
   }
-
   return deleteStyleByIdMethod( mDataSource, styleId, msgError );
 }
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4301,8 +4301,7 @@ QList<QgsRelation> QgsVectorLayer::referencingRelations( int idx ) const
 
 int QgsVectorLayer::listStylesInDatabase( QStringList &ids, QStringList &names, QStringList &descriptions, QString &msgError )
 {
-  QgsProviderRegistry * pReg = QgsProviderRegistry::instance();
-  QLibrary *myLib = pReg->providerLibrary( mProviderKey );
+  QScopedPointer<QLibrary> myLib( QgsProviderRegistry::instance()->providerLibrary( mProviderKey ) );
   if ( !myLib )
   {
     msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
@@ -4312,7 +4311,6 @@ int QgsVectorLayer::listStylesInDatabase( QStringList &ids, QStringList &names, 
 
   if ( !listStylesExternalMethod )
   {
-    delete myLib;
     msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "listStyles" ) );
     return -1;
   }
@@ -4322,8 +4320,7 @@ int QgsVectorLayer::listStylesInDatabase( QStringList &ids, QStringList &names, 
 
 QString QgsVectorLayer::getStyleFromDatabase( const QString& styleId, QString &msgError )
 {
-  QgsProviderRegistry * pReg = QgsProviderRegistry::instance();
-  QLibrary *myLib = pReg->providerLibrary( mProviderKey );
+  QScopedPointer<QLibrary> myLib( QgsProviderRegistry::instance()->providerLibrary( mProviderKey ) );
   if ( !myLib )
   {
     msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
@@ -4333,7 +4330,6 @@ QString QgsVectorLayer::getStyleFromDatabase( const QString& styleId, QString &m
 
   if ( !getStyleByIdMethod )
   {
-    delete myLib;
     msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "getStyleById" ) );
     return QObject::tr( "" );
   }
@@ -4343,7 +4339,7 @@ QString QgsVectorLayer::getStyleFromDatabase( const QString& styleId, QString &m
 
 bool QgsVectorLayer::deleteStyleFromDatabase( const QString& styleId, QString &msgError )
 {
-  QLibrary *myLib = QgsProviderRegistry::instance()->providerLibrary( mProviderKey );
+  QScopedPointer<QLibrary> myLib( QgsProviderRegistry::instance()->providerLibrary( mProviderKey ) );
   if ( !myLib )
   {
     msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
@@ -4352,7 +4348,6 @@ bool QgsVectorLayer::deleteStyleFromDatabase( const QString& styleId, QString &m
   deleteStyleById_t* deleteStyleByIdMethod = reinterpret_cast< deleteStyleById_t * >( cast_to_fptr( myLib->resolve( "deleteStyleById" ) ) );
   if ( !deleteStyleByIdMethod )
   {
-    delete myLib;
     msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "deleteStyleById" ) );
     return false;
   }
@@ -4365,8 +4360,7 @@ void QgsVectorLayer::saveStyleToDatabase( const QString& name, const QString& de
 {
 
   QString sldStyle, qmlStyle;
-  QgsProviderRegistry * pReg = QgsProviderRegistry::instance();
-  QLibrary *myLib = pReg->providerLibrary( mProviderKey );
+  QScopedPointer<QLibrary> myLib( QgsProviderRegistry::instance()->providerLibrary( mProviderKey ) );
   if ( !myLib )
   {
     msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
@@ -4376,7 +4370,6 @@ void QgsVectorLayer::saveStyleToDatabase( const QString& name, const QString& de
 
   if ( !saveStyleExternalMethod )
   {
-    delete myLib;
     msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "saveStyle" ) );
     return;
   }
@@ -4412,8 +4405,7 @@ QString QgsVectorLayer::loadNamedStyle( const QString &theURI, bool &theResultFl
   QgsDataSourceUri dsUri( theURI );
   if ( !loadFromLocalDB && mDataProvider && mDataProvider->isSaveAndLoadStyleToDBSupported() )
   {
-    QgsProviderRegistry * pReg = QgsProviderRegistry::instance();
-    QLibrary *myLib = pReg->providerLibrary( mProviderKey );
+    QScopedPointer<QLibrary> myLib( QgsProviderRegistry::instance()->providerLibrary( mProviderKey ) );
     if ( myLib )
     {
       loadStyle_t* loadStyleExternalMethod = reinterpret_cast< loadStyle_t * >( cast_to_fptr( myLib->resolve( "loadStyle" ) ) );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -120,7 +120,7 @@ typedef QString getStyleById_t(
   QString& errCause
 );
 
-typedef void deleteStyleById_t(
+typedef bool deleteStyleById_t(
   const QString& uri,
   QString styleID,
   QString& errCause
@@ -4341,14 +4341,14 @@ QString QgsVectorLayer::getStyleFromDatabase( const QString& styleId, QString &m
   return getStyleByIdMethod( mDataSource, styleId, msgError );
 }
 
-void QgsVectorLayer::deleteStyleFromDatabase( const QString& styleId, QString &msgError )
+bool QgsVectorLayer::deleteStyleFromDatabase( const QString& styleId, QString &msgError )
 {
   QgsProviderRegistry * pReg = QgsProviderRegistry::instance();
   QLibrary *myLib = pReg->providerLibrary( mProviderKey );
   if ( !myLib )
   {
     msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
-    return;
+    return false;
   }
   deleteStyleById_t* deleteStyleByIdMethod = reinterpret_cast< deleteStyleById_t * >( cast_to_fptr( myLib->resolve( "deleteStyleById" ) ) );
 
@@ -4356,7 +4356,7 @@ void QgsVectorLayer::deleteStyleFromDatabase( const QString& styleId, QString &m
   {
     delete myLib;
     msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "deleteStyleById" ) );
-    return;
+    return false;
   }
 
   return deleteStyleByIdMethod( mDataSource, styleId, msgError );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -786,6 +786,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     virtual QString getStyleFromDatabase( const QString& styleId, QString &msgError );
 
     /**
+     * Will delete the named style corresponding to style id provided from the database
+     */
+    virtual void deleteStyleFromDatabase( const QString& styleId, QString &msgError );
+
+    /**
      * Load a named style from file/local db/datasource db
      * @param theURI the URI of the style or the URI of the layer
      * @param theResultFlag will be set to true if a named style is correctly loaded

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -786,7 +786,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     virtual QString getStyleFromDatabase( const QString& styleId, QString &msgError );
 
     /**
-     * Will delete the named style corresponding to style id provided from the database
+     * Delete a style from the database
+     * @note added in QGIS 3.0
+     * @param styleId the provider's layer_styles table id of the style to delete
+     * @param msgError reference to string that will be updated with any error messages
+     * @return true in case of success
      */
     virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError );
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -788,7 +788,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Will delete the named style corresponding to style id provided from the database
      */
-    virtual void deleteStyleFromDatabase( const QString& styleId, QString &msgError );
+    virtual bool deleteStyleFromDatabase( const QString& styleId, QString &msgError );
 
     /**
      * Load a named style from file/local db/datasource db

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4632,12 +4632,8 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   return numberOfRelatedStyles;
 }
 
-void QgsPostgresProvider::deleteStyleById( const QString &uri, QString styleId, QString &errCause )
+void QgsPostgresProvider::deleteStyleById( const QString &uri, QString styleId, QString &errCause ) const
 {
-  QgsDebugMsg( "deleteStyleById" );
-  QgsDebugMsg( styleId );
-  QgsDebugMsg( uri );
-
   QgsDataSourceUri dsUri( uri );
 
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -53,14 +53,15 @@ inline qint32 FID2PKINT( qint64 x )
   return QgsPostgresUtils::fid_to_int32pk( x );
 }
 
-static bool tableExists( QgsPostgresConn& conn, const QString& name )
+static bool tableExists( QgsPostgresConn &conn, const QString &name )
 {
-  QgsPostgresResult res( conn.PQexec( "SELECT COUNT(*) FROM information_schema.tables WHERE table_name=" + QgsPostgresConn::quotedValue( name ) ) );
+  QgsPostgresResult res( conn.PQexec(
+                           "SELECT COUNT(*) FROM information_schema.tables WHERE table_name=" + QgsPostgresConn::quotedValue( name ) ) );
   return res.PQgetvalue( 0, 0 ).toInt() > 0;
 }
 
 QgsPostgresPrimaryKeyType
-QgsPostgresProvider::pkType( const QgsField& f ) const
+QgsPostgresProvider::pkType( const QgsField &f ) const
 {
   switch ( f.type() )
   {
@@ -80,22 +81,11 @@ QgsPostgresProvider::pkType( const QgsField& f ) const
 }
 
 
-
-QgsPostgresProvider::QgsPostgresProvider( QString const & uri )
-    : QgsVectorDataProvider( uri )
-    , mValid( false )
-    , mPrimaryKeyType( PktUnknown )
-    , mSpatialColType( SctNone )
-    , mDetectedGeomType( QgsWkbTypes::Unknown )
-    , mForce2d( false )
-    , mRequestedGeomType( QgsWkbTypes::Unknown )
-    , mShared( new QgsPostgresSharedData )
-    , mUseEstimatedMetadata( false )
-    , mSelectAtIdDisabled( false )
-    , mEnabledCapabilities( 0 )
-    , mConnectionRO( nullptr )
-    , mConnectionRW( nullptr )
-    , mTransaction( nullptr )
+QgsPostgresProvider::QgsPostgresProvider( QString const &uri )
+    : QgsVectorDataProvider( uri ), mValid( false ), mPrimaryKeyType( PktUnknown ), mSpatialColType( SctNone ),
+    mDetectedGeomType( QgsWkbTypes::Unknown ), mForce2d( false ), mRequestedGeomType( QgsWkbTypes::Unknown ),
+    mShared( new QgsPostgresSharedData ), mUseEstimatedMetadata( false ), mSelectAtIdDisabled( false ),
+    mEnabledCapabilities( 0 ), mConnectionRO( nullptr ), mConnectionRW( nullptr ), mTransaction( nullptr )
 {
 
   QgsDebugMsg( QString( "URI: %1 " ).arg( uri ) );
@@ -201,32 +191,56 @@ QgsPostgresProvider::QgsPostgresProvider( QString const & uri )
   //fill type names into sets
   setNativeTypes( QList<NativeType>()
                   // integer types
-                  << QgsVectorDataProvider::NativeType( tr( "Whole number (smallint - 16bit)" ), QStringLiteral( "int2" ), QVariant::Int, -1, -1, 0, 0 )
-                  << QgsVectorDataProvider::NativeType( tr( "Whole number (integer - 32bit)" ), QStringLiteral( "int4" ), QVariant::Int, -1, -1, 0, 0 )
-                  << QgsVectorDataProvider::NativeType( tr( "Whole number (integer - 64bit)" ), QStringLiteral( "int8" ), QVariant::LongLong, -1, -1, 0, 0 )
-                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (numeric)" ), QStringLiteral( "numeric" ), QVariant::Double, 1, 20, 0, 20 )
-                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (decimal)" ), QStringLiteral( "decimal" ), QVariant::Double, 1, 20, 0, 20 )
+                  << QgsVectorDataProvider::NativeType( tr( "Whole number (smallint - 16bit)" ),
+                                                        QStringLiteral( "int2" ), QVariant::Int, -1, -1, 0, 0 )
+                  << QgsVectorDataProvider::NativeType( tr( "Whole number (integer - 32bit)" ),
+                                                        QStringLiteral( "int4" ), QVariant::Int, -1, -1, 0, 0 )
+                  << QgsVectorDataProvider::NativeType( tr( "Whole number (integer - 64bit)" ),
+                                                        QStringLiteral( "int8" ), QVariant::LongLong, -1, -1, 0, 0 )
+                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (numeric)" ), QStringLiteral( "numeric" ),
+                                                        QVariant::Double, 1, 20, 0, 20 )
+                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (decimal)" ), QStringLiteral( "decimal" ),
+                                                        QVariant::Double, 1, 20, 0, 20 )
 
                   // floating point
-                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (real)" ), QStringLiteral( "real" ), QVariant::Double, -1, -1, -1, -1 )
-                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (double)" ), QStringLiteral( "double precision" ), QVariant::Double, -1, -1, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (real)" ), QStringLiteral( "real" ),
+                                                        QVariant::Double, -1, -1, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Decimal number (double)" ),
+                                                        QStringLiteral( "double precision" ), QVariant::Double, -1,
+                                                        -1, -1, -1 )
 
                   // string types
-                  << QgsVectorDataProvider::NativeType( tr( "Text, fixed length (char)" ), QStringLiteral( "char" ), QVariant::String, 1, 255, -1, -1 )
-                  << QgsVectorDataProvider::NativeType( tr( "Text, limited variable length (varchar)" ), QStringLiteral( "varchar" ), QVariant::String, 1, 255, -1, -1 )
-                  << QgsVectorDataProvider::NativeType( tr( "Text, unlimited length (text)" ), QStringLiteral( "text" ), QVariant::String, -1, -1, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Text, fixed length (char)" ), QStringLiteral( "char" ),
+                                                        QVariant::String, 1, 255, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Text, limited variable length (varchar)" ),
+                                                        QStringLiteral( "varchar" ), QVariant::String, 1, 255, -1,
+                                                        -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Text, unlimited length (text)" ),
+                                                        QStringLiteral( "text" ), QVariant::String, -1, -1, -1, -1 )
 
                   // date type
-                  << QgsVectorDataProvider::NativeType( tr( "Date" ), QStringLiteral( "date" ), QVariant::Date, -1, -1, -1, -1 )
-                  << QgsVectorDataProvider::NativeType( tr( "Time" ), QStringLiteral( "time" ), QVariant::Time, -1, -1, -1, -1 )
-                  << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), QStringLiteral( "timestamp without time zone" ), QVariant::DateTime, -1, -1, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Date" ), QStringLiteral( "date" ), QVariant::Date, -1,
+                                                        -1, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Time" ), QStringLiteral( "time" ), QVariant::Time, -1,
+                                                        -1, -1, -1 )
+                  << QgsVectorDataProvider::NativeType( tr( "Date & Time" ),
+                                                        QStringLiteral( "timestamp without time zone" ),
+                                                        QVariant::DateTime, -1, -1, -1, -1 )
 
                   // complex types
-                  << QgsVectorDataProvider::NativeType( tr( "Map" ), QStringLiteral( "hstore" ), QVariant::Map, -1, -1, -1, -1, QVariant::String )
-                  << QgsVectorDataProvider::NativeType( tr( "Array of number (integer - 32bit)" ), QStringLiteral( "int4[]" ), QVariant::List, -1, -1, -1, -1, QVariant::Int )
-                  << QgsVectorDataProvider::NativeType( tr( "Array of number (integer - 64bit)" ), QStringLiteral( "int8[]" ), QVariant::List, -1, -1, -1, -1, QVariant::LongLong )
-                  << QgsVectorDataProvider::NativeType( tr( "Array of number (double)" ), QStringLiteral( "double precision[]" ), QVariant::List, -1, -1, -1, -1, QVariant::Double )
-                  << QgsVectorDataProvider::NativeType( tr( "Array of text" ), QStringLiteral( "text[]" ), QVariant::StringList, -1, -1, -1, -1, QVariant::String )
+                  << QgsVectorDataProvider::NativeType( tr( "Map" ), QStringLiteral( "hstore" ), QVariant::Map, -1,
+                                                        -1, -1, -1, QVariant::String )
+                  << QgsVectorDataProvider::NativeType( tr( "Array of number (integer - 32bit)" ),
+                                                        QStringLiteral( "int4[]" ), QVariant::List, -1, -1, -1, -1,
+                                                        QVariant::Int )
+                  << QgsVectorDataProvider::NativeType( tr( "Array of number (integer - 64bit)" ),
+                                                        QStringLiteral( "int8[]" ), QVariant::List, -1, -1, -1, -1,
+                                                        QVariant::LongLong )
+                  << QgsVectorDataProvider::NativeType( tr( "Array of number (double)" ),
+                                                        QStringLiteral( "double precision[]" ), QVariant::List, -1,
+                                                        -1, -1, -1, QVariant::Double )
+                  << QgsVectorDataProvider::NativeType( tr( "Array of text" ), QStringLiteral( "text[]" ),
+                                                        QVariant::StringList, -1, -1, -1, -1, QVariant::String )
                 );
 
   QString key;
@@ -279,17 +293,17 @@ QgsPostgresProvider::~QgsPostgresProvider()
 }
 
 
-QgsAbstractFeatureSource* QgsPostgresProvider::featureSource() const
+QgsAbstractFeatureSource *QgsPostgresProvider::featureSource() const
 {
   return new QgsPostgresFeatureSource( this );
 }
 
-QgsPostgresConn* QgsPostgresProvider::connectionRO() const
+QgsPostgresConn *QgsPostgresProvider::connectionRO() const
 {
   return mTransaction ? mTransaction->connection() : mConnectionRO;
 }
 
-QgsPostgresConn* QgsPostgresProvider::connectionRW()
+QgsPostgresConn *QgsPostgresProvider::connectionRW()
 {
   if ( mTransaction )
   {
@@ -302,15 +316,15 @@ QgsPostgresConn* QgsPostgresProvider::connectionRW()
   return mConnectionRW;
 }
 
-QgsTransaction* QgsPostgresProvider::transaction() const
+QgsTransaction *QgsPostgresProvider::transaction() const
 {
-  return static_cast<QgsTransaction*>( mTransaction );
+  return static_cast<QgsTransaction *>( mTransaction );
 }
 
-void QgsPostgresProvider::setTransaction( QgsTransaction* transaction )
+void QgsPostgresProvider::setTransaction( QgsTransaction *transaction )
 {
   // static_cast since layers cannot be added to a transaction of a non-matching provider
-  mTransaction = static_cast<QgsPostgresTransaction*>( transaction );
+  mTransaction = static_cast<QgsPostgresTransaction *>( transaction );
 }
 
 void QgsPostgresProvider::disconnectDb()
@@ -334,17 +348,20 @@ QString QgsPostgresProvider::storageType() const
 }
 
 #if QT_VERSION >= 0x050000 && QT_VERSION < 0x050600
+
 #include <algorithm>
-template <typename T>
+
+template<typename T>
 bool operator<( const QList<T> &lhs, const QList<T> &rhs )
 {
   return std::lexicographical_compare( lhs.begin(), lhs.end(),
                                        rhs.begin(), rhs.end() );
 }
+
 #endif
 
 
-QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest& request ) const
+QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest &request ) const
 {
   if ( !mValid )
   {
@@ -352,10 +369,9 @@ QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest& re
     return QgsFeatureIterator();
   }
 
-  QgsPostgresFeatureSource* featureSrc = static_cast<QgsPostgresFeatureSource*>( featureSource() );
+  QgsPostgresFeatureSource *featureSrc = static_cast<QgsPostgresFeatureSource *>( featureSource() );
   return QgsFeatureIterator( new QgsPostgresFeatureIterator( featureSrc, true, request ) );
 }
-
 
 
 QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias ) const
@@ -378,7 +394,8 @@ QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias )
     case PktInt:
     case PktUint64:
       Q_ASSERT( mPrimaryKeyAttrs.size() == 1 );
-      whereClause = QStringLiteral( "%3%1=$%2" ).arg( quotedIdentifier( field( mPrimaryKeyAttrs[0] ).name() ) ).arg( offset ).arg( aliased );
+      whereClause = QStringLiteral( "%3%1=$%2" ).arg( quotedIdentifier( field( mPrimaryKeyAttrs[0] ).name() ) ).arg( offset ).arg(
+                      aliased );
       break;
 
     case PktFidMap:
@@ -389,7 +406,8 @@ QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias )
         int idx = mPrimaryKeyAttrs[i];
         QgsField fld = field( idx );
 
-        whereClause += delim + QStringLiteral( "%3%1=$%2" ).arg( connectionRO()->fieldExpression( fld ) ).arg( offset++ ).arg( aliased );
+        whereClause +=
+          delim + QStringLiteral( "%3%1=$%2" ).arg( connectionRO()->fieldExpression( fld ) ).arg( offset++ ).arg( aliased );
         delim = QStringLiteral( " AND " );
       }
     }
@@ -445,7 +463,8 @@ void QgsPostgresProvider::appendPkParams( QgsFeatureId featureId, QStringList &p
         }
         else
         {
-          QgsDebugMsg( QString( "FAILURE: Key value %1 for feature %2 not found." ).arg( mPrimaryKeyAttrs[i] ).arg( featureId ) );
+          QgsDebugMsg(
+            QString( "FAILURE: Key value %1 for feature %2 not found." ).arg( mPrimaryKeyAttrs[i] ).arg( featureId ) );
           params << QStringLiteral( "NULL" );
         }
       }
@@ -463,11 +482,14 @@ void QgsPostgresProvider::appendPkParams( QgsFeatureId featureId, QStringList &p
 
 QString QgsPostgresProvider::whereClause( QgsFeatureId featureId ) const
 {
-  return QgsPostgresUtils::whereClause( featureId, mAttributeFields, connectionRO(), mPrimaryKeyType, mPrimaryKeyAttrs, mShared );
+  return QgsPostgresUtils::whereClause( featureId, mAttributeFields, connectionRO(), mPrimaryKeyType, mPrimaryKeyAttrs,
+                                        mShared );
 }
 
 
-QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields& fields, QgsPostgresConn* conn, QgsPostgresPrimaryKeyType pkType, const QList<int>& pkAttrs, QSharedPointer<QgsPostgresSharedData> sharedData )
+QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields &fields, QgsPostgresConn *conn,
+                                       QgsPostgresPrimaryKeyType pkType, const QList<int> &pkAttrs,
+                                       QSharedPointer<QgsPostgresSharedData> sharedData )
 {
   QString whereClause;
 
@@ -485,12 +507,14 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields& 
 
     case PktInt:
       Q_ASSERT( pkAttrs.size() == 1 );
-      whereClause = QStringLiteral( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ).arg( FID2PKINT( featureId ) );
+      whereClause = QStringLiteral( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ).arg(
+                      FID2PKINT( featureId ) );
       break;
 
     case PktUint64:
       Q_ASSERT( pkAttrs.size() == 1 );
-      whereClause = QStringLiteral( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ).arg( featureId );
+      whereClause = QStringLiteral( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ).arg(
+                      featureId );
       break;
 
     case PktFidMap:
@@ -532,7 +556,9 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields& 
   return whereClause;
 }
 
-QString QgsPostgresUtils::whereClause( const QgsFeatureIds& featureIds, const QgsFields& fields, QgsPostgresConn* conn, QgsPostgresPrimaryKeyType pkType, const QList<int>& pkAttrs, QSharedPointer<QgsPostgresSharedData> sharedData )
+QString QgsPostgresUtils::whereClause( const QgsFeatureIds &featureIds, const QgsFields &fields, QgsPostgresConn *conn,
+                                       QgsPostgresPrimaryKeyType pkType, const QList<int> &pkAttrs,
+                                       QSharedPointer<QgsPostgresSharedData> sharedData )
 {
   switch ( pkType )
   {
@@ -546,11 +572,14 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds& featureIds, const Qg
       if ( !featureIds.isEmpty() )
       {
         QString delim;
-        expr = QStringLiteral( "%1 IN (" ).arg(( pkType == PktOid ? QStringLiteral( "oid" ) : QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ) );
+        expr = QStringLiteral( "%1 IN (" ).arg(
+                 ( pkType == PktOid ? QStringLiteral( "oid" ) : QgsPostgresConn::quotedIdentifier(
+                     fields.at( pkAttrs[0] ).name() ) ) );
 
         Q_FOREACH ( const QgsFeatureId featureId, featureIds )
         {
-          expr += delim + FID_TO_STRING( pkType == PktOid ? featureId : pkType == PktUint64 ? featureId : FID2PKINT( featureId ) );
+          expr += delim + FID_TO_STRING(
+                    pkType == PktOid ? featureId : pkType == PktUint64 ? featureId : FID2PKINT( featureId ) );
           delim = ',';
         }
         expr += ')';
@@ -568,13 +597,14 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds& featureIds, const Qg
       {
         whereClauses << whereClause( featureId, fields, conn, pkType, pkAttrs, sharedData );
       }
-      return whereClauses.isEmpty() ? QLatin1String( "" ) : whereClauses.join( QStringLiteral( " OR " ) ).prepend( '(' ).append( ')' );
+      return whereClauses.isEmpty() ? QLatin1String( "" ) : whereClauses.join( QStringLiteral( " OR " ) ).prepend( '(' ).append(
+               ')' );
     }
   }
   return QString(); //avoid warning
 }
 
-QString QgsPostgresUtils::andWhereClauses( const QString& c1, const QString& c2 )
+QString QgsPostgresUtils::andWhereClauses( const QString &c1, const QString &c2 )
 {
   if ( c1.isEmpty() )
     return c2;
@@ -607,14 +637,15 @@ QString QgsPostgresProvider::filterWhereClause() const
 
   if ( mRequestedGeomType != QgsWkbTypes::Unknown && mRequestedGeomType != mDetectedGeomType )
   {
-    where += delim + QgsPostgresConn::postgisTypeFilter( mGeometryColumn, ( QgsWkbTypes::Type )mRequestedGeomType, mSpatialColType == SctGeography );
+    where += delim + QgsPostgresConn::postgisTypeFilter( mGeometryColumn, ( QgsWkbTypes::Type ) mRequestedGeomType,
+             mSpatialColType == SctGeography );
     delim = QStringLiteral( " AND " );
   }
 
   return where;
 }
 
-void QgsPostgresProvider::setExtent( QgsRectangle& newExtent )
+void QgsPostgresProvider::setExtent( QgsRectangle &newExtent )
 {
   mLayerExtent.setXMaximum( newExtent.xMaximum() );
   mLayerExtent.setXMinimum( newExtent.xMinimum() );
@@ -788,7 +819,7 @@ bool QgsPostgresProvider::loadFields()
     int attnum = result.PQftablecol( i );
     int atttypid = attTypeIdMap[tableoid][attnum];
 
-    const PGTypeInfo& typeInfo = typeMap.value( fldtyp );
+    const PGTypeInfo &typeInfo = typeMap.value( fldtyp );
     QString fieldTypeName = typeInfo.typeName;
     QString fieldTType = typeInfo.typeType;
     int fieldSize = typeInfo.typeLen;
@@ -958,7 +989,8 @@ bool QgsPostgresProvider::loadFields()
       }
       else
       {
-        QgsMessageLog::logMessage( tr( "Field %1 ignored, because of unsupported type %2" ).arg( fieldName, fieldTypeName ), tr( "PostGIS" ) );
+        QgsMessageLog::logMessage( tr( "Field %1 ignored, because of unsupported type %2" ).arg( fieldName, fieldTypeName ),
+                                   tr( "PostGIS" ) );
         continue;
       }
 
@@ -978,7 +1010,8 @@ bool QgsPostgresProvider::loadFields()
     }
     else
     {
-      QgsMessageLog::logMessage( tr( "Field %1 ignored, because of unsupported type %2" ).arg( fieldName, fieldTType ), tr( "PostGIS" ) );
+      QgsMessageLog::logMessage( tr( "Field %1 ignored, because of unsupported type %2" ).arg( fieldName, fieldTType ),
+                                 tr( "PostGIS" ) );
       continue;
     }
 
@@ -1025,9 +1058,11 @@ void QgsPostgresProvider::setEditorWidgets()
       // CREATE TABLE qgis_editor_widget_styles (schema_name TEXT NOT NULL, table_name TEXT NOT NULL, field_name TEXT NOT NULL,
       //                                         type TEXT NOT NULL, config TEXT,
       //                                         PRIMARY KEY(schema_name, table_name, field_name));
-      QgsField& field = mAttributeFields[i];
-      const QString sql = QStringLiteral( "SELECT type, config FROM %1 WHERE schema_name = %2 and table_name = %3 and field_name = %4 LIMIT 1" ).
-                          arg( EDITOR_WIDGET_STYLES_TABLE, quotedValue( mSchemaName ), quotedValue( mTableName ), quotedValue( field.name() ) );
+      QgsField &field = mAttributeFields[i];
+      const QString sql = QStringLiteral(
+                            "SELECT type, config FROM %1 WHERE schema_name = %2 and table_name = %3 and field_name = %4 LIMIT 1" ).
+                          arg( EDITOR_WIDGET_STYLES_TABLE, quotedValue( mSchemaName ), quotedValue( mTableName ),
+                               quotedValue( field.name() ) );
       QgsPostgresResult result( connectionRO()->PQexec( sql ) );
       for ( int i = 0; i < result.PQntuples(); ++i )
       {
@@ -1043,7 +1078,9 @@ void QgsPostgresProvider::setEditorWidgets()
           }
           else
           {
-            QgsMessageLog::logMessage( tr( "Cannot parse widget configuration for field %1.%2.%3\n" ).arg( mSchemaName, mTableName, field.name() ), tr( "PostGIS" ) );
+            QgsMessageLog::logMessage(
+              tr( "Cannot parse widget configuration for field %1.%2.%3\n" ).arg( mSchemaName, mTableName,
+                  field.name() ), tr( "PostGIS" ) );
           }
         }
 
@@ -1065,10 +1102,11 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     QgsPostgresResult testAccess( connectionRO()->PQexec( sql ) );
     if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK )
     {
-      QgsMessageLog::logMessage( tr( "Unable to access the %1 relation.\nThe error message from the database was:\n%2.\nSQL: %3" )
-                                 .arg( mQuery,
-                                       testAccess.PQresultErrorMessage(),
-                                       sql ), tr( "PostGIS" ) );
+      QgsMessageLog::logMessage(
+        tr( "Unable to access the %1 relation.\nThe error message from the database was:\n%2.\nSQL: %3" )
+        .arg( mQuery,
+              testAccess.PQresultErrorMessage(),
+              sql ), tr( "PostGIS" ) );
       return false;
     }
 
@@ -1079,7 +1117,9 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
       testAccess = connectionRO()->PQexec( QStringLiteral( "SELECT pg_is_in_recovery()" ) );
       if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK || testAccess.PQgetvalue( 0, 0 ) == QLatin1String( "t" ) )
       {
-        QgsMessageLog::logMessage( tr( "PostgreSQL is still in recovery after a database crash\n(or you are connected to a (read-only) slave).\nWrite accesses will be denied." ), tr( "PostGIS" ) );
+        QgsMessageLog::logMessage(
+          tr( "PostgreSQL is still in recovery after a database crash\n(or you are connected to a (read-only) slave).\nWrite accesses will be denied." ),
+          tr( "PostGIS" ) );
         inRecovery = true;
       }
     }
@@ -1123,11 +1163,12 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
       testAccess = connectionRO()->PQexec( sql );
       if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK )
       {
-        QgsMessageLog::logMessage( tr( "Unable to determine table access privileges for the %1 relation.\nThe error message from the database was:\n%2.\nSQL: %3" )
-                                   .arg( mQuery,
-                                         testAccess.PQresultErrorMessage(),
-                                         sql ),
-                                   tr( "PostGIS" ) );
+        QgsMessageLog::logMessage(
+          tr( "Unable to determine table access privileges for the %1 relation.\nThe error message from the database was:\n%2.\nSQL: %3" )
+          .arg( mQuery,
+                testAccess.PQresultErrorMessage(),
+                sql ),
+          tr( "PostGIS" ) );
         return false;
       }
 
@@ -1165,11 +1206,13 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
                      "relname=%1 AND nspname=%2" )
             .arg( quotedValue( mTableName ),
                   quotedValue( mSchemaName ),
-                  connectionRO()->pgVersion() < 80100 ? "pg_get_userbyid(relowner)=current_user" : "pg_has_role(relowner,'MEMBER')" );
+                  connectionRO()->pgVersion() < 80100 ? "pg_get_userbyid(relowner)=current_user"
+                  : "pg_has_role(relowner,'MEMBER')" );
       testAccess = connectionRO()->PQexec( sql );
       if ( testAccess.PQresultStatus() == PGRES_TUPLES_OK && testAccess.PQntuples() == 1 )
       {
-        mEnabledCapabilities |= QgsVectorDataProvider::AddAttributes | QgsVectorDataProvider::DeleteAttributes | QgsVectorDataProvider::RenameAttributes;
+        mEnabledCapabilities |= QgsVectorDataProvider::AddAttributes | QgsVectorDataProvider::DeleteAttributes |
+                                QgsVectorDataProvider::RenameAttributes;
       }
     }
   }
@@ -1205,9 +1248,10 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     testAccess = connectionRO()->PQexec( sql );
     if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK )
     {
-      QgsMessageLog::logMessage( tr( "Unable to execute the query.\nThe error message from the database was:\n%1.\nSQL: %2" )
-                                 .arg( testAccess.PQresultErrorMessage(),
-                                       sql ), tr( "PostGIS" ) );
+      QgsMessageLog::logMessage(
+        tr( "Unable to execute the query.\nThe error message from the database was:\n%1.\nSQL: %2" )
+        .arg( testAccess.PQresultErrorMessage(),
+              sql ), tr( "PostGIS" ) );
       return false;
     }
 
@@ -1218,7 +1262,8 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
   }
 
   // supports geometry simplification on provider side
-  mEnabledCapabilities |= ( QgsVectorDataProvider::SimplifyGeometries | QgsVectorDataProvider::SimplifyGeometriesWithTopologicalValidation );
+  mEnabledCapabilities |= ( QgsVectorDataProvider::SimplifyGeometries |
+                            QgsVectorDataProvider::SimplifyGeometriesWithTopologicalValidation );
 
   //supports transactions
   mEnabledCapabilities |= QgsVectorDataProvider::TransactionSupport;
@@ -1255,7 +1300,9 @@ bool QgsPostgresProvider::determinePrimaryKey()
     QgsPostgresResult res( connectionRO()->PQexec( sql ) );
     bool isParentTable( res.PQntuples() == 0 || res.PQgetvalue( 0, 0 ).toInt() > 0 );
 
-    sql = QStringLiteral( "SELECT indexrelid FROM pg_index WHERE indrelid=%1::regclass AND (indisprimary OR indisunique) ORDER BY CASE WHEN indisprimary THEN 1 ELSE 2 END LIMIT 1" ).arg( quotedValue( mQuery ) );
+    sql = QStringLiteral(
+            "SELECT indexrelid FROM pg_index WHERE indrelid=%1::regclass AND (indisprimary OR indisunique) ORDER BY CASE WHEN indisprimary THEN 1 ELSE 2 END LIMIT 1" ).arg(
+            quotedValue( mQuery ) );
     QgsDebugMsg( QString( "Retrieving first primary or unique index: %1" ).arg( sql ) );
 
     res = connectionRO()->PQexec( sql );
@@ -1284,7 +1331,8 @@ bool QgsPostgresProvider::determinePrimaryKey()
         mPrimaryKeyAttrs.clear();
 
         // If there is an oid on the table, use that instead,
-        sql = QStringLiteral( "SELECT attname FROM pg_attribute WHERE attname='oid' AND attrelid=regclass(%1)" ).arg( quotedValue( mQuery ) );
+        sql = QStringLiteral( "SELECT attname FROM pg_attribute WHERE attname='oid' AND attrelid=regclass(%1)" ).arg(
+                quotedValue( mQuery ) );
 
         res = connectionRO()->PQexec( sql );
         if ( res.PQntuples() == 1 )
@@ -1296,19 +1344,26 @@ bool QgsPostgresProvider::determinePrimaryKey()
         }
         else
         {
-          sql = QStringLiteral( "SELECT attname FROM pg_attribute WHERE attname='ctid' AND attrelid=regclass(%1)" ).arg( quotedValue( mQuery ) );
+          sql = QStringLiteral( "SELECT attname FROM pg_attribute WHERE attname='ctid' AND attrelid=regclass(%1)" ).arg(
+                  quotedValue( mQuery ) );
 
           res = connectionRO()->PQexec( sql );
           if ( res.PQntuples() == 1 )
           {
             mPrimaryKeyType = PktTid;
 
-            QgsMessageLog::logMessage( tr( "Primary key is ctid - changing of existing features disabled (%1; %2)" ).arg( mGeometryColumn, mQuery ) );
-            mEnabledCapabilities &= ~( QgsVectorDataProvider::DeleteFeatures | QgsVectorDataProvider::ChangeAttributeValues | QgsVectorDataProvider::ChangeGeometries | QgsVectorDataProvider::ChangeFeatures );
+            QgsMessageLog::logMessage(
+              tr( "Primary key is ctid - changing of existing features disabled (%1; %2)" ).arg( mGeometryColumn,
+                  mQuery ) );
+            mEnabledCapabilities &= ~( QgsVectorDataProvider::DeleteFeatures |
+                                       QgsVectorDataProvider::ChangeAttributeValues |
+                                       QgsVectorDataProvider::ChangeGeometries | QgsVectorDataProvider::ChangeFeatures );
           }
           else
           {
-            QgsMessageLog::logMessage( tr( "The table has no column suitable for use as a key. QGIS requires a primary key, a PostgreSQL oid column or a ctid for tables." ), tr( "PostGIS" ) );
+            QgsMessageLog::logMessage(
+              tr( "The table has no column suitable for use as a key. QGIS requires a primary key, a PostgreSQL oid column or a ctid for tables." ),
+              tr( "PostGIS" ) );
           }
         }
       }
@@ -1325,7 +1380,9 @@ bool QgsPostgresProvider::determinePrimaryKey()
     {
       // have a primary key or unique index
       QString indrelid = res.PQgetvalue( 0, 0 );
-      sql = QStringLiteral( "SELECT attname,attnotnull FROM pg_index,pg_attribute WHERE indexrelid=%1 AND indrelid=attrelid AND pg_attribute.attnum=any(pg_index.indkey)" ).arg( indrelid );
+      sql = QStringLiteral(
+              "SELECT attname,attnotnull FROM pg_index,pg_attribute WHERE indexrelid=%1 AND indrelid=attrelid AND pg_attribute.attnum=any(pg_index.indkey)" ).arg(
+              indrelid );
 
       QgsDebugMsg( "Retrieving key columns: " + sql );
       res = connectionRO()->PQexec( sql );
@@ -1341,7 +1398,8 @@ bool QgsPostgresProvider::determinePrimaryKey()
         QString name = res.PQgetvalue( i, 0 );
         if ( res.PQgetvalue( i, 1 ).startsWith( 'f' ) )
         {
-          QgsMessageLog::logMessage( tr( "Unique column '%1' doesn't have a NOT NULL constraint." ).arg( name ), tr( "PostGIS" ) );
+          QgsMessageLog::logMessage( tr( "Unique column '%1' doesn't have a NOT NULL constraint." ).arg( name ),
+                                     tr( "PostGIS" ) );
           mightBeNull = true;
         }
 
@@ -1381,7 +1439,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
     QgsFieldConstraints constraints = mAttributeFields.at( fieldIdx ).constraints();
     constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
     constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
-    mAttributeFields[ fieldIdx ].setConstraints( constraints );
+    mAttributeFields[fieldIdx].setConstraints( constraints );
   }
 
   mValid = mPrimaryKeyType != PktUnknown;
@@ -1390,7 +1448,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
 }
 
 /* static */
-QStringList QgsPostgresProvider::parseUriKey( const QString& key )
+QStringList QgsPostgresProvider::parseUriKey( const QString &key )
 {
   if ( key.isEmpty() ) return QStringList();
 
@@ -1405,7 +1463,7 @@ QStringList QgsPostgresProvider::parseUriKey( const QString& key )
     {
       if ( key[i] == '"' )
       {
-        if ( i + 1 < key.size() && key[i+1] == '"' )
+        if ( i + 1 < key.size() && key[i + 1] == '"' )
         {
           i++;
         }
@@ -1452,13 +1510,13 @@ void QgsPostgresProvider::determinePrimaryKeyFromUriKeyColumn()
 
     primaryKey = QLatin1String( "" );
     QString del = QLatin1String( "" );
-    Q_FOREACH ( const QString& col, cols )
+    Q_FOREACH ( const QString &col, cols )
     {
       primaryKey += del + quotedIdentifier( col );
       del = QStringLiteral( "," );
     }
 
-    Q_FOREACH ( const QString& col, cols )
+    Q_FOREACH ( const QString &col, cols )
     {
       int idx = fieldNameIndex( col );
       if ( idx < 0 )
@@ -1484,7 +1542,8 @@ void QgsPostgresProvider::determinePrimaryKeyFromUriKeyColumn()
       }
       else
       {
-        QgsMessageLog::logMessage( tr( "Primary key field '%1' for view/query not unique." ).arg( primaryKey ), tr( "PostGIS" ) );
+        QgsMessageLog::logMessage( tr( "Primary key field '%1' for view/query not unique." ).arg( primaryKey ),
+                                   tr( "PostGIS" ) );
       }
     }
     else
@@ -1498,7 +1557,7 @@ void QgsPostgresProvider::determinePrimaryKeyFromUriKeyColumn()
   }
 }
 
-bool QgsPostgresProvider::uniqueData( const QString& quotedColNames )
+bool QgsPostgresProvider::uniqueData( const QString &quotedColNames )
 {
   // Check to see if the given columns contain unique data
   QString sql = QStringLiteral( "SELECT count(distinct (%1))=count((%1)) FROM %2%3" )
@@ -1562,7 +1621,7 @@ void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues
       sql += QStringLiteral( " WHERE %1" ).arg( mSqlWhereClause );
     }
 
-    sql +=  QStringLiteral( " ORDER BY %1" ).arg( quotedIdentifier( fld.name() ) );
+    sql += QStringLiteral( " ORDER BY %1" ).arg( quotedIdentifier( fld.name() ) );
 
     if ( limit >= 0 )
     {
@@ -1583,7 +1642,8 @@ void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues
   }
 }
 
-QStringList QgsPostgresProvider::uniqueStringsMatching( int index, const QString& substring, int limit, QgsFeedback* feedback ) const
+QStringList QgsPostgresProvider::uniqueStringsMatching( int index, const QString &substring, int limit,
+    QgsFeedback *feedback ) const
 {
   QStringList results;
 
@@ -1603,7 +1663,7 @@ QStringList QgsPostgresProvider::uniqueStringsMatching( int index, const QString
     sql += QString( " %1 ILIKE '%%2%'" ).arg( quotedIdentifier( fld.name() ), substring );
 
 
-    sql +=  QString( " ORDER BY %1" ).arg( quotedIdentifier( fld.name() ) );
+    sql += QString( " ORDER BY %1" ).arg( quotedIdentifier( fld.name() ) );
 
     if ( limit >= 0 )
     {
@@ -1629,7 +1689,7 @@ QStringList QgsPostgresProvider::uniqueStringsMatching( int index, const QString
   return results;
 }
 
-void QgsPostgresProvider::enumValues( int index, QStringList& enumList ) const
+void QgsPostgresProvider::enumValues( int index, QStringList &enumList ) const
 {
   enumList.clear();
 
@@ -1668,11 +1728,12 @@ void QgsPostgresProvider::enumValues( int index, QStringList& enumList ) const
   }
 }
 
-bool QgsPostgresProvider::parseEnumRange( QStringList& enumValues, const QString& attributeName ) const
+bool QgsPostgresProvider::parseEnumRange( QStringList &enumValues, const QString &attributeName ) const
 {
   enumValues.clear();
 
-  QString enumRangeSql = QStringLiteral( "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid=(SELECT atttypid::regclass FROM pg_attribute WHERE attrelid=%1::regclass AND attname=%2)" )
+  QString enumRangeSql = QStringLiteral(
+                           "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid=(SELECT atttypid::regclass FROM pg_attribute WHERE attrelid=%1::regclass AND attname=%2)" )
                          .arg( quotedValue( mQuery ),
                                quotedValue( attributeName ) );
   QgsPostgresResult enumRangeRes( connectionRO()->PQexec( enumRangeSql ) );
@@ -1687,17 +1748,21 @@ bool QgsPostgresProvider::parseEnumRange( QStringList& enumValues, const QString
   return true;
 }
 
-bool QgsPostgresProvider::parseDomainCheckConstraint( QStringList& enumValues, const QString& attributeName ) const
+bool QgsPostgresProvider::parseDomainCheckConstraint( QStringList &enumValues, const QString &attributeName ) const
 {
   enumValues.clear();
 
   //is it a domain type with a check constraint?
-  QString domainSql = QStringLiteral( "SELECT domain_name FROM information_schema.columns WHERE table_name=%1 AND column_name=%2" ).arg( quotedValue( mTableName ), quotedValue( attributeName ) );
+  QString domainSql = QStringLiteral(
+                        "SELECT domain_name FROM information_schema.columns WHERE table_name=%1 AND column_name=%2" ).arg(
+                        quotedValue( mTableName ), quotedValue( attributeName ) );
   QgsPostgresResult domainResult( connectionRO()->PQexec( domainSql ) );
   if ( domainResult.PQresultStatus() == PGRES_TUPLES_OK && domainResult.PQntuples() > 0 )
   {
     //a domain type
-    QString domainCheckDefinitionSql = QStringLiteral( "SELECT consrc FROM pg_constraint WHERE conname=(SELECT constraint_name FROM information_schema.domain_constraints WHERE domain_name=%1)" ).arg( quotedValue( domainResult.PQgetvalue( 0, 0 ) ) );
+    QString domainCheckDefinitionSql = QStringLiteral(
+                                         "SELECT consrc FROM pg_constraint WHERE conname=(SELECT constraint_name FROM information_schema.domain_constraints WHERE domain_name=%1)" ).arg(
+                                         quotedValue( domainResult.PQgetvalue( 0, 0 ) ) );
     QgsPostgresResult domainCheckRes( connectionRO()->PQexec( domainCheckDefinitionSql ) );
     if ( domainCheckRes.PQresultStatus() == PGRES_TUPLES_OK && domainCheckRes.PQntuples() > 0 )
     {
@@ -1806,7 +1871,8 @@ QVariant QgsPostgresProvider::defaultValue( int fieldId ) const
   return QVariant();
 }
 
-bool QgsPostgresProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint, const QVariant& value ) const
+bool
+QgsPostgresProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint, const QVariant &value ) const
 {
   if ( providerProperty( EvaluateDefaultValues, false ).toBool() )
   {
@@ -1820,7 +1886,7 @@ bool QgsPostgresProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstrain
   }
 }
 
-QString QgsPostgresProvider::paramValue( const QString& fieldValue, const QString &defaultValue ) const
+QString QgsPostgresProvider::paramValue( const QString &fieldValue, const QString &defaultValue ) const
 {
   if ( fieldValue.isNull() )
     return QString::null;
@@ -1876,8 +1942,7 @@ void QgsPostgresProvider::dropOrphanedTopoGeoms()
                 .arg( mTopoLayerInfo.layerId )
                 .arg( quotedIdentifier( mGeometryColumn ),
                       quotedIdentifier( mSchemaName ),
-                      quotedIdentifier( mTableName ) )
-                ;
+                      quotedIdentifier( mTableName ) );
 
   QgsDebugMsg( "TopoGeom orphans cleanup query: " + sql );
 
@@ -1934,7 +1999,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
   if ( mIsQuery )
     return false;
 
-  QgsPostgresConn* conn = connectionRW();
+  QgsPostgresConn *conn = connectionRW();
   if ( !conn )
   {
     return false;
@@ -2088,7 +2153,8 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
     }
 
     QgsDebugMsg( QString( "prepare addfeatures: %1" ).arg( insert ) );
-    QgsPostgresResult stmt( conn->PQprepare( QStringLiteral( "addfeatures" ), insert, fieldId.size() + offset - 1, nullptr ) );
+    QgsPostgresResult stmt(
+      conn->PQprepare( QStringLiteral( "addfeatures" ), insert, fieldId.size() + offset - 1, nullptr ) );
 
     if ( stmt.PQresultStatus() != PGRES_COMMAND_OK )
       throw PGException( stmt );
@@ -2113,12 +2179,12 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
         if ( value.isNull() )
         {
           QgsField fld = field( attrIdx );
-          v = paramValue( defaultValues[ i ], defaultValues[ i ] );
+          v = paramValue( defaultValues[i], defaultValues[i] );
           features->setAttribute( attrIdx, convertValue( fld.type(), fld.subType(), v ) );
         }
         else
         {
-          v = paramValue( value.toString(), defaultValues[ i ] );
+          v = paramValue( value.toString(), defaultValues[i] );
 
           if ( v != value.toString() )
           {
@@ -2199,7 +2265,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
   return returnvalue;
 }
 
-bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds & id )
+bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds &id )
 {
   bool returnvalue = true;
 
@@ -2209,7 +2275,7 @@ bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds & id )
     return false;
   }
 
-  QgsPostgresConn* conn = connectionRW();
+  QgsPostgresConn *conn = connectionRW();
   if ( !conn )
   {
     return false;
@@ -2270,7 +2336,7 @@ bool QgsPostgresProvider::truncate()
     return false;
   }
 
-  QgsPostgresConn* conn = connectionRW();
+  QgsPostgresConn *conn = connectionRW();
   if ( !conn )
   {
     return false;
@@ -2327,7 +2393,7 @@ bool QgsPostgresProvider::addAttributes( const QList<QgsField> &attributes )
   if ( attributes.isEmpty() )
     return true;
 
-  QgsPostgresConn* conn = connectionRW();
+  QgsPostgresConn *conn = connectionRW();
   if ( !conn )
   {
     return false;
@@ -2390,14 +2456,14 @@ bool QgsPostgresProvider::addAttributes( const QList<QgsField> &attributes )
   return returnvalue;
 }
 
-bool QgsPostgresProvider::deleteAttributes( const QgsAttributeIds& ids )
+bool QgsPostgresProvider::deleteAttributes( const QgsAttributeIds &ids )
 {
   bool returnvalue = true;
 
   if ( mIsQuery )
     return false;
 
-  QgsPostgresConn* conn = connectionRW();
+  QgsPostgresConn *conn = connectionRW();
   if ( !conn )
   {
     return false;
@@ -2445,7 +2511,7 @@ bool QgsPostgresProvider::deleteAttributes( const QgsAttributeIds& ids )
   return returnvalue;
 }
 
-bool QgsPostgresProvider::renameAttributes( const QgsFieldNameMap& renamedAttributes )
+bool QgsPostgresProvider::renameAttributes( const QgsFieldNameMap &renamedAttributes )
 {
   if ( mIsQuery )
     return false;
@@ -2477,7 +2543,7 @@ bool QgsPostgresProvider::renameAttributes( const QgsFieldNameMap& renamedAttrib
   }
   sql += QLatin1String( "COMMIT;" );
 
-  QgsPostgresConn* conn = connectionRW();
+  QgsPostgresConn *conn = connectionRW();
   if ( !conn )
   {
     return false;
@@ -2594,7 +2660,7 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
           if ( !attrs.contains( idx ) )
             continue;
 
-          k[i] = attrs[ idx ];
+          k[i] = attrs[idx];
         }
 
         mShared->insertFid( fid, k );
@@ -2614,7 +2680,7 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
   return returnvalue;
 }
 
-void QgsPostgresProvider::appendGeomParam( const QgsGeometry& geom, QStringList &params ) const
+void QgsPostgresProvider::appendGeomParam( const QgsGeometry &geom, QStringList &params ) const
 {
   if ( geom.isEmpty() )
   {
@@ -2645,7 +2711,7 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
   if ( mIsQuery || mGeometryColumn.isNull() )
     return false;
 
-  QgsPostgresConn* conn = connectionRW();
+  QgsPostgresConn *conn = connectionRW();
   if ( !conn )
   {
     return false;
@@ -2683,8 +2749,9 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
       result = connectionRO()->PQprepare( QStringLiteral( "getid" ), getid, 1, nullptr );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
       {
-        QgsDebugMsg( QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
-                     .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( getid ) );
+        QgsDebugMsg(
+          QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+          .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( getid ) );
         throw PGException( result );
       }
 
@@ -2698,8 +2765,9 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
       result = conn->PQprepare( QStringLiteral( "replacetopogeom" ), replace, 2, nullptr );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
       {
-        QgsDebugMsg( QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
-                     .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( replace ) );
+        QgsDebugMsg(
+          QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+          .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( replace ) );
         throw PGException( result );
       }
 
@@ -2718,8 +2786,9 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
     result = conn->PQprepare( QStringLiteral( "updatefeatures" ), update, 2, nullptr );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
     {
-      QgsDebugMsg( QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
-                   .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( update ) );
+      QgsDebugMsg(
+        QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+        .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( update ) );
       throw PGException( result );
     }
 
@@ -2740,8 +2809,9 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
         result = connectionRO()->PQexecPrepared( QStringLiteral( "getid" ), params );
         if ( result.PQresultStatus() != PGRES_TUPLES_OK )
         {
-          QgsDebugMsg( QString( "Exception thrown due to PQexecPrepared of 'getid' returning != PGRES_TUPLES_OK (%1 != expected %2)" )
-                       .arg( result.PQresultStatus() ).arg( PGRES_TUPLES_OK ) );
+          QgsDebugMsg(
+            QString( "Exception thrown due to PQexecPrepared of 'getid' returning != PGRES_TUPLES_OK (%1 != expected %2)" )
+            .arg( result.PQresultStatus() ).arg( PGRES_TUPLES_OK ) );
           throw PGException( result );
         }
         // TODO: watch out for NULL, handle somehow
@@ -2772,8 +2842,9 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
         result = conn->PQexec( replace );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         {
-          QgsDebugMsg( QString( "Exception thrown due to PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
-                       .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( replace ) );
+          QgsDebugMsg(
+            QString( "Exception thrown due to PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+            .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( replace ) );
           throw PGException( result );
         }
         // TODO: use prepared query here
@@ -2787,8 +2858,9 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
         result = conn->PQexec( replace );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         {
-          QgsDebugMsg( QString( "Exception thrown due to PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
-                       .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( replace ) );
+          QgsDebugMsg(
+            QString( "Exception thrown due to PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+            .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( replace ) );
           throw PGException( result );
         }
       } // if TopoGeometry
@@ -2916,13 +2988,14 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
         QgsPostgresResult result( conn->PQprepare( QStringLiteral( "updatefeature" ), sql, 1, nullptr ) );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
         {
-          QgsDebugMsg( QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
-                       .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( sql ) );
+          QgsDebugMsg(
+            QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+            .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( sql ) );
           throw PGException( result );
         }
 
         QStringList params;
-        const QgsGeometry &geom = geometry_map[ fid ];
+        const QgsGeometry &geom = geometry_map[fid];
         appendGeomParam( geom, params );
 
         result = conn->PQexecPrepared( QStringLiteral( "updatefeature" ), params );
@@ -2943,7 +3016,7 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
           if ( !attrs.contains( idx ) )
             continue;
 
-          k[i] = attrs[ idx ];
+          k[i] = attrs[idx];
         }
 
         mShared->insertFid( fid, k );
@@ -2980,7 +3053,7 @@ QgsVectorDataProvider::Capabilities QgsPostgresProvider::capabilities() const
   return mEnabledCapabilities;
 }
 
-bool QgsPostgresProvider::setSubsetString( const QString& theSQL, bool updateFeatureCount )
+bool QgsPostgresProvider::setSubsetString( const QString &theSQL, bool updateFeatureCount )
 {
   QString prevWhere = mSqlWhereClause;
 
@@ -3046,7 +3119,8 @@ long QgsPostgresProvider::featureCount() const
   // - but make huge dataset usable.
   if ( !mIsQuery && mUseEstimatedMetadata )
   {
-    sql = QStringLiteral( "SELECT reltuples::int FROM pg_catalog.pg_class WHERE oid=regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
+    sql = QStringLiteral( "SELECT reltuples::int FROM pg_catalog.pg_class WHERE oid=regclass(%1)::oid" ).arg(
+            quotedValue( mQuery ) );
   }
   else
   {
@@ -3092,7 +3166,8 @@ QgsRectangle QgsPostgresProvider::extent() const
       {
         if ( result.PQgetvalue( 0, 0 ).toInt() > 0 )
         {
-          sql = QStringLiteral( "SELECT reltuples::int FROM pg_catalog.pg_class WHERE oid=regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
+          sql = QStringLiteral( "SELECT reltuples::int FROM pg_catalog.pg_class WHERE oid=regclass(%1)::oid" ).arg(
+                  quotedValue( mQuery ) );
           result = connectionRO()->PQexec( sql );
           if ( result.PQresultStatus() == PGRES_TUPLES_OK
                && result.PQntuples() == 1
@@ -3100,7 +3175,8 @@ QgsRectangle QgsPostgresProvider::extent() const
           {
             sql = QStringLiteral( "SELECT %1(%2,%3,%4)" )
                   .arg( connectionRO()->majorVersion() < 2 ? "estimated_extent" :
-                        ( connectionRO()->majorVersion() == 2 && connectionRO()->minorVersion() < 1 ? "st_estimated_extent" : "st_estimatedextent" ),
+                        ( connectionRO()->majorVersion() == 2 && connectionRO()->minorVersion() < 1
+                          ? "st_estimated_extent" : "st_estimatedextent" ),
                         quotedValue( mSchemaName ),
                         quotedValue( mTableName ),
                         quotedValue( mGeometryColumn ) );
@@ -3211,7 +3287,9 @@ bool QgsPostgresProvider::getGeometryDetails()
       result = connectionRO()->PQexec( sql );
       if ( tableoid > 0 && PGRES_TUPLES_OK == result.PQresultStatus() )
       {
-        sql = QStringLiteral( "SELECT pg_namespace.nspname,pg_class.relname FROM pg_class,pg_namespace WHERE pg_class.relnamespace=pg_namespace.oid AND pg_class.oid=%1" ).arg( tableoid );
+        sql = QStringLiteral(
+                "SELECT pg_namespace.nspname,pg_class.relname FROM pg_class,pg_namespace WHERE pg_class.relnamespace=pg_namespace.oid AND pg_class.oid=%1" ).arg(
+                tableoid );
         result = connectionRO()->PQexec( sql );
 
         if ( PGRES_TUPLES_OK == result.PQresultStatus() && 1 == result.PQntuples() )
@@ -3219,7 +3297,9 @@ bool QgsPostgresProvider::getGeometryDetails()
           schemaName = result.PQgetvalue( 0, 0 );
           tableName = result.PQgetvalue( 0, 1 );
 
-          sql = QStringLiteral( "SELECT a.attname, t.typname FROM pg_attribute a, pg_type t WHERE a.attrelid=%1 AND a.attnum=%2 AND a.atttypid = t.oid" ).arg( tableoid ).arg( column );
+          sql = QStringLiteral(
+                  "SELECT a.attname, t.typname FROM pg_attribute a, pg_type t WHERE a.attrelid=%1 AND a.attnum=%2 AND a.atttypid = t.oid" ).arg(
+                  tableoid ).arg( column );
           result = connectionRO()->PQexec( sql );
           if ( PGRES_TUPLES_OK == result.PQresultStatus() && 1 == result.PQntuples() )
           {
@@ -3261,7 +3341,8 @@ bool QgsPostgresProvider::getGeometryDetails()
   if ( !schemaName.isEmpty() )
   {
     // check geometry columns
-    sql = QStringLiteral( "SELECT upper(type),srid,coord_dimension FROM geometry_columns WHERE f_table_name=%1 AND f_geometry_column=%2 AND f_table_schema=%3" )
+    sql = QStringLiteral(
+            "SELECT upper(type),srid,coord_dimension FROM geometry_columns WHERE f_table_name=%1 AND f_geometry_column=%2 AND f_table_schema=%3" )
           .arg( quotedValue( tableName ),
                 quotedValue( geomCol ),
                 quotedValue( schemaName ) );
@@ -3290,7 +3371,8 @@ bool QgsPostgresProvider::getGeometryDetails()
     if ( detectedType.isEmpty() )
     {
       // check geography columns
-      sql = QStringLiteral( "SELECT upper(type),srid FROM geography_columns WHERE f_table_name=%1 AND f_geography_column=%2 AND f_table_schema=%3" )
+      sql = QStringLiteral(
+              "SELECT upper(type),srid FROM geography_columns WHERE f_table_name=%1 AND f_geography_column=%2 AND f_table_schema=%3" )
             .arg( quotedValue( tableName ),
                   quotedValue( geomCol ),
                   quotedValue( schemaName ) );
@@ -3345,7 +3427,8 @@ bool QgsPostgresProvider::getGeometryDetails()
     if ( detectedType.isEmpty() && connectionRO()->hasPointcloud() )
     {
       // check pointcloud columns
-      sql = QStringLiteral( "SELECT 'POLYGON',srid FROM pointcloud_columns WHERE \"table\"=%1 AND \"column\"=%2 AND \"schema\"=%3" )
+      sql = QStringLiteral(
+              "SELECT 'POLYGON',srid FROM pointcloud_columns WHERE \"table\"=%1 AND \"column\"=%2 AND \"schema\"=%3" )
             .arg( quotedValue( tableName ),
                   quotedValue( geomCol ),
                   quotedValue( schemaName ) );
@@ -3403,12 +3486,13 @@ bool QgsPostgresProvider::getGeometryDetails()
     result = connectionRO()->PQexec( sql );
     if ( PGRES_TUPLES_OK == result.PQresultStatus() )
     {
-      sql = QStringLiteral( "SELECT (SELECT t.typname FROM pg_type t WHERE oid = %1), upper(postgis_typmod_type(%2)), postgis_typmod_srid(%2)" )
+      sql = QStringLiteral(
+              "SELECT (SELECT t.typname FROM pg_type t WHERE oid = %1), upper(postgis_typmod_type(%2)), postgis_typmod_srid(%2)" )
             .arg( QString::number( result.PQftype( 0 ) ), QString::number( result.PQfmod( 0 ) ) );
       result = connectionRO()->PQexec( sql, false );
       if ( result.PQntuples() == 1 )
       {
-        geomColType  = result.PQgetvalue( 0, 0 );
+        geomColType = result.PQgetvalue( 0, 0 );
         detectedType = result.PQgetvalue( 0, 1 );
         detectedSrid = result.PQgetvalue( 0, 2 );
         if ( geomColType == QLatin1String( "geometry" ) )
@@ -3421,14 +3505,18 @@ bool QgsPostgresProvider::getGeometryDetails()
           mSpatialColType = SctPcPatch;
         else
         {
-          detectedType = mRequestedGeomType == QgsWkbTypes::Unknown ? QLatin1String( "" ) : QgsPostgresConn::postgisWkbTypeName( mRequestedGeomType );
+          detectedType =
+            mRequestedGeomType == QgsWkbTypes::Unknown ? QLatin1String( "" ) : QgsPostgresConn::postgisWkbTypeName(
+              mRequestedGeomType );
           detectedSrid = mRequestedSrid;
         }
       }
       else
       {
         connectionRO()->PQexecNR( QStringLiteral( "COMMIT" ) );
-        detectedType = mRequestedGeomType == QgsWkbTypes::Unknown ? QLatin1String( "" ) : QgsPostgresConn::postgisWkbTypeName( mRequestedGeomType );
+        detectedType =
+          mRequestedGeomType == QgsWkbTypes::Unknown ? QLatin1String( "" ) : QgsPostgresConn::postgisWkbTypeName(
+            mRequestedGeomType );
       }
     }
     else
@@ -3439,7 +3527,7 @@ bool QgsPostgresProvider::getGeometryDetails()
   }
 
   mDetectedGeomType = QgsPostgresConn::wkbTypeFromPostgis( detectedType );
-  mDetectedSrid     = detectedSrid;
+  mDetectedSrid = detectedSrid;
 
   if ( mDetectedGeomType == QgsWkbTypes::Unknown )
   {
@@ -3449,16 +3537,16 @@ bool QgsPostgresProvider::getGeometryDetails()
     if ( !mIsQuery )
     {
       layerProperty.schemaName = schemaName;
-      layerProperty.tableName  = tableName;
+      layerProperty.tableName = tableName;
     }
     else
     {
       layerProperty.schemaName = QLatin1String( "" );
-      layerProperty.tableName  = mQuery;
+      layerProperty.tableName = mQuery;
     }
     layerProperty.geometryColName = mGeometryColumn;
     layerProperty.geometryColType = mSpatialColType;
-    layerProperty.force2d         = false;
+    layerProperty.force2d = false;
 
     QString delim = QLatin1String( "" );
 
@@ -3477,7 +3565,8 @@ bool QgsPostgresProvider::getGeometryDetails()
       // no data - so take what's requested
       if ( mRequestedGeomType == QgsWkbTypes::Unknown || mRequestedSrid.isEmpty() )
       {
-        QgsMessageLog::logMessage( tr( "Geometry type and srid for empty column %1 of %2 undefined." ).arg( mGeometryColumn, mQuery ) );
+        QgsMessageLog::logMessage(
+          tr( "Geometry type and srid for empty column %1 of %2 undefined." ).arg( mGeometryColumn, mQuery ) );
       }
     }
     else
@@ -3487,7 +3576,8 @@ bool QgsPostgresProvider::getGeometryDetails()
       {
         QgsWkbTypes::Type wkbType = layerProperty.types.at( i );
 
-        if (( wkbType != QgsWkbTypes::Unknown && ( mRequestedGeomType == QgsWkbTypes::Unknown || mRequestedGeomType == wkbType ) ) &&
+        if (( wkbType != QgsWkbTypes::Unknown &&
+              ( mRequestedGeomType == QgsWkbTypes::Unknown || mRequestedGeomType == wkbType ) ) &&
             ( mRequestedSrid.isEmpty() || layerProperty.srids.at( i ) == mRequestedSrid.toInt() ) )
           break;
       }
@@ -3499,14 +3589,16 @@ bool QgsPostgresProvider::getGeometryDetails()
         {
           // only what we requested is available
           mDetectedGeomType = layerProperty.types.at( 0 );
-          mDetectedSrid     = QString::number( layerProperty.srids.at( 0 ) );
-          mForce2d          = layerProperty.force2d;
+          mDetectedSrid = QString::number( layerProperty.srids.at( 0 ) );
+          mForce2d = layerProperty.force2d;
         }
       }
       else
       {
         // geometry type undetermined or not unrequested
-        QgsMessageLog::logMessage( tr( "Feature type or srid for %1 of %2 could not be determined or was not requested." ).arg( mGeometryColumn, mQuery ) );
+        QgsMessageLog::logMessage(
+          tr( "Feature type or srid for %1 of %2 could not be determined or was not requested." ).arg(
+            mGeometryColumn, mQuery ) );
       }
     }
   }
@@ -3625,10 +3717,10 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
   return true;
 }
 
-QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const QString& uri,
+QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const QString &uri,
     const QgsFields &fields,
     QgsWkbTypes::Type wkbType,
-    const QgsCoordinateReferenceSystem& srs,
+    const QgsCoordinateReferenceSystem &srs,
     bool overwrite,
     QMap<int, int> *oldToNewAttrIdxMap,
     QString *errorMessage,
@@ -3692,7 +3784,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
   else
   {
     pkList = parseUriKey( primaryKey );
-    Q_FOREACH ( const QString& col, pkList )
+    Q_FOREACH ( const QString &col, pkList )
     {
       // search for the passed field
       QString type;
@@ -3759,12 +3851,12 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
         throw PGException( result );
     }
 
-    sql = QStringLiteral( "CREATE TABLE %1(" ) .arg( schemaTableName );
+    sql = QStringLiteral( "CREATE TABLE %1(" ).arg( schemaTableName );
     QString pk;
     for ( int i = 0; i < pkList.size(); ++i )
     {
       QString col = pkList[i];
-      const QString& type = pkType[i];
+      const QString &type = pkType[i];
 
       if ( options && options->value( QStringLiteral( "lowercaseFieldNames" ), false ).toBool() )
       {
@@ -3777,14 +3869,14 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
 
       if ( i )
       {
-        pk  += QLatin1String( "," );
+        pk += QLatin1String( "," );
         sql += QLatin1String( "," );
       }
 
       pk += col;
       sql += col + " " + type;
     }
-    sql += QStringLiteral( ", PRIMARY KEY (%1) )" ) .arg( pk );
+    sql += QStringLiteral( ", PRIMARY KEY (%1) )" ).arg( pk );
 
     result = conn->PQexec( sql );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK )
@@ -3883,7 +3975,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
         {
           //convert field name to lowercase (TODO: avoid doing this
           //over and over)
-          col =  col.toLower();
+          col = col.toLower();
         }
         if ( fld.name() == col )
         {
@@ -3938,7 +4030,8 @@ QgsCoordinateReferenceSystem QgsPostgresProvider::crs() const
   srs.createFromSrid( srid );
   if ( !srs.isValid() )
   {
-    QgsPostgresResult result( connectionRO()->PQexec( QStringLiteral( "SELECT proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) ) );
+    QgsPostgresResult result(
+      connectionRO()->PQexec( QStringLiteral( "SELECT proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) ) );
     if ( result.PQresultStatus() == PGRES_TUPLES_OK )
       srs = QgsCoordinateReferenceSystem::fromProj4( result.PQgetvalue( 0, 0 ) );
   }
@@ -3961,12 +4054,12 @@ size_t QgsPostgresProvider::layerCount() const
 } // QgsPostgresProvider::layerCount()
 
 
-QString  QgsPostgresProvider::name() const
+QString QgsPostgresProvider::name() const
 {
   return POSTGRES_KEY;
 } //  QgsPostgresProvider::name()
 
-QString  QgsPostgresProvider::description() const
+QString QgsPostgresProvider::description() const
 {
   QString pgVersion( tr( "PostgreSQL version: unknown" ) );
   QString postgisVersion( tr( "unknown" ) );
@@ -3995,12 +4088,12 @@ QString  QgsPostgresProvider::description() const
   return tr( "PostgreSQL/PostGIS provider\n%1\nPostGIS %2" ).arg( pgVersion, postgisVersion );
 } //  QgsPostgresProvider::description()
 
-static void jumpSpace( const QString& txt, int& i )
+static void jumpSpace( const QString &txt, int &i )
 {
   while ( i < txt.length() && txt.at( i ).isSpace() ) ++i;
 }
 
-static QString getNextString( const QString& txt, int& i, const QString& sep )
+static QString getNextString( const QString &txt, int &i, const QString &sep )
 {
   jumpSpace( txt, i );
   QString cur = txt.mid( i );
@@ -4020,7 +4113,8 @@ static QString getNextString( const QString& txt, int& i, const QString& sep )
       return QString::null;
     }
     i += sep.length();
-    return stringRe.cap( 1 ).replace( QLatin1String( "\\\"" ), QLatin1String( "\"" ) ).replace( QLatin1String( "\\\\" ), QLatin1String( "\\" ) );
+    return stringRe.cap( 1 ).replace( QLatin1String( "\\\"" ), QLatin1String( "\"" ) ).replace( QLatin1String( "\\\\" ),
+           QLatin1String( "\\" ) );
   }
   else
   {
@@ -4035,7 +4129,7 @@ static QString getNextString( const QString& txt, int& i, const QString& sep )
   }
 }
 
-static QVariant parseHstore( const QString& txt )
+static QVariant parseHstore( const QString &txt )
 {
   QVariantMap result;
   int i = 0;
@@ -4054,7 +4148,7 @@ static QVariant parseHstore( const QString& txt )
   return result;
 }
 
-static QVariant parseOtherArray( const QString& txt, QVariant::Type subType )
+static QVariant parseOtherArray( const QString &txt, QVariant::Type subType )
 {
   int i = 0;
   QVariantList result;
@@ -4071,7 +4165,7 @@ static QVariant parseOtherArray( const QString& txt, QVariant::Type subType )
   return result;
 }
 
-static QVariant parseStringArray( const QString& txt )
+static QVariant parseStringArray( const QString &txt )
 {
   int i = 0;
   QStringList result;
@@ -4088,7 +4182,7 @@ static QVariant parseStringArray( const QString& txt )
   return result;
 }
 
-static QVariant parseArray( const QString& txt, QVariant::Type type, QVariant::Type subType )
+static QVariant parseArray( const QString &txt, QVariant::Type type, QVariant::Type subType )
 {
   if ( !txt.startsWith( '{' ) || !txt.endsWith( '}' ) )
   {
@@ -4102,7 +4196,7 @@ static QVariant parseArray( const QString& txt, QVariant::Type type, QVariant::T
     return parseOtherArray( inner, subType );
 }
 
-QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type subType, const QString& value )
+QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type subType, const QString &value )
 {
   switch ( type )
   {
@@ -4120,14 +4214,17 @@ QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type 
   }
 }
 
-QList<QgsVectorLayer*> QgsPostgresProvider::searchLayers( const QList<QgsVectorLayer*>& layers, const QString& connectionInfo, const QString& schema, const QString& tableName )
+QList<QgsVectorLayer *>
+QgsPostgresProvider::searchLayers( const QList<QgsVectorLayer *> &layers, const QString &connectionInfo,
+                                   const QString &schema, const QString &tableName )
 {
-  QList<QgsVectorLayer*> result;
-  Q_FOREACH ( QgsVectorLayer* layer, layers )
+  QList<QgsVectorLayer *> result;
+  Q_FOREACH ( QgsVectorLayer *layer, layers )
   {
-    const QgsPostgresProvider* pgProvider = qobject_cast<QgsPostgresProvider*>( layer->dataProvider() );
+    const QgsPostgresProvider *pgProvider = qobject_cast<QgsPostgresProvider *>( layer->dataProvider() );
     if ( pgProvider &&
-         pgProvider->mUri.connectionInfo( false ) == connectionInfo && pgProvider->mSchemaName == schema && pgProvider->mTableName == tableName )
+         pgProvider->mUri.connectionInfo( false ) == connectionInfo && pgProvider->mSchemaName == schema &&
+         pgProvider->mTableName == tableName )
     {
       result.append( layer );
     }
@@ -4135,7 +4232,8 @@ QList<QgsVectorLayer*> QgsPostgresProvider::searchLayers( const QList<QgsVectorL
   return result;
 }
 
-QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer* self, const QList<QgsVectorLayer*>& layers ) const
+QList<QgsRelation>
+QgsPostgresProvider::discoverRelations( const QgsVectorLayer *self, const QList<QgsVectorLayer *> &layers ) const
 {
   QList<QgsRelation> result;
   QString sql(
@@ -4146,7 +4244,8 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer*
     "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU2 "
     "ON KCU2.CONSTRAINT_CATALOG = RC.UNIQUE_CONSTRAINT_CATALOG AND KCU2.CONSTRAINT_SCHEMA = RC.UNIQUE_CONSTRAINT_SCHEMA AND KCU2.CONSTRAINT_NAME = RC.UNIQUE_CONSTRAINT_NAME "
     "AND KCU2.ORDINAL_POSITION = KCU1.ORDINAL_POSITION "
-    "WHERE KCU1.CONSTRAINT_SCHEMA=" + QgsPostgresConn::quotedValue( mSchemaName ) + " AND KCU1.TABLE_NAME=" + QgsPostgresConn::quotedValue( mTableName ) +
+    "WHERE KCU1.CONSTRAINT_SCHEMA=" + QgsPostgresConn::quotedValue( mSchemaName ) +
+    " AND KCU1.TABLE_NAME=" + QgsPostgresConn::quotedValue( mTableName ) +
     "GROUP BY RC.CONSTRAINT_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION " +
     "ORDER BY KCU1.ORDINAL_POSITION"
   );
@@ -4166,10 +4265,11 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer*
     const QString refTable = sqlResult.PQgetvalue( row, 3 );
     const QString refColumn = sqlResult.PQgetvalue( row, 4 );
     const QString position = sqlResult.PQgetvalue( row, 5 );
-    if ( position == QLatin1String( "1" ) )
-    { // first reference field => try to find if we have layers for the referenced table
-      const QList<QgsVectorLayer*> foundLayers = searchLayers( layers, mUri.connectionInfo( false ), refSchema, refTable );
-      Q_FOREACH ( const QgsVectorLayer* foundLayer, foundLayers )
+    if ( position ==
+         QLatin1String( "1" ) )   // first reference field => try to find if we have layers for the referenced table
+    {
+      const QList<QgsVectorLayer *> foundLayers = searchLayers( layers, mUri.connectionInfo( false ), refSchema, refTable );
+      Q_FOREACH ( const QgsVectorLayer *foundLayer, foundLayers )
       {
         QgsRelation relation;
         relation.setRelationName( name );
@@ -4188,8 +4288,8 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer*
         }
       }
     }
-    else
-    { // multi reference field => add the field pair to all the referenced layers found
+    else   // multi reference field => add the field pair to all the referenced layers found
+    {
       for ( int i = 0; i < nbFound; ++i )
       {
         result[result.size() - 1 - i].addFieldPair( fkColumn, refColumn );
@@ -4208,7 +4308,7 @@ QgsAttrPalIndexNameHash QgsPostgresProvider::palAttributeIndexNames() const
  * Class factory to return a pointer to a newly created
  * QgsPostgresProvider object
  */
-QGISEXTERN QgsPostgresProvider * classFactory( const QString *uri )
+QGISEXTERN QgsPostgresProvider *classFactory( const QString *uri )
 {
   return new QgsPostgresProvider( *uri );
 }
@@ -4217,7 +4317,7 @@ QGISEXTERN QgsPostgresProvider * classFactory( const QString *uri )
 */
 QGISEXTERN QString providerKey()
 {
-  return  POSTGRES_KEY;
+  return POSTGRES_KEY;
 }
 
 /**
@@ -4256,10 +4356,10 @@ QGISEXTERN QgsDataItem *dataItem( QString thePath, QgsDataItem *parentItem )
 // ---------------------------------------------------------------------------
 
 QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
-  const QString& uri,
+  const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,
-  const QgsCoordinateReferenceSystem& srs,
+  const QgsCoordinateReferenceSystem &srs,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdxMap,
   QString *errorMessage,
@@ -4271,7 +4371,7 @@ QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
          );
 }
 
-QGISEXTERN bool deleteLayer( const QString& uri, QString& errCause )
+QGISEXTERN bool deleteLayer( const QString &uri, QString &errCause )
 {
   QgsDebugMsg( "deleting layer " + uri );
 
@@ -4344,7 +4444,8 @@ QGISEXTERN bool deleteLayer( const QString& uri, QString& errCause )
   return true;
 }
 
-QGISEXTERN bool deleteSchema( const QString& schema, const QgsDataSourceUri& uri, QString& errCause, bool cascade = false )
+QGISEXTERN bool
+deleteSchema( const QString &schema, const QgsDataSourceUri &uri, QString &errCause, bool cascade = false )
 {
   QgsDebugMsg( "deleting schema " + schema );
 
@@ -4378,9 +4479,9 @@ QGISEXTERN bool deleteSchema( const QString& schema, const QgsDataSourceUri& uri
   return true;
 }
 
-QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QString& sldStyle,
-                           const QString& styleName, const QString& styleDescription,
-                           const QString& uiFileContent, bool useAsDefault, QString& errCause )
+QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle,
+                           const QString &styleName, const QString &styleDescription,
+                           const QString &uiFileContent, bool useAsDefault, QString &errCause )
 {
   QgsDataSourceUri dsUri( uri );
 
@@ -4410,7 +4511,9 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
                                          ")" ) );
     if ( res.PQresultStatus() != PGRES_COMMAND_OK )
     {
-      errCause = QObject::tr( "Unable to save layer style. It's not possible to create the destination table on the database. Maybe this is due to table permissions (user=%1). Please contact your database admin" ).arg( dsUri.username() );
+      errCause = QObject::tr(
+                   "Unable to save layer style. It's not possible to create the destination table on the database. Maybe this is due to table permissions (user=%1). Please contact your database admin" ).arg(
+                   dsUri.username() );
       conn->unref();
       return false;
     }
@@ -4440,7 +4543,8 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
                 .arg( QgsPostgresConn::quotedValue( dsUri.geometryColumn() ) )
                 .arg( QgsPostgresConn::quotedValue( styleName.isEmpty() ? dsUri.table() : styleName ) )
                 .arg( useAsDefault ? "true" : "false" )
-                .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
+                .arg( QgsPostgresConn::quotedValue(
+                        styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
                 .arg( QgsPostgresConn::quotedValue( dsUri.username() ) )
                 .arg( uiFileColumn )
                 .arg( uiFileValue )
@@ -4465,7 +4569,8 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
   if ( res.PQntuples() > 0 )
   {
     if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
+                                QObject::tr(
+                                  "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
                                 .arg( styleName.isEmpty() ? dsUri.table() : styleName ),
                                 QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
     {
@@ -4486,7 +4591,8 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
                    " AND f_geometry_column=%9"
                    " AND styleName=%10" )
           .arg( useAsDefault ? "true" : "false" )
-          .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
+          .arg( QgsPostgresConn::quotedValue(
+                  styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.username() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
@@ -4517,7 +4623,9 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
 
   bool saved = res.PQresultStatus() == PGRES_COMMAND_OK;
   if ( !saved )
-    errCause = QObject::tr( "Unable to save layer style. It's not possible to insert a new record into the style table. Maybe this is due to table permissions (user=%1). Please contact your database administrator." ).arg( dsUri.username() );
+    errCause = QObject::tr(
+                 "Unable to save layer style. It's not possible to insert a new record into the style table. Maybe this is due to table permissions (user=%1). Please contact your database administrator." ).arg(
+                 dsUri.username() );
 
   conn->unref();
 
@@ -4525,7 +4633,7 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
 }
 
 
-QGISEXTERN QString loadStyle( const QString& uri, QString& errCause )
+QGISEXTERN QString loadStyle( const QString &uri, QString &errCause )
 {
   QgsDataSourceUri dsUri( uri );
 
@@ -4563,7 +4671,7 @@ QGISEXTERN QString loadStyle( const QString& uri, QString& errCause )
 }
 
 QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &names,
-                           QStringList &descriptions, QString& errCause )
+                           QStringList &descriptions, QString &errCause )
 {
   QgsDataSourceUri dsUri( uri );
 
@@ -4632,7 +4740,36 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   return numberOfRelatedStyles;
 }
 
-QGISEXTERN QString getStyleById( const QString& uri, QString styleId, QString& errCause )
+void QgsPostgresProvider::deleteStyleById( const QString &uri, QString styleId, QString &errCause )
+{
+  QgsDebugMsg( "deleteStyleById" );
+  QgsDebugMsg( styleId );
+  QgsDebugMsg( uri );
+
+  QgsDataSourceUri dsUri( uri );
+
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );
+  }
+  else
+  {
+    QString deleteStyleQuery = QStringLiteral( "DELETE FROM layer_styles WHERE id=%1" ).arg(
+                                 QgsPostgresConn::quotedValue( styleId ) );
+    QgsPostgresResult result( conn->PQexec( deleteStyleQuery ) );
+    if ( result.PQresultStatus() != PGRES_COMMAND_OK )
+    {
+      QgsDebugMsg(
+        QString( "PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+        .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( deleteStyleQuery ) );
+      QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( deleteStyleQuery ) );
+      errCause = QObject::tr( "Error executing the delete query. The query was logged" );
+    }
+  }
+}
+
+QGISEXTERN QString getStyleById( const QString &uri, QString styleId, QString &errCause )
 {
   QgsDataSourceUri dsUri( uri );
 
@@ -4644,14 +4781,16 @@ QGISEXTERN QString getStyleById( const QString& uri, QString styleId, QString& e
   }
 
   QString style;
-  QString selectQmlQuery = QStringLiteral( "SELECT styleQml FROM layer_styles WHERE id=%1" ).arg( QgsPostgresConn::quotedValue( styleId ) );
+  QString selectQmlQuery = QStringLiteral( "SELECT styleQml FROM layer_styles WHERE id=%1" ).arg(
+                             QgsPostgresConn::quotedValue( styleId ) );
   QgsPostgresResult result( conn->PQexec( selectQmlQuery ) );
   if ( result.PQresultStatus() == PGRES_TUPLES_OK )
   {
     if ( result.PQntuples() == 1 )
       style = result.PQgetvalue( 0, 0 );
     else
-      errCause = QObject::tr( "Consistency error in table '%1'. Style id should be unique" ).arg( QStringLiteral( "layer_styles" ) );
+      errCause = QObject::tr( "Consistency error in table '%1'. Style id should be unique" ).arg(
+                   QStringLiteral( "layer_styles" ) );
   }
   else
   {
@@ -4664,7 +4803,7 @@ QGISEXTERN QString getStyleById( const QString& uri, QString styleId, QString& e
   return style;
 }
 
-QGISEXTERN QgsTransaction* createTransaction( const QString& connString )
+QGISEXTERN QgsTransaction *createTransaction( const QString &connString )
 {
   return new QgsPostgresTransaction( connString );
 }
@@ -4677,8 +4816,7 @@ QGISEXTERN void cleanupProvider()
 // ----------
 
 QgsPostgresSharedData::QgsPostgresSharedData()
-    : mFeaturesCounted( -1 )
-    , mFidCounter( 0 )
+    : mFeaturesCounted( -1 ), mFidCounter( 0 )
 {
 }
 
@@ -4718,7 +4856,7 @@ void QgsPostgresSharedData::setFeaturesCounted( long count )
 }
 
 
-QgsFeatureId QgsPostgresSharedData::lookupFid( const QVariantList& v )
+QgsFeatureId QgsPostgresSharedData::lookupFid( const QVariantList &v )
 {
   QMutexLocker locker( &mMutex );
 
@@ -4740,13 +4878,13 @@ QVariantList QgsPostgresSharedData::removeFid( QgsFeatureId fid )
 {
   QMutexLocker locker( &mMutex );
 
-  QVariantList v = mFidToKey[ fid ];
+  QVariantList v = mFidToKey[fid];
   mFidToKey.remove( fid );
   mKeyToFid.remove( v );
   return v;
 }
 
-void QgsPostgresSharedData::insertFid( QgsFeatureId fid, const QVariantList& k )
+void QgsPostgresSharedData::insertFid( QgsFeatureId fid, const QVariantList &k )
 {
   QMutexLocker locker( &mMutex );
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4648,13 +4648,13 @@ void QgsPostgresProvider::deleteStyleById( const QString &uri, QString styleId, 
   else
   {
     QString deleteStyleQuery = QStringLiteral( "DELETE FROM layer_styles WHERE id=%1" ).arg(
-            QgsPostgresConn::quotedValue( styleId ) );
+                                 QgsPostgresConn::quotedValue( styleId ) );
     QgsPostgresResult result( conn->PQexec( deleteStyleQuery ) );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK )
     {
       QgsDebugMsg(
-              QString( "PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
-                      .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( deleteStyleQuery ) );
+        QString( "PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
+        .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( deleteStyleQuery ) );
       QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( deleteStyleQuery ) );
       errCause = QObject::tr( "Error executing the delete query. The query was logged" );
     }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4632,7 +4632,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   return numberOfRelatedStyles;
 }
 
-void QgsPostgresProvider::deleteStyleById( const QString &uri, QString styleId, QString &errCause ) const
+QGISEXTERN void deleteStyleById( const QString &uri, QString styleId, QString &errCause )
 {
   QgsDataSourceUri dsUri( uri );
 
@@ -4655,6 +4655,9 @@ void QgsPostgresProvider::deleteStyleById( const QString &uri, QString styleId, 
       errCause = QObject::tr( "Error executing the delete query. The query was logged" );
     }
   }
+
+  conn->unref();
+
 }
 
 QGISEXTERN QString getStyleById( const QString& uri, QString styleId, QString& errCause )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4632,14 +4632,16 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   return numberOfRelatedStyles;
 }
 
-QGISEXTERN void deleteStyleById( const QString &uri, QString styleId, QString &errCause )
+QGISEXTERN bool deleteStyleById( const QString &uri, QString styleId, QString &errCause )
 {
   QgsDataSourceUri dsUri( uri );
+  bool deleted;
 
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );
+    deleted = false;
   }
   else
   {
@@ -4653,11 +4655,15 @@ QGISEXTERN void deleteStyleById( const QString &uri, QString styleId, QString &e
         .arg( result.PQresultStatus() ).arg( PGRES_COMMAND_OK ).arg( deleteStyleQuery ) );
       QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( deleteStyleQuery ) );
       errCause = QObject::tr( "Error executing the delete query. The query was logged" );
+      deleted = false;
+    }
+    else
+    {
+      deleted = true;
     }
   }
-
   conn->unref();
-
+  return deleted;
 }
 
 QGISEXTERN QString getStyleById( const QString& uri, QString styleId, QString& errCause )

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -132,7 +132,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     virtual void enumValues( int index, QStringList& enumList ) const override;
     bool isValid() const override;
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
-    virtual bool isDeleteStyleFromDBSupported() const override { return true; }
+    virtual bool isDeleteStyleFromDbSupported() const override { return true; }
     QgsAttributeList attributeIndexes() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QString defaultValueClause( int fieldId ) const override;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -133,7 +133,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     bool isValid() const override;
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
     virtual bool isDeleteStyleFromDBSupported() const override { return true; }
-    void deleteStyleById( const QString& uri, QString styleId, QString& errCause );
+    void deleteStyleById( const QString& uri, QString styleId, QString& errCause ) const override;
     QgsAttributeList attributeIndexes() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QString defaultValueClause( int fieldId ) const override;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -132,6 +132,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     virtual void enumValues( int index, QStringList& enumList ) const override;
     bool isValid() const override;
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
+    virtual bool isDeleteStyleFromDBSupported() const override { return true; }
+    void deleteStyleById( const QString& uri, QString styleId, QString& errCause );
     QgsAttributeList attributeIndexes() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QString defaultValueClause( int fieldId ) const override;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -133,7 +133,6 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     bool isValid() const override;
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
     virtual bool isDeleteStyleFromDBSupported() const override { return true; }
-    void deleteStyleById( const QString& uri, QString styleId, QString& errCause ) const override;
     QgsAttributeList attributeIndexes() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QString defaultValueClause( int fieldId ) const override;

--- a/src/ui/qgsloadstylefromdbdialog.ui
+++ b/src/ui/qgsloadstylefromdbdialog.ui
@@ -82,6 +82,19 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="mDeleteButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Delete Style</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="mLoadButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -663,19 +663,20 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         status = vl.loadNamedStyle(mFilePath)
         self.assertTrue(status)
 
-        errorMsg = vl.saveStyleToDatabase("name", "description", False, "")
+        errorMsg = vl.saveStyleToDatabase("by day", "faded greens and elegant patterns", False, "")
         self.assertEqual(errorMsg, "")
 
-        qml, errmsg = vl.getStyleFromDatabase("not_existing")
+        # the style id should be "1", not "by day"
+        qml, errmsg = vl.getStyleFromDatabase("by day")
         self.assertEqual(qml, "")
         self.assertNotEqual(errmsg, "")
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 1)
         self.assertEqual(errmsg, "")
-        self.assertEqual(idlist, ['1'])
-        self.assertEqual(namelist, ['name'])
-        self.assertEqual(desclist, ['description'])
+        self.assertEqual(idlist, ["1"])
+        self.assertEqual(namelist, ["by day"])
+        self.assertEqual(desclist, ["faded greens and elegant patterns"])
 
         qml, errmsg = vl.getStyleFromDatabase("100")
         self.assertEqual(qml, "")
@@ -685,8 +686,10 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
         self.assertEqual(errmsg, "")
 
-        uri = vl.dataProvider().dataSourceUri()
-        vl.dataProvider().deleteStyleById(uri, "1", errmsg)
+        errmsg = vl.deleteStyleFromDatabase("101")
+        self.assertEqual(errmsg, "")
+
+        errmsg = vl.deleteStyleFromDatabase("1")
         self.assertEqual(errmsg, "")
 
         # table layer_styles does exit, but is now empty

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -686,13 +686,11 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
         self.assertEqual(errmsg, "")
 
-        errmsg = ''
-        res = vl.deleteStyleFromDatabase("100", errmsg)
+        res, errmsg = vl.deleteStyleFromDatabase("100")
         self.assertTrue(res)
         self.assertEqual(errmsg, "")
 
-        errmsg = ''
-        res = vl.deleteStyleFromDatabase("1", errmsg)
+        res, errmsg = vl.deleteStyleFromDatabase("1")
         self.assertTrue(res)
         self.assertEqual(errmsg, "")
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -645,7 +645,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         vl = self.getEditableLayer()
         self.assertTrue(vl.isValid())
         self.assertTrue(vl.dataProvider().isSaveAndLoadStyleToDBSupported())
-        self.assertTrue(vl.dataProvider().isDeleteStyleFromDBSupported())
+        self.assertTrue(vl.dataProvider().isDeleteStyleFromDbSupported())
 
         # table layer_styles does not exit
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -686,10 +686,12 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
         self.assertEqual(errmsg, "")
 
-        errmsg = vl.deleteStyleFromDatabase("101")
+        res, errmsg = vl.deleteStyleFromDatabase("100")
+        self.assertTrue(res)
         self.assertEqual(errmsg, "")
 
-        errmsg = vl.deleteStyleFromDatabase("1")
+        res, errmsg = vl.deleteStyleFromDatabase("1")
+        self.assertTrue(res)
         self.assertEqual(errmsg, "")
 
         # table layer_styles does exit, but is now empty

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -686,11 +686,13 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
         self.assertEqual(errmsg, "")
 
-        res, errmsg = vl.deleteStyleFromDatabase("100")
+        errmsg = ''
+        res = vl.deleteStyleFromDatabase("100", errmsg)
         self.assertTrue(res)
         self.assertEqual(errmsg, "")
 
-        res, errmsg = vl.deleteStyleFromDatabase("1")
+        errmsg = ''
+        res = vl.deleteStyleFromDatabase("1", errmsg)
         self.assertTrue(res)
         self.assertEqual(errmsg, "")
 


### PR DESCRIPTION
Hi,

As already been discussed on the [mailing list](https://lists.osgeo.org/pipermail/qgis-developer/2017-January/046570.html) there was no way to remove a saved style from the database.

This PR adds the possibility to remove a style from the database, just for the postgres provider, for now.
Each provider has a new method `virtual bool isDeleteStyleFromDBSupported()` which return false until we add this functionality to it. Only `qgspostgresprovider` returns `true` and implements `QgsPostgresProvider::deleteStyleById`.

If the provider does not support this feature, the delete button is hidden from the interface.

The dialog for load and delete styles looks almost the same. It has a new title and a new delete button. The buttons (delete and load) are only enabled when a style is selected.

![saved styles manager](https://cloud.githubusercontent.com/assets/163681/22341724/ce65028c-e3e9-11e6-8f19-de069828d9e2.png)

After deleting the style from the database, instead of just remove the row from the interface, I am reading the style again from the database. The reason is that this kind of provider is used in environments with multiple users that might have added, deleted of updated the styles in the meanwhile.

Feedback is very welcome. I would like thank @luipir and @nyalldawson the feedback already sent on the mailing list.

The changes might have small impact on the documentation. Should I do something about it or it will be managed by the documentation team?