### PR TITLE
Optimise expression context storage/retrieval of features

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -992,6 +992,12 @@ QgsExpressionItem        {#qgis_api_break_3_0_QgsExpressionItem}
 - CustomSortRole was renamed to CUSTOM_SORT_ROLE
 - ItemTypeRole was renamed to ITEM_TYPE_ROLE
 
+QgsExpressionContext      {#qgis_api_break_3_0_QgsExpressionContext}
+--------------------
+
+- EXPR_FEATURE was removed. Use the direct feature manipulation methods feature(), hasFeature() and setFeature() instead
+
+
 QgsExpressionContextUtils       {#qgis_api_break_3_0_QgsExpressionContextUtils}
 -------------------------
 

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -197,10 +197,8 @@ class QgsExpressionContextScope
 
     void setFeature( const QgsFeature& feature );
 
-    /** Convenience function for setting a fields for the scope. Any existing
-     * fields set by the scope will be overwritten.
-     * @param fields fields for scope
-     */
+    void removeFeature();
+
     void setFields( const QgsFields& fields );
 };
 

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -189,17 +189,12 @@ class QgsExpressionContextScope
      */
     QStringList functionNames() const;
 
-    /** Adds a function to the scope.
-     * @param name function name
-     * @param function function to insert. Ownership is transferred to the scope.
-     * @see addVariable()
-     */
     void addFunction( const QString& name, QgsScopedExpressionFunction* function /Transfer/ );
 
-    /** Convenience function for setting a feature for the scope. Any existing
-     * feature set by the scope will be overwritten.
-     * @param feature feature for scope
-     */
+    bool hasFeature() const;
+
+    QgsFeature feature() const;
+
     void setFeature( const QgsFeature& feature );
 
     /** Convenience function for setting a fields for the scope. Any existing
@@ -414,9 +409,7 @@ class QgsExpressionContext
      */
     void setFeature( const QgsFeature& feature );
 
-    /** Convenience function for retrieving the feature for the context, if set.
-     * @see setFeature
-     */
+    bool hasFeature() const;
     QgsFeature feature() const;
 
     /** Convenience function for setting a fields for the context. The fields
@@ -481,8 +474,6 @@ class QgsExpressionContext
 
     //! Inbuilt variable name for fields storage
     static const QString EXPR_FIELDS;
-    //! Inbuilt variable name for feature storage
-    static const QString EXPR_FEATURE;
     //! Inbuilt variable name for value original value variable
     static const QString EXPR_ORIGINAL_VALUE;
     //! Inbuilt variable name for symbol color variable

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -318,8 +318,8 @@ static QgsFeature getFeature( const QVariant& value, QgsExpression* parent )
   return 0;
 }
 
-#define FEAT_FROM_CONTEXT(c, f) if (!(c) || !(c)->hasVariable(QgsExpressionContext::EXPR_FEATURE)) return QVariant(); \
-  QgsFeature f = qvariant_cast<QgsFeature>( (c)->variable( QgsExpressionContext::EXPR_FEATURE ) );
+#define FEAT_FROM_CONTEXT(c, f) if (!(c) || !(c)->hasFeature() ) return QVariant(); \
+  QgsFeature f = ( c )->feature();
 
 static QgsExpression::Node* getNode( const QVariant& value, QgsExpression* parent )
 {
@@ -5495,7 +5495,7 @@ QVariant QgsExpression::NodeColumnRef::eval( QgsExpression *parent, const QgsExp
     }
   }
 
-  if ( context && context->hasVariable( QgsExpressionContext::EXPR_FEATURE ) )
+  if ( context && context->hasFeature() )
   {
     QgsFeature feature = context->feature();
     if ( index >= 0 )

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -21,6 +21,7 @@
 #include <QString>
 #include <QStringList>
 #include <QSet>
+#include "qgsfeature.h"
 #include "qgsexpression.h"
 
 class QgsExpression;
@@ -250,11 +251,26 @@ class CORE_EXPORT QgsExpressionContextScope
      */
     void addFunction( const QString& name, QgsScopedExpressionFunction* function );
 
+    /**
+     * Returns true if the scope has a feature associated with it.
+     * @note added in QGIS 3.0
+     * @see feature()
+     */
+    bool hasFeature() const { return mHasFeature; }
+
+    /**
+     * Sets the feature associated with the scope.
+     * @see setFeature()
+     * @see hasFeature()
+     * @note added in QGIS 3.0
+     */
+    QgsFeature feature() const { return mFeature; }
+
     /** Convenience function for setting a feature for the scope. Any existing
      * feature set by the scope will be overwritten.
      * @param feature feature for scope
      */
-    void setFeature( const QgsFeature& feature );
+    void setFeature( const QgsFeature& feature ) { mHasFeature = true; mFeature = feature; }
 
     /** Convenience function for setting a fields for the scope. Any existing
      * fields set by the scope will be overwritten.
@@ -266,6 +282,8 @@ class CORE_EXPORT QgsExpressionContextScope
     QString mName;
     QHash<QString, StaticVariable> mVariables;
     QHash<QString, QgsScopedExpressionFunction* > mFunctions;
+    bool mHasFeature = false;
+    QgsFeature mFeature;
 
     bool variableNameSort( const QString &a, const QString &b );
 };
@@ -474,6 +492,13 @@ class CORE_EXPORT QgsExpressionContext
      */
     void setFeature( const QgsFeature& feature );
 
+    /**
+     * Returns true if the context has a feature associated with it.
+     * @note added in QGIS 3.0
+     * @see feature()
+     */
+    bool hasFeature() const;
+
     /** Convenience function for retrieving the feature for the context, if set.
      * @see setFeature
      */
@@ -541,8 +566,6 @@ class CORE_EXPORT QgsExpressionContext
 
     //! Inbuilt variable name for fields storage
     static const QString EXPR_FIELDS;
-    //! Inbuilt variable name for feature storage
-    static const QString EXPR_FEATURE;
     //! Inbuilt variable name for value original value variable
     static const QString EXPR_ORIGINAL_VALUE;
     //! Inbuilt variable name for symbol color variable

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -269,8 +269,18 @@ class CORE_EXPORT QgsExpressionContextScope
     /** Convenience function for setting a feature for the scope. Any existing
      * feature set by the scope will be overwritten.
      * @param feature feature for scope
+     * @see removeFeature()
+     * @see feature()
      */
     void setFeature( const QgsFeature& feature ) { mHasFeature = true; mFeature = feature; }
+
+    /**
+     * Removes any feature associated with the scope.
+     * @note added in QGIS 3.0
+     * @see setFeature()
+     * @see hasFeature()
+     */
+    void removeFeature() { mHasFeature = false; mFeature = QgsFeature(); }
 
     /** Convenience function for setting a fields for the scope. Any existing
      * fields set by the scope will be overwritten.

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -437,6 +437,9 @@ void TestQgsExpressionContext::setFeature()
   scope.setFeature( feature );
   QVERIFY( scope.hasFeature() );
   QCOMPARE( scope.feature().id(), 50LL );
+  scope.removeFeature();
+  QVERIFY( !scope.hasFeature() );
+  QVERIFY( !scope.feature().isValid() );
 
   //test setting a feature in a context with no scopes
   QgsExpressionContext emptyContext;

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -432,10 +432,11 @@ void TestQgsExpressionContext::evaluate()
 void TestQgsExpressionContext::setFeature()
 {
   QgsFeature feature( 50LL );
+  feature.setValid( true );
   QgsExpressionContextScope scope;
   scope.setFeature( feature );
-  QVERIFY( scope.hasVariable( QgsExpressionContext::EXPR_FEATURE ) );
-  QCOMPARE(( qvariant_cast<QgsFeature>( scope.variable( QgsExpressionContext::EXPR_FEATURE ) ) ).id(), 50LL );
+  QVERIFY( scope.hasFeature() );
+  QCOMPARE( scope.feature().id(), 50LL );
 
   //test setting a feature in a context with no scopes
   QgsExpressionContext emptyContext;
@@ -443,16 +444,16 @@ void TestQgsExpressionContext::setFeature()
   emptyContext.setFeature( feature );
   //setFeature should have created a scope
   QCOMPARE( emptyContext.scopeCount(), 1 );
-  QVERIFY( emptyContext.hasVariable( QgsExpressionContext::EXPR_FEATURE ) );
-  QCOMPARE(( qvariant_cast<QgsFeature>( emptyContext.variable( QgsExpressionContext::EXPR_FEATURE ) ) ).id(), 50LL );
+  QVERIFY( emptyContext.feature().isValid() );
+  QCOMPARE( emptyContext.feature().id(), 50LL );
   QCOMPARE( emptyContext.feature().id(), 50LL );
 
   QgsExpressionContext contextWithScope;
   contextWithScope << new QgsExpressionContextScope();
   contextWithScope.setFeature( feature );
   QCOMPARE( contextWithScope.scopeCount(), 1 );
-  QVERIFY( contextWithScope.hasVariable( QgsExpressionContext::EXPR_FEATURE ) );
-  QCOMPARE(( qvariant_cast<QgsFeature>( contextWithScope.variable( QgsExpressionContext::EXPR_FEATURE ) ) ).id(), 50LL );
+  QVERIFY( contextWithScope.feature().isValid() );
+  QCOMPARE( contextWithScope.feature().id(), 50LL );
   QCOMPARE( contextWithScope.feature().id(), 50LL );
 }
 
@@ -652,7 +653,7 @@ void TestQgsExpressionContext::featureBasedContext()
 
   QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, fields );
 
-  QgsFeature evalFeature = qvariant_cast<QgsFeature>( context.variable( QStringLiteral( "_feature_" ) ) );
+  QgsFeature evalFeature = context.feature();
   QgsFields evalFields = qvariant_cast<QgsFields>( context.variable( QStringLiteral( "_fields_" ) ) );
   QCOMPARE( evalFeature.attributes(), f.attributes() );
   QCOMPARE( evalFields, fields );


### PR DESCRIPTION
Shortcuts storage and retrieval of the associated feature by not storing them in the variable hash and incurring the QHash insert/lookup costs.

Shaves ~10% rendering time off a 1 million point layer