### PR TITLE
[ui] make layer rendering collapsed by default

### DIFF
--- a/src/ui/qgsrendererv2propsdialogbase.ui
+++ b/src/ui/qgsrendererv2propsdialogbase.ui
@@ -102,10 +102,10 @@
             <bool>false</bool>
            </property>
            <property name="collapsed" stdset="0">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="saveCollapsedState" stdset="0">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout">
             <property name="leftMargin">


### PR DESCRIPTION
@nyalldawson , @anitagraser , @timlinux , this PR implements what we've been referring to for a long time in various discussions, namely making the layer rendering group box collapsed by default.

If there are no objections, I'll merge this by the end of the weekend.