### PR TITLE
Use a path resolver class instead of QgsProject::instance() in map layers

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1226,6 +1226,7 @@ QgsLayerDefinition        {#qgis_api_break_3_0_QgsLayerDefinition}
 ------------------
 
 - loadLayerDefinition() now also requires QgsProject as the second argument
+- loadLayerDefinition() and exportLayerDefinition() variants that take QDomDocument as the first argument now expect QgsPathResolver as the last argument
 
 
 QgsLayerPropertiesWidget        {#qgis_api_break_3_0_QgsLayerPropertiesWidget}
@@ -1347,7 +1348,7 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 - capitaliseLayerName() was renamed to capitalizeLayerName() <!--#spellok-->
 - asLayerDefinition(), fromLayerDefinition(), fromLayerDefinitionFile() were moved to QgsLayerDefinition class and renamed to exportLayerDefinitionLayers() resp. loadLayerDefinitionLayers()
 - loadNamedStyleFromDb() was renamed to loadNamedStyleFromDatabase()
-
+- readLayerXml() and writeLayerXml() expect QgsPathResolver reference as the last argument
 
 
 QgsMapLayerRegistry        {#qgis_api_break_3_0_QgsMapLayerRegistry}
@@ -1589,6 +1590,7 @@ QgsProject        {#qgis_api_break_3_0_QgsProject}
 - read( const QFileInfo& file ) was replaced by read( const QString& filename ).
 - write( const QFileInfo& file ) was replaced by write( const QString& filename ).
 - createEmbeddedLayer() does not take vectorLayerList as the third parameter anymore.
+- writePath() does not accept second argument (relativeBasePath) anymore. Use QgsPathResolver instead.
 
 
 QgsProjectPropertyValue        {#qgis_api_break_3_0_QgsProjectPropertyValue}

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -107,6 +107,7 @@
 %Include qgspaintenginehack.sip
 %Include qgspainting.sip
 %Include qgspallabeling.sip
+%Include qgspathresolver.sip
 %Include qgspluginlayer.sip
 %Include qgspluginlayerregistry.sip
 %Include qgspoint.sip

--- a/python/core/qgslayerdefinition.sip
+++ b/python/core/qgslayerdefinition.sip
@@ -12,12 +12,12 @@ class QgsLayerDefinition
 %End
   public:
     static bool loadLayerDefinition( const QString & path, QgsProject* project, QgsLayerTreeGroup* rootGroup, QString &errorMessage /Out/ );
-    static bool loadLayerDefinition( QDomDocument doc, QgsProject* project, QgsLayerTreeGroup* rootGroup, QString &errorMessage /Out/ );
+    static bool loadLayerDefinition( QDomDocument doc, QgsProject* project, QgsLayerTreeGroup* rootGroup, QString &errorMessage /Out/, const QgsPathResolver& pathResolver );
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage /Out/ );
-    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
+    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage /Out/, const QgsPathResolver& pathResolver );
 
-    static QDomDocument exportLayerDefinitionLayers( const QList<QgsMapLayer*>& layers, const QString& relativeBasePath = QString::null );
-    static QList<QgsMapLayer*> loadLayerDefinitionLayers( QDomDocument& document ) /Factory/;
+    static QDomDocument exportLayerDefinitionLayers( const QList<QgsMapLayer*>& layers, const QgsPathResolver& pathResolver );
+    static QList<QgsMapLayer*> loadLayerDefinitionLayers( QDomDocument& document, const QgsPathResolver& pathResolver ) /Factory/;
     static QList<QgsMapLayer*> loadLayerDefinitionLayers( const QString &qlrfile ) /Factory/;
 
     /**

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -321,39 +321,9 @@ class QgsMapLayer : QObject
      */
     virtual bool isSpatial() const;
 
-    /** Sets state from Dom document
-       @param layerElement The Dom element corresponding to ``maplayer'' tag
-       @note
+    bool readLayerXml( const QDomElement& layerElement, const QgsPathResolver& pathResolver );
 
-       The Dom node corresponds to a Dom document project file XML element read
-       by QgsProject.
-
-       This, in turn, calls readXml(), which is over-rideable by sub-classes so
-       that they can read their own specific state from the given Dom node.
-
-       Invoked by QgsProject::read().
-
-       @returns true if successful
-     */
-    bool readLayerXml( const QDomElement& layerElement );
-
-    /** Stores state in Dom node
-     * @param layerElement is a Dom element corresponding to ``maplayer'' tag
-     * @param document is a the dom document being written
-     * @param relativeBasePath base path for relative paths
-     * @note
-     *
-     * The Dom node corresponds to a Dom document project file XML element to be
-     * written by QgsProject.
-     *
-     * This, in turn, calls writeXml(), which is over-rideable by sub-classes so
-     * that they can write their own specific state to the given Dom node.
-     *
-     * Invoked by QgsProject::write().
-     *
-     * @returns true if successful
-     */
-    bool writeLayerXml( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null ) const;
+    bool writeLayerXml( QDomElement& layerElement, QDomDocument& document, const QgsPathResolver& pathResolver ) const;
 
     /** Set a custom property for layer. Properties are stored in a map and saved in project file.
      * @see customProperty()

--- a/python/core/qgspathresolver.sip
+++ b/python/core/qgspathresolver.sip
@@ -1,0 +1,15 @@
+
+class QgsPathResolver
+{
+%TypeHeaderCode
+#include <qgspathresolver.h>
+%End
+
+  public:
+    explicit QgsPathResolver( const QString& baseFileName = QString() );
+
+    QString writePath( const QString& filename ) const;
+
+    QString readPath( const QString& filename ) const;
+
+};

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -233,12 +233,14 @@ class QgsProject : QObject, QgsExpressionContextGenerator
      */
     void dumpProperties() const;
 
+    QgsPathResolver pathResolver() const;
+
     /**
      * Prepare a filename to save it to the project file.
      * Creates an absolute or relative path according to the project settings.
      * Paths written to the project file should be prepared with this method.
     */
-    QString writePath( const QString& filename, const QString& relativeBasePath = QString::null ) const;
+    QString writePath( const QString& filename ) const;
 
     /** Turn filename read from the project file to an absolute path */
     QString readPath( QString filename ) const;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -187,6 +187,7 @@ SET(QGIS_CORE_SRCS
   qgspaintenginehack.cpp
   qgspainting.cpp
   qgspallabeling.cpp
+  qgspathresolver.cpp
   qgspluginlayer.cpp
   qgspluginlayerregistry.cpp
   qgspoint.cpp
@@ -726,6 +727,7 @@ SET(QGIS_CORE_HDRS
   qgspaintenginehack.h
   qgspainting.h
   qgspallabeling.h
+  qgspathresolver.h
   qgspluginlayerregistry.h
   qgspointlocator.h
   qgsprojectbadlayerhandler.h

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -27,6 +27,7 @@ class QDomDocument;
 class QgsLayerTreeGroup;
 class QgsLayerTreeNode;
 class QgsMapLayer;
+class QgsPathResolver;
 class QgsProject;
 
 /** \ingroup core
@@ -42,11 +43,11 @@ class CORE_EXPORT QgsLayerDefinition
     //! Loads the QLR at path into QGIS.  New layers are added to given project into layer tree specified by rootGroup
     static bool loadLayerDefinition( const QString & path, QgsProject* project, QgsLayerTreeGroup* rootGroup, QString &errorMessage );
     //! Loads the QLR from the XML document.  New layers are added to given project into layer tree specified by rootGroup
-    static bool loadLayerDefinition( QDomDocument doc, QgsProject* project, QgsLayerTreeGroup* rootGroup, QString &errorMessage );
+    static bool loadLayerDefinition( QDomDocument doc,  QgsProject* project, QgsLayerTreeGroup* rootGroup, QString &errorMessage, const QgsPathResolver& pathResolver );
     //! Export the selected layer tree nodes to a QLR file
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage );
     //! Export the selected layer tree nodes to a QLR-XML document
-    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
+    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QgsPathResolver& pathResolver );
 
     /** Returns the given layer as a layer definition document
      *  Layer definitions store the data source as well as styling and custom properties.
@@ -56,12 +57,12 @@ class CORE_EXPORT QgsLayerDefinition
      *  This is a low-level routine that does not write layer tree.
      *  @see exportLayerDefinition()
      */
-    static QDomDocument exportLayerDefinitionLayers( const QList<QgsMapLayer*>& layers, const QString& relativeBasePath = QString::null );
+    static QDomDocument exportLayerDefinitionLayers( const QList<QgsMapLayer*>& layers, const QgsPathResolver& pathResolver );
 
     //! Creates new layers from a layer definition document.
     //! This is a low-level routine that does not resolve layer ID conflicts, dependencies and joins
     //! @see loadLayerDefinition()
-    static QList<QgsMapLayer*> loadLayerDefinitionLayers( QDomDocument& document );
+    static QList<QgsMapLayer*> loadLayerDefinitionLayers( QDomDocument& document, const QgsPathResolver& pathResolver );
     //! Creates new layers from a layer definition file (.QLR)
     //! This is a low-level routine that does not resolve layer ID conflicts, dependencies and joins
     //! @see loadLayerDefinition()

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -353,6 +353,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** Sets state from Dom document
        @param layerElement The Dom element corresponding to ``maplayer'' tag
+       @param pathResolver object for conversion between relative and absolute paths
        @note
 
        The Dom node corresponds to a Dom document project file XML element read

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -38,6 +38,7 @@
 class QgsMapLayerLegend;
 class QgsMapLayerRenderer;
 class QgsMapLayerStyleManager;
+class QgsPathResolver;
 class QgsProject;
 
 class QDomDocument;
@@ -364,20 +365,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
        @returns true if successful
      */
-    bool readLayerXml( const QDomElement& layerElement );
-
-    /** Sets state from Dom document for a specific project.
-      * @param layerElement The Dom element corresponding to ``maplayer'' tag
-      * @param project
-      * @returns true if successful
-      */
-    bool readLayerXml( const QDomElement& layerElement, const QgsProject *project );
-
+    bool readLayerXml( const QDomElement& layerElement, const QgsPathResolver& pathResolver );
 
     /** Stores state in Dom node
      * @param layerElement is a Dom element corresponding to ``maplayer'' tag
      * @param document is a the dom document being written
-     * @param relativeBasePath base path for relative paths
+     * @param pathResolver object for conversion between relative and absolute paths
      * @note
      *
      * The Dom node corresponds to a Dom document project file XML element to be
@@ -390,7 +383,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      *
      * @returns true if successful
      */
-    bool writeLayerXml( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null ) const;
+    bool writeLayerXml( QDomElement& layerElement, QDomDocument& document, const QgsPathResolver& pathResolver ) const;
 
     /** Set a custom property for layer. Properties are stored in a map and saved in project file.
      * @see customProperty()

--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -72,8 +72,8 @@ QString QgsPathResolver::readPath( const QString& filename ) const
     // from the filename.
 
     QFileInfo pfi( mBaseFileName );
-    QString home = pfi.exists() ? pfi.canonicalPath() : QString();
-    if ( home.isNull() )
+    QString home = pfi.absoluteFilePath();
+    if ( home.isEmpty() )
       return vsiPrefix + src;
 
     QFileInfo fi( home + '/' + src );
@@ -141,13 +141,13 @@ QString QgsPathResolver::readPath( const QString& filename ) const
 
 QString QgsPathResolver::writePath( const QString& src ) const
 {
-  if ( mBaseFileName.isNull() || src.isEmpty() )
+  if ( mBaseFileName.isEmpty() || src.isEmpty() )
   {
     return src;
   }
 
   QFileInfo pfi( mBaseFileName );
-  QString projPath = pfi.canonicalFilePath();
+  QString projPath = pfi.absoluteFilePath();
 
   if ( projPath.isEmpty() )
   {

--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -1,0 +1,230 @@
+/***************************************************************************
+  qgspathresolver.cpp
+  --------------------------------------
+  Date                 : February 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspathresolver.h"
+
+#include "qgis.h"
+
+#include <QFileInfo>
+
+
+QgsPathResolver::QgsPathResolver( const QString& baseFileName )
+    : mBaseFileName( baseFileName )
+{
+}
+
+
+QString QgsPathResolver::readPath( const QString& filename ) const
+{
+  QString src = filename;
+
+  if ( mBaseFileName.isNull() )
+  {
+    return src;
+  }
+
+  // if this is a VSIFILE, remove the VSI prefix and append to final result
+  QString vsiPrefix = qgsVsiPrefix( src );
+  if ( ! vsiPrefix.isEmpty() )
+  {
+    // unfortunately qgsVsiPrefix returns prefix also for files like "/x/y/z.gz"
+    // so we need to check if we really have the prefix
+    if ( src.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) )
+      src.remove( 0, vsiPrefix.size() );
+    else
+      vsiPrefix.clear();
+  }
+
+  // relative path should always start with ./ or ../
+  if ( !src.startsWith( QLatin1String( "./" ) ) && !src.startsWith( QLatin1String( "../" ) ) )
+  {
+#if defined(Q_OS_WIN)
+    if ( src.startsWith( "\\\\" ) ||
+         src.startsWith( "//" ) ||
+         ( src[0].isLetter() && src[1] == ':' ) )
+    {
+      // UNC or absolute path
+      return vsiPrefix + src;
+    }
+#else
+    if ( src[0] == '/' )
+    {
+      // absolute path
+      return vsiPrefix + src;
+    }
+#endif
+
+    // so this one isn't absolute, but also doesn't start // with ./ or ../.
+    // That means that it was saved with an earlier version of "relative path support",
+    // where the source file had to exist and only the project directory was stripped
+    // from the filename.
+
+    QFileInfo pfi( mBaseFileName );
+    QString home = pfi.exists() ? pfi.canonicalPath() : QString();
+    if ( home.isNull() )
+      return vsiPrefix + src;
+
+    QFileInfo fi( home + '/' + src );
+
+    if ( !fi.exists() )
+    {
+      return vsiPrefix + src;
+    }
+    else
+    {
+      return vsiPrefix + fi.canonicalFilePath();
+    }
+  }
+
+  QString srcPath = src;
+  QString projPath = mBaseFileName;
+
+  if ( projPath.isEmpty() )
+  {
+    return vsiPrefix + src;
+  }
+
+#if defined(Q_OS_WIN)
+  srcPath.replace( '\\', '/' );
+  projPath.replace( '\\', '/' );
+
+  bool uncPath = projPath.startsWith( "//" );
+#endif
+
+  QStringList srcElems = srcPath.split( '/', QString::SkipEmptyParts );
+  QStringList projElems = projPath.split( '/', QString::SkipEmptyParts );
+
+#if defined(Q_OS_WIN)
+  if ( uncPath )
+  {
+    projElems.insert( 0, "" );
+    projElems.insert( 0, "" );
+  }
+#endif
+
+  // remove project file element
+  projElems.removeLast();
+
+  // append source path elements
+  projElems << srcElems;
+  projElems.removeAll( QStringLiteral( "." ) );
+
+  // resolve ..
+  int pos;
+  while (( pos = projElems.indexOf( QStringLiteral( ".." ) ) ) > 0 )
+  {
+    // remove preceding element and ..
+    projElems.removeAt( pos - 1 );
+    projElems.removeAt( pos - 1 );
+  }
+
+#if !defined(Q_OS_WIN)
+  // make path absolute
+  projElems.prepend( QLatin1String( "" ) );
+#endif
+
+  return vsiPrefix + projElems.join( QStringLiteral( "/" ) );
+}
+
+
+QString QgsPathResolver::writePath( const QString& src ) const
+{
+  if ( mBaseFileName.isNull() || src.isEmpty() )
+  {
+    return src;
+  }
+
+  QFileInfo pfi( mBaseFileName );
+  QString projPath = pfi.canonicalFilePath();
+
+  if ( projPath.isEmpty() )
+  {
+    return src;
+  }
+
+  QFileInfo srcFileInfo( src );
+  QString srcPath = srcFileInfo.exists() ? srcFileInfo.canonicalFilePath() : src;
+
+  // if this is a VSIFILE, remove the VSI prefix and append to final result
+  QString vsiPrefix = qgsVsiPrefix( src );
+  if ( ! vsiPrefix.isEmpty() )
+  {
+    srcPath.remove( 0, vsiPrefix.size() );
+  }
+
+#if defined( Q_OS_WIN )
+  const Qt::CaseSensitivity cs = Qt::CaseInsensitive;
+
+  srcPath.replace( '\\', '/' );
+
+  if ( srcPath.startsWith( "//" ) )
+  {
+    // keep UNC prefix
+    srcPath = "\\\\" + srcPath.mid( 2 );
+  }
+
+  projPath.replace( '\\', '/' );
+  if ( projPath.startsWith( "//" ) )
+  {
+    // keep UNC prefix
+    projPath = "\\\\" + projPath.mid( 2 );
+  }
+#else
+  const Qt::CaseSensitivity cs = Qt::CaseSensitive;
+#endif
+
+  QStringList projElems = mBaseFileName.split( '/', QString::SkipEmptyParts );
+  QStringList srcElems = srcPath.split( '/', QString::SkipEmptyParts );
+
+  // remove project file element
+  projElems.removeLast();
+
+  projElems.removeAll( QStringLiteral( "." ) );
+  srcElems.removeAll( QStringLiteral( "." ) );
+
+  // remove common part
+  int n = 0;
+  while ( !srcElems.isEmpty() &&
+          !projElems.isEmpty() &&
+          srcElems[0].compare( projElems[0], cs ) == 0 )
+  {
+    srcElems.removeFirst();
+    projElems.removeFirst();
+    n++;
+  }
+
+  if ( n == 0 )
+  {
+    // no common parts; might not even by a file
+    return src;
+  }
+
+  if ( !projElems.isEmpty() )
+  {
+    // go up to the common directory
+    for ( int i = 0; i < projElems.size(); i++ )
+    {
+      srcElems.insert( 0, QStringLiteral( ".." ) );
+    }
+  }
+  else
+  {
+    // let it start with . nevertheless,
+    // so relative path always start with either ./ or ../
+    srcElems.insert( 0, QStringLiteral( "." ) );
+  }
+
+  return vsiPrefix + srcElems.join( QStringLiteral( "/" ) );
+}

--- a/src/core/qgspathresolver.h
+++ b/src/core/qgspathresolver.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+  qgspathresolver.h
+  --------------------------------------
+  Date                 : February 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPATHRESOLVER_H
+#define QGSPATHRESOLVER_H
+
+#include "qgis_core.h"
+
+#include <QString>
+
+
+/** \ingroup core
+ * Resolves relative paths into absolute paths and vice versa. Used for writing
+ *
+ * @note added in QGIS 3.0
+ */
+class CORE_EXPORT QgsPathResolver
+{
+  public:
+    //! Initialize path resolver with a base filename. Null filename means no conversion between relative/absolute path
+    explicit QgsPathResolver( const QString& baseFileName = QString() );
+
+    /**
+     * Prepare a filename to save it to the project file.
+     * Creates an absolute or relative path according to the project settings.
+     * Paths written to the project file should be prepared with this method.
+    */
+    QString writePath( const QString& filename ) const;
+
+    //! Turn filename read from the project file to an absolute path
+    QString readPath( const QString& filename ) const;
+
+  private:
+    //! path to a file that is the base for relative path resolution
+    QString mBaseFileName;
+};
+
+#endif // QGSPATHRESOLVER_H

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -48,6 +48,7 @@ class QgsLayerTreeGroup;
 class QgsLayerTreeRegistryBridge;
 class QgsMapLayer;
 class QgsMapThemeCollection;
+class QgsPathResolver;
 class QgsProjectBadLayerHandler;
 class QgsRelationManager;
 class QgsTolerance;
@@ -295,12 +296,18 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     //           and redundantly prints sub-keys.
     void dumpProperties() const;
 
+    /** Return path resolver object with considering whether the project uses absolute
+     * or relative paths and using current project's path.
+     * @note added in QGIS 3.0
+     */
+    QgsPathResolver pathResolver() const;
+
     /**
      * Prepare a filename to save it to the project file.
      * Creates an absolute or relative path according to the project settings.
      * Paths written to the project file should be prepared with this method.
     */
-    QString writePath( const QString& filename, const QString& relativeBasePath = QString::null ) const;
+    QString writePath( const QString& filename ) const;
 
     //! Turn filename read from the project file to an absolute path
     QString readPath( QString filename ) const;

--- a/src/core/qgsprojectfiletransform.cpp
+++ b/src/core/qgsprojectfiletransform.cpp
@@ -26,6 +26,7 @@
 #include <QDomDocument>
 #include <QPrinter> //to find out screen resolution
 #include <cstdlib>
+#include "qgspathresolver.h"
 #include "qgsproject.h"
 #include "qgsprojectproperty.h"
 #include "qgsrasterbandstats.h"
@@ -486,7 +487,7 @@ void QgsProjectFileTransform::transform1800to1900()
     QgsRasterLayer rasterLayer;
     // TODO: We have to use more data from project file to read the layer it correctly,
     // OTOH, we should not read it until it was converted
-    rasterLayer.readLayerXml( layerNode.toElement() );
+    rasterLayer.readLayerXml( layerNode.toElement(), QgsProject::instance()->pathResolver() );
     convertRasterProperties( mDom, layerNode, rasterPropertiesElem, &rasterLayer );
   }
 

--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -23,6 +23,7 @@
 #include "qgscsexception.h"
 #include "qgsdatasourceuri.h"
 #include "qgsmslayercache.h"
+#include "qgspathresolver.h"
 #include "qgsrasterlayer.h"
 #include "qgsvectorlayerjoinbuffer.h"
 #include "qgseditorwidgetregistry.h"
@@ -273,7 +274,7 @@ QgsMapLayer* QgsServerProjectParser::createLayerFromElement( const QDomElement& 
       QObject::connect( layer, SIGNAL( readCustomSymbology( const QDomElement&, QString& ) ), QgsEditorWidgetRegistry::instance(), SLOT( readSymbology( const QDomElement&, QString& ) ) );
     }
 
-    layer->readLayerXml( const_cast<QDomElement&>( elem ) ); //should be changed to const in QgsMapLayer
+    layer->readLayerXml( const_cast<QDomElement&>( elem ), QgsProject::instance()->pathResolver() ); //should be changed to const in QgsMapLayer
     //layer->setLayerName( layerName( elem ) );
 
     if ( !layer->isValid() )

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -16,6 +16,7 @@
 #include <QObject>
 
 #include <qgsapplication.h>
+#include "qgspathresolver.h"
 #include <qgsproject.h>
 #include "qgsunittypes.h"
 
@@ -30,6 +31,7 @@ class TestQgsProject : public QObject
     void cleanup();// will be called after every testfunction.
 
     void testReadPath();
+    void testPathResolver();
     void testProjectUnits();
     void variablesChanged();
 };
@@ -83,6 +85,23 @@ void TestQgsProject::testReadPath()
   QCOMPARE( prj->readPath( "/vsigzip/./x.gz" ), QString( "/vsigzip/%1/home/qgis/x.gz" ).arg( prefix ) ); // not sure how useful this really is...
 
   delete prj;
+}
+
+void TestQgsProject::testPathResolver()
+{
+  QgsPathResolver resolverRel( "/home/qgis/test.qgs" );
+  QCOMPARE( resolverRel.writePath( "/home/qgis/file1.txt" ), QString( "./file1.txt" ) );
+  QCOMPARE( resolverRel.writePath( "/home/qgis/subdir/file1.txt" ), QString( "./subdir/file1.txt" ) );
+  QCOMPARE( resolverRel.writePath( "/home/file1.txt" ), QString( "../file1.txt" ) );
+  QCOMPARE( resolverRel.readPath( "./file1.txt" ), QString( "/home/qgis/file1.txt" ) );
+  QCOMPARE( resolverRel.readPath( "./subdir/file1.txt" ), QString( "/home/qgis/subdir/file1.txt" ) );
+  QCOMPARE( resolverRel.readPath( "../file1.txt" ), QString( "/home/file1.txt" ) );
+  QCOMPARE( resolverRel.readPath( "/home/qgis/file1.txt" ), QString( "/home/qgis/file1.txt" ) );
+
+  QgsPathResolver resolverAbs;
+  QCOMPARE( resolverAbs.writePath( "/home/qgis/file1.txt" ), QString( "/home/qgis/file1.txt" ) );
+  QCOMPARE( resolverAbs.readPath( "/home/qgis/file1.txt" ), QString( "/home/qgis/file1.txt" ) );
+  QCOMPARE( resolverAbs.readPath( "./file1.txt" ), QString( "./file1.txt" ) );
 }
 
 void TestQgsProject::testProjectUnits()

--- a/tests/src/core/testqgsvectorlayerjoinbuffer.cpp
+++ b/tests/src/core/testqgsvectorlayerjoinbuffer.cpp
@@ -21,6 +21,7 @@
 #include <qgsvectorlayer.h>
 #include "qgsfeatureiterator.h"
 #include "qgslayertreegroup.h"
+#include "qgspathresolver.h"
 #include <qgsvectordataprovider.h>
 #include <qgsapplication.h>
 #include <qgsvectorlayerjoinbuffer.h>
@@ -501,14 +502,14 @@ void TestVectorLayerJoinBuffer::testJoinLayerDefinitionFile()
   // Generate QLR
   QDomDocument qlrDoc( QStringLiteral( "qgis-layer-definition" ) );
   QString errorMessage;
-  r = QgsLayerDefinition::exportLayerDefinition( qlrDoc, mProject.layerTreeRoot()->children(), errorMessage );
+  r = QgsLayerDefinition::exportLayerDefinition( qlrDoc, mProject.layerTreeRoot()->children(), errorMessage, QgsPathResolver() );
   QVERIFY2( r, errorMessage.toUtf8().constData() );
 
   // Clear
   mProject.removeAllMapLayers();
 
   // Load QLR
-  r = QgsLayerDefinition::loadLayerDefinition( qlrDoc, &mProject, mProject.layerTreeRoot(), errorMessage );
+  r = QgsLayerDefinition::loadLayerDefinition( qlrDoc, &mProject, mProject.layerTreeRoot(), errorMessage, QgsPathResolver() );
   QVERIFY2( r, errorMessage.toUtf8().constData() );
 
   // Get layer

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -19,6 +19,7 @@ from qgis.core import (
     QgsLayerDefinition,
     QgsPoint,
     QgsMapLayer,
+    QgsPathResolver,
     QgsVectorLayer,
     QgsFeatureRequest,
     QgsFeature,
@@ -283,11 +284,11 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
         myMemoryLayer.updateFields()
 
         # Export the layer to a layer-definition-XML
-        qlr = QgsLayerDefinition.exportLayerDefinitionLayers([myMemoryLayer])
+        qlr = QgsLayerDefinition.exportLayerDefinitionLayers([myMemoryLayer], QgsPathResolver())
         assert qlr is not None
 
         # Import the layer from the layer-definition-XML
-        layers = QgsLayerDefinition.loadLayerDefinitionLayers(qlr)
+        layers = QgsLayerDefinition.loadLayerDefinitionLayers(qlr, QgsPathResolver())
         assert layers is not None
         myImportedLayer = layers[0]
         assert myImportedLayer is not None

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -15,6 +15,7 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 from qgis.core import (QgsMapRendererCache,
+                       QgsPathResolver,
                        QgsRectangle,
                        QgsVectorLayer,
                        QgsProject)
@@ -30,8 +31,8 @@ class TestQgsMapLayer(unittest.TestCase):
         # write to xml
         doc = QDomDocument("testdoc")
         elem = doc.createElement("maplayer")
-        self.assertTrue(source.writeLayerXml(elem, doc))
-        self.assertTrue(dest.readLayerXml(elem), QgsProject.instance())
+        self.assertTrue(source.writeLayerXml(elem, doc, QgsPathResolver()))
+        self.assertTrue(dest.readLayerXml(elem, QgsPathResolver()), QgsProject.instance())
 
     def testGettersSetters(self):
         # test auto refresh getters/setters


### PR DESCRIPTION
A new class QgsPathResolver is introduced for conversion between absolute and relative paths when reading/writing XML.

Cleaned up code in layer definition file support (.lyr) to better handle relative/absolute path conversion.
