### PR TITLE
Fix fill stroke color bug in SLD export

### DIFF
--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -344,7 +344,7 @@ void QgsSimpleFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, c
     QDomElement strokeElem = doc.createElement( QStringLiteral( "se:Stroke" ) );
     symbolizerElem.appendChild( strokeElem );
     double strokeWidth = QgsSymbolLayerUtils::rescaleUom( mStrokeWidth, mStrokeWidthUnit, props );
-    QgsSymbolLayerUtils::lineToSld( doc, strokeElem, mStrokeStyle, strokeWidth, strokeWidth, &mPenJoinStyle );
+    QgsSymbolLayerUtils::lineToSld( doc, strokeElem, mStrokeStyle, mStrokeColor, strokeWidth, &mPenJoinStyle );
   }
 
   // <se:Displacement>


### PR DESCRIPTION
Patch fixes fill stroke color value when style is exported to SLD

## Description
This patch fixes bug in stroke color in fill styling when the style is exported to SLD. Code used stroke width value as stroke color attribute when calling QgsSymbolLayerUtils::lineToSld() function. This resulted color values like `#000001` if the stroke width had value 1.0 . Fix in code is trivial and explains the issue.

I could not find exact issue number for this bug.
