### PR TITLE
OGR data provider: use transactions when changing attributes and geometries (if possible) (#16216)

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1319,6 +1319,8 @@ bool QgsOgrProvider::addFeatures( QgsFeatureList &flist )
 
   setRelevantFields( ogrLayer, true, attributeIndexes() );
 
+  const bool inTransaction = startTransaction();
+
   bool returnvalue = true;
   for ( QgsFeatureList::iterator it = flist.begin(); it != flist.end(); ++it )
   {
@@ -1326,6 +1328,11 @@ bool QgsOgrProvider::addFeatures( QgsFeatureList &flist )
     {
       returnvalue = false;
     }
+  }
+
+  if ( inTransaction )
+  {
+    commitTransaction();
   }
 
   if ( !syncToDisc() )
@@ -1818,6 +1825,8 @@ bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds &id )
   if ( !doInitialActionsForEdition() )
     return false;
 
+  const bool inTransaction = startTransaction();
+
   bool returnvalue = true;
   for ( QgsFeatureIds::const_iterator it = id.begin(); it != id.end(); ++it )
   {
@@ -1825,6 +1834,11 @@ bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds &id )
     {
       returnvalue = false;
     }
+  }
+
+  if ( inTransaction )
+  {
+    commitTransaction();
   }
 
   if ( !syncToDisc() )

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -167,6 +167,12 @@ class QgsOgrProvider : public QgsVectorDataProvider
     unsigned char *getGeometryPointer( OGRFeatureH fet );
     QString ogrWkbGeometryTypeName( OGRwkbGeometryType type ) const;
 
+    //! Starts a transaction if possible and return true in that case
+    bool startTransaction();
+
+    //! Commits a transaction
+    bool commitTransaction();
+
     QgsFields mAttributeFields;
 
     //! Map of field index to default value


### PR DESCRIPTION
This is a followup to  https://github.com/qgis/QGIS/pull/4175
