### PR TITLE
FindQGIS.cmake updates

### DIFF
--- a/cmake/FindQGIS.cmake
+++ b/cmake/FindQGIS.cmake
@@ -15,6 +15,7 @@
 ##                               (^ use forward slashes!)
 ## OSGEO4W_QGIS_SUBDIR   = qgis[-rel|-ltr][-dev], in OSGEO4W_ROOT/apps/
 ## QGIS_MAC_PATH         = /path/to/any/QGIS.app/Contents
+## QGIS_BUILD_PATH       = [A-Z:]/path/to/QGIS/build/directory
 ##
 ## Tim Sutton
 ## Larry Shaffer (2017-01-31)
@@ -104,6 +105,7 @@ ELSE(WIN32)
     FIND_PATH(QGIS_PLUGIN_DIR
       NAMES libspatialqueryplugin.so
       PATHS
+        ${QGIS_BUILD_PATH}/PlugIns/qgis
         ${QGIS_MAC_PATH}/PlugIns/qgis
         ${QGIS_PREFIX_PATH}/lib/qgis/plugins/
         /usr/lib64/qgis/plugins
@@ -116,6 +118,7 @@ ELSE(WIN32)
     FIND_PATH(QGIS_INCLUDE_DIR
       NAMES qgis.h
       PATHS
+        ${QGIS_BUILD_PATH}/output/lib/qgis_core.framework/Headers
         ${QGIS_MAC_PATH}/Frameworks/qgis_core.framework/Headers
         {QGIS_PREFIX_PATH}/include/qgis
         /usr/include/qgis
@@ -126,6 +129,7 @@ ELSE(WIN32)
     FIND_PATH(QGIS_UI_INCLUDE_DIR
       NAMES ui_qgscredentialdialog.h
       PATHS
+        ${QGIS_BUILD_PATH}/src/ui
         ${QGIS_MAC_PATH}/Frameworks/qgis_gui.framework/Headers
         {QGIS_PREFIX_PATH}/include/qgis
         /usr/include/qgis
@@ -138,6 +142,7 @@ ELSE(WIN32)
       FIND_PATH(QGIS_GUI_INCLUDE_DIR
         NAMES qgisgui.h
         PATHS
+          ${QGIS_BUILD_PATH}/output/lib
           ${QGIS_MAC_PATH}/Frameworks
           /Library/Frameworks
           PATH_SUFFIXES qgis_gui.framework/Headers
@@ -145,6 +150,7 @@ ELSE(WIN32)
       FIND_PATH(QGIS_ANALYSIS_INCLUDE_DIR
         NAMES qgsinterpolator.h
         PATHS
+          ${QGIS_BUILD_PATH}/output/lib
           ${QGIS_MAC_PATH}/Frameworks
           /Library/Frameworks
           PATH_SUFFIXES qgis_analysis.framework/Headers
@@ -160,6 +166,7 @@ ELSE(WIN32)
     FIND_LIBRARY(QGIS_CORE_LIBRARY
       NAMES qgis_core
       PATHS
+        ${QGIS_BUILD_PATH}/output/lib
         ${QGIS_MAC_PATH}/Frameworks
         ${QGIS_MAC_PATH}/lib
         ${QGIS_PREFIX_PATH}/lib/
@@ -172,6 +179,7 @@ ELSE(WIN32)
     FIND_LIBRARY(QGIS_GUI_LIBRARY
       NAMES qgis_gui
       PATHS
+        ${QGIS_BUILD_PATH}/output/lib
         ${QGIS_MAC_PATH}/Frameworks
         ${QGIS_MAC_PATH}/lib
         ${QGIS_PREFIX_PATH}/lib/
@@ -184,6 +192,7 @@ ELSE(WIN32)
     FIND_LIBRARY(QGIS_ANALYSIS_LIBRARY
       NAMES qgis_analysis
       PATHS
+        ${QGIS_BUILD_PATH}/output/lib
         ${QGIS_MAC_PATH}/Frameworks
         ${QGIS_MAC_PATH}/lib
         ${QGIS_PREFIX_PATH}/lib/

--- a/cmake/FindQGIS.cmake
+++ b/cmake/FindQGIS.cmake
@@ -12,6 +12,15 @@
 
 #MESSAGE("Searching for QGIS")
 IF(WIN32)
+  # OSGEO4W_QGIS_SUBDIR relative install: qgis[-rel|-ltr][-dev], etc.
+  IF (NOT OSGEO4W_QGIS_SUBDIR OR "${OSGEO4W_QGIS_SUBDIR}" STREQUAL "")
+    IF (NOT "$ENV{OSGEO4W_QGIS_SUBDIR}" STREQUAL "")
+      SET (OSGEO4W_QGIS_SUBDIR $ENV{OSGEO4W_QGIS_SUBDIR})
+    ELSE ()
+      SET (OSGEO4W_QGIS_SUBDIR qgis)
+    ENDIF ()
+  ENDIF ()
+
   #MESSAGE("Searching for QGIS in $ENV{PROGRAMFILES}/QGIS")
   IF (MINGW)
     FIND_PATH(QGIS_PLUGIN_DIR
@@ -40,7 +49,7 @@ IF(WIN32)
     FIND_PATH(QGIS_PLUGIN_DIR
       NAMES spatialqueryplugin.dll
       PATHS
-        "$ENV{OSGEO4W_ROOT}/apps/qgis/plugins"
+        "$ENV{OSGEO4W_ROOT}/apps/${OSGEO4W_QGIS_SUBDIR}/plugins"
         "$ENV{PROGRAMFILES}/QGIS/plugins"
     )
     FIND_PATH(QGIS_INCLUDE_DIR
@@ -49,6 +58,7 @@ IF(WIN32)
         "$ENV{INCLUDE}"
         "$ENV{LIB_DIR}/include/qgis"
         "$ENV{OSGEO4W_ROOT}/include"
+        "$ENV{OSGEO4W_ROOT}/apps/${OSGEO4W_QGIS_SUBDIR}/include"
         "$ENV{PROGRAMFILES}/QGIS/include"
     )
     FIND_LIBRARY(QGIS_CORE_LIBRARY
@@ -57,6 +67,7 @@ IF(WIN32)
         "$ENV{LIB_DIR}/lib/"
         "$ENV{LIB}"
         "$ENV{OSGEO4W_ROOT}/lib"
+        "$ENV{OSGEO4W_ROOT}/apps/${OSGEO4W_QGIS_SUBDIR}/lib"
         "$ENV{PROGRAMFILES}/QGIS/lib"
     )
     FIND_LIBRARY(QGIS_GUI_LIBRARY
@@ -65,6 +76,7 @@ IF(WIN32)
         "$ENV{LIB_DIR}"
         "$ENV{LIB}"
         "$ENV{OSGEO4W_ROOT}/lib"
+        "$ENV{OSGEO4W_ROOT}/apps/${OSGEO4W_QGIS_SUBDIR}/lib"
         "$ENV{PROGRAMFILES}/QGIS/lib"
     )
     FIND_LIBRARY(QGIS_ANALYSIS_LIBRARY
@@ -73,6 +85,7 @@ IF(WIN32)
         "$ENV{LIB_DIR}"
         "$ENV{LIB}"
         "$ENV{OSGEO4W_ROOT}/lib"
+        "$ENV{OSGEO4W_ROOT}/apps/${OSGEO4W_QGIS_SUBDIR}/lib"
         "$ENV{PROGRAMFILES}/QGIS/lib"
     )
   ENDIF (MSVC)

--- a/cmake/FindQGIS.cmake
+++ b/cmake/FindQGIS.cmake
@@ -9,6 +9,10 @@
 ## QGIS_INCLUDE_DIR      = where to find headers
 ## QGIS_UI_INCLUDE_DIR   = where to find ui_* generated headers
 ##
+## Definitions or ENV variables affecting search locations
+##
+## QGIS_MAC_PATH         = /path/to/any/QGIS.app/Contents
+##
 ## Tim Sutton
 ## Larry Shaffer (2017-01-31)
 
@@ -93,34 +97,33 @@ IF(WIN32)
   ENDIF (MSVC)
 ELSE(WIN32)
   IF(UNIX)
-    # try to use bundle on mac
-    SET (QGIS_MAC_PATH /Applications/QGIS.app/Contents)
     #MESSAGE("Searching for QGIS in /usr/bin; /usr/local/bin")
     FIND_PATH(QGIS_PLUGIN_DIR
       NAMES libspatialqueryplugin.so
       PATHS
+        ${QGIS_MAC_PATH}/PlugIns/qgis
         ${QGIS_PREFIX_PATH}/lib/qgis/plugins/
         /usr/lib64/qgis/plugins
         /usr/lib/qgis
         /usr/lib/qgis/plugins
         /usr/local/lib/qgis/plugins
-        ${QGIS_MAC_PATH}/PlugIns/qgis
         "$ENV{LIB_DIR}/lib/qgis/plugins"
         "$ENV{LIB_DIR}/lib/qgis"
     )
     FIND_PATH(QGIS_INCLUDE_DIR
       NAMES qgis.h
       PATHS
+        ${QGIS_MAC_PATH}/Frameworks/qgis_core.framework/Headers
         {QGIS_PREFIX_PATH}/include/qgis
         /usr/include/qgis
         /usr/local/include/qgis
         /Library/Frameworks/qgis_core.framework/Headers
-        ${QGIS_MAC_PATH}/Frameworks/qgis_core.framework/Headers
         "$ENV{LIB_DIR}/include/qgis"
     )
     FIND_PATH(QGIS_UI_INCLUDE_DIR
       NAMES ui_qgscredentialdialog.h
       PATHS
+        ${QGIS_MAC_PATH}/Frameworks/qgis_gui.framework/Headers
         {QGIS_PREFIX_PATH}/include/qgis
         /usr/include/qgis
         /usr/local/include/qgis
@@ -132,14 +135,16 @@ ELSE(WIN32)
       FIND_PATH(QGIS_GUI_INCLUDE_DIR
         NAMES qgisgui.h
         PATHS
-          /Library/Frameworks/qgis_core.framework/Headers
-          ${QGIS_MAC_PATH}/Frameworks/qgis_gui.framework/Headers
+          ${QGIS_MAC_PATH}/Frameworks
+          /Library/Frameworks
+          PATH_SUFFIXES qgis_gui.framework/Headers
       )
       FIND_PATH(QGIS_ANALYSIS_INCLUDE_DIR
         NAMES qgsinterpolator.h
         PATHS
-          /Library/Frameworks/qgis_analysis.framework/Headers
-          ${QGIS_MAC_PATH}/Frameworks/qgis_analysis.framework/Headers
+          ${QGIS_MAC_PATH}/Frameworks
+          /Library/Frameworks
+          PATH_SUFFIXES qgis_analysis.framework/Headers
       )
       SET(QGIS_INCLUDE_DIR
         ${QGIS_INCLUDE_DIR}
@@ -152,34 +157,37 @@ ELSE(WIN32)
     FIND_LIBRARY(QGIS_CORE_LIBRARY
       NAMES qgis_core
       PATHS
+        ${QGIS_MAC_PATH}/Frameworks
+        ${QGIS_MAC_PATH}/lib
         ${QGIS_PREFIX_PATH}/lib/
         /usr/lib64
         /usr/lib
         /usr/local/lib
         /Library/Frameworks
-        ${QGIS_MAC_PATH}/Frameworks
         "$ENV{LIB_DIR}/lib/"
     )
     FIND_LIBRARY(QGIS_GUI_LIBRARY
       NAMES qgis_gui
       PATHS
+        ${QGIS_MAC_PATH}/Frameworks
+        ${QGIS_MAC_PATH}/lib
         ${QGIS_PREFIX_PATH}/lib/
         /usr/lib64
         /usr/lib
         /usr/local/lib
         /Library/Frameworks
-        ${QGIS_MAC_PATH}/Frameworks
         "$ENV{LIB_DIR}/lib/"
     )
     FIND_LIBRARY(QGIS_ANALYSIS_LIBRARY
       NAMES qgis_analysis
       PATHS
+        ${QGIS_MAC_PATH}/Frameworks
+        ${QGIS_MAC_PATH}/lib
         ${QGIS_PREFIX_PATH}/lib/
         /usr/lib64
         /usr/lib
         /usr/local/lib
         /Library/Frameworks
-        ${QGIS_MAC_PATH}/Frameworks
         "$ENV{LIB_DIR}/lib/"
     )
   ENDIF(UNIX)

--- a/cmake/FindQGIS.cmake
+++ b/cmake/FindQGIS.cmake
@@ -11,6 +11,9 @@
 ##
 ## Definitions or ENV variables affecting search locations
 ##
+## OSGEO4W_ROOT          = [A-Z]:/path/to/OSGeo4W/install/root
+##                               (^ use forward slashes!)
+## OSGEO4W_QGIS_SUBDIR   = qgis[-rel|-ltr][-dev], in OSGEO4W_ROOT/apps/
 ## QGIS_MAC_PATH         = /path/to/any/QGIS.app/Contents
 ##
 ## Tim Sutton

--- a/cmake/FindQGIS.cmake
+++ b/cmake/FindQGIS.cmake
@@ -7,8 +7,10 @@
 ## QGIS_ANALYSIS_LIBRARY = full path to the ANALYSIS library
 ## QGIS_PLUGIN_DIR       = full path to where QGIS plugins are installed
 ## QGIS_INCLUDE_DIR      = where to find headers
+## QGIS_UI_INCLUDE_DIR   = where to find ui_* generated headers
 ##
 ## Tim Sutton
+## Larry Shaffer (2017-01-31)
 
 #MESSAGE("Searching for QGIS")
 IF(WIN32)
@@ -100,6 +102,7 @@ ELSE(WIN32)
         ${QGIS_PREFIX_PATH}/lib/qgis/plugins/
         /usr/lib64/qgis/plugins
         /usr/lib/qgis
+        /usr/lib/qgis/plugins
         /usr/local/lib/qgis/plugins
         ${QGIS_MAC_PATH}/PlugIns/qgis
         "$ENV{LIB_DIR}/lib/qgis/plugins"
@@ -113,6 +116,15 @@ ELSE(WIN32)
         /usr/local/include/qgis
         /Library/Frameworks/qgis_core.framework/Headers
         ${QGIS_MAC_PATH}/Frameworks/qgis_core.framework/Headers
+        "$ENV{LIB_DIR}/include/qgis"
+    )
+    FIND_PATH(QGIS_UI_INCLUDE_DIR
+      NAMES ui_qgscredentialdialog.h
+      PATHS
+        {QGIS_PREFIX_PATH}/include/qgis
+        /usr/include/qgis
+        /usr/local/include/qgis
+        /Library/Frameworks/qgis_gui.framework/Headers
         "$ENV{LIB_DIR}/include/qgis"
     )
     # also get other frameworks' headers folders on OS X
@@ -133,8 +145,10 @@ ELSE(WIN32)
         ${QGIS_INCLUDE_DIR}
         ${QGIS_GUI_INCLUDE_DIR}
         ${QGIS_ANALYSIS_INCLUDE_DIR}
+        ${QGIS_UI_INCLUDE_DIR}
       )
     ENDIF (APPLE)
+
     FIND_LIBRARY(QGIS_CORE_LIBRARY
       NAMES qgis_core
       PATHS


### PR DESCRIPTION
Various updates to `FindQGIS.cmake` module:

* Support for OSGeo4W subdirectories `qgis[-rel|-ltr][-dev]`, in `OSGEO4W_ROOT/apps/`
* Support for any macOS QGIS.app bundle, located anywhere on disk
* Add QGIS_UI_INCLUDE_DIR output variable for location of `ui_*` headers
* Preliminary (macOS-only) support for finding QGIS in its build directory
* Document some variables

**Discussion points**

* Could place all macOS searches in a totally separate APPLE section, instead of mixed with UNIX
* Missing Win and Linux support for QGIS_BUILD_PATH can be added, though I think this will require an additional variable for QGIS_SRC_PATH to find the headers.

These fixes came about after considerable work to get out-of-source builds for authentication method C++ plugins.