### PR TITLE
Take wfs gml directly from geometry

### DIFF
--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -248,33 +248,16 @@ QDomElement QgsCompoundCurve::asGML2( QDomDocument& doc, int precision, const QS
 
 QDomElement QgsCompoundCurve::asGML3( QDomDocument& doc, int precision, const QString& ns ) const
 {
-  QDomElement elemCurve = doc.createElementNS( ns, QStringLiteral( "Curve" ) );
-
-  QDomElement elemSegments = doc.createElementNS( ns, QStringLiteral( "segments" ) );
-
+  QDomElement compoundCurveElem = doc.createElementNS( ns, QStringLiteral( "CompositeCurve" ) );
   Q_FOREACH ( const QgsCurve* curve, mCurves )
   {
-    if ( dynamic_cast<const QgsLineString*>( curve ) )
-    {
-      QgsPointSequence pts;
-      curve->points( pts );
-
-      QDomElement elemLineStringSegment = doc.createElementNS( ns, QStringLiteral( "LineStringSegment" ) );
-      elemLineStringSegment.appendChild( QgsGeometryUtils::pointsToGML3( pts, doc, precision, ns, is3D() ) );
-      elemSegments.appendChild( elemLineStringSegment );
-    }
-    else if ( dynamic_cast<const QgsCircularString*>( curve ) )
-    {
-      QgsPointSequence pts;
-      curve->points( pts );
-
-      QDomElement elemArcString = doc.createElementNS( ns, QStringLiteral( "ArcString" ) );
-      elemArcString.appendChild( QgsGeometryUtils::pointsToGML3( pts, doc, precision, ns, is3D() ) );
-      elemSegments.appendChild( elemArcString );
-    }
+    QDomElement curveMemberElem = doc.createElementNS( ns, QStringLiteral( "curveMember" ) );
+    QDomElement curveElem = curve->asGML3( doc, precision, ns );
+    curveMemberElem.appendChild( curveElem );
+    compoundCurveElem.appendChild( curveMemberElem );
   }
-  elemCurve.appendChild( elemSegments );
-  return elemCurve;
+
+  return compoundCurveElem;
 }
 
 QString QgsCompoundCurve::asJSON( int precision ) const

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -308,18 +308,26 @@ QDomElement QgsCurvePolygon::asGML3( QDomDocument& doc, int precision, const QSt
 {
   QDomElement elemCurvePolygon = doc.createElementNS( ns, QStringLiteral( "Polygon" ) );
   QDomElement elemExterior = doc.createElementNS( ns, QStringLiteral( "exterior" ) );
-  QDomElement outerRing = exteriorRing()->asGML2( doc, precision, ns );
-  outerRing.toElement().setTagName( QStringLiteral( "LinearRing" ) );
-  elemExterior.appendChild( outerRing );
+  QDomElement curveElem = exteriorRing()->asGML3( doc, precision, ns );
+  if ( curveElem.tagName() == "LineString" )
+  {
+    curveElem.setTagName( QStringLiteral( "LinearRing" ) );
+  }
+  elemExterior.appendChild( curveElem );
   elemCurvePolygon.appendChild( elemExterior );
-  QDomElement elemInterior = doc.createElementNS( ns, QStringLiteral( "interior" ) );
+
+  elemCurvePolygon.appendChild( elemExterior );
   for ( int i = 0, n = numInteriorRings(); i < n; ++i )
   {
-    QDomElement innerRing = interiorRing( i )->asGML2( doc, precision, ns );
-    innerRing.toElement().setTagName( QStringLiteral( "LinearRing" ) );
+    QDomElement elemInterior = doc.createElementNS( ns, QStringLiteral( "interior" ) );
+    QDomElement innerRing = interiorRing( i )->asGML3( doc, precision, ns );
+    if ( innerRing.tagName() == "LineString" )
+    {
+      innerRing.setTagName( QStringLiteral( "LinearRing" ) );
+    }
     elemInterior.appendChild( innerRing );
+    elemCurvePolygon.appendChild( elemInterior );
   }
-  elemCurvePolygon.appendChild( elemInterior );
   return elemCurvePolygon;
 }
 

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -207,14 +207,9 @@ QDomElement QgsLineString::asGML3( QDomDocument& doc, int precision, const QStri
   QgsPointSequence pts;
   points( pts );
 
-  QDomElement elemCurve = doc.createElementNS( ns, QStringLiteral( "Curve" ) );
-  QDomElement elemSegments = doc.createElementNS( ns, QStringLiteral( "segments" ) );
-  QDomElement elemArcString = doc.createElementNS( ns, QStringLiteral( "LineStringSegment" ) );
-  elemArcString.appendChild( QgsGeometryUtils::pointsToGML3( pts, doc, precision, ns, is3D() ) );
-  elemSegments.appendChild( elemArcString );
-  elemCurve.appendChild( elemSegments );
-
-  return elemCurve;
+  QDomElement elemLineString = doc.createElementNS( ns, QStringLiteral( "LineString" ) );
+  elemLineString.appendChild( QgsGeometryUtils::pointsToGML3( pts, doc, precision, ns, is3D() ) );
+  return elemLineString;
 }
 
 QString QgsLineString::asJSON( int precision ) const

--- a/src/core/geometry/qgsmultilinestring.cpp
+++ b/src/core/geometry/qgsmultilinestring.cpp
@@ -60,7 +60,7 @@ QDomElement QgsMultiLineString::asGML2( QDomDocument& doc, int precision, const 
 
 QDomElement QgsMultiLineString::asGML3( QDomDocument& doc, int precision, const QString& ns ) const
 {
-  QDomElement elemMultiCurve = doc.createElementNS( ns, QStringLiteral( "MultiLineString" ) );
+  QDomElement elemMultiCurve = doc.createElementNS( ns, QStringLiteral( "MultiCurve" ) );
   Q_FOREACH ( const QgsAbstractGeometry *geom, mGeometries )
   {
     if ( dynamic_cast<const QgsLineString*>( geom ) )

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1162,7 +1162,14 @@ namespace QgsWfs
           gmlElem = QgsOgcUtils::geometryToGML( &centroid, doc, prec );
         }
         else
-          gmlElem = QgsOgcUtils::geometryToGML( &geom, doc, prec );
+        {
+          QgsAbstractGeometry* abstractGeom = geom.geometry();
+          if ( abstractGeom )
+          {
+            gmlElem = abstractGeom->asGML2( doc, prec, "http://www.opengis.net/gml" );
+          }
+        }
+
         if ( !gmlElem.isNull() )
         {
           QgsRectangle box = geom.boundingBox();
@@ -1237,7 +1244,14 @@ namespace QgsWfs
           gmlElem = QgsOgcUtils::geometryToGML( &centroid, doc, QStringLiteral( "GML3" ), prec );
         }
         else
-          gmlElem = QgsOgcUtils::geometryToGML( &geom, doc, QStringLiteral( "GML3" ), prec );
+        {
+          QgsAbstractGeometry* abstractGeom = geom.geometry();
+          if ( abstractGeom )
+          {
+            gmlElem = abstractGeom->asGML3( doc, prec, "http://www.opengis.net/gml" );
+          }
+        }
+
         if ( !gmlElem.isNull() )
         {
           QgsRectangle box = geom.boundingBox();

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -1530,9 +1530,9 @@ void TestQgsGeometry::lineString()
   QCOMPARE( elemToString( exportLineFloat.asGML2( doc, 3 ) ), expectedGML2prec3 );
 
   //asGML3
-  QString expectedGML3( QStringLiteral( "<Curve xmlns=\"gml\"><segments xmlns=\"gml\"><LineStringSegment xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">31 32 41 42 51 52</posList></LineStringSegment></segments></Curve>" ) );
+  QString expectedGML3( QStringLiteral( "<LineString xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">31 32 41 42 51 52</posList></LineString>" ) );
   QCOMPARE( elemToString( exportLine.asGML3( doc ) ), expectedGML3 );
-  QString expectedGML3prec3( QStringLiteral( "<Curve xmlns=\"gml\"><segments xmlns=\"gml\"><LineStringSegment xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">0.333 0.667 1.333 1.667 2.333 2.667</posList></LineStringSegment></segments></Curve>" ) );
+  QString expectedGML3prec3( QStringLiteral( "<LineString xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">0.333 0.667 1.333 1.667 2.333 2.667</posList></LineString>" ) );
   QCOMPARE( elemToString( exportLineFloat.asGML3( doc, 3 ) ), expectedGML3prec3 );
 
   //asJSON
@@ -3017,11 +3017,12 @@ void TestQgsGeometry::polygon()
   QCOMPARE( elemToString( exportPolygonFloat.asGML2( doc, 3 ) ), expectedGML2prec3 );
 
   //as GML3
-  QString expectedGML3( QStringLiteral( "<Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\">0,0 0,10 10,10 10,0 0,0</coordinates></LinearRing></exterior>" ) );
-  expectedGML3 += QStringLiteral( "<interior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\">1,1 1,9 9,9 9,1 1,1</coordinates></LinearRing></interior></Polygon>" );
+  QString expectedGML3( QStringLiteral( "<Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">0 0 0 10 10 10 10 0 0 0</posList></LinearRing></exterior>" ) );
+  expectedGML3 += QStringLiteral( "<interior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">1 1 1 9 9 9 9 1 1 1</posList></LinearRing></interior></Polygon>" );
+
   QCOMPARE( elemToString( exportPolygon.asGML3( doc ) ), expectedGML3 );
-  QString expectedGML3prec3( QStringLiteral( "<Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\">1.111,1.111 1.111,11.111 11.111,11.111 11.111,1.111 1.111,1.111</coordinates></LinearRing></exterior>" ) );
-  expectedGML3prec3 += QStringLiteral( "<interior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\">0.667,0.667 0.667,1.333 1.333,1.333 1.333,0.667 0.667,0.667</coordinates></LinearRing></interior></Polygon>" );
+  QString expectedGML3prec3( QStringLiteral( "<Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">1.111 1.111 1.111 11.111 11.111 11.111 11.111 1.111 1.111 1.111</posList></LinearRing></exterior>" ) );
+  expectedGML3prec3 += QStringLiteral( "<interior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">0.667 0.667 0.667 1.333 1.333 1.333 1.333 0.667 0.667 0.667</posList></LinearRing></interior></Polygon>" );
   QCOMPARE( elemToString( exportPolygonFloat.asGML3( doc, 3 ) ), expectedGML3prec3 );
 
   //removing the fourth to last vertex removes the whole ring

--- a/tests/testdata/qgis_server/wfs_getfeature_limit2.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_limit2.txt
@@ -13,9 +13,9 @@ Content-Type: text/xml; charset=utf-8
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <gml:Point srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253</gml:coordinates>
-   </gml:Point>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
+   </Point>
   </qgs:geometry>
   <qgs:id>1</qgs:id>
   <qgs:name>one</qgs:name>
@@ -30,9 +30,9 @@ Content-Type: text/xml; charset=utf-8
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <gml:Point srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568</gml:coordinates>
-   </gml:Point>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
+   </Point>
   </qgs:geometry>
   <qgs:id>2</qgs:id>
   <qgs:name>two</qgs:name>

--- a/tests/testdata/qgis_server/wfs_getfeature_nobbox.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_nobbox.txt
@@ -13,9 +13,9 @@ Content-Type: text/xml; charset=utf-8
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <gml:Point srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253</gml:coordinates>
-   </gml:Point>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
+   </Point>
   </qgs:geometry>
   <qgs:id>1</qgs:id>
   <qgs:name>one</qgs:name>
@@ -30,9 +30,9 @@ Content-Type: text/xml; charset=utf-8
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <gml:Point srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568</gml:coordinates>
-   </gml:Point>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
+   </Point>
   </qgs:geometry>
   <qgs:id>2</qgs:id>
   <qgs:name>two</qgs:name>
@@ -47,9 +47,9 @@ Content-Type: text/xml; charset=utf-8
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <gml:Point srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20345931,44.90139484</gml:coordinates>
-   </gml:Point>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20345931,44.90139484</coordinates>
+   </Point>
   </qgs:geometry>
   <qgs:id>3</qgs:id>
   <qgs:name>three</qgs:name>

--- a/tests/testdata/qgis_server/wfs_getfeature_start1_limit1.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_start1_limit1.txt
@@ -13,9 +13,9 @@ Content-Type: text/xml; charset=utf-8
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <gml:Point srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568</gml:coordinates>
-   </gml:Point>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
+   </Point>
   </qgs:geometry>
   <qgs:id>2</qgs:id>
   <qgs:name>two</qgs:name>

--- a/tests/testdata/qgis_server/wfs_getfeature_startindex2.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_startindex2.txt
@@ -13,9 +13,9 @@ Content-Type: text/xml; charset=utf-8
    </gml:Box>
   </gml:boundedBy>
   <qgs:geometry>
-   <gml:Point srsName="EPSG:4326">
-    <gml:coordinates cs="," ts=" ">8.20345931,44.90139484</gml:coordinates>
-   </gml:Point>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20345931,44.90139484</coordinates>
+   </Point>
   </qgs:geometry>
   <qgs:id>3</qgs:id>
   <qgs:name>three</qgs:name>


### PR DESCRIPTION
In the WFS server, QgsOGCUtils is used to generate gml from QGIS geometries. However this is a problem with newer geometry types like curvepolygon, compoundcurve, etc. With the new geometry classes, each subclass has the functions asGML2 / asGML3. This PR changes the server code to use asGML2 / asGML3.

This is a first travis test to see which unit tests will fail.