### PR TITLE
Some API cleanup and QML exposure

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1651,7 +1651,9 @@ QgsRasterRenderer
 QgsRelation        {#qgis_api_break_3_0_QgsRelation}
 -----------
 
-- createFromXML() has been renamed to createFromXml()
+- `createFromXML()` has been renamed to `QgsRelation::createFromXml()`
+- `setRelationName()` has been renamed to `QgsRelation::setName()`
+- `setRelationId()` has been renamed to `QgsRelation::setId()`
 
 
 QgsRenderChecker        {#qgis_api_break_3_0_QgsRenderChecker}
@@ -1664,7 +1666,7 @@ setExcludeAttributesWms()
 setExcludeAttributesWfs()
 - editorWidgetV2() and editorWidgetV2Config() have been removed and QgsEditorWidgetRegistry::instance()->findBest() must be used instead.
 - setEditorWidgetV2(), setEditorWidgetV2Config() have been removed and their equivalent in editFormConfig() must be used instead.
-- setCheckedState() is removed. Use editFormConfig()->setWidgetConfig()` instead.
+- setCheckedState() is removed. Use `editFormConfig()->setWidgetConfig()` instead.
 - valueMap(), valueRelation(), dateFormat(), widgetSize() have been removed. Use QgsEditorWidgetRegistry::instance()->findBest().config() instead.
 
 

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -412,14 +412,7 @@ class QgsProject : QObject, QgsExpressionContextGenerator
     void setCustomVariables( const QVariantMap& customVariables );
     int count() const;
 
-    /** Retrieve a pointer to a registered layer by layer ID.
-     * @param theLayerId ID of layer to retrieve
-     * @returns matching layer, or nullptr if no matching layer found
-     * @see mapLayersByName()
-     * @see mapLayers()
-     */
-    //TODO QGIS 3.0 - rename theLayerId to layerId
-    QgsMapLayer* mapLayer( const QString& theLayerId ) const;
+    QgsMapLayer* mapLayer( const QString& layerId ) const;
 
     /** Retrieve a list of matching registered layers by layer name.
      * @param layerName name of layers to match
@@ -436,79 +429,12 @@ class QgsProject : QObject, QgsExpressionContextGenerator
      */
     QMap<QString, QgsMapLayer*> mapLayers() const;
 
-    /**
-     * @brief
-     * Add a list of layers to the map of loaded layers.
-     *
-     * The layersAdded() and layerWasAdded() signals will always be emitted.
-     * The legendLayersAdded() signal is emitted only if addToLegend is true.
-     *
-     * @param theMapLayers  A list of layer which should be added to the registry
-     * @param addToLegend   If true (by default), the layers will be added to the
-     *                      legend and to the main canvas. If you have a private
-     *                      layer you can set this parameter to false to hide it.
-     * @param takeOwnership Ownership will be transferred to the layer registry.
-     *                      If you specify false here you have take care of deleting
-     *                      the layers yourself. Not available in python.
-     *
-     * @return a list of the map layers that were added
-     *         successfully. If a layer is invalid, or already exists in the registry,
-     *         it will not be part of the returned QList.
-     *
-     * @note As a side-effect QgsProject is made dirty.
-     * @note takeOwnership is not available in the Python bindings - the registry will always
-     * take ownership
-     * @note added in QGIS 1.8
-     * @see addMapLayer()
-     */
-    QList<QgsMapLayer *> addMapLayers( const QList<QgsMapLayer *>& theMapLayers /Transfer/,
+    QList<QgsMapLayer *> addMapLayers( const QList<QgsMapLayer *>& layers /Transfer/,
                                        bool addToLegend = true );
 
-    /**
-     * @brief
-     * Add a layer to the map of loaded layers.
-     *
-     * The layersAdded() and layerWasAdded() signals will always be emitted.
-     * The legendLayersAdded() signal is emitted only if addToLegend is true.
-     * If you are adding multiple layers at once, you should use
-     * addMapLayers() instead.
-     *
-     * @param theMapLayer A layer to add to the registry
-     * @param addToLegend If true (by default), the layer will be added to the
-     *                    legend and to the main canvas. If you have a private
-     *                    layer you can set this parameter to false to hide it.
-     * @param takeOwnership Ownership will be transferred to the layer registry.
-     *                      If you specify false here you have take care of deleting
-     *                      the layer yourself. Not available in python.
-     *
-     * @return nullptr if unable to add layer, otherwise pointer to newly added layer
-     *
-     * @see addMapLayers
-     *
-     * @note As a side-effect QgsProject is made dirty.
-     * @note Use addMapLayers if adding more than one layer at a time
-     * @note takeOwnership is not available in the Python bindings - the registry will always
-     * take ownership
-     * @see addMapLayers()
-     */
-    QgsMapLayer* addMapLayer( QgsMapLayer * theMapLayer /Transfer/, bool addToLegend = true );
+    QgsMapLayer* addMapLayer( QgsMapLayer * layer /Transfer/, bool addToLegend = true );
 
-    /**
-     * @brief
-     * Remove a set of layers from the registry by layer ID.
-     *
-     * The specified layers will be removed from the registry. If the registry has ownership
-     * of any layers these layers will also be deleted.
-     *
-     * @param theLayerIds list of IDs of the layers to remove
-     *
-     * @note As a side-effect the QgsProject instance is marked dirty.
-     * @note added in QGIS 1.8
-     * @see removeMapLayer()
-     * @see removeAllMapLayers()
-     */
-    // TODO QGIS 3.0 - rename theLayerIds to layerIds
-    void removeMapLayers( const QStringList& theLayerIds );
+    void removeMapLayers( const QStringList& layerIds );
 
     /**
      * @brief
@@ -525,21 +451,7 @@ class QgsProject : QObject, QgsExpressionContextGenerator
      */
     void removeMapLayers( const QList<QgsMapLayer*>& layers );
 
-    /**
-     * @brief
-     * Remove a layer from the registry by layer ID.
-     *
-     * The specified layer will be removed from the registry. If the registry has ownership
-     * of the layer then it will also be deleted.
-     *
-     * @param theLayerId ID of the layer to remove
-     *
-     * @note As a side-effect the QgsProject instance is marked dirty.
-     * @see removeMapLayers()
-     * @see removeAllMapLayers()
-     */
-    // TODO QGIS 3.0 - rename theLayerId to layerId
-    void removeMapLayer( const QString& theLayerId );
+    void removeMapLayer( const QString& layerId );
 
     /**
      * @brief
@@ -673,15 +585,7 @@ class QgsProject : QObject, QgsExpressionContextGenerator
     // signals from QgsMapLayerRegistry
     //
 
-    /**
-     * Emitted when one or more layers are about to be removed from the registry.
-     *
-     * @param theLayerIds A list of IDs for the layers which are to be removed.
-     * @see layerWillBeRemoved()
-     * @see layersRemoved()
-     */
-    // TODO QGIS 3.0 - rename theLayerIds to layerIds
-    void layersWillBeRemoved( const QStringList& theLayerIds );
+    void layersWillBeRemoved( const QStringList& layerIds );
 
     /**
      * Emitted when one or more layers are about to be removed from the registry.
@@ -692,17 +596,7 @@ class QgsProject : QObject, QgsExpressionContextGenerator
      */
     void layersWillBeRemoved( const QList<QgsMapLayer*>& layers );
 
-    /**
-     * Emitted when a layer is about to be removed from the registry.
-     *
-     * @param theLayerId The ID of the layer to be removed.
-     *
-     * @note Consider using {@link layersWillBeRemoved()} instead
-     * @see layersWillBeRemoved()
-     * @see layerRemoved()
-     */
-    //TODO QGIS 3.0 - rename theLayerId to layerId
-    void layerWillBeRemoved( const QString& theLayerId );
+    void layerWillBeRemoved( const QString& layerId );
 
     /**
      * Emitted when a layer is about to be removed from the registry.
@@ -715,25 +609,9 @@ class QgsProject : QObject, QgsExpressionContextGenerator
      */
     void layerWillBeRemoved( QgsMapLayer* layer );
 
-    /**
-     * Emitted after one or more layers were removed from the registry.
-     *
-     * @param theLayerIds  A list of IDs of the layers which were removed.
-     * @see layersWillBeRemoved()
-     */
-    //TODO QGIS 3.0 - rename theLayerIds to layerIds
-    void layersRemoved( const QStringList& theLayerIds );
+    void layersRemoved( const QStringList& layerIds );
 
-    /**
-     * Emitted after a layer was removed from the registry.
-     *
-     * @param theLayerId The ID of the layer removed.
-     *
-     * @note Consider using {@link layersRemoved()} instead
-     * @see layerWillBeRemoved()
-     */
-    //TODO QGIS 3.0 - rename theLayerId to layerId
-    void layerRemoved( const QString& theLayerId );
+    void layerRemoved( const QString& layerId );
 
     /**
      * Emitted when all layers are removed, before {@link layersWillBeRemoved()} and
@@ -744,40 +622,11 @@ class QgsProject : QObject, QgsExpressionContextGenerator
     //TODO QGIS 3.0 - rename to past tense
     void removeAll();
 
-    /**
-     * Emitted when one or more layers were added to the registry.
-     * This signal is also emitted for layers added to the registry,
-     * but not to the legend.
-     *
-     * @param theMapLayers List of layers which have been added.
-     *
-     * @see legendLayersAdded()
-     * @see layerWasAdded()
-     */
-    //TODO QGIS 3.0 - rename theMapLayers to mapLayers
-    void layersAdded( const QList<QgsMapLayer *>& theMapLayers );
+    void layersAdded( const QList<QgsMapLayer *>& layers );
 
-    /**
-     * Emitted when a layer was added to the registry.
-     *
-     * @param theMapLayer The ID of the layer which has been added.
-     *
-     * @note Consider using {@link layersAdded()} instead
-     * @see layersAdded()
-     */
-    // TODO QGIS 3.0 - rename theMapLayer to layer
-    void layerWasAdded( QgsMapLayer* theMapLayer );
+    void layerWasAdded( QgsMapLayer* layer );
 
-    /**
-     * Emitted, when a layer was added to the registry and the legend.
-     * Layers can also be private layers, which are signalled by
-     * {@link layersAdded()} and {@link layerWasAdded()} but will not be
-     * advertised by this signal.
-     *
-     * @param theMapLayers List of {@link QgsMapLayer}s which were added to the legend.
-     */
-    //TODO QGIS 3.0 rename theMapLayers to mapLayers
-    void legendLayersAdded( const QList<QgsMapLayer*>& theMapLayers );
+    void legendLayersAdded( const QList<QgsMapLayer*>& layers );
 
   public slots:
     /**

--- a/python/core/qgsrelation.sip
+++ b/python/core/qgsrelation.sip
@@ -42,19 +42,9 @@ class QgsRelation
      */
     void writeXml( QDomNode& node, QDomDocument& doc ) const;
 
-    /**
-     * Set an id for this relation
-     *
-     * @param id
-     */
-    void setRelationId( const QString& id );
+    void setId( const QString& id );
 
-    /**
-     * Set a name for this relation
-     *
-     * @param name
-     */
-    void setRelationName( const QString& name );
+    void setName( const QString& name );
 
     /**
      * Set the referencing (child) layer id. This layer will be searched in the registry.
@@ -256,10 +246,4 @@ class QgsRelation
      */
     bool hasEqualDefinition( const QgsRelation& other ) const;
 
-  protected:
-    /**
-     * Updates the validity status of this relation.
-     * Will be called internally whenever a member is changed.
-     */
-    void updateRelationStatus();
 };

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -114,9 +114,9 @@ void QgsRelationManagerDialog::on_mBtnAddRelation_clicked()
       relationId = tempId.arg( suffix );
       ++suffix;
     }
-    relation.setRelationId( relationId );
+    relation.setId( relationId );
     relation.addFieldPair( addDlg.references().at( 0 ).first, addDlg.references().at( 0 ).second );
-    relation.setRelationName( addDlg.relationName() );
+    relation.setName( addDlg.relationName() );
 
     addRelation( relation );
   }
@@ -153,7 +153,7 @@ QList< QgsRelation > QgsRelationManagerDialog::relations()
   {
     QgsRelation relation = mRelationsTable->item( i, 0 )->data( Qt::UserRole ).value<QgsRelation>();
     // The name can be editted in the table, so apply this one
-    relation.setRelationName( mRelationsTable->item( i, 0 )->data( Qt::DisplayRole ).toString() );
+    relation.setName( mRelationsTable->item( i, 0 )->data( Qt::DisplayRole ).toString() );
     relations << relation;
   }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -518,6 +518,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgspointlocator.h
   qgsproject.h
   qgsrelationmanager.h
+  qgsrelation.h
   qgsrunprocess.h
   qgssnappingconfig.h
   qgssnappingutils.h
@@ -743,7 +744,6 @@ SET(QGIS_CORE_HDRS
   qgsproviderregistry.h
   qgspythonrunner.h
   qgsrectangle.h
-  qgsrelation.h
   qgsrenderchecker.h
   qgsrendercontext.h
   qgsruntimeprofiler.h

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2001,9 +2001,9 @@ int QgsProject::count() const
   return mMapLayers.size();
 }
 
-QgsMapLayer * QgsProject::mapLayer( const QString& theLayerId ) const
+QgsMapLayer * QgsProject::mapLayer( const QString& layerId ) const
 {
-  return mMapLayers.value( theLayerId );
+  return mMapLayers.value( layerId );
 }
 
 QList<QgsMapLayer *> QgsProject::mapLayersByName( const QString& layerName ) const
@@ -2020,12 +2020,12 @@ QList<QgsMapLayer *> QgsProject::mapLayersByName( const QString& layerName ) con
 }
 
 QList<QgsMapLayer *> QgsProject::addMapLayers(
-  const QList<QgsMapLayer *>& theMapLayers,
+  const QList<QgsMapLayer *>& layers,
   bool addToLegend,
   bool takeOwnership )
 {
   QList<QgsMapLayer *> myResultList;
-  Q_FOREACH ( QgsMapLayer* myLayer, theMapLayers )
+  Q_FOREACH ( QgsMapLayer* myLayer, layers )
   {
     if ( !myLayer || !myLayer->isValid() )
     {
@@ -2056,19 +2056,19 @@ QList<QgsMapLayer *> QgsProject::addMapLayers(
 }
 
 QgsMapLayer *
-QgsProject::addMapLayer( QgsMapLayer* theMapLayer,
+QgsProject::addMapLayer( QgsMapLayer* layer,
                          bool addToLegend,
                          bool takeOwnership )
 {
   QList<QgsMapLayer *> addedLayers;
-  addedLayers = addMapLayers( QList<QgsMapLayer*>() << theMapLayer, addToLegend, takeOwnership );
+  addedLayers = addMapLayers( QList<QgsMapLayer*>() << layer, addToLegend, takeOwnership );
   return addedLayers.isEmpty() ? nullptr : addedLayers[0];
 }
 
-void QgsProject::removeMapLayers( const QStringList& theLayerIds )
+void QgsProject::removeMapLayers( const QStringList& layerIds )
 {
   QList<QgsMapLayer*> layers;
-  Q_FOREACH ( const QString &myId, theLayerIds )
+  Q_FOREACH ( const QString &myId, layerIds )
   {
     layers << mMapLayers.value( myId );
   }
@@ -2116,9 +2116,9 @@ void QgsProject::removeMapLayers( const QList<QgsMapLayer*>& layers )
   emit layersRemoved( layerIds );
 }
 
-void QgsProject::removeMapLayer( const QString& theLayerId )
+void QgsProject::removeMapLayer( const QString& layerId )
 {
-  removeMapLayers( QList<QgsMapLayer*>() << mMapLayers.value( theLayerId ) );
+  removeMapLayers( QList<QgsMapLayer*>() << mMapLayers.value( layerId ) );
 }
 
 void QgsProject::removeMapLayer( QgsMapLayer* layer )

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -80,6 +80,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs )
     Q_PROPERTY( QgsMapThemeCollection* mapThemeCollection READ mapThemeCollection NOTIFY mapThemeCollectionChanged )
     Q_PROPERTY( QgsSnappingConfig snappingConfig READ snappingConfig WRITE setSnappingConfig NOTIFY snappingConfigChanged )
+    Q_PROPERTY( QgsRelationManager* relationManager READ relationManager )
     Q_PROPERTY( QList<QgsVectorLayer*> avoidIntersectionsLayers READ avoidIntersectionsLayers WRITE setAvoidIntersectionsLayers NOTIFY avoidIntersectionsLayersChanged )
 
   public:

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -509,13 +509,12 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     int count() const;
 
     /** Retrieve a pointer to a registered layer by layer ID.
-     * @param theLayerId ID of layer to retrieve
+     * @param layerId ID of layer to retrieve
      * @returns matching layer, or nullptr if no matching layer found
      * @see mapLayersByName()
      * @see mapLayers()
      */
-    //TODO QGIS 3.0 - rename theLayerId to layerId
-    QgsMapLayer* mapLayer( const QString& theLayerId ) const;
+    QgsMapLayer* mapLayer( const QString& layerId ) const;
 
     /** Retrieve a list of matching registered layers by layer name.
      * @param layerName name of layers to match
@@ -623,15 +622,14 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * The specified layers will be removed from the registry. If the registry has ownership
      * of any layers these layers will also be deleted.
      *
-     * @param theLayerIds list of IDs of the layers to remove
+     * @param layerIds list of IDs of the layers to remove
      *
      * @note As a side-effect the QgsProject instance is marked dirty.
      * @note added in QGIS 1.8
      * @see removeMapLayer()
      * @see removeAllMapLayers()
      */
-    // TODO QGIS 3.0 - rename theLayerIds to layerIds
-    void removeMapLayers( const QStringList& theLayerIds );
+    void removeMapLayers( const QStringList& layerIds );
 
     /**
      * @brief
@@ -656,14 +654,13 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * The specified layer will be removed from the registry. If the registry has ownership
      * of the layer then it will also be deleted.
      *
-     * @param theLayerId ID of the layer to remove
+     * @param layerId ID of the layer to remove
      *
      * @note As a side-effect the QgsProject instance is marked dirty.
      * @see removeMapLayers()
      * @see removeAllMapLayers()
      */
-    // TODO QGIS 3.0 - rename theLayerId to layerId
-    void removeMapLayer( const QString& theLayerId );
+    void removeMapLayer( const QString& layerId );
 
     /**
      * @brief
@@ -800,12 +797,11 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Emitted when one or more layers are about to be removed from the registry.
      *
-     * @param theLayerIds A list of IDs for the layers which are to be removed.
+     * @param layerIds A list of IDs for the layers which are to be removed.
      * @see layerWillBeRemoved()
      * @see layersRemoved()
      */
-    // TODO QGIS 3.0 - rename theLayerIds to layerIds
-    void layersWillBeRemoved( const QStringList& theLayerIds );
+    void layersWillBeRemoved( const QStringList& layerIds );
 
     /**
      * Emitted when one or more layers are about to be removed from the registry.
@@ -819,14 +815,13 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Emitted when a layer is about to be removed from the registry.
      *
-     * @param theLayerId The ID of the layer to be removed.
+     * @param layerId The ID of the layer to be removed.
      *
      * @note Consider using {@link layersWillBeRemoved()} instead
      * @see layersWillBeRemoved()
      * @see layerRemoved()
      */
-    //TODO QGIS 3.0 - rename theLayerId to layerId
-    void layerWillBeRemoved( const QString& theLayerId );
+    void layerWillBeRemoved( const QString& layerId );
 
     /**
      * Emitted when a layer is about to be removed from the registry.
@@ -842,22 +837,20 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Emitted after one or more layers were removed from the registry.
      *
-     * @param theLayerIds  A list of IDs of the layers which were removed.
+     * @param layerIds  A list of IDs of the layers which were removed.
      * @see layersWillBeRemoved()
      */
-    //TODO QGIS 3.0 - rename theLayerIds to layerIds
-    void layersRemoved( const QStringList& theLayerIds );
+    void layersRemoved( const QStringList& layerIds );
 
     /**
      * Emitted after a layer was removed from the registry.
      *
-     * @param theLayerId The ID of the layer removed.
+     * @param layerId The ID of the layer removed.
      *
      * @note Consider using {@link layersRemoved()} instead
      * @see layerWillBeRemoved()
      */
-    //TODO QGIS 3.0 - rename theLayerId to layerId
-    void layerRemoved( const QString& theLayerId );
+    void layerRemoved( const QString& layerId );
 
     /**
      * Emitted when all layers are removed, before {@link layersWillBeRemoved()} and
@@ -873,24 +866,20 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * This signal is also emitted for layers added to the registry,
      * but not to the legend.
      *
-     * @param theMapLayers List of layers which have been added.
+     * @param layers List of layers which have been added.
      *
      * @see legendLayersAdded()
      * @see layerWasAdded()
      */
-    //TODO QGIS 3.0 - rename theMapLayers to mapLayers
-    void layersAdded( const QList<QgsMapLayer *>& theMapLayers );
+    void layersAdded( const QList<QgsMapLayer *>& layers );
 
     /**
      * Emitted when a layer was added to the registry.
      *
-     * @param theMapLayer The ID of the layer which has been added.
-     *
      * @note Consider using {@link layersAdded()} instead
      * @see layersAdded()
      */
-    // TODO QGIS 3.0 - rename theMapLayer to layer
-    void layerWasAdded( QgsMapLayer* theMapLayer );
+    void layerWasAdded( QgsMapLayer* layer );
 
     /**
      * Emitted, when a layer was added to the registry and the legend.
@@ -898,10 +887,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * {@link layersAdded()} and {@link layerWasAdded()} but will not be
      * advertised by this signal.
      *
-     * @param theMapLayers List of {@link QgsMapLayer}s which were added to the legend.
+     * @param layers List of {@link QgsMapLayer}s which were added to the legend.
      */
-    //TODO QGIS 3.0 rename theMapLayers to mapLayers
-    void legendLayersAdded( const QList<QgsMapLayer*>& theMapLayers );
+    void legendLayersAdded( const QList<QgsMapLayer*>& layers );
 
   public slots:
 

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -109,14 +109,14 @@ void QgsRelation::writeXml( QDomNode &node, QDomDocument &doc ) const
   node.appendChild( elem );
 }
 
-void QgsRelation::setRelationId( const QString& id )
+void QgsRelation::setId( const QString& id )
 {
   mRelationId = id;
 
   updateRelationStatus();
 }
 
-void QgsRelation::setRelationName( const QString& name )
+void QgsRelation::setName( const QString& name )
 {
   mRelationName = name;
 }
@@ -314,6 +314,26 @@ bool QgsRelation::isValid() const
 bool QgsRelation::hasEqualDefinition( const QgsRelation& other ) const
 {
   return mReferencedLayerId == other.mReferencedLayerId && mReferencingLayerId == other.mReferencingLayerId && mFieldPairs == other.mFieldPairs;
+}
+
+QString QgsRelation::resolveReferencedField( const QString& referencingField ) const
+{
+  Q_FOREACH ( const FieldPair& pair, mFieldPairs )
+  {
+    if ( pair.first == referencingField )
+      return pair.second;
+  }
+  return QString();
+}
+
+QString QgsRelation::resolveReferencingField( const QString& referencedField ) const
+{
+  Q_FOREACH ( const FieldPair& pair, mFieldPairs )
+  {
+    if ( pair.second == referencedField )
+      return pair.first;
+  }
+  return QString();
 }
 
 void QgsRelation::updateRelationStatus()

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -34,6 +34,15 @@ class QgsAttributes;
  */
 class CORE_EXPORT QgsRelation
 {
+    Q_GADGET
+
+    Q_PROPERTY( QString id READ id WRITE setId )
+    Q_PROPERTY( QgsVectorLayer* referencingLayer READ referencingLayer )
+    Q_PROPERTY( QgsVectorLayer* referencedLayer READ referencedLayer )
+    Q_PROPERTY( QString name READ name WRITE setName )
+    Q_PROPERTY( bool isValid READ isValid )
+
+
   public:
 
     /**
@@ -87,29 +96,21 @@ class CORE_EXPORT QgsRelation
 
     /**
      * Set an id for this relation
-     *
-     * @param id
      */
-    void setRelationId( const QString& id );
+    void setId( const QString& id );
 
     /**
      * Set a name for this relation
-     *
-     * @param name
      */
-    void setRelationName( const QString& name );
+    void setName( const QString& name );
 
     /**
      * Set the referencing (child) layer id. This layer will be searched in the registry.
-     *
-     * @param id
      */
     void setReferencingLayer( const QString& id );
 
     /**
      * Set the referenced (parent) layer id. This layer will be searched in the registry.
-     *
-     * @param id
      */
     void setReferencedLayer( const QString& id );
 
@@ -291,7 +292,21 @@ class CORE_EXPORT QgsRelation
      */
     bool hasEqualDefinition( const QgsRelation& other ) const;
 
-  protected:
+    /**
+     * Get the referenced field counterpart given a referencing field.
+     *
+     * @note Added in QGIS 3.0
+     */
+    Q_INVOKABLE QString resolveReferencedField( const QString& referencingField ) const;
+
+    /**
+     * Get the referencing field counterpart given a referenced field.
+     *
+     * @note Added in QGIS 3.0
+     */
+    Q_INVOKABLE QString resolveReferencingField( const QString& referencedField ) const;
+
+  private:
 
     /**
      * Updates the validity status of this relation.
@@ -299,7 +314,6 @@ class CORE_EXPORT QgsRelation
      */
     void updateRelationStatus();
 
-  private:
     //! Unique Id
     QString mRelationId;
     //! Human redable name

--- a/src/core/qgsrelationmanager.h
+++ b/src/core/qgsrelationmanager.h
@@ -84,7 +84,7 @@ class CORE_EXPORT QgsRelationManager : public QObject
      * @return A relation. Invalid if not found.
      * @see relationsByName()
      */
-    QgsRelation relation( const QString& id ) const;
+    Q_INVOKABLE QgsRelation relation( const QString& id ) const;
 
     /** Returns a list of relations with matching names.
      * @param name relation name to search for. Searching is case insensitive.

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4174,7 +4174,7 @@ QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer*
       Q_FOREACH ( const QgsVectorLayer* foundLayer, foundLayers )
       {
         QgsRelation relation;
-        relation.setRelationName( name );
+        relation.setName( name );
         relation.setReferencingLayer( self->id() );
         relation.setReferencedLayer( foundLayer->id() );
         relation.addFieldPair( fkColumn, refColumn );

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -5486,7 +5486,7 @@ QList<QgsRelation> QgsSpatiaLiteProvider::discoverRelations( const QgsVectorLaye
         Q_FOREACH ( const QgsVectorLayer* foundLayer, foundLayers )
         {
           QgsRelation relation;
-          relation.setRelationName( name );
+          relation.setName( name );
           relation.setReferencingLayer( self->id() );
           relation.setReferencedLayer( foundLayer->id() );
           relation.addFieldPair( fkColumn, refColumn );

--- a/tests/src/core/testqgscomposerhtml.cpp
+++ b/tests/src/core/testqgscomposerhtml.cpp
@@ -283,8 +283,8 @@ void TestQgsComposerHtml::javascriptSetFeature()
   mComposition->atlasComposition().setEnabled( true );
 
   QgsRelation rel;
-  rel.setRelationId( QStringLiteral( "rel1" ) );
-  rel.setRelationName( QStringLiteral( "relation one" ) );
+  rel.setId( QStringLiteral( "rel1" ) );
+  rel.setName( QStringLiteral( "relation one" ) );
   rel.setReferencingLayer( childLayer->id() );
   rel.setReferencedLayer( parentLayer->id() );
   rel.addFieldPair( QStringLiteral( "y" ), QStringLiteral( "foreignkey" ) );

--- a/tests/src/core/testqgscomposertablev2.cpp
+++ b/tests/src/core/testqgscomposertablev2.cpp
@@ -493,7 +493,7 @@ void TestQgsComposerTableV2::attributeTableRelationSource()
 
   //create a relation
   QgsRelation relation;
-  relation.setRelationId( QStringLiteral( "testrelation" ) );
+  relation.setId( QStringLiteral( "testrelation" ) );
   relation.setReferencedLayer( atlasLayer->id() );
   relation.setReferencingLayer( mVectorLayer->id() );
   relation.addFieldPair( QStringLiteral( "Class" ), QStringLiteral( "Class" ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -181,8 +181,8 @@ class TestQgsExpression: public QObject
       QgsProject::instance()->addMapLayer( mChildLayer );
 
       QgsRelation rel;
-      rel.setRelationId( QStringLiteral( "my_rel" ) );
-      rel.setRelationName( QStringLiteral( "relation name" ) );
+      rel.setId( QStringLiteral( "my_rel" ) );
+      rel.setName( QStringLiteral( "relation name" ) );
       rel.setReferencedLayer( mAggregatesLayer->id() );
       rel.setReferencingLayer( mChildLayer->id() );
       rel.addFieldPair( QStringLiteral( "parent" ), QStringLiteral( "col1" ) );

--- a/tests/src/gui/testqgseditorwidgetregistry.cpp
+++ b/tests/src/gui/testqgseditorwidgetregistry.cpp
@@ -121,8 +121,8 @@ class TestQgsEditorWidgetRegistry: public QObject
 
       //create a relation between them
       QgsRelation relation;
-      relation.setRelationId( QStringLiteral( "vl1->vl2" ) );
-      relation.setRelationName( QStringLiteral( "vl1->vl2" ) );
+      relation.setId( QStringLiteral( "vl1->vl2" ) );
+      relation.setName( QStringLiteral( "vl1->vl2" ) );
       relation.setReferencingLayer( vl1.id() );
       relation.setReferencedLayer( vl2.id() );
       relation.addFieldPair( "fk", "pk" );

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -133,8 +133,8 @@ class TestQgsRelationReferenceFieldFormatter(unittest.TestCase):
         fieldFormatter = QgsRelationReferenceFieldFormatter()
 
         rel = QgsRelation()
-        rel.setRelationId('rel1')
-        rel.setRelationName('Relation Number One')
+        rel.setId('rel1')
+        rel.setName('Relation Number One')
         rel.setReferencingLayer(first_layer.id())
         rel.setReferencedLayer(second_layer.id())
         rel.addFieldPair('foreign_key', 'pkid')
@@ -184,8 +184,8 @@ class TestQgsRelationReferenceFieldFormatter(unittest.TestCase):
 
         # Invalid relation
         rel = QgsRelation()
-        rel.setRelationId('rel2')
-        rel.setRelationName('Relation Number Two')
+        rel.setId('rel2')
+        rel.setName('Relation Number Two')
         rel.setReferencingLayer(first_layer.id())
         rel.addFieldPair('foreign_key', 'pkid')
         self.assertFalse(rel.isValid())

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -451,8 +451,8 @@ class TestQgsJSONUtils(unittest.TestCase):
         QgsProject.instance().addMapLayers([child, parent])
 
         rel = QgsRelation()
-        rel.setRelationId('rel1')
-        rel.setRelationName('relation one')
+        rel.setId('rel1')
+        rel.setName('relation one')
         rel.setReferencingLayer(child.id())
         rel.setReferencedLayer(parent.id())
         rel.addFieldPair('y', 'foreignkey')

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -81,10 +81,10 @@ class TestQgsRelation(unittest.TestCase):
         rel = QgsRelation()
         assert not rel.isValid()
 
-        rel.setRelationId('rel1')
+        rel.setId('rel1')
         assert not rel.isValid()
 
-        rel.setRelationName('Relation Number One')
+        rel.setName('Relation Number One')
         assert not rel.isValid()
 
         rel.setReferencingLayer(self.referencingLayer.id())
@@ -99,8 +99,8 @@ class TestQgsRelation(unittest.TestCase):
     def test_getRelatedFeatures(self):
         rel = QgsRelation()
 
-        rel.setRelationId('rel1')
-        rel.setRelationName('Relation Number One')
+        rel.setId('rel1')
+        rel.setName('Relation Number One')
         rel.setReferencingLayer(self.referencingLayer.id())
         rel.setReferencedLayer(self.referencedLayer.id())
         rel.addFieldPair('foreignkey', 'y')
@@ -114,8 +114,8 @@ class TestQgsRelation(unittest.TestCase):
 
     def test_getReferencedFeature(self):
         rel = QgsRelation()
-        rel.setRelationId('rel1')
-        rel.setRelationName('Relation Number One')
+        rel.setId('rel1')
+        rel.setName('Relation Number One')
         rel.setReferencingLayer(self.referencingLayer.id())
         rel.setReferencedLayer(self.referencedLayer.id())
         rel.addFieldPair('foreignkey', 'y')
@@ -130,8 +130,8 @@ class TestQgsRelation(unittest.TestCase):
     def test_fieldPairs(self):
         rel = QgsRelation()
 
-        rel.setRelationId('rel1')
-        rel.setRelationName('Relation Number One')
+        rel.setId('rel1')
+        rel.setName('Relation Number One')
         rel.setReferencingLayer(self.referencingLayer.id())
         rel.setReferencedLayer(self.referencedLayer.id())
         rel.addFieldPair('foreignkey', 'y')

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -66,7 +66,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         cls.rel_a.setReferencingLayer(cls.vl_link.id())
         cls.rel_a.setReferencedLayer(cls.vl_a.id())
         cls.rel_a.addFieldPair('fk_author', 'pk')
-        cls.rel_a.setRelationId('rel_a')
+        cls.rel_a.setId('rel_a')
         assert(cls.rel_a.isValid())
         cls.relMgr.addRelation(cls.rel_a)
 
@@ -74,7 +74,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         cls.rel_b.setReferencingLayer(cls.vl_link.id())
         cls.rel_b.setReferencedLayer(cls.vl_b.id())
         cls.rel_b.addFieldPair('fk_book', 'pk')
-        cls.rel_b.setRelationId('rel_b')
+        cls.rel_b.setId('rel_b')
         assert(cls.rel_b.isValid())
         cls.relMgr.addRelation(cls.rel_b)
 

--- a/tests/src/python/test_qgsrelationmanager.py
+++ b/tests/src/python/test_qgsrelationmanager.py
@@ -62,8 +62,8 @@ class TestQgsRelationManager(unittest.TestCase):
         self.assertEqual(len(relations), 0)
 
         rel = self.createRelation()
-        rel.setRelationId('rel1')
-        rel.setRelationName('Relation Number One')
+        rel.setId('rel1')
+        rel.setName('Relation Number One')
         assert rel.isValid()
 
         manager.addRelation(rel)
@@ -73,8 +73,8 @@ class TestQgsRelationManager(unittest.TestCase):
         self.assertEqual(relations['rel1'].id(), 'rel1')
 
         rel = self.createRelation()
-        rel.setRelationId('rel2')
-        rel.setRelationName('Relation Number Two')
+        rel.setId('rel2')
+        rel.setName('Relation Number Two')
         assert rel.isValid()
 
         manager.addRelation(rel)
@@ -93,13 +93,13 @@ class TestQgsRelationManager(unittest.TestCase):
 
         # add two relations
         rel = self.createRelation()
-        rel.setRelationId('rel1')
-        rel.setRelationName('Relation Number One')
+        rel.setId('rel1')
+        rel.setName('Relation Number One')
         assert rel.isValid()
         manager.addRelation(rel)
         rel = self.createRelation()
-        rel.setRelationId('rel2')
-        rel.setRelationName('Relation Number Two')
+        rel.setId('rel2')
+        rel.setName('Relation Number Two')
         assert rel.isValid()
         manager.addRelation(rel)
 
@@ -121,18 +121,18 @@ class TestQgsRelationManager(unittest.TestCase):
 
         # add some relations
         rel = self.createRelation()
-        rel.setRelationId('rel1')
-        rel.setRelationName('my relation')
+        rel.setId('rel1')
+        rel.setName('my relation')
         assert rel.isValid()
         manager.addRelation(rel)
         rel = self.createRelation()
-        rel.setRelationId('rel2')
-        rel.setRelationName('dupe name')
+        rel.setId('rel2')
+        rel.setName('dupe name')
         assert rel.isValid()
         manager.addRelation(rel)
         rel = self.createRelation()
-        rel.setRelationId('rel3')
-        rel.setRelationName('dupe name')
+        rel.setId('rel3')
+        rel.setName('dupe name')
         assert rel.isValid()
         manager.addRelation(rel)
 


### PR DESCRIPTION
Cleans up with some API

 * Remove `the`-prefix from method parameters in QgsProject
 * Align setters and getters for methods in QgsRelation

And expose relations to QML