### PR TITLE
Rename "Db"/"DB" in API to "Database"

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -83,6 +83,7 @@ Renamed Classes        {#qgis_api_break_3_0_renamed_classes}
 <tr><td>QgsCptCityColorRampV2DialogBase<td>QgsCptCityColorRampDialogBase
 <tr><td>QgsCurvePolygonV2<td>QgsCurvePolygon
 <tr><td>QgsCurveV2<td>QgsCurve
+<tr><td>QgsDbFilterProxyModel<td>QgsDatabaseFilterProxyModel
 <tr><td>QgsDiagramRendererV2<td>QgsDiagramRenderer
 <tr><td>QgsEditorWidgetV2<td>QgsEditorWidget
 <tr><td>QgsEllipseSymbolLayerV2<td>QgsEllipseSymbolLayer
@@ -399,6 +400,17 @@ QgsAdvancedDigitizingDockWidget        {#qgis_api_break_3_0_QgsAdvancedDigitizin
 - canvasReleaseEvent takes now QgsAdvancedDigitizingDockWidget::CaptureMode as second argument.
 
 
+QgsApplication        {#qgis_api_break_3_0_QgsApplication}
+--------------
+
+- qgisMasterDbFilePath() was renamed to qgisMasterDatabaseFilePath()
+- qgisMasterDatabaseFilePath() was renamed to qgisUserDatabaseFilePath()
+- qgisAuthDbFilePath() was renamed to qgisAuthDatabaseFilePath()
+- srsDbFilePath() was renamed to srsDatabaseFilePath()
+- setAuthDbDirPath() was renamed to setAuthDatabaseDirPath()
+- createDB() was renamed to createDatabase()
+
+
 QgsAtlasComposition        {#qgis_api_break_3_0_QgsAtlasComposition}
 -------------------
 
@@ -435,6 +447,19 @@ QgsAuthConfigUriEdit        {#qgis_api_break_3_0_QgsAuthConfigUriEdit}
 --------------------
 
 - hasConfigID() has been renamed to hasConfigId()
+
+
+QgsAuthManager        {#qgis_api_break_3_0_QgsAuthManager}
+--------------
+
+- authDbConnection() was renamed to authDatabaseConnection()
+- authDbConfigTable() was renamed to authDatabaseConfigTable()
+- authDbServersTable() was renamed to authDatabaseServersTable()
+- authenticationDbPath() was renamed to authenticationDatabasePath()
+- masterPasswordHashInDb() was renamed to masterPasswordHashInDatabase()
+- scheduledAuthDbErase() was renamed to scheduledAuthDatabaseErase()
+- setScheduledAuthDbErase() was renamed to setScheduledAuthDatabaseErase()
+- setScheduledAuthDbEraseRequestEmitted() was renamed to setScheduledAuthDatabaseEraseRequestEmitted()
 
 
 QgsAuthMethod        {#qgis_api_break_3_0_QgsAuthMethod}
@@ -699,6 +724,7 @@ called if changes are made to the CRS database.
 - geographicCRSAuthId() has been renamed to geographicCrsAuthId()
 - geographicFlag() was renamed to isGeographic()
 - axisInverted() was renamed to hasAxisInverted()
+- syncDb() was renamed to syncDatabase()
 
 
 QgsCoordinateTransform        {#qgis_api_break_3_0_QgsCoordinateTransform}
@@ -1316,6 +1342,8 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 - writeLayerXML() was renamed to writeLayerXml()
 - capitaliseLayerName() was renamed to capitalizeLayerName() <!--#spellok-->
 - asLayerDefinition(), fromLayerDefinition(), fromLayerDefinitionFile() were moved to QgsLayerDefinition class and renamed to exportLayerDefinitionLayers() resp. loadLayerDefinitionLayers()
+- loadNamedStyleFromDb() was renamed to loadNamedStyleFromDatabase()
+
 
 
 QgsMapLayerRegistry        {#qgis_api_break_3_0_QgsMapLayerRegistry}
@@ -1428,6 +1456,13 @@ QgsOSMElement        {#qgis_api_break_3_0_QgsOSMElement}
 -------------
 
 - elemID() has been renamed to elemId()
+
+
+QgsOSMXmlImport        {#qgis_api_break_3_0_QgsOSMXmlImport}
+-------------
+
+- setOutputDbFileName() and outputDbFileName() have been renamed to setOutputDatabaseFileName()
+and outputDatabaseFileName()
 
 
 QgsOwsConnection        {#qgis_api_break_3_0_QgsOwsConnection}
@@ -1906,6 +1941,7 @@ capabilities have been removed, as they were unused and had no effect.
 clause fragment which must be evaluated by the provider in order to calculate the default value. In
 QGIS 3.0 defaultValue() only returns literal, constant defaultValues. A new method defaultValueClause
 has been added which returns the SQL clause fragments which must be evaluated by the provider itself.
+- isSaveAndLoadStyleToDBSupported() was renamed to isSaveAndLoadStyleToDatabaseSupported()
 
 
 QgsVectorJoinInfo   {#qgis_api_break_3_0_QgsVectorJoinInfo}

--- a/python/analysis/openstreetmap/qgsosmimport.sip
+++ b/python/analysis/openstreetmap/qgsosmimport.sip
@@ -19,8 +19,8 @@ class QgsOSMXmlImport : public QObject
     void setInputXmlFileName( const QString& xmlFileName );
     QString inputXmlFileName() const;
 
-    void setOutputDbFileName( const QString& dbFileName );
-    QString outputDbFileName() const;
+    void setOutputDatabaseFileName( const QString& fileName );
+    QString outputDatabaseFileName() const;
 
     /**
      * Run import. This will parse the XML file and store the data in a SQLite database.

--- a/python/core/auth/qgsauthmanager.sip
+++ b/python/core/auth/qgsauthmanager.sip
@@ -27,13 +27,13 @@ class QgsAuthManager : QObject
     ~QgsAuthManager();
 
     /** Set up the application instance of the authentication database connection */
-    QSqlDatabase authDbConnection() const;
+    QSqlDatabase authDatabaseConnection() const;
 
     /** Name of the authentication database table that stores configs */
-    const QString authDbConfigTable() const;
+    const QString authDatabaseConfigTable() const;
 
     /** Name of the authentication database table that stores server exceptions/configs */
-    const QString authDbServersTable() const;
+    const QString authDatabaseServersTable() const;
 
     /** Initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database */
     bool init( const QString& pluginPath = QString::null );
@@ -45,9 +45,9 @@ class QgsAuthManager : QObject
     const QString disabledMessage() const;
 
     /** The standard authentication database file in ~/.qgis3/ or defined location
-     * @see QgsApplication::qgisAuthDbFilePath
+     * @see QgsApplication::qgisAuthDatabaseFilePath
      */
-    const QString authenticationDbPath() const;
+    const QString authenticationDatabasePath() const;
 
     /** Main call to initially set or continually check master password is set
      * @note If it is not set, the user is asked for its input
@@ -72,7 +72,7 @@ class QgsAuthManager : QObject
     bool masterPasswordIsSet() const;
 
     /** Verify a password hash existing in authentication database */
-    bool masterPasswordHashInDb() const;
+    bool masterPasswordHashInDatabase() const;
 
     /** Clear supplied master password
      * @note This will not necessarily clear authenticated connections cached in network connection managers
@@ -95,7 +95,7 @@ class QgsAuthManager : QObject
 
     /** Whether there is a scheduled opitonal erase of authentication database.
      */
-    bool scheduledAuthDbErase();
+    bool scheduledAuthDatabaseErase();
 
     /** Schedule an optional erase of authentication database, starting when mutex is lockable.
      * @note When an erase is scheduled, any attempt to set the master password,
@@ -107,7 +107,7 @@ class QgsAuthManager : QObject
      * through the given application, to prompt the erase operation (e.g. via a dialog);
      * if no access to user interaction occurs wihtin 90 seconds, it cancels the schedule.
      */
-    void setScheduledAuthDbErase( bool scheduleErase );
+    void setScheduledAuthDatabaseErase( bool scheduleErase );
 
     /** Re-emit a signal to schedule an optional erase of authentication database.
      * @note This can be called from the slot connected to a previously emitted scheduling signal,
@@ -116,7 +116,7 @@ class QgsAuthManager : QObject
      * @param emitted Setting to false will cause signal to be emitted by the schedule timer.
      * Setting to true will stop any emitting, but will not stop the schedule timer.
      */
-    void setScheduledAuthDbEraseRequestEmitted( bool emitted );
+    void setScheduledAuthDatabaseEraseRequestEmitted( bool emitted );
 
     /** Simple text tag describing authentication system for message logs */
     QString authManTag() const;

--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -168,16 +168,16 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
     static QString i18nPath();
 
     //! Returns the path to the master qgis.db file.
-    static QString qgisMasterDbFilePath();
+    static QString qgisMasterDatabaseFilePath();
 
     //! Returns the path to the settings directory in user's home dir
     static QString qgisSettingsDirPath();
 
     //! Returns the path to the user qgis.db file.
-    static QString qgisUserDbFilePath();
+    static QString qgisUserDatabaseFilePath();
 
     //! Returns the path to the user authentication database file: qgis-auth.db.
-    static QString qgisAuthDbFilePath();
+    static QString qgisAuthDatabaseFilePath();
 
     //! Returns the path to the splash screen image directory.
     static QString splashPath();
@@ -186,7 +186,7 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
     static QString iconsPath();
 
     //! Returns the path to the srs.db file.
-    static QString srsDbFilePath();
+    static QString srsDatabaseFilePath();
 
     //! Returns the paths to svg directories.
     static QStringList svgPaths();
@@ -287,13 +287,13 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
     static void setDefaultSvgPaths( const QStringList& pathList );
 
     //! Alters authentication data base directory path - used by 3rd party apps
-    static void setAuthDbDirPath( const QString& theAuthDbDirPath );
+    static void setAuthDatabaseDirPath( const QString& theAuthDbDirPath );
 
     //! loads providers
     static void initQgis();
 
     //! initialize qgis.db
-    static bool createDB( QString* errorMessage = 0 );
+    static bool createDatabase( QString* errorMessage = 0 );
 
     //! Create the users theme folder
     static bool createThemeFolder();

--- a/python/core/qgscoordinatereferencesystem.sip
+++ b/python/core/qgscoordinatereferencesystem.sip
@@ -87,13 +87,13 @@
  * CRS Database and Custom CRS
  * ===========================
  *
- * The database of CRS shipped with QGIS is stored in a SQLite database (see QgsApplication::srsDbFilePath())
+ * The database of CRS shipped with QGIS is stored in a SQLite database (see QgsApplication::srsDatabaseFilePath())
  * and it is based on the data files maintained by GDAL project (a variety of .csv and .wkt files).
  *
  * Sometimes it happens that users need to use a CRS definition that is not well known
  * or that has been only created with a specific purpose (and thus its definition is not
  * available in our database of CRS). Whenever a new CRS definition is seen, it will
- * be added to the local databse (in user's home directory, see QgsApplication::qgisUserDbFilePath()).
+ * be added to the local databse (in user's home directory, see QgsApplication::qgisUserDatabaseFilePath()).
  * QGIS also features a GUI for management of local custom CRS definitions.
  *
  * There are therefore two databases: one for shipped CRS definitions and one for custom CRS definitions.
@@ -496,7 +496,7 @@ class QgsCoordinateReferenceSystem
      *   negative number of failed updates in case of errors.
      * @note This is used internally and should not be necessary to call in client code
      */
-    static int syncDb();
+    static int syncDatabase();
 
 
     /** Save the proj4-string as a custom CRS

--- a/python/core/qgsdbfilterproxymodel.sip
+++ b/python/core/qgsdbfilterproxymodel.sip
@@ -1,11 +1,11 @@
-class QgsDbFilterProxyModel: QSortFilterProxyModel
+class QgsDatabaseFilterProxyModel: QSortFilterProxyModel
 {
 %TypeHeaderCode
 #include <qgsdbfilterproxymodel.h>
 %End
   public:
-    QgsDbFilterProxyModel( QObject* parent /TransferThis/ = 0 );
-    ~QgsDbFilterProxyModel();
+    QgsDatabaseFilterProxyModel( QObject* parent /TransferThis/ = 0 );
+    ~QgsDatabaseFilterProxyModel();
     /** Calls QSortFilterProxyModel::setFilterWildcard and triggers update*/
     void _setFilterWildcard( const QString& pattern );
     /** Calls QSortFilterProxyModel::setFilterRegExp and triggers update*/

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -425,7 +425,7 @@ class QgsMapLayer : QObject
      * @param qml will be set to QML style content from database
      * @returns true if style was successfully loaded
      */
-    virtual bool loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qml /Out/ );
+    virtual bool loadNamedStyleFromDatabase( const QString &db, const QString &uri, QString &qml /Out/ );
 
     /**
      * Import the properties of this layer from a QDomDocument

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -405,7 +405,7 @@ class QgsVectorDataProvider : QgsDataProvider
      * It returns false by default.
      * Must be implemented by providers that support saving and loading styles to db returning true
      */
-    virtual bool isSaveAndLoadStyleToDBSupported() const;
+    virtual bool isSaveAndLoadStyleToDatabaseSupported() const;
 
     /**
      * Checks if the provider supports style removal
@@ -413,7 +413,7 @@ class QgsVectorDataProvider : QgsDataProvider
      * @note added in QGIS 3.0
      * @return true if delete operation is supported by the provider
      */
-    virtual bool isDeleteStyleFromDbSupported() const;
+    virtual bool isDeleteStyleFromDatabaseSupported() const;
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 

--- a/python/core/symbology-ng/qgsstyle.sip
+++ b/python/core/symbology-ng/qgsstyle.sip
@@ -215,7 +215,7 @@ class QgsStyle : QObject
      *  \note added in QGIS 3.0
      *  \see createMemoryDb()
      */
-    bool createDb( const QString& filename );
+    bool createDatabase( const QString& filename );
 
     /** Creates a temporary memory database
      *
@@ -224,7 +224,7 @@ class QgsStyle : QObject
      *  \note added in QGIS 3.0
      *  \see createDb()
      */
-    bool createMemoryDb();
+    bool createMemoryDatabase();
 
     /** Creates tables structure for new database
      *
@@ -305,7 +305,7 @@ class QgsStyle : QObject
 
   protected:
     //! Convenience function to open the DB and return a sqlite3 object
-    bool openDB( const QString& filename );
+    bool openDatabase( const QString& filename );
 
     /** Convenience function that would run queries which don't generate return values
      *  \param query query to run

--- a/src/analysis/openstreetmap/qgsosmimport.h
+++ b/src/analysis/openstreetmap/qgsosmimport.h
@@ -42,8 +42,17 @@ class ANALYSIS_EXPORT QgsOSMXmlImport : public QObject
     void setInputXmlFileName( const QString& xmlFileName ) { mXmlFileName = xmlFileName; }
     QString inputXmlFileName() const { return mXmlFileName; }
 
-    void setOutputDbFileName( const QString& dbFileName ) { mDbFileName = dbFileName; }
-    QString outputDbFileName() const { return mDbFileName; }
+    /**
+     * Sets the filename for the output database.
+     * @see outputDatabaseFileName()
+     */
+    void setOutputDatabaseFileName( const QString& fileName ) { mDbFileName = fileName; }
+
+    /**
+     * Returns the filename for the output database.
+     * @see setOutputDatabaseFileName()
+     */
+    QString outputDatabaseFileName() const { return mDbFileName; }
 
     /**
      * Run import. This will parse the XML file and store the data in a SQLite database.

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1040,7 +1040,7 @@ int main( int argc, char *argv[] )
   // set authentication database directory
   if ( !authdbdirectory.isEmpty() )
   {
-    QgsApplication::setAuthDbDirPath( authdbdirectory );
+    QgsApplication::setAuthDatabaseDirPath( authdbdirectory );
   }
 
   //set up splash screen

--- a/src/app/openstreetmap/qgsosmimportdialog.cpp
+++ b/src/app/openstreetmap/qgsosmimportdialog.cpp
@@ -92,7 +92,7 @@ void QgsOSMImportDialog::onOK()
   }
 
   mImport->setInputXmlFileName( editXmlFileName->text() );
-  mImport->setOutputDbFileName( editDbFileName->text() );
+  mImport->setOutputDatabaseFileName( editDbFileName->text() );
 
   buttonBox->setEnabled( false );
   QApplication::setOverrideCursor( Qt::WaitCursor );
@@ -114,7 +114,7 @@ void QgsOSMImportDialog::onOK()
   {
     // create connection - this is a bit hacky, sorry for that.
     QSettings settings;
-    settings.setValue( QStringLiteral( "/SpatiaLite/connections/%1/sqlitepath" ).arg( editConnName->text() ), mImport->outputDbFileName() );
+    settings.setValue( QStringLiteral( "/SpatiaLite/connections/%1/sqlitepath" ).arg( editConnName->text() ), mImport->outputDatabaseFileName() );
   }
 
   QMessageBox::information( this, tr( "OpenStreetMap import" ), tr( "Import has been successful." ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -634,7 +634,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   qApp->processEvents();
   // Do this early on before anyone else opens it and prevents us copying it
   QString dbError;
-  if ( !QgsApplication::createDB( &dbError ) )
+  if ( !QgsApplication::createDatabase( &dbError ) )
   {
     QMessageBox::critical( this, tr( "Private qgis.db" ), dbError );
   }
@@ -11916,7 +11916,7 @@ void QgisApp::eraseAuthenticationDatabase()
     if ( layertree && layertree->customProperty( QStringLiteral( "loading" ) ).toBool() )
     {
       QgsDebugMsg( "Project loading, skipping auth db erase" );
-      QgsAuthManager::instance()->setScheduledAuthDbEraseRequestEmitted( false );
+      QgsAuthManager::instance()->setScheduledAuthDatabaseEraseRequestEmitted( false );
       return;
     }
   }

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -69,12 +69,12 @@ QgsBookmarks::QgsBookmarks( QWidget *parent )
 
   // open the database
   QSqlDatabase db = QSqlDatabase::addDatabase( QStringLiteral( "QSQLITE" ), QStringLiteral( "bookmarks" ) );
-  db.setDatabaseName( QgsApplication::qgisUserDbFilePath() );
+  db.setDatabaseName( QgsApplication::qgisUserDatabaseFilePath() );
   if ( !db.open() )
   {
     QMessageBox::warning( this, tr( "Error" ),
                           tr( "Unable to open bookmarks database.\nDatabase: %1\nDriver: %2\nDatabase: %3" )
-                          .arg( QgsApplication::qgisUserDbFilePath(),
+                          .arg( QgsApplication::qgisUserDatabaseFilePath(),
                                 db.lastError().driverText(),
                                 db.lastError().databaseText() )
                         );

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -87,7 +87,7 @@ void QgsCustomProjectionDialog::populateList()
   sqlite3_stmt *myPreparedStatement;
   int           myResult;
   //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::qgisUserDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
+  myResult = sqlite3_open_v2( QgsApplication::qgisUserDatabaseFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
   if ( myResult != SQLITE_OK )
   {
     QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
@@ -150,10 +150,10 @@ bool  QgsCustomProjectionDialog::deleteCrs( const QString& id )
   QString mySql = "delete from tbl_srs where srs_id=" + quotedValue( id );
   QgsDebugMsg( mySql );
   //check the db is available
-  myResult = sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8(), &myDatabase );
+  myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
   if ( myResult != SQLITE_OK )
   {
-    QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDbFilePath() ) );
+    QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDatabaseFilePath() ) );
     // XXX This will likely never happen since on open, sqlite creates the
     //     database if it does not exist.
     Q_ASSERT( myResult == SQLITE_OK );
@@ -180,18 +180,18 @@ void  QgsCustomProjectionDialog::insertProjection( const QString& myProjectionAc
   QString mySql;
   const char   *myTail;
   //check the db is available
-  int           myResult = sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8(), &myDatabase );
+  int           myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
   if ( myResult != SQLITE_OK )
   {
-    QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDbFilePath() ) );
+    QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDatabaseFilePath() ) );
     // XXX This will likely never happen since on open, sqlite creates the
     //     database if it does not exist.
     Q_ASSERT( myResult == SQLITE_OK );
   }
-  int srsResult = sqlite3_open( QgsApplication::srsDbFilePath().toUtf8(), &srsDatabase );
+  int srsResult = sqlite3_open( QgsApplication::srsDatabaseFilePath().toUtf8(), &srsDatabase );
   if ( myResult != SQLITE_OK )
   {
-    QgsDebugMsg( QString( "Can't open database %1 [%2]" ).arg( QgsApplication::srsDbFilePath(), sqlite3_errmsg( srsDatabase ) ) );
+    QgsDebugMsg( QString( "Can't open database %1 [%2]" ).arg( QgsApplication::srsDatabaseFilePath(), sqlite3_errmsg( srsDatabase ) ) );
   }
   else
   {
@@ -268,10 +268,10 @@ bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem myCRS, con
     sqlite3_stmt *myPreparedStatement;
     int           myResult;
     //check if the db is available
-    myResult = sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8(), &myDatabase );
+    myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
     if ( myResult != SQLITE_OK )
     {
-      QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDbFilePath() ) );
+      QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDatabaseFilePath() ) );
       // XXX This will likely never happen since on open, sqlite creates the
       //     database if it does not exist.
       Q_ASSERT( myResult == SQLITE_OK );

--- a/src/app/qgsloadstylefromdbdialog.cpp
+++ b/src/app/qgsloadstylefromdbdialog.cpp
@@ -107,7 +107,7 @@ QString QgsLoadStyleFromDBDialog::getSelectedStyleId()
 void QgsLoadStyleFromDBDialog::setLayer( QgsVectorLayer *l )
 {
   mLayer = l;
-  mDeleteButton->setVisible( mLayer->dataProvider()->isDeleteStyleFromDbSupported() );
+  mDeleteButton->setVisible( mLayer->dataProvider()->isDeleteStyleFromDatabaseSupported() );
 }
 
 void QgsLoadStyleFromDBDialog::onRelatedTableSelectionChanged()

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1880,7 +1880,7 @@ void QgsProjectProperties::populateEllipsoidList()
   mEllipsoidList.append( myItem );
 
   //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
+  myResult = sqlite3_open_v2( QgsApplication::srsDatabaseFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
   if ( myResult )
   {
     QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -158,7 +158,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mSaveAsMenu->addAction( tr( "SLD File..." ) );
 
   //Only if the provider support loading & saving styles to db add new choices
-  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDBSupported() )
+  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDatabaseSupported() )
   {
     //for loading
     mLoadStyleMenu = new QMenu( this );
@@ -706,7 +706,7 @@ void QgsVectorLayerProperties::loadDefaultStyle_clicked()
   QString msg;
   bool defaultLoadedFlag = false;
 
-  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDBSupported() )
+  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDatabaseSupported() )
   {
     QMessageBox askToUser;
     askToUser.setText( tr( "Load default style from: " ) );
@@ -761,7 +761,7 @@ void QgsVectorLayerProperties::saveDefaultStyle_clicked()
 {
   apply();
   QString errorMsg;
-  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDBSupported() )
+  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDatabaseSupported() )
   {
     QMessageBox askToUser;
     askToUser.setText( tr( "Save default style to: " ) );

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -74,13 +74,13 @@ class CORE_EXPORT QgsAuthManager : public QObject
     ~QgsAuthManager();
 
     //! Set up the application instance of the authentication database connection
-    QSqlDatabase authDbConnection() const;
+    QSqlDatabase authDatabaseConnection() const;
 
     //! Name of the authentication database table that stores configs
-    const QString authDbConfigTable() const { return AUTH_CONFIG_TABLE; }
+    const QString authDatabaseConfigTable() const { return AUTH_CONFIG_TABLE; }
 
     //! Name of the authentication database table that stores server exceptions/configs
-    const QString authDbServersTable() const { return AUTH_SERVERS_TABLE; }
+    const QString authDatabaseServersTable() const { return AUTH_SERVERS_TABLE; }
 
     //! Initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
     bool init( const QString& pluginPath = QString::null );
@@ -92,9 +92,9 @@ class CORE_EXPORT QgsAuthManager : public QObject
     const QString disabledMessage() const;
 
     /** The standard authentication database file in ~/.qgis3/ or defined location
-     * @see QgsApplication::qgisAuthDbFilePath
+     * @see QgsApplication::qgisAuthDatabaseFilePath
      */
-    const QString authenticationDbPath() const { return mAuthDbPath; }
+    const QString authenticationDatabasePath() const { return mAuthDbPath; }
 
     /** Main call to initially set or continually check master password is set
      * @note If it is not set, the user is asked for its input
@@ -119,7 +119,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
     bool masterPasswordIsSet() const;
 
     //! Verify a password hash existing in authentication database
-    bool masterPasswordHashInDb() const;
+    bool masterPasswordHashInDatabase() const;
 
     /** Clear supplied master password
      * @note This will not necessarily clear authenticated connections cached in network connection managers
@@ -143,7 +143,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
     /** Whether there is a scheduled opitonal erase of authentication database.
      * @note not available in Python bindings
      */
-    bool scheduledAuthDbErase() { return mScheduledDbErase; }
+    bool scheduledAuthDatabaseErase() { return mScheduledDbErase; }
 
     /** Schedule an optional erase of authentication database, starting when mutex is lockable.
      * @note When an erase is scheduled, any attempt to set the master password,
@@ -156,7 +156,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * if no access to user interaction occurs wihtin 90 seconds, it cancels the schedule.
      * @note not available in Python bindings
      */
-    void setScheduledAuthDbErase( bool scheduleErase );
+    void setScheduledAuthDatabaseErase( bool scheduleErase );
 
     /** Re-emit a signal to schedule an optional erase of authentication database.
      * @note This can be called from the slot connected to a previously emitted scheduling signal,
@@ -165,7 +165,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * @param emitted Setting to false will cause signal to be emitted by the schedule timer.
      * Setting to true will stop any emitting, but will not stop the schedule timer.
      */
-    void setScheduledAuthDbEraseRequestEmitted( bool emitted ) { mScheduledDbEraseRequestEmitted = emitted; }
+    void setScheduledAuthDatabaseEraseRequestEmitted( bool emitted ) { mScheduledDbEraseRequestEmitted = emitted; }
 
     //! Simple text tag describing authentication system for message logs
     QString authManTag() const { return AUTH_MAN_TAG; }
@@ -533,7 +533,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * the erase. It relies upon a slot connected to the signal in calling application
      * (the one that initiated the erase) to initiate the erase, when it is ready.
      * Upon activation, a receiving slot should get confimation from the user, then
-     * IMMEDIATELY call setScheduledAuthDbErase( false ) to stop the scheduling timer.
+     * IMMEDIATELY call setScheduledAuthDatabaseErase( false ) to stop the scheduling timer.
      * If receiving slot is NOT ready to initiate the erase, e.g. project is still loading,
      * it can skip the confirmation and request another signal emit from the scheduling timer.
      */

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -236,7 +236,7 @@ void QgsApplication::init( QString customConfigPath )
   ABISYM( mAuthDbDirPath ) = qgisSettingsDirPath();
   if ( getenv( "QGIS_AUTH_DB_DIR_PATH" ) )
   {
-    setAuthDbDirPath( getenv( "QGIS_AUTH_DB_DIR_PATH" ) );
+    setAuthDatabaseDirPath( getenv( "QGIS_AUTH_DB_DIR_PATH" ) );
   }
 
 
@@ -416,7 +416,7 @@ void QgsApplication::setDefaultSvgPaths( const QStringList& pathList )
   ABISYM( mDefaultSvgPaths ) = pathList;
 }
 
-void QgsApplication::setAuthDbDirPath( const QString& theAuthDbDirPath )
+void QgsApplication::setAuthDatabaseDirPath( const QString& theAuthDbDirPath )
 {
   QFileInfo fi( theAuthDbDirPath );
   if ( fi.exists() && fi.isDir() && fi.isWritable() )
@@ -689,7 +689,7 @@ QString QgsApplication::i18nPath()
 /*!
   Returns the path to the master qgis.db file.
 */
-QString QgsApplication::qgisMasterDbFilePath()
+QString QgsApplication::qgisMasterDatabaseFilePath()
 {
   return ABISYM( mPkgDataPath ) + QStringLiteral( "/resources/qgis.db" );
 }
@@ -705,7 +705,7 @@ QString QgsApplication::qgisSettingsDirPath()
 /*!
   Returns the path to the user qgis.db file.
 */
-QString QgsApplication::qgisUserDbFilePath()
+QString QgsApplication::qgisUserDatabaseFilePath()
 {
   return qgisSettingsDirPath() + QStringLiteral( "qgis.db" );
 }
@@ -713,7 +713,7 @@ QString QgsApplication::qgisUserDbFilePath()
 /*!
   Returns the path to the user authentication database file: qgis-auth.db.
 */
-QString QgsApplication::qgisAuthDbFilePath()
+QString QgsApplication::qgisAuthDatabaseFilePath()
 {
   return ABISYM( mAuthDbDirPath ) + QStringLiteral( "qgis-auth.db" );
 }
@@ -736,7 +736,7 @@ QString QgsApplication::iconsPath()
 /*!
   Returns the path to the srs.db file.
 */
-QString QgsApplication::srsDbFilePath()
+QString QgsApplication::srsDatabaseFilePath()
 {
   if ( ABISYM( mRunningFromBuildDir ) )
   {
@@ -999,8 +999,8 @@ QString QgsApplication::showSettings()
                           activeThemePath(),
                           defaultThemePath(),
                           svgPaths().join( tr( "\n\t\t", "match indentation of application state" ) ),
-                          qgisMasterDbFilePath() )
-                    .arg( qgisAuthDbFilePath() );
+                          qgisMasterDatabaseFilePath() )
+                    .arg( qgisAuthDatabaseFilePath() );
   return myState;
 }
 
@@ -1395,7 +1395,7 @@ QgsActionScopeRegistry* QgsApplication::actionScopeRegistry()
   return instance()->mActionScopeRegistry;
 }
 
-bool QgsApplication::createDB( QString *errorMessage )
+bool QgsApplication::createDatabase( QString *errorMessage )
 {
   // set a working directory up for gdal to write .aux.xml files into
   // for cases where the raster dir is read only to the user
@@ -1417,13 +1417,13 @@ bool QgsApplication::createDB( QString *errorMessage )
 #endif
 
   // Check qgis.db and make private copy if necessary
-  QFile qgisPrivateDbFile( QgsApplication::qgisUserDbFilePath() );
+  QFile qgisPrivateDbFile( QgsApplication::qgisUserDatabaseFilePath() );
 
   // first we look for ~/.qgis/qgis.db
   if ( !qgisPrivateDbFile.exists() )
   {
     // if it doesn't exist we copy it in from the global resources dir
-    QString qgisMasterDbFileName = QgsApplication::qgisMasterDbFilePath();
+    QString qgisMasterDbFileName = QgsApplication::qgisMasterDatabaseFilePath();
     QFile masterFile( qgisMasterDbFileName );
 
     // Must be sure there is destination directory ~/.qgis
@@ -1445,7 +1445,7 @@ bool QgsApplication::createDB( QString *errorMessage )
   {
     // migrate if necessary
     sqlite3 *db;
-    if ( sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8().constData(), &db ) != SQLITE_OK )
+    if ( sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8().constData(), &db ) != SQLITE_OK )
     {
       if ( errorMessage )
       {

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -157,16 +157,16 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString i18nPath();
 
     //! Returns the path to the master qgis.db file.
-    static QString qgisMasterDbFilePath();
+    static QString qgisMasterDatabaseFilePath();
 
     //! Returns the path to the settings directory in user's home dir
     static QString qgisSettingsDirPath();
 
     //! Returns the path to the user qgis.db file.
-    static QString qgisUserDbFilePath();
+    static QString qgisUserDatabaseFilePath();
 
     //! Returns the path to the user authentication database file: qgis-auth.db.
-    static QString qgisAuthDbFilePath();
+    static QString qgisAuthDatabaseFilePath();
 
     //! Returns the path to the splash screen image directory.
     static QString splashPath();
@@ -175,7 +175,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString iconsPath();
 
     //! Returns the path to the srs.db file.
-    static QString srsDbFilePath();
+    static QString srsDatabaseFilePath();
 
     //! Returns the paths to svg directories.
     static QStringList svgPaths();
@@ -276,13 +276,13 @@ class CORE_EXPORT QgsApplication : public QApplication
     static void setDefaultSvgPaths( const QStringList& pathList );
 
     //! Alters authentication data base directory path - used by 3rd party apps
-    static void setAuthDbDirPath( const QString& theAuthDbDirPath );
+    static void setAuthDatabaseDirPath( const QString& theAuthDbDirPath );
 
     //! loads providers
     static void initQgis();
 
     //! initialize qgis.db
-    static bool createDB( QString* errorMessage = nullptr );
+    static bool createDatabase( QString* errorMessage = nullptr );
 
     //! Create the users theme folder
     static bool createThemeFolder();

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -136,13 +136,13 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem& );
  * CRS Database and Custom CRS
  * ===========================
  *
- * The database of CRS shipped with QGIS is stored in a SQLite database (see QgsApplication::srsDbFilePath())
+ * The database of CRS shipped with QGIS is stored in a SQLite database (see QgsApplication::srsDatabaseFilePath())
  * and it is based on the data files maintained by GDAL project (a variety of .csv and .wkt files).
  *
  * Sometimes it happens that users need to use a CRS definition that is not well known
  * or that has been only created with a specific purpose (and thus its definition is not
  * available in our database of CRS). Whenever a new CRS definition is seen, it will
- * be added to the local databse (in user's home directory, see QgsApplication::qgisUserDbFilePath()).
+ * be added to the local databse (in user's home directory, see QgsApplication::qgisUserDatabaseFilePath()).
  * QGIS also features a GUI for management of local custom CRS definitions.
  *
  * There are therefore two databases: one for shipped CRS definitions and one for custom CRS definitions.
@@ -555,7 +555,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *   negative number of failed updates in case of errors.
      * @note This is used internally and should not be necessary to call in client code
      */
-    static int syncDb();
+    static int syncDatabase();
 
 
     /** Save the proj4-string as a custom CRS
@@ -659,7 +659,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     //! Open SQLite db and show message if cannot be opened
     //! @return the same code as sqlite3_open
-    static int openDb( const QString& path, sqlite3 **db, bool readonly = true );
+    static int openDatabase( const QString& path, sqlite3 **db, bool readonly = true );
 
     //! Work out the projection units and set the appropriate local variable
     void setMapUnits();
@@ -672,7 +672,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     //! Initialize the CRS object by looking up CRS database in path given in db argument,
     //! using first CRS entry where expression = 'value'
-    bool loadFromDb( const QString& db, const QString& expression, const QString& value );
+    bool loadFromDatabase( const QString& db, const QString& expression, const QString& value );
 
     static bool loadIds( QHash<int, QString> &wkts );
     static bool loadWkts( QHash<int, QString> &wkts, const char *filename );

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -690,7 +690,7 @@ QList< QList< int > > QgsCoordinateTransform::datumTransformations( const QgsCoo
 void QgsCoordinateTransform::searchDatumTransform( const QString& sql, QList< int >& transforms )
 {
   sqlite3* db;
-  int openResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
+  int openResult = sqlite3_open_v2( QgsApplication::srsDatabaseFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
   if ( openResult != SQLITE_OK )
   {
     sqlite3_close( db );
@@ -724,7 +724,7 @@ QString QgsCoordinateTransform::datumTransformString( int datumTransform )
 bool QgsCoordinateTransform::datumTransformCrsInfo( int datumTransform, int& epsgNr, QString& srcProjection, QString& dstProjection, QString &remarks, QString &scope, bool &preferred, bool &deprecated )
 {
   sqlite3* db;
-  int openResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
+  int openResult = sqlite3_open_v2( QgsApplication::srsDatabaseFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
   if ( openResult != SQLITE_OK )
   {
     sqlite3_close( db );

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -235,7 +235,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
       QString transformString;
 
       sqlite3* db;
-      int openResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
+      int openResult = sqlite3_open_v2( QgsApplication::srsDatabaseFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
       if ( openResult != SQLITE_OK )
       {
         sqlite3_close( db );

--- a/src/core/qgsdbfilterproxymodel.cpp
+++ b/src/core/qgsdbfilterproxymodel.cpp
@@ -17,12 +17,12 @@
 
 #include "qgsdbfilterproxymodel.h"
 
-QgsDbFilterProxyModel::QgsDbFilterProxyModel( QObject* parent ): QSortFilterProxyModel( parent )
+QgsDatabaseFilterProxyModel::QgsDatabaseFilterProxyModel( QObject* parent ): QSortFilterProxyModel( parent )
 {
 
 }
 
-bool QgsDbFilterProxyModel::filterAcceptsRow( int row, const QModelIndex & source_parent ) const
+bool QgsDatabaseFilterProxyModel::filterAcceptsRow( int row, const QModelIndex & source_parent ) const
 {
   //if parent is valid, we have a toplevel item that should be always shown
   if ( !source_parent.isValid() )
@@ -35,13 +35,13 @@ bool QgsDbFilterProxyModel::filterAcceptsRow( int row, const QModelIndex & sourc
   return QSortFilterProxyModel::filterAcceptsRow( row, source_parent );
 }
 
-void QgsDbFilterProxyModel::_setFilterWildcard( const QString& pattern )
+void QgsDatabaseFilterProxyModel::_setFilterWildcard( const QString& pattern )
 {
   QSortFilterProxyModel::setFilterWildcard( pattern );
   emit layoutChanged();
 }
 
-void QgsDbFilterProxyModel::_setFilterRegExp( const QString& pattern )
+void QgsDatabaseFilterProxyModel::_setFilterRegExp( const QString& pattern )
 {
   QSortFilterProxyModel::setFilterRegExp( pattern );
   emit layoutChanged();

--- a/src/core/qgsdbfilterproxymodel.h
+++ b/src/core/qgsdbfilterproxymodel.h
@@ -22,17 +22,27 @@
 
 #include "qgis_core.h"
 
-/** \ingroup core
+/**
+ * \class QgsDatabaseFilterProxyModel
+ * \ingroup core
  * A class that implements a custom filter and can be used
- as a proxy for QgsDbTableModel*/
-class CORE_EXPORT QgsDbFilterProxyModel: public QSortFilterProxyModel
+ * as a proxy for QgsDbTableModel
+ * \note added in QGIS 3.0
+*/
+class CORE_EXPORT QgsDatabaseFilterProxyModel: public QSortFilterProxyModel
 {
     Q_OBJECT
 
   public:
-    QgsDbFilterProxyModel( QObject* parent = nullptr );
+
+    /**
+     * Constructor for QgsDatabaseFilterProxyModel.
+     */
+    QgsDatabaseFilterProxyModel( QObject* parent = nullptr );
+
     //! Calls QSortFilterProxyModel::setFilterWildcard and triggers update
     void _setFilterWildcard( const QString& pattern );
+
     //! Calls QSortFilterProxyModel::setFilterRegExp and triggers update
     void _setFilterRegExp( const QString& pattern );
 

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -154,7 +154,7 @@ bool QgsDistanceArea::setEllipsoid( const QString& ellipsoid )
   // Continue with PROJ.4 list of ellipsoids.
 
   //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
+  myResult = sqlite3_open_v2( QgsApplication::srsDatabaseFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
   if ( myResult )
   {
     QgsMessageLog::logMessage( QObject::tr( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -992,7 +992,7 @@ QString QgsMapLayer::loadDefaultStyle( bool & resultFlag )
   return loadNamedStyle( styleURI(), resultFlag );
 }
 
-bool QgsMapLayer::loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qml )
+bool QgsMapLayer::loadNamedStyleFromDatabase( const QString &db, const QString &uri, QString &qml )
 {
   QgsDebugMsg( QString( "db = %1 uri = %2" ).arg( db, uri ) );
 
@@ -1064,9 +1064,9 @@ QString QgsMapLayer::loadNamedStyle( const QString &uri, bool &resultFlag )
     QgsDebugMsg( QString( "project fileName: %1" ).arg( project.absoluteFilePath() ) );
 
     QString qml;
-    if ( loadNamedStyleFromDb( QDir( QgsApplication::qgisSettingsDirPath() ).absoluteFilePath( QStringLiteral( "qgis.qmldb" ) ), uri, qml ) ||
-         ( project.exists() && loadNamedStyleFromDb( project.absoluteDir().absoluteFilePath( project.baseName() + ".qmldb" ), uri, qml ) ) ||
-         loadNamedStyleFromDb( QDir( QgsApplication::pkgDataPath() ).absoluteFilePath( QStringLiteral( "resources/qgis.qmldb" ) ), uri, qml ) )
+    if ( loadNamedStyleFromDatabase( QDir( QgsApplication::qgisSettingsDirPath() ).absoluteFilePath( QStringLiteral( "qgis.qmldb" ) ), uri, qml ) ||
+         ( project.exists() && loadNamedStyleFromDatabase( project.absoluteDir().absoluteFilePath( project.baseName() + ".qmldb" ), uri, qml ) ) ||
+         loadNamedStyleFromDatabase( QDir( QgsApplication::pkgDataPath() ).absoluteFilePath( QStringLiteral( "resources/qgis.qmldb" ) ), uri, qml ) )
     {
       resultFlag = myDocument.setContent( qml, &myErrorMessage, &line, &column );
       if ( !resultFlag )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -463,7 +463,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * @param qml will be set to QML style content from database
      * @returns true if style was successfully loaded
      */
-    virtual bool loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qml );
+    virtual bool loadNamedStyleFromDatabase( const QString &db, const QString &uri, QString &qml );
 
     /**
      * Import the properties of this layer from a QDomDocument

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -690,12 +690,12 @@ QStringList QgsVectorDataProvider::errors() const
   return mErrors;
 }
 
-bool QgsVectorDataProvider::isSaveAndLoadStyleToDBSupported() const
+bool QgsVectorDataProvider::isSaveAndLoadStyleToDatabaseSupported() const
 {
   return false;
 }
 
-bool QgsVectorDataProvider::isDeleteStyleFromDbSupported() const
+bool QgsVectorDataProvider::isDeleteStyleFromDatabaseSupported() const
 {
   return false;
 }

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -468,13 +468,13 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * It returns false by default.
      * Must be implemented by providers that support saving and loading styles to db returning true
      */
-    virtual bool isSaveAndLoadStyleToDBSupported() const;
+    virtual bool isSaveAndLoadStyleToDatabaseSupported() const;
 
     /**
      * It returns false by default.
      * Must be implemented by providers that support delete styles from db returning true
      */
-    virtual bool isDeleteStyleFromDbSupported() const;
+    virtual bool isDeleteStyleFromDatabaseSupported() const;
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4374,7 +4374,7 @@ QString QgsVectorLayer::loadNamedStyle( const QString &theURI, bool &theResultFl
 QString QgsVectorLayer::loadNamedStyle( const QString &theURI, bool &theResultFlag, bool loadFromLocalDB )
 {
   QgsDataSourceUri dsUri( theURI );
-  if ( !loadFromLocalDB && mDataProvider && mDataProvider->isSaveAndLoadStyleToDBSupported() )
+  if ( !loadFromLocalDB && mDataProvider && mDataProvider->isSaveAndLoadStyleToDatabaseSupported() )
   {
     QScopedPointer<QLibrary> myLib( QgsProviderRegistry::instance()->providerLibrary( mProviderKey ) );
     if ( myLib )

--- a/src/core/symbology-ng/qgsstyle.cpp
+++ b/src/core/symbology-ng/qgsstyle.cpp
@@ -59,7 +59,7 @@ QgsStyle* QgsStyle::defaultStyle() // static
     if ( !QFile::exists( styleFilename ) )
     {
       sDefaultStyle = new QgsStyle;
-      sDefaultStyle->createDb( styleFilename );
+      sDefaultStyle->createDatabase( styleFilename );
       if ( QFile::exists( QgsApplication::defaultStylePath() ) )
       {
         sDefaultStyle->importXml( QgsApplication::defaultStylePath() );
@@ -283,7 +283,7 @@ QStringList QgsStyle::colorRampNames()
   return mColorRamps.keys();
 }
 
-bool QgsStyle::openDB( const QString& filename )
+bool QgsStyle::openDatabase( const QString& filename )
 {
   int rc = sqlite3_open( filename.toUtf8(), &mCurrentDB );
   if ( rc )
@@ -296,10 +296,10 @@ bool QgsStyle::openDB( const QString& filename )
   return true;
 }
 
-bool QgsStyle::createDb( const QString& filename )
+bool QgsStyle::createDatabase( const QString& filename )
 {
   mErrorString.clear();
-  if ( !openDB( filename ) )
+  if ( !openDatabase( filename ) )
   {
     mErrorString = QStringLiteral( "Unable to create database" );
     QgsDebugMsg( mErrorString );
@@ -311,10 +311,10 @@ bool QgsStyle::createDb( const QString& filename )
   return true;
 }
 
-bool QgsStyle::createMemoryDb()
+bool QgsStyle::createMemoryDatabase()
 {
   mErrorString.clear();
-  if ( !openDB( QStringLiteral( ":memory:" ) ) )
+  if ( !openDatabase( QStringLiteral( ":memory:" ) ) )
   {
     mErrorString = QStringLiteral( "Unable to create temporary memory database" );
     QgsDebugMsg( mErrorString );
@@ -359,7 +359,7 @@ bool QgsStyle::load( const QString& filename )
   mErrorString.clear();
 
   // Open the sqlite database
-  if ( !openDB( filename ) )
+  if ( !openDatabase( filename ) )
   {
     mErrorString = QStringLiteral( "Unable to open database file specified" );
     QgsDebugMsg( mErrorString );

--- a/src/core/symbology-ng/qgsstyle.h
+++ b/src/core/symbology-ng/qgsstyle.h
@@ -281,7 +281,7 @@ class CORE_EXPORT QgsStyle : public QObject
      *  \note added in QGIS 3.0
      *  \see createMemoryDb()
      */
-    bool createDb( const QString& filename );
+    bool createDatabase( const QString& filename );
 
     /** Creates a temporary memory database
      *
@@ -290,7 +290,7 @@ class CORE_EXPORT QgsStyle : public QObject
      *  \note added in QGIS 3.0
      *  \see createDb()
      */
-    bool createMemoryDb();
+    bool createMemoryDatabase();
 
     /** Creates tables structure for new database
      *
@@ -388,7 +388,7 @@ class CORE_EXPORT QgsStyle : public QObject
     static QgsStyle* sDefaultStyle;
 
     //! Convenience function to open the DB and return a sqlite3 object
-    bool openDB( const QString& filename );
+    bool openDatabase( const QString& filename );
 
     /** Convenience function that would run queries which don't generate return values
      *

--- a/src/crssync/main.cpp
+++ b/src/crssync/main.cpp
@@ -52,7 +52,7 @@ int main( int argc, char ** argv )
 
   CPLPushErrorHandler( showError );
 
-  int res = QgsCoordinateReferenceSystem::syncDb();
+  int res = QgsCoordinateReferenceSystem::syncDatabase();
 
   CPLPopErrorHandler();
 

--- a/src/gui/auth/qgsauthconfigeditor.cpp
+++ b/src/gui/auth/qgsauthconfigeditor.cpp
@@ -55,8 +55,8 @@ QgsAuthConfigEditor::QgsAuthConfigEditor( QWidget *parent, bool showUtilities, b
 
     setShowUtilitiesButton( showUtilities );
 
-    mConfigModel = new QSqlTableModel( this, QgsAuthManager::instance()->authDbConnection() );
-    mConfigModel->setTable( QgsAuthManager::instance()->authDbConfigTable() );
+    mConfigModel = new QSqlTableModel( this, QgsAuthManager::instance()->authDatabaseConnection() );
+    mConfigModel->setTable( QgsAuthManager::instance()->authDatabaseConfigTable() );
     mConfigModel->select();
 
     mConfigModel->setHeaderData( 0, Qt::Horizontal, tr( "ID" ) );

--- a/src/gui/auth/qgsauthguiutils.cpp
+++ b/src/gui/auth/qgsauthguiutils.cpp
@@ -120,7 +120,7 @@ void QgsAuthGuiUtils::resetMasterPassword( QgsMessageBar *msgbar, int timeout, Q
   QgsMessageBar::MessageLevel level( QgsMessageBar::INFO );
 
   // check that a master password is even set in auth db
-  if ( !QgsAuthManager::instance()->masterPasswordHashInDb() )
+  if ( !QgsAuthManager::instance()->masterPasswordHashInDatabase() )
   {
     msg = QObject::tr( "Master password reset: NO current password hash in database" );
     msgbar->pushMessage( QgsAuthManager::instance()->authManTag(), msg, QgsMessageBar::WARNING, 0 );
@@ -206,7 +206,7 @@ void QgsAuthGuiUtils::eraseAuthenticationDatabase( QgsMessageBar *msgbar, int ti
                                        QMessageBox::Ok | QMessageBox::Cancel,
                                        QMessageBox::Cancel );
 
-  QgsAuthManager::instance()->setScheduledAuthDbErase( false );
+  QgsAuthManager::instance()->setScheduledAuthDatabaseErase( false );
 
   if ( btn == QMessageBox::Cancel )
   {

--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -165,7 +165,7 @@ void QgsCredentialDialog::requestCredentialsMasterPassword( QString * password, 
       {
         if ( stored && chkbxEraseAuthDb->isChecked() )
         {
-          QgsAuthManager::instance()->setScheduledAuthDbErase( true );
+          QgsAuthManager::instance()->setScheduledAuthDatabaseErase( true );
         }
         else
         {

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -188,7 +188,7 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
 
   if ( QgsVectorLayer* layer = qobject_cast<QgsVectorLayer*>( mLayer ) )
   {
-    if ( layer->dataProvider()->isSaveAndLoadStyleToDBSupported() )
+    if ( layer->dataProvider()->isSaveAndLoadStyleToDatabaseSupported() )
     {
       QMessageBox askToUser;
       askToUser.setText( tr( "Save default style to: " ) );
@@ -230,7 +230,7 @@ void QgsMapLayerStyleManagerWidget::loadDefault()
 
   if ( QgsVectorLayer* layer = qobject_cast<QgsVectorLayer*>( mLayer ) )
   {
-    if ( layer->dataProvider()->isSaveAndLoadStyleToDBSupported() )
+    if ( layer->dataProvider()->isSaveAndLoadStyleToDatabaseSupported() )
     {
       QMessageBox askToUser;
       askToUser.setText( tr( "Load default style from: " ) );

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -48,7 +48,7 @@ QgsProjectionSelector::QgsProjectionSelector( QWidget* parent, const char *name,
   }
 
   // Get the full path name to the sqlite3 spatial reference database.
-  mSrsDatabaseFileName = QgsApplication::srsDbFilePath();
+  mSrsDatabaseFileName = QgsApplication::srsDatabaseFilePath();
 
   lstCoordinateSystems->header()->setResizeMode( AuthidColumn, QHeaderView::Stretch );
   lstCoordinateSystems->header()->resizeSection( QgisCrsIdColumn, 0 );
@@ -307,7 +307,7 @@ QString QgsProjectionSelector::selectedProj4String()
   QString databaseFileName;
   if ( srsId.toLong() >= USER_CRS_START_ID )
   {
-    databaseFileName = QgsApplication::qgisUserDbFilePath();
+    databaseFileName = QgsApplication::qgisUserDatabaseFilePath();
     if ( !QFileInfo::exists( databaseFileName ) ) //its unlikely that this condition will ever be reached
       return QString();
   }
@@ -371,7 +371,7 @@ QString QgsProjectionSelector::getSelectedExpression( const QString& expression 
   QString databaseFileName;
   if ( lvi->text( QgisCrsIdColumn ).toLong() >= USER_CRS_START_ID )
   {
-    databaseFileName = QgsApplication::qgisUserDbFilePath();
+    databaseFileName = QgsApplication::qgisUserDatabaseFilePath();
     if ( !QFileInfo::exists( databaseFileName ) )
     {
       return QString();
@@ -478,7 +478,7 @@ void QgsProjectionSelector::loadUserCrsList( QSet<QString> *crsFilter )
 
   //determine where the user proj database lives for this user. If none is found an empty
   //now only will be shown
-  QString databaseFileName = QgsApplication::qgisUserDbFilePath();
+  QString databaseFileName = QgsApplication::qgisUserDatabaseFilePath();
   // first we look for ~/.qgis/qgis.db
   // if it doesn't exist we copy it in from the global resources dir
 
@@ -887,7 +887,7 @@ long QgsProjectionSelector::getLargestCrsIdMatch( const QString& theSql )
   // first we search the users db as any srsid there will be definition be greater than in sys db
 
   //check the db is available
-  QString databaseFileName = QgsApplication::qgisUserDbFilePath();
+  QString databaseFileName = QgsApplication::qgisUserDatabaseFilePath();
   if ( QFileInfo::exists( databaseFileName ) ) //only bother trying to open if the file exists
   {
     result = sqlite3_open_v2( databaseFileName.toUtf8().data(), &database, SQLITE_OPEN_READONLY, nullptr );

--- a/src/gui/symbology-ng/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstyleexportimportdialog.cpp
@@ -55,7 +55,7 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle* style, QWidget
            this, SLOT( selectionChanged( const QItemSelection&, const QItemSelection& ) ) );
 
   mTempStyle = new QgsStyle();
-  mTempStyle->createMemoryDb();
+  mTempStyle->createMemoryDatabase();
 
   // TODO validate
   mFileName = QLatin1String( "" );

--- a/src/providers/db2/qgsdb2sourceselect.h
+++ b/src/providers/db2/qgsdb2sourceselect.h
@@ -181,7 +181,7 @@ class QgsDb2SourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
 
     //! Model that acts as datasource for mTableTreeWidget
     QgsDb2TableModel mTableModel;
-    QgsDbFilterProxyModel mProxyModel;
+    QgsDatabaseFilterProxyModel mProxyModel;
 
     QPushButton *mBuildQueryButton;
     QPushButton *mAddButton;

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -99,7 +99,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
 
     bool isValid() const override;
 
-    virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
+    virtual bool isSaveAndLoadStyleToDatabaseSupported() const override { return true; }
 
     virtual bool addFeatures( QgsFeatureList & flist ) override;
 

--- a/src/providers/mssql/qgsmssqlsourceselect.h
+++ b/src/providers/mssql/qgsmssqlsourceselect.h
@@ -179,7 +179,7 @@ class QgsMssqlSourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
 
     //! Model that acts as datasource for mTableTreeWidget
     QgsMssqlTableModel mTableModel;
-    QgsDbFilterProxyModel mProxyModel;
+    QgsDatabaseFilterProxyModel mProxyModel;
 
     QPushButton *mBuildQueryButton;
     QPushButton *mAddButton;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3607,7 +3607,7 @@ bool QgsOgrProvider::leaveUpdateMode()
   return true;
 }
 
-bool QgsOgrProvider::isSaveAndLoadStyleToDBSupported() const
+bool QgsOgrProvider::isSaveAndLoadStyleToDatabaseSupported() const
 {
   // We could potentially extend support for styling to other drivers
   // with multiple layer support.

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -91,7 +91,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     virtual void setEncoding( const QString& e ) override;
     virtual bool enterUpdateMode() override;
     virtual bool leaveUpdateMode() override;
-    virtual bool isSaveAndLoadStyleToDBSupported() const override;
+    virtual bool isSaveAndLoadStyleToDatabaseSupported() const override;
     QString fileVectorFilters() const override;
     //! Return a string containing the available database drivers
     QString databaseDrivers() const;

--- a/src/providers/postgres/qgspgsourceselect.h
+++ b/src/providers/postgres/qgspgsourceselect.h
@@ -151,7 +151,7 @@ class QgsPgSourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
 
     //! Model that acts as datasource for mTableTreeWidget
     QgsPgTableModel mTableModel;
-    QgsDbFilterProxyModel mProxyModel;
+    QgsDatabaseFilterProxyModel mProxyModel;
 
     QPushButton *mBuildQueryButton;
     QPushButton *mAddButton;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -131,8 +131,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
         QgsFeedback* feedback = nullptr ) const override;
     virtual void enumValues( int index, QStringList& enumList ) const override;
     bool isValid() const override;
-    virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
-    virtual bool isDeleteStyleFromDbSupported() const override { return true; }
+    virtual bool isSaveAndLoadStyleToDatabaseSupported() const override { return true; }
+    virtual bool isDeleteStyleFromDatabaseSupported() const override { return true; }
     QgsAttributeList attributeIndexes() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QString defaultValueClause( int fieldId ) const override;

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -101,7 +101,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
         QgsFeedback* feedback = nullptr ) const override;
 
     bool isValid() const override;
-    virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
+    virtual bool isSaveAndLoadStyleToDatabaseSupported() const override { return true; }
     bool addFeatures( QgsFeatureList & flist ) override;
     bool deleteFeatures( const QgsFeatureIds & id ) override;
     bool truncate() override;

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -123,7 +123,7 @@ class QgsSpatiaLiteSourceSelect: public QDialog, private Ui::QgsDbSourceSelectBa
     QMap < QString, QPair < QString, QIcon > >mLayerIcons;
     //! Model that acts as datasource for mTableTreeWidget
     QgsSpatiaLiteTableModel mTableModel;
-    QgsDbFilterProxyModel mProxyModel;
+    QgsDatabaseFilterProxyModel mProxyModel;
 
     QString layerURI( const QModelIndex &index );
     QPushButton *mBuildQueryButton;

--- a/src/server/qgsconfigparserutils.cpp
+++ b/src/server/qgsconfigparserutils.cpp
@@ -269,7 +269,7 @@ void QgsConfigParserUtils::appendLayerBoundingBox( QDomElement& layerElem, QDomD
 QStringList QgsConfigParserUtils::createCrsListForLayer( QgsMapLayer* theMapLayer )
 {
   QStringList crsNumbers;
-  QString myDatabaseFileName = QgsApplication::srsDbFilePath();
+  QString myDatabaseFileName = QgsApplication::srsDatabaseFilePath();
   sqlite3      *myDatabase;
   const char   *myTail;
   sqlite3_stmt *myPreparedStatement;

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -235,11 +235,11 @@ bool QgsServer::init( )
   QgsMessageLog::logMessage( "Prefix  PATH: " + QgsApplication::prefixPath(), QStringLiteral( "Server" ), QgsMessageLog::INFO );
   QgsMessageLog::logMessage( "Plugin  PATH: " + QgsApplication::pluginPath(), QStringLiteral( "Server" ), QgsMessageLog::INFO );
   QgsMessageLog::logMessage( "PkgData PATH: " + QgsApplication::pkgDataPath(), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  QgsMessageLog::logMessage( "User DB PATH: " + QgsApplication::qgisUserDbFilePath(), QStringLiteral( "Server" ), QgsMessageLog::INFO );
-  QgsMessageLog::logMessage( "Auth DB PATH: " + QgsApplication::qgisAuthDbFilePath(), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  QgsMessageLog::logMessage( "User DB PATH: " + QgsApplication::qgisUserDatabaseFilePath(), QStringLiteral( "Server" ), QgsMessageLog::INFO );
+  QgsMessageLog::logMessage( "Auth DB PATH: " + QgsApplication::qgisAuthDatabaseFilePath(), QStringLiteral( "Server" ), QgsMessageLog::INFO );
   QgsMessageLog::logMessage( "SVG PATHS: " + QgsApplication::svgPaths().join( QDir::separator() ), QStringLiteral( "Server" ), QgsMessageLog::INFO );
 
-  QgsApplication::createDB(); //init qgis.db (e.g. necessary for user crs)
+  QgsApplication::createDatabase(); //init qgis.db (e.g. necessary for user crs)
 
   // Instantiate authentication system
   //   creates or uses qgis-auth.db in ~/.qgis3/ or directory defined by QGIS_AUTH_DB_DIR_PATH env variable

--- a/tests/src/core/testqgsauthmanager.cpp
+++ b/tests/src/core/testqgsauthmanager.cpp
@@ -91,7 +91,7 @@ void TestQgsAuthManager::initTestCase()
   mReport += "<p>" + mySettings + "</p>\n";
 
   // verify QGIS_AUTH_DB_DIR_PATH (temp auth db path) worked
-  QString db1( QFileInfo( QgsAuthManager::instance()->authenticationDbPath() ).canonicalFilePath() );
+  QString db1( QFileInfo( QgsAuthManager::instance()->authenticationDatabasePath() ).canonicalFilePath() );
   QString db2( QFileInfo( mTempDir + "/qgis-auth.db" ).canonicalFilePath() );
   QVERIFY2( db1 == db2, "Auth db temp path does not match db path of manager" );
 
@@ -180,7 +180,7 @@ void TestQgsAuthManager::testMasterPassword()
   QgsAuthManager *authm = QgsAuthManager::instance();
 
   QVERIFY( authm->masterPasswordIsSet() );
-  QVERIFY( authm->masterPasswordHashInDb() );
+  QVERIFY( authm->masterPasswordHashInDatabase() );
   QVERIFY( authm->masterPasswordSame( mPass ) );
   QVERIFY( !authm->masterPasswordSame( "wrongpass" ) );
   QVERIFY( authm->setMasterPassword() );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -77,7 +77,7 @@ class TestQgsExpression: public QObject
       QgsApplication::init();
       QgsApplication::initQgis();
       // Will make sure the settings dir with the style file for color ramp is created
-      QgsApplication::createDB();
+      QgsApplication::createDatabase();
       QgsApplication::showSettings();
 
       //create a point layer that will be used in all tests...

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -71,7 +71,7 @@ class TestQgsPointLocator : public QObject
       QgsApplication::init();
       QgsApplication::initQgis();
       // Will make sure the settings dir with the style file for color ramp is created
-      QgsApplication::createDB();
+      QgsApplication::createDatabase();
       QgsApplication::showSettings();
 
       // vector layer with a triangle:

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -53,7 +53,7 @@ class TestQgsSnappingUtils : public QObject
       QgsApplication::init();
       QgsApplication::initQgis();
       // Will make sure the settings dir with the style file for color ramp is created
-      QgsApplication::createDB();
+      QgsApplication::createDatabase();
       QgsApplication::showSettings();
 
       // vector layer with a triangle:

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -81,7 +81,7 @@ void TestStyle::initTestCase()
   // initialize with test settings directory so we don't mess with user's stuff
   QgsApplication::init( QDir::tempPath() + "/dot-qgis" );
   QgsApplication::initQgis();
-  QgsApplication::createDB();
+  QgsApplication::createDatabase();
   mTestDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
 
   // output test environment
@@ -94,7 +94,7 @@ void TestStyle::initTestCase()
 
   //initize a temporary memory-based style for tests to avoid clashing with shipped symbols
   mStyle = new QgsStyle();
-  mStyle->createMemoryDb();
+  mStyle->createMemoryDatabase();
 
   // cpt-city ramp, small selection available in <testdir>/cpt-city
   QgsCptCityArchive::initArchives();

--- a/tests/src/core/testqgssymbol.cpp
+++ b/tests/src/core/testqgssymbol.cpp
@@ -84,7 +84,7 @@ void TestQgsSymbol::initTestCase()
   // initialize with test settings directory so we don't mess with user's stuff
   QgsApplication::init( QDir::tempPath() + "/dot-qgis" );
   QgsApplication::initQgis();
-  QgsApplication::createDB();
+  QgsApplication::createDatabase();
   mTestDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
 
   // output test environment

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -229,7 +229,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         # First test with invalid URI
         vl = QgsVectorLayer('/idont/exist.gpkg', 'test', 'ogr')
 
-        self.assertFalse(vl.dataProvider().isSaveAndLoadStyleToDBSupported())
+        self.assertFalse(vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, -1)
@@ -271,7 +271,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         vl2 = QgsVectorLayer('{}|layername=test2'.format(tmpfile), 'test2', 'ogr')
         self.assertTrue(vl2.isValid())
 
-        self.assertTrue(vl.dataProvider().isSaveAndLoadStyleToDBSupported())
+        self.assertTrue(vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 0)

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -644,8 +644,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         vl = self.getEditableLayer()
         self.assertTrue(vl.isValid())
-        self.assertTrue(vl.dataProvider().isSaveAndLoadStyleToDBSupported())
-        self.assertTrue(vl.dataProvider().isDeleteStyleFromDbSupported())
+        self.assertTrue(vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
+        self.assertTrue(vl.dataProvider().isDeleteStyleFromDatabaseSupported())
 
         # table layer_styles does not exit
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()

--- a/tests/src/python/test_qgsauthsystem.py
+++ b/tests/src/python/test_qgsauthsystem.py
@@ -49,7 +49,7 @@ class TestQgsAuthManager(unittest.TestCase):
 
         cls.mpass = 'pass'  # master password
 
-        db1 = QFileInfo(cls.authm.authenticationDbPath()).canonicalFilePath()
+        db1 = QFileInfo(cls.authm.authenticationDatabasePath()).canonicalFilePath()
         db2 = QFileInfo(AUTHDBDIR + '/qgis-auth.db').canonicalFilePath()
         msg = 'Auth db temp path does not match db path of manager'
         assert db1 == db2, msg
@@ -61,7 +61,7 @@ class TestQgsAuthManager(unittest.TestCase):
         qDebug(testheader)
 
         if (not self.authm.masterPasswordIsSet()
-                or not self.authm.masterPasswordHashInDb()):
+                or not self.authm.masterPasswordHashInDatabase()):
             self.set_master_password()
 
     def widget_dialog(self, widget):
@@ -90,7 +90,7 @@ class TestQgsAuthManager(unittest.TestCase):
         self.assertTrue(self.authm.masterPasswordIsSet(), msg)
 
         msg = 'Master password hash is not in database'
-        self.assertTrue(self.authm.masterPasswordHashInDb(), msg)
+        self.assertTrue(self.authm.masterPasswordHashInDatabase(), msg)
 
         msg = 'Master password not verified against hash in database'
         self.assertTrue(self.authm.verifyMasterPassword(), msg)
@@ -527,7 +527,7 @@ class TestQgsAuthManager(unittest.TestCase):
         # qDebug('Backup db path: {0}'.format(backup))
         msg = 'Could not retrieve backup path for reset master password op'
         self.assertIsNotNone(backup)
-        self.assertTrue(backup != self.authm.authenticationDbPath(), msg)
+        self.assertTrue(backup != self.authm.authenticationDatabasePath(), msg)
 
         msg = 'Could not verify reset master password'
         self.assertTrue(self.authm.setMasterPassword('newpass', True), msg)
@@ -539,7 +539,7 @@ class TestQgsAuthManager(unittest.TestCase):
         self.assertTrue(len(self.authm.configIds()) == 0, msg)
 
         msg = 'Auth db does not exist'
-        self.assertTrue(os.path.exists(self.authm.authenticationDbPath()), msg)
+        self.assertTrue(os.path.exists(self.authm.authenticationDatabasePath()), msg)
 
         QTest.qSleep(1000)  # necessary for new backup to have different name
 
@@ -552,11 +552,11 @@ class TestQgsAuthManager(unittest.TestCase):
         # qDebug('Erase db backup db path: {0}'.format(backup))
         msg = 'Could not retrieve backup path for erase db op'
         self.assertIsNotNone(backup)
-        self.assertTrue(backup != self.authm.authenticationDbPath(), msg)
+        self.assertTrue(backup != self.authm.authenticationDatabasePath(), msg)
 
         msg = 'Master password not erased from auth db'
         self.assertTrue(not self.authm.masterPasswordIsSet()
-                        and not self.authm.masterPasswordHashInDb(), msg)
+                        and not self.authm.masterPasswordHashInDatabase(), msg)
 
         self.set_master_password()
 


### PR DESCRIPTION
Motivations:
- consistency - we generally use expanded names, and this also matches Qt API which uses Database instead of Db
- avoids unpredictable capitalization throughout API (mix of "Db" and "DB")