### PR TITLE
Update and add icons to dialog

### DIFF
--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -43,7 +43,7 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer* rasterLa
 {
   setupUi( this );
   mAddNoDataManuallyToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
-  mLoadTransparentNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionSharingImport.svg" ) ) );
+  mLoadTransparentNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionFileOpen.svg" ) ) );
   mRemoveSelectedNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyRemove.svg" ) ) );
   mRemoveAllNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemove.svg" ) ) );
 

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -42,9 +42,9 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer* rasterLa
     , mResolutionState( OriginalResolution )
 {
   setupUi( this );
-  mAddNoDataManuallyToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
-  mLoadTransparentNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionEditCopy.svg" ) ) );
-  mRemoveSelectedNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
+  mAddNoDataManuallyToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
+  mLoadTransparentNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionSharingImport.svg" ) ) );
+  mRemoveSelectedNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyRemove.svg" ) ) );
   mRemoveAllNoDataToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemove.svg" ) ) );
 
   mNoDataTableWidget->setColumnCount( 2 );

--- a/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
+++ b/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
@@ -58,6 +58,19 @@
           </property>
          </widget>
         </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </widget>
      </item>
@@ -127,7 +140,7 @@
          <item row="0" column="0">
           <widget class="QPushButton" name="mOptionsAddButton">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -150,7 +163,7 @@
          <item row="0" column="1">
           <widget class="QPushButton" name="mOptionsDeleteButton">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -177,6 +190,19 @@
             <string>Help</string>
            </property>
           </widget>
+         </item>
+         <item row="0" column="4">
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>

--- a/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
+++ b/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
@@ -30,6 +30,10 @@
           <property name="text">
            <string>New</string>
           </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+          </property>
          </widget>
         </item>
         <item>
@@ -37,12 +41,20 @@
           <property name="text">
            <string>Remove</string>
           </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QPushButton" name="mProfileResetButton">
           <property name="text">
            <string>Reset</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
           </property>
          </widget>
         </item>
@@ -121,12 +133,16 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>+</string>
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
            </property>
            <property name="iconSize">
             <size>
-             <width>1</width>
-             <height>1</height>
+             <width>16</width>
+             <height>16</height>
             </size>
            </property>
           </widget>
@@ -154,7 +170,11 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>-</string>
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
            </property>
           </widget>
          </item>
@@ -218,6 +238,8 @@
   <tabstop>mOptionsHelpButton</tabstop>
   <tabstop>mOptionsLineEdit</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
+++ b/src/ui/qgsrasterformatsaveoptionswidgetbase.ui
@@ -122,7 +122,7 @@
          </column>
         </widget>
        </item>
-       <item row="0" column="1">
+       <item row="1" column="0">
         <layout class="QGridLayout" name="gridLayout_4">
          <item row="0" column="0">
           <widget class="QPushButton" name="mOptionsAddButton">
@@ -147,20 +147,6 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QPushButton" name="mOptionsValidateButton">
-           <property name="text">
-            <string>Validate</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0" colspan="2">
-          <widget class="QPushButton" name="mOptionsHelpButton">
-           <property name="text">
-            <string>Help</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="1">
           <widget class="QPushButton" name="mOptionsDeleteButton">
            <property name="sizePolicy">
@@ -178,21 +164,19 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
-          <spacer name="verticalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="mOptionsValidateButton">
+           <property name="text">
+            <string>Validate</string>
            </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QPushButton" name="mOptionsHelpButton">
+           <property name="text">
+            <string>Help</string>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+          </widget>
          </item>
         </layout>
        </item>

--- a/src/ui/qgsrasterlayersaveasdialogbase.ui
+++ b/src/ui/qgsrasterlayersaveasdialogbase.ui
@@ -190,7 +190,7 @@ datasets with maximum width and height specified below.</string>
         <x>0</x>
         <y>0</y>
         <width>541</width>
-        <height>583</height>
+        <height>754</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -235,7 +235,6 @@ datasets with maximum width and height specified below.</string>
          <property name="saveCollapsedState" stdset="0">
           <bool>true</bool>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2"/>
         </widget>
        </item>
        <item>
@@ -530,67 +529,23 @@ datasets with maximum width and height specified below.</string>
          <property name="checked">
           <bool>false</bool>
          </property>
-         <property name="collapsed" stdset="0">
+         <property name="collapsed">
           <bool>false</bool>
          </property>
-         <property name="saveCollapsedState" stdset="0">
+         <property name="saveCollapsedState">
           <bool>true</bool>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_7">
           <item>
-           <widget class="QTableWidget" name="mNoDataTableWidget">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <attribute name="horizontalHeaderDefaultSectionSize">
-             <number>140</number>
-            </attribute>
-            <attribute name="horizontalHeaderMinimumSectionSize">
-             <number>100</number>
-            </attribute>
-           </widget>
-          </item>
-          <item>
            <layout class="QGridLayout" name="gridLayout">
-            <item row="1" column="0">
-             <widget class="QToolButton" name="mAddNoDataManuallyToolButton">
-              <property name="toolTip">
-               <string>Add values manually</string>
+            <item row="2" column="1">
+             <widget class="QPushButton" name="mRemoveSelectedNoDataToolButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
-              <property name="text">
-               <string>...</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QToolButton" name="mLoadTransparentNoDataToolButton">
-              <property name="toolTip">
-               <string>Load user defined fully transparent (100%) values </string>
-              </property>
-              <property name="text">
-               <string>...</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionSharingImport.svg</normaloff>:/images/themes/default/mActionSharingImport.svg</iconset>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QToolButton" name="mRemoveSelectedNoDataToolButton">
               <property name="toolTip">
                <string>Remove selected row</string>
               </property>
@@ -598,7 +553,7 @@ datasets with maximum width and height specified below.</string>
                <string notr="true"/>
               </property>
               <property name="text">
-               <string>...</string>
+               <string/>
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
@@ -606,13 +561,81 @@ datasets with maximum width and height specified below.</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
-             <widget class="QToolButton" name="mRemoveAllNoDataToolButton">
+            <item row="2" column="0">
+             <widget class="QPushButton" name="mAddNoDataManuallyToolButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Add values manually</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" colspan="5">
+             <widget class="QTableWidget" name="mNoDataTableWidget">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <attribute name="horizontalHeaderDefaultSectionSize">
+               <number>250</number>
+              </attribute>
+              <attribute name="horizontalHeaderMinimumSectionSize">
+               <number>200</number>
+              </attribute>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QPushButton" name="mLoadTransparentNoDataToolButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Load user defined fully transparent (100%) values </string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QPushButton" name="mRemoveAllNoDataToolButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="toolTip">
                <string>Clear all</string>
               </property>
               <property name="text">
-               <string>...</string>
+               <string/>
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">

--- a/src/ui/qgsrasterlayersaveasdialogbase.ui
+++ b/src/ui/qgsrasterlayersaveasdialogbase.ui
@@ -551,6 +551,12 @@ datasets with maximum width and height specified below.</string>
               <height>0</height>
              </size>
             </property>
+            <attribute name="horizontalHeaderDefaultSectionSize">
+             <number>140</number>
+            </attribute>
+            <attribute name="horizontalHeaderMinimumSectionSize">
+             <number>100</number>
+            </attribute>
            </widget>
           </item>
           <item>
@@ -565,7 +571,7 @@ datasets with maximum width and height specified below.</string>
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionNewAttribute.svg</normaloff>:/images/themes/default/mActionNewAttribute.svg</iconset>
+                <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
               </property>
              </widget>
             </item>
@@ -579,7 +585,7 @@ datasets with maximum width and height specified below.</string>
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+                <normaloff>:/images/themes/default/mActionSharingImport.svg</normaloff>:/images/themes/default/mActionSharingImport.svg</iconset>
               </property>
              </widget>
             </item>
@@ -596,7 +602,7 @@ datasets with maximum width and height specified below.</string>
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionDeleteAttribute.svg</normaloff>:/images/themes/default/mActionDeleteAttribute.svg</iconset>
+                <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
               </property>
              </widget>
             </item>

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -137,6 +137,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="mAddToCanvas">
+         <property name="text">
+          <string>Add saved file to map</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBox" name="mAttributesSelection">
          <property name="title">
           <string>Select fields to export and their export options</string>
@@ -199,16 +209,6 @@
            </widget>
           </item>
          </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="mAddToCanvas">
-         <property name="text">
-          <string>Add saved file to map</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
         </widget>
        </item>
        <item>
@@ -287,7 +287,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsExtentGroupBox" name="mExtentGroupBox"/>
+        <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+         <property name="title">
+          <string>Extent</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QgsCollapsibleGroupBox" name="mDatasourceOptionsGroupBox">
@@ -411,6 +415,19 @@
          <zorder>mOgrLayerOptions</zorder>
         </widget>
        </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -458,7 +475,6 @@
   <tabstop>mSelectedOnly</tabstop>
   <tabstop>mSelectAllAttributes</tabstop>
   <tabstop>mDeselectAllAttributes</tabstop>
-  <tabstop>mAddToCanvas</tabstop>
   <tabstop>mSymbologyExportComboBox</tabstop>
   <tabstop>mScaleSpinBox</tabstop>
   <tabstop>mGeometryGroupBox</tabstop>


### PR DESCRIPTION
Raster Layer --> save as: I think these icons better fit the purposes than the current (before at left, after at right)
![image](https://cloud.githubusercontent.com/assets/7983394/22439821/59cbb452-e731-11e6-9360-4b7da209e23a.png)

Vector layer --> save as: Move the "Add saved file to map" upper and insert a vertical spacer at the bottom  (before at left, after at right)
![image](https://cloud.githubusercontent.com/assets/7983394/22439981/fea6a158-e731-11e6-964b-0c44f5682716.png)
