### PR TITLE
Travis CI improvements (performance, readability)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
     - os: linux
       language: python # This lets us use newer python versions from virtualenv
       env:
-        - BUILD=qt5
-        - QT_VERSION=5
         - LLVM_VERSION=3.8
         - TRAVIS_CONFIG=linux
       sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       sudo: false
       cache:
         apt: true
+        pip: true
         directories:
           - $HOME/.ccache
           - $HOME/depcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         apt: true
         directories:
           - $HOME/.ccache
+          - $HOME/depcache
         timeout: 1000
       compiler: clang
       python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
             - txt2tags
             - xvfb
             - clang-3.8
+            - grc
 
 
     - os: linux

--- a/ci/travis/linux/.grc.colors
+++ b/ci/travis/linux/.grc.colors
@@ -1,0 +1,53 @@
+# A readme that explains the configuration options can be found here
+# http://korpus.juls.savba.sk/~garabik/software/grc/README.txt
+
+####################
+# Early exit, lines that do not need to be processed further
+####################
+
+# DEFAULT: the final FAILED line in failed nose tests
+regexp=^FAILED (failures=[0-9])$
+colours=default
+count=stop
+-
+
+###################
+# Failed test block
+###################
+
+# YELLOW: A test failed, start a yellow block
+regexp=^FAIL[:\!].*
+colours=yellow
+count=block
+-
+# YELLOW END: End block on next successful test
+regexp=^PASS
+colours=default
+count=unblock
+-
+# YELLOW END: End block on next successful test
+regexp=^Ran
+colours=default
+count=unblock
+-
+
+####################
+# Unit test name (title)
+####################
+
+# RED: test name
+regexp=.*Test.*\*\*\*Failed.*sec
+colours=red
+-
+
+####################
+# Successful tests
+####################
+
+# DARK GRAY: passed tests should be unobtrusive
+regexp=.*Test.*Passed.*sec
+colours="\033[90m"
+-
+# DARK GRAY: Start test lines should be unobtrusive
+regexp=\s{8}Start.*
+colours="\033[90m"

--- a/ci/travis/linux/before_install.sh
+++ b/ci/travis/linux/before_install.sh
@@ -13,9 +13,6 @@
 #                                                                         #
 ###########################################################################
 
-export DEBIAN_FRONTEND=noninteractive
-export CORES=2
-
 ##################################################
 #
 # Get precompiled dependencies
@@ -24,12 +21,20 @@ export CORES=2
 
 pushd ${HOME}
 
+# fetching data from github should be just as fast as S3
 curl -L https://github.com/opengisch/osgeo4travis/archive/qt5bin.tar.gz | tar -xzC /home/travis --strip-components=1
-curl -L https://cmake.org/files/v3.5/cmake-3.5.0-Linux-x86_64.tar.gz | tar --strip-components=1 -zxC /home/travis/osgeo4travis
+
+# other dependencies live in a cached folder
+pushd depcache
+# Download newer version of cmake than in the repository
+[[ -f cmake-3.5.0-Linux-x86_64.tar.gz ]] || curl -O https://cmake.org/files/v3.5/cmake-3.5.0-Linux-x86_64.tar.gz
+tar --strip-components=1 -zx -f cmake-3.5.0-Linux-x86_64.tar.gz -C /home/travis/osgeo4travis 
 
 # Download OTB package for Processing tests
-wget https://www.orfeo-toolbox.org/packages/archives/OTB/OTB-5.6.0-Linux64.run -O /home/travis/OTB-5.6.0-Linux64.run && sh /home/travis/OTB-5.6.0-Linux64.run
+[[ -f OTB-5.6.0-Linux64.run ]] || curl -O https://www.orfeo-toolbox.org/packages/archives/OTB/OTB-5.6.0-Linux64.run
+sh ./OTB-5.6.0-Linux64.run
 
+popd
 popd
 
 pip install psycopg2 numpy nose2 pyyaml mock future termcolor

--- a/ci/travis/linux/before_install.sh
+++ b/ci/travis/linux/before_install.sh
@@ -22,7 +22,10 @@
 pushd ${HOME}
 
 # fetching data from github should be just as fast as S3
-curl -L https://github.com/opengisch/osgeo4travis/archive/qt5bin.tar.gz | tar -xzC /home/travis --strip-components=1
+curl -L https://github.com/opengisch/osgeo4travis/archive/qt5bin.tar.gz | tar --strip-components=1 -xz -C /home/travis &
+SETUP_OSGEO4W_PID=$!
+
+mkdir /home/travis/osgeo4travis
 
 # other dependencies live in a cached folder
 pushd depcache
@@ -33,6 +36,8 @@ tar --strip-components=1 -zx -f cmake-3.5.0-Linux-x86_64.tar.gz -C /home/travis/
 # Download OTB package for Processing tests
 [[ -f OTB-5.6.0-Linux64.run ]] || curl -O https://www.orfeo-toolbox.org/packages/archives/OTB/OTB-5.6.0-Linux64.run
 sh ./OTB-5.6.0-Linux64.run
+
+wait $SETUP_OSGEO4W_PID
 
 popd
 popd

--- a/ci/travis/linux/script.sh
+++ b/ci/travis/linux/script.sh
@@ -32,5 +32,6 @@ if [ "$CACHE_WARMING" = true ] ; then
   xvfb-run ctest -V -R NOTESTS -S ./qgis-test-travis.ctest --output-on-failure
   false
 else
-  xvfb-run ctest -V -E "$(cat ${DIR}/blacklist.txt | sed -r '/^(#.*?)?$/d' | paste -sd '|' -)" -S ./qgis-test-travis.ctest --output-on-failure
+  grc -c ${TRAVIS_BUILD_DIR}/ci/travis/linux/.grc.colors \
+	  xvfb-run ctest -V -E "$(cat ${DIR}/blacklist.txt | sed -r '/^(#.*?)?$/d' | paste -sd '|' -)" -S ./qgis-test-travis.ctest --output-on-failure
 fi

--- a/tests/testdata/provider/testdata_pg.sh
+++ b/tests/testdata/provider/testdata_pg.sh
@@ -11,5 +11,5 @@ SCRIPTS="
 dropdb qgis_test 2> /dev/null || true
 createdb qgis_test || exit 1
 for f in ${SCRIPTS}; do
-  psql -f $f qgis_test --set ON_ERROR_STOP=1 || exit 1
+  psql -q -f $f qgis_test --set ON_ERROR_STOP=1 || exit 1
 done


### PR DESCRIPTION
This strips a minute or two from the bootstrapping process on travis by caching a couple of additional things.

It also colorizes the output to make it easier to find output related to failures.

![screen shot 2017-03-04 at 14 53 16](https://cloud.githubusercontent.com/assets/588407/23579279/5e534c74-00ea-11e7-9ead-242a3e319870.png)
