### PR TITLE
Add more official documentation links to help button

### DIFF
--- a/src/app/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.h
@@ -20,7 +20,7 @@
 
 #include <ui_qgsvectorlayersaveasdialogbase.h>
 #include <QDialog>
-#include "qgscontexthelp.h"
+#include "qgshelp.h"
 #include "qgsfields.h"
 #include "qgsvectorfilewriter.h"
 #include "qgis_app.h"
@@ -112,7 +112,7 @@ class APP_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     void on_leFilename_textChanged( const QString& text );
     void on_browseFilename_clicked();
     void on_mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem& crs );
-    void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#save-layer-into-file" ) ); }
     void on_mSymbologyExportComboBox_currentIndexChanged( const QString& text );
     void on_mGeometryTypeComboBox_currentIndexChanged( int index );
     void accept() override;

--- a/src/app/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/qgsdecorationcopyrightdialog.cpp
@@ -100,5 +100,5 @@ void QgsDecorationCopyrightDialog::apply()
 
 void QgsDecorationCopyrightDialog::on_buttonBox_helpRequested()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#id57" ) );
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#copyright-label" ) );
 }

--- a/src/app/qgsdecorationgriddialog.cpp
+++ b/src/app/qgsdecorationgriddialog.cpp
@@ -178,7 +178,7 @@ QgsDecorationGridDialog::~QgsDecorationGridDialog()
 
 void QgsDecorationGridDialog::on_buttonBox_helpRequested()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#id56" ) );
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#grid" ) );
 }
 
 void QgsDecorationGridDialog::on_buttonBox_accepted()

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -61,7 +61,7 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     void closeEvent( QCloseEvent *e ) override;
 
     //! Show the help for the dialog
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#id38" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#measuring" ) ); }
 
     //! When any external settings change
     void updateSettings();

--- a/src/gui/qgsnewvectorlayerdialog.h
+++ b/src/gui/qgsnewvectorlayerdialog.h
@@ -19,7 +19,7 @@
 
 #include "ui_qgsnewvectorlayerdialogbase.h"
 #include "qgisgui.h"
-#include "qgscontexthelp.h"
+#include "qgshelp.h"
 
 #include "qgis.h"
 #include "qgis_gui.h"
@@ -55,7 +55,7 @@ class GUI_EXPORT QgsNewVectorLayerDialog: public QDialog, private Ui::QgsNewVect
     void on_mRemoveAttributeButton_clicked();
     void on_mFileFormatComboBox_currentIndexChanged( int index );
     void on_mTypeBox_currentIndexChanged( int index );
-    void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/editing_geometry_attributes.html#creating-a-new-shapefile-layer" ) ); }
     void nameChanged( const QString& );
     void selectionChanged();
 

--- a/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.h
+++ b/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.h
@@ -72,7 +72,7 @@ class eVisDatabaseConnectionGui : public QDialog, private Ui::eVisDatabaseConnec
     void drawNewVectorLayer( const QString&, const QString&, const QString& );
 
     void on_buttonBox_accepted();
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "plugins/plugins_evis.html#id11" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "plugins/plugins_evis.html#database-connection" ) ); }
 
     void on_cboxDatabaseType_currentIndexChanged( int );
     void on_cboxPredefinedQueryList_currentIndexChanged( int );

--- a/src/providers/db2/qgsdb2newconnection.h
+++ b/src/providers/db2/qgsdb2newconnection.h
@@ -48,7 +48,7 @@ class QgsDb2NewConnection : public QDialog, private Ui::QgsDb2NewConnectionBase
     void on_btnListDatabase_clicked();
     void on_btnConnect_clicked();
     void on_cb_trustedConnection_clicked();
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#id33" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#db2-spatial-layers" ) ); }
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     QgsAuthConfigSelect * mAuthConfigSelect;

--- a/src/providers/db2/qgsdb2sourceselect.h
+++ b/src/providers/db2/qgsdb2sourceselect.h
@@ -146,7 +146,7 @@ class QgsDb2SourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
     //!Sets a new regular expression to the model
     void setSearchExpression( const QString& regexp );
 
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#id33" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#db2-spatial-layers" ) ); }
 
     void columnThreadFinished();
 

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -62,7 +62,7 @@ class QgsDelimitedTextSourceSelect : public QDialog, private Ui::QgsDelimitedTex
     void on_buttonBox_rejected();
     void on_buttonBox_helpRequested()
     {
-      QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#id8" ) );
+      QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#delimited-text-files" ) );
     }
     void on_btnBrowseForFile_clicked();
 

--- a/src/providers/oracle/qgsoraclenewconnection.h
+++ b/src/providers/oracle/qgsoraclenewconnection.h
@@ -39,7 +39,7 @@ class QgsOracleNewConnection : public QDialog, private Ui::QgsOracleNewConnectio
   public slots:
     void accept();
     void on_btnConnect_clicked();
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#id2" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#oracle-spatial-layers" ) ); }
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
 };

--- a/src/providers/oracle/qgsoraclesourceselect.h
+++ b/src/providers/oracle/qgsoraclesourceselect.h
@@ -134,7 +134,7 @@ class QgsOracleSourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
     //!Sets a new regular expression to the model
     void setSearchExpression( const QString& regexp );
 
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#id2" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#oracle-spatial-layers" ) ); }
 
     void columnThreadFinished();
 

--- a/src/providers/postgres/qgspgnewconnection.h
+++ b/src/providers/postgres/qgspgnewconnection.h
@@ -39,7 +39,7 @@ class QgsPgNewConnection : public QDialog, private Ui::QgsPgNewConnectionBase
     void accept() override;
     void on_btnConnect_clicked();
     void on_cb_geometryColumnsOnly_clicked();
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#id14" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#postgis-layers" ) ); }
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     QgsAuthConfigSelect * mAuthConfigSelect;

--- a/src/providers/postgres/qgspgsourceselect.h
+++ b/src/providers/postgres/qgspgsourceselect.h
@@ -116,7 +116,7 @@ class QgsPgSourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
     //!Sets a new regular expression to the model
     void setSearchExpression( const QString& regexp );
 
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#id14" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#postgis-layers" ) ); }
 
     void columnThreadFinished();
 

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -95,7 +95,7 @@ class QgsWMSSourceSelect : public QDialog, private Ui::QgsWMSSourceSelectBase
     //! Add some default wms servers to the list
     void on_btnAddDefault_clicked();
 
-    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_ogc/ogc_client_support.html#id5" ) ); }
+    void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_ogc/ogc_client_support.html#wms-wmts-client" ) ); }
 
   private:
     //! Populate the connection list combo box


### PR DESCRIPTION
Context help files were placed at a single place. I still think that a single place to hold doc links used through the application would be handy. Having to browse folders to find the right file in which to add the link is not that fun nor intuitive (for me, anyway). 
Moreover, do not minimize the "chances" that links might be broken between doc releases. Eg, during Bonn hackfest, we moved a lot of sections from qgis-gui and qgis-configuration chapters to general tools chapter and vice versa, hence breaking links that could be in use in 2.14 documentation. While trying to keep links, this can easily change eg because of new features in the dialog that require a more descriptive section title.
A kind of dictionary(?) based on @rduivenvoorde work at http://hub.qgis.org/wiki/quantum-gis/ContextHelp.  All one needs to do then is replace the link (or add new key, value for each new help button) and the help is updated. And doc writers could fix this kind of changes.
It'll also help to easily see where doc is missing
@m-kuhn @alexbruy 