### PR TITLE
Avoid accidental changes to spin box values when wheeling over a scroll area

### DIFF
--- a/python/gui/editorwidgets/qgsdoublespinbox.sip
+++ b/python/gui/editorwidgets/qgsdoublespinbox.sip
@@ -80,4 +80,5 @@ class QgsDoubleSpinBox : QDoubleSpinBox
   protected:
     virtual void changeEvent( QEvent* event );
     virtual void paintEvent( QPaintEvent* event );
+	void wheelEvent( QWheelEvent *event );
 };

--- a/python/gui/editorwidgets/qgsspinbox.sip
+++ b/python/gui/editorwidgets/qgsspinbox.sip
@@ -81,4 +81,5 @@ class QgsSpinBox : QSpinBox
 
     virtual void changeEvent( QEvent* event );
     virtual void paintEvent( QPaintEvent* event );
+	void wheelEvent( QWheelEvent *event );
 };

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -35,6 +35,10 @@ QgsDoubleSpinBox::QgsDoubleSpinBox( QWidget *parent )
 {
   mLineEdit = new QgsSpinBoxLineEdit();
 
+  // avoid wheel events such as those caused by temporarily hovering a spin box
+  // while scrolling a scroll area
+  setFocusPolicy( Qt::StrongFocus );
+
   setLineEdit( mLineEdit );
 
   QSize msz = minimumSizeHint();
@@ -60,6 +64,21 @@ void QgsDoubleSpinBox::changeEvent( QEvent *event )
 {
   QDoubleSpinBox::changeEvent( event );
   mLineEdit->setShowClearButton( shouldShowClearForValue( value() ) );
+}
+
+void QgsDoubleSpinBox::wheelEvent( QWheelEvent *event )
+{
+  // to avoid wheel events such as those caused by temporarily hovering a spin box
+  // while scrolling a scroll area, we only allow changing the value with a wheel
+  // event when the spin box is focused
+  if ( !hasFocus() )
+  {
+    event->ignore();
+  }
+  else
+  {
+    QDoubleSpinBox::wheelEvent( event );
+  }
 }
 
 void QgsDoubleSpinBox::paintEvent( QPaintEvent *event )

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -103,6 +103,7 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
 
   protected:
     virtual void changeEvent( QEvent *event ) override;
+    void wheelEvent( QWheelEvent *event ) override;
 
   private slots:
     void changed( double value );

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -35,6 +35,10 @@ QgsSpinBox::QgsSpinBox( QWidget *parent )
 {
   mLineEdit = new QgsSpinBoxLineEdit();
 
+  // avoid wheel events such as those caused by temporarily hovering a spin box
+  // while scrolling a scroll area
+  setFocusPolicy( Qt::StrongFocus );
+
   setLineEdit( mLineEdit );
 
   QSize msz = minimumSizeHint();
@@ -66,6 +70,21 @@ void QgsSpinBox::paintEvent( QPaintEvent *event )
 {
   mLineEdit->setShowClearButton( shouldShowClearForValue( value() ) );
   QSpinBox::paintEvent( event );
+}
+
+void QgsSpinBox::wheelEvent( QWheelEvent *event )
+{
+  // to avoid wheel events such as those caused by temporarily hovering a spin box
+  // while scrolling a scroll area, we only allow changing the value with a wheel
+  // event when the spin box is focused
+  if ( !hasFocus() )
+  {
+    event->ignore();
+  }
+  else
+  {
+    QSpinBox::wheelEvent( event );
+  }
 }
 
 void QgsSpinBox::changed( int value )

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -104,6 +104,7 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
 
     virtual void changeEvent( QEvent *event ) override;
     virtual void paintEvent( QPaintEvent *event ) override;
+    void wheelEvent( QWheelEvent *event ) override;
 
   private slots:
     void changed( int value );


### PR DESCRIPTION
This change prevents the mouse wheel from changing values inside a spin box if the spin box is not focused. It avoids users accidentally changing values when scrolling over a scroll area containing spin boxes.

You can still scroll to alter the value, you just need to click inside the spin box *first*.

I'm not sure if this is the best fix. It works well for spin boxes, but requires that all spin boxes are Qgs(Double)SpinBox (which they should be anyway, but not all are). However, this issue also affects comboboxes, sliders, and likely other widgets too which we don't subclass.

Another possible solution could be installing event filters on all the child widgets of these types after setting up UIs. However, the downside of that approach is that we need to ensure that every layout we create does setup all these event filters, or we'll get wildly inconsistent behaviour across different parts of the UI. 

Suggestions/thoughts/etc welcome...