### PR TITLE
MetaSearch: consolidate "Add WxS" buttons into single dropdown button

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -128,9 +128,9 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.btnNext.clicked.connect(self.navigate)
         self.btnLast.clicked.connect(self.navigate)
 
-        self.btnAddToWms.clicked.connect(self.add_to_ows)
-        self.btnAddToWfs.clicked.connect(self.add_to_ows)
-        self.btnAddToWcs.clicked.connect(self.add_to_ows)
+        self.mActionAddWms.triggered.connect(self.add_to_ows)
+        self.mActionAddWfs.triggered.connect(self.add_to_ows)
+        self.mActionAddWcs.triggered.connect(self.add_to_ows)
         self.btnShowXml.clicked.connect(self.show_xml)
 
         # settings
@@ -614,13 +614,14 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
                     wcs_link_types]):
                 if link_type in wmswmst_link_types:
                     services['wms'] = link['url']
-                    self.btnAddToWms.setEnabled(True)
+                    self.mActionAddWms.setEnabled(True)
                 if link_type in wfs_link_types:
                     services['wfs'] = link['url']
-                    self.btnAddToWfs.setEnabled(True)
+                    self.mActionAddWfs.setEnabled(True)
                 if link_type in wcs_link_types:
                     services['wcs'] = link['url']
-                    self.btnAddToWcs.setEnabled(True)
+                    self.mActionAddWcs.setEnabled(True)
+                self.tbAddData.setEnabled(True)
 
             set_item_data(item, 'link', json.dumps(services))
 
@@ -695,13 +696,13 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         caller = self.sender().objectName()
 
         # stype = human name,/Qgis/connections-%s,providername
-        if caller == 'btnAddToWms':
+        if caller == 'mActionAddWms':
             stype = ['OGC:WMS/OGC:WMTS', 'wms', 'wms']
             data_url = item_data['wms']
-        elif caller == 'btnAddToWfs':
+        elif caller == 'mActionAddWfs':
             stype = ['OGC:WFS', 'wfs', 'WFS']
             data_url = item_data['wfs']
-        elif caller == 'btnAddToWcs':
+        elif caller == 'mActionAddWcs':
             stype = ['OGC:WCS', 'wcs', 'wcs']
             data_url = item_data['wcs']
 
@@ -834,9 +835,10 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         """Convenience function to disable WMS/WMTS|WFS|WCS buttons"""
 
         if services:
-            self.btnAddToWms.setEnabled(False)
-            self.btnAddToWfs.setEnabled(False)
-            self.btnAddToWcs.setEnabled(False)
+            self.tbAddData.setEnabled(False)
+            self.mActionAddWms.setEnabled(False)
+            self.mActionAddWfs.setEnabled(False)
+            self.mActionAddWcs.setEnabled(False)
 
         if xml:
             self.btnShowXml.setEnabled(False)

--- a/python/plugins/MetaSearch/ui/maindialog.ui
+++ b/python/plugins/MetaSearch/ui/maindialog.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>653</width>
+    <width>656</width>
     <height>550</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>MetaSearch</string>
@@ -193,14 +199,41 @@
           <string>Results</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_5">
-          <item row="0" column="0" colspan="3">
+          <item row="1" column="0" colspan="3">
            <widget class="QLabel" name="lblResults">
             <property name="text">
              <string/>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="5">
+          <item row="3" column="0">
+           <widget class="QPushButton" name="btnFirst">
+            <property name="text">
+             <string>&lt;&lt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3" colspan="2">
+           <widget class="QPushButton" name="btnShowXml">
+            <property name="text">
+             <string>View search results as XML</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QPushButton" name="btnPrev">
+            <property name="minimumSize">
+             <size>
+              <width>145</width>
+              <height>27</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>&lt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="5">
            <widget class="QTreeWidget" name="treeRecords">
             <property name="toolTip">
              <string>Double click to see full record information</string>
@@ -238,66 +271,7 @@
             </column>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="btnPrev">
-            <property name="minimumSize">
-             <size>
-              <width>145</width>
-              <height>27</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>&lt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3" colspan="2">
-           <widget class="QPushButton" name="btnShowXml">
-            <property name="text">
-             <string>View search results as XML</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QPushButton" name="btnFirst">
-            <property name="text">
-             <string>&lt;&lt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QPushButton" name="btnAddToWms">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Add WMS/WMTS</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QPushButton" name="btnAddToWfs">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>145</width>
-              <height>27</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Add WFS</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
+          <item row="3" column="4">
            <widget class="QPushButton" name="btnLast">
             <property name="minimumSize">
              <size>
@@ -310,20 +284,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="3">
-           <widget class="QPushButton" name="btnAddToWcs">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Add WCS</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
+          <item row="3" column="3">
            <widget class="QPushButton" name="btnNext">
             <property name="minimumSize">
              <size>
@@ -336,17 +297,82 @@
             </property>
            </widget>
           </item>
+          <item row="5" column="0">
+           <widget class="QToolButton" name="tbAddData">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>145</width>
+              <height>27</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>145</width>
+              <height>27</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Add Data</string>
+            </property>
+            <property name="popupMode">
+             <enum>QToolButton::InstantPopup</enum>
+            </property>
+            <property name="toolButtonStyle">
+             <enum>Qt::ToolButtonTextOnly</enum>
+            </property>
+            <property name="autoRaise">
+             <bool>false</bool>
+            </property>
+            <property name="arrowType">
+             <enum>Qt::NoArrow</enum>
+            </property>
+            <action name="mActionAddWms">
+             <property name="icon">
+              <iconset>
+               <normaloff>:/images/themes/default/mActionAddWmsLayer.svg</normaloff>:/images/themes/default/mActionAddWmsLayer.svg</iconset>
+             </property>
+             <property name="text">
+              <string>Add WMS/WMTS</string>
+             </property>
+            </action>
+            <action name="mActionAddWfs">
+             <property name="icon">
+              <iconset>
+               <normaloff>:/images/themes/default/mActionAddWfsLayer.svg</normaloff>:/images/themes/default/mActionAddWfsLayer.svg</iconset>
+             </property>
+             <property name="text">
+              <string>Add WFS</string>
+             </property>
+            </action>
+            <action name="mActionAddWcs">
+             <property name="icon">
+              <iconset>
+               <normaloff>:/images/themes/default/mActionAddWcsLayer.svg</normaloff>:/images/themes/default/mActionAddWcsLayer.svg</iconset>
+             </property>
+             <property name="text">
+              <string>Add WCS</string>
+             </property>
+            </action>
+            <addaction name="mActionAddWms"/>
+            <addaction name="mActionAddWfs"/>
+            <addaction name="mActionAddWcs"/>
+           </widget>
+          </item>
          </layout>
          <zorder>treeRecords</zorder>
          <zorder>lblResults</zorder>
          <zorder>btnPrev</zorder>
          <zorder>btnFirst</zorder>
          <zorder>btnShowXml</zorder>
-         <zorder>btnAddToWms</zorder>
-         <zorder>btnAddToWfs</zorder>
          <zorder>btnLast</zorder>
-         <zorder>btnAddToWcs</zorder>
          <zorder>btnNext</zorder>
+         <zorder>tbAddData</zorder>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
cc @rduivenvoorde 

This PR consolidates MetaSearch's "Add WxS" buttons into a single dropdown to help cut down on UI clutter, which allows for addition of more "Add ..." service type buttons.