### PR TITLE
Replace links used in the PR template

### DIFF
--- a/.github/CONTRIBUTE.md
+++ b/.github/CONTRIBUTE.md
@@ -21,5 +21,5 @@ Getting your pull request merged
 This is a volunteer project, so sometimes it may take a little while to merge
 your pull request.
 
-There is a [guide with hints for getting your pull requests merged](https://www.qgis.org/en/site/getinvolved/development/qgisdevelopersguide/git.html#pull-requests)
+There is a [guide with hints for getting your pull requests merged](https://docs.qgis.org/testing/en/docs/developers_guide/git.html#pull-requests)
 in the developers guide.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Include a few sentences describing the overall goals for this PR (pull request).
 - [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
 - [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
 - [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
-- [ ] I have read the [QGIS Coding Standards](https://www.qgis.org/en/site/getinvolved/development/qgisdevelopersguide/codingstandards.html) and this PR complies with them
+- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
 - [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
 - [ ] New unit tests have been added for core changes
 - [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit


### PR DESCRIPTION
## Description
Use link to developer's guide doc instead of qgis.org (the dev guidelines will be removed from that site with 2.18 doc release)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://www.qgis.org/en/site/getinvolved/development/qgisdevelopersguide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
