### PR TITLE
Improvements to attribute table performance

### DIFF
--- a/python/core/qgsvectorlayercache.sip
+++ b/python/core/qgsvectorlayercache.sip
@@ -33,19 +33,10 @@ class QgsVectorLayerCache : QObject
      */
     int cacheSize();
 
-    /**
-     * Enable or disable the caching of geometries
-     *
-     * @param cacheGeometry    Enable or disable the caching of geometries
-     */
     void setCacheGeometry( bool cacheGeometry );
 
+    bool cacheGeometry() const;
 
-    /**
-     * Set the subset of attributes to be cached
-     *
-     * @param attributes   The attributes to be cached
-     */
     void setCacheSubsetOfAttributes( const QgsAttributeList& attributes );
 
     /**

--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -32,16 +32,8 @@ class QgsDualView : QStackedWidget
     explicit QgsDualView( QWidget* parent /TransferThis/ = 0 );
     virtual ~QgsDualView();
 
-    /**
-     * Has to be called to initialize the dual view.
-     *
-     * @param layer      The layer which should be used to fetch features
-     * @param mapCanvas  The mapCanvas (used for the FilterMode
-     *                   {@link QgsAttributeTableFilterModel::ShowVisible}
-     * @param request    Use a modified request to limit the shown features
-     * @param context    The context in which this view is shown
-     */
-    void init( QgsVectorLayer* layer, QgsMapCanvas* mapCanvas, const QgsFeatureRequest& request = QgsFeatureRequest(), const QgsAttributeEditorContext& context = QgsAttributeEditorContext() );
+    void init( QgsVectorLayer* layer, QgsMapCanvas* mapCanvas, const QgsFeatureRequest& request = QgsFeatureRequest(), const QgsAttributeEditorContext& context = QgsAttributeEditorContext(),
+               bool loadFeatures = true );
 
     /**
      * Change the current view mode.

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -83,7 +83,6 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
   : QDialog( parent, flags )
   , mDock( nullptr )
   , mLayer( layer )
-  , mRubberBand( nullptr )
   , mCurrentSearchWidgetWrapper( nullptr )
 {
   setObjectName( QStringLiteral( "QgsAttributeTableDialog/" ) + layer->id() );
@@ -145,8 +144,8 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
   }
   else if ( initialMode == QgsAttributeTableFilterModel::ShowSelected )
   {
-    if ( theLayer->selectedFeatureCount() > 0 )
-      r.setFilterFids( theLayer->selectedFeatureIds() );
+    if ( layer->selectedFeatureCount() > 0 )
+      r.setFilterFids( layer->selectedFeatureIds() );
   }
   if ( !needsGeom )
     r.setFlags( QgsFeatureRequest::NoGeometry );
@@ -344,7 +343,7 @@ QgsAttributeTableDialog::~QgsAttributeTableDialog()
 void QgsAttributeTableDialog::updateTitle()
 {
   QWidget *w = mDock ? qobject_cast<QWidget *>( mDock ) : qobject_cast<QWidget *>( this );
-  w->setWindowTitle( tr( " %1 :: Features total: %2, filtered: %3, selected: %4%5" )
+  w->setWindowTitle( tr( " %1 :: Features total: %2, filtered: %3, selected: %4" )
                      .arg( mLayer->name() )
                      .arg( qMax( static_cast< long >( mMainView->featureCount() ), mLayer->featureCount() ) ) // layer count may be estimated, so use larger of the two
                      .arg( mMainView->filteredFeatureCount() )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -134,8 +134,9 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
 
   QgsFeatureRequest r;
   bool needsGeom = false;
+  QgsAttributeTableFilterModel::FilterMode initialMode = static_cast< QgsAttributeTableFilterModel::FilterMode>( settings.value( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowAll ).toInt() );
   if ( mLayer->geometryType() != QgsWkbTypes::NullGeometry &&
-       settings.value( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowAll ).toInt() == QgsAttributeTableFilterModel::ShowVisible )
+       initialMode == QgsAttributeTableFilterModel::ShowVisible )
   {
     QgsMapCanvas *mc = QgisApp::instance()->mapCanvas();
     QgsRectangle extent( mc->mapSettings().mapToLayerCoordinates( layer, mc->extent() ) );
@@ -146,6 +147,11 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
 
     mActionShowAllFilter->setText( tr( "Show All Features In Initial Canvas Extent" ) );
     needsGeom = true;
+  }
+  else if ( initialMode == QgsAttributeTableFilterModel::ShowSelected )
+  {
+    if ( theLayer->selectedFeatureCount() > 0 )
+      r.setFilterFids( theLayer->selectedFeatureIds() );
   }
   if ( !needsGeom )
     r.setFlags( QgsFeatureRequest::NoGeometry );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -141,11 +141,6 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
     QgsMapCanvas *mc = QgisApp::instance()->mapCanvas();
     QgsRectangle extent( mc->mapSettings().mapToLayerCoordinates( layer, mc->extent() ) );
     r.setFilterRect( extent );
-
-    mRubberBand = new QgsRubberBand( mc, QgsWkbTypes::PolygonGeometry );
-    mRubberBand->setToGeometry( QgsGeometry::fromRect( extent ), layer );
-
-    mActionShowAllFilter->setText( tr( "Show All Features In Initial Canvas Extent" ) );
     needsGeom = true;
   }
   else if ( initialMode == QgsAttributeTableFilterModel::ShowSelected )
@@ -344,7 +339,6 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
 QgsAttributeTableDialog::~QgsAttributeTableDialog()
 {
   delete myDa;
-  delete mRubberBand;
 }
 
 void QgsAttributeTableDialog::updateTitle()
@@ -355,7 +349,6 @@ void QgsAttributeTableDialog::updateTitle()
                      .arg( mMainView->featureCount() )
                      .arg( mMainView->filteredFeatureCount() )
                      .arg( mLayer->selectedFeatureCount() )
-                     .arg( mRubberBand ? tr( ", spatially limited" ) : QLatin1String( "" ) )
                    );
 
   if ( mMainView->filterMode() == QgsAttributeTableFilterModel::ShowAll )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -157,7 +157,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
     r.setFlags( QgsFeatureRequest::NoGeometry );
 
   // Initialize dual view
-  mMainView->init( mLayer, QgisApp::instance()->mapCanvas(), r, mEditorContext );
+  mMainView->init( mLayer, QgisApp::instance()->mapCanvas(), r, mEditorContext, false );
 
   QgsAttributeTableConfig config = mLayer->attributeTableConfig();
   mMainView->setAttributeTableConfig( config );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -346,7 +346,7 @@ void QgsAttributeTableDialog::updateTitle()
   QWidget *w = mDock ? qobject_cast<QWidget *>( mDock ) : qobject_cast<QWidget *>( this );
   w->setWindowTitle( tr( " %1 :: Features total: %2, filtered: %3, selected: %4%5" )
                      .arg( mLayer->name() )
-                     .arg( mMainView->featureCount() )
+                     .arg( qMax( static_cast< long >( mMainView->featureCount() ), mLayer->featureCount() ) ) // layer count may be estimated, so use larger of the two
                      .arg( mMainView->filteredFeatureCount() )
                      .arg( mLayer->selectedFeatureCount() )
                    );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -133,6 +133,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
   mEditorContext.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
 
   QgsFeatureRequest r;
+  bool needsGeom = false;
   if ( mLayer->geometryType() != QgsWkbTypes::NullGeometry &&
        settings.value( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowAll ).toInt() == QgsAttributeTableFilterModel::ShowVisible )
   {
@@ -144,7 +145,10 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
     mRubberBand->setToGeometry( QgsGeometry::fromRect( extent ), layer );
 
     mActionShowAllFilter->setText( tr( "Show All Features In Initial Canvas Extent" ) );
+    needsGeom = true;
   }
+  if ( !needsGeom )
+    r.setFlags( QgsFeatureRequest::NoGeometry );
 
   // Initialize dual view
   mMainView->init( mLayer, QgisApp::instance()->mapCanvas(), r, mEditorContext );

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -229,7 +229,6 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     QSignalMapper *mFilterActionMapper = nullptr;
 
     QgsVectorLayer *mLayer = nullptr;
-    QgsRubberBand *mRubberBand = nullptr;
     QgsSearchWidgetWrapper *mCurrentSearchWidgetWrapper = nullptr;
     QStringList mVisibleFields;
     QgsAttributeEditorContext mEditorContext;

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -237,7 +237,7 @@ void QgsVectorLayerCache::attributeAdded( int field )
 {
   Q_UNUSED( field )
   mCachedAttributes.append( field );
-  mCache.clear();
+  invalidate();
 }
 
 void QgsVectorLayerCache::attributeDeleted( int field )
@@ -273,6 +273,7 @@ void QgsVectorLayerCache::layerDeleted()
 void QgsVectorLayerCache::invalidate()
 {
   mCache.clear();
+  mFullCache = false;
   emit invalidated();
 }
 

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -58,9 +58,9 @@ int QgsVectorLayerCache::cacheSize()
 
 void QgsVectorLayerCache::setCacheGeometry( bool cacheGeometry )
 {
-  bool shouldCache = cacheGeometry && mLayer->hasGeometryType();
-  bool mustInvalidate = shouldCache && !mCacheGeometry; // going from no geometry -> geometry, so have to clear existing cache entries
-  mCacheGeometry = shouldCache;
+  bool shouldCacheGeometry = cacheGeometry && mLayer->hasGeometryType();
+  bool mustInvalidate = shouldCacheGeometry && !mCacheGeometry; // going from no geometry -> geometry, so have to clear existing cache entries
+  mCacheGeometry = shouldCacheGeometry;
   if ( cacheGeometry )
   {
     connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayerCache::geometryChanged );
@@ -237,7 +237,6 @@ void QgsVectorLayerCache::attributeAdded( int field )
 {
   Q_UNUSED( field )
   mCachedAttributes.append( field );
-  mFullCache = false;
   mCache.clear();
 }
 
@@ -274,7 +273,6 @@ void QgsVectorLayerCache::layerDeleted()
 void QgsVectorLayerCache::invalidate()
 {
   mCache.clear();
-  mFullCache = false;
   emit invalidated();
 }
 

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -58,7 +58,9 @@ int QgsVectorLayerCache::cacheSize()
 
 void QgsVectorLayerCache::setCacheGeometry( bool cacheGeometry )
 {
-  mCacheGeometry = cacheGeometry && mLayer->hasGeometryType();
+  bool shouldCache = cacheGeometry && mLayer->hasGeometryType();
+  bool mustInvalidate = shouldCache && !mCacheGeometry; // going from no geometry -> geometry, so have to clear existing cache entries
+  mCacheGeometry = shouldCache;
   if ( cacheGeometry )
   {
     connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayerCache::geometryChanged );
@@ -66,6 +68,10 @@ void QgsVectorLayerCache::setCacheGeometry( bool cacheGeometry )
   else
   {
     disconnect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayerCache::geometryChanged );
+  }
+  if ( mustInvalidate )
+  {
+    invalidate();
   }
 }
 

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -237,6 +237,7 @@ void QgsVectorLayerCache::attributeAdded( int field )
 {
   Q_UNUSED( field )
   mCachedAttributes.append( field );
+  mFullCache = false;
   mCache.clear();
 }
 
@@ -273,6 +274,7 @@ void QgsVectorLayerCache::layerDeleted()
 void QgsVectorLayerCache::invalidate()
 {
   mCache.clear();
+  mFullCache = false;
   emit invalidated();
 }
 

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -141,6 +141,8 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * be used for slow data sources, be aware, that the call to this method might take a long time.
      *
      * @param fullCache   True: enable full caching, False: disable full caching
+     * @note when a cache is invalidated() (e.g. by adding an attribute to a layer) this setting
+     * is reset. A full cache rebuild must be performed by calling setFullCache( true ) again.
      * @see hasFullCache()
      */
     void setFullCache( bool fullCache );
@@ -319,7 +321,9 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     void featureAdded( QgsFeatureId fid );
 
     /**
-     * The cache has been invalidated and cleared.
+     * The cache has been invalidated and cleared. Note that when a cache is invalidated
+     * the fullCache() setting will be cleared, and a full cache rebuild via setFullCache( true )
+     * will need to be performed.
      */
     void invalidated();
 

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -106,9 +106,16 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * Enable or disable the caching of geometries
      *
      * @param cacheGeometry    Enable or disable the caching of geometries
+     * @see cacheGeometry()
      */
     void setCacheGeometry( bool cacheGeometry );
 
+    /**
+     * Returns true if the cache will fetch and cache feature geometries.
+     * @note added in QGIS 3.0
+     * @see setCacheGeometry()
+     */
+    bool cacheGeometry() const { return mCacheGeometry; }
 
     /**
      * Set the subset of attributes to be cached

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -60,13 +60,13 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
 
   loadAttributes();
 
-  connect( mLayerCache, SIGNAL( attributeValueChanged( QgsFeatureId, int, const QVariant & ) ), this, SLOT( attributeValueChanged( QgsFeatureId, int, const QVariant & ) ) );
-  connect( layer(), SIGNAL( featuresDeleted( QgsFeatureIds ) ), this, SLOT( featuresDeleted( QgsFeatureIds ) ) );
-  connect( layer(), SIGNAL( attributeDeleted( int ) ), this, SLOT( attributeDeleted( int ) ) );
-  connect( layer(), SIGNAL( updatedFields() ), this, SLOT( updatedFields() ) );
-  connect( layer(), SIGNAL( editCommandEnded() ), this, SLOT( editCommandEnded() ) );
-  connect( mLayerCache, SIGNAL( featureAdded( QgsFeatureId ) ), this, SLOT( featureAdded( QgsFeatureId ) ) );
-  connect( mLayerCache, SIGNAL( cachedLayerDeleted() ), this, SLOT( layerDeleted() ) );
+  connect( mLayerCache, &QgsVectorLayerCache::attributeValueChanged, this, &QgsAttributeTableModel::attributeValueChanged );
+  connect( layer(), &QgsVectorLayer::featuresDeleted, this, &QgsAttributeTableModel::featuresDeleted );
+  connect( layer(), &QgsVectorLayer::attributeDeleted, this, &QgsAttributeTableModel::attributeDeleted );
+  connect( layer(), &QgsVectorLayer::updatedFields, this, &QgsAttributeTableModel::updatedFields );
+  connect( layer(), &QgsVectorLayer::editCommandEnded, this, &QgsAttributeTableModel::editCommandEnded );
+  connect( mLayerCache, &QgsVectorLayerCache::featureAdded, this, &QgsAttributeTableModel::featureAdded );
+  connect( mLayerCache, &QgsVectorLayerCache::cachedLayerDeleted, this, &QgsAttributeTableModel::layerDeleted );
 }
 
 bool QgsAttributeTableModel::loadFeatureAtId( QgsFeatureId fid ) const
@@ -430,7 +430,7 @@ void QgsAttributeTableModel::loadLayer()
 
   emit finished();
 
-  connect( mLayerCache, SIGNAL( invalidated() ), this, SLOT( loadLayer() ), Qt::UniqueConnection );
+  connect( mLayerCache, &QgsVectorLayerCache::invalidated, this, &QgsAttributeTableModel::loadLayer, Qt::UniqueConnection );
 
   endResetModel();
 }

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -724,6 +724,7 @@ void QgsDualView::updateSelectedFeatures()
     r.disableFilter();
   mMasterModel->setRequest( r );
   mMasterModel->loadLayer();
+  emit filterChanged();
 }
 
 void QgsDualView::extentChanged()
@@ -736,6 +737,7 @@ void QgsDualView::extentChanged()
     mMasterModel->setRequest( r );
     mMasterModel->loadLayer();
   }
+  emit filterChanged();
 }
 
 void QgsDualView::featureFormAttributeChanged()

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -273,10 +273,8 @@ void QgsDualView::initLayerCache( bool cacheGeometry )
   mLayerCache->setCacheGeometry( cacheGeometry );
   if ( 0 == cacheSize || 0 == ( QgsVectorDataProvider::SelectAtId & mLayer->dataProvider()->capabilities() ) )
   {
-    connect( mLayerCache, &QgsVectorLayerCache::progress, this, &QgsDualView::progress );
-    connect( mLayerCache, &QgsVectorLayerCache::finished, this, &QgsDualView::finished );
-
-    mLayerCache->setFullCache( true );
+    connect( mLayerCache, &QgsVectorLayerCache::invalidated, this, &QgsDualView::rebuildFullLayerCache );
+    rebuildFullLayerCache();
   }
 }
 
@@ -677,6 +675,14 @@ void QgsDualView::panToCurrentFeature()
   {
     canvas->panToFeatureIds( mLayer, ids );
   }
+}
+
+void QgsDualView::rebuildFullLayerCache()
+{
+  connect( mLayerCache, &QgsVectorLayerCache::progress, this, &QgsDualView::progress, Qt::UniqueConnection );
+  connect( mLayerCache, &QgsVectorLayerCache::finished, this, &QgsDualView::finished, Qt::UniqueConnection );
+
+  mLayerCache->setFullCache( true );
 }
 
 void QgsDualView::previewExpressionChanged( const QString &expression )

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -68,7 +68,7 @@ QgsDualView::QgsDualView( QWidget *parent )
   connect( mFeatureList, &QgsFeatureListView::displayExpressionChanged, this, &QgsDualView::previewExpressionChanged );
 }
 
-void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request, const QgsAttributeEditorContext &context )
+void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request, const QgsAttributeEditorContext &context, bool loadFeatures )
 {
   mMapCanvas = mapCanvas;
 
@@ -85,7 +85,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   connect( mTableView, &QgsAttributeTableView::columnResized, this, &QgsDualView::tableColumnResized );
 
   initLayerCache( !( request.flags() & QgsFeatureRequest::NoGeometry ) || !request.filterRect().isNull() );
-  initModels( mapCanvas, request );
+  initModels( mapCanvas, request, loadFeatures );
 
   mConditionalFormatWidget->setLayer( mLayer );
 
@@ -194,9 +194,6 @@ QgsDualView::ViewMode QgsDualView::view() const
 
 void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filterMode )
 {
-  if ( mFilterModel->filterMode() == filterMode )
-    return;
-
   // cleanup any existing connections
   switch ( mFilterModel->filterMode() )
   {
@@ -217,17 +214,23 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
   QgsFeatureRequest r = mMasterModel->request();
   bool needsGeometry = filterMode == QgsAttributeTableFilterModel::ShowVisible;
 
+  bool requiresTableReload = ( r.filterType() != QgsFeatureRequest::FilterNone || !r.filterRect().isNull() ) // previous request was subset
+                             || ( needsGeometry && r.flags() & QgsFeatureRequest::NoGeometry ) // no geometry for last request
+                             || ( mMasterModel->rowCount() == 0 ); // no features
+
   if ( !needsGeometry )
     r.setFlags( r.flags() | QgsFeatureRequest::NoGeometry );
   else
     r.setFlags( r.flags() & ~( QgsFeatureRequest::NoGeometry ) );
+  r.setFilterFids( QgsFeatureIds() );
+  r.setFilterRect( QgsRectangle() );
+  r.disableFilter();
 
+  // setup new connections and filter request parameters
   switch ( filterMode )
   {
     case QgsAttributeTableFilterModel::ShowVisible:
       connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsDualView::extentChanged );
-      r.setFilterFids( QgsFeatureIds() );
-      r.disableFilter();
       if ( mMapCanvas )
       {
         QgsRectangle rect = mMapCanvas->mapSettings().mapToLayerCoordinates( mLayer, mMapCanvas->extent() );
@@ -238,23 +241,23 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
     case QgsAttributeTableFilterModel::ShowAll:
     case QgsAttributeTableFilterModel::ShowEdited:
     case QgsAttributeTableFilterModel::ShowFilteredList:
-      r.setFilterFids( QgsFeatureIds() );
-      r.disableFilter();
       break;
 
     case QgsAttributeTableFilterModel::ShowSelected:
       connect( masterModel()->layer(), &QgsVectorLayer::selectionChanged, this, &QgsDualView::updateSelectedFeatures );
       if ( masterModel()->layer()->selectedFeatureCount() > 0 )
         r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
-      else
-        r.disableFilter();
       break;
   }
 
-  mMasterModel->setRequest( r );
-  whileBlocking( mLayerCache )->setCacheGeometry( needsGeometry );
-  mMasterModel->loadLayer();
+  if ( requiresTableReload )
+  {
+    mMasterModel->setRequest( r );
+    whileBlocking( mLayerCache )->setCacheGeometry( needsGeometry );
+    mMasterModel->loadLayer();
+  }
 
+  //update filter model
   mFilterModel->setFilterMode( filterMode );
   emit filterChanged();
 }
@@ -278,7 +281,7 @@ void QgsDualView::initLayerCache( bool cacheGeometry )
   }
 }
 
-void QgsDualView::initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request )
+void QgsDualView::initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request, bool loadFeatures )
 {
   delete mFeatureListModel;
   delete mFilterModel;
@@ -294,7 +297,8 @@ void QgsDualView::initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &
 
   connect( mConditionalFormatWidget, &QgsFieldConditionalFormatWidget::rulesUpdated, mMasterModel, &QgsAttributeTableModel::fieldConditionalStyleChanged );
 
-  mMasterModel->loadLayer();
+  if ( loadFeatures )
+    mMasterModel->loadLayer();
 
   mFilterModel = new QgsAttributeTableFilterModel( mapCanvas, mMasterModel, mMasterModel );
 
@@ -711,6 +715,9 @@ void QgsDualView::sortByPreviewExpression()
 void QgsDualView::updateSelectedFeatures()
 {
   QgsFeatureRequest r = mMasterModel->request();
+  if ( r.filterType() == QgsFeatureRequest::FilterNone && r.filterRect().isNull() )
+    return; // already requested all features
+
   if ( masterModel()->layer()->selectedFeatureCount() > 0 )
     r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
   else
@@ -722,13 +729,13 @@ void QgsDualView::updateSelectedFeatures()
 void QgsDualView::extentChanged()
 {
   QgsFeatureRequest r = mMasterModel->request();
-  if ( mMapCanvas )
+  if ( mMapCanvas && ( r.filterType() != QgsFeatureRequest::FilterNone || !r.filterRect().isNull() ) )
   {
     QgsRectangle rect = mMapCanvas->mapSettings().mapToLayerCoordinates( mLayer, mMapCanvas->extent() );
     r.setFilterRect( rect );
+    mMasterModel->setRequest( r );
+    mMasterModel->loadLayer();
   }
-  mMasterModel->setRequest( r );
-  mMasterModel->loadLayer();
 }
 
 void QgsDualView::featureFormAttributeChanged()

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -192,6 +192,16 @@ QgsDualView::ViewMode QgsDualView::view() const
 
 void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filterMode )
 {
+  bool needsGeometry = filterMode == QgsAttributeTableFilterModel::ShowVisible;
+
+  QgsFeatureRequest r = mMasterModel->request();
+  if ( !needsGeometry )
+    r.setFlags( r.flags() | QgsFeatureRequest::NoGeometry );
+  else
+    r.setFlags( r.flags() & ~( QgsFeatureRequest::NoGeometry ) );
+  mMasterModel->setRequest( r );
+  whileBlocking( mLayerCache )->setCacheGeometry( needsGeometry );
+
   mFilterModel->setFilterMode( filterMode );
   emit filterChanged();
 }

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -82,7 +82,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   connect( mTableView->horizontalHeader(), &QHeaderView::customContextMenuRequested, this, &QgsDualView::showViewHeaderMenu );
   connect( mTableView, &QgsAttributeTableView::columnResized, this, &QgsDualView::tableColumnResized );
 
-  initLayerCache( !request.filterRect().isNull() );
+  initLayerCache( !( request.flags() & QgsFeatureRequest::NoGeometry ) || !request.filterRect().isNull() );
   initModels( mapCanvas, request );
 
   mConditionalFormatWidget->setLayer( mLayer );

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -80,8 +80,11 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      *                   {@link QgsAttributeTableFilterModel::ShowVisible}
      * @param request    Use a modified request to limit the shown features
      * @param context    The context in which this view is shown
+     * @param loadFeatures whether to initially load all features into the view. If set to
+     * false, limited features can later be loaded using setFilterMode()
      */
-    void init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request = QgsFeatureRequest(), const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
+    void init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request = QgsFeatureRequest(), const QgsAttributeEditorContext &context = QgsAttributeEditorContext(),
+               bool loadFeatures = true );
 
     /**
      * Change the current view mode.

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -327,6 +327,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     //! Pans to the active feature
     void panToCurrentFeature();
 
+    void rebuildFullLayerCache();
+
   private:
     void initLayerCache( bool cacheGeometry );
     void initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request );

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -324,7 +324,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void panToCurrentFeature();
 
   private:
-    void initLayerCache( QgsVectorLayer *layer, bool cacheGeometry );
+    void initLayerCache( bool cacheGeometry );
     void initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request );
 
     QgsAttributeEditorContext mEditorContext;
@@ -336,6 +336,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     QMenu *mPreviewColumnsMenu = nullptr;
     QMenu *mHorizontalHeaderMenu = nullptr;
     QgsVectorLayerCache *mLayerCache = nullptr;
+    QgsVectorLayer *mLayer = nullptr;
     QProgressDialog *mProgressDlg = nullptr;
     QgsIFeatureSelectionManager *mFeatureSelectionManager = nullptr;
     QgsDistanceArea mDistanceArea;

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -334,7 +334,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
   private:
     void initLayerCache( bool cacheGeometry );
-    void initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request );
+    void initModels( QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request, bool loadFeatures );
 
     QgsAttributeEditorContext mEditorContext;
     QgsAttributeTableModel *mMasterModel = nullptr;

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -297,6 +297,10 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void sortByPreviewExpression();
 
+    void updateSelectedFeatures();
+
+    void extentChanged();
+
     /**
      * Will be called whenever the currently shown feature form changes.
      * Will forward this signal to the feature list to visually represent
@@ -343,6 +347,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     QString mDisplayExpression;
     QgsAttributeTableConfig mConfig;
     QScrollArea *mAttributeEditorScrollArea = nullptr;
+    QgsMapCanvas *mMapCanvas = nullptr;
 
     friend class TestQgsDualView;
 };

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -24,7 +24,7 @@
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgsunittypes.h"
-#include <QSettings>
+#include "qgssettings.h"
 
 #include "qgstest.h"
 
@@ -178,11 +178,13 @@ void TestQgsAttributeTable::testFieldCalculationArea()
 
 void TestQgsAttributeTable::testNoGeom()
 {
+  QgsSettings s;
+
   //test that by default the attribute table DOESN'T fetch geometries (because performance)
   std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=col1:double" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
   QVERIFY( tempLayer->isValid() );
 
-  QSettings().setValue( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowAll );
+  s.setValue( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowAll );
   std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( tempLayer.get() ) );
 
   QVERIFY( !dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
@@ -190,7 +192,7 @@ void TestQgsAttributeTable::testNoGeom()
 
   // but if we are requesting only visible features, then geometry must be fetched...
 
-  QSettings().setValue( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowVisible );
+  s.setValue( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowVisible );
   dlg.reset( new QgsAttributeTableDialog( tempLayer.get() ) );
   QVERIFY( dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
   QVERIFY( !( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry ) );

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgsunittypes.h"
+#include <QSettings>
 
 #include "qgstest.h"
 
@@ -43,6 +44,7 @@ class TestQgsAttributeTable : public QObject
     void cleanup() {} // will be called after every testfunction.
     void testFieldCalculation();
     void testFieldCalculationArea();
+    void testNoGeom();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -62,6 +64,13 @@ void TestQgsAttributeTable::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
   mQgisApp = new QgisApp();
+
+  // setup the test QSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  QSettings().setValue( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowAll );
 }
 
 //runs after all tests
@@ -166,6 +175,27 @@ void TestQgsAttributeTable::testFieldCalculationArea()
   expected = 389.6117565069;
   QVERIFY( qgsDoubleNear( f.attribute( "col1" ).toDouble(), expected, 0.001 ) );
 }
+
+void TestQgsAttributeTable::testNoGeom()
+{
+  //test that by default the attribute table DOESN'T fetch geometries (because performance)
+  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=col1:double" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  QVERIFY( tempLayer->isValid() );
+
+  QSettings().setValue( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowAll );
+  std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( tempLayer.get() ) );
+
+  QVERIFY( !dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
+  QVERIFY( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry );
+
+  // but if we are requesting only visible features, then geometry must be fetched...
+
+  QSettings().setValue( QStringLiteral( "/qgis/attributeTableBehavior" ), QgsAttributeTableFilterModel::ShowVisible );
+  dlg.reset( new QgsAttributeTableDialog( tempLayer.get() ) );
+  QVERIFY( dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
+  QVERIFY( !( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry ) );
+}
+
 
 QGSTEST_MAIN( TestQgsAttributeTable )
 #include "testqgsattributetable.moc"

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -194,6 +194,17 @@ void TestQgsAttributeTable::testNoGeom()
   dlg.reset( new QgsAttributeTableDialog( tempLayer.get() ) );
   QVERIFY( dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
   QVERIFY( !( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry ) );
+
+  // try changing existing dialog to no geometry mode
+  dlg->filterShowAll();
+  QVERIFY( !dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
+  QVERIFY( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry );
+
+  // and back to a geometry mode
+  dlg->filterVisible();
+  QVERIFY( dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
+  QVERIFY( !( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry ) );
+
 }
 
 

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -384,13 +384,6 @@ void TestVectorLayerCache::testCacheGeom()
   {
     QVERIFY( f.hasGeometry() );
   }
-
-  // another test...
-  cache.setCacheGeometry( false );
-  cache.setFullCache( true );
-  QVERIFY( cache.hasFullCache() );
-  cache.setCacheGeometry( true );
-  QVERIFY( !cache.hasFullCache() );
 }
 
 void TestVectorLayerCache::onCommittedFeaturesAdded( const QString &layerId, const QgsFeatureList &features )

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -384,6 +384,13 @@ void TestVectorLayerCache::testCacheGeom()
   {
     QVERIFY( f.hasGeometry() );
   }
+
+  // another test...
+  cache.setCacheGeometry( false );
+  cache.setFullCache( true );
+  QVERIFY( cache.hasFullCache() );
+  cache.setCacheGeometry( true );
+  QVERIFY( !cache.hasFullCache() );
 }
 
 void TestVectorLayerCache::onCommittedFeaturesAdded( const QString &layerId, const QgsFeatureList &features )

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -242,6 +242,15 @@ void TestVectorLayerCache::testFullCache()
   {
     QVERIFY( cache.isFidCached( f.id() ) );
   }
+
+  // add a feature to the layer
+  mPointsLayer->startEditing();
+  QgsFeature f2( mPointsLayer->fields() );
+  QVERIFY( mPointsLayer->addFeature( f2 ) );
+  QVERIFY( cache.hasFullCache() );
+  QVERIFY( cache.isFidCached( f2.id() ) );
+
+  mPointsLayer->rollBack();
 }
 
 void TestVectorLayerCache::testFullCacheThroughRequest()
@@ -375,6 +384,13 @@ void TestVectorLayerCache::testCacheGeom()
   {
     QVERIFY( f.hasGeometry() );
   }
+
+  // another test...
+  cache.setCacheGeometry( false );
+  cache.setFullCache( true );
+  QVERIFY( cache.hasFullCache() );
+  cache.setCacheGeometry( true );
+  QVERIFY( !cache.hasFullCache() );
 }
 
 void TestVectorLayerCache::onCommittedFeaturesAdded( const QString &layerId, const QgsFeatureList &features )

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -56,6 +56,7 @@ class TestQgsDualView : public QObject
     void testSort();
 
     void testAttributeFormSharedValueScanning();
+    void testNoGeom();
 
   private:
     QgsMapCanvas *mCanvas = nullptr;
@@ -268,6 +269,36 @@ void TestQgsDualView::testAttributeFormSharedValueScanning()
   QCOMPARE( fieldSharedValues.value( 2 ).toInt(), 3 );
   QCOMPARE( fieldSharedValues.value( 3 ).toInt(), 2 );
   QVERIFY( mixedValueFields.isEmpty() );
+}
+
+void TestQgsDualView::testNoGeom()
+{
+  //test that both the master model and cache for the dual view either both request geom or both don't request geom
+  std::unique_ptr< QgsDualView > dv( new QgsDualView() );
+
+  // request with geometry
+  QgsFeatureRequest req;
+  dv->init( mPointsLayer, mCanvas, req );
+  // check that both master model AND cache are using geometry
+  QgsAttributeTableModel* model = dv->masterModel();
+  QVERIFY( model->layerCache()->cacheGeometry() );
+  QVERIFY( !( model->request().flags() & QgsFeatureRequest::NoGeometry ) );
+
+  // request with NO geometry, but using filter rect (which should override and request geom)
+  req = QgsFeatureRequest().setFilterRect( QgsRectangle( 1, 2, 3, 4 ) );
+  dv.reset( new QgsDualView() );
+  dv->init( mPointsLayer, mCanvas, req );
+  model = dv->masterModel();
+  QVERIFY( model->layerCache()->cacheGeometry() );
+  QVERIFY( !( model->request().flags() & QgsFeatureRequest::NoGeometry ) );
+
+  // request with NO geometry
+  req = QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry );
+  dv.reset( new QgsDualView() );
+  dv->init( mPointsLayer, mCanvas, req );
+  model = dv->masterModel();
+  QVERIFY( !model->layerCache()->cacheGeometry() );
+  QVERIFY(( model->request().flags() & QgsFeatureRequest::NoGeometry ) );
 }
 
 QGSTEST_MAIN( TestQgsDualView )

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -280,7 +280,7 @@ void TestQgsDualView::testNoGeom()
   QgsFeatureRequest req;
   dv->init( mPointsLayer, mCanvas, req );
   // check that both master model AND cache are using geometry
-  QgsAttributeTableModel* model = dv->masterModel();
+  QgsAttributeTableModel *model = dv->masterModel();
   QVERIFY( model->layerCache()->cacheGeometry() );
   QVERIFY( !( model->request().flags() & QgsFeatureRequest::NoGeometry ) );
 
@@ -298,7 +298,7 @@ void TestQgsDualView::testNoGeom()
   dv->init( mPointsLayer, mCanvas, req );
   model = dv->masterModel();
   QVERIFY( !model->layerCache()->cacheGeometry() );
-  QVERIFY(( model->request().flags() & QgsFeatureRequest::NoGeometry ) );
+  QVERIFY( ( model->request().flags() & QgsFeatureRequest::NoGeometry ) );
 }
 
 QGSTEST_MAIN( TestQgsDualView )


### PR DESCRIPTION
This PR:

1. Implements a bunch of fixes to QgsVectorLayerCache which were preventing the cache being used in certain circumstances by the attribute table dialog
2. Ensures that the table does NOT load feature geometry by default (and adds tests to enforce this)
3. Moves partial responsibility for filtering attribute table to dual view master model. This avoids requiring the table to load ALL features when the table is set to just display selected or visible features. 

Together these changes dramatically improve the load time of the attribute table when working with large layers. And if you set the table to display selected features or visible features by default, then the benefits are enormous.

Not for merging yet - there's an issue with the dialog title & with occasional double-load of features on table load I need to address first.

On behalf of Faunalia, sponsored by ENEL