### PR TITLE
[FEATURE] Multi canvas/additional map views

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -557,6 +557,7 @@
         <file>themes/default/processingResult.svg</file>
         <file>themes/default/search.svg</file>
         <file>themes/default/mActionNewMap.svg</file>
+        <file>themes/default/mActionMapSettings.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/images.qrc
+++ b/images/images.qrc
@@ -558,6 +558,7 @@
         <file>themes/default/search.svg</file>
         <file>themes/default/mActionNewMap.svg</file>
         <file>themes/default/mActionMapSettings.svg</file>
+        <file>themes/default/mActionLockExtent.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/images.qrc
+++ b/images/images.qrc
@@ -556,6 +556,7 @@
         <file>themes/default/processingAlgorithm.svg</file>
         <file>themes/default/processingResult.svg</file>
         <file>themes/default/search.svg</file>
+        <file>themes/default/mActionNewMap.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mActionLockExtent.svg
+++ b/images/themes/default/mActionLockExtent.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg20"
+   sodipodi:docname="mActionLockExtent.svg"
+   inkscape:version="0.92.1 r">
+  <metadata
+     id="metadata26">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs24" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1132"
+     inkscape:window-height="916"
+     id="namedview22"
+     showgrid="true"
+     inkscape:zoom="33.375"
+     inkscape:cx="7.1310861"
+     inkscape:cy="7.5927961"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg20">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4526" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#6d97c4;fill-rule:evenodd;stroke:#415a75;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     inkscape:connector-curvature="0"
+     id="path4"
+     d="M 14.5,13.5 H 9.4999793 L 11.166653,11.833327 9.4999793,10.166653 11.166651,8.49998 12.833326,10.166653 14.499998,8.49998 Z" />
+  <path
+     style="opacity:0.7;fill:#fcffff;fill-rule:evenodd;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     inkscape:connector-curvature="0"
+     id="path10"
+     d="m 6.0854127,4.570286 c 1.2542366,-1.881355 2.7858151,-2.1309826 3.76271,-1.2542367 0.9768953,0.8767459 -1.2542368,0.6271183 -2.5084734,1.881355 -1.2542366,1.2542366 0,3.7627099 -1.2542366,3.7627099 -1.2542366,0 -1.2542366,-2.5084733 0,-4.3898282 z" />
+  <path
+     style="fill:#6d97c4;fill-rule:evenodd;stroke:#415a75;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     inkscape:connector-curvature="0"
+     id="path14"
+     d="M 14.5,1.5000002 V 6.5000209 L 12.833326,4.8333456 11.166652,6.5000209 9.4999793,4.8333468 11.166652,3.1666741 9.4999793,1.5000006 Z" />
+  <path
+     style="fill:#6d97c4;fill-rule:evenodd;stroke:#415a75;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     inkscape:connector-curvature="0"
+     id="path16"
+     d="M 2.5,1.5000002 H 7.5000208 L 5.8333464,3.1666739 7.5000208,4.8333475 5.833347,6.500021 4.1666735,4.8333475 2.5000002,6.500021 Z" />
+  <path
+     style="fill:#6d97c4;fill-rule:evenodd;stroke:#415a75;stroke-width:0.99999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     inkscape:connector-curvature="0"
+     id="path14-3"
+     d="M 2.5,14.499999 V 9.4999798 l 1.6666739,1.6666742 1.6666728,-1.6666742 1.6666739,1.6666732 -1.6666739,1.666672 1.6666739,1.666673 z" />
+  <path
+     id="path2"
+     d="M 3.3724264,8.3336432 C 3.4582294,5.7125241 4.0588308,4.5258991 6.135095,4.6857259 8.2111253,4.8451683 8.67798,6.1128125 8.5917932,8.7341416"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#888a85;stroke-width:3;stroke-linecap:square;stroke-linejoin:round" />
+  <path
+     id="path4-6"
+     d="M 3.3712993,8.3336432 C 3.4560835,5.6317535 4.0495536,4.3772911 6.1011648,4.542043 8.152545,4.7063986 8.6138563,6.0443769 8.528693,8.7464831"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#eeeeec;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round" />
+  <rect
+     id="rect6"
+     y="8.4996204"
+     x="1.4999999"
+     width="9"
+     ry="0.85714287"
+     rx="0.69230771"
+     height="6.0000005"
+     style="fill:#f1db1e;stroke:#c4a000;stroke-width:0.99999976;stroke-linecap:square" />
+</svg>

--- a/images/themes/default/mActionMapSettings.svg
+++ b/images/themes/default/mActionMapSettings.svg
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg23"
+   sodipodi:docname="mActionMapSettings.svg"
+   inkscape:version="0.92.1 r">
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs27">
+    <linearGradient
+       id="a-3"
+       gradientTransform="matrix(-0.10786508,0.87849049,0.87408031,0.10732357,-1.811623,758.65836)"
+       gradientUnits="userSpaceOnUse"
+       x1="304.76001"
+       x2="335.29999"
+       y1="64.294998"
+       y2="81.926003">
+      <stop
+         offset="0"
+         stop-color="#d3d7cf"
+         id="stop2-6" />
+      <stop
+         offset=".18304"
+         stop-color="#babdb6"
+         id="stop4-7" />
+      <stop
+         offset=".31893"
+         stop-color="#fff"
+         id="stop6" />
+      <stop
+         offset=".87644"
+         stop-color="#babdb6"
+         id="stop8" />
+      <stop
+         offset="1"
+         stop-color="#eeeeec"
+         id="stop10" />
+    </linearGradient>
+    <linearGradient
+       id="b"
+       gradientTransform="matrix(-0.34112292,0.26690344,0.34708506,0.44633485,7.3860378,1027.6433)"
+       gradientUnits="userSpaceOnUse"
+       x1="-6.3077998"
+       x2="-9.7747002"
+       y1="44.229"
+       y2="44.139999">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="c"
+       gradientTransform="matrix(-0.67481701,0.52736572,0.29432462,0.37835898,77.717559,981.12162)"
+       gradientUnits="userSpaceOnUse"
+       x1="97.442001"
+       x2="90.221001"
+       y1="35.152"
+       y2="35.078999">
+      <stop
+         offset="0"
+         stop-color="#f8e27e"
+         id="stop18" />
+      <stop
+         offset="1"
+         stop-color="#e3d189"
+         id="stop20" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview25"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12.40678"
+     inkscape:cy="11.59322"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg23" />
+  <linearGradient
+     id="a"
+     gradientUnits="userSpaceOnUse"
+     x1="3.5"
+     x2="11.5"
+     y1="19.5"
+     y2="19.5">
+    <stop
+       offset="0"
+       stop-color="#b7b7b7"
+       id="stop2" />
+    <stop
+       offset="1"
+       stop-color="#e6e6e6"
+       id="stop4" />
+  </linearGradient>
+  <g
+     transform="translate(0 -8)"
+     id="g21">
+    <path
+       d="m21.5 29.5h-17c-1 0-1.977816-1.420625-2-2.5v-16.5h19z"
+       fill="url(#a)"
+       fill-rule="evenodd"
+       stroke="#9a9a9a"
+       id="path7" />
+    <path
+       d="m6.5 9.9999996c-1-.9999995-3-.9999995-4 0v16.0000004c1-1 3-1 4 0z"
+       fill="#e6e6e6"
+       fill-rule="evenodd"
+       stroke="#9a9a9a"
+       id="path9" />
+    <g
+       transform="matrix(.69230769 0 0 .69230769 1.8461539 9.8461539)"
+       id="g19" />
+  </g>
+  <g
+     id="g73"
+     transform="matrix(0.77430229,0,0,0.77430229,-0.92444663,-790.99716)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path63"
+       style="fill:url(#a-3);fill-rule:evenodd;stroke:#3b3b3b;stroke-width:1.0266068;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:0.3612"
+       d="m 10.457382,1032.309 c -0.0557,-0.8562 0.634116,-0.2492 0.875491,0 1.024776,0.7434 2.030407,1.5156 3.067343,2.2407 0.725037,0.2552 1.421475,-0.3125 1.904389,-0.793 0.69153,-0.772 1.365424,-1.7692 1.239142,-2.855 -0.0999,-0.5511 -0.678194,-0.7556 -1.060023,-1.087 -0.948649,-0.7006 -1.905189,-1.3938 -2.848652,-2.099 0.0499,-0.5363 0.921102,-0.4312 1.352206,-0.4538 1.799481,0.032 3.760889,0.6193 4.847708,2.1483 0.893786,1.2432 1.095967,2.9098 0.645088,4.3593 0.248756,1.355 0.749129,2.6839 1.605411,3.7751 -1.055028,0.7755 -2.110005,1.5509 -3.165032,2.3264 -0.74403,-0.9699 -1.666431,-1.8128 -2.743678,-2.3982 -1.597268,0.2334 -3.230567,-0.5195 -4.193648,-1.7921 -0.762442,-0.9748 -1.327479,-2.1438 -1.525916,-3.3671 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.23106001;fill:url(#b)"
+       id="path65"
+       d="m 20.569654,1038.9536 c -0.377958,0.2957 -0.449831,0.8327 -0.161152,1.2039 l 5.276506,7.7275 c 0.288677,0.3713 1.28112,0.076 1.659095,-0.2199 0.377957,-0.2957 0.905829,-1.1891 0.617119,-1.5603 l -6.181727,-7.0148 c -0.288677,-0.3712 -0.825389,-0.432 -1.203364,-0.1363 z" />
+    <path
+       style="fill:#f0f3f2;fill-rule:evenodd"
+       inkscape:connector-curvature="0"
+       id="path67"
+       d="m 10.776308,1032.3503 c 0.0041,0.017 0.02652,0.01 0.02736,0 l 3.280939,2.4093 c 0.441955,0.3249 1.026164,0.2014 1.532663,-0.063 0.511499,-0.2667 1.030216,-0.7135 1.465827,-1.3248 0.436534,-0.6127 0.691989,-1.2801 0.782256,-1.8547 0.09008,-0.5733 -0.0071,-1.1337 -0.432392,-1.4464 l -3.308254,-2.4126 c -3.27e-4,-0.012 0.0053,-0.029 0.0034,-0.028 -0.02145,0.016 0.01356,0.01 0.02736,0 1.60773,-0.1726 3.391001,0.2382 4.500933,1.0542 1.518297,1.1161 2.06238,3.1241 1.496172,4.9767 -0.567334,1.8439 -2.398541,3.2549 -4.002325,3.466 -1.037771,0.1302 -2.105965,-0.1107 -2.984774,-0.7566 -1.106711,-0.8138 -2.046256,-2.4203 -2.389076,-4.0275 h -9.3e-5 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path69"
+       style="fill:url(#c);stroke:#3b3b3b;stroke-width:0.86699998;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:0.69999999"
+       d="m 21.969626,1036.9102 9.581585,11.1009 c 0.570734,0.7337 -0.03271,2.1379 -1.34119,3.1605 -1.308483,1.0226 -2.814237,1.2668 -3.384954,0.5331 l -8.399386,-12.0247 3.546142,-2.7701 z m 6.345662,11.8213 c -0.650481,0.5084 -0.785855,1.4312 -0.461469,1.8482 0.324412,0.4169 1.282238,0.4855 1.932707,-0.023 0.650479,-0.5084 0.754739,-1.407 0.430357,-1.8239 -0.324413,-0.417 -1.251126,-0.5098 -1.901595,0 z" />
+    <path
+       style="fill:#ffffff;fill-opacity:0.57758622;stroke:#3b3b3b;stroke-width:1.28935945"
+       inkscape:connector-curvature="0"
+       id="path71"
+       transform="matrix(0.82455744,-0.56577825,0.66205623,0.74945417,0,0)"
+       d="m -679.10767,874.67072 h 3.57105 v 0.57711 h -3.57105 z" />
+  </g>
+</svg>

--- a/images/themes/default/mActionNewMap.svg
+++ b/images/themes/default/mActionNewMap.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg23"
+   sodipodi:docname="mActionNewMap.svg"
+   inkscape:version="0.92.1 r">
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs27" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1463"
+     inkscape:window-height="554"
+     id="namedview25"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="1.3220339"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg23" />
+  <linearGradient
+     id="a"
+     gradientUnits="userSpaceOnUse"
+     x1="3.5"
+     x2="11.5"
+     y1="19.5"
+     y2="19.5"
+     gradientTransform="translate(0,-8)">
+    <stop
+       offset="0"
+       stop-color="#b7b7b7"
+       id="stop2" />
+    <stop
+       offset="1"
+       stop-color="#e6e6e6"
+       id="stop4" />
+  </linearGradient>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#a);fill-rule:evenodd;stroke:#9a9a9a"
+     id="path7"
+     d="m 21.5,21.5 h -17 c -1,0 -1.977816,-1.420625 -2,-2.5 V 2.5 h 19 z" />
+  <path
+     style="fill:#e6e6e6;fill-rule:evenodd;stroke:#9a9a9a"
+     inkscape:connector-curvature="0"
+     id="path9"
+     d="m 6.5,1.9999996 c -1,-0.9999995 -3,-0.9999995 -4,0 V 18 c 1,-1 3,-1 4,0 z" />
+  <g
+     id="g16"
+     transform="translate(33)">
+    <rect
+       style="fill:#c4a000"
+       id="rect10"
+       y="13"
+       x="-20"
+       width="11"
+       rx="2.0114901"
+       height="11" />
+    <path
+       style="fill:#fcffff"
+       inkscape:connector-curvature="0"
+       id="path12"
+       d="m -15,14 v 2.0625 c -0.537663,0.111041 -1.024662,0.383291 -1.375,0.78125 l -1.78125,-1.03125 -0.5,0.875 1.78125,1.03125 C -16.957063,17.966182 -17,18.225145 -17,18.5 c 0,0.274855 0.04294,0.533818 0.125,0.78125 l -1.78125,1.03125 0.5,0.875 1.78125,-1.03125 c 0.352503,0.40042 0.832682,0.670182 1.375,0.78125 V 23 h 1 v -2.0625 c 0.537663,-0.111041 1.024662,-0.383291 1.375,-0.78125 l 1.78125,1.03125 0.5,-0.875 -1.78125,-1.03125 C -12.042937,19.033818 -12,18.774855 -12,18.5 c 0,-0.274855 -0.04294,-0.533818 -0.125,-0.78125 l 1.78125,-1.03125 -0.5,-0.875 -1.78125,1.03125 C -12.977503,16.44333 -13.457682,16.173568 -14,16.0625 V 14 Z m 0.5,3.5 c 0.552,0 1,0.448 1,1 0,0.552 -0.448,1 -1,1 -0.552,0 -1,-0.448 -1,-1 0,-0.552 0.448,-1 1,-1 z" />
+    <path
+       style="opacity:0.3;fill:#fcffff;fill-rule:evenodd"
+       inkscape:connector-curvature="0"
+       id="path14"
+       d="m -19,19 9,-0.0096 c 0,0 0,0 0,-2 C -10,14 -11,14 -14.5,14 c -3.5,0 -4.5,0 -4.5,3 0,2 0,2 0,2 z" />
+  </g>
+</svg>

--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -58,7 +58,15 @@ class QgisInterface : QObject
 
     /* Exposed functions */
 
-    //! Zoom to full extent of map layers
+    virtual QList< QgsMapCanvas* > mapCanvases() = 0;
+
+    virtual QgsMapCanvas* createNewMapCanvas( const QString& name ) = 0;
+
+  public slots:
+
+
+
+
     virtual void zoomFull() = 0;
 
     //! Zoom to previous view extent

--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -62,6 +62,8 @@ class QgisInterface : QObject
 
     virtual QgsMapCanvas* createNewMapCanvas( const QString& name ) = 0;
 
+    virtual void closeMapCanvas( const QString &name ) = 0;
+
   public slots:
 
 

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -97,6 +97,10 @@ class QgsMapCanvas : QGraphicsView
     void setSegmentationTolerance( double tolerance );
     void setSegmentationToleranceType( QgsAbstractGeometry::SegmentationToleranceType type );
 
+    QList< QgsMapCanvasAnnotationItem *> annotationItems() const;
+    bool annotationsVisible() const;
+    void setAnnotationsVisible( bool visible );
+
   public slots:
 
     //! Repaints the canvas map

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -47,6 +47,7 @@ SET(QGIS_APP_SRCS
   qgslabelinggui.cpp
   qgslabelingwidget.cpp
   qgsloadstylefromdbdialog.cpp
+  qgsmapcanvasdockwidget.cpp
   qgsmaplayerstyleguiutils.cpp
   qgsrulebasedlabelingwidget.cpp
   qgssavestyletodbdialog.cpp
@@ -225,6 +226,7 @@ SET (QGIS_APP_MOC_HDRS
   qgslabelingwidget.h
   qgslabelpropertydialog.h
   qgsloadstylefromdbdialog.h
+  qgsmapcanvasdockwidget.h
   qgsmaplayerstyleguiutils.h
   qgsrulebasedlabelingwidget.h
   qgssavestyletodbdialog.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9702,7 +9702,7 @@ void QgisApp::newMapCanvas()
     }
   }
 
-  createNewMapCanvas( name );
+  createNewMapCanvas( name, true );
 }
 
 void QgisApp::setExtent( const QgsRectangle &rect )
@@ -11750,8 +11750,8 @@ void QgisApp::writeProject( QDomDocument &doc )
     node.setAttribute( QStringLiteral( "y" ), w->y() );
     node.setAttribute( QStringLiteral( "width" ), w->width() );
     node.setAttribute( QStringLiteral( "height" ), w->height() );
-    node.setAttribute( QStringLiteral( "floating" ), w->isFloating() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
-    node.setAttribute( QStringLiteral( "synced" ), w->isViewExtentSynchronized() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+    node.setAttribute( QStringLiteral( "floating" ), w->isFloating() );
+    node.setAttribute( QStringLiteral( "synced" ), w->isViewExtentSynchronized() );
     mapViewNode.appendChild( node );
   }
   qgisNode.appendChild( mapViewNode );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3177,7 +3177,7 @@ void QgisApp::closeAdditionalMapCanvases()
   freezeCanvases( true ); // closing docks may cause canvases to resize, and we don't want a map refresh occurring
   Q_FOREACH ( QgsMapCanvasDockWidget *w, findChildren< QgsMapCanvasDockWidget * >() )
   {
-    w->closeWithoutWarning();
+    w->close();
     delete w;
   }
   freezeCanvases( false );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3132,7 +3132,8 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating,
   mapCanvasWidget->setFloating( isFloating );
   if ( dockGeometry.isEmpty() )
   {
-    mapCanvasWidget->resize( 400, 400 );
+    // try to guess a nice initial placement for view - about 3/4 along, half way down
+    mapCanvasWidget->setGeometry( QRect( rect().width() * 0.75, rect().height() * 0.5, 400, 400 ) );
   }
   else
   {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3129,7 +3129,6 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name )
 
   mapCanvas->setLayers( mMapCanvas->layers() );
   mapCanvas->setExtent( mMapCanvas->extent() );
-  mapCanvas->setCachingEnabled( true );
 
   mapCanvas->setDestinationCrs( QgsProject::instance()->crs() );
 
@@ -10609,11 +10608,6 @@ void QgisApp::projectProperties()
            &QgsStatusBarScaleWidget::updateScales );
   QApplication::restoreOverrideCursor();
 
-  //pass any refresh signals off to canvases
-  // Line below was commented out by wonder three years ago (r4949).
-  // It is needed to refresh scale bar after changing display units.
-  connect( pp, SIGNAL( refresh() ), mMapCanvas, SLOT( refresh() ) );
-
   // Display the modal dialog box.
   pp->exec();
 
@@ -10626,7 +10620,7 @@ void QgisApp::projectProperties()
 
   // delete the property sheet object
   delete pp;
-} // QgisApp::projectProperties
+}
 
 
 QgsClipboard *QgisApp::clipboard()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1488,8 +1488,11 @@ void QgisApp::dropEventTimeout()
 void QgisApp::annotationCreated( QgsAnnotation *annotation )
 {
   // create canvas annotation item for annotation
-  QgsMapCanvasAnnotationItem *canvasItem = new QgsMapCanvasAnnotationItem( annotation, mMapCanvas );
-  Q_UNUSED( canvasItem ); //item is already added automatically to canvas scene
+  Q_FOREACH ( QgsMapCanvas *canvas, mapCanvases() )
+  {
+    QgsMapCanvasAnnotationItem *canvasItem = new QgsMapCanvasAnnotationItem( annotation, canvas );
+    Q_UNUSED( canvasItem ); //item is already added automatically to canvas scene
+  }
 }
 
 void QgisApp::registerCustomDropHandler( QgsCustomDropHandler *handler )
@@ -3120,6 +3123,13 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name )
   QgsMapCanvas *mapCanvas = mapCanvasWidget->mapCanvas();
   mapCanvas->freeze( true );
   mapCanvas->setObjectName( name );
+
+  // add existing annotations to canvas
+  Q_FOREACH ( QgsAnnotation *annotation, QgsProject::instance()->annotationManager()->annotations() )
+  {
+    QgsMapCanvasAnnotationItem *canvasItem = new QgsMapCanvasAnnotationItem( annotation, mapCanvas );
+    Q_UNUSED( canvasItem ); //item is already added automatically to canvas scene
+  }
 
   applyProjectSettingsToCanvas( mapCanvas );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3172,6 +3172,7 @@ void QgisApp::closeAdditionalMapCanvases()
   Q_FOREACH ( QgsMapCanvasDockWidget *w, findChildren< QgsMapCanvasDockWidget * >() )
   {
     w->closeWithoutWarning();
+    delete w;
   }
   freezeCanvases( false );
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3176,6 +3176,19 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating,
   return mapCanvas;
 }
 
+void QgisApp::closeMapCanvas( const QString &name )
+{
+  Q_FOREACH ( QgsMapCanvasDockWidget *w, findChildren< QgsMapCanvasDockWidget * >() )
+  {
+    if ( w->mapCanvas()->objectName() == name )
+    {
+      w->close();
+      delete w;
+      break;
+    }
+  }
+}
+
 void QgisApp::closeAdditionalMapCanvases()
 {
   freezeCanvases( true ); // closing docks may cause canvases to resize, and we don't want a map refresh occurring

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3150,7 +3150,19 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name )
 
   addDockWidget( Qt::RightDockWidgetArea, mapCanvasWidget );
   mapCanvas->freeze( false );
+  markDirty();
+  connect( mapCanvasWidget, &QgsMapCanvasDockWidget::closed, this, &QgisApp::markDirty );
   return mapCanvas;
+}
+
+void QgisApp::closeAdditionalMapCanvases()
+{
+  freezeCanvases( true ); // closing docks may cause canvases to resize, and we don't want a map refresh occurring
+  Q_FOREACH ( QgsMapCanvasDockWidget *w, findChildren< QgsMapCanvasDockWidget * >() )
+  {
+    w->closeWithoutWarning();
+  }
+  freezeCanvases( false );
 }
 
 void QgisApp::freezeCanvases( bool frozen )
@@ -9793,6 +9805,8 @@ void QgisApp::closeProject()
   mLegendExpressionFilterButton->setExpressionText( QLatin1String( "" ) );
   mLegendExpressionFilterButton->setChecked( false );
   mActionFilterLegend->setChecked( false );
+
+  closeAdditionalMapCanvases();
 
   deletePrintComposers();
   removeAnnotationItems();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3113,7 +3113,7 @@ QgsMapCanvas *QgisApp::mapCanvas()
   return mMapCanvas;
 }
 
-QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating, const QRect &dockGeometry, bool synced, bool showCursor )
+QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating, const QRect &dockGeometry, bool synced, bool showCursor, bool scaleSynced, double scaleFactor )
 {
   Q_FOREACH ( QgsMapCanvas *canvas, mapCanvases() )
   {
@@ -3168,8 +3168,10 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating,
   connect( mapCanvasWidget, &QgsMapCanvasDockWidget::closed, this, &QgisApp::markDirty );
   connect( mapCanvasWidget, &QgsMapCanvasDockWidget::renameTriggered, this, &QgisApp::renameView );
 
-  mapCanvasWidget->setViewExtentSynchronized( synced );
+  mapCanvasWidget->setViewCenterSynchronized( synced );
   mapCanvasWidget->setCursorMarkerVisible( showCursor );
+  mapCanvasWidget->setScaleFactor( scaleFactor );
+  mapCanvasWidget->setViewScaleSynchronized( scaleSynced );
 
   return mapCanvas;
 }
@@ -11753,8 +11755,10 @@ void QgisApp::writeProject( QDomDocument &doc )
     node.setAttribute( QStringLiteral( "width" ), w->width() );
     node.setAttribute( QStringLiteral( "height" ), w->height() );
     node.setAttribute( QStringLiteral( "floating" ), w->isFloating() );
-    node.setAttribute( QStringLiteral( "synced" ), w->isViewExtentSynchronized() );
+    node.setAttribute( QStringLiteral( "synced" ), w->isViewCenterSynchronized() );
     node.setAttribute( QStringLiteral( "showCursor" ), w->isCursorMarkerVisible() );
+    node.setAttribute( QStringLiteral( "scaleSynced" ), w->isViewScaleSynchronized() );
+    node.setAttribute( QStringLiteral( "scaleFactor" ), w->scaleFactor() );
     mapViewNode.appendChild( node );
   }
   qgisNode.appendChild( mapViewNode );
@@ -11791,8 +11795,10 @@ void QgisApp::readProject( const QDomDocument &doc )
       bool floating = elementNode.attribute( QStringLiteral( "floating" ), QStringLiteral( "0" ) ).toInt();
       bool synced = elementNode.attribute( QStringLiteral( "synced" ), QStringLiteral( "0" ) ).toInt();
       bool showCursor = elementNode.attribute( QStringLiteral( "showCursor" ), QStringLiteral( "0" ) ).toInt();
+      bool scaleSynced = elementNode.attribute( QStringLiteral( "scaleSynced" ), QStringLiteral( "0" ) ).toInt();
+      double scaleFactor = elementNode.attribute( QStringLiteral( "scaleFactor" ), QStringLiteral( "1" ) ).toDouble();
 
-      QgsMapCanvas *mapCanvas = createNewMapCanvas( mapName, floating, QRect( x, y, w, h ), synced, showCursor );
+      QgsMapCanvas *mapCanvas = createNewMapCanvas( mapName, floating, QRect( x, y, w, h ), synced, showCursor, scaleSynced, scaleFactor );
       mapCanvas->readProject( doc );
     }
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3126,6 +3126,7 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating,
 
   QgsMapCanvasDockWidget *mapCanvasWidget = new QgsMapCanvasDockWidget( name, this );
   mapCanvasWidget->setAllowedAreas( Qt::AllDockWidgetAreas );
+  mapCanvasWidget->setMainCanvas( mMapCanvas );
 
   mapCanvasWidget->setFloating( isFloating );
   if ( dockGeometry.isEmpty() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3143,6 +3143,7 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating,
   mapCanvas->freeze( true );
   mapCanvas->setObjectName( name );
   connect( mapCanvas, &QgsMapCanvas::messageEmitted, this, &QgisApp::displayMessage );
+  connect( mLayerTreeCanvasBridge, &QgsLayerTreeMapCanvasBridge::canvasLayersChanged, mapCanvas, &QgsMapCanvas::setLayers );
 
   applyProjectSettingsToCanvas( mapCanvas );
   applyDefaultSettingsToCanvas( mapCanvas );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2560,7 +2560,7 @@ void QgisApp::createStatusBar()
                                    "the rotation" ) );
   mRotationEdit->setToolTip( tr( "Current clockwise map rotation in degrees" ) );
   statusBar()->addPermanentWidget( mRotationEdit, 0 );
-  connect( mRotationEdit, SIGNAL( valueChanged( double ) ), this, SLOT( userRotation() ) );
+  connect( mRotationEdit, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgisApp::userRotation );
 
   showRotation();
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3113,7 +3113,7 @@ QgsMapCanvas *QgisApp::mapCanvas()
   return mMapCanvas;
 }
 
-QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating, const QRect &dockGeometry, bool synced )
+QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating, const QRect &dockGeometry, bool synced, bool showCursor )
 {
   Q_FOREACH ( QgsMapCanvas *canvas, mapCanvases() )
   {
@@ -3169,6 +3169,7 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating,
   connect( mapCanvasWidget, &QgsMapCanvasDockWidget::renameTriggered, this, &QgisApp::renameView );
 
   mapCanvasWidget->setViewExtentSynchronized( synced );
+  mapCanvasWidget->setCursorMarkerVisible( showCursor );
 
   return mapCanvas;
 }
@@ -11753,6 +11754,7 @@ void QgisApp::writeProject( QDomDocument &doc )
     node.setAttribute( QStringLiteral( "height" ), w->height() );
     node.setAttribute( QStringLiteral( "floating" ), w->isFloating() );
     node.setAttribute( QStringLiteral( "synced" ), w->isViewExtentSynchronized() );
+    node.setAttribute( QStringLiteral( "showCursor" ), w->isCursorMarkerVisible() );
     mapViewNode.appendChild( node );
   }
   qgisNode.appendChild( mapViewNode );
@@ -11788,8 +11790,9 @@ void QgisApp::readProject( const QDomDocument &doc )
       int h = elementNode.attribute( QStringLiteral( "height" ), QStringLiteral( "400" ) ).toInt();
       bool floating = elementNode.attribute( QStringLiteral( "floating" ), QStringLiteral( "0" ) ).toInt();
       bool synced = elementNode.attribute( QStringLiteral( "synced" ), QStringLiteral( "0" ) ).toInt();
+      bool showCursor = elementNode.attribute( QStringLiteral( "showCursor" ), QStringLiteral( "0" ) ).toInt();
 
-      QgsMapCanvas *mapCanvas = createNewMapCanvas( mapName, floating, QRect( x, y, w, h ), synced );
+      QgsMapCanvas *mapCanvas = createNewMapCanvas( mapName, floating, QRect( x, y, w, h ), synced, showCursor );
       mapCanvas->readProject( doc );
     }
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -185,6 +185,7 @@
 #include "qgslayertreeviewdefaultactions.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
+#include "qgsmapcanvasdockwidget.h"
 #include "qgsmapcanvassnappingutils.h"
 #include "qgsmapcanvastracer.h"
 #include "qgsmaplayer.h"
@@ -3113,19 +3114,18 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name )
     }
   }
 
-  QgsMapCanvas *mapCanvas = new QgsMapCanvas( this );
-  \
+  QgsMapCanvasDockWidget *mapCanvasWidget = new QgsMapCanvasDockWidget( name, this );
+  mapCanvasWidget->setAllowedAreas( Qt::AllDockWidgetAreas );
+
+  QgsMapCanvas *mapCanvas = mapCanvasWidget->mapCanvas();
   mapCanvas->freeze( true );
   mapCanvas->setObjectName( name );
 
-  QDockWidget *mapWidget = new QDockWidget( name, this );
-  mapWidget->setAllowedAreas( Qt::AllDockWidgetAreas );
-  mapWidget->setWidget( mapCanvas );
   applyProjectSettingsToCanvas( mapCanvas );
 
   mapCanvas->setDestinationCrs( QgsProject::instance()->crs() );
 
-  addDockWidget( Qt::RightDockWidgetArea, mapWidget );
+  addDockWidget( Qt::RightDockWidgetArea, mapCanvasWidget );
   mapCanvas->freeze( false );
   return mapCanvas;
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3113,7 +3113,7 @@ QgsMapCanvas *QgisApp::mapCanvas()
   return mMapCanvas;
 }
 
-QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating, const QRect &dockGeometry )
+QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating, const QRect &dockGeometry, bool synced )
 {
   Q_FOREACH ( QgsMapCanvas *canvas, mapCanvases() )
   {
@@ -3166,6 +3166,9 @@ QgsMapCanvas *QgisApp::createNewMapCanvas( const QString &name, bool isFloating,
   markDirty();
   connect( mapCanvasWidget, &QgsMapCanvasDockWidget::closed, this, &QgisApp::markDirty );
   connect( mapCanvasWidget, &QgsMapCanvasDockWidget::renameTriggered, this, &QgisApp::renameView );
+
+  mapCanvasWidget->setViewExtentSynchronized( synced );
+
   return mapCanvas;
 }
 
@@ -11748,6 +11751,7 @@ void QgisApp::writeProject( QDomDocument &doc )
     node.setAttribute( QStringLiteral( "width" ), w->width() );
     node.setAttribute( QStringLiteral( "height" ), w->height() );
     node.setAttribute( QStringLiteral( "floating" ), w->isFloating() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+    node.setAttribute( QStringLiteral( "synced" ), w->isViewExtentSynchronized() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
     mapViewNode.appendChild( node );
   }
   qgisNode.appendChild( mapViewNode );
@@ -11782,8 +11786,9 @@ void QgisApp::readProject( const QDomDocument &doc )
       int w = elementNode.attribute( QStringLiteral( "width" ), QStringLiteral( "400" ) ).toInt();
       int h = elementNode.attribute( QStringLiteral( "height" ), QStringLiteral( "400" ) ).toInt();
       bool floating = elementNode.attribute( QStringLiteral( "floating" ), QStringLiteral( "0" ) ).toInt();
+      bool synced = elementNode.attribute( QStringLiteral( "synced" ), QStringLiteral( "0" ) ).toInt();
 
-      QgsMapCanvas *mapCanvas = createNewMapCanvas( mapName, floating, QRect( x, y, w, h ) );
+      QgsMapCanvas *mapCanvas = createNewMapCanvas( mapName, floating, QRect( x, y, w, h ), synced );
       mapCanvas->readProject( doc );
     }
   }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -246,6 +246,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
                                       double scaleFactor = 1.0 );
 
     /**
+     * Closes the additional map canvas with matching \a name.
+     */
+    void closeMapCanvas( const QString &name );
+
+    /**
      * Closes any additional map canvases. The main map canvas will not
      * be affected.
      */

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -241,7 +241,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * and \a dockGeometry arguments can be used to specify an initial floating state
      * and widget geometry rect for the dock.
      */
-    QgsMapCanvas *createNewMapCanvas( const QString &name, bool isFloating = false, const QRect &dockGeometry = QRect() );
+    QgsMapCanvas *createNewMapCanvas( const QString &name, bool isFloating = false, const QRect &dockGeometry = QRect(),
+                                      bool synced = false );
 
     /**
      * Closes any additional map canvases. The main map canvas will not

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -236,8 +236,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     QList< QgsMapCanvas * > mapCanvases();
 
-    //! Create a new map canvas with the specified unique \a name
-    QgsMapCanvas *createNewMapCanvas( const QString &name );
+    /**
+     * Create a new map canvas with the specified unique \a name. The \a isFloating
+     * and \a dockGeometry arguments can be used to specify an initial floating state
+     * and widget geometry rect for the dock.
+     */
+    QgsMapCanvas *createNewMapCanvas( const QString &name, bool isFloating = false, const QRect &dockGeometry = QRect() );
 
     /**
      * Closes any additional map canvases. The main map canvas will not

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1563,6 +1563,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     void applyProjectSettingsToCanvas( QgsMapCanvas *canvas );
 
+    /**
+     * Applies global qgis settings to the specified canvas
+     */
+    void applyDefaultSettingsToCanvas( QgsMapCanvas *canvas );
+
     QgisAppStyleSheet *mStyleSheetBuilder = nullptr;
 
     // actions for menus and toolbars -----------------

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -231,6 +231,14 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Get the mapcanvas object from the app
     QgsMapCanvas *mapCanvas();
 
+    /**
+     * Returns a list of all map canvases open in the app.
+     */
+    QList< QgsMapCanvas * > mapCanvases();
+
+    //! Create a new map canvas with the specified unique \a name
+    QgsMapCanvas *createNewMapCanvas( const QString &name );
+
     //! Return the messageBar object which allows displaying unobtrusive messages to the user.
     QgsMessageBar *messageBar();
 
@@ -1024,6 +1032,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void showAlignRasterTool();
     void embedLayers();
 
+    //! Creates a new map canvas view
+    void newMapCanvas();
+
     //! Create a new empty vector layer
     void newVectorLayer();
     //! Create a new memory layer
@@ -1513,6 +1524,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Returns all annotation items in the canvas
     QList<QgsMapCanvasAnnotationItem *> annotationItems();
+
     //! Removes annotation items in the canvas
     void removeAnnotationItems();
 
@@ -1754,6 +1766,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QSplashScreen *mSplash = nullptr;
     //! list of recently opened/saved project files
     QList<QgsWelcomePageItemsModel::RecentProjectData> mRecentProjects;
+
     //! Print composers of this project, accessible by id string
     QSet<QgsComposer *> mPrintComposers;
     //! QGIS-internal vector feature clipboard

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -239,6 +239,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Create a new map canvas with the specified unique \a name
     QgsMapCanvas *createNewMapCanvas( const QString &name );
 
+    /**
+     * Freezes all map canvases (or thaws them if the \a frozen argument is false).
+     */
+    void freezeCanvases( bool frozen = true );
+
     //! Return the messageBar object which allows displaying unobtrusive messages to the user.
     QgsMessageBar *messageBar();
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -240,6 +240,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsMapCanvas *createNewMapCanvas( const QString &name );
 
     /**
+     * Closes any additional map canvases. The main map canvas will not
+     * be affected.
+     */
+    void closeAdditionalMapCanvases();
+
+    /**
      * Freezes all map canvases (or thaws them if the \a frozen argument is false).
      */
     void freezeCanvases( bool frozen = true );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -242,7 +242,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * and widget geometry rect for the dock.
      */
     QgsMapCanvas *createNewMapCanvas( const QString &name, bool isFloating = false, const QRect &dockGeometry = QRect(),
-                                      bool synced = false );
+                                      bool synced = false, bool showCursor = true );
 
     /**
      * Closes any additional map canvases. The main map canvas will not

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -759,6 +759,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QMenu *panelMenu() { return mPanelMenu; }
 
+    void renameView();
+
   protected:
 
     //! Handle state changes (WindowTitleChange)

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -242,7 +242,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * and widget geometry rect for the dock.
      */
     QgsMapCanvas *createNewMapCanvas( const QString &name, bool isFloating = false, const QRect &dockGeometry = QRect(),
-                                      bool synced = false, bool showCursor = true );
+                                      bool synced = false, bool showCursor = true, bool scaleSynced = false,
+                                      double scaleFactor = 1.0 );
 
     /**
      * Closes any additional map canvases. The main map canvas will not

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -341,6 +341,11 @@ QgsMapCanvas *QgisAppInterface::createNewMapCanvas( const QString &name )
   return qgis->createNewMapCanvas( name );
 }
 
+void QgisAppInterface::closeMapCanvas( const QString &name )
+{
+  qgis->closeMapCanvas( name );
+}
+
 QgsLayerTreeMapCanvasBridge *QgisAppInterface::layerTreeCanvasBridge()
 {
   return qgis->layerTreeCanvasBridge();

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -331,6 +331,16 @@ QgsMapCanvas *QgisAppInterface::mapCanvas()
   return qgis->mapCanvas();
 }
 
+QList<QgsMapCanvas *> QgisAppInterface::mapCanvases()
+{
+  return qgis->mapCanvases();
+}
+
+QgsMapCanvas *QgisAppInterface::createNewMapCanvas( const QString &name )
+{
+  return qgis->createNewMapCanvas( name );
+}
+
 QgsLayerTreeMapCanvasBridge *QgisAppInterface::layerTreeCanvasBridge()
 {
   return qgis->layerTreeCanvasBridge();

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -179,6 +179,9 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     //! Return a pointer to the map canvas used by qgisapp
     QgsMapCanvas *mapCanvas() override;
 
+    QList< QgsMapCanvas * > mapCanvases() override;
+    QgsMapCanvas *createNewMapCanvas( const QString &name ) override;
+
     /**
      * Returns a pointer to the layer tree canvas bridge
      *

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -181,6 +181,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
 
     QList< QgsMapCanvas * > mapCanvases() override;
     QgsMapCanvas *createNewMapCanvas( const QString &name ) override;
+    virtual void closeMapCanvas( const QString &name ) override;
 
     /**
      * Returns a pointer to the layer tree canvas bridge

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -130,7 +130,7 @@ bool QgsGuiVectorLayerTools::stopEditing( QgsVectorLayer *layer, bool allowCance
         break;
 
       case QMessageBox::Discard:
-        QgisApp::instance()->mapCanvas()->freeze( true );
+        QgisApp::instance()->freezeCanvases();
         if ( !layer->rollBack() )
         {
           QgisApp::instance()->messageBar()->pushMessage( tr( "Error" ),
@@ -138,7 +138,7 @@ bool QgsGuiVectorLayerTools::stopEditing( QgsVectorLayer *layer, bool allowCance
               QgsMessageBar::CRITICAL );
           res = false;
         }
-        QgisApp::instance()->mapCanvas()->freeze( false );
+        QgisApp::instance()->freezeCanvases( false );
 
         layer->triggerRepaint();
         break;
@@ -149,9 +149,9 @@ bool QgsGuiVectorLayerTools::stopEditing( QgsVectorLayer *layer, bool allowCance
   }
   else //layer not modified
   {
-    QgisApp::instance()->mapCanvas()->freeze( true );
+    QgisApp::instance()->freezeCanvases( true );
     layer->rollBack();
-    QgisApp::instance()->mapCanvas()->freeze( false );
+    QgisApp::instance()->freezeCanvases( false );
     res = true;
     layer->triggerRepaint();
   }

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -19,6 +19,7 @@
 #include "qgsstatusbarmagnifierwidget.h"
 #include "qgsdoublespinbox.h"
 #include "qgssettings.h"
+#include "qgsmaptoolpan.h"
 #include <QMessageBox>
 #include <QMenu>
 #include <QToolBar>
@@ -36,6 +37,8 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   setWindowTitle( name );
   mMapCanvas = new QgsMapCanvas( this );
+  mPanTool = new QgsMapToolPan( mMapCanvas );
+  mMapCanvas->setMapTool( mPanTool );
 
   mMainWidget->setLayout( new QVBoxLayout() );
   mMainWidget->layout()->setContentsMargins( 0, 0, 0, 0 );

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -17,7 +17,6 @@
 #include "qgscsexception.h"
 #include "qgsprojectionselectiondialog.h"
 #include "qgsscalecombobox.h"
-#include "qgsstatusbarmagnifierwidget.h"
 #include "qgsdoublespinbox.h"
 #include "qgssettings.h"
 #include "qgsmaptoolpan.h"
@@ -171,12 +170,6 @@ QgsMapCanvas *QgsMapCanvasDockWidget::mapCanvas()
   return mMapCanvas;
 }
 
-void QgsMapCanvasDockWidget::closeWithoutWarning()
-{
-  mShowCloseWarning = false;
-  close();
-}
-
 void QgsMapCanvasDockWidget::setViewExtentSynchronized( bool enabled )
 {
   mActionSyncView->setChecked( enabled );
@@ -185,20 +178,6 @@ void QgsMapCanvasDockWidget::setViewExtentSynchronized( bool enabled )
 bool QgsMapCanvasDockWidget::isViewExtentSynchronized() const
 {
   return mActionSyncView->isChecked();
-}
-
-void QgsMapCanvasDockWidget::closeEvent( QCloseEvent *event )
-{
-  if ( mShowCloseWarning && mMapCanvas->layerCount() > 0
-       && QMessageBox::question( this, tr( "Close map view" ),
-                                 tr( "Are you sure you want to close this map view?" ), QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) == QMessageBox::No )
-  {
-    event->ignore();
-  }
-  else
-  {
-    event->accept();
-  }
 }
 
 void QgsMapCanvasDockWidget::setMapCrs()

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+    qgsmapcanvasdockwidget.cpp
+    --------------------------
+    begin                : February 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsmapcanvasdockwidget.h"
+#include "qgsmapcanvas.h"
+#include "qgsprojectionselectiondialog.h"
+
+QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *parent )
+  : QgsDockWidget( parent )
+{
+  setupUi( this );
+
+  mContents->layout()->setContentsMargins( 0, 0, 0, 0 );
+  mContents->layout()->setMargin( 0 );
+  static_cast< QVBoxLayout * >( mContents->layout() )->setSpacing( 0 );
+
+  setWindowTitle( name );
+  mMapCanvas = new QgsMapCanvas( this );
+
+  mMainWidget->setLayout( new QVBoxLayout() );
+  mMainWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
+  mMainWidget->layout()->setMargin( 0 );
+
+  mMainWidget->layout()->addWidget( mMapCanvas );
+
+  connect( mActionSetCrs, &QAction::triggered, this, &QgsMapCanvasDockWidget::setMapCrs );
+}
+
+QgsMapCanvas *QgsMapCanvasDockWidget::mapCanvas()
+{
+  return mMapCanvas;
+}
+
+void QgsMapCanvasDockWidget::setMapCrs()
+{
+  QgsProjectionSelectionDialog dlg;
+  dlg.setCrs( mMapCanvas->mapSettings().destinationCrs() );
+
+  if ( dlg.exec() )
+  {
+    mMapCanvas->setDestinationCrs( dlg.crs() );
+  }
+}

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -87,9 +87,14 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   settingsMenu->addSeparator();
   settingsMenu->addAction( mActionSetCrs );
+  settingsMenu->addAction( mActionShowAnnotations );
   settingsMenu->addAction( mActionRename );
-  settingsMenu->addSeparator();
+
+  connect( settingsMenu, &QMenu::aboutToShow, this, &QgsMapCanvasDockWidget::settingsMenuAboutToShow );
+
   connect( mActionRename, &QAction::triggered, this, &QgsMapCanvasDockWidget::renameTriggered );
+  mActionShowAnnotations->setChecked( mMapCanvas->annotationsVisible() );
+  connect( mActionShowAnnotations, &QAction::toggled, this, [ = ]( bool checked ) { mMapCanvas->setAnnotationsVisible( checked ); } );
 
   mScaleCombo = settingsAction->scaleCombo();
   mRotationEdit = settingsAction->rotationSpinBox();
@@ -277,6 +282,11 @@ void QgsMapCanvasDockWidget::menuAboutToShow()
     mMenuPresetActions.append( a );
   }
   mMenu->addActions( mMenuPresetActions );
+}
+
+void QgsMapCanvasDockWidget::settingsMenuAboutToShow()
+{
+  whileBlocking( mActionShowAnnotations )->setChecked( mMapCanvas->annotationsVisible() );
 }
 
 

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -59,10 +59,15 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   connect( mActionSetCrs, &QAction::triggered, this, &QgsMapCanvasDockWidget::setMapCrs );
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::mapCrsChanged );
   mapCrsChanged();
-  menu->addAction( mActionSetCrs );
 
   QgsMapSettingsAction *settingsAction = new QgsMapSettingsAction( menu );
   menu->addAction( settingsAction );
+
+  menu->addSeparator();
+  menu->addAction( mActionSetCrs );
+  menu->addAction( mActionRename );
+  connect( mActionRename, &QAction::triggered, this, &QgsMapCanvasDockWidget::renameTriggered );
+
   mScaleCombo = settingsAction->scaleCombo();
   mRotationEdit = settingsAction->rotationSpinBox();
   mMagnificationEdit = settingsAction->magnifierSpinBox();

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -177,6 +177,16 @@ void QgsMapCanvasDockWidget::closeWithoutWarning()
   close();
 }
 
+void QgsMapCanvasDockWidget::setViewExtentSynchronized( bool enabled )
+{
+  mActionSyncView->setChecked( enabled );
+}
+
+bool QgsMapCanvasDockWidget::isViewExtentSynchronized() const
+{
+  return mActionSyncView->isChecked();
+}
+
 void QgsMapCanvasDockWidget::closeEvent( QCloseEvent *event )
 {
   if ( mShowCloseWarning && mMapCanvas->layerCount() > 0

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -24,6 +24,9 @@
 #include "qgsmapthemecollection.h"
 #include "qgsproject.h"
 #include "qgsmapthemes.h"
+#include "qgslayertreeview.h"
+#include "qgslayertreeviewdefaultactions.h"
+#include "qgisapp.h"
 #include <QMessageBox>
 #include <QMenu>
 #include <QToolBar>
@@ -65,7 +68,8 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   QMenu *settingsMenu = new QMenu();
   QToolButton *settingsButton = new QToolButton();
-  btnMapThemes->setAutoRaise( true );
+  settingsButton->setAutoRaise( true );
+  settingsButton->setToolTip( tr( "View Settings" ) );
   settingsButton->setMenu( settingsMenu );
   settingsButton->setPopupMode( QToolButton::InstantPopup );
   settingsButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapSettings.svg" ) ) );
@@ -73,6 +77,9 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   connect( mActionSetCrs, &QAction::triggered, this, &QgsMapCanvasDockWidget::setMapCrs );
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::mapCrsChanged );
+  connect( mActionZoomFullExtent, &QAction::triggered, mMapCanvas, &QgsMapCanvas::zoomToFullExtent );
+  connect( mActionZoomToLayer, &QAction::triggered, mMapCanvas, [ = ] { QgisApp::instance()->layerTreeView()->defaultActions()->zoomToLayer( mMapCanvas ); } );
+  connect( mActionZoomToSelected, &QAction::triggered, mMapCanvas, [ = ] { mMapCanvas->zoomToSelected(); } );
   mapCrsChanged();
 
   QgsMapSettingsAction *settingsAction = new QgsMapSettingsAction( settingsMenu );

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -261,7 +261,7 @@ void QgsMapCanvasDockWidget::mapExtentChanged()
 
 void QgsMapCanvasDockWidget::mapCrsChanged()
 {
-  mActionSetCrs->setText( tr( "Change Map CRS (%1)" ).arg( mMapCanvas->mapSettings().destinationCrs().isValid() ?
+  mActionSetCrs->setText( tr( "Change Map CRS (%1)…" ).arg( mMapCanvas->mapSettings().destinationCrs().isValid() ?
                           mMapCanvas->mapSettings().destinationCrs().authid() :
                           tr( "No projection" ) ) );
 }

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -44,9 +44,15 @@ QgsMapCanvas *QgsMapCanvasDockWidget::mapCanvas()
   return mMapCanvas;
 }
 
+void QgsMapCanvasDockWidget::closeWithoutWarning()
+{
+  mShowCloseWarning = false;
+  close();
+}
+
 void QgsMapCanvasDockWidget::closeEvent( QCloseEvent *event )
 {
-  if ( mMapCanvas->layerCount() > 0
+  if ( mShowCloseWarning && mMapCanvas->layerCount() > 0
        && QMessageBox::question( this, tr( "Close map view" ),
                                  tr( "Are you sure you want to close this map view?" ), QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) == QMessageBox::No )
   {

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -43,7 +43,6 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   mMainWidget->layout()->addWidget( mMapCanvas );
 
-  connect( mActionSetCrs, &QAction::triggered, this, &QgsMapCanvasDockWidget::setMapCrs );
   connect( mActionSyncView, &QAction::toggled, this, &QgsMapCanvasDockWidget::syncView );
 
   QMenu *menu = new QMenu();
@@ -53,6 +52,11 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
   toolButton->setPopupMode( QToolButton::InstantPopup );
   toolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapSettings.svg" ) ) );
   mToolbar->addWidget( toolButton );
+
+  connect( mActionSetCrs, &QAction::triggered, this, &QgsMapCanvasDockWidget::setMapCrs );
+  connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMapCanvasDockWidget::mapCrsChanged );
+  mapCrsChanged();
+  menu->addAction( mActionSetCrs );
 
   QgsMapSettingsAction *settingsAction = new QgsMapSettingsAction( menu );
   menu->addAction( settingsAction );
@@ -186,6 +190,13 @@ void QgsMapCanvasDockWidget::mapExtentChanged()
   destCanvas->refresh();
 
   syncView( true );
+}
+
+void QgsMapCanvasDockWidget::mapCrsChanged()
+{
+  mActionSetCrs->setText( tr( "Change Map CRS (%1)" ).arg( mMapCanvas->mapSettings().destinationCrs().isValid() ?
+                          mMapCanvas->mapSettings().destinationCrs().authid() :
+                          tr( "No projection" ) ) );
 }
 
 QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -44,6 +44,7 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   setWindowTitle( name );
   mMapCanvas = new QgsMapCanvas( this );
+
   mPanTool = new QgsMapToolPan( mMapCanvas );
   mMapCanvas->setMapTool( mPanTool );
 
@@ -53,7 +54,11 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   mMainWidget->layout()->addWidget( mMapCanvas );
 
-  connect( mActionSyncView, &QAction::toggled, this, &QgsMapCanvasDockWidget::syncView );
+  connect( mActionSyncView, &QAction::toggled, this, [ = ]( bool active )
+  {
+    syncViewExtent( mMainCanvas );
+    syncView( active );
+  } );
 
   mMenu = new QMenu();
   connect( mMenu, &QMenu::aboutToShow, this, &QgsMapCanvasDockWidget::menuAboutToShow );
@@ -212,12 +217,8 @@ void QgsMapCanvasDockWidget::syncView( bool enabled )
   }
 }
 
-void QgsMapCanvasDockWidget::mapExtentChanged()
+void QgsMapCanvasDockWidget::syncViewExtent( QgsMapCanvas *sourceCanvas )
 {
-  QgsMapCanvas *sourceCanvas = qobject_cast< QgsMapCanvas * >( sender() );
-  if ( !sourceCanvas )
-    return;
-
   // avoid infinite recursion
   syncView( false );
 
@@ -237,6 +238,15 @@ void QgsMapCanvasDockWidget::mapExtentChanged()
   destCanvas->refresh();
 
   syncView( true );
+}
+
+void QgsMapCanvasDockWidget::mapExtentChanged()
+{
+  QgsMapCanvas *sourceCanvas = qobject_cast< QgsMapCanvas * >( sender() );
+  if ( !sourceCanvas )
+    return;
+
+  syncViewExtent( sourceCanvas );
 }
 
 void QgsMapCanvasDockWidget::mapCrsChanged()

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -15,11 +15,13 @@
 #include "qgsmapcanvasdockwidget.h"
 #include "qgsmapcanvas.h"
 #include "qgsprojectionselectiondialog.h"
+#include <QMessageBox>
 
 QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *parent )
   : QgsDockWidget( parent )
 {
   setupUi( this );
+  setAttribute( Qt::WA_DeleteOnClose );
 
   mContents->layout()->setContentsMargins( 0, 0, 0, 0 );
   mContents->layout()->setMargin( 0 );
@@ -42,9 +44,24 @@ QgsMapCanvas *QgsMapCanvasDockWidget::mapCanvas()
   return mMapCanvas;
 }
 
+void QgsMapCanvasDockWidget::closeEvent( QCloseEvent *event )
+{
+  if ( mMapCanvas->layerCount() > 0
+       && QMessageBox::question( this, tr( "Close map view" ),
+                                 tr( "Are you sure you want to close this map view?" ), QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) == QMessageBox::No )
+  {
+    event->ignore();
+  }
+  else
+  {
+    event->accept();
+  }
+}
+
 void QgsMapCanvasDockWidget::setMapCrs()
 {
   QgsProjectionSelectionDialog dlg;
+  dlg.setShowNoProjection( true );
   dlg.setCrs( mMapCanvas->mapSettings().destinationCrs() );
 
   if ( dlg.exec() )

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -1,0 +1,48 @@
+/***************************************************************************
+    qgsmapcanvasdockwidget.h
+    ------------------------
+    begin                : February 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSMAPCANVASDOCKWIDGET_H
+#define QGSMAPCANVASDOCKWIDGET_H
+
+#include <ui_qgsmapcanvasdockwidgetbase.h>
+
+#include "qgsdockwidget.h"
+#include "qgis_app.h"
+
+class QgsMapCanvas;
+
+class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsMapCanvasDockWidgetBase
+{
+    Q_OBJECT
+  public:
+    explicit QgsMapCanvasDockWidget( const QString &name, QWidget *parent = nullptr );
+
+    /**
+     * Returns the map canvas contained in the dock widget.
+     */
+    QgsMapCanvas *mapCanvas();
+
+  private slots:
+
+    void setMapCrs();
+
+  private:
+
+    QgsMapCanvas *mMapCanvas = nullptr;
+
+
+};
+
+
+#endif // QGSMAPCANVASDOCKWIDGET_H

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -18,6 +18,7 @@
 #include <ui_qgsmapcanvasdockwidgetbase.h>
 
 #include "qgsdockwidget.h"
+#include "qgspoint.h"
 #include "qgis_app.h"
 #include <QWidgetAction>
 #include <QTimer>
@@ -28,6 +29,7 @@ class QgsScaleComboBox;
 class QgsDoubleSpinBox;
 class QgsStatusBarMagnifierWidget;
 class QgsMapToolPan;
+class QgsVertexMarker;
 
 /**
  * \class QgsMapCanvasDockWidget
@@ -43,7 +45,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     /**
      * Sets the main app map canvas.
      */
-    void setMainCanvas( QgsMapCanvas *canvas ) { mMainCanvas = canvas; }
+    void setMainCanvas( QgsMapCanvas *canvas );
 
     /**
      * Returns the map canvas contained in the dock widget.
@@ -52,10 +54,27 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
 
     /**
      * Sets whether the view extent should be synchronized with the main canvas extent.
+     * @see isViewExtentSynchronized()
      */
     void setViewExtentSynchronized( bool enabled );
 
+    /**
+     * Returns true if the view extent is synchronized with the main canvas extent.
+     * @see setViewExtentSynchronized()
+     */
     bool isViewExtentSynchronized() const;
+
+    /**
+     * Sets whether the cursor position marker is visible.
+     * @see isCursorMarkerVisible()
+     */
+    void setCursorMarkerVisible( bool visible );
+
+    /**
+     * Returns true if the cursor position marker is visible.
+     * @see setCursorMarkerVisible()
+     */
+    bool isCursorMarkerVisible() const;
 
   signals:
 
@@ -73,6 +92,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     void mapCrsChanged();
     void menuAboutToShow();
     void settingsMenuAboutToShow();
+    void syncMarker( const QgsPoint &p );
 
   private:
 
@@ -89,6 +109,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     bool mBlockExtentSync = false;
     QgsMapToolPan *mPanTool = nullptr;
     QTimer mResizeTimer;
+    QgsVertexMarker *mXyMarker = nullptr;
     void syncViewExtent( QgsMapCanvas *sourceCanvas );
 };
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -30,6 +30,7 @@ class QgsDoubleSpinBox;
 class QgsStatusBarMagnifierWidget;
 class QgsMapToolPan;
 class QgsVertexMarker;
+class QCheckBox;
 
 /**
  * \class QgsMapCanvasDockWidget
@@ -53,16 +54,16 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     QgsMapCanvas *mapCanvas();
 
     /**
-     * Sets whether the view extent should be synchronized with the main canvas extent.
-     * @see isViewExtentSynchronized()
+     * Sets whether the view center should be synchronized with the main canvas center.
+     * @see isViewCenterSynchronized()
      */
-    void setViewExtentSynchronized( bool enabled );
+    void setViewCenterSynchronized( bool enabled );
 
     /**
      * Returns true if the view extent is synchronized with the main canvas extent.
-     * @see setViewExtentSynchronized()
+     * @see setViewCenterSynchronized()
      */
-    bool isViewExtentSynchronized() const;
+    bool isViewCenterSynchronized() const;
 
     /**
      * Sets whether the cursor position marker is visible.
@@ -76,6 +77,34 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
      */
     bool isCursorMarkerVisible() const;
 
+    /**
+     * Returns the scaling factor for main canvas scale to view scale.
+     * @see setScaleFactor()
+     * @see isViewScaleSynchronized()
+     */
+    double scaleFactor() const;
+
+    /**
+     * Sets the scaling \a factor for main canvas scale to view scale.
+     * @see scaleFactor()
+     * @see setViewScaleSynchronized()
+     */
+    void setScaleFactor( double factor );
+
+    /**
+     * Sets whether the view scale should be synchronized with the main canvas center.
+     * @see isViewScaleSynchronized()
+     * @see setScaleFactor()
+     */
+    void setViewScaleSynchronized( bool enabled );
+
+    /**
+     * Returns true if the view scale is synchronized with the main canvas extent.
+     * @see setViewScaleSynchronized()
+     * @see scaleFactor()
+     */
+    bool isViewScaleSynchronized() const;
+
   signals:
 
     void renameTriggered();
@@ -87,12 +116,12 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
   private slots:
 
     void setMapCrs();
-    void syncView( bool enabled );
     void mapExtentChanged();
     void mapCrsChanged();
     void menuAboutToShow();
     void settingsMenuAboutToShow();
     void syncMarker( const QgsPoint &p );
+    void mapScaleChanged();
 
   private:
 
@@ -103,6 +132,8 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     QgsScaleComboBox *mScaleCombo = nullptr;
     QgsDoubleSpinBox *mRotationEdit = nullptr;
     QgsDoubleSpinBox *mMagnificationEdit = nullptr;
+    QgsDoubleSpinBox *mScaleFactorWidget = nullptr;
+    QCheckBox *mSyncScaleCheckBox = nullptr;
     bool mBlockScaleUpdate = false;
     bool mBlockRotationUpdate = false;
     bool mBlockMagnificationUpdate = false;
@@ -110,7 +141,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     QgsMapToolPan *mPanTool = nullptr;
     QTimer mResizeTimer;
     QgsVertexMarker *mXyMarker = nullptr;
-    void syncViewExtent( QgsMapCanvas *sourceCanvas );
+    void syncViewCenter( QgsMapCanvas *sourceCanvas );
 };
 
 /**
@@ -130,11 +161,15 @@ class QgsMapSettingsAction: public QWidgetAction
     QgsScaleComboBox *scaleCombo() { return mScaleCombo; }
     QgsDoubleSpinBox *rotationSpinBox() { return mRotationWidget; }
     QgsDoubleSpinBox *magnifierSpinBox() { return mMagnifierWidget; }
+    QgsDoubleSpinBox *scaleFactorSpinBox() { return mScaleFactorWidget; }
+    QCheckBox *syncScaleCheckBox() { return mSyncScaleCheckBox; }
 
   private:
     QgsScaleComboBox *mScaleCombo = nullptr;
     QgsDoubleSpinBox *mRotationWidget = nullptr;
     QgsDoubleSpinBox *mMagnifierWidget = nullptr;
+    QCheckBox *mSyncScaleCheckBox = nullptr;
+    QgsDoubleSpinBox *mScaleFactorWidget = nullptr;
 };
 
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -33,6 +33,10 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
      */
     QgsMapCanvas *mapCanvas();
 
+  protected:
+
+    virtual void closeEvent( QCloseEvent *event ) override;
+
   private slots:
 
     void setMapCrs();

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -69,6 +69,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     void mapExtentChanged();
     void mapCrsChanged();
     void menuAboutToShow();
+    void settingsMenuAboutToShow();
 
   private:
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -61,6 +61,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     void setMapCrs();
     void syncView( bool enabled );
     void mapExtentChanged();
+    void mapCrsChanged();
 
   private:
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -50,11 +50,6 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     QgsMapCanvas *mapCanvas();
 
     /**
-     * Closes the dock, bypassing the usual warning prompt.
-     */
-    void closeWithoutWarning();
-
-    /**
      * Sets whether the view extent should be synchronized with the main canvas extent.
      */
     void setViewExtentSynchronized( bool enabled );
@@ -64,10 +59,6 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
   signals:
 
     void renameTriggered();
-
-  protected:
-
-    virtual void closeEvent( QCloseEvent *event ) override;
 
   private slots:
 
@@ -82,7 +73,6 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMapCanvas *mMainCanvas = nullptr;
-    bool mShowCloseWarning = true;
     QMenu *mMenu = nullptr;
     QList<QAction *> mMenuPresetActions;
     QgsScaleComboBox *mScaleCombo = nullptr;

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -54,6 +54,10 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
      */
     void closeWithoutWarning();
 
+  signals:
+
+    void renameTriggered();
+
   protected:
 
     virtual void closeEvent( QCloseEvent *event ) override;

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -19,9 +19,16 @@
 
 #include "qgsdockwidget.h"
 #include "qgis_app.h"
+#include <QWidgetAction>
 
 class QgsMapCanvas;
+class QgsScaleComboBox;
 
+/**
+ * \class QgsMapCanvasDockWidget
+ * A dock widget with an embedded map canvas, for additional map views.
+ * \note added in QGIS 3.0
+ */
 class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsMapCanvasDockWidgetBase
 {
     Q_OBJECT
@@ -58,8 +65,28 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMapCanvas *mMainCanvas = nullptr;
     bool mShowCloseWarning = true;
+    QgsScaleComboBox *mScaleCombo = nullptr;
+    bool mBlockScaleUpdate = false;
+};
 
+/**
+ * \class QgsScaleComboAction
+ * Allows embedding a scale combo into a menu.
+ * \note added in QGIS 3.0
+ */
 
+class QgsScaleComboAction: public QWidgetAction
+{
+    Q_OBJECT
+
+  public:
+
+    QgsScaleComboAction( QWidget *parent = nullptr );
+
+    QgsScaleComboBox *scaleCombo() { return mScaleCombo; }
+
+  private:
+    QgsScaleComboBox *mScaleCombo = nullptr;
 };
 
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -23,6 +23,7 @@
 
 class QgsMapCanvas;
 class QgsScaleComboBox;
+class QgsDoubleSpinBox;
 
 /**
  * \class QgsMapCanvasDockWidget
@@ -66,27 +67,31 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     QgsMapCanvas *mMainCanvas = nullptr;
     bool mShowCloseWarning = true;
     QgsScaleComboBox *mScaleCombo = nullptr;
+    QgsDoubleSpinBox *mRotationEdit = nullptr;
     bool mBlockScaleUpdate = false;
+    bool mBlockRotationUpdate = false;
 };
 
 /**
- * \class QgsScaleComboAction
- * Allows embedding a scale combo into a menu.
+ * \class QgsMapSettingsAction
+ * Allows embedding a scale, rotation and other map settings into a menu.
  * \note added in QGIS 3.0
  */
 
-class QgsScaleComboAction: public QWidgetAction
+class QgsMapSettingsAction: public QWidgetAction
 {
     Q_OBJECT
 
   public:
 
-    QgsScaleComboAction( QWidget *parent = nullptr );
+    QgsMapSettingsAction( QWidget *parent = nullptr );
 
     QgsScaleComboBox *scaleCombo() { return mScaleCombo; }
+    QgsDoubleSpinBox *rotationEdit() { return mRotationEdit; }
 
   private:
     QgsScaleComboBox *mScaleCombo = nullptr;
+    QgsDoubleSpinBox *mRotationEdit = nullptr;
 };
 
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -24,6 +24,7 @@
 class QgsMapCanvas;
 class QgsScaleComboBox;
 class QgsDoubleSpinBox;
+class QgsStatusBarMagnifierWidget;
 
 /**
  * \class QgsMapCanvasDockWidget
@@ -68,8 +69,10 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     bool mShowCloseWarning = true;
     QgsScaleComboBox *mScaleCombo = nullptr;
     QgsDoubleSpinBox *mRotationEdit = nullptr;
+    QgsDoubleSpinBox *mMagnificationEdit = nullptr;
     bool mBlockScaleUpdate = false;
     bool mBlockRotationUpdate = false;
+    bool mBlockMagnificationUpdate = false;
 };
 
 /**
@@ -87,11 +90,13 @@ class QgsMapSettingsAction: public QWidgetAction
     QgsMapSettingsAction( QWidget *parent = nullptr );
 
     QgsScaleComboBox *scaleCombo() { return mScaleCombo; }
-    QgsDoubleSpinBox *rotationEdit() { return mRotationEdit; }
+    QgsDoubleSpinBox *rotationSpinBox() { return mRotationWidget; }
+    QgsDoubleSpinBox *magnifierSpinBox() { return mMagnifierWidget; }
 
   private:
     QgsScaleComboBox *mScaleCombo = nullptr;
-    QgsDoubleSpinBox *mRotationEdit = nullptr;
+    QgsDoubleSpinBox *mRotationWidget = nullptr;
+    QgsDoubleSpinBox *mMagnifierWidget = nullptr;
 };
 
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -54,6 +54,13 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
      */
     void closeWithoutWarning();
 
+    /**
+     * Sets whether the view extent should be synchronized with the main canvas extent.
+     */
+    void setViewExtentSynchronized( bool enabled );
+
+    bool isViewExtentSynchronized() const;
+
   signals:
 
     void renameTriggered();

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -68,12 +68,15 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     void syncView( bool enabled );
     void mapExtentChanged();
     void mapCrsChanged();
+    void menuAboutToShow();
 
   private:
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMapCanvas *mMainCanvas = nullptr;
     bool mShowCloseWarning = true;
+    QMenu *mMenu = nullptr;
+    QList<QAction *> mMenuPresetActions;
     QgsScaleComboBox *mScaleCombo = nullptr;
     QgsDoubleSpinBox *mRotationEdit = nullptr;
     QgsDoubleSpinBox *mMagnificationEdit = nullptr;

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -20,11 +20,13 @@
 #include "qgsdockwidget.h"
 #include "qgis_app.h"
 #include <QWidgetAction>
+#include <memory>
 
 class QgsMapCanvas;
 class QgsScaleComboBox;
 class QgsDoubleSpinBox;
 class QgsStatusBarMagnifierWidget;
+class QgsMapToolPan;
 
 /**
  * \class QgsMapCanvasDockWidget
@@ -74,6 +76,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     bool mBlockScaleUpdate = false;
     bool mBlockRotationUpdate = false;
     bool mBlockMagnificationUpdate = false;
+    QgsMapToolPan *mPanTool = nullptr;
 };
 
 /**

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -20,6 +20,7 @@
 #include "qgsdockwidget.h"
 #include "qgis_app.h"
 #include <QWidgetAction>
+#include <QTimer>
 #include <memory>
 
 class QgsMapCanvas;
@@ -60,6 +61,10 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
 
     void renameTriggered();
 
+  protected:
+
+    void resizeEvent( QResizeEvent *e ) override;
+
   private slots:
 
     void setMapCrs();
@@ -81,7 +86,9 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     bool mBlockScaleUpdate = false;
     bool mBlockRotationUpdate = false;
     bool mBlockMagnificationUpdate = false;
+    bool mBlockExtentSync = false;
     QgsMapToolPan *mPanTool = nullptr;
+    QTimer mResizeTimer;
     void syncViewExtent( QgsMapCanvas *sourceCanvas );
 };
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -33,6 +33,11 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
      */
     QgsMapCanvas *mapCanvas();
 
+    /**
+     * Closes the dock, bypassing the usual warning prompt.
+     */
+    void closeWithoutWarning();
+
   protected:
 
     virtual void closeEvent( QCloseEvent *event ) override;
@@ -44,6 +49,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
   private:
 
     QgsMapCanvas *mMapCanvas = nullptr;
+    bool mShowCloseWarning = true;
 
 
 };

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -29,6 +29,11 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     explicit QgsMapCanvasDockWidget( const QString &name, QWidget *parent = nullptr );
 
     /**
+     * Sets the main app map canvas.
+     */
+    void setMainCanvas( QgsMapCanvas *canvas ) { mMainCanvas = canvas; }
+
+    /**
      * Returns the map canvas contained in the dock widget.
      */
     QgsMapCanvas *mapCanvas();
@@ -45,10 +50,13 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
   private slots:
 
     void setMapCrs();
+    void syncView( bool enabled );
+    void mapExtentChanged();
 
   private:
 
     QgsMapCanvas *mMapCanvas = nullptr;
+    QgsMapCanvas *mMainCanvas = nullptr;
     bool mShowCloseWarning = true;
 
 

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -85,6 +85,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     bool mBlockRotationUpdate = false;
     bool mBlockMagnificationUpdate = false;
     QgsMapToolPan *mPanTool = nullptr;
+    void syncViewExtent( QgsMapCanvas *sourceCanvas );
 };
 
 /**

--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -336,24 +336,14 @@ QgsMapCanvasAnnotationItem *QgsMapToolAnnotation::selectedItem() const
 
 QList<QgsMapCanvasAnnotationItem *> QgsMapToolAnnotation::annotationItems() const
 {
-  QList<QgsMapCanvasAnnotationItem *> annotationItemList;
-  if ( !mCanvas || !mCanvas->scene() )
+  if ( !mCanvas )
   {
-    return annotationItemList;
+    return QList<QgsMapCanvasAnnotationItem *>();
   }
-
-  QList<QGraphicsItem *>  itemList = mCanvas->scene()->items();
-  QList<QGraphicsItem *>::iterator it = itemList.begin();
-  for ( ; it != itemList.end(); ++it )
+  else
   {
-    QgsMapCanvasAnnotationItem *aItem = dynamic_cast<QgsMapCanvasAnnotationItem *>( *it );
-    if ( aItem )
-    {
-      annotationItemList.push_back( aItem );
-    }
+    return mCanvas->annotationItems();
   }
-
-  return annotationItemList;
 }
 
 void QgsMapToolAnnotation::toggleTextItemVisibilities()

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -812,21 +812,25 @@ void QgsProjectProperties::apply()
   }
 
   //set the color for selections
-  QColor myColor = pbnSelectionColor->color();
-  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorRedPart" ), myColor.red() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorGreenPart" ), myColor.green() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorBluePart" ), myColor.blue() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorAlphaPart" ), myColor.alpha() );
-  mMapCanvas->setSelectionColor( myColor );
+  QColor selectionColor = pbnSelectionColor->color();
+  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorRedPart" ), selectionColor.red() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorGreenPart" ), selectionColor.green() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorBluePart" ), selectionColor.blue() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/SelectionColorAlphaPart" ), selectionColor.alpha() );
+
 
   //set the color for canvas
-  myColor = pbnCanvasColor->color();
-  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), myColor.red() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), myColor.green() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), myColor.blue() );
-  mMapCanvas->setCanvasColor( myColor );
-  QgisApp::instance()->mapOverviewCanvas()->setBackgroundColor( myColor );
-  QgisApp::instance()->mapOverviewCanvas()->refresh();
+  QColor canvasColor = pbnCanvasColor->color();
+  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), canvasColor.red() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), canvasColor.green() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), canvasColor.blue() );
+
+  Q_FOREACH ( QgsMapCanvas *canvas, QgisApp::instance()->mapCanvases() )
+  {
+    canvas->setCanvasColor( canvasColor );
+    canvas->setSelectionColor( selectionColor );
+  }
+  QgisApp::instance()->mapOverviewCanvas()->setBackgroundColor( canvasColor );
 
   //save project scales
   QStringList myScales;
@@ -1140,7 +1144,12 @@ void QgsProjectProperties::apply()
   //save variables
   QgsProject::instance()->setCustomVariables( mVariableEditor->variablesInActiveScope() );
 
-  emit refresh();
+  //refresh canvases to reflect new properties, eg background color and scale bar after changing display units.
+  Q_FOREACH ( QgsMapCanvas *canvas, QgisApp::instance()->mapCanvases() )
+  {
+    canvas->refresh();
+  }
+  QgisApp::instance()->mapOverviewCanvas()->refresh();
 }
 
 void QgsProjectProperties::showProjectionsTab()

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -829,6 +829,7 @@ void QgsProjectProperties::apply()
   {
     canvas->setCanvasColor( canvasColor );
     canvas->setSelectionColor( selectionColor );
+    canvas->enableMapTileRendering( mMapTileRenderingCheckBox->isChecked() );
   }
   QgisApp::instance()->mapOverviewCanvas()->setBackgroundColor( canvasColor );
 

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -162,9 +162,6 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     //! Signal used to inform listeners that project scale list may have changed
     void scalesChanged( const QStringList &scales = QStringList() );
 
-    //! let listening canvases know to refresh
-    void refresh();
-
   private:
 
     //! Formats for displaying coordinates

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -104,6 +104,18 @@ class GUI_EXPORT QgisInterface : public QObject
      */
     virtual bool removeCustomActionForLayerType( QAction *action ) = 0;
 
+    /**
+     * Returns a list of all map canvases open in the app.
+     * @note added in QGIS 3.0
+     */
+    virtual QList< QgsMapCanvas * > mapCanvases() = 0;
+
+    /**
+     * Create a new map canvas with the specified unique \a name.
+     * @note added in QGIS 3.0
+     */
+    virtual QgsMapCanvas *createNewMapCanvas( const QString &name ) = 0;
+
   public slots: // TODO: do these functions really need to be slots?
 
     /* Exposed functions */

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -113,8 +113,16 @@ class GUI_EXPORT QgisInterface : public QObject
     /**
      * Create a new map canvas with the specified unique \a name.
      * @note added in QGIS 3.0
+     * @see closeMapCanvas()
      */
     virtual QgsMapCanvas *createNewMapCanvas( const QString &name ) = 0;
+
+    /**
+     * Closes the additional map canvas with matching \a name.
+     * @note added in QGIS 3.0
+     * @see createNewMapCanvas()
+     */
+    virtual void closeMapCanvas( const QString &name ) = 0;
 
   public slots: // TODO: do these functions really need to be slots?
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1544,7 +1544,6 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )
   }
 }
 
-//! Write property of QColor bgColor.
 void QgsMapCanvas::setCanvasColor( const QColor &color )
 {
   // background of map's pixmap
@@ -1561,7 +1560,7 @@ void QgsMapCanvas::setCanvasColor( const QColor &color )
 
   // background of QGraphicsScene
   mScene->setBackgroundBrush( bgBrush );
-} // setBackgroundColor
+}
 
 QColor QgsMapCanvas::canvasColor() const
 {

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1890,6 +1890,7 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
         setTheme( elem.attribute( QStringLiteral( "theme" ) ) );
       }
     }
+    setAnnotationsVisible( elem.attribute( QStringLiteral( "annotationsVisible" ), QStringLiteral( "1" ) ).toInt() );
   }
   else
   {
@@ -1910,9 +1911,10 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
   QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element ok
 
   QDomElement mapcanvasNode = doc.createElement( QStringLiteral( "mapcanvas" ) );
-  mapcanvasNode.setAttribute( "name", objectName() );
+  mapcanvasNode.setAttribute( QStringLiteral( "name" ), objectName() );
   if ( !mTheme.isEmpty() )
-    mapcanvasNode.setAttribute( "theme", mTheme );
+    mapcanvasNode.setAttribute( QStringLiteral( "theme" ), mTheme );
+  mapcanvasNode.setAttribute( QStringLiteral( "annotationsVisible" ), mAnnotationsVisible );
   qgisNode.appendChild( mapcanvasNode );
 
   mSettings.writeXml( mapcanvasNode, doc );
@@ -2073,4 +2075,30 @@ void QgsMapCanvas::setSegmentationTolerance( double tolerance )
 void QgsMapCanvas::setSegmentationToleranceType( QgsAbstractGeometry::SegmentationToleranceType type )
 {
   mSettings.setSegmentationToleranceType( type );
+}
+
+QList<QgsMapCanvasAnnotationItem *> QgsMapCanvas::annotationItems() const
+{
+  QList<QgsMapCanvasAnnotationItem *> annotationItemList;
+  QList<QGraphicsItem *> itemList = mScene->items();
+  QList<QGraphicsItem *>::iterator it = itemList.begin();
+  for ( ; it != itemList.end(); ++it )
+  {
+    QgsMapCanvasAnnotationItem *aItem = dynamic_cast< QgsMapCanvasAnnotationItem *>( *it );
+    if ( aItem )
+    {
+      annotationItemList.push_back( aItem );
+    }
+  }
+
+  return annotationItemList;
+}
+
+void QgsMapCanvas::setAnnotationsVisible( bool show )
+{
+  mAnnotationsVisible = show;
+  Q_FOREACH ( QgsMapCanvasAnnotationItem *item, annotationItems() )
+  {
+    item->setVisible( show );
+  }
 }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1857,6 +1857,21 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
   {
     QDomNode node = nodes.item( 0 );
 
+    // Search the specific MapCanvas node using the name
+    if ( nodes.count() > 1 )
+    {
+      for ( int i = 0; i < nodes.size(); ++i )
+      {
+        QDomElement elementNode = nodes.at( i ).toElement();
+
+        if ( elementNode.hasAttribute( "name" ) && elementNode.attribute( "name" ) == objectName() )
+        {
+          node = nodes.at( i );
+          break;
+        }
+      }
+    }
+
     QgsMapSettings tmpSettings;
     tmpSettings.readXml( node );
     setDestinationCrs( tmpSettings.destinationCrs() );
@@ -1886,6 +1901,7 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
   QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element ok
 
   QDomElement mapcanvasNode = doc.createElement( QStringLiteral( "mapcanvas" ) );
+  mapcanvasNode.setAttribute( "name", objectName() );
   qgisNode.appendChild( mapcanvasNode );
 
   mSettings.writeXml( mapcanvasNode, doc );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1864,7 +1864,7 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
       {
         QDomElement elementNode = nodes.at( i ).toElement();
 
-        if ( elementNode.hasAttribute( "name" ) && elementNode.attribute( "name" ) == objectName() )
+        if ( elementNode.hasAttribute( QStringLiteral( "name" ) ) && elementNode.attribute( QStringLiteral( "name" ) ) == objectName() )
         {
           node = nodes.at( i );
           break;
@@ -1881,6 +1881,15 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
     enableMapTileRendering( tmpSettings.testFlag( QgsMapSettings::RenderMapTile ) );
 
     clearExtentHistory(); // clear the extent history on project load
+
+    QDomElement elem = node.toElement();
+    if ( elem.hasAttribute( QStringLiteral( "theme" ) ) )
+    {
+      if ( QgsProject::instance()->mapThemeCollection()->hasMapTheme( elem.attribute( QStringLiteral( "theme" ) ) ) )
+      {
+        setTheme( elem.attribute( QStringLiteral( "theme" ) ) );
+      }
+    }
   }
   else
   {
@@ -1902,6 +1911,8 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
 
   QDomElement mapcanvasNode = doc.createElement( QStringLiteral( "mapcanvas" ) );
   mapcanvasNode.setAttribute( "name", objectName() );
+  if ( !mTheme.isEmpty() )
+    mapcanvasNode.setAttribute( "theme", mTheme );
   qgisNode.appendChild( mapcanvasNode );
 
   mSettings.writeXml( mapcanvasNode, doc );

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -63,7 +63,7 @@ class QgsMapOverviewCanvas;
 class QgsMapTool;
 class QgsSnappingUtils;
 class QgsRubberBand;
-
+class QgsMapCanvasAnnotationItem;
 
 /** \ingroup gui
  * Map canvas is a class for displaying all GIS data types on a canvas.
@@ -468,6 +468,26 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     @param type the segmentation tolerance typename*/
     void setSegmentationToleranceType( QgsAbstractGeometry::SegmentationToleranceType type );
 
+    /**
+     * Returns a list of all annotation items in the canvas.
+     * @note added in QGIS 3.0
+     */
+    QList< QgsMapCanvasAnnotationItem *> annotationItems() const;
+
+    /**
+     * Returns true if annotations are visible within the map canvas.
+     * @note added in QGIS 3.0
+     * @see setAnnotationsVisible()
+     */
+    bool annotationsVisible() const { return mAnnotationsVisible; }
+
+    /**
+     * Sets whether annotations are \a visible in the canvas.
+     * @note added in QGIS 3.0
+     * @see annotationsVisible()
+     */
+    void setAnnotationsVisible( bool visible );
+
   public slots:
 
     //! Repaints the canvas map
@@ -783,6 +803,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     QTimer mAutoRefreshTimer;
 
     QString mTheme;
+
+    bool mAnnotationsVisible = true;
 
     //! Force a resize of the map canvas item
     //! @note added in 2.16

--- a/src/gui/qgsmapcanvasannotationitem.cpp
+++ b/src/gui/qgsmapcanvasannotationitem.cpp
@@ -33,6 +33,9 @@ QgsMapCanvasAnnotationItem::QgsMapCanvasAnnotationItem( QgsAnnotation *annotatio
   , mAnnotation( annotation )
 {
   setFlag( QGraphicsItem::ItemIsSelectable, true );
+  if ( mapCanvas && !mapCanvas->annotationsVisible() )
+    setVisible( false );
+
   connect( mAnnotation, &QgsAnnotation::appearanceChanged, this, [this] { update(); } );
   connect( mAnnotation, &QgsAnnotation::moved, this, [this] { updatePosition(); } );
   connect( mAnnotation, &QgsAnnotation::moved, this, &QgsMapCanvasAnnotationItem::setFeatureForMapPosition );

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -53,7 +53,9 @@
     <addaction name="mActionDxfExport"/>
     <addaction name="mActionDwgImport"/>
     <addaction name="separator"/>
+    <addaction name="mActionNewMapCanvas"/>
     <addaction name="mActionSnappingOptions"/>
+    <addaction name="separator"/>
     <addaction name="mActionNewPrintComposer"/>
     <addaction name="mActionShowComposerManager"/>
     <addaction name="mPrintComposersMenu"/>
@@ -332,6 +334,7 @@
    <addaction name="mActionOpenProject"/>
    <addaction name="mActionSaveProject"/>
    <addaction name="mActionSaveProjectAs"/>
+   <addaction name="mActionNewMapCanvas"/>
    <addaction name="mActionNewPrintComposer"/>
    <addaction name="mActionShowComposerManager"/>
   </widget>
@@ -638,6 +641,21 @@
    </property>
    <property name="text">
     <string>Save as &amp;Image...</string>
+   </property>
+  </action>
+  <action name="mActionNewMapCanvas">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionNewMap.svg</normaloff>:/images/themes/default/mActionNewMap.svg</iconset>
+   </property>
+   <property name="text">
+    <string>New &amp;Map View</string>
+   </property>
+   <property name="toolTip">
+    <string>New Map View</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+M</string>
    </property>
   </action>
   <action name="mActionNewPrintComposer">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -53,7 +53,6 @@
     <addaction name="mActionDxfExport"/>
     <addaction name="mActionDwgImport"/>
     <addaction name="separator"/>
-    <addaction name="mActionNewMapCanvas"/>
     <addaction name="mActionSnappingOptions"/>
     <addaction name="separator"/>
     <addaction name="mActionNewPrintComposer"/>
@@ -93,6 +92,7 @@
      <addaction name="mActionPreviewProtanope"/>
      <addaction name="mActionPreviewDeuteranope"/>
     </widget>
+    <addaction name="mActionNewMapCanvas"/>
     <addaction name="mActionPan"/>
     <addaction name="mActionPanToSelected"/>
     <addaction name="mActionZoomIn"/>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -73,7 +73,7 @@
      <normaloff>:/images/themes/default/propertyicons/CRS.svg</normaloff>:/images/themes/default/propertyicons/CRS.svg</iconset>
    </property>
    <property name="text">
-    <string>Set Map CRS</string>
+    <string>Set Map CRS...</string>
    </property>
    <property name="toolTip">
     <string>Set Map CRS</string>
@@ -92,6 +92,14 @@
    </property>
    <property name="toolTip">
     <string>Synchronize View with Main Map</string>
+   </property>
+  </action>
+  <action name="mActionRename">
+   <property name="text">
+    <string>Rename view...</string>
+   </property>
+   <property name="toolTip">
+    <string>Rename View</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -88,7 +88,7 @@
    </property>
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/sync_views.svg</normaloff>:/images/themes/default/sync_views.svg</iconset>
+     <normaloff>:/images/themes/default/mActionLockExtent.svg</normaloff>:/images/themes/default/mActionLockExtent.svg</iconset>
    </property>
    <property name="text">
     <string>Synchronize view</string>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -76,7 +76,7 @@
      <normaloff>:/images/themes/default/propertyicons/CRS.svg</normaloff>:/images/themes/default/propertyicons/CRS.svg</iconset>
    </property>
    <property name="text">
-    <string>Set Map CRS...</string>
+    <string>Set Map CRS…</string>
    </property>
    <property name="toolTip">
     <string>Set Map CRS</string>
@@ -91,7 +91,7 @@
      <normaloff>:/images/themes/default/mActionLockExtent.svg</normaloff>:/images/themes/default/mActionLockExtent.svg</iconset>
    </property>
    <property name="text">
-    <string>Synchronize view</string>
+    <string>Synchronize View</string>
    </property>
    <property name="toolTip">
     <string>Synchronize View with Main Map</string>
@@ -99,7 +99,7 @@
   </action>
   <action name="mActionRename">
    <property name="text">
-    <string>Rename view...</string>
+    <string>Rename View…</string>
    </property>
    <property name="toolTip">
     <string>Rename View</string>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -41,7 +41,6 @@
       <property name="floatable">
        <bool>false</bool>
       </property>
-      <addaction name="mActionSetCrs"/>
       <addaction name="mActionSyncView"/>
      </widget>
     </item>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -94,7 +94,7 @@
     <string>Synchronize View</string>
    </property>
    <property name="toolTip">
-    <string>Synchronize View with Main Map</string>
+    <string>Synchronize View Center with Main Map</string>
    </property>
   </action>
   <action name="mActionRename">

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -42,6 +42,9 @@
        <bool>false</bool>
       </property>
       <addaction name="mActionSyncView"/>
+      <addaction name="mActionZoomFullExtent"/>
+      <addaction name="mActionZoomToSelected"/>
+      <addaction name="mActionZoomToLayer"/>
      </widget>
     </item>
     <item>
@@ -100,6 +103,33 @@
    </property>
    <property name="toolTip">
     <string>Rename View</string>
+   </property>
+  </action>
+  <action name="mActionZoomToSelected">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomToSelected.svg</normaloff>:/images/themes/default/mActionZoomToSelected.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom to &amp;Selection</string>
+   </property>
+  </action>
+  <action name="mActionZoomToLayer">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomToLayer.svg</normaloff>:/images/themes/default/mActionZoomToLayer.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom to &amp;Layer</string>
+   </property>
+  </action>
+  <action name="mActionZoomFullExtent">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomFullExtent.svg</normaloff>:/images/themes/default/mActionZoomFullExtent.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom &amp;Full</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -143,6 +143,14 @@
     <string>Show Annotations</string>
    </property>
   </action>
+  <action name="mActionShowCursor">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Cursor Position</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -132,6 +132,17 @@
     <string>Zoom &amp;Full</string>
    </property>
   </action>
+  <action name="mActionShowAnnotations">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Annotations</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Annotations</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsMapCanvasDockWidgetBase</class>
+ <widget class="QgsDockWidget" name="QgsMapCanvasDockWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>216</width>
+    <height>138</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Map Canvas</string>
+  </property>
+  <widget class="QWidget" name="mContents">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QToolBar" name="mToolbar">
+      <property name="iconSize">
+       <size>
+        <width>16</width>
+        <height>16</height>
+       </size>
+      </property>
+      <property name="floatable">
+       <bool>false</bool>
+      </property>
+      <addaction name="mActionSetCrs"/>
+     </widget>
+    </item>
+    <item>
+     <widget class="QWidget" name="mMainWidget" native="true">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+      </layout>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <action name="mActionSetCrs">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/propertyicons/CRS.svg</normaloff>:/images/themes/default/propertyicons/CRS.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Set Map CRS</string>
+   </property>
+   <property name="toolTip">
+    <string>Set Map CRS</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDockWidget</class>
+   <extends>QDockWidget</extends>
+   <header>qgsdockwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/ui/qgsmapcanvasdockwidgetbase.ui
+++ b/src/ui/qgsmapcanvasdockwidgetbase.ui
@@ -42,6 +42,7 @@
        <bool>false</bool>
       </property>
       <addaction name="mActionSetCrs"/>
+      <addaction name="mActionSyncView"/>
      </widget>
     </item>
     <item>
@@ -77,6 +78,21 @@
    </property>
    <property name="toolTip">
     <string>Set Map CRS</string>
+   </property>
+  </action>
+  <action name="mActionSyncView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/sync_views.svg</normaloff>:/images/themes/default/sync_views.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Synchronize view</string>
+   </property>
+   <property name="toolTip">
+    <string>Synchronize View with Main Map</string>
    </property>
   </action>
  </widget>

--- a/tests/src/python/test_qgsmapthemecollection.py
+++ b/tests/src/python/test_qgsmapthemecollection.py
@@ -211,5 +211,6 @@ class TestQgsMapThemeCollection(unittest.TestCase):
         self.assertEqual(prj.mapThemeCollection().masterVisibleLayers(), [layer, layer2, layer3])
 
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsmapthemecollection.py
+++ b/tests/src/python/test_qgsmapthemecollection.py
@@ -211,6 +211,5 @@ class TestQgsMapThemeCollection(unittest.TestCase):
         self.assertEqual(prj.mapThemeCollection().masterVisibleLayers(), [layer, layer2, layer3])
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Sponsor
-----------

Amt für Geoinformation des Kantons Bern and OpenGIS.ch


## Description

This PR adds support for additional map views. This feature is known by a few names - data frames in ESRI speak, "new map windows" in MapInfo land, or dockable mirror maps/auxiliary windows in QGIS plugin speak:

![image](https://cloud.githubusercontent.com/assets/1829991/23849798/a6ea092e-0828-11e7-8e7b-98935c11b1b1.png)


What this includes:

- a very stable, well tested and robust way of showing other views of your map data. Instead of aiming to implement every feature desirable in multi canvas, instead this PR focuses on getting the basics right. This can then be built on top of in future to add in extra features if desired.

- Map views can have different extent to the main canvas, and use a pan tool so that you can zoom in/out and navigate the view. There's also a toolbar in views with shortcuts for zoom full/zoom layer/zoom selection 
![image](https://cloud.githubusercontent.com/assets/1829991/23849824/bf8e1a06-0828-11e7-99d0-23efae9ac0fa.png)

- map views use the same layers as the main canvas. This means a single selection is used regardless of which view it's shown in, and views will also show features and changes present in the layer's edit buffers correctly.

- map views can either follow the main canvas style, or be set to follow a map theme preset. Styling cannot be done in map views - this must be done in the main canvas view. This is by design, with the intention of keeping the interface simple. QGIS already has strong support for map themes (eg in main canvas and composer), so it makes sense to keep a consistent approach here and utilise map themes for setting presets of visible layers and styles for display in additional map views. 
![image](https://cloud.githubusercontent.com/assets/1829991/23849897/f28d011a-0828-11e7-9e6d-1a096111bd22.png)

- map views can have different scale/rotation/magnification/CRS from the main canvas. 
![image](https://cloud.githubusercontent.com/assets/1829991/23849920/092cdee0-0829-11e7-9f72-1bd8f5f33a04.png)

- annotations work flawlessly across views, including reprojected views

What this is NOT:

- a "kitchen sink" approach addressing everyone's wishlists for multi canvas. That can come later, but the important thing is getting the foundation right.
- horribly complex. All the horribly complex stuff has already landed in master (annotation refactoring, map theme & canvas work, composer separation from canvas). Most changes in this PR are limited to QgisApp and a new QgsMapCanvasDockWidget class (in app for now, until the API stabilises at which time I'll move it to gui). 
- a complete port of @ahuarte47's fantastic earlier work in https://github.com/qgis/QGIS-Enhancement-Proposals/issues/70. Full credit to @ahuarte47 - it was only when digging into this that I realised the full depth of your work here! Various bits of this PR have been taken from your branch, and they certainly sped things along. As stated, this is not a full port of QEP 70 as it does not include any of the map tool changes tackled there. Hopefully those changes can be pulled across at a later stage after these fundamentals have been merged. This PR also takes a different approach with layers in that it re-uses the layers from the main canvas, and does not require multiple copies of layers to be present to show in additional map views. This change was made to simplify use of additional views, and to maintain consistency across views (same selection, same edit buffer, etc).
- a complete port of the existing Auxiliary Map Window/Dockable Mirror Map plugins. It's close to this - but there's a few missing bits. Specifically the ability to show cursor location, highlight map extent, and also the scale factor from those plugins. I'd like to address this at some stage to remove the need for the plugins.

How come docked views don't restore correctly?
---------------------------------------------------------------

It's a Qt limitation. There's unfortunately nothing we can do about this. @ahuarte47's PR used the approach of saving the window state in a project as a way to work around this, but upon much reflection I decided that losing the state of docked windows is the lesser of two evils here. If we save state in a project then it's an all-or-nothing approach, meaning that loading an older project will cause all toolbars and panels to reset to the position from when that project was saved. Even worse, if you loaded someone else's project you'd get all your window state reset to match theirs. In the end I think we need to play it safe and just accept that we can't restore docked view state... 

What about server?
--------------------------

What about it? It's not affected here. If server wants to hook into this it's a matter of exposing support for rendering maps using different theme presets. That's not related to this work though.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://www.qgis.org/en/site/getinvolved/development/qgisdevelopersguide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
