### PR TITLE
Remove duplicate QgsRasterLayer constructor

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1569,6 +1569,9 @@ QgsRasterInterface        {#qgis_api_break_3_0_QgsRasterInterface}
 QgsRasterLayer        {#qgis_api_break_3_0_QgsRasterLayer}
 --------------
 
+- The constructor variant with loadDefaultStyleFlag as the 3rd parameter was removed. Use the
+constructor variant which accepts a data provider string and loadDefaultStyleFlag as the
+4th parameter instead.
 - setDrawingStyle() was removed. Use setRendererForDrawingStyle() or setRenderer() instead.
 - previewAsPixmap() was removed. Use previewAsImage() instead.
 - updateProgress() had no effect and was removed.

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -357,7 +357,7 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator
      *
      */
     QgsVectorLayer( const QString& path = QString::null, const QString& baseName = QString::null,
-                    const QString& providerLib = QString::null, bool loadDefaultStyleFlag = true );
+                    const QString& providerLib = "ogr", bool loadDefaultStyleFlag = true );
 
     /** Destructor */
     virtual ~QgsVectorLayer();

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -33,19 +33,9 @@ class QgsRasterLayer : QgsMapLayer
      *
      * -
      * */
-    QgsRasterLayer( const QString &path,
-                    const QString &baseName = QString::null,
-                    bool loadDefaultStyleFlag = true );
-
-    //TODO - QGIS 3.0
-    //This constructor is confusing if used with string literals for providerKey,
-    //as the previous constructor will be called with the literal for providerKey
-    //implicitly converted to a bool.
-    //for QGIS 3.0, make either constructor explicit or alter the signatures
-    /** \brief [ data provider interface ] Constructor in provider mode */
     QgsRasterLayer( const QString &uri,
-                    const QString &baseName,
-                    const QString &providerKey,
+                    const QString &baseName = QString(),
+                    const QString &providerKey = "gdal",
                     bool loadDefaultStyleFlag = true );
 
     /** \brief The destructor */

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -453,7 +453,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      */
     QgsVectorLayer( const QString& path = QString::null, const QString& baseName = QString::null,
-                    const QString& providerLib = QString::null, bool loadDefaultStyleFlag = true );
+                    const QString& providerLib = "ogr", bool loadDefaultStyleFlag = true );
 
 
     virtual ~QgsVectorLayer();

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -104,38 +104,6 @@ QgsRasterLayer::QgsRasterLayer()
   mValid = false;
 }
 
-QgsRasterLayer::QgsRasterLayer(
-  const QString& path,
-  const QString& baseName,
-  bool loadDefaultStyleFlag )
-    : QgsMapLayer( RasterLayer, baseName, path )
-    , QSTRING_NOT_SET( QStringLiteral( "Not Set" ) )
-    , TRSTRING_NOT_SET( tr( "Not Set" ) )
-    , mDataProvider( nullptr )
-{
-  QgsDebugMsgLevel( "Entered", 4 );
-
-  // TODO, call constructor with provider key
-  init();
-  setDataProvider( QStringLiteral( "gdal" ) );
-  if ( !mValid ) return;
-
-  bool defaultLoadedFlag = false;
-  if ( mValid && loadDefaultStyleFlag )
-  {
-    loadDefaultStyle( defaultLoadedFlag );
-  }
-  if ( !defaultLoadedFlag )
-  {
-    setDefaultContrastEnhancement();
-  }
-  return;
-} // QgsRasterLayer ctor
-
-/**
- * @todo Rename into a general constructor when the old raster interface is retired
- * parameter dummy is just there to distinguish this function signature from the old non-provider one.
- */
 QgsRasterLayer::QgsRasterLayer( const QString & uri,
                                 const QString & baseName,
                                 const QString & providerKey,

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -179,19 +179,9 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      *
      * -
      * */
-    QgsRasterLayer( const QString &path,
-                    const QString &baseName = QString::null,
-                    bool loadDefaultStyleFlag = true );
-
-    //TODO - QGIS 3.0
-    //This constructor is confusing if used with string literals for providerKey,
-    //as the previous constructor will be called with the literal for providerKey
-    //implicitly converted to a bool.
-    //for QGIS 3.0, make either constructor explicit or alter the signatures
-    //! \brief [ data provider interface ] Constructor in provider mode
     QgsRasterLayer( const QString &uri,
-                    const QString &baseName,
-                    const QString &providerKey,
+                    const QString &baseName = QString(),
+                    const QString &providerKey = "gdal",
                     bool loadDefaultStyleFlag = true );
 
     ~QgsRasterLayer();


### PR DESCRIPTION
Avoids confusing overload behavior when constructing QgsRasterLayers from c++ code. This extra constructor was causing character literals to be converted to a boolean loadDefaultStyle flag instead of being used as the provider key. Removing the extra constructor avoids this, and removes some duplicate code.