### PR TITLE
[Feature] Conditional styles for relation reference widget

### DIFF
--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -37,7 +37,7 @@ QgsVectorLayer *QgsAttributeTableDelegate::layer( const QAbstractItemModel *mode
   if ( tm )
     return tm->layer();
 
-  const QgsAttributeTableFilterModel *fm = dynamic_cast<const QgsAttributeTableFilterModel *>( model );
+  const QgsAttributeTableFilterModel *fm = qobject_cast<const QgsAttributeTableFilterModel *>( model );
   if ( fm )
     return fm->layer();
 
@@ -50,7 +50,7 @@ const QgsAttributeTableModel *QgsAttributeTableDelegate::masterModel( const QAbs
   if ( tm )
     return tm;
 
-  const QgsAttributeTableFilterModel *fm = dynamic_cast<const QgsAttributeTableFilterModel *>( model );
+  const QgsAttributeTableFilterModel *fm = qobject_cast<const QgsAttributeTableFilterModel *>( model );
   if ( fm )
     return fm->masterModel();
 

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -60,13 +60,13 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
 
   loadAttributes();
 
-  connect( mLayerCache, SIGNAL( attributeValueChanged( QgsFeatureId, int, const QVariant & ) ), this, SLOT( attributeValueChanged( QgsFeatureId, int, const QVariant & ) ) );
-  connect( layer(), SIGNAL( featuresDeleted( QgsFeatureIds ) ), this, SLOT( featuresDeleted( QgsFeatureIds ) ) );
-  connect( layer(), SIGNAL( attributeDeleted( int ) ), this, SLOT( attributeDeleted( int ) ) );
-  connect( layer(), SIGNAL( updatedFields() ), this, SLOT( updatedFields() ) );
-  connect( layer(), SIGNAL( editCommandEnded() ), this, SLOT( editCommandEnded() ) );
-  connect( mLayerCache, SIGNAL( featureAdded( QgsFeatureId ) ), this, SLOT( featureAdded( QgsFeatureId ) ) );
-  connect( mLayerCache, SIGNAL( cachedLayerDeleted() ), this, SLOT( layerDeleted() ) );
+  connect( mLayerCache, &QgsVectorLayerCache::attributeValueChanged, this, &QgsAttributeTableModel::attributeValueChanged );
+  connect( layer(), &QgsVectorLayer::featuresDeleted, this, &QgsAttributeTableModel::featuresDeleted );
+  connect( layer(), &QgsVectorLayer::attributeDeleted, this, &QgsAttributeTableModel::attributeDeleted );
+  connect( layer(), &QgsVectorLayer::updatedFields, this, &QgsAttributeTableModel::updatedFields );
+  connect( layer(), &QgsVectorLayer::editCommandEnded, this, &QgsAttributeTableModel::editCommandEnded );
+  connect( mLayerCache, &QgsVectorLayerCache::featureAdded, this, &QgsAttributeTableModel::featureAdded );
+  connect( mLayerCache, &QgsVectorLayerCache::cachedLayerDeleted, this, &QgsAttributeTableModel::layerDeleted );
 }
 
 bool QgsAttributeTableModel::loadFeatureAtId( QgsFeatureId fid ) const
@@ -658,7 +658,6 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
       {
         styles = QgsConditionalStyle::matchingConditionalStyles( layer()->conditionalStyles()->rowStyles(), QVariant(),  mExpressionContext );
         mRowStylesMap.insert( index.row(), styles );
-
       }
 
       QgsConditionalStyle rowstyle = QgsConditionalStyle::compressStyles( styles );

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -23,6 +23,8 @@
 
 #include "qgsfeaturemodel.h"
 #include "qgsfeature.h" // QgsFeatureId
+#include "qgsexpressioncontext.h"
+#include "qgsconditionalstyle.h"
 #include "qgis_gui.h"
 
 class QgsAttributeTableFilterModel;
@@ -123,10 +125,12 @@ class GUI_EXPORT QgsFeatureListModel : public QAbstractProxyModel, public QgsFea
     void onEndInsertRows( const QModelIndex &parent, int first, int last );
 
   private:
-    QgsExpression *mExpression = nullptr;
+    mutable QgsExpression mDisplayExpression;
     QgsAttributeTableFilterModel *mFilterModel = nullptr;
     QString mParserErrorString;
     bool mInjectNull;
+    mutable QgsExpressionContext mExpressionContext;
+    mutable QMap< QgsFeatureId, QList<QgsConditionalStyle> > mRowStylesMap;
 };
 
 Q_DECLARE_METATYPE( QgsFeatureListModel::FeatureInfo )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -515,10 +515,25 @@ void QgsRelationReferenceWidget::init()
       mFilterContainer->hide();
     }
 
-    QgsExpression exp( mReferencedLayer->displayExpression() );
+    QgsExpression displayExpression( mReferencedLayer->displayExpression() );
 
-    requestedAttrs += exp.referencedColumns();
+    requestedAttrs += displayExpression.referencedColumns();
     requestedAttrs << mRelation.fieldPairs().at( 0 ).second;
+
+    Q_FOREACH ( const QgsConditionalStyle &style, mReferencedLayer->conditionalStyles()->rowStyles() )
+    {
+      QgsExpression exp( style.rule() );
+      requestedAttrs += exp.referencedColumns();
+    }
+
+    if ( displayExpression.isField() )
+    {
+      Q_FOREACH ( const QgsConditionalStyle &style, mReferencedLayer->conditionalStyles()->fieldStyles( *displayExpression.referencedColumns().constBegin() ) )
+      {
+        QgsExpression exp( style.rule() );
+        requestedAttrs += exp.referencedColumns();
+      }
+    }
 
     QgsAttributeList attributes;
     Q_FOREACH ( const QString &attr, requestedAttrs )


### PR DESCRIPTION
In long-distance heating, there are some heat carrier fluids that really no longer should be used like Wodka.

This feature helps to properly communicate to the person in charge of digitizing that he should not assign one of the "inactive" heat carrier fluids new heatings.

As a side-effect, this flexible way of styling built for the attribute table once by @NathanW2 (good job by the way) is now available also in the relation reference widget.

Note: if you don't want to style the whole row in the attribute table, there is the alternative approach of styling a single field and define the "display expression" to only include this field. This can be used in combination with *virtual fields* for maximum flexibility.

![peek 2017-03-03 16-49](https://cloud.githubusercontent.com/assets/588407/23557834/bad7de6a-0031-11e7-9e24-1b593d89d159.gif)
