### PR TITLE
Add a title to the raster resampling dialog

### DIFF
--- a/src/app/qgsalignrasterdialog.cpp
+++ b/src/app/qgsalignrasterdialog.cpp
@@ -380,6 +380,7 @@ void QgsAlignRasterDialog::runAlign()
 
 QgsAlignRasterLayerConfigDialog::QgsAlignRasterLayerConfigDialog()
 {
+  setWindowTitle( tr( "Configure Layer Resampling" ) );
   QVBoxLayout* layout = new QVBoxLayout();
 
   cboLayers = new QgsMapLayerComboBox( this );


### PR DESCRIPTION
A missing title. Any better wording?
![raster_align_edit](https://cloud.githubusercontent.com/assets/7983394/22610718/0daba9c2-ea67-11e6-95a9-326ff92e43b3.png)
