### PR TITLE
[FEATURE] epoch() expression function

### DIFF
--- a/resources/function_help/json/epoch
+++ b/resources/function_help/json/epoch
@@ -1,0 +1,7 @@
+{
+  "name": "epoch",
+  "type": "function",
+  "description": "Return the interval in milliseconds between the unix epoch and a given date value.",
+  "arguments": [ {"arg":"date","description":"a date or datetime value"} ],
+  "examples": [ { "expression":"epoch(to_date('2017-01-01'))", "returns":"1483203600000"} ]
+}

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1721,6 +1721,18 @@ static QVariant fcnSeconds( const QVariantList& values, const QgsExpressionConte
   }
 }
 
+static QVariant fcnEpoch( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
+{
+  QDateTime dt = getDateTimeValue( values.at( 0 ), parent );
+  if ( dt.isValid() )
+  {
+    return QVariant( dt.toMSecsSinceEpoch() );
+  }
+  else
+  {
+    return QVariant();
+  }
+}
 
 #define ENSURE_GEOM_TYPE(f, g, geomtype) \
   if ( !(f).hasGeometry() ) \
@@ -3903,6 +3915,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( QStringLiteral( "hour" ), 1, fcnHour, QStringLiteral( "Date and Time" ) )
     << new StaticFunction( QStringLiteral( "minute" ), 1, fcnMinute, QStringLiteral( "Date and Time" ) )
     << new StaticFunction( QStringLiteral( "second" ), 1, fcnSeconds, QStringLiteral( "Date and Time" ) )
+    << new StaticFunction( QStringLiteral( "epoch" ), ParameterList() << Parameter( QStringLiteral( "date" ) ), fcnEpoch, QStringLiteral( "Date and Time" ) )
     << new StaticFunction( QStringLiteral( "day_of_week" ), 1, fcnDayOfWeek, QStringLiteral( "Date and Time" ) )
     << new StaticFunction( QStringLiteral( "lower" ), 1, fcnLower, QStringLiteral( "String" ) )
     << new StaticFunction( QStringLiteral( "upper" ), 1, fcnUpper, QStringLiteral( "String" ) )

--- a/src/ui/qgspropertyassistantwidgetbase.ui
+++ b/src/ui/qgspropertyassistantwidgetbase.ui
@@ -86,10 +86,10 @@
          <number>6</number>
         </property>
         <property name="minimum">
-         <double>-99999999.000000000000000</double>
+         <double>-99999999999999.000000000000000</double>
         </property>
         <property name="maximum">
-         <double>99999999.000000000000000</double>
+         <double>99999999999999.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -99,10 +99,10 @@
          <number>6</number>
         </property>
         <property name="minimum">
-         <double>-99999999.000000000000000</double>
+         <double>-99999999999999.000000000000000</double>
         </property>
         <property name="maximum">
-         <double>99999999.000000000000000</double>
+         <double>99999999999999.000000000000000</double>
         </property>
        </widget>
       </item>

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -968,6 +968,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "date - date" ) << "to_date('2013-03-04') - to_date('2013-03-01')" << false << QVariant( QgsInterval( 3*24*60*60 ) );
       QTest::newRow( "datetime - datetime" ) << "to_datetime('2013-03-04 08:30:00') - to_datetime('2013-03-01 05:15:00')" << false << QVariant( QgsInterval( 3*24*60*60 + 3 * 60*60 + 15*60 ) );
       QTest::newRow( "time - time" ) << "to_time('08:30:00') - to_time('05:15:00')" << false << QVariant( QgsInterval( 3 * 60*60 + 15*60 ) );
+      QTest::newRow( "epoch" ) << "epoch(to_date('2017-01-01'))" << false << QVariant(( qlonglong )1483203600000 );
+      QTest::newRow( "epoch invalid date" ) << "epoch('invalid')" << true << QVariant();
 
       // Color functions
       QTest::newRow( "ramp color" ) << "ramp_color('Spectral',0.3)" << false << QVariant( "254,190,116,255" );


### PR DESCRIPTION
This PR adds an epoch() function to the expression engine which returns the interval in milliseconds between the unix epoch and a given date value.

For e.g., `epoch(to_date('2017-01-01'))` will return `1483203600000.`

It's a useful function to have, and can lead to exciting results when used alongside @nyalldawson 's color property assistant:
![untitled](https://cloud.githubusercontent.com/assets/1728657/23008544/e00834aa-f442-11e6-983f-0455f42b1892.png)
_Want to quickly shade polygons based on a date field? Sure can do!_