### PR TITLE
[FEATURE] Add support for Windows jump lists

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -803,6 +803,7 @@ int main( int argc, char *argv[] )
 
   myApp.setWindowIcon( QIcon( QgsApplication::appIconPath() ) );
 
+
   //
   // Set up the QSettings environment must be done after qapp is created
   QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -85,6 +85,13 @@
 #include <QWinTaskbarProgress>
 #endif
 
+#ifdef Q_OS_WIN
+#include <QtWinExtras/QWinJumpList>
+#include <QtWinExtras/QWinJumpListItem>
+#include <QtWinExtras/QWinJumpListCategory>
+#endif
+
+
 //
 // Mac OS X Includes
 // Must include before GEOS 3 due to unqualified use of 'Point'
@@ -3327,6 +3334,21 @@ void QgisApp::updateRecentProjectPaths()
 
   if ( mWelcomePage )
     mWelcomePage->setRecentProjects( mRecentProjects );
+
+#if defined(Q_OS_WIN)
+  QWinJumpList jumplist;
+  jumplist.recent()->clear();
+  Q_FOREACH ( const QgsWelcomePageItemsModel::RecentProjectData& recentProject, mRecentProjects )
+  {
+    QString name = recentProject.title != recentProject.path ? recentProject.title : QFileInfo( recentProject.path ).baseName();
+    QWinJumpListItem *newProject = new QWinJumpListItem( QWinJumpListItem::Link );
+    newProject->setTitle( name );
+    newProject->setFilePath( QDir::toNativeSeparators( QCoreApplication::applicationFilePath() ) );
+    newProject->setArguments( QStringList( recentProject.path ) );
+    jumplist.recent()->addItem( newProject );
+  }
+#endif
+
 } // QgisApp::updateRecentProjectPaths
 
 // add this file to the recently opened/saved projects list


### PR DESCRIPTION
Adds support for jump lists on the QGIS task/start menu icon.

![image](https://cloud.githubusercontent.com/assets/381660/23100382/1d049148-f6cb-11e6-8428-03b699e4c153.png)

Currently only adds the recent projects list but will also add support for "Configs" as per https://github.com/qgis/QGIS-Enhancement-Proposals/issues/82 to fast load based on a saved config.

Also note there is a Qt bug with Tasks https://bugreports.qt.io/browse/QTBUG-41155