### PR TITLE
[style dock] fix defining min/max values via raster histogram

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -432,13 +432,11 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
       {
         if ( rlayer->dataProvider()->capabilities() & QgsRasterDataProvider::Size )
         {
-          if ( mRasterStyleWidget )
+          if ( !mRasterStyleWidget )
           {
-            mRasterStyleWidget->deleteLater();
-            delete mRasterStyleWidget;
+            mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
+            mRasterStyleWidget->syncToLayer( rlayer );
           }
-          mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
-          mRasterStyleWidget->syncToLayer( rlayer );
           connect( mRasterStyleWidget, SIGNAL( widgetChanged() ), this, SLOT( autoApply() ) );
 
           QgsRasterHistogramWidget *widget = new QgsRasterHistogramWidget( rlayer, mWidgetStack );

--- a/src/gui/raster/qgsrasterhistogramwidget.cpp
+++ b/src/gui/raster/qgsrasterhistogramwidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsrasterrendererregistry.h"
 #include "qgsrasterrendererwidget.h"
 #include "qgsrasterhistogramwidget.h"
+#include "qgsrasterminmaxwidget.h"
 #include "qgsrasterdataprovider.h"
 #include "qgssettings.h"
 
@@ -963,7 +964,13 @@ void QgsRasterHistogramWidget::applyHistoMin()
     {
       min = leHistoMin->text();
       if ( mHistoUpdateStyleToMinMax )
+      {
         mRendererWidget->setMin( min, i );
+        if ( mRendererWidget->minMaxWidget() )
+        {
+          mRendererWidget->minMaxWidget()->userHasSetManualMinMaxValues();
+        }
+      }
     }
   }
 
@@ -992,7 +999,13 @@ void QgsRasterHistogramWidget::applyHistoMax()
     {
       max = leHistoMax->text();
       if ( mHistoUpdateStyleToMinMax )
+      {
         mRendererWidget->setMax( max, i );
+        if ( mRendererWidget->minMaxWidget() )
+        {
+          mRendererWidget->minMaxWidget()->userHasSetManualMinMaxValues();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Description
This RP resurrects the setting of raster band min/max values through the style dock's histogram tab. It also switch the computation min / max widget method to "user defined" (which prevents values from being reverted to default when changing saturation / contrast / etc. values).

@rouault , @NathanW2 , are you OK with the proposed change? 

P.S. @rouault , as you might have noticed, I filed a bug yesterday on min / max values broken when opening a raster layer's properties window (http://hub.qgis.org/issues/16353). This PR doesn't fix that bug, it's still in need of your attention :smile:

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
