### PR TITLE
Open sublayers in a group

### DIFF
--- a/python/gui/qgssublayersdialog.sip
+++ b/python/gui/qgssublayersdialog.sip
@@ -39,6 +39,18 @@ class QgsSublayersDialog : QDialog
     //! @note added in 2.16
     QgsSublayersDialog::LayerDefinitionList selection();
 
+    //! Set if we should display the add to group checkbox
+    //! @note added in 3.0
+    void setShowAddToGroupCheckbox( bool showAddToGroupCheckbox );
+
+    //! If we should display the add to group checkbox
+    //! @note added in 3.0
+    bool showAddToGroupCheckbox() const;
+
+    //! If we should add layers in a group
+    //! @note added in 3.0
+    bool addToGroupCheckbox() const;
+
   public slots:
     void on_buttonBox_helpRequested();
     int exec();

--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -59,6 +59,13 @@ QgsSublayersDialog::QgsSublayersDialog( ProviderType providerType, const QString
 
   QgsSettings settings;
   restoreGeometry( settings.value( "/Windows/" + mName + "SubLayers/geometry" ).toByteArray() );
+
+  // Checkbox about adding sublayers to a group
+  checkboxAddToGroup = new QCheckBox( tr( "Add layers to a group" ) );
+  bool addToGroup = settings.value( QStringLiteral( "/qgis/openSublayersInGroup" ), false ).toBool();
+  checkboxAddToGroup->setChecked( addToGroup );
+  if ( mShowAddToGroupCheckbox )
+    buttonBox->addButton( checkboxAddToGroup, QDialogButtonBox::ActionRole );
 }
 
 QgsSublayersDialog::~QgsSublayersDialog()
@@ -177,5 +184,7 @@ int QgsSublayersDialog::exec()
   int ret = QDialog::exec();
   if ( overrideCursor )
     QApplication::setOverrideCursor( cursor );
+
+  settings.setValue( QStringLiteral( "/qgis/openSublayersInGroup" ), checkboxAddToGroup->isChecked() );
   return ret;
 }

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -17,6 +17,7 @@
 #define QGSSUBLAYERSDIALOG_H
 
 #include <QDialog>
+#include <QCheckBox>
 #include <ui_qgssublayersdialogbase.h>
 #include "qgscontexthelp.h"
 #include "qgis_gui.h"
@@ -63,6 +64,18 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
     //! @note added in 2.16
     LayerDefinitionList selection();
 
+    //! Set if we should display the add to group checkbox
+    //! @note added in 3.0
+    void setShowAddToGroupCheckbox( bool showAddToGroupCheckbox ) { mShowAddToGroupCheckbox = showAddToGroupCheckbox; }
+
+    //! If we should display the add to group checkbox
+    //! @note added in 3.0
+    bool showAddToGroupCheckbox() const { return mShowAddToGroupCheckbox; }
+
+    //! If we should add layers in a group
+    //! @note added in 3.0
+    bool addToGroupCheckbox() const { return checkboxAddToGroup->isChecked(); }
+
   public slots:
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
     int exec();
@@ -72,6 +85,8 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
     QStringList mSelectedSubLayers;
     bool mShowCount;  //!< Whether to show number of features in the table
     bool mShowType;   //!< Whether to show type in the table
+    bool mShowAddToGroupCheckbox;   //!< Whether to show the add to group checkbox
+    QCheckBox *checkboxAddToGroup = nullptr;
 };
 
 #endif


### PR DESCRIPTION
## Description
When you open many sublayers, you can open them in a group with this new checkbox.

![capture d ecran 2017-03-17 a 16 17 25](https://cloud.githubusercontent.com/assets/1609292/24049742/443abcbc-0b2d-11e7-9f6d-2dfbf91bb8cd.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

Funded by Kartoza