### PR TITLE
Dynamically adjust postgres feature queue size

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -110,8 +110,6 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
 
     bool mIsTransactionConnection;
 
-    static const int FEATURE_QUEUE_SIZE;
-
   private:
     virtual bool providerCanSimplify( QgsSimplifyMethod::MethodType methodType ) const override;
 


### PR DESCRIPTION
This is an alternative approach to #4208

Lower the default queue size, but automatically adjust it based on how long each fetch takes. This change keeps fetching responsive even for slow connections or databases. The current approach with a fixed queue size can result in very slow feature fetching, which prevents UI updates for multiple seconds.

This change allows the queue size to shrink or grow based on how quickly the features are being fetched. Slow fetching results in a smaller queue size, fast fetching will increase the queue size.