### PR TITLE
Make protected members in QgsMapRendererJob not part of public API

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1339,6 +1339,8 @@ be returned instead of a null pointer if no transformation is required.
 QgsMapRendererJob        {#qgis_api_break_3_0_QgsMapRendererJob}
 -----------------
 
+- All protected members are now considered private, and are no longer exposed to the Python bindings. QgsMapRendererJob
+and subclasses are not designed to be subclassed in PyQGIS.
 - reprojectToLayerExtent() now takes a QgsCoordinateTransform reference, not a pointer. An invalid QgsCoordinateTransform should
 be used instead of a null pointer if no transformation is required.
 - prepareJobs() and drawLabeling() (neither available in PyQGIS) do not take QgsPalLabeling parameter anymore. All drawing of labels is done by QgsLabelingEngine.

--- a/python/core/qgsmaprenderercustompainterjob.sip
+++ b/python/core/qgsmaprenderercustompainterjob.sip
@@ -51,12 +51,4 @@ class QgsMapRendererCustomPainterJob : QgsMapRendererJob
      */
     void renderSynchronously();
 
-  protected slots:
-    void futureFinished();
-
-  protected:
-    static void staticRender( QgsMapRendererCustomPainterJob* self ); // function to be used within the thread
-
-    // these methods are called within worker thread
-    void doRender();
 };

--- a/python/core/qgsmaprendererjob.sip
+++ b/python/core/qgsmaprendererjob.sip
@@ -1,41 +1,3 @@
-
-struct LayerRenderJob
-{
-  QgsRenderContext context;
-  QImage* img; // may be null if it is not necessary to draw to separate image (e.g. sequential rendering)
-  QgsMapLayerRenderer* renderer; // must be deleted
-  QPainter::CompositionMode blendMode;
-  bool cached; // if true, img already contains cached image from previous rendering
-  QString layerId;
-};
-
-typedef QList<LayerRenderJob> LayerRenderJobs;
-
-
-/**
- * Abstract base class for map rendering implementations.
- *
- * The API is designed in a way that rendering is done asynchronously, therefore
- * the caller is not blocked while the rendering is in progress. Non-blocking
- * operation is quite important because the rendering can take considerable
- * amount of time.
- *
- * Common use case:
- * 0. prepare QgsMapSettings with rendering configuration (extent, layer, map size, ...)
- * 1. create QgsMapRendererJob subclass with QgsMapSettings instance
- * 2. connect to job's finished() signal
- * 3. call start(). Map rendering will start in background, the function immediately returns
- * 4. at some point, slot connected to finished() signal is called, map rendering is done
- *
- * It is possible to cancel the rendering job while it is active by calling cancel() function.
- *
- * The following subclasses are available:
- * - QgsMapRendererSequentialJob - renders map in one background thread to an image
- * - QgsMapRendererParallelJob - renders map in multiple background threads to an image
- * - QgsMapRendererCustomPainterJob - renders map with given QPainter in one background thread
- *
- * @note added in 2.4
- */
 class QgsMapRendererJob : QObject
 {
 %TypeHeaderCode
@@ -122,31 +84,6 @@ class QgsMapRendererJob : QObject
     //! emitted when asynchronous rendering is finished (or canceled).
     void finished();
 
-  protected:
-
-    /** Convenience function to project an extent into the layer source
-     * CRS, but also split it into two extents if it crosses
-     * the +/- 180 degree line. Modifies the given extent to be in the
-     * source CRS coordinates, and if it was split, returns true, and
-     * also sets the contents of the r2 parameter
-     */
-    static bool reprojectToLayerExtent( const QgsMapLayer *ml, const QgsCoordinateTransform& ct, QgsRectangle &extent, QgsRectangle &r2 );
-
-    //! @note not available in python bindings
-    // LayerRenderJobs prepareJobs( QPainter* painter, QgsLabelingEngine* labelingEngine2 );
-
-    //! @note not available in python bindings
-    // void cleanupJobs( LayerRenderJobs& jobs );
-
-    static QImage composeImage( const QgsMapSettings& settings, const LayerRenderJobs& jobs );
-
-    bool needTemporaryImage( QgsMapLayer* ml );
-
-    //! @note not available in Python bindings
-    // static void drawLabeling( const QgsMapSettings& settings, QgsRenderContext& renderContext, QgsLabelingEngine* labelingEngine2, QPainter* painter );
-
-    //! called when rendering has finished to update all layers' geometry caches
-    void updateLayerGeometryCaches();
 };
 
 

--- a/python/core/qgsmaprendererparalleljob.sip
+++ b/python/core/qgsmaprendererparalleljob.sip
@@ -26,14 +26,4 @@ class QgsMapRendererParallelJob : QgsMapRendererQImageJob
     // from QgsMapRendererJobWithPreview
     virtual QImage renderedImage();
 
-  protected slots:
-    //! layers are rendered, labeling is still pending
-    void renderLayersFinished();
-    //! all rendering is finished, including labeling
-    void renderingFinished();
-
-  protected:
-
-    static void renderLayerStatic( LayerRenderJob& job );
-    static void renderLabelsStatic( QgsMapRendererParallelJob* self );
 };

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -24,7 +24,6 @@
 #include "qgsvectorlayer.h"
 #include "qgsrenderer.h"
 
-
 QgsMapRendererCustomPainterJob::QgsMapRendererCustomPainterJob( const QgsMapSettings& settings, QPainter* painter )
     : QgsMapRendererJob( settings )
     , mPainter( painter )

--- a/src/core/qgsmaprenderercustompainterjob.h
+++ b/src/core/qgsmaprenderercustompainterjob.h
@@ -71,16 +71,15 @@ class CORE_EXPORT QgsMapRendererCustomPainterJob : public QgsMapRendererJob
      */
     void renderSynchronously();
 
-  protected slots:
+  private slots:
     void futureFinished();
 
-  protected:
+  private:
     static void staticRender( QgsMapRendererCustomPainterJob* self ); // function to be used within the thread
 
     // these methods are called within worker thread
     void doRender();
 
-  private:
     QPainter* mPainter;
     QFuture<void> mFuture;
     QFutureWatcher<void> mFutureWatcher;
@@ -90,6 +89,7 @@ class CORE_EXPORT QgsMapRendererCustomPainterJob : public QgsMapRendererJob
     bool mActive;
     LayerRenderJobs mLayerJobs;
     bool mRenderSynchronously;
+
 };
 
 

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -34,6 +34,8 @@
 #include "qgsvectorlayer.h"
 #include "qgscsexception.h"
 
+///@cond PRIVATE
+
 QgsMapRendererJob::QgsMapRendererJob( const QgsMapSettings& settings )
     : mSettings( settings )
     , mCache( nullptr )
@@ -388,3 +390,5 @@ void QgsMapRendererJob::logRenderingTime( const LayerRenderJobs& jobs )
   }
   QgsMessageLog::logMessage( QStringLiteral( "---" ), tr( "Rendering" ) );
 }
+
+///@endcond PRIVATE

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -37,10 +37,10 @@ class QgsMapRendererCache;
 class QgsPalLabeling;
 class QgsFeatureFilterProvider;
 
+/// @cond PRIVATE
 
 /** \ingroup core
  * Structure keeping low-level rendering job information.
- * @note not part of public API!
  */
 struct LayerRenderJob
 {
@@ -56,6 +56,7 @@ struct LayerRenderJob
 
 typedef QList<LayerRenderJob> LayerRenderJobs;
 
+///@endcond PRIVATE
 
 /** \ingroup core
  * Abstract base class for map rendering implementations.
@@ -168,6 +169,31 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
 
   protected:
 
+    QgsMapSettings mSettings;
+    QTime mRenderingStart;
+    Errors mErrors;
+
+    QgsMapRendererCache* mCache = nullptr;
+
+    int mRenderingTime = 0;
+
+    //! @note not available in python bindings
+    LayerRenderJobs prepareJobs( QPainter* painter, QgsLabelingEngine* labelingEngine2 );
+
+    //! @note not available in python bindings
+    static QImage composeImage( const QgsMapSettings& settings, const LayerRenderJobs& jobs );
+
+    //! @note not available in python bindings
+    void logRenderingTime( const LayerRenderJobs& jobs );
+
+    //! @note not available in python bindings
+    void cleanupJobs( LayerRenderJobs& jobs );
+
+    //! @note not available in Python bindings
+    static void drawLabeling( const QgsMapSettings& settings, QgsRenderContext& renderContext, QgsLabelingEngine* labelingEngine2, QPainter* painter );
+
+  private:
+
     /** Convenience function to project an extent into the layer source
      * CRS, but also split it into two extents if it crosses
      * the +/- 180 degree line. Modifies the given extent to be in the
@@ -176,38 +202,17 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
      */
     static bool reprojectToLayerExtent( const QgsMapLayer *ml, const QgsCoordinateTransform &ct, QgsRectangle &extent, QgsRectangle &r2 );
 
-    //! @note not available in python bindings
-    LayerRenderJobs prepareJobs( QPainter* painter, QgsLabelingEngine* labelingEngine2 );
-
-    //! @note not available in python bindings
-    void cleanupJobs( LayerRenderJobs& jobs );
-
-    //! @note not available in python bindings
-    void logRenderingTime( const LayerRenderJobs& jobs );
-
-    static QImage composeImage( const QgsMapSettings& settings, const LayerRenderJobs& jobs );
-
     bool needTemporaryImage( QgsMapLayer* ml );
-
-    //! @note not available in Python bindings
-    static void drawLabeling( const QgsMapSettings& settings, QgsRenderContext& renderContext, QgsLabelingEngine* labelingEngine2, QPainter* painter );
 
     //! called when rendering has finished to update all layers' geometry caches
     void updateLayerGeometryCaches();
-    QgsMapSettings mSettings;
-    Errors mErrors;
-
-    QgsMapRendererCache* mCache;
 
     //! list of layer IDs for which the geometry cache should be updated
     QStringList mRequestedGeomCacheForLayers;
     //! map of geometry caches
     QMap<QString, QgsGeometryCache> mGeometryCaches;
 
-    QTime mRenderingStart;
-    int mRenderingTime;
-
-    const QgsFeatureFilterProvider *mFeatureFilterProvider;
+    const QgsFeatureFilterProvider *mFeatureFilterProvider = nullptr;
 };
 
 

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -24,7 +24,6 @@
 
 #include <QtConcurrentMap>
 
-
 QgsMapRendererParallelJob::QgsMapRendererParallelJob( const QgsMapSettings& settings )
     : QgsMapRendererQImageJob( settings )
     , mStatus( Idle )

--- a/src/core/qgsmaprendererparalleljob.h
+++ b/src/core/qgsmaprendererparalleljob.h
@@ -44,18 +44,16 @@ class CORE_EXPORT QgsMapRendererParallelJob : public QgsMapRendererQImageJob
     // from QgsMapRendererJobWithPreview
     virtual QImage renderedImage() override;
 
-  protected slots:
+  private slots:
     //! layers are rendered, labeling is still pending
     void renderLayersFinished();
     //! all rendering is finished, including labeling
     void renderingFinished();
 
-  protected:
+  private:
 
     static void renderLayerStatic( LayerRenderJob& job );
     static void renderLabelsStatic( QgsMapRendererParallelJob* self );
-
-  protected:
 
     QImage mFinalImage;
 
@@ -72,6 +70,7 @@ class CORE_EXPORT QgsMapRendererParallelJob : public QgsMapRendererQImageJob
     QgsRenderContext mLabelingRenderContext;
     QFuture<void> mLabelingFuture;
     QFutureWatcher<void> mLabelingFutureWatcher;
+
 };
 
 

--- a/src/core/qgsmaprenderersequentialjob.cpp
+++ b/src/core/qgsmaprenderersequentialjob.cpp
@@ -19,7 +19,6 @@
 #include "qgsmaprenderercustompainterjob.h"
 #include "qgspallabeling.h"
 
-
 QgsMapRendererSequentialJob::QgsMapRendererSequentialJob( const QgsMapSettings& settings )
     : QgsMapRendererQImageJob( settings )
     , mInternalJob( nullptr )
@@ -138,4 +137,3 @@ void QgsMapRendererSequentialJob::internalFinished()
 
   emit finished();
 }
-

--- a/src/core/qgsmaprenderersequentialjob.h
+++ b/src/core/qgsmaprenderersequentialjob.h
@@ -50,12 +50,13 @@ class CORE_EXPORT QgsMapRendererSequentialJob : public QgsMapRendererQImageJob
 
     void internalFinished();
 
-  protected:
+  private:
 
     QgsMapRendererCustomPainterJob* mInternalJob;
     QImage mImage;
     QPainter* mPainter;
     QgsLabelingResults* mLabelingResults;
+
 };
 
 


### PR DESCRIPTION
QgsMapRendererJob and subclasses are not designed to be subclassed outside of core QGIS code. Marking them private API allows us to change them after API is frozen again.