### PR TITLE
Update UI for XYZ Connection Dialog

### DIFF
--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -21,6 +21,10 @@ QgsXyzConnectionDialog::QgsXyzConnectionDialog( QWidget *parent )
   : QDialog( parent )
 {
   setupUi( this );
+
+  // Behavior for min and max zoom check box
+  connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
+  connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
 }
 
 void QgsXyzConnectionDialog::setConnection( const QgsXyzConnection &conn )
@@ -43,28 +47,4 @@ QgsXyzConnection QgsXyzConnectionDialog::connection() const
   if ( mCheckBoxZMax->isChecked() )
     conn.zMax = mSpinZMax->value();
   return conn;
-}
-
-void QgsXyzConnectionDialog::on_mCheckBoxZMin_stateChanged( int state )
-{
-  if ( state == Qt::Checked )
-  {
-    mSpinZMin->setEnabled( true );
-  }
-  else
-  {
-    mSpinZMin->setEnabled( false );
-  }
-}
-
-void QgsXyzConnectionDialog::on_mCheckBoxZMax_stateChanged( int state )
-{
-  if ( state == Qt::Checked )
-  {
-    mSpinZMax->setEnabled( true );
-  }
-  else
-  {
-    mSpinZMax->setEnabled( false );
-  }
 }

--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -44,3 +44,27 @@ QgsXyzConnection QgsXyzConnectionDialog::connection() const
     conn.zMax = mSpinZMax->value();
   return conn;
 }
+
+void QgsXyzConnectionDialog::on_mCheckBoxZMin_stateChanged( int state )
+{
+  if ( state == Qt::Checked )
+  {
+    mSpinZMin->setEnabled( true );
+  }
+  else
+  {
+    mSpinZMin->setEnabled( false );
+  }
+}
+
+void QgsXyzConnectionDialog::on_mCheckBoxZMax_stateChanged( int state )
+{
+  if ( state == Qt::Checked )
+  {
+    mSpinZMax->setEnabled( true );
+  }
+  else
+  {
+    mSpinZMax->setEnabled( false );
+  }
+}

--- a/src/providers/wms/qgsxyzconnectiondialog.h
+++ b/src/providers/wms/qgsxyzconnectiondialog.h
@@ -33,10 +33,6 @@ class QgsXyzConnectionDialog : public QDialog, public Ui::QgsXyzConnectionDialog
 
     QgsXyzConnection connection() const;
 
-  public slots:
-    void on_mCheckBoxZMin_stateChanged( int state );
-    void on_mCheckBoxZMax_stateChanged( int state );
-
 };
 
 #endif // QGSXYZCONNECTIONDIALOG_H

--- a/src/providers/wms/qgsxyzconnectiondialog.h
+++ b/src/providers/wms/qgsxyzconnectiondialog.h
@@ -33,6 +33,10 @@ class QgsXyzConnectionDialog : public QDialog, public Ui::QgsXyzConnectionDialog
 
     QgsXyzConnection connection() const;
 
+  public slots:
+    void on_mCheckBoxZMin_stateChanged( int state );
+    void on_mCheckBoxZMax_stateChanged( int state );
+
 };
 
 #endif // QGSXYZCONNECTIONDIALOG_H

--- a/src/ui/qgsxyzconnectiondialog.ui
+++ b/src/ui/qgsxyzconnectiondialog.ui
@@ -15,16 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Name</string>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="mEditUrl">
+       <property name="placeholderText">
+        <string>http://example.com/{z}/{x}/{y}.png</string>
        </property>
       </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="mEditName"/>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
@@ -33,38 +30,73 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="mEditUrl">
-       <property name="placeholderText">
-        <string>http://example.com/{z}/{x}/{y}.png</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QCheckBox" name="mCheckBoxZMin">
        <property name="text">
         <string>Min. Zoom Level</string>
        </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Name</string>
+       </property>
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QSpinBox" name="mSpinZMin"/>
+      <widget class="QSpinBox" name="mSpinZMin">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
      </item>
      <item row="3" column="0">
       <widget class="QCheckBox" name="mCheckBoxZMax">
        <property name="text">
         <string>Max. Zoom Level</string>
        </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item row="3" column="1">
       <widget class="QSpinBox" name="mSpinZMax">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="value">
         <number>18</number>
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="mEditName"/>
+     </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
Funded by Kartoza.

Previously it was like this:
<img width="902" alt="screen shot 2017-03-12 at 11 52 30" src="https://cloud.githubusercontent.com/assets/1421861/23829218/c181293a-071e-11e7-9740-9e558b99b147.png">

I update it to make the example url more readable and tidy. I also disable/enable the min and max spin box according to the check box. Now, it looks like this:
<img width="971" alt="screen shot 2017-03-12 at 12 03 16" src="https://cloud.githubusercontent.com/assets/1421861/23829222/f3f22f86-071e-11e7-8876-3bfb79eeaf50.png">
