### PR TITLE
[processing] fixed update of toolbox after editing script providers

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -172,11 +172,12 @@ class Processing(object):
     def updateAlgsList():
         """Call this method when there has been any change that
         requires the list of algorithms to be created again from
-        algorithm providers.
+        algorithm providers. Use reloadProvider() for a more fine-grained
+        update.
         """
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         for p in Processing.providers:
-            Processing.reloadProvider(p)
+            Processing.reloadProvider(p.id())
         QApplication.restoreOverrideCursor()
 
     @staticmethod

--- a/python/plugins/processing/core/alglist.py
+++ b/python/plugins/processing/core/alglist.py
@@ -38,8 +38,6 @@ class AlgorithmList(QObject):
     # and values are list with all algorithms from that provider
     algs = {}
 
-    providers = []
-
     def removeProvider(self, provider_id):
         if provider_id in self.algs:
             del self.algs[provider_id]
@@ -47,7 +45,7 @@ class AlgorithmList(QObject):
         QgsApplication.processingRegistry().removeProvider(provider_id)
 
     def reloadProvider(self, provider_id):
-        for p in self.providers:
+        for p in QgsApplication.processingRegistry().providers():
             if p.id() == provider_id:
                 p.loadAlgorithms()
                 self.algs[p.id()] = {a.commandLineName(): a for a in p.algs}

--- a/python/plugins/processing/gui/CreateNewScriptAction.py
+++ b/python/plugins/processing/gui/CreateNewScriptAction.py
@@ -62,8 +62,3 @@ class CreateNewScriptAction(ToolboxAction):
         if self.scriptType == self.SCRIPT_R:
             dlg = ScriptEditorDialog(ScriptEditorDialog.SCRIPT_R, None)
         dlg.show()
-        if dlg.update:
-            if self.scriptType == self.SCRIPT_PYTHON:
-                algList.reloadProvider('script')
-            elif self.scriptType == self.SCRIPT_R:
-                algList.reloadProvider('r')

--- a/python/plugins/processing/gui/EditScriptAction.py
+++ b/python/plugins/processing/gui/EditScriptAction.py
@@ -50,9 +50,3 @@ class EditScriptAction(ContextAction):
     def execute(self):
         dlg = ScriptEditorDialog(self.scriptType, self.itemData)
         dlg.show()
-        dlg.exec_()
-        if dlg.update:
-            if self.scriptType == ScriptEditorDialog.SCRIPT_PYTHON:
-                algList.reloadProvider('script')
-            elif self.scriptType == ScriptEditorDialog.SCRIPT_R:
-                algList.reloadProvider('r')

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -384,7 +384,7 @@ class TreeProviderItem(QTreeWidgetItem):
 
     def refresh(self):
         self.takeChildren()
-        Processing.updateAlgsList()
+        #Processing.updateAlgsList()
         self.populate()
 
     def populate(self):

--- a/python/plugins/processing/gui/ScriptEditorDialog.py
+++ b/python/plugins/processing/gui/ScriptEditorDialog.py
@@ -49,6 +49,7 @@ from processing.algs.r.RAlgorithm import RAlgorithm
 from processing.algs.r.RUtils import RUtils
 from processing.script.ScriptAlgorithm import ScriptAlgorithm
 from processing.script.ScriptUtils import ScriptUtils
+from processing.core.alglist import algList
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
 WIDGET, BASE = uic.loadUiType(
@@ -169,11 +170,20 @@ class ScriptEditorDialog(BASE, WIDGET):
                                        QMessageBox.Yes | QMessageBox.No, QMessageBox.No
                                        )
             if ret == QMessageBox.Yes:
+                self.updateProviders()
                 evt.accept()
             else:
                 evt.ignore()
         else:
+            self.updateProviders()
             evt.accept()
+
+    def updateProviders(self):
+        if self.update:
+            if self.algType == self.SCRIPT_PYTHON:
+                algList.reloadProvider('script')
+            elif self.algType == self.SCRIPT_R:
+                algList.reloadProvider('r')
 
     def editHelp(self):
         if self.alg is None:


### PR DESCRIPTION
@nyalldawson I found some issues with the alglist and the registry, probably stuff that you forgot to update in the python code after moving the registry to core. Please, take a look at this when you have time. Basically, it makes the provider correctly update and the toolbox be refreshed, once a new script is added (or any provider that might change its content at runtime, such as the modeler provider)

If you can think of any other area where similar issues might appear after your changes, let me know so i can check and work on it.

