### PR TITLE
 Add between/not between to numerical fields in select by form

### DIFF
--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -100,10 +100,6 @@ QgsSearchWidgetWrapper::FilterFlags QgsDefaultSearchWidgetWrapper::supportedFlag
     case QVariant::Double:
     case QVariant::LongLong:
     case QVariant::ULongLong:
-      //numeric
-      flags |= GreaterThan | LessThan | GreaterThanOrEqualTo | LessThanOrEqualTo;
-      break;
-
     case QVariant::Date:
     case QVariant::DateTime:
     case QVariant::Time:


### PR DESCRIPTION
This should work in 2.18. Can we consider it to be a bug fix?