### PR TITLE
harmonize all providers to use lowercase qgis as settings key

### DIFF
--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -42,8 +42,8 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
 
   QgsSettings settings;
 
-  QString key = "/Qgis/connections-" + mService.toLower() + '/' + mConnName;
-  QString credentialsKey = "/Qgis/" + mService + '/' + mConnName;
+  QString key = "qgis//connections-" + mService.toLower() + '/' + mConnName;
+  QString credentialsKey = "qgis//" + mService + '/' + mConnName;
 
   QStringList connStringParts;
 
@@ -99,25 +99,25 @@ QgsDataSourceUri QgsOwsConnection::uri() const
 QStringList QgsOwsConnection::connectionList( const QString &service )
 {
   QgsSettings settings;
-  settings.beginGroup( "/Qgis/connections-" + service.toLower() );
+  settings.beginGroup( "qgis//connections-" + service.toLower() );
   return settings.childGroups();
 }
 
 QString QgsOwsConnection::selectedConnection( const QString &service )
 {
   QgsSettings settings;
-  return settings.value( "/Qgis/connections-" + service.toLower() + "/selected" ).toString();
+  return settings.value( "qgis//connections-" + service.toLower() + "/selected" ).toString();
 }
 
 void QgsOwsConnection::setSelectedConnection( const QString &service, const QString &name )
 {
   QgsSettings settings;
-  settings.setValue( "/Qgis/connections-" + service.toLower() + "/selected", name );
+  settings.setValue( "qgis//connections-" + service.toLower() + "/selected", name );
 }
 
 void QgsOwsConnection::deleteConnection( const QString &service, const QString &name )
 {
   QgsSettings settings;
-  settings.remove( "/Qgis/connections-" + service.toLower() + '/' + name );
-  settings.remove( "/Qgis/" + service + '/' + name );
+  settings.remove( "qgis//connections-" + service.toLower() + '/' + name );
+  settings.remove( "qgis//" + service + '/' + name );
 }

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -69,7 +69,7 @@ QgsNewHttpConnection::QgsNewHttpConnection(
     QgsSettings settings;
 
     QString key = mBaseKey + connName;
-    QString credentialsKey = "/Qgis/" + mCredentialsBaseKey + '/' + connName;
+    QString credentialsKey = "qgis//" + mCredentialsBaseKey + '/' + connName;
     txtName->setText( connName );
     txtUrl->setText( settings.value( key + "/url" ).toString() );
 
@@ -124,10 +124,10 @@ QgsNewHttpConnection::QgsNewHttpConnection(
     }
   }
 
-  if ( mBaseKey != QLatin1String( "/Qgis/connections-wms/" ) )
+  if ( mBaseKey != QLatin1String( "qgis//connections-wms/" ) )
   {
-    if ( mBaseKey != QLatin1String( "/Qgis/connections-wcs/" ) &&
-         mBaseKey != QLatin1String( "/Qgis/connections-wfs/" ) )
+    if ( mBaseKey != QLatin1String( "qgis//connections-wcs/" ) &&
+         mBaseKey != QLatin1String( "qgis//connections-wfs/" ) )
     {
       cbxIgnoreAxisOrientation->setVisible( false );
       cbxInvertAxisOrientation->setVisible( false );
@@ -135,12 +135,12 @@ QgsNewHttpConnection::QgsNewHttpConnection(
       mGroupBox->layout()->removeWidget( cbxInvertAxisOrientation );
     }
 
-    if ( mBaseKey == QLatin1String( "/Qgis/connections-wfs/" ) )
+    if ( mBaseKey == QLatin1String( "qgis//connections-wfs/" ) )
     {
       cbxIgnoreAxisOrientation->setText( tr( "Ignore axis orientation (WFS 1.1/WFS 2.0)" ) );
     }
 
-    if ( mBaseKey == QLatin1String( "/Qgis/connections-wcs/" ) )
+    if ( mBaseKey == QLatin1String( "qgis//connections-wcs/" ) )
     {
       cbxIgnoreGetMapURI->setText( tr( "Ignore GetCoverage URI reported in capabilities" ) );
       cbxIgnoreAxisOrientation->setText( tr( "Ignore axis orientation" ) );
@@ -167,7 +167,7 @@ QgsNewHttpConnection::QgsNewHttpConnection(
     mGroupBox->layout()->removeWidget( lblReferer );
   }
 
-  if ( mBaseKey != QLatin1String( "/Qgis/connections-wfs/" ) )
+  if ( mBaseKey != QLatin1String( "qgis//connections-wfs/" ) )
   {
     cmbVersion->setVisible( false );
     mGroupBox->layout()->removeWidget( cmbVersion );
@@ -201,7 +201,7 @@ void QgsNewHttpConnection::accept()
 {
   QgsSettings settings;
   QString key = mBaseKey + txtName->text();
-  QString credentialsKey = "/Qgis/" + mCredentialsBaseKey + '/' + txtName->text();
+  QString credentialsKey = "qgis//" + mCredentialsBaseKey + '/' + txtName->text();
 
   // warn if entry was renamed to an existing connection
   if ( ( mOriginalConnName.isNull() || mOriginalConnName.compare( txtName->text(), Qt::CaseInsensitive ) != 0 ) &&
@@ -227,7 +227,7 @@ void QgsNewHttpConnection::accept()
   if ( !mOriginalConnName.isNull() && mOriginalConnName != key )
   {
     settings.remove( mBaseKey + mOriginalConnName );
-    settings.remove( "/Qgis/" + mCredentialsBaseKey + '/' + mOriginalConnName );
+    settings.remove( "qgis//" + mCredentialsBaseKey + '/' + mOriginalConnName );
     settings.sync();
   }
 
@@ -255,15 +255,15 @@ void QgsNewHttpConnection::accept()
 
   settings.setValue( key + "/url", url.toString() );
 
-  if ( mBaseKey == QLatin1String( "/Qgis/connections-wms/" ) ||
-       mBaseKey == QLatin1String( "/Qgis/connections-wcs/" ) ||
-       mBaseKey == QLatin1String( "/Qgis/connections-wfs/" ) )
+  if ( mBaseKey == QLatin1String( "qgis//connections-wms/" ) ||
+       mBaseKey == QLatin1String( "qgis//connections-wcs/" ) ||
+       mBaseKey == QLatin1String( "qgis//connections-wfs/" ) )
   {
     settings.setValue( key + "/ignoreAxisOrientation", cbxIgnoreAxisOrientation->isChecked() );
     settings.setValue( key + "/invertAxisOrientation", cbxInvertAxisOrientation->isChecked() );
   }
 
-  if ( mBaseKey == QLatin1String( "/Qgis/connections-wms/" ) || mBaseKey == QLatin1String( "/Qgis/connections-wcs/" ) )
+  if ( mBaseKey == QLatin1String( "qgis//connections-wms/" ) || mBaseKey == QLatin1String( "qgis//connections-wcs/" ) )
   {
     settings.setValue( key + "/ignoreGetMapURI", cbxIgnoreGetMapURI->isChecked() );
     settings.setValue( key + "/smoothPixmapTransform", cbxSmoothPixmapTransform->isChecked() );
@@ -290,11 +290,11 @@ void QgsNewHttpConnection::accept()
 
     settings.setValue( key + "/dpiMode", dpiMode );
   }
-  if ( mBaseKey == QLatin1String( "/Qgis/connections-wms/" ) )
+  if ( mBaseKey == QLatin1String( "qgis//connections-wms/" ) )
   {
     settings.setValue( key + "/ignoreGetFeatureInfoURI", cbxIgnoreGetFeatureInfoURI->isChecked() );
   }
-  if ( mBaseKey == QLatin1String( "/Qgis/connections-wfs/" ) )
+  if ( mBaseKey == QLatin1String( "qgis//connections-wfs/" ) )
   {
     QString version = QStringLiteral( "auto" );
     switch ( cmbVersion->currentIndex() )

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -33,7 +33,7 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
 
   public:
     //! Constructor
-    QgsNewHttpConnection( QWidget *parent = nullptr, const QString &baseKey = "/Qgis/connections-wms/", const QString &connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
+    QgsNewHttpConnection( QWidget *parent = nullptr, const QString &baseKey = "qgis/connections-wms/", const QString &connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
   public slots:
     // Saves the connection to ~/.qt/qgisrc

--- a/src/gui/qgssourceselectdialog.cpp
+++ b/src/gui/qgssourceselectdialog.cpp
@@ -220,7 +220,7 @@ QString QgsSourceSelectDialog::getPreferredCrs( const QSet<QString> &crsSet ) co
 void QgsSourceSelectDialog::addEntryToServerList()
 {
 
-  QgsNewHttpConnection nc( 0, QStringLiteral( "/Qgis/connections-%1/" ).arg( mServiceName.toLower() ) );
+  QgsNewHttpConnection nc( 0, QStringLiteral( "qgis/connections-%1/" ).arg( mServiceName.toLower() ) );
   nc.setWindowTitle( tr( "Create a new %1 connection" ).arg( mServiceName ) );
 
   if ( nc.exec() )
@@ -232,7 +232,7 @@ void QgsSourceSelectDialog::addEntryToServerList()
 
 void QgsSourceSelectDialog::modifyEntryOfServerList()
 {
-  QgsNewHttpConnection nc( 0, QStringLiteral( "/Qgis/connections-%1/" ).arg( mServiceName.toLower() ), cmbConnections->currentText() );
+  QgsNewHttpConnection nc( 0, QStringLiteral( "qgis/connections-%1/" ).arg( mServiceName.toLower() ), cmbConnections->currentText() );
   nc.setWindowTitle( tr( "Modify %1 connection" ).arg( mServiceName ) );
 
   if ( nc.exec() )

--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -67,7 +67,7 @@ void QgsAfsRootItem::connectionsChanged()
 
 void QgsAfsRootItem::newConnection()
 {
-  QgsNewHttpConnection nc( 0, QStringLiteral( "/Qgis/connections-arcgisfeatureserver/" ) );
+  QgsNewHttpConnection nc( 0, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ) );
   nc.setWindowTitle( tr( "Create a new ArcGisFeatureServer connection" ) );
 
   if ( nc.exec() )
@@ -130,7 +130,7 @@ QList<QAction *> QgsAfsConnectionItem::actions()
 
 void QgsAfsConnectionItem::editConnection()
 {
-  QgsNewHttpConnection nc( 0, QStringLiteral( "/Qgis/connections-arcgisfeatureserver/" ), mName );
+  QgsNewHttpConnection nc( 0, QStringLiteral( "qgis/connections-arcgisfeatureserver/" ), mName );
   nc.setWindowTitle( tr( "Modify ArcGisFeatureServer connection" ) );
 
   if ( nc.exec() )

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -64,7 +64,7 @@ void QgsAmsRootItem::connectionsChanged()
 
 void QgsAmsRootItem::newConnection()
 {
-  QgsNewHttpConnection nc( 0, QStringLiteral( "/Qgis/connections-arcgismapserver/" ) );
+  QgsNewHttpConnection nc( 0, QStringLiteral( "qgis/connections-arcgismapserver/" ) );
   nc.setWindowTitle( tr( "Create a new ArcGisMapServer connection" ) );
 
   if ( nc.exec() )
@@ -145,7 +145,7 @@ QList<QAction *> QgsAmsConnectionItem::actions()
 
 void QgsAmsConnectionItem::editConnection()
 {
-  QgsNewHttpConnection nc( 0, QStringLiteral( "/Qgis/connections-arcgismapserver/" ), mName );
+  QgsNewHttpConnection nc( 0, QStringLiteral( "qgis/connections-arcgismapserver/" ), mName );
   nc.setWindowTitle( tr( "Modify ArcGisMapServer connection" ) );
 
   if ( nc.exec() )

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -185,8 +185,8 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   mCompileStatus = NoCompilation;
   if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
-    QgsDebugMsg( QString( "compileExpressions: %1" ).arg( QgsSettings().value( "/qgis/compileExpressions", true ).toString() ) );
-    if ( QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() )
+    QgsDebugMsg( QString( "compileExpressions: %1" ).arg( QgsSettings().value( "qgis/compileExpressions", true ).toString() ) );
+    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
     {
       QgsDb2ExpressionCompiler compiler = QgsDb2ExpressionCompiler( mSource );
       QgsDebugMsg( "expression dump: " + request.filterExpression()->dump() );
@@ -218,8 +218,8 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
 
   QStringList orderByParts;
   mOrderByCompiled = true;
-  QgsDebugMsg( QString( "compileExpressions: %1" ).arg( QgsSettings().value( "/qgis/compileExpressions", true ).toString() ) );
-  if ( QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() && limitAtProvider )
+  QgsDebugMsg( QString( "compileExpressions: %1" ).arg( QgsSettings().value( "qgis/compileExpressions", true ).toString() ) );
+  if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() && limitAtProvider )
   {
     Q_FOREACH ( const QgsFeatureRequest::OrderByClause &clause, request.orderBy() )
     {

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -178,7 +178,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   mCompileStatus = NoCompilation;
   if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
-    if ( QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() )
+    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
     {
       QgsMssqlExpressionCompiler compiler = QgsMssqlExpressionCompiler( mSource );
       QgsSqlExpressionCompiler::Result result = compiler.compile( request.filterExpression() );
@@ -209,7 +209,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   QStringList orderByParts;
   mOrderByCompiled = true;
 
-  if ( QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() )
+  if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
   {
     Q_FOREACH ( const QgsFeatureRequest::OrderByClause &clause, request.orderBy() )
     {

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -115,7 +115,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   }
 
   if ( request.filterType() == QgsFeatureRequest::FilterExpression
-       && QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() )
+       && QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
   {
     QgsSqlExpressionCompiler *compiler = nullptr;
     if ( source->mDriverName == QLatin1String( "SQLite" ) || source->mDriverName == QLatin1String( "GPKG" ) )

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3391,7 +3391,7 @@ void QgsOgrProvider::open( OpenMode mode )
     if ( QFileInfo( mFilePath ).suffix().compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0 &&
          IsLocalFile( mFilePath ) &&
          !CPLGetConfigOption( "OGR_SQLITE_JOURNAL", NULL ) &&
-         QgsSettings().value( QStringLiteral( "/qgis/walForSqlite3" ), true ).toBool() )
+         QgsSettings().value( QStringLiteral( "qgis/walForSqlite3" ), true ).toBool() )
     {
       // For GeoPackage, we force opening of the file in WAL (Write Ahead Log)
       // mode so as to avoid readers blocking writer(s), and vice-versa.

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -169,7 +169,7 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
   bool useFallback = false;
   if ( request.filterType() == QgsFeatureRequest::FilterExpression )
   {
-    if ( QgsSettings().value( "/qgis/compileExpressions", true ).toBool() )
+    if ( QgsSettings().value( "qgis/compileExpressions", true ).toBool() )
     {
       QgsOracleExpressionCompiler compiler( mSource );
       QgsSqlExpressionCompiler::Result result = compiler.compile( mRequest.filterExpression() );

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -227,7 +227,7 @@ QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags f
   connect( mTablesTreeView->selectionModel(), SIGNAL( selectionChanged( const QItemSelection &, const QItemSelection & ) ), this, SLOT( treeWidgetSelectionChanged( const QItemSelection &, const QItemSelection & ) ) );
 
   QgsSettings settings;
-  mTablesTreeView->setSelectionMode( settings.value( "/qgis/addOracleDC", false ).toBool() ?
+  mTablesTreeView->setSelectionMode( settings.value( "qgis/addOracleDC", false ).toBool() ?
                                      QAbstractItemView::ExtendedSelection :
                                      QAbstractItemView::MultiSelection );
 
@@ -358,7 +358,7 @@ void QgsOracleSourceSelect::on_mTablesTreeView_clicked( const QModelIndex &index
 void QgsOracleSourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex &index )
 {
   QgsSettings settings;
-  if ( settings.value( "/qgis/addOracleDC", false ).toBool() )
+  if ( settings.value( "qgis/addOracleDC", false ).toBool() )
   {
     addTables();
   }

--- a/src/providers/ows/qgsowsdataitems.cpp
+++ b/src/providers/ows/qgsowsdataitems.cpp
@@ -146,7 +146,7 @@ QList<QAction *> QgsOWSConnectionItem::actions()
 void QgsOWSConnectionItem::editConnection()
 {
 #if 0
-  QgsNewHttpConnection nc( 0, "/Qgis/connections-ows/", mName );
+  QgsNewHttpConnection nc( 0, "qgis/connections-ows/", mName );
 
   if ( nc.exec() )
   {
@@ -235,7 +235,7 @@ void QgsOWSRootItem::connectionsChanged()
 void QgsOWSRootItem::newConnection()
 {
 #if 0
-  QgsNewHttpConnection nc( 0, "/Qgis/connections-ows/" );
+  QgsNewHttpConnection nc( 0, "qgis/connections-ows/" );
 
   if ( nc.exec() )
   {

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -96,7 +96,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
     }
     mFilterRequiresGeometry = request.filterExpression()->needsGeometry();
 
-    if ( QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() )
+    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
     {
       //IMPORTANT - this MUST be the last clause added!
       QgsPostgresExpressionCompiler compiler = QgsPostgresExpressionCompiler( source );
@@ -132,7 +132,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
   //     SELECT my_int_col::text FROM some_table ORDER BY some_table.my_int_col
   // but that's non-trivial
 #if 0
-  if ( QgsSettings().value( "/qgis/compileExpressions", true ).toBool() )
+  if ( QgsSettings().value( "qgis/compileExpressions", true ).toBool() )
   {
     Q_FOREACH ( const QgsFeatureRequest::OrderByClause &clause, request.orderBy() )
     {

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -98,7 +98,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
       mFetchGeometry = true;
     }
 
-    if ( QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() )
+    if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
     {
       QgsSQLiteExpressionCompiler compiler = QgsSQLiteExpressionCompiler( source->mFields );
 
@@ -137,7 +137,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
 
   mOrderByCompiled = true;
 
-  if ( QgsSettings().value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() )
+  if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
   {
     Q_FOREACH ( const QgsFeatureRequest::OrderByClause &clause, request.orderBy() )
     {

--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -98,7 +98,7 @@ QList<QAction *> QgsWCSConnectionItem::actions()
 
 void QgsWCSConnectionItem::editConnection()
 {
-  QgsNewHttpConnection nc( nullptr, QStringLiteral( "/Qgis/connections-wcs/" ), mName );
+  QgsNewHttpConnection nc( nullptr, QStringLiteral( "qgis/connections-wcs/" ), mName );
 
   if ( nc.exec() )
   {
@@ -265,7 +265,7 @@ void QgsWCSRootItem::connectionsChanged()
 
 void QgsWCSRootItem::newConnection()
 {
-  QgsNewHttpConnection nc( nullptr, QStringLiteral( "/Qgis/connections-wcs/" ) );
+  QgsNewHttpConnection nc( nullptr, QStringLiteral( "qgis/connections-wcs/" ) );
 
   if ( nc.exec() )
   {

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -482,7 +482,7 @@ QString QgsWfsCapabilities::NormalizeSRSName( QString crsName )
 int QgsWfsCapabilities::defaultExpirationInSec()
 {
   QgsSettings s;
-  return s.value( QStringLiteral( "/qgis/defaultCapabilitiesExpiry" ), "24" ).toInt() * 60 * 60;
+  return s.value( QStringLiteral( "qgis/defaultCapabilitiesExpiry" ), "24" ).toInt() * 60 * 60;
 }
 
 void QgsWfsCapabilities::parseSupportedOperations( const QDomElement &operationsElem,

--- a/src/providers/wfs/qgswfsconstants.cpp
+++ b/src/providers/wfs/qgswfsconstants.cpp
@@ -40,7 +40,7 @@ const QString QgsWFSConstants::URI_PARAM_HIDEDOWNLOADPROGRESSDIALOG( QStringLite
 
 const QString QgsWFSConstants::VERSION_AUTO( QStringLiteral( "auto" ) );
 
-const QString QgsWFSConstants::CONNECTIONS_WFS( QStringLiteral( "/Qgis/connections-wfs/" ) );
+const QString QgsWFSConstants::CONNECTIONS_WFS( QStringLiteral( "qgis/connections-wfs/" ) );
 const QString QgsWFSConstants::SETTINGS_VERSION( QStringLiteral( "version" ) );
 const QString QgsWFSConstants::SETTINGS_MAXNUMFEATURES( QStringLiteral( "maxnumfeatures" ) );
 

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -402,7 +402,7 @@ void QgsWFSFeatureDownloader::run( bool serializeFeatures, int maxFeatures )
   bool interrupted = false;
   bool truncatedResponse = false;
   QgsSettings s;
-  const int maxRetry = s.value( QStringLiteral( "/qgis/defaultTileMaxRetry" ), "3" ).toInt();
+  const int maxRetry = s.value( QStringLiteral( "qgis/defaultTileMaxRetry" ), "3" ).toInt();
   int retryIter = 0;
   int lastValidTotalDownloadedFeatureCount = 0;
   int pagingIter = 1;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2075,7 +2075,7 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
           if ( cmd.expirationDate().isNull() )
           {
             QgsSettings s;
-            cmd.setExpirationDate( QDateTime::currentDateTime().addSecs( s.value( QStringLiteral( "/qgis/defaultCapabilitiesExpiry" ), "24" ).toInt() * 60 * 60 ) );
+            cmd.setExpirationDate( QDateTime::currentDateTime().addSecs( s.value( QStringLiteral( "qgis/defaultCapabilitiesExpiry" ), "24" ).toInt() * 60 * 60 ) );
           }
 
           nam->cache()->updateMetaData( cmd );

--- a/src/providers/wms/qgswmsconnection.cpp
+++ b/src/providers/wms/qgswmsconnection.cpp
@@ -43,8 +43,8 @@ QgsWMSConnection::QgsWMSConnection( const QString &connName )
 
   QgsSettings settings;
 
-  QString key = "/Qgis/connections-wms/" + mConnName;
-  QString credentialsKey = "/Qgis/WMS/" + mConnName;
+  QString key = "qgis/connections-wms/" + mConnName;
+  QString credentialsKey = "qgis/WMS/" + mConnName;
 
   QStringList connStringParts;
 
@@ -143,6 +143,6 @@ void QgsWMSConnection::setSelectedConnection( const QString &name )
 void QgsWMSConnection::deleteConnection( const QString &name )
 {
   QgsSettings settings;
-  settings.remove( "/Qgis/connections-wms/" + name );
-  settings.remove( "/Qgis/WMS/" + name );
+  settings.remove( "qgis/connections-wms/" + name );
+  settings.remove( "qgis/WMS/" + name );
 }

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -231,7 +231,7 @@ QList<QAction *> QgsWMSConnectionItem::actions()
 
 void QgsWMSConnectionItem::editConnection()
 {
-  QgsNewHttpConnection nc( nullptr, QStringLiteral( "/Qgis/connections-wms/" ), mName );
+  QgsNewHttpConnection nc( nullptr, QStringLiteral( "qgis/connections-wms/" ), mName );
 
   if ( nc.exec() )
   {

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3320,7 +3320,7 @@ QUrl QgsWmsProvider::getLegendGraphicFullURL( double scale, const QgsRectangle &
 
   // add config parameter related to resolution
   QgsSettings s;
-  int defaultLegendGraphicResolution = s.value( QStringLiteral( "/qgis/defaultLegendGraphicResolution" ), 0 ).toInt();
+  int defaultLegendGraphicResolution = s.value( QStringLiteral( "qgis/defaultLegendGraphicResolution" ), 0 ).toInt();
   QgsDebugMsg( QString( "defaultLegendGraphicResolution: %1" ).arg( defaultLegendGraphicResolution ) );
   if ( defaultLegendGraphicResolution )
   {
@@ -3781,7 +3781,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
     if ( cmd.expirationDate().isNull() )
     {
       QgsSettings s;
-      cmd.setExpirationDate( QDateTime::currentDateTime().addSecs( s.value( QStringLiteral( "/qgis/defaultTileExpiry" ), "24" ).toInt() * 60 * 60 ) );
+      cmd.setExpirationDate( QDateTime::currentDateTime().addSecs( s.value( QStringLiteral( "qgis/defaultTileExpiry" ), "24" ).toInt() * 60 * 60 ) );
     }
 
     QgsNetworkAccessManager::instance()->cache()->updateMetaData( cmd );
@@ -3998,7 +3998,7 @@ void QgsWmsTiledImageDownloadHandler::repeatTileRequest( QNetworkRequest const &
   retry++;
 
   QgsSettings s;
-  int maxRetry = s.value( QStringLiteral( "/qgis/defaultTileMaxRetry" ), "3" ).toInt();
+  int maxRetry = s.value( QStringLiteral( "qgis/defaultTileMaxRetry" ), "3" ).toInt();
   if ( retry > maxRetry )
   {
     if ( stat.errors < 100 )

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -179,7 +179,7 @@ void QgsWMSSourceSelect::on_btnNew_clicked()
 
 void QgsWMSSourceSelect::on_btnEdit_clicked()
 {
-  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, QStringLiteral( "/Qgis/connections-wms/" ), cmbConnections->currentText() );
+  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, QStringLiteral( "qgis/connections-wms/" ), cmbConnections->currentText() );
 
   if ( nc->exec() )
   {
@@ -1223,7 +1223,7 @@ void QgsWMSSourceSelect::on_btnAddWMS_clicked()
   QString wmsUrl = tableWidgetWMSList->item( selectedRow, 2 )->text();
 
   QgsSettings settings;
-  if ( settings.contains( QStringLiteral( "Qgis/connections-wms/%1/url" ).arg( wmsTitle ) ) )
+  if ( settings.contains( QStringLiteral( "qgis/connections-wms/%1/url" ).arg( wmsTitle ) ) )
   {
     QString msg = tr( "The %1 connection already exists. Do you want to overwrite it?" ).arg( wmsTitle );
     QMessageBox::StandardButton result = QMessageBox::information( this, tr( "Confirm Overwrite" ), msg, QMessageBox::Ok | QMessageBox::Cancel );

--- a/src/providers/wms/qgsxyzconnection.cpp
+++ b/src/providers/wms/qgsxyzconnection.cpp
@@ -40,7 +40,7 @@ QStringList QgsXyzConnectionUtils::connectionList()
 QgsXyzConnection QgsXyzConnectionUtils::connection( const QString &name )
 {
   QgsSettings settings;
-  settings.beginGroup( "/Qgis/connections-xyz/" + name );
+  settings.beginGroup( "qgis/connections-xyz/" + name );
 
   QgsXyzConnection conn;
   conn.name = name;
@@ -53,13 +53,13 @@ QgsXyzConnection QgsXyzConnectionUtils::connection( const QString &name )
 void QgsXyzConnectionUtils::deleteConnection( const QString &name )
 {
   QgsSettings settings;
-  settings.remove( "/Qgis/connections-xyz/" + name );
+  settings.remove( "qgis/connections-xyz/" + name );
 }
 
 void QgsXyzConnectionUtils::addConnection( const QgsXyzConnection &conn )
 {
   QgsSettings settings;
-  settings.beginGroup( "/Qgis/connections-xyz/" + conn.name );
+  settings.beginGroup( "qgis/connections-xyz/" + conn.name );
   settings.setValue( QStringLiteral( "url" ), conn.url );
   settings.setValue( QStringLiteral( "zmin" ), conn.zMin );
   settings.setValue( QStringLiteral( "zmax" ), conn.zMax );


### PR DESCRIPTION
## Description
This started with fixing XYZ browser panel list as well as ArcGisRest browser panel list / connection dialog, and ended up being a broader update of QgsSettings in the src/providers folder. The PR lower-cases "qgis/" and removes the leading "/" from the settings key strings.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://www.qgis.org/en/site/getinvolved/development/qgisdevelopersguide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
