### PR TITLE
fix QgsProject::readNumEntry() validity check

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1432,7 +1432,7 @@ int QgsProject::readNumEntry( const QString& scope, const QString &key, int def,
     value = property->value();
   }
 
-  bool valid = value.canConvert( QVariant::String );
+  bool valid = value.canConvert( QVariant::Int );
 
   if ( ok )
   {

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -14,13 +14,17 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 # This will get replaced with a git SHA1 when you do a git archive
 __revision__ = '$Format:%H$'
 
+import os
+
 import qgis  # NOQA
 
 from qgis.core import QgsProject, QgsApplication, QgsUnitTypes, QgsCoordinateReferenceSystem
 
 from qgis.testing import start_app, unittest
+from utilities import (unitTestDataPath)
 
 start_app()
+TEST_DATA_DIR = unitTestDataPath()
 
 
 class TestQgsProject(unittest.TestCase):
@@ -139,6 +143,15 @@ class TestQgsProject(unittest.TestCase):
 
         prj.setAreaUnits(QgsUnitTypes.AreaSquareFeet)
         self.assertEqual(prj.areaUnits(), QgsUnitTypes.AreaSquareFeet)
+
+    def testReadEntry(self):
+        prj = QgsProject.instance()
+        prj.read(os.path.join(TEST_DATA_DIR, 'labeling/test-labeling.qgs'))
+
+        #valid key, valid int value
+        self.assertEqual(prj.readNumEntry("SpatialRefSys", "/ProjectionsEnabled", -1)[0], 0)
+        #invalid key
+        self.assertEqual(prj.readNumEntry("SpatialRefSys", "/InvalidKey", -1)[0], -1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Halfway through debugging a project load issue, I've stumbled on a tiny issue with the QgsProject::readNumEntry(), whereas it wrongly validates for a string conversion when it should check for an int one.

Not the end of the world, but we might as well fix this.