### PR TITLE
[ui] adjust size and spacing of welcome screen title

### DIFF
--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -43,7 +43,11 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget* parent )
   recentProjectsContainer->setLayout( new QVBoxLayout );
   recentProjectsContainer->layout()->setContentsMargins( 0, 0, 0, 0 );
   recentProjectsContainer->layout()->setMargin( 0 );
-  QLabel* recentProjectsTitle = new QLabel( QStringLiteral( "<h1>%1</h1>" ).arg( tr( "Recent Projects" ) ) );
+
+  int titleSize = QApplication::fontMetrics().height() * 1.4;
+  QLabel* recentProjectsTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold;'>%2</div>" ).arg( titleSize ).arg( tr( "Recent Projects" ) ) );
+  recentProjectsTitle->setContentsMargins( 0, 3, 0, 0 );
+
   recentProjectsContainer->layout()->addWidget( recentProjectsTitle );
 
   QListView* recentProjectsListView = new QListView();


### PR DESCRIPTION
Before (top) vs. proposed (bottom):
![untitled](https://cloud.githubusercontent.com/assets/1728657/22859873/4f4e6366-f11e-11e6-838b-de4e5412b9f9.png)

This PR tries to balance the welcome page UI a bit by reducing the size of the "Recent Projects" label, and adding a small top margin. 