### PR TITLE
Resize number selector widget in Processing

### DIFF
--- a/python/plugins/processing/ui/widgetNumberSelector.ui
+++ b/python/plugins/processing/ui/widgetNumberSelector.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>249</width>
-    <height>37</height>
+    <height>26</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
To avoid this
![number_selector](https://cloud.githubusercontent.com/assets/7983394/23504069/4b986360-ff3e-11e6-901e-33907ff590e8.PNG)
