### PR TITLE
Avoid getting stuck in raster projector loop for long times

### DIFF
--- a/src/core/raster/qgsbrightnesscontrastfilter.cpp
+++ b/src/core/raster/qgsbrightnesscontrastfilter.cpp
@@ -110,33 +110,30 @@ QgsRasterBlock *QgsBrightnessContrastFilter::block( int bandNo, QgsRectangle  co
   Q_UNUSED( bandNo );
   QgsDebugMsgLevel( QString( "width = %1 height = %2 extent = %3" ).arg( width ).arg( height ).arg( extent.toString() ), 4 );
 
-  QgsRasterBlock *outputBlock = new QgsRasterBlock();
+  std::unique_ptr< QgsRasterBlock > outputBlock( new QgsRasterBlock() );
   if ( !mInput )
   {
-    return outputBlock;
+    return outputBlock.release();
   }
 
   // At this moment we know that we read rendered image
   int bandNumber = 1;
-  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, width, height, feedback );
+  std::unique_ptr< QgsRasterBlock > inputBlock( mInput->block( bandNumber, extent, width, height, feedback ) );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );
-    delete inputBlock;
-    return outputBlock;
+    return outputBlock.release();
   }
 
   if ( mBrightness == 0 && mContrast == 0 )
   {
     QgsDebugMsgLevel( "No brightness changes.", 4 );
-    delete outputBlock;
-    return inputBlock;
+    return inputBlock.release();
   }
 
   if ( !outputBlock->reset( Qgis::ARGB32_Premultiplied, width, height ) )
   {
-    delete inputBlock;
-    return outputBlock;
+    return outputBlock.release();
   }
 
   // adjust image
@@ -164,8 +161,7 @@ QgsRasterBlock *QgsBrightnessContrastFilter::block( int bandNo, QgsRectangle  co
     outputBlock->setColor( i, qRgba( r, g, b, alpha ) );
   }
 
-  delete inputBlock;
-  return outputBlock;
+  return outputBlock.release();
 }
 
 int QgsBrightnessContrastFilter::adjustColorComponent( int colorComponent, int alpha, int brightness, double contrastFactor ) const

--- a/src/core/raster/qgscontrastenhancement.h
+++ b/src/core/raster/qgscontrastenhancement.h
@@ -26,6 +26,7 @@ class originally created circa 2004 by T.Sutton, Gary E.Sherman, Steve Halasz
 
 #include "qgis.h"
 #include "qgsraster.h"
+#include <memory>
 
 class QgsContrastEnhancementFunction;
 class QDomDocument;
@@ -120,7 +121,7 @@ class CORE_EXPORT QgsContrastEnhancement
     ContrastEnhancementAlgorithm mContrastEnhancementAlgorithm;
 
     //! \brief Pointer to the contrast enhancement function
-    QgsContrastEnhancementFunction *mContrastEnhancementFunction = nullptr;
+    std::unique_ptr< QgsContrastEnhancementFunction > mContrastEnhancementFunction;
 
     //! \brief Flag indicating if the lookup table needs to be regenerated
     bool mEnhancementDirty;

--- a/src/core/raster/qgshuesaturationfilter.cpp
+++ b/src/core/raster/qgshuesaturationfilter.cpp
@@ -119,33 +119,30 @@ QgsRasterBlock *QgsHueSaturationFilter::block( int bandNo, QgsRectangle  const &
   Q_UNUSED( bandNo );
   QgsDebugMsgLevel( QString( "width = %1 height = %2 extent = %3" ).arg( width ).arg( height ).arg( extent.toString() ), 4 );
 
-  QgsRasterBlock *outputBlock = new QgsRasterBlock();
+  std::unique_ptr< QgsRasterBlock > outputBlock( new QgsRasterBlock() );
   if ( !mInput )
   {
-    return outputBlock;
+    return outputBlock.release();
   }
 
   // At this moment we know that we read rendered image
   int bandNumber = 1;
-  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, width, height, feedback );
+  std::unique_ptr< QgsRasterBlock > inputBlock( mInput->block( bandNumber, extent, width, height, feedback ) );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );
-    delete inputBlock;
-    return outputBlock;
+    return outputBlock.release();
   }
 
   if ( mSaturation == 0 && mGrayscaleMode == GrayscaleOff && !mColorizeOn )
   {
     QgsDebugMsgLevel( "No hue/saturation change.", 4 );
-    delete outputBlock;
-    return inputBlock;
+    return inputBlock.release();
   }
 
   if ( !outputBlock->reset( Qgis::ARGB32_Premultiplied, width, height ) )
   {
-    delete inputBlock;
-    return outputBlock;
+    return outputBlock.release();
   }
 
   // adjust image
@@ -216,8 +213,7 @@ QgsRasterBlock *QgsHueSaturationFilter::block( int bandNo, QgsRectangle  const &
     outputBlock->setColor( i, qRgba( r, g, b, alpha ) );
   }
 
-  delete inputBlock;
-  return outputBlock;
+  return outputBlock.release();
 }
 
 // Process a colorization and update resultant HSL & RGB values

--- a/src/core/raster/qgsmultibandcolorrenderer.cpp
+++ b/src/core/raster/qgsmultibandcolorrenderer.cpp
@@ -133,10 +133,10 @@ QgsRasterRenderer *QgsMultiBandColorRenderer::create( const QDomElement &elem, Q
 QgsRasterBlock *QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  const &extent, int width, int height, QgsRasterBlockFeedback *feedback )
 {
   Q_UNUSED( bandNo );
-  QgsRasterBlock *outputBlock = new QgsRasterBlock();
+  std::unique_ptr< QgsRasterBlock > outputBlock( new QgsRasterBlock() );
   if ( !mInput )
   {
-    return outputBlock;
+    return outputBlock.release();
   }
 
   //In some (common) cases, we can simplify the drawing loop considerably and save render time
@@ -161,7 +161,7 @@ QgsRasterBlock *QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
   {
     // no need to draw anything if no band is set
     // TODO:: we should probably return default color block
-    return outputBlock;
+    return outputBlock.release();
   }
 
   if ( mAlphaBand > 0 )
@@ -195,7 +195,7 @@ QgsRasterBlock *QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
       {
         delete bandBlocks[*bandIt];
       }
-      return outputBlock;
+      return outputBlock.release();
     }
   }
 
@@ -222,7 +222,7 @@ QgsRasterBlock *QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
     {
       delete bandBlocks.value( i );
     }
-    return outputBlock;
+    return outputBlock.release();
   }
 
   QRgb myDefaultColor = NODATA_COLOR;
@@ -323,7 +323,7 @@ QgsRasterBlock *QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
     delete bandDelIt.value();
   }
 
-  return outputBlock;
+  return outputBlock.release();
 }
 
 void QgsMultiBandColorRenderer::writeXml( QDomDocument &doc, QDomElement &parentElem ) const

--- a/src/core/raster/qgsrasternuller.cpp
+++ b/src/core/raster/qgsrasternuller.cpp
@@ -73,7 +73,7 @@ QgsRasterBlock *QgsRasterNuller::block( int bandNo, QgsRectangle  const &extent,
     return new QgsRasterBlock();
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( bandNo, extent, width, height, feedback );
+  std::unique_ptr< QgsRasterBlock > inputBlock( mInput->block( bandNo, extent, width, height, feedback ) );
   if ( !inputBlock )
   {
     return new QgsRasterBlock();
@@ -82,10 +82,10 @@ QgsRasterBlock *QgsRasterNuller::block( int bandNo, QgsRectangle  const &extent,
   // We don't support nuller for color types
   if ( QgsRasterBlock::typeIsColor( inputBlock->dataType() ) )
   {
-    return inputBlock;
+    return inputBlock.release();
   }
 
-  QgsRasterBlock *outputBlock = new QgsRasterBlock( inputBlock->dataType(), width, height );
+  std::unique_ptr< QgsRasterBlock > outputBlock( new QgsRasterBlock( inputBlock->dataType(), width, height ) );
   if ( mHasOutputNoData.value( bandNo - 1 ) || inputBlock->hasNoDataValue() )
   {
     double noDataValue;
@@ -122,8 +122,6 @@ QgsRasterBlock *QgsRasterNuller::block( int bandNo, QgsRectangle  const &extent,
       }
     }
   }
-  delete inputBlock;
-
-  return outputBlock;
+  return outputBlock.release();
 }
 

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -75,7 +75,7 @@ void QgsRasterProjector::setCrs( const QgsCoordinateReferenceSystem &srcCRS, con
 
 ProjectorData::ProjectorData( const QgsRectangle &extent, int width, int height, QgsRasterInterface *input, const QgsCoordinateTransform &inverseCt, QgsRasterProjector::Precision precision )
   : mApproximate( false )
-  , mInverseCt( new QgsCoordinateTransform( inverseCt ) )
+  , mInverseCt( inverseCt )
   , mDestExtent( extent )
   , mDestRows( height )
   , mDestCols( width )
@@ -210,7 +210,6 @@ ProjectorData::~ProjectorData()
 {
   delete[] pHelperTop;
   delete[] pHelperBottom;
-  delete mInverseCt;
 }
 
 
@@ -345,7 +344,7 @@ void ProjectorData::calcSrcRowsCols()
     //double
     QgsRectangle srcExtent;
     int srcXSize, srcYSize;
-    if ( QgsRasterProjector::extentSize( *mInverseCt, mDestExtent, mDestCols, mDestRows, srcExtent, srcXSize, srcYSize ) )
+    if ( QgsRasterProjector::extentSize( mInverseCt, mDestExtent, mDestCols, mDestRows, srcExtent, srcXSize, srcYSize ) )
     {
       double srcXRes = srcExtent.width() / srcXSize;
       double srcYRes = srcExtent.height() / srcYSize;
@@ -457,9 +456,9 @@ bool ProjectorData::preciseSrcRowCol( int destRow, int destCol, int *srcRow, int
   QgsDebugMsgLevel( QString( "x = %1 y = %2" ).arg( x ).arg( y ), 5 );
 #endif
 
-  if ( mInverseCt->isValid() )
+  if ( mInverseCt.isValid() )
   {
-    mInverseCt->transformInPlace( x, y, z );
+    mInverseCt.transformInPlace( x, y, z );
   }
 
 #ifdef QGISDEBUG
@@ -774,17 +773,16 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
     return new QgsRasterBlock();
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( bandNo, pd.srcExtent(), pd.srcCols(), pd.srcRows(), feedback );
+  std::unique_ptr< QgsRasterBlock > inputBlock( mInput->block( bandNo, pd.srcExtent(), pd.srcCols(), pd.srcRows(), feedback ) );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );
-    delete inputBlock;
     return new QgsRasterBlock();
   }
 
   qgssize pixelSize = QgsRasterBlock::typeSize( mInput->dataType( bandNo ) );
 
-  QgsRasterBlock *outputBlock = new QgsRasterBlock( inputBlock->dataType(), width, height );
+  std::unique_ptr< QgsRasterBlock > outputBlock( new QgsRasterBlock( inputBlock->dataType(), width, height ) );
   if ( inputBlock->hasNoDataValue() )
   {
     outputBlock->setNoDataValue( inputBlock->noDataValue() );
@@ -792,8 +790,7 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
   if ( !outputBlock->isValid() )
   {
     QgsDebugMsg( "Cannot create block" );
-    delete inputBlock;
-    return outputBlock;
+    return outputBlock.release();
   }
 
   // set output to no data, it should be fast
@@ -850,9 +847,7 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
     }
   }
 
-  delete inputBlock;
-
-  return outputBlock;
+  return outputBlock.release();
 }
 
 bool QgsRasterProjector::destExtentSize( const QgsRectangle &srcExtent, int srcXSize, int srcYSize,

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -751,6 +751,9 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
     return new QgsRasterBlock();
   }
 
+  if ( feedback && feedback->isCanceled() )
+    return new QgsRasterBlock();
+
   if ( ! mSrcCRS.isValid() || ! mDestCRS.isValid() || mSrcCRS == mDestCRS )
   {
     QgsDebugMsgLevel( "No projection necessary", 4 );
@@ -813,6 +816,8 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
   int srcRow, srcCol;
   for ( int i = 0; i < height; ++i )
   {
+    if ( feedback && feedback->isCanceled() )
+      break;
     for ( int j = 0; j < width; ++j )
     {
       bool inside = pd.srcRowCol( i, j, &srcRow, &srcCol );
@@ -832,12 +837,12 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
       char *destBits = outputBlock->bits( destIndex );
       if ( !srcBits )
       {
-        QgsDebugMsg( QString( "Cannot get input block data: row = %1 col = %2" ).arg( i ).arg( j ) );
+        // QgsDebugMsg( QString( "Cannot get input block data: row = %1 col = %2" ).arg( i ).arg( j ) );
         continue;
       }
       if ( !destBits )
       {
-        QgsDebugMsg( QString( "Cannot set output block data: srcRow = %1 srcCol = %2" ).arg( srcRow ).arg( srcCol ) );
+        // QgsDebugMsg( QString( "Cannot set output block data: srcRow = %1 srcCol = %2" ).arg( srcRow ).arg( srcCol ) );
         continue;
       }
       memcpy( destBits, srcBits, pixelSize );

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -29,12 +29,12 @@
 
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransform.h"
 #include "qgsrasterinterface.h"
 
 #include <cmath>
 
 class QgsPoint;
-class QgsCoordinateTransform;
 
 /** \ingroup core
  * \brief QgsRasterProjector implements approximate projection support for
@@ -193,7 +193,7 @@ class ProjectorData
     bool mApproximate;
 
     //! Transformation from destination CRS to source CRS
-    QgsCoordinateTransform *mInverseCt = nullptr;
+    QgsCoordinateTransform mInverseCt;
 
     //! Destination extent
     QgsRectangle mDestExtent;

--- a/src/core/raster/qgsrasterresamplefilter.h
+++ b/src/core/raster/qgsrasterresamplefilter.h
@@ -20,8 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgsrasterinterface.h"
-
-class QgsRasterResampler;
+#include "qgsrasterresampler.h"
 
 class QDomElement;
 
@@ -32,7 +31,6 @@ class CORE_EXPORT QgsRasterResampleFilter : public QgsRasterInterface
 {
   public:
     QgsRasterResampleFilter( QgsRasterInterface *input = nullptr );
-    ~QgsRasterResampleFilter();
 
     QgsRasterResampleFilter *clone() const override;
 
@@ -46,11 +44,11 @@ class CORE_EXPORT QgsRasterResampleFilter : public QgsRasterInterface
 
     //! Set resampler for zoomed in scales. Takes ownership of the object
     void setZoomedInResampler( QgsRasterResampler *r );
-    const QgsRasterResampler *zoomedInResampler() const { return mZoomedInResampler; }
+    const QgsRasterResampler *zoomedInResampler() const { return mZoomedInResampler.get(); }
 
     //! Set resampler for zoomed out scales. Takes ownership of the object
     void setZoomedOutResampler( QgsRasterResampler *r );
-    const QgsRasterResampler *zoomedOutResampler() const { return mZoomedOutResampler; }
+    const QgsRasterResampler *zoomedOutResampler() const { return mZoomedOutResampler.get(); }
 
     void setMaxOversampling( double os ) { mMaxOversampling = os; }
     double maxOversampling() const { return mMaxOversampling; }
@@ -62,9 +60,9 @@ class CORE_EXPORT QgsRasterResampleFilter : public QgsRasterInterface
 
   protected:
     //! Resampler used if screen resolution is higher than raster resolution (zoomed in). 0 means no resampling (nearest neighbour)
-    QgsRasterResampler *mZoomedInResampler = nullptr;
+    std::unique_ptr< QgsRasterResampler > mZoomedInResampler;
     //! Resampler used if raster resolution is higher than raster resolution (zoomed out). 0 mean no resampling (nearest neighbour)
-    QgsRasterResampler *mZoomedOutResampler = nullptr;
+    std::unique_ptr< QgsRasterResampler > mZoomedOutResampler;
 
     //! Maximum boundary for oversampling (to avoid too much data traffic). Default: 2.0
     double mMaxOversampling;

--- a/src/core/raster/qgsrastershader.cpp
+++ b/src/core/raster/qgsrastershader.cpp
@@ -26,17 +26,11 @@ email                : ersts@amnh.org
 #include <QDomElement>
 
 QgsRasterShader::QgsRasterShader( double minimumValue, double maximumValue )
+  : mMinimumValue( minimumValue )
+  , mMaximumValue( maximumValue )
+  , mRasterShaderFunction( new QgsRasterShaderFunction( mMinimumValue, mMaximumValue ) )
 {
   QgsDebugMsgLevel( "called.", 4 );
-
-  mMinimumValue = minimumValue;
-  mMaximumValue = maximumValue;
-  mRasterShaderFunction = new QgsRasterShaderFunction( mMinimumValue, mMaximumValue );
-}
-
-QgsRasterShader::~QgsRasterShader()
-{
-  delete mRasterShaderFunction;
 }
 
 /**
@@ -92,13 +86,12 @@ void QgsRasterShader::setRasterShaderFunction( QgsRasterShaderFunction *function
 {
   QgsDebugMsgLevel( "called.", 4 );
 
-  if ( mRasterShaderFunction == function )
+  if ( mRasterShaderFunction.get() == function )
     return;
 
   if ( function )
   {
-    delete mRasterShaderFunction;
-    mRasterShaderFunction = function;
+    mRasterShaderFunction.reset( function );
   }
 }
 
@@ -142,7 +135,7 @@ void QgsRasterShader::writeXml( QDomDocument &doc, QDomElement &parent ) const
   }
 
   QDomElement rasterShaderElem = doc.createElement( QStringLiteral( "rastershader" ) );
-  QgsColorRampShader *colorRampShader = dynamic_cast<QgsColorRampShader *>( mRasterShaderFunction );
+  QgsColorRampShader *colorRampShader = dynamic_cast<QgsColorRampShader *>( mRasterShaderFunction.get() );
   if ( colorRampShader )
   {
     QDomElement colorRampShaderElem = doc.createElement( QStringLiteral( "colorrampshader" ) );

--- a/src/core/raster/qgsrastershader.h
+++ b/src/core/raster/qgsrastershader.h
@@ -34,7 +34,6 @@ class CORE_EXPORT QgsRasterShader
 
   public:
     QgsRasterShader( double minimumValue = 0.0, double maximumValue = 255.0 );
-    ~QgsRasterShader();
 
     //! QgsRasterShader cannot be copied
     QgsRasterShader( const QgsRasterShader &rh ) = delete;
@@ -52,8 +51,8 @@ class CORE_EXPORT QgsRasterShader
     //! \brief Return the minimum value for the raster shader
     double minimumValue() { return mMinimumValue; }
 
-    QgsRasterShaderFunction *rasterShaderFunction() { return mRasterShaderFunction; }
-    const QgsRasterShaderFunction *rasterShaderFunction() const { return mRasterShaderFunction; }
+    QgsRasterShaderFunction *rasterShaderFunction() { return mRasterShaderFunction.get(); }
+    const QgsRasterShaderFunction *rasterShaderFunction() const { return mRasterShaderFunction.get(); }
 
     /*
      *
@@ -94,7 +93,7 @@ class CORE_EXPORT QgsRasterShader
     double mMaximumValue;
 
     //! \brief Pointer to the shader function
-    QgsRasterShaderFunction *mRasterShaderFunction = nullptr;
+    std::unique_ptr< QgsRasterShaderFunction > mRasterShaderFunction;
 
 };
 #endif

--- a/src/core/raster/qgsrastershaderfunction.cpp
+++ b/src/core/raster/qgsrastershaderfunction.cpp
@@ -20,12 +20,11 @@ email                : ersts@amnh.org
 #include "qgsrastershaderfunction.h"
 
 QgsRasterShaderFunction::QgsRasterShaderFunction( double minimumValue, double maximumValue )
+  : mMaximumValue( maximumValue )
+  , mMinimumValue( minimumValue )
+  , mMinimumMaximumRange( mMaximumValue - mMinimumValue )
 {
   QgsDebugMsgLevel( "entered.", 4 );
-
-  mMinimumValue = minimumValue;
-  mMaximumValue = maximumValue;
-  mMinimumMaximumRange = mMaximumValue - mMinimumValue;
 }
 
 /**

--- a/src/core/raster/qgssinglebandgrayrenderer.cpp
+++ b/src/core/raster/qgssinglebandgrayrenderer.cpp
@@ -24,14 +24,12 @@
 #include <QColor>
 #include <memory>
 
-QgsSingleBandGrayRenderer::QgsSingleBandGrayRenderer( QgsRasterInterface *input, int grayBand ):
-  QgsRasterRenderer( input, QStringLiteral( "singlebandgray" ) ), mGrayBand( grayBand ), mGradient( BlackToWhite ), mContrastEnhancement( nullptr )
+QgsSingleBandGrayRenderer::QgsSingleBandGrayRenderer( QgsRasterInterface *input, int grayBand )
+  : QgsRasterRenderer( input, QStringLiteral( "singlebandgray" ) )
+  , mGrayBand( grayBand )
+  , mGradient( BlackToWhite )
+  , mContrastEnhancement( nullptr )
 {
-}
-
-QgsSingleBandGrayRenderer::~QgsSingleBandGrayRenderer()
-{
-  delete mContrastEnhancement;
 }
 
 QgsSingleBandGrayRenderer *QgsSingleBandGrayRenderer::clone() const
@@ -76,8 +74,7 @@ QgsRasterRenderer *QgsSingleBandGrayRenderer::create( const QDomElement &elem, Q
 
 void QgsSingleBandGrayRenderer::setContrastEnhancement( QgsContrastEnhancement *ce )
 {
-  delete mContrastEnhancement;
-  mContrastEnhancement = ce;
+  mContrastEnhancement.reset( ce );
 }
 
 QgsRasterBlock *QgsSingleBandGrayRenderer::block( int bandNo, QgsRectangle  const &extent, int width, int height, QgsRasterBlockFeedback *feedback )

--- a/src/core/raster/qgssinglebandgrayrenderer.h
+++ b/src/core/raster/qgssinglebandgrayrenderer.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgsrasterrenderer.h"
+#include <memory>
 
 class QgsContrastEnhancement;
 class QDomElement;
@@ -37,7 +38,6 @@ class CORE_EXPORT QgsSingleBandGrayRenderer: public QgsRasterRenderer
     };
 
     QgsSingleBandGrayRenderer( QgsRasterInterface *input, int grayBand );
-    ~QgsSingleBandGrayRenderer();
 
     //! QgsSingleBandGrayRenderer cannot be copied. Use clone() instead.
     QgsSingleBandGrayRenderer( const QgsSingleBandGrayRenderer & ) = delete;
@@ -52,7 +52,7 @@ class CORE_EXPORT QgsSingleBandGrayRenderer: public QgsRasterRenderer
 
     int grayBand() const { return mGrayBand; }
     void setGrayBand( int band ) { mGrayBand = band; }
-    const QgsContrastEnhancement *contrastEnhancement() const { return mContrastEnhancement; }
+    const QgsContrastEnhancement *contrastEnhancement() const { return mContrastEnhancement.get(); }
     //! Takes ownership
     void setContrastEnhancement( QgsContrastEnhancement *ce );
 
@@ -68,7 +68,7 @@ class CORE_EXPORT QgsSingleBandGrayRenderer: public QgsRasterRenderer
   private:
     int mGrayBand;
     Gradient mGradient;
-    QgsContrastEnhancement *mContrastEnhancement = nullptr;
+    std::unique_ptr< QgsContrastEnhancement > mContrastEnhancement;
 
 };
 

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.h
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.h
@@ -37,7 +37,6 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
 
     //! Note: takes ownership of QgsRasterShader
     QgsSingleBandPseudoColorRenderer( QgsRasterInterface *input, int band = -1, QgsRasterShader *shader = nullptr );
-    ~QgsSingleBandPseudoColorRenderer();
 
     //! QgsSingleBandPseudoColorRenderer cannot be copied. Use clone() instead.
     QgsSingleBandPseudoColorRenderer( const QgsSingleBandPseudoColorRenderer & ) = delete;
@@ -54,10 +53,10 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
     void setShader( QgsRasterShader *shader );
 
     //! Returns the raster shader
-    QgsRasterShader *shader() { return mShader; }
+    QgsRasterShader *shader() { return mShader.get(); }
 
     //! @note available in python as constShader
-    const QgsRasterShader *shader() const { return mShader; }
+    const QgsRasterShader *shader() const { return mShader.get(); }
 
     /** Creates a color ramp shader
      * @param colorRamp vector color ramp
@@ -93,7 +92,7 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
 
   private:
 
-    QgsRasterShader *mShader = nullptr;
+    std::unique_ptr< QgsRasterShader > mShader;
     int mBand;
 
     // Minimum and maximum values used for automatic classification, these


### PR DESCRIPTION
I somehow encountered a situation where the raster projector got stuck for a long time continually spewing out "Cannot get input block data" messages (was using a wms and zoomed outside the valid bounds).

I couldn't reproduce reliably, but I believe this change should avoid the projector burning away with calculations that aren't required anymore. @wonder-sk look ok to you?