### PR TITLE
Add `env()` expression function

### DIFF
--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2694,6 +2694,30 @@ class TestQgsExpression: public QObject
       QVariant result3 = e3.evaluate( &context );
 
       Q_ASSERT( result3.isNull() );
+
+      QgsExpressionContextScope* scope = new QgsExpressionContextScope();
+      scope->setVariable( QStringLiteral( "EXPRESSION_ENV_BLACKLIST" ), QStringLiteral( "password, PROTECTED_VALUE" ) );
+      context << scope;
+
+      setenv( "password", "1234", 1 );
+      setenv( "PROTECTED_VALUE", "password", 1 );
+
+      QgsExpression e4( "env('password')" );
+      QVariant result4 = e4.evaluate( &context );
+
+      Q_ASSERT( result4.isNull() );
+      Q_ASSERT( e4.hasEvalError() );
+
+      QgsExpression e5( "env('PROTECTED_VALUE')" );
+      QVariant result5 = e5.evaluate( &context );
+
+      Q_ASSERT( result5.isNull() );
+      Q_ASSERT( e5.hasEvalError() );
+
+
+
+      unsetenv( "password" );
+      unsetenv( "PROTECTED_VALUE" );
     }
 
     void test_formatPreviewString()


### PR DESCRIPTION
This adds a new expression function `env( name )` to get the value of an environment variable.

This is handy to get path prefixes (drive letters etc) for shared documents on network drives etc.

What I wonder is the security perspective, it seems to be common to inject login credentials for databases via environment variables to things like docker containers. I added the possibility to add a blacklist for protected environment variables via an expression variable `EXPRESSION_ENV_BLACKLIST`.

What does the server team think? Is this ok? Should this be configurable in a different way? (QSettings, Another environment variable...)?

I would generally prefer to make people aware that using environment variables for credentials is not best practice, but having an option to prevent access to some variables won't hurt either.

@mhugent @elpaso @pblottiere @dmarteau @pvalsecc @timlinux @3nids 