### PR TITLE
show shortcuts in advanced digitizing tools tooltips + fix small typo

### DIFF
--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -6769,6 +6769,7 @@ tabacco:tobacco
 tahn:than
 taht:that
 talekd:talked
+tangeant:tangent
 targetted:targeted
 targetting:targeting
 tast:taste

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -197,6 +197,31 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas* 
   mSettingsButton->setMenu( menu );
   connect( mSettingsButton, SIGNAL( triggered( QAction* ) ), this, SLOT( settingsButtonTriggered( QAction* ) ) );
 
+  // set tooltips
+  mConstructionModeButton->setToolTip( "<b>" + tr( "Construction mode" ) + "</b><br>(" + tr( "press c to toggle on/off" ) + ")" );
+  mPerpendicularButton->setToolTip( "<b>" + tr( "Perpendicular" ) + "</b><br>(" + tr( "press p to switch between perpendicular, parallel and normal mode" ) + ")" );
+  mParallelButton->setToolTip( "<b>" + tr( "Parallel" ) + "</b><br>(" + tr( "press p to switch between perpendicular, parallel and normal mode" ) + ")" );
+
+  mDistanceLineEdit->setToolTip( "<b>" + tr( "Distance" ) + "</b><br>(" + tr( "press d for quick access" ) + ")" );
+  mLockDistanceButton->setToolTip( "<b>" + tr( "Lock distance" ) + "</b><br>(" + tr( "press Ctrl + d for quick access" ) + ")" );
+  mRepeatingLockDistanceButton->setToolTip( "<b>" + tr( "Continuously lock distance" ) + "</b>" );
+
+  mRelativeAngleButton->setToolTip( "<b>" + tr( "Toggles relative angle to previous segment" ) + "</b><br>(" + tr( "press Shift + a for quick access" ) + ")" );
+  mAngleLineEdit->setToolTip( "<b>" + tr( "Angle" ) + "</b><br>(" + tr( "press a for quick access" ) + ")" );
+  mLockAngleButton->setToolTip( "<b>" + tr( "Lock angle" ) + "</b><br>(" + tr( "press Ctrl + a for quick access" ) + ")" );
+  mRepeatingLockAngleButton->setToolTip( "<b>" + tr( "Continuously lock angle" ) + "</b>" );
+
+  mRelativeXButton->setToolTip( "<b>" + tr( "Toggles relative x to previous node" ) + "</b><br>(" + tr( "press Shift + x for quick access" ) + ")" );
+  mXLineEdit->setToolTip( "<b>" + tr( "X coordinate" ) + "</b><br>(" + tr( "press x for quick access" ) + ")" );
+  mLockXButton->setToolTip( "<b>" + tr( "Lock x coordinate" ) + "</b><br>(" + tr( "press Ctrl + x for quick access" ) + ")" );
+  mRepeatingLockXButton->setToolTip( "<b>" + tr( "Continuously lock x coordinate" ) + "</b>" );
+
+  mRelativeYButton->setToolTip( "<b>" + tr( "Toggles relative y to previous node" ) + "</b><br>(" + tr( "press Shift + y for quick access" ) + ")" );
+  mYLineEdit->setToolTip( "<b>" + tr( "Y coordinate" ) + "</b><br>(" + tr( "press y for quick access" ) + ")" );
+  mLockYButton->setToolTip( "<b>" + tr( "Lock y coordinate" ) + "</b><br>(" + tr( "press Ctrl + y for quick access" ) + ")" );
+  mRepeatingLockYButton->setToolTip( "<b>" + tr( "Continuously lock y coordinate" ) + "</b>" );
+
+
   updateCapacity( true );
   disable();
 }

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -56,7 +56,7 @@ bool QgsAdvancedDigitizingDockWidget::lineCircleIntersection( const QgsPoint& ce
 
   if ( disc < 0 )
   {
-    //no intersection or tangeant
+    //no intersection or tangent
     return false;
   }
   else
@@ -567,7 +567,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent* e )
   QgsPoint penultimatePt = penultimatePoint( &penulPointExist );
 
   // *****************************
-  // ---- X Constrain
+  // ---- X constraint
   if ( mXConstraint->isLocked() )
   {
     if ( !mXConstraint->relative() )
@@ -594,7 +594,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent* e )
     }
   }
   // *****************************
-  // ---- Y Constrain
+  // ---- Y constraint
   if ( mYConstraint->isLocked() )
   {
     if ( !mYConstraint->relative() )
@@ -621,7 +621,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent* e )
     }
   }
   // *****************************
-  // ---- Angle constrain
+  // ---- Angle constraint
   // input angles are in degrees
   if ( mAngleConstraint->lockMode() == CadConstraint::SoftLock )
   {

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -117,7 +117,8 @@
               <item row="0" column="2">
                <widget class="QToolButton" name="mParallelButton">
                 <property name="toolTip">
-                 <string>Parallel</string>
+                 <string>Parallel;
+press p to switch between perpendicular, parallel and normal mode</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -140,7 +141,8 @@
               <item row="0" column="1">
                <widget class="QToolButton" name="mPerpendicularButton">
                 <property name="toolTip">
-                 <string>Perpendicular</string>
+                 <string>Perpendicular;
+press p to switch between perpendicular, parallel and normal mode</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -163,7 +165,8 @@
               <item row="0" column="0">
                <widget class="QToolButton" name="mConstructionModeButton">
                 <property name="toolTip">
-                 <string>Construction mode</string>
+                 <string>Construction mode;
+press c to toggle on/off</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -243,14 +246,16 @@
             <item row="3" column="2">
              <widget class="QLineEdit" name="mYLineEdit">
               <property name="toolTip">
-               <string>Y coordinate</string>
+               <string>Y coordinate;
+press y for quick access</string>
               </property>
              </widget>
             </item>
             <item row="3" column="3">
              <widget class="QToolButton" name="mLockYButton">
               <property name="toolTip">
-               <string>Lock y coordinate</string>
+               <string>Lock y coordinate;
+press Ctrl + y for quick access</string>
               </property>
               <property name="text">
                <string>...</string>
@@ -267,7 +272,8 @@
             <item row="2" column="3">
              <widget class="QToolButton" name="mLockXButton">
               <property name="toolTip">
-               <string>Lock x coordinate</string>
+               <string>Lock x coordinate;
+press Ctrl + x for quick access</string>
               </property>
               <property name="text">
                <string>...</string>
@@ -284,7 +290,8 @@
             <item row="3" column="0">
              <widget class="QToolButton" name="mRelativeYButton">
               <property name="toolTip">
-               <string>Toggles relative y to previous node</string>
+               <string>Toggles relative y to previous node;
+press Shift + y for quick access</string>
               </property>
               <property name="text">
                <string>...</string>
@@ -301,7 +308,8 @@
             <item row="1" column="3">
              <widget class="QToolButton" name="mLockAngleButton">
               <property name="toolTip">
-               <string>Lock angle</string>
+               <string>Lock angle;
+press Ctrl + a for quick access</string>
               </property>
               <property name="text">
                <string>...</string>
@@ -318,7 +326,8 @@
             <item row="2" column="2">
              <widget class="QLineEdit" name="mXLineEdit">
               <property name="toolTip">
-               <string>X coordinate</string>
+               <string>X coordinate;
+press x for quick access</string>
               </property>
              </widget>
             </item>
@@ -332,7 +341,8 @@
             <item row="1" column="0">
              <widget class="QToolButton" name="mRelativeAngleButton">
               <property name="toolTip">
-               <string>Toggles relative angle to previous segment</string>
+               <string>Toggles relative angle to previous segment;
+press Shift + a for quick access</string>
               </property>
               <property name="text">
                <string>...</string>
@@ -352,7 +362,8 @@
             <item row="1" column="2">
              <widget class="QLineEdit" name="mAngleLineEdit">
               <property name="toolTip">
-               <string>Angle</string>
+               <string>Angle;
+press a for quick access</string>
               </property>
              </widget>
             </item>
@@ -373,7 +384,8 @@
             <item row="0" column="3">
              <widget class="QToolButton" name="mLockDistanceButton">
               <property name="toolTip">
-               <string>Lock distance</string>
+               <string>Lock distance;
+press Ctrl + d for quick access</string>
               </property>
               <property name="text">
                <string>...</string>
@@ -390,14 +402,16 @@
             <item row="0" column="2">
              <widget class="QLineEdit" name="mDistanceLineEdit">
               <property name="toolTip">
-               <string>Distance</string>
+               <string>Distance;
+press d for quick access</string>
               </property>
              </widget>
             </item>
             <item row="2" column="0">
              <widget class="QToolButton" name="mRelativeXButton">
               <property name="toolTip">
-               <string>Toggles relative x to previous node</string>
+               <string>Toggles relative x to previous node;
+press Shift + x for quick access</string>
               </property>
               <property name="text">
                <string>...</string>

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -117,8 +117,7 @@
               <item row="0" column="2">
                <widget class="QToolButton" name="mParallelButton">
                 <property name="toolTip">
-                 <string>Parallel;
-press p to switch between perpendicular, parallel and normal mode</string>
+                 <string/>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -141,8 +140,7 @@ press p to switch between perpendicular, parallel and normal mode</string>
               <item row="0" column="1">
                <widget class="QToolButton" name="mPerpendicularButton">
                 <property name="toolTip">
-                 <string>Perpendicular;
-press p to switch between perpendicular, parallel and normal mode</string>
+                 <string/>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -165,8 +163,7 @@ press p to switch between perpendicular, parallel and normal mode</string>
               <item row="0" column="0">
                <widget class="QToolButton" name="mConstructionModeButton">
                 <property name="toolTip">
-                 <string>Construction mode;
-press c to toggle on/off</string>
+                 <string/>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -246,16 +243,14 @@ press c to toggle on/off</string>
             <item row="3" column="2">
              <widget class="QLineEdit" name="mYLineEdit">
               <property name="toolTip">
-               <string>Y coordinate;
-press y for quick access</string>
+               <string/>
               </property>
              </widget>
             </item>
             <item row="3" column="3">
              <widget class="QToolButton" name="mLockYButton">
               <property name="toolTip">
-               <string>Lock y coordinate;
-press Ctrl + y for quick access</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -272,8 +267,7 @@ press Ctrl + y for quick access</string>
             <item row="2" column="3">
              <widget class="QToolButton" name="mLockXButton">
               <property name="toolTip">
-               <string>Lock x coordinate;
-press Ctrl + x for quick access</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -290,8 +284,7 @@ press Ctrl + x for quick access</string>
             <item row="3" column="0">
              <widget class="QToolButton" name="mRelativeYButton">
               <property name="toolTip">
-               <string>Toggles relative y to previous node;
-press Shift + y for quick access</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -308,8 +301,7 @@ press Shift + y for quick access</string>
             <item row="1" column="3">
              <widget class="QToolButton" name="mLockAngleButton">
               <property name="toolTip">
-               <string>Lock angle;
-press Ctrl + a for quick access</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -326,8 +318,7 @@ press Ctrl + a for quick access</string>
             <item row="2" column="2">
              <widget class="QLineEdit" name="mXLineEdit">
               <property name="toolTip">
-               <string>X coordinate;
-press x for quick access</string>
+               <string/>
               </property>
              </widget>
             </item>
@@ -341,8 +332,7 @@ press x for quick access</string>
             <item row="1" column="0">
              <widget class="QToolButton" name="mRelativeAngleButton">
               <property name="toolTip">
-               <string>Toggles relative angle to previous segment;
-press Shift + a for quick access</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -362,8 +352,7 @@ press Shift + a for quick access</string>
             <item row="1" column="2">
              <widget class="QLineEdit" name="mAngleLineEdit">
               <property name="toolTip">
-               <string>Angle;
-press a for quick access</string>
+               <string/>
               </property>
              </widget>
             </item>
@@ -384,8 +373,7 @@ press a for quick access</string>
             <item row="0" column="3">
              <widget class="QToolButton" name="mLockDistanceButton">
               <property name="toolTip">
-               <string>Lock distance;
-press Ctrl + d for quick access</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -402,16 +390,14 @@ press Ctrl + d for quick access</string>
             <item row="0" column="2">
              <widget class="QLineEdit" name="mDistanceLineEdit">
               <property name="toolTip">
-               <string>Distance;
-press d for quick access</string>
+               <string/>
               </property>
              </widget>
             </item>
             <item row="2" column="0">
              <widget class="QToolButton" name="mRelativeXButton">
               <property name="toolTip">
-               <string>Toggles relative x to previous node;
-press Shift + x for quick access</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -428,7 +414,7 @@ press Shift + x for quick access</string>
             <item row="0" column="4">
              <widget class="QToolButton" name="mRepeatingLockDistanceButton">
               <property name="toolTip">
-               <string>Continuously lock distance</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -445,7 +431,7 @@ press Shift + x for quick access</string>
             <item row="1" column="4">
              <widget class="QToolButton" name="mRepeatingLockAngleButton">
               <property name="toolTip">
-               <string>Continuously lock angle</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -462,7 +448,7 @@ press Shift + x for quick access</string>
             <item row="2" column="4">
              <widget class="QToolButton" name="mRepeatingLockXButton">
               <property name="toolTip">
-               <string>Continuously lock x coordinate</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>
@@ -479,7 +465,7 @@ press Shift + x for quick access</string>
             <item row="3" column="4">
              <widget class="QToolButton" name="mRepeatingLockYButton">
               <property name="toolTip">
-               <string>Continuously lock y coordinate</string>
+               <string/>
               </property>
               <property name="text">
                <string>...</string>


### PR DESCRIPTION
I couldn't find any docs regarding the advanced digitizing panel shortcuts and I lost quite a bit of time finding them out.
They should now be fully presented in the tooltips.

![untitled](https://cloud.githubusercontent.com/assets/3179646/22591440/3d7d4ca4-ea1d-11e6-95da-8326893ebb4e.gif)

Any suggestions are welcomed.