### PR TITLE
Expose GEOS polygonize operation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -319,7 +319,6 @@ Depends:
  gdal-bin,
  python3-gdal,
  python3-matplotlib,
- python3-shapely,
  libqgis-customwidgets,
  ${misc:Depends}
 XB-Python-Version: ${python:Versions}

--- a/debian/control.in
+++ b/debian/control.in
@@ -348,7 +348,6 @@ Depends:
  gdal-bin,
  python3-gdal,
  python3-matplotlib,
- python3-shapely,
  libqgis-customwidgets,
  ${misc:Depends}
 XB-Python-Version: ${python:Versions}

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -777,6 +777,8 @@ class QgsGeometry
      */
     static QgsGeometry unaryUnion( const QList<QgsGeometry>& geometryList );
 
+    static QgsGeometry polygonize( const QList< QgsGeometry>& lines );
+
     /** Converts the geometry to straight line segments, if it is a curved geometry type.
      * @note added in QGIS 2.10
      * @see requiresConversionToStraightSegments

--- a/python/plugins/processing/algs/qgis/Polygonize.py
+++ b/python/plugins/processing/algs/qgis/Polygonize.py
@@ -51,6 +51,7 @@ class Polygonize(GeoAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Polygonize')
         self.group, self.i18n_group = self.trAlgorithm('Vector geometry tools')
+        self.tags = self.tr('create,lines,polygons,convert')
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterBoolean(self.FIELDS,

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -34,13 +34,6 @@ try:
 except:
     hasMatplotlib = False
 
-try:
-    import shapely
-    assert shapely  # silence pyflakes
-    hasShapely = True
-except:
-    hasShapely = False
-
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (Qgis,
@@ -190,6 +183,7 @@ from .ShortestPathLayerToPoint import ShortestPathLayerToPoint
 from .ServiceAreaFromPoint import ServiceAreaFromPoint
 from .ServiceAreaFromLayer import ServiceAreaFromLayer
 from .TruncateTable import TruncateTable
+from .Polygonize import Polygonize
 
 pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
@@ -258,7 +252,7 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                         RasterCalculator(), Heatmap(), Orthogonalize(),
                         ShortestPathPointToPoint(), ShortestPathPointToLayer(),
                         ShortestPathLayerToPoint(), ServiceAreaFromPoint(),
-                        ServiceAreaFromLayer(), TruncateTable()
+                        ServiceAreaFromLayer(), TruncateTable(), Polygonize()
                         ]
 
         if hasMatplotlib:
@@ -274,10 +268,6 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                 VectorLayerScatterplot(), MeanAndStdDevPlot(), BarPlot(),
                 PolarPlot(),
             ])
-
-        if hasShapely:
-            from .Polygonize import Polygonize
-            self.alglist.extend([Polygonize()])
 
         if Qgis.QGIS_VERSION_INT >= 21300:
             from .ExecuteSQL import ExecuteSQL

--- a/python/plugins/processing/tests/testdata/custom/polygonize_lines.gfs
+++ b/python/plugins/processing/tests/testdata/custom/polygonize_lines.gfs
@@ -1,0 +1,21 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>polygonize_lines</Name>
+    <ElementPath>polygonize_lines</ElementPath>
+    <!--LINESTRING-->
+    <GeometryType>2</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>6</FeatureCount>
+      <ExtentXMin>-0.80000</ExtentXMin>
+      <ExtentXMax>0.80000</ExtentXMax>
+      <ExtentYMin>-0.40000</ExtentYMin>
+      <ExtentYMax>0.80000</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>id</Name>
+      <ElementPath>id</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/custom/polygonize_lines.gml
+++ b/python/plugins/processing/tests/testdata/custom/polygonize_lines.gml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-0.8</gml:X><gml:Y>-0.4</gml:Y></gml:coord>
+      <gml:coord><gml:X>0.8</gml:X><gml:Y>0.8</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                      
+  <gml:featureMember>
+    <ogr:polygonize_lines fid="polygonize_lines.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-0.6,-0.4 -0.6,0.6 0.6,0.6</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+    </ogr:polygonize_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygonize_lines fid="polygonize_lines.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-0.0,0.8 0,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+    </ogr:polygonize_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygonize_lines fid="polygonize_lines.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>0.2,0.4 -0.8,0.4</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+    </ogr:polygonize_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygonize_lines fid="polygonize_lines.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-0.8,0.2 0.6,0.2 -0.8,-0.4</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+    </ogr:polygonize_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygonize_lines fid="polygonize_lines.4">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>0.8,0.6 0.8,0.0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+    </ogr:polygonize_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygonize_lines fid="polygonize_lines.5">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>0.8,0.6 0.8,0.0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+    </ogr:polygonize_lines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/polygonize.gfs
+++ b/python/plugins/processing/tests/testdata/expected/polygonize.gfs
@@ -1,0 +1,26 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>polygonize</Name>
+    <ElementPath>polygonize</ElementPath>
+    <!--POLYGON-->
+    <GeometryType>3</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>3</FeatureCount>
+      <ExtentXMin>-0.60000</ExtentXMin>
+      <ExtentXMax>0.60000</ExtentXMax>
+      <ExtentYMin>-0.31429</ExtentYMin>
+      <ExtentYMax>0.60000</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>area</Name>
+      <ElementPath>area</ElementPath>
+      <Type>Real</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>perimeter</Name>
+      <ElementPath>perimeter</ElementPath>
+      <Type>Real</Type>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/polygonize.gml
+++ b/python/plugins/processing/tests/testdata/expected/polygonize.gml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-0.6</gml:X><gml:Y>-0.3142857142857143</gml:Y></gml:coord>
+      <gml:coord><gml:X>0.6</gml:X><gml:Y>0.6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                       
+  <gml:featureMember>
+    <ogr:polygonize fid="polygonize.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-0.6,0.2 0.0,0.2 0.6,0.2 -0.6,-0.314285714285714 -0.6,0.2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:area>0.31</ogr:area>
+      <ogr:perimeter>3.02</ogr:perimeter>
+    </ogr:polygonize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygonize fid="polygonize.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>0.0,0.2 -0.6,0.2 -0.6,0.4 0.0,0.4 0.0,0.2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:area>0.12</ogr:area>
+      <ogr:perimeter>1.60</ogr:perimeter>
+    </ogr:polygonize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygonize fid="polygonize.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-0.6,0.4 -0.6,0.6 0.0,0.6 0.0,0.4 -0.6,0.4</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:area>0.12</ogr:area>
+      <ogr:perimeter>1.60</ogr:perimeter>
+    </ogr:polygonize>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -2299,3 +2299,16 @@ tests:
       OUTPUT_LAYER:
         name: expected/zonal_statistics.gml
         type: vector
+
+  - algorithm: qgis:polygonize
+    name: Polygonize
+    params:
+      FIELDS: false
+      GEOMETRY: true
+      INPUT:
+        name: custom/polygonize_lines.gml
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/polygonize.gml
+        type: vector

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1940,7 +1940,25 @@ bool QgsGeometry::isGeosEqual( const QgsGeometry& g ) const
   return geos.isEqual( *( g.d->geometry ) );
 }
 
-QgsGeometry QgsGeometry::unaryUnion( const QList<QgsGeometry>& geometryList )
+QgsGeometry QgsGeometry::unaryUnion( const QList<QgsGeometry>& geometries )
+{
+  QgsGeos geos( nullptr );
+
+  QList<QgsAbstractGeometry*> geomV2List;
+  QList<QgsGeometry>::const_iterator it = geometries.constBegin();
+  for ( ; it != geometries.constEnd(); ++it )
+  {
+    if ( !(( *it ).isNull() ) )
+    {
+      geomV2List.append(( *it ).geometry() );
+    }
+  }
+
+  QgsAbstractGeometry* geom = geos.combine( geomV2List );
+  return QgsGeometry( geom );
+}
+
+QgsGeometry QgsGeometry::polygonize( const QList<QgsGeometry>& geometryList )
 {
   QgsGeos geos( nullptr );
 
@@ -1954,8 +1972,7 @@ QgsGeometry QgsGeometry::unaryUnion( const QList<QgsGeometry>& geometryList )
     }
   }
 
-  QgsAbstractGeometry* geom = geos.combine( geomV2List );
-  return QgsGeometry( geom );
+  return geos.polygonize( geomV2List );
 }
 
 void QgsGeometry::convertToStraightSegment()

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -843,11 +843,21 @@ class CORE_EXPORT QgsGeometry
      **/
     void validateGeometry( QList<Error> &errors );
 
-    /** Compute the unary union on a list of geometries. May be faster than an iterative union on a set of geometries.
-     * @param geometryList a list of QgsGeometry as input
-     * @returns the new computed QgsGeometry, or an empty QgsGeometry
+    /** Compute the unary union on a list of \a geometries. May be faster than an iterative union on a set of geometries.
+     * The returned geometry will be fully noded, i.e. a node will be created at every common intersection of the
+     * input geometries. An empty geometry will be returned in the case of errors.
      */
-    static QgsGeometry unaryUnion( const QList<QgsGeometry>& geometryList );
+    static QgsGeometry unaryUnion( const QList<QgsGeometry>& geometries );
+
+    /**
+     * Creates a GeometryCollection geometry containing possible polygons formed from the constituent
+     * linework of a set of \a geometries. The input geometries must be fully noded (i.e. nodes exist
+     * at every common intersection of the geometries). The easiest way to ensure this is to first
+     * call unaryUnion() on the set of input geometries and then pass the result to polygonize().
+     * An empty geometry will be returned in the case of errors.
+     * @note added in QGIS 3.0
+     */
+    static QgsGeometry polygonize( const QList< QgsGeometry>& geometries );
 
     /** Converts the geometry to straight line segments, if it is a curved geometry type.
      * @note added in QGIS 2.10

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -141,6 +141,15 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      */
     double lineLocatePoint( const QgsPointV2& point, QString* errorMsg = nullptr ) const;
 
+    /**
+     * Creates a GeometryCollection geometry containing possible polygons formed from the constituent
+     * linework of a set of \a geometries. The input geometries must be fully noded (i.e. nodes exist
+     * at every common intersection of the geometries). The easiest way to ensure this is to first
+     * unary union these geometries by calling combine() on the set of input geometries and then
+     * pass the result to polygonize().
+     * An empty geometry will be returned in the case of errors.
+     * @note added in QGIS 3.0
+     */
     static QgsGeometry polygonize( const QList<QgsAbstractGeometry*>& geometries, QString* errorMsg = nullptr );
 
     /** Create a geometry from a GEOSGeometry

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -141,6 +141,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      */
     double lineLocatePoint( const QgsPointV2& point, QString* errorMsg = nullptr ) const;
 
+    static QgsGeometry polygonize( const QList<QgsAbstractGeometry*>& geometries, QString* errorMsg = nullptr );
+
     /** Create a geometry from a GEOSGeometry
      * @param geos GEOSGeometry. Ownership is NOT transferred.
      */

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -3724,6 +3724,37 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertTrue(compareWkt(result, exp, 0.00001),
                         "orthogonalize: mismatch Expected:\n{}\nGot:\n{}\n".format(exp, result))
 
+    def testPolygonize(self):
+        o = QgsGeometry.polygonize([])
+        self.assertFalse(o)
+        empty = QgsGeometry()
+        o = QgsGeometry.polygonize([empty])
+        self.assertFalse(o)
+        line = QgsGeometry.fromWkt('LineString()')
+        o = QgsGeometry.polygonize([line])
+        self.assertFalse(o)
+
+        l1 = QgsGeometry.fromWkt("LINESTRING (100 180, 20 20, 160 20, 100 180)")
+        l2 = QgsGeometry.fromWkt("LINESTRING (100 180, 80 60, 120 60, 100 180)")
+        o = QgsGeometry.polygonize([l1, l2])
+        exp = "GeometryCollection(POLYGON ((100 180, 160 20, 20 20, 100 180), (100 180, 80 60, 120 60, 100 180)),POLYGON ((100 180, 120 60, 80 60, 100 180)))"
+        result = o.exportToWkt()
+        self.assertTrue(compareWkt(result, exp, 0.00001),
+                        "polygonize: mismatch Expected:\n{}\nGot:\n{}\n".format(exp, result))
+
+        lines = [QgsGeometry.fromWkt('LineString(0 0, 1 1)'),
+                 QgsGeometry.fromWkt('LineString(0 0, 0 1)'),
+                 QgsGeometry.fromWkt('LineString(0 1, 1 1)'),
+                 QgsGeometry.fromWkt('LineString(1 1, 1 0)'),
+                 QgsGeometry.fromWkt('LineString(1 0, 0 0)'),
+                 QgsGeometry.fromWkt('LineString(5 5, 6 6)'),
+                 QgsGeometry.fromWkt('Point(0, 0)')]
+        o = QgsGeometry.polygonize(lines)
+        exp = "GeometryCollection (Polygon ((0 0, 1 1, 1 0, 0 0)),Polygon ((1 1, 0 0, 0 1, 1 1)))"
+        result = o.exportToWkt()
+        self.assertTrue(compareWkt(result, exp, 0.00001),
+                        "polygonize: mismatch Expected:\n{}\nGot:\n{}\n".format(exp, result))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Exposes the GEOS polygonize operation to QgsGeometry. Also ports the processing polygonize algorithm from shapely to native QgsGeometry classes for efficiency (instead of  conversion from qgsgeometry -> python array -> shapely geometry -> geos -> shapely geometry -> wkt -> qgsgeometry we are just doing qgsgeometry -> geos -> qgsgeometry) and to avoid the need for another external dependency.