### PR TITLE
enforce lower-case qgssettings keys

### DIFF
--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -84,10 +84,10 @@ QgsSettings::~QgsSettings()
 
 void QgsSettings::beginGroup( const QString &prefix )
 {
-  mUserSettings->beginGroup( prefix );
+  mUserSettings->beginGroup( prefix.toLower() );
   if ( mGlobalSettings )
   {
-    mGlobalSettings->beginGroup( prefix );
+    mGlobalSettings->beginGroup( prefix.toLower() );
   }
 }
 
@@ -152,7 +152,7 @@ QStringList QgsSettings::childGroups() const
 
 QVariant QgsSettings::value( const QString &key, const QVariant &defaultValue, const QgsSettings::Section section ) const
 {
-  QString pKey = prefixedKey( key, section );
+  QString pKey = prefixedKey( key.toLower(), section );
   if ( !mUserSettings->value( pKey ).isNull() )
   {
     return mUserSettings->value( pKey );
@@ -166,7 +166,7 @@ QVariant QgsSettings::value( const QString &key, const QVariant &defaultValue, c
 
 bool QgsSettings::contains( const QString &key, const QgsSettings::Section section ) const
 {
-  QString pKey = prefixedKey( key, section );
+  QString pKey = prefixedKey( key.toLower(), section );
   return mUserSettings->contains( pKey ) ||
          ( mGlobalSettings && mGlobalSettings->contains( pKey ) );
 }
@@ -183,7 +183,7 @@ void QgsSettings::sync()
 
 void QgsSettings::remove( const QString &key )
 {
-  mUserSettings->remove( key );
+  mUserSettings->remove( key.toLower() );
 }
 
 QString QgsSettings::prefixedKey( const QString &key, const Section section ) const
@@ -208,18 +208,18 @@ QString QgsSettings::prefixedKey( const QString &key, const Section section ) co
       break;
     case Section::NoSection:
     default:
-      return sanitizeKey( key );
+      return sanitizeKey( key.toLower() );
   }
-  return prefix  + "/" + sanitizeKey( key );
+  return prefix  + "/" + sanitizeKey( key.toLower() );
 }
 
 
 int QgsSettings::beginReadArray( const QString &prefix )
 {
-  int size = mUserSettings->beginReadArray( prefix );
+  int size = mUserSettings->beginReadArray( prefix.toLower() );
   if ( 0 == size && mGlobalSettings )
   {
-    size = mGlobalSettings->beginReadArray( prefix );
+    size = mGlobalSettings->beginReadArray( prefix.toLower() );
     mUsingGlobalArray = ( size > 0 );
   }
   return size;
@@ -250,7 +250,7 @@ void QgsSettings::setArrayIndex( int i )
 void QgsSettings::setValue( const QString &key, const QVariant &value, const QgsSettings::Section section )
 {
   // TODO: add valueChanged signal
-  mUserSettings->setValue( prefixedKey( key, section ), value );
+  mUserSettings->setValue( prefixedKey( key.toLower(), section ), value );
 }
 
 // To lower case and clean the path

--- a/tests/src/python/test_qgssettings.py
+++ b/tests/src/python/test_qgssettings.py
@@ -130,8 +130,7 @@ class TestQgsSettings(unittest.TestCase):
         self.settings.endGroup()
         self.settings.beginGroup('testqgissettings/names')
         self.settings.setValue('name4', 'qgisrocks-4')
-        keys = list(self.settings.childKeys())
-        keys.sort()
+        keys = sorted(self.settings.childKeys())
         self.assertEqual(keys, ['name1', 'name2', 'name3', 'name4'])
         self.settings.endGroup()
         self.assertEqual('qgisrocks-1', self.settings.value('testqgissettings/names/name1'))
@@ -217,6 +216,12 @@ class TestQgsSettings(unittest.TestCase):
 
         self.settings.setValue('testqgissettings/name3', 'qgisrocks3')
         self.assertTrue(self.settings.contains('testqgissettings/name3'))
+
+    def test_remove(self):
+        self.settings.setValue('testQgisSettings/temp', True)
+        self.assertEqual(self.settings.value('testqgissettings/temp'), True)
+        self.settings.remove('testQgisSettings/temp')
+        self.assertEqual(self.settings.value('testqgissettings/temp'), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@NathanW2 , @nyalldawson , @jef-n , @elpaso , this PR enforces lower-case keys when using QgsSettings, which fixes *a bunch* of issues (startup plugin load, WMS connection dialog, etc. etc.).

Somehow, setValue() was case insensitive, but other bits ( like remove() ) were case sensitive. 