### PR TITLE
fix otf state when loading project through menu shortcuts

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5302,11 +5302,6 @@ void QgisApp::openProject( QAction *action )
   QString debugme = action->data().toString();
   if ( saveDirty() )
     addProject( debugme );
-
-  //set the projections enabled icon in the status bar
-  int myProjectionEnabledFlag =
-    QgsProject::instance()->readNumEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectionsEnabled" ), 0 );
-  mMapCanvas->setCrsTransformEnabled( myProjectionEnabledFlag );
 }
 
 void QgisApp::runScript( const QString &filePath )


### PR DESCRIPTION
When opening a QGIS project via the "Open Recent > ..." menu shortcut *during* an ongoing session, projection information (CRS and OTF state) can fail to load properly.  It's an odd one, and I can't come up with a reduced, shareable test project. 

This PR fixes the problem by removing a few lines of code in the openProject( QAction ) function. Those lines aren't needed to load the CRS & OTF state (for e.g., see the fileOpen() function).

@nyalldawson , @wonder-sk , I do not know why the removed lines were causing a problem. But I've been testing this for 24 hours and all is good (and improved).