### PR TITLE
[needs-docs] Attribute table "show selected features" shows no featureswhen none are selected

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -144,8 +144,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QWidget
   }
   else if ( initialMode == QgsAttributeTableFilterModel::ShowSelected )
   {
-    if ( layer->selectedFeatureCount() > 0 )
-      r.setFilterFids( layer->selectedFeatureIds() );
+    r.setFilterFids( layer->selectedFeatureIds() );
   }
   if ( !needsGeom )
     r.setFlags( QgsFeatureRequest::NoGeometry );

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -311,7 +311,7 @@ bool QgsAttributeTableFilterModel::filterAcceptsRow( int sourceRow, const QModel
       return mFilteredFeatures.contains( masterModel()->rowToId( sourceRow ) );
 
     case ShowSelected:
-      return layer()->selectedFeatureIds().isEmpty() || layer()->selectedFeatureIds().contains( masterModel()->rowToId( sourceRow ) );
+      return layer()->selectedFeatureIds().contains( masterModel()->rowToId( sourceRow ) );
 
     case ShowVisible:
       return mFilteredFeatures.contains( masterModel()->rowToId( sourceRow ) );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -245,8 +245,7 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
 
     case QgsAttributeTableFilterModel::ShowSelected:
       connect( masterModel()->layer(), &QgsVectorLayer::selectionChanged, this, &QgsDualView::updateSelectedFeatures );
-      if ( masterModel()->layer()->selectedFeatureCount() > 0 )
-        r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
+      r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
       break;
   }
 
@@ -718,10 +717,7 @@ void QgsDualView::updateSelectedFeatures()
   if ( r.filterType() == QgsFeatureRequest::FilterNone && r.filterRect().isNull() )
     return; // already requested all features
 
-  if ( masterModel()->layer()->selectedFeatureCount() > 0 )
-    r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
-  else
-    r.disableFilter();
+  r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
   mMasterModel->setRequest( r );
   mMasterModel->loadLayer();
   emit filterChanged();

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -50,6 +50,7 @@ class TestQgsDualView : public QObject
     void testColumnHeaders();
 
     void testData();
+    void testFilterSelected();
 
     void testSelectAll();
 
@@ -132,6 +133,36 @@ void TestQgsDualView::testData()
     QModelIndex index = mDualView->tableView()->model()->index( 0, i );
     QCOMPARE( mDualView->tableView()->model()->data( index ).toString(), fld.displayString( feature.attribute( i ) ) );
   }
+}
+
+void TestQgsDualView::testFilterSelected()
+{
+  QgsFeature feature;
+  QList< QgsFeatureId > ids;
+  QgsFeatureIterator it = mPointsLayer->getFeatures( QgsFeatureRequest().setOrderBy( QgsFeatureRequest::OrderBy() << QgsFeatureRequest::OrderByClause( "Heading" ) ) );
+  while ( it.nextFeature( feature ) )
+    ids << feature.id();
+
+  // select some features
+  QList< QgsFeatureId > selected;
+  selected << ids.at( 1 ) << ids.at( 3 );
+  mPointsLayer->selectByIds( selected.toSet() );
+
+  mDualView->setFilterMode( QgsAttributeTableFilterModel::ShowSelected );
+  QCOMPARE( mDualView->tableView()->model()->rowCount(), 2 );
+
+  int headingIdx = mPointsLayer->fields().lookupField( "Heading" );
+  QgsField fld = mPointsLayer->fields().at( headingIdx );
+  for ( int i = 0; i < selected.count(); ++i )
+  {
+    mPointsLayer->getFeatures( QgsFeatureRequest().setFilterFid( selected.at( i ) ) ).nextFeature( feature );
+    QModelIndex index = mDualView->tableView()->model()->index( i, headingIdx );
+    QCOMPARE( mDualView->tableView()->model()->data( index ).toString(), fld.displayString( feature.attribute( headingIdx ) ) );
+  }
+
+  // select none
+  mPointsLayer->removeSelection();
+  QCOMPARE( mDualView->tableView()->model()->rowCount(), 0 );
 }
 
 void TestQgsDualView::testSelectAll()


### PR DESCRIPTION
This change is being driven by performance - the "show selected" mode can be used to speed up the attribute table loading for large layers.
The current behaviour (showing ALL features when none are selected) breaks this performance benefit, because if users accidently open the table with no selection then they are forced to wait for the entire table to load (sometimes takes hours on large tables/slow connections).