### PR TITLE
[FEATURE][needs-docs] new custom widget PasswordLineEdit

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -134,6 +134,7 @@
 %Include qgsowssourceselect.sip
 %Include qgspanelwidget.sip
 %Include qgspanelwidgetstack.sip
+%Include qgspasswordlineedit.sip
 %Include qgspixmaplabel.sip
 %Include qgspluginmanagerinterface.sip
 %Include qgspresetcolorrampdialog.sip

--- a/python/gui/qgspasswordlineedit.sip
+++ b/python/gui/qgspasswordlineedit.sip
@@ -1,0 +1,28 @@
+/** \class QgsPasswordLineEdit
+ * \ingroup gui
+ * QLineEdit subclass with built in support for showing/hiding
+ * entered password.
+ * @note added in QGIS 3.0
+ **/
+class QgsPasswordLineEdit : QLineEdit
+{
+%TypeHeaderCode
+#include <qgspasswordlineedit.h>
+%End
+
+  public:
+
+    /** Constructor for QgsPasswordLineEdit.
+     * @param parent parent widget
+     */
+    QgsPasswordLineEdit( QWidget *parent = nullptr );
+
+    /** Define if a lock icon shall be shown on the left of the widget
+     * @param visible set to false to hide the lock icon
+     */
+    void setShowLockIcon( bool visible );
+
+    /** Returns if a lock icon shall be shown on the left of the widget
+     */
+    bool showLockIcon() const;
+};

--- a/src/customwidgets/CMakeLists.txt
+++ b/src/customwidgets/CMakeLists.txt
@@ -14,7 +14,7 @@ SET (QGIS_CUSTOMWIDGETS_SRCS
   qgiscustomwidgets.cpp
   qgscollapsiblegroupboxplugin.cpp
   qgscolorbuttonplugin.cpp
-  qgsdatetimeeditplugin.cpp  
+  qgsdatetimeeditplugin.cpp
   qgsdockwidgetplugin.cpp
   qgsdoublespinboxplugin.cpp
   qgsexpressionbuilderwidgetplugin.cpp
@@ -25,6 +25,7 @@ SET (QGIS_CUSTOMWIDGETS_SRCS
   qgsfilewidgetplugin.cpp
   qgsfilterlineeditplugin.cpp
   qgsmaplayercomboboxplugin.cpp
+  qgspasswordlineeditplugin.cpp
   qgsprojectionselectionwidgetplugin.cpp
   qgspropertyoverridebuttonplugin.cpp
   qgsrelationeditorwidgetplugin.cpp
@@ -49,6 +50,7 @@ SET (QGIS_CUSTOMWIDGETS_MOC_HDRS
   qgsfilewidgetplugin.h
   qgsfilterlineeditplugin.h
   qgsmaplayercomboboxplugin.h
+  qgspasswordlineeditplugin.h
   qgsprojectionselectionwidgetplugin.h
   qgspropertyoverridebuttonplugin.h
   qgsrelationeditorwidgetplugin.h

--- a/src/customwidgets/qgspasswordlineeditplugin.cpp
+++ b/src/customwidgets/qgspasswordlineeditplugin.cpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+   qgsfilterlineeditplugin.cpp
+    --------------------------------------
+   Date                 : March 13, 2017
+   Copyright            : (C) 2017 Alexander Bruy
+   Email                : alexander dot bruy at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgiscustomwidgets.h"
+#include "qgspasswordlineedit.h"
+#include "qgspasswordlineeditplugin.h"
+
+
+QgsPasswordLineEditPlugin::QgsPasswordLineEditPlugin( QObject *parent )
+  : QObject( parent )
+  , mInitialized( false )
+{
+}
+
+
+QString QgsPasswordLineEditPlugin::name() const
+{
+  return "QgsPasswordLineEdit";
+}
+
+QString QgsPasswordLineEditPlugin::group() const
+{
+  return QgisCustomWidgets::groupName();
+}
+
+QString QgsPasswordLineEditPlugin::includeFile() const
+{
+  return "qgspasswordlineedit.h";
+}
+
+QIcon QgsPasswordLineEditPlugin::icon() const
+{
+  return QIcon( ":/images/icons/qgis-icon-60x60.png" );
+}
+
+bool QgsPasswordLineEditPlugin::isContainer() const
+{
+  return false;
+}
+
+QWidget *QgsPasswordLineEditPlugin::createWidget( QWidget *parent )
+{
+  return new QgsPasswordLineEdit( parent );
+}
+
+bool QgsPasswordLineEditPlugin::isInitialized() const
+{
+  return mInitialized;
+}
+
+void QgsPasswordLineEditPlugin::initialize( QDesignerFormEditorInterface *core )
+{
+  Q_UNUSED( core );
+  if ( mInitialized )
+    return;
+  mInitialized = true;
+}
+
+
+QString QgsPasswordLineEditPlugin::toolTip() const
+{
+  return "";
+}
+
+QString QgsPasswordLineEditPlugin::whatsThis() const
+{
+  return "";
+}
+
+QString QgsPasswordLineEditPlugin::domXml() const
+{
+  return QString( "<ui language=\"c++\">\n"
+                  " <widget class=\"%1\" name=\"mLineEdit\">\n"
+                  "  <property name=\"geometry\">\n"
+                  "   <rect>\n"
+                  "    <x>0</x>\n"
+                  "    <y>0</y>\n"
+                  "    <width>60</width>\n"
+                  "    <height>27</height>\n"
+                  "   </rect>\n"
+                  "  </property>\n"
+                  " </widget>\n"
+                  "</ui>\n" )
+         .arg( name() );
+}

--- a/src/customwidgets/qgspasswordlineeditplugin.h
+++ b/src/customwidgets/qgspasswordlineeditplugin.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+   qgspasswordlineeditplugin.h
+    --------------------------------------
+   Date                 : March 13, 2017
+   Copyright            : (C) 2017 Alexander Bruy
+   Email                : alexander dot bruy at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSPASSWORDLINEEDITPLUGIN_H
+#define QGSPASSWORDLINEEDITPLUGIN_H
+
+
+#include <QtGlobal>
+#include <QtUiPlugin/QDesignerCustomWidgetInterface>
+#include <QtUiPlugin/QDesignerExportWidget>
+#include "qgis_customwidgets.h"
+
+
+class CUSTOMWIDGETS_EXPORT QgsPasswordLineEditPlugin : public QObject, public QDesignerCustomWidgetInterface
+{
+    Q_OBJECT
+    Q_INTERFACES( QDesignerCustomWidgetInterface )
+
+  public:
+    explicit QgsPasswordLineEditPlugin( QObject *parent = 0 );
+
+  private:
+    bool mInitialized;
+
+    // QDesignerCustomWidgetInterface interface
+  public:
+    QString name() const override;
+    QString group() const override;
+    QString includeFile() const override;
+    QIcon icon() const override;
+    bool isContainer() const override;
+    QWidget *createWidget( QWidget *parent ) override;
+    bool isInitialized() const override;
+    void initialize( QDesignerFormEditorInterface *core ) override;
+    QString toolTip() const override;
+    QString whatsThis() const override;
+    QString domXml() const override;
+};
+#endif // QGSPASSWORDLINEEDITPLUGIN_H

--- a/src/customwidgets/qgspasswordlineeditplugin.h
+++ b/src/customwidgets/qgspasswordlineeditplugin.h
@@ -32,7 +32,7 @@ class CUSTOMWIDGETS_EXPORT QgsPasswordLineEditPlugin : public QObject, public QD
     explicit QgsPasswordLineEditPlugin( QObject *parent = 0 );
 
   private:
-    bool mInitialized;
+    bool mInitialized = false;
 
     // QDesignerCustomWidgetInterface interface
   public:

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -276,6 +276,7 @@ SET(QGIS_GUI_SRCS
   qgssourceselectdialog.cpp
   qgspanelwidget.cpp
   qgspanelwidgetstack.cpp
+  qgspasswordlineedit.cpp
   qgspixmaplabel.cpp
   qgspluginmanagerinterface.cpp
   qgspresetcolorrampdialog.cpp
@@ -422,6 +423,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgssourceselectdialog.h
   qgspanelwidget.h
   qgspanelwidgetstack.h
+  qgspasswordlineedit.h
   qgspixmaplabel.h
   qgspluginmanagerinterface.h
   qgspresetcolorrampdialog.h

--- a/src/gui/auth/qgsauthmasterpassresetdialog.cpp
+++ b/src/gui/auth/qgsauthmasterpassresetdialog.cpp
@@ -80,16 +80,6 @@ void QgsMasterPasswordResetDialog::on_leMasterPassNew_textChanged( const QString
   validatePasswords();
 }
 
-void QgsMasterPasswordResetDialog::on_chkPassShowCurrent_stateChanged( int state )
-{
-  leMasterPassCurrent->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
-}
-
-void QgsMasterPasswordResetDialog::on_chkPassShowNew_stateChanged( int state )
-{
-  leMasterPassNew->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
-}
-
 void QgsMasterPasswordResetDialog::validatePasswords()
 {
   QString ss1 = mPassCurOk ? QgsAuthGuiUtils::greenTextStyleSheet( QStringLiteral( "QLineEdit" ) )

--- a/src/gui/auth/qgsauthmasterpassresetdialog.h
+++ b/src/gui/auth/qgsauthmasterpassresetdialog.h
@@ -45,9 +45,6 @@ class GUI_EXPORT QgsMasterPasswordResetDialog : public QDialog, private Ui::QgsM
     void on_leMasterPassCurrent_textChanged( const QString &pass );
     void on_leMasterPassNew_textChanged( const QString &pass );
 
-    void on_chkPassShowCurrent_stateChanged( int state );
-    void on_chkPassShowNew_stateChanged( int state );
-
   private:
     void validatePasswords();
 

--- a/src/gui/qgspasswordlineedit.cpp
+++ b/src/gui/qgspasswordlineedit.cpp
@@ -35,7 +35,7 @@ QgsPasswordLineEdit::QgsPasswordLineEdit( QWidget *parent )
     mActionLock = addAction( QgsApplication::getThemeIcon( "/lockedGray.svg" ), QLineEdit::LeadingPosition );
   }
 
-  connect( mActionShowHidePassword, SIGNAL( triggered( bool ) ), this, SLOT( togglePasswordVisibility( bool ) ) );
+  connect( mActionShowHidePassword, &QAction::triggered, this, &QgsPasswordLineEdit::togglePasswordVisibility );
 }
 
 void QgsPasswordLineEdit::togglePasswordVisibility( bool toggled )

--- a/src/gui/qgspasswordlineedit.cpp
+++ b/src/gui/qgspasswordlineedit.cpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+                              qgspasswordlineedit.cpp
+                              ------------------------
+  begin                : March 13, 2017
+  copyright            : (C) 2017 by Alexander Bruy
+  email                : alexander dot bruy at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspasswordlineedit.h"
+#include "qgsapplication.h"
+
+QgsPasswordLineEdit::QgsPasswordLineEdit( QWidget *parent )
+  : QLineEdit( parent )
+  , mActionShowHidePassword( nullptr )
+  , mActionLock( nullptr )
+  , mLockIconVisible( false )
+{
+  mShowPasswordIcon = QgsApplication::getThemeIcon( "/mActionShowAllLayers.svg" );
+  mHidePasswordIcon = QgsApplication::getThemeIcon( "/mActionHideAllLayers.svg" );
+
+  mActionShowHidePassword = addAction( mShowPasswordIcon, QLineEdit::TrailingPosition );
+  mActionShowHidePassword->setCheckable( true );
+
+  if ( mLockIconVisible )
+  {
+    mActionLock = addAction( QgsApplication::getThemeIcon( "/lockedGray.svg" ), QLineEdit::LeadingPosition );
+  }
+
+  connect( mActionShowHidePassword, SIGNAL( triggered( bool ) ), this, SLOT( togglePasswordVisibility( bool ) ) );
+}
+
+void QgsPasswordLineEdit::togglePasswordVisibility( bool toggled )
+{
+  if ( toggled )
+  {
+    setEchoMode( QLineEdit::Normal );
+    mActionShowHidePassword->setIcon( mHidePasswordIcon );
+  }
+  else
+  {
+    setEchoMode( QLineEdit::Password );
+    mActionShowHidePassword->setIcon( mShowPasswordIcon );
+  }
+}
+
+void QgsPasswordLineEdit::setShowLockIcon( bool visible )
+{
+  mLockIconVisible = visible;
+  if ( mLockIconVisible )
+  {
+    if ( !mActionLock )
+    {
+      mActionLock = addAction( QgsApplication::getThemeIcon( "/lockedGray.svg" ), QLineEdit::LeadingPosition );
+    }
+  }
+  else
+  {
+    if ( mActionLock )
+    {
+      removeAction( mActionLock );
+      mActionLock = nullptr;
+    }
+  }
+}

--- a/src/gui/qgspasswordlineedit.h
+++ b/src/gui/qgspasswordlineedit.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+                              qgspasswordlineedit.h
+                              ------------------------
+  begin                : March 13, 2017
+  copyright            : (C) 2017 by Alexander Bruy
+  email                : alexander dot bruy at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPASSWORDLINEEDIT_H
+#define QGSPASSWORDLINEEDIT_H
+
+#include <QLineEdit>
+#include <QAction>
+
+#include "qgis_gui.h"
+
+class QToolButton;
+
+/** \class QgsPasswordLineEdit
+ * \ingroup gui
+ * QLineEdit subclass with built in support for showing/hiding
+ * entered password.
+ * @note added in QGIS 3.0
+ **/
+class GUI_EXPORT QgsPasswordLineEdit : public QLineEdit
+{
+    Q_OBJECT
+
+  public:
+
+    /** Constructor for QgsPasswordLineEdit.
+     * @param parent parent widget
+     */
+    QgsPasswordLineEdit( QWidget *parent = nullptr );
+
+    /** Define if a lock icon shall be shown on the left of the widget
+     * @param visible set to false to hide the lock icon
+     */
+    void setShowLockIcon( bool visible );
+
+    /** Returns if a lock icon shall be shown on the left of the widget
+     */
+    bool showLockIcon() const { return mLockIconVisible; }
+
+  private slots:
+    void togglePasswordVisibility( bool toggled );
+
+  private:
+
+    QAction *mActionShowHidePassword = nullptr;
+    QAction *mActionLock = nullptr;
+
+    QIcon mShowPasswordIcon;
+    QIcon mHidePasswordIcon;
+
+    bool mLockIconVisible;
+    QSize mIconsSize;
+};
+
+#endif // QGSPASSWORDLINEEDIT_H

--- a/src/gui/qgspasswordlineedit.h
+++ b/src/gui/qgspasswordlineedit.h
@@ -23,8 +23,6 @@
 
 #include "qgis_gui.h"
 
-class QToolButton;
-
 /** \class QgsPasswordLineEdit
  * \ingroup gui
  * QLineEdit subclass with built in support for showing/hiding

--- a/src/gui/qgspasswordlineedit.h
+++ b/src/gui/qgspasswordlineedit.h
@@ -32,6 +32,7 @@
 class GUI_EXPORT QgsPasswordLineEdit : public QLineEdit
 {
     Q_OBJECT
+    Q_PROPERTY( bool showLockIcon READ showLockIcon WRITE setShowLockIcon )
 
   public:
 

--- a/src/ui/auth/qgsauthmasterpassresetdialog.ui
+++ b/src/ui/auth/qgsauthmasterpassresetdialog.ui
@@ -29,34 +29,14 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>6</number>
+    <widget class="QgsPasswordLineEdit" name="leMasterPassCurrent">
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
      </property>
-     <item>
-      <widget class="QLineEdit" name="leMasterPassCurrent">
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-       <property name="placeholderText">
-        <string>Required</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="chkPassShowCurrent">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Show</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="placeholderText">
+      <string>Required</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QLabel" name="label_7">
@@ -73,34 +53,14 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>6</number>
+    <widget class="QgsPasswordLineEdit" name="leMasterPassNew">
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
      </property>
-     <item>
-      <widget class="QLineEdit" name="leMasterPassNew">
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-       <property name="placeholderText">
-        <string>Required</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="chkPassShowNew">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Show</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="placeholderText">
+      <string>Required</string>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -170,11 +130,16 @@ and re-encrypted using new password</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>leMasterPassCurrent</tabstop>
-  <tabstop>chkPassShowCurrent</tabstop>
   <tabstop>leMasterPassNew</tabstop>
-  <tabstop>chkPassShowNew</tabstop>
   <tabstop>chkKeepBackup</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -81,7 +81,7 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QLineEdit" name="lePassword">
+        <widget class="QgsPasswordLineEdit" name="lePassword">
          <property name="echoMode">
           <enum>QLineEdit::Password</enum>
          </property>
@@ -220,6 +220,13 @@ font-style: italic;
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>leUsername</tabstop>
   <tabstop>lePassword</tabstop>

--- a/src/ui/qgsdb2newconnectionbase.ui
+++ b/src/ui/qgsdb2newconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>445</width>
-    <height>386</height>
+    <height>399</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -120,7 +120,16 @@
           <string>Authentication</string>
          </attribute>
          <layout class="QGridLayout" name="gridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>5</number>
+          </property>
+          <property name="topMargin">
+           <number>5</number>
+          </property>
+          <property name="rightMargin">
+           <number>5</number>
+          </property>
+          <property name="bottomMargin">
            <number>5</number>
           </property>
           <item row="0" column="0">
@@ -134,7 +143,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="txtPassword">
+           <widget class="QgsPasswordLineEdit" name="txtPassword">
             <property name="echoMode">
              <enum>QLineEdit::Password</enum>
             </property>
@@ -189,6 +198,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>txtName</tabstop>
   <tabstop>txtService</tabstop>

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -154,7 +154,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLineEdit" name="txtPassword">
+            <widget class="QgsPasswordLineEdit" name="txtPassword">
              <property name="enabled">
               <bool>false</bool>
              </property>
@@ -270,6 +270,11 @@ Untick save if you don't wish to be the case.</string>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsMessageBar</class>
    <extends>QWidget</extends>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -92,7 +92,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="txtPassword">
+           <widget class="QgsPasswordLineEdit" name="txtPassword">
             <property name="echoMode">
              <enum>QLineEdit::Password</enum>
             </property>
@@ -262,6 +262,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>txtName</tabstop>
   <tabstop>txtUrl</tabstop>

--- a/src/ui/qgsnewogrconnectionbase.ui
+++ b/src/ui/qgsnewogrconnectionbase.ui
@@ -26,7 +26,16 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <property name="spacing">
@@ -135,7 +144,7 @@
        </widget>
       </item>
       <item row="6" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtPassword">
+       <widget class="QgsPasswordLineEdit" name="txtPassword">
         <property name="echoMode">
          <enum>QLineEdit::Password</enum>
         </property>
@@ -168,6 +177,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cmbDatabaseTypes</tabstop>
   <tabstop>txtName</tabstop>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -311,7 +311,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>13</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -340,8 +340,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>702</height>
+                <width>857</width>
+                <height>680</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1026,8 +1026,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1110</height>
+                <width>541</width>
+                <height>1065</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1556,8 +1556,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>787</height>
+                <width>495</width>
+                <height>685</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1924,8 +1924,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1110</height>
+                <width>674</width>
+                <height>936</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -2675,8 +2675,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>674</height>
+                <width>142</width>
+                <height>239</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -2826,8 +2826,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>674</height>
+                <width>501</width>
+                <height>316</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3169,8 +3169,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>674</height>
+                <width>604</width>
+                <height>589</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3460,7 +3460,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     <property name="value">
                      <number>200</number>
                     </property>
-                    <property name="showClearButton" stdset="100">
+                    <property name="showClearButton" stdset="0">
                      <bool>true</bool>
                     </property>
                    </widget>
@@ -3613,8 +3613,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>674</height>
+                <width>480</width>
+                <height>571</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -3882,8 +3882,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>828</height>
+                <width>543</width>
+                <height>696</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4460,8 +4460,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>674</height>
+                <width>412</width>
+                <height>368</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4599,8 +4599,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>674</height>
+                <width>408</width>
+                <height>531</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -4812,8 +4812,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>674</height>
+                <width>273</width>
+                <height>236</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -4922,7 +4922,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                 <x>0</x>
                 <y>0</y>
                 <width>843</width>
-                <height>790</height>
+                <height>689</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5161,7 +5161,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                         </widget>
                        </item>
                        <item row="3" column="2">
-                        <widget class="QLineEdit" name="leProxyPassword">
+                        <widget class="QgsPasswordLineEdit" name="leProxyPassword">
                          <property name="toolTip">
                           <string>Leave this blank if no proxy username / password are required</string>
                          </property>
@@ -5435,6 +5435,11 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>508</height>
+    <height>513</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,7 +26,16 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <property name="spacing">
@@ -205,7 +214,7 @@
        <widget class="QLineEdit" name="txtHost"/>
       </item>
       <item row="5" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtPassword">
+       <widget class="QgsPasswordLineEdit" name="txtPassword">
         <property name="echoMode">
          <enum>QLineEdit::Password</enum>
         </property>
@@ -271,6 +280,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>txtName</tabstop>
   <tabstop>txtDatabase</tabstop>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -90,7 +90,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="txtPassword">
+           <widget class="QgsPasswordLineEdit" name="txtPassword">
             <property name="echoMode">
              <enum>QLineEdit::Password</enum>
             </property>
@@ -315,6 +315,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>txtName</tabstop>
   <tabstop>txtService</tabstop>


### PR DESCRIPTION
Add new custom widget for editing passwords with build-in "show/hide" button.
![password-nolock](https://cloud.githubusercontent.com/assets/776954/23896562/88ef39c8-08b2-11e7-8cc1-4a69a7927e0d.png)
Widget also has ability to show "lock" icon on the left side, this may be useful when one wants widget without accompanying label.
![invisible-password-lock](https://cloud.githubusercontent.com/assets/776954/23896615/b1f5c7ec-08b2-11e7-8318-b2d40a4ceb9e.png)
![visible-password-lock](https://cloud.githubusercontent.com/assets/776954/23896620/b55d9b4e-08b2-11e7-97a0-d347563f77f5.png)

Widget also added to the QGIS Qt Designer's custom widgets and some QGIS dialogs were updated to use it. If PR will be merged, corresponding documentation screenshots should be updated.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
