### PR TITLE
Use weak layer pointers in labeling engine

### DIFF
--- a/src/core/annotations/qgsannotation.h
+++ b/src/core/annotations/qgsannotation.h
@@ -348,7 +348,7 @@ class CORE_EXPORT QgsAnnotation : public QObject
     QPointF mBalloonSegmentPoint2;
 
     //! Associated layer (or nullptr if not attached to a layer)
-    QPointer<QgsMapLayer> mMapLayer;
+    QgsWeakMapLayerPointer mMapLayer;
 
     //! Associated feature, or invalid feature if no feature associated
     QgsFeature mFeature;

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -1231,7 +1231,7 @@ bool QgsComposerMap::writeXml( QDomElement& elem, QDomDocument & doc ) const
 
   //layer set
   QDomElement layerSetElem = doc.createElement( QStringLiteral( "LayerSet" ) );
-  Q_FOREACH ( const QPointer<QgsMapLayer>& layerPtr, mLayers )
+  Q_FOREACH ( const QgsWeakMapLayerPointer& layerPtr, mLayers )
   {
     QgsMapLayer* layer = layerPtr.data();
     if ( !layer )
@@ -1557,7 +1557,7 @@ void QgsComposerMap::setLayerStyleOverrides( const QMap<QString, QString>& overr
 void QgsComposerMap::storeCurrentLayerStyles()
 {
   mLayerStyleOverrides.clear();
-  Q_FOREACH ( const QPointer<QgsMapLayer>& layerPtr, mLayers )
+  Q_FOREACH ( const QgsWeakMapLayerPointer& layerPtr, mLayers )
   {
     if ( QgsMapLayer* layer = layerPtr.data() )
     {

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -23,6 +23,7 @@
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrendercontext.h"
+#include "qgsmaplayer.h"
 #include <QFont>
 #include <QGraphicsRectItem>
 
@@ -542,7 +543,7 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     bool mKeepLayerSet;
 
     //! Stored layer list (used if layer live-link mKeepLayerSet is disabled)
-    QList< QPointer<QgsMapLayer> > mLayers;
+    QgsWeakMapLayerPointerList mLayers;
 
     bool mKeepLayerStyles;
     //! Stored style names (value) to be used with particular layer IDs (key) instead of default style

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -332,7 +332,7 @@ static QgsExpression::Node* getNode( const QVariant& value, QgsExpression* paren
 
 QgsVectorLayer* getVectorLayer( const QVariant& value, QgsExpression* )
 {
-  QgsMapLayer* ml = value.value< QPointer<QgsMapLayer> >().data();
+  QgsMapLayer* ml = value.value< QgsWeakMapLayerPointer >().data();
   QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( ml );
   if ( !vl )
   {

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -760,7 +760,7 @@ QgsExpressionContextScope* QgsExpressionContextUtils::layerScope( const QgsMapLa
 
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_name" ), layer->name(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_id" ), layer->id(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer" ), QVariant::fromValue<QPointer<QgsMapLayer> >( QPointer<QgsMapLayer>( const_cast<QgsMapLayer*>( layer ) ) ), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer" ), QVariant::fromValue<QgsWeakMapLayerPointer >( QgsWeakMapLayerPointer( const_cast<QgsMapLayer*>( layer ) ) ), true ) );
 
   const QgsVectorLayer* vLayer = dynamic_cast< const QgsVectorLayer* >( layer );
   if ( vLayer )

--- a/src/core/qgslabelingengine.h
+++ b/src/core/qgslabelingengine.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsAbstractLabelProvider
 
   public:
     //! Construct the provider with default values
-    QgsAbstractLabelProvider( const QString& layerId = QString(), const QString& providerId = QString() );
+    QgsAbstractLabelProvider( QgsMapLayer* layer, const QString& providerId = QString() );
 
     virtual ~QgsAbstractLabelProvider() = default;
 
@@ -74,6 +74,9 @@ class CORE_EXPORT QgsAbstractLabelProvider
 
     //! Returns ID of associated layer, or empty string if no layer is associated with the provider.
     QString layerId() const { return mLayerId; }
+
+    //! Returns the associated layer, or nullptr if no layer is associated with the provider.
+    QgsMapLayer* layer() const { return mLayer.data(); }
 
     //! Returns provider ID - useful in case there is more than one label provider within a layer
     //! (e.g. in case of rule-based labeling - provider ID = rule's key). May be empty string if
@@ -106,6 +109,8 @@ class CORE_EXPORT QgsAbstractLabelProvider
     QString mName;
     //! Associated layer's ID, if applicable
     QString mLayerId;
+    //! Weak pointer to source layer
+    QgsWeakMapLayerPointer mLayer;
     //! Associated provider ID (one layer may have multiple providers, e.g. in rule-based labeling)
     QString mProviderId;
     //! Flags altering drawing and registration of features
@@ -187,10 +192,10 @@ class CORE_EXPORT QgsLabelingEngine
     const QgsMapSettings& mapSettings() const { return mMapSettings; }
 
     /**
-     * Returns a list of layer IDs for layers with providers in the engine.
+     * Returns a list of layers with providers in the engine.
      * @note added in QGIS 3.0
      */
-    QStringList participatingLayerIds() const;
+    QList< QgsMapLayer* > participatingLayers() const;
 
     //! Add provider of label features. Takes ownership of the provider
     void addProvider( QgsAbstractLabelProvider* provider );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -920,4 +920,18 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
 Q_DECLARE_METATYPE( QgsMapLayer* )
 
+/**
+ * Weak pointer for QgsMapLayer
+ * @note added in QGIS 3.0
+ * @note not available in Python bindings
+ */
+typedef QPointer< QgsMapLayer > QgsWeakMapLayerPointer;
+
+/**
+ * A list of weak pointers to QgsMapLayers.
+ * @note added in QGIS 3.0
+ * @note not available in Python bindings
+ */
+typedef QList< QgsWeakMapLayerPointer > QgsWeakMapLayerPointerList;
+
 #endif

--- a/src/core/qgsmaplayerlistutils.h
+++ b/src/core/qgsmaplayerlistutils.h
@@ -16,11 +16,11 @@
 
 /// @cond PRIVATE
 
-inline QList<QgsMapLayer*> _qgis_listQPointerToRaw( const QList< QPointer<QgsMapLayer> >& layers )
+inline QList<QgsMapLayer*> _qgis_listQPointerToRaw( const QgsWeakMapLayerPointerList& layers )
 {
   QList<QgsMapLayer*> lst;
   lst.reserve( layers.count() );
-  Q_FOREACH ( const QPointer<QgsMapLayer>& layerPtr, layers )
+  Q_FOREACH ( const QgsWeakMapLayerPointer& layerPtr, layers )
   {
     if ( layerPtr )
       lst.append( layerPtr.data() );
@@ -28,9 +28,9 @@ inline QList<QgsMapLayer*> _qgis_listQPointerToRaw( const QList< QPointer<QgsMap
   return lst;
 }
 
-inline QList< QPointer<QgsMapLayer> > _qgis_listRawToQPointer( const QList<QgsMapLayer*>& layers )
+inline QgsWeakMapLayerPointerList _qgis_listRawToQPointer( const QList<QgsMapLayer*>& layers )
 {
-  QList< QPointer<QgsMapLayer> > lst;
+  QgsWeakMapLayerPointerList lst;
   lst.reserve( layers.count() );
   Q_FOREACH ( QgsMapLayer* layer, layers )
   {
@@ -39,11 +39,11 @@ inline QList< QPointer<QgsMapLayer> > _qgis_listRawToQPointer( const QList<QgsMa
   return lst;
 }
 
-inline QStringList _qgis_listQPointerToIDs( const QList< QPointer<QgsMapLayer> >& layers )
+inline QStringList _qgis_listQPointerToIDs( const QgsWeakMapLayerPointerList& layers )
 {
   QStringList lst;
   lst.reserve( layers.count() );
-  Q_FOREACH ( const QPointer<QgsMapLayer>& layerPtr, layers )
+  Q_FOREACH ( const QgsWeakMapLayerPointer& layerPtr, layers )
   {
     if ( layerPtr )
       lst << layerPtr->id();
@@ -93,7 +93,7 @@ inline static QgsMapLayer* _qgis_findLayer( const QList< QgsMapLayer*> layers, c
   }
 }
 
-inline uint qHash( const QPointer< QgsMapLayer >& key )
+inline uint qHash( const QgsWeakMapLayerPointer& key )
 {
   return qHash( key ? key->id() : QString() );
 }

--- a/src/core/qgsmaprenderercache.cpp
+++ b/src/core/qgsmaprenderercache.cpp
@@ -35,7 +35,7 @@ void QgsMapRendererCache::clearInternal()
   mScale = 0;
 
   // make sure we are disconnected from all layers
-  Q_FOREACH ( const QPointer< QgsMapLayer >& layer, mConnectedLayers )
+  Q_FOREACH ( const QgsWeakMapLayerPointer& layer, mConnectedLayers )
   {
     if ( layer.data() )
     {
@@ -48,9 +48,9 @@ void QgsMapRendererCache::clearInternal()
 
 void QgsMapRendererCache::dropUnusedConnections()
 {
-  QSet< QPointer< QgsMapLayer > > stillDepends = dependentLayers();
-  QSet< QPointer< QgsMapLayer > > disconnects = mConnectedLayers.subtract( stillDepends );
-  Q_FOREACH ( const QPointer< QgsMapLayer >& layer, disconnects )
+  QSet< QgsWeakMapLayerPointer > stillDepends = dependentLayers();
+  QSet< QgsWeakMapLayerPointer > disconnects = mConnectedLayers.subtract( stillDepends );
+  Q_FOREACH ( const QgsWeakMapLayerPointer& layer, disconnects )
   {
     if ( layer.data() )
     {
@@ -61,13 +61,13 @@ void QgsMapRendererCache::dropUnusedConnections()
   mConnectedLayers = stillDepends;
 }
 
-QSet<QPointer<QgsMapLayer> > QgsMapRendererCache::dependentLayers() const
+QSet<QgsWeakMapLayerPointer > QgsMapRendererCache::dependentLayers() const
 {
-  QSet< QPointer< QgsMapLayer > > result;
+  QSet< QgsWeakMapLayerPointer > result;
   QMap<QString, CacheParameters>::const_iterator it = mCachedImages.constBegin();
   for ( ; it != mCachedImages.constEnd(); ++it )
   {
-    Q_FOREACH ( const QPointer< QgsMapLayer >& l, it.value().dependentLayers )
+    Q_FOREACH ( const QgsWeakMapLayerPointer& l, it.value().dependentLayers )
     {
       if ( l.data() )
         result << l;
@@ -107,7 +107,7 @@ void QgsMapRendererCache::setCacheImage( const QString& cacheKey, const QImage& 
     if ( layer )
     {
       params.dependentLayers << layer;
-      if ( !mConnectedLayers.contains( QPointer< QgsMapLayer >( layer ) ) )
+      if ( !mConnectedLayers.contains( QgsWeakMapLayerPointer( layer ) ) )
       {
         connect( layer, &QgsMapLayer::repaintRequested, this, &QgsMapRendererCache::layerRequestedRepaint );
         mConnectedLayers << layer;

--- a/src/core/qgsmaprenderercache.h
+++ b/src/core/qgsmaprenderercache.h
@@ -99,7 +99,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
     struct CacheParameters
     {
       QImage cachedImage;
-      QList< QPointer< QgsMapLayer > > dependentLayers;
+      QgsWeakMapLayerPointerList dependentLayers;
     };
 
     //! Invalidate cache contents (without locking)
@@ -108,7 +108,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
     //! Disconnects from layers we no longer care about
     void dropUnusedConnections();
 
-    QSet< QPointer< QgsMapLayer > > dependentLayers() const;
+    QSet< QgsWeakMapLayerPointer > dependentLayers() const;
 
     mutable QMutex mMutex;
     QgsRectangle mExtent;
@@ -117,7 +117,7 @@ class CORE_EXPORT QgsMapRendererCache : public QObject
     //! Map of cache key to cache parameters
     QMap<QString, CacheParameters> mCachedImages;
     //! List of all layers on which this cache is currently connected
-    QSet< QPointer< QgsMapLayer > > mConnectedLayers;
+    QSet< QgsWeakMapLayerPointer > mConnectedLayers;
 };
 
 

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -50,7 +50,7 @@ struct LayerRenderJob
   QPainter::CompositionMode blendMode;
   double opacity;
   bool cached; // if true, img already contains cached image from previous rendering
-  QPointer< QgsMapLayer > layer;
+  QgsWeakMapLayerPointer layer;
   int renderingTime; //!< Time it took to render the layer in ms (it is -1 if not rendered or still rendering)
 };
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -551,7 +551,7 @@ QgsRectangle QgsMapSettings::fullExtent() const
   // iterate through the map layers and test each layers extent
   // against the current min and max values
   QgsDebugMsg( QString( "Layer count: %1" ).arg( mLayers.count() ) );
-  Q_FOREACH ( const QPointer<QgsMapLayer>& layerPtr, mLayers )
+  Q_FOREACH ( const QgsWeakMapLayerPointer& layerPtr, mLayers )
   {
     if ( QgsMapLayer* lyr = layerPtr.data() )
     {

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -30,13 +30,13 @@
 #include "qgsrectangle.h"
 #include "qgsscalecalculator.h"
 #include "qgsexpressioncontext.h"
+#include "qgsmaplayer.h"
 
 class QPainter;
 
 class QgsCoordinateTransform;
 class QgsScaleCalculator;
 class QgsMapRendererJob;
-class QgsMapLayer;
 
 
 /** \ingroup core
@@ -310,7 +310,7 @@ class CORE_EXPORT QgsMapSettings
     double mMagnificationFactor;
 
     //! list of layers to be rendered (stored as weak pointers)
-    QList< QPointer<QgsMapLayer> > mLayers;
+    QgsWeakMapLayerPointerList mLayers;
     QMap<QString, QString> mLayerStyleOverrides;
     QString mCustomRenderFlags;
     QgsExpressionContext mExpressionContext;

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -84,7 +84,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
         QSet<QString> checkedLegendItems;
       private:
         //! Weak pointer to the layer
-        QPointer<QgsMapLayer> mLayer;
+        QgsWeakMapLayerPointer mLayer;
     };
 
     /**

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -24,29 +24,8 @@
 #include "feature.h"
 #include "labelposition.h"
 
-
-QgsVectorLayerDiagramProvider::QgsVectorLayerDiagramProvider(
-  const QgsDiagramLayerSettings* diagSettings,
-  const QgsDiagramRenderer* diagRenderer,
-  const QString& layerId,
-  const QgsFields& fields,
-  const QgsCoordinateReferenceSystem& crs,
-  QgsAbstractFeatureSource* source,
-  bool ownsSource )
-    : QgsAbstractLabelProvider( layerId )
-    , mSettings( *diagSettings )
-    , mDiagRenderer( diagRenderer->clone() )
-    , mFields( fields )
-    , mLayerCrs( crs )
-    , mSource( source )
-    , mOwnsSource( ownsSource )
-{
-  init();
-}
-
-
 QgsVectorLayerDiagramProvider::QgsVectorLayerDiagramProvider( QgsVectorLayer* layer, bool ownFeatureLoop )
-    : QgsAbstractLabelProvider( layer->id() )
+    : QgsAbstractLabelProvider( layer )
     , mSettings( *layer->diagramLayerSettings() )
     , mDiagRenderer( layer->diagramRenderer()->clone() )
     , mFields( layer->fields() )

--- a/src/core/qgsvectorlayerdiagramprovider.h
+++ b/src/core/qgsvectorlayerdiagramprovider.h
@@ -62,15 +62,6 @@ class CORE_EXPORT QgsVectorLayerDiagramProvider : public QgsAbstractLabelProvide
     //! Convenience constructor to initialize the provider from given vector layer
     explicit QgsVectorLayerDiagramProvider( QgsVectorLayer* layer, bool ownFeatureLoop = true );
 
-    //! Construct diagram provider with all the necessary configuration parameters
-    QgsVectorLayerDiagramProvider( const QgsDiagramLayerSettings* diagSettings,
-                                   const QgsDiagramRenderer* diagRenderer,
-                                   const QString& layerId,
-                                   const QgsFields& fields,
-                                   const QgsCoordinateReferenceSystem& crs,
-                                   QgsAbstractFeatureSource* source,
-                                   bool ownsSource );
-
     //! Clean up
     ~QgsVectorLayerDiagramProvider();
 

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -35,7 +35,7 @@
 using namespace pal;
 
 QgsVectorLayerLabelProvider::QgsVectorLayerLabelProvider( QgsVectorLayer* layer, const QString& providerId, bool withFeatureLoop, const QgsPalLayerSettings* settings, const QString& layerName )
-    : QgsAbstractLabelProvider( layer->id(), providerId )
+    : QgsAbstractLabelProvider( layer, providerId )
     , mSettings( settings ? *settings : QgsPalLayerSettings::fromLayer( layer ) )
     , mLayerGeometryType( layer->geometryType() )
     , mRenderer( layer->renderer() )
@@ -57,25 +57,6 @@ QgsVectorLayerLabelProvider::QgsVectorLayerLabelProvider( QgsVectorLayer* layer,
 
   init();
 }
-
-QgsVectorLayerLabelProvider::QgsVectorLayerLabelProvider( const QgsPalLayerSettings& settings,
-    const QString& layerId,
-    const QgsFields& fields,
-    const QgsCoordinateReferenceSystem& crs,
-    QgsAbstractFeatureSource* source,
-    bool ownsSource, QgsFeatureRenderer* renderer )
-    : QgsAbstractLabelProvider( layerId )
-    , mSettings( settings )
-    , mLayerGeometryType( QgsWkbTypes::UnknownGeometry )
-    , mRenderer( renderer )
-    , mFields( fields )
-    , mCrs( crs )
-    , mSource( source )
-    , mOwnsSource( ownsSource )
-{
-  init();
-}
-
 
 void QgsVectorLayerLabelProvider::init()
 {

--- a/src/core/qgsvectorlayerlabelprovider.h
+++ b/src/core/qgsvectorlayerlabelprovider.h
@@ -44,15 +44,6 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
                                           const QgsPalLayerSettings* settings = nullptr,
                                           const QString& layerName = QString() );
 
-    //! Construct diagram provider with all the necessary configuration parameters
-    QgsVectorLayerLabelProvider( const QgsPalLayerSettings& settings,
-                                 const QString& layerId,
-                                 const QgsFields& fields,
-                                 const QgsCoordinateReferenceSystem& crs,
-                                 QgsAbstractFeatureSource* source,
-                                 bool ownsSource,
-                                 QgsFeatureRenderer* renderer = nullptr );
-
     ~QgsVectorLayerLabelProvider();
 
     virtual QList<QgsLabelFeature*> labelFeatures( QgsRenderContext& context ) override;

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -538,18 +538,18 @@ void TestQgsLabelingEngine::testCapitalization()
 void TestQgsLabelingEngine::testParticipatingLayers()
 {
   QgsLabelingEngine engine;
-  QVERIFY( engine.participatingLayerIds().isEmpty() );
+  QVERIFY( engine.participatingLayers().isEmpty() );
 
   QgsPalLayerSettings settings1;
   QgsVectorLayerLabelProvider* provider = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test" ), true, &settings1 );
   engine.addProvider( provider );
-  QCOMPARE( engine.participatingLayerIds(), QStringList() << vl->id() );
+  QCOMPARE( engine.participatingLayers(), QList<QgsMapLayer*>() << vl );
 
   QgsVectorLayer* layer2 = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "layer2" ), QStringLiteral( "memory" ) );
   QgsPalLayerSettings settings2;
   QgsVectorLayerLabelProvider* provider2 = new QgsVectorLayerLabelProvider( layer2, QStringLiteral( "test2" ), true, &settings2 );
   engine.addProvider( provider2 );
-  QCOMPARE( engine.participatingLayerIds().toSet(), QSet< QString >() << vl->id() << layer2->id() );
+  QCOMPARE( engine.participatingLayers().toSet(), QSet< QgsMapLayer* >() << vl << layer2 );
 
   // add a rule-based labeling node
   QgsRuleBasedLabeling::Rule* root = new QgsRuleBasedLabeling::Rule( 0 );
@@ -561,7 +561,7 @@ void TestQgsLabelingEngine::testParticipatingLayers()
   QgsVectorLayer* layer3 = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "layer3" ), QStringLiteral( "memory" ) );
   QgsRuleBasedLabelProvider* ruleProvider = new QgsRuleBasedLabelProvider( QgsRuleBasedLabeling( root ), layer3 );
   engine.addProvider( ruleProvider );
-  QCOMPARE( engine.participatingLayerIds().toSet(), QSet< QString >() << vl->id() << layer2->id() << layer3->id() );
+  QCOMPARE( engine.participatingLayers().toSet(), QSet< QgsMapLayer* >() << vl << layer2 << layer3 );
 }
 
 bool TestQgsLabelingEngine::imageCheck( const QString& testName, QImage &image, int mismatchCount )

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -198,7 +198,7 @@ void TestQgsMapSettings::testMapLayerListUtils()
   l = _qgis_findLayer( listRawSource, QStringLiteral( "z" ) );
   QCOMPARE( !l, true );
 
-  QList< QPointer<QgsMapLayer> > listQPointer = _qgis_listRawToQPointer( listRawSource );
+  QgsWeakMapLayerPointerList listQPointer = _qgis_listRawToQPointer( listRawSource );
 
   QCOMPARE( listQPointer.count(), 2 );
   QCOMPARE( listQPointer[0].data(), vlA );


### PR DESCRIPTION
This flips the labeling engine/providers to use weak map layer pointers instead of layer ids. It removes an existing use of the project instance (and avoids another one I was about to add!)

I've also added some typedefs for QPointer QgsMapLayer* - I got sick of writing these out in full!