### PR TITLE
add grid renderer for points displacement. funded by Kartoza

### DIFF
--- a/python/core/symbology/qgspointdisplacementrenderer.sip
+++ b/python/core/symbology/qgspointdisplacementrenderer.sip
@@ -23,7 +23,8 @@ class QgsPointDisplacementRenderer: QgsPointDistanceRenderer
     enum Placement
     {
       Ring,
-      ConcentricRings
+      ConcentricRings,
+      Grid
     };
 
     QgsPointDisplacementRenderer( const QString &labelAttributeName = QString() );

--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -75,11 +75,17 @@ void QgsPointDisplacementRenderer::drawGroup( QPointF centerPoint, QgsRenderCont
   QList<QPointF> symbolPositions;
   QList<QPointF> labelPositions;
   double circleRadius = -1.0;
-  calculateSymbolAndLabelPositions( symbolContext, centerPoint, group.size(), diagonal, symbolPositions, labelPositions, circleRadius );
+  double gridRadius;
+  int gridSize;
+
+  calculateSymbolAndLabelPositions( symbolContext, centerPoint, group.size(), diagonal, symbolPositions, labelPositions, circleRadius, gridRadius, gridSize );
 
   //draw circle
   if ( circleRadius > 0 )
     drawCircle( circleRadius, symbolContext, centerPoint, group.size() );
+  //draw grid
+  else
+    drawGrid( gridSize, symbolContext, symbolPositions, group.size() );
 
   if ( group.size() > 1 )
   {
@@ -221,7 +227,8 @@ void QgsPointDisplacementRenderer::setCenterSymbol( QgsMarkerSymbol *symbol )
 }
 
 void QgsPointDisplacementRenderer::calculateSymbolAndLabelPositions( QgsSymbolRenderContext &symbolContext, QPointF centerPoint, int nPosition,
-    double symbolDiagonal, QList<QPointF> &symbolPositions, QList<QPointF> &labelShifts, double &circleRadius ) const
+    double symbolDiagonal, QList<QPointF> &symbolPositions, QList<QPointF> &labelShifts, double &circleRadius, double &gridRadius,
+    int &gridSize ) const
 {
   symbolPositions.clear();
   labelShifts.clear();
@@ -293,6 +300,75 @@ void QgsPointDisplacementRenderer::calculateSymbolAndLabelPositions( QgsSymbolRe
         circleRadius = radiusCurrentRing;
       }
       break;
+    }
+    case Grid:
+    {
+      double centerDiagonal = symbolContext.renderContext().convertToPainterUnits( M_SQRT2 * mCenterSymbol->size(),
+                              mCenterSymbol->sizeUnit(), mCenterSymbol->sizeMapUnitScale() );
+      int pointsRemaining = nPosition;
+      gridSize = ceil( sqrt( pointsRemaining ) );
+      if ( pointsRemaining - pow( gridSize - 1, 2 ) < gridSize )
+        gridSize -= 1;
+      double originalPointRadius = ( ( centerDiagonal / 2.0 + symbolDiagonal / 2.0 ) + symbolDiagonal ) / 2;
+      double userPointRadius =  originalPointRadius + circleAdditionPainterUnits;
+
+      int yIndex = 0;
+      while ( pointsRemaining > 0 )
+      {
+        for ( int xIndex = 0; xIndex < gridSize && pointsRemaining > 0; ++xIndex )
+        {
+          QPointF positionShift( userPointRadius * xIndex, userPointRadius * yIndex );
+          QPointF labelShift( ( userPointRadius + symbolDiagonal / 2 ) * xIndex, ( userPointRadius + symbolDiagonal / 2 ) * yIndex );
+          symbolPositions.append( centerPoint + positionShift );
+          labelShifts.append( labelShift );
+          pointsRemaining--;
+        }
+        yIndex++;
+      }
+
+      centralizeGrid( symbolPositions, userPointRadius, gridSize );
+      centralizeGrid( labelShifts, userPointRadius, gridSize );
+      gridRadius = userPointRadius;
+      break;
+    }
+  }
+}
+
+void QgsPointDisplacementRenderer::centralizeGrid( QList<QPointF> &pointSymbolPositions, double radius, int size ) const
+{
+  double shiftAmount = -radius * ( size - 1 ) / 2;
+  QPointF centralShift( shiftAmount, shiftAmount );
+  for ( int i = 0; i < pointSymbolPositions.size(); ++i )
+  {
+    pointSymbolPositions[i] += centralShift;
+  }
+}
+
+void QgsPointDisplacementRenderer::drawGrid( int gridSizeUnits, QgsSymbolRenderContext &context,
+    QList<QPointF> pointSymbolPositions, int nSymbols )
+{
+  QPainter *p = context.renderContext().painter();
+  if ( nSymbols < 2 || !p ) //draw grid only if multiple features
+  {
+    return;
+  }
+
+  QPen gridPen( mCircleColor );
+  gridPen.setWidthF( context.outputLineWidth( mCircleWidth ) );
+  p->setPen( gridPen );
+
+  for ( int i = 0; i < pointSymbolPositions.size(); ++i )
+  {
+    if ( i + 1 < pointSymbolPositions.size() && 0 != ( i + 1 ) % gridSizeUnits )
+    {
+      QLineF gridLineRow( pointSymbolPositions[i], pointSymbolPositions[i + 1] );
+      p->drawLine( gridLineRow );
+    }
+
+    if ( i + gridSizeUnits < pointSymbolPositions.size() )
+    {
+      QLineF gridLineColumn( pointSymbolPositions[i], pointSymbolPositions[i + gridSizeUnits] );
+      p->drawLine( gridLineColumn );
     }
   }
 }

--- a/src/core/symbology/qgspointdisplacementrenderer.h
+++ b/src/core/symbology/qgspointdisplacementrenderer.h
@@ -35,7 +35,8 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsPointDistanceRenderer
     enum Placement
     {
       Ring, //!< Place points in a single ring around group
-      ConcentricRings //!< Place points in concentric rings around group
+      ConcentricRings, //!< Place points in concentric rings around group
+      Grid //!< Place points in a grid around group
     };
 
     /** Constructor for QgsPointDisplacementRenderer.
@@ -141,9 +142,13 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsPointDistanceRenderer
     virtual void drawGroup( QPointF centerPoint, QgsRenderContext &context, const QgsPointDistanceRenderer::ClusteredGroup &group ) override SIP_FORCE;
 
     //helper functions
-    void calculateSymbolAndLabelPositions( QgsSymbolRenderContext &symbolContext, QPointF centerPoint, int nPosition, double symbolDiagonal, QList<QPointF> &symbolPositions, QList<QPointF> &labelShifts, double &circleRadius ) const;
+    void calculateSymbolAndLabelPositions( QgsSymbolRenderContext &symbolContext, QPointF centerPoint, int nPosition, double symbolDiagonal, QList<QPointF> &symbolPositions, QList<QPointF> &labelShifts, double &circleRadius,
+                                           double &gridRadius, int &gridSize ) const;
     void drawCircle( double radiusPainterUnits, QgsSymbolRenderContext &context, QPointF centerPoint, int nSymbols );
     void drawSymbols( const ClusteredGroup &group, QgsRenderContext &context, const QList<QPointF> &symbolPositions );
+    void drawGrid( int gridSizeUnits, QgsSymbolRenderContext &context,
+                   QList<QPointF> pointSymbolPositions, int nSymbols );
+    void centralizeGrid( QList<QPointF> &pointSymbolPositions, double radius, int size ) const;
 };
 
 #endif // QGSPOINTDISPLACEMENTRENDERER_H

--- a/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
@@ -68,6 +68,7 @@ QgsPointDisplacementRendererWidget::QgsPointDisplacementRendererWidget( QgsVecto
 
   mPlacementComboBox->addItem( tr( "Ring" ), QgsPointDisplacementRenderer::Ring );
   mPlacementComboBox->addItem( tr( "Concentric rings" ), QgsPointDisplacementRenderer::ConcentricRings );
+  mPlacementComboBox->addItem( tr( "Grid" ), QgsPointDisplacementRenderer::Grid );
 
   //insert attributes into combo box
   if ( layer )

--- a/src/ui/qgspointdisplacementrendererwidgetbase.ui
+++ b/src/ui/qgspointdisplacementrendererwidgetbase.ui
@@ -215,7 +215,7 @@
       <item row="3" column="0">
        <widget class="QLabel" name="mCircleRadiusLabel">
         <property name="text">
-         <string>Ring size adjustment</string>
+         <string>Size adjustment</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Description
Add new grid points displacement renderer for layer styling. This is based on http://gis.stackexchange.com/questions/227242/convert-stacked-points-into-grid

![qgis 5e21641 - points_displacement_037](https://cloud.githubusercontent.com/assets/11134669/23885386/37c9b760-08a5-11e7-86de-09d5d4b33c26.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
