### PR TITLE
Dynamically adjust postgres feature queue size (backport)

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -118,8 +118,6 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
 
     bool mIsTransactionConnection;
 
-    static const int sFeatureQueueSize;
-
   private:
     //! returns whether the iterator supports simplify geometries on provider side
     virtual bool providerCanSimplify( QgsSimplifyMethod::MethodType methodType ) const override;


### PR DESCRIPTION
Lower the default queue size, but automatically adjust it
based on how long each fetch takes. This change keeps fetching
responsive even for slow connections or databases. The current
approach with a fixed queue size can result in very slow feature
fetching, which prevents UI updates for multiple seconds.

(cherry-picked from fbe4be8)