### PR TITLE
A different approach to avoiding accidently scroll changes

### DIFF
--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -46,7 +46,7 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -1139,6 +1139,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header location="global">qgis.gui</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -154,6 +154,7 @@
 %Include qgsscalerangewidget.sip
 %Include qgsscalevisibilitydialog.sip
 %Include qgsscalewidget.sip
+%Include qgsscrollarea.sip
 %Include qgssearchquerybuilder.sip
 %Include qgsshortcutsmanager.sip
 %Include qgsslider.sip

--- a/python/gui/qgsscrollarea.sip
+++ b/python/gui/qgsscrollarea.sip
@@ -1,0 +1,15 @@
+class QgsScrollArea : QScrollArea
+{
+%TypeHeaderCode
+#include <qgsscrollarea.h>
+%End
+
+  public:
+    explicit QgsScrollArea( QWidget *parent /TransferThis/ = 0 );
+    void scrollOccurred();
+    bool hasScrolled() const;
+
+  protected:
+    void wheelEvent( QWheelEvent *event );
+
+};

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -30,13 +30,14 @@ __revision__ = '$Format:%H$'
 from qgis.PyQt.QtCore import Qt, QUrl, QMetaObject
 from qgis.PyQt.QtWidgets import (QDialog, QDialogButtonBox, QLabel, QLineEdit,
                                  QFrame, QPushButton, QSizePolicy, QVBoxLayout,
-                                 QHBoxLayout, QTabWidget, QWidget, QScrollArea,
+                                 QHBoxLayout, QTabWidget, QWidget,
                                  QTextBrowser)
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
 
 from qgis.core import QgsNetworkAccessManager
 
-from qgis.gui import QgsMessageBar
+from qgis.gui import (QgsMessageBar,
+                      QgsScrollArea)
 
 from processing.gui.wrappers import InvalidParameterValue
 from processing.gui.MultipleInputPanel import MultipleInputPanel
@@ -187,7 +188,7 @@ class ModelerParametersDialog(QDialog):
         self.tabWidget.setMinimumWidth(300)
         self.paramPanel = QWidget()
         self.paramPanel.setLayout(self.verticalLayout)
-        self.scrollArea = QScrollArea()
+        self.scrollArea = QgsScrollArea()
         self.scrollArea.setWidget(self.paramPanel)
         self.scrollArea.setWidgetResizable(True)
         self.tabWidget.addTab(self.scrollArea, self.tr('Parameters'))

--- a/python/plugins/processing/ui/DlgModeler.ui
+++ b/python/plugins/processing/ui/DlgModeler.ui
@@ -44,7 +44,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QScrollArea" name="scrollArea_1">
+     <widget class="QgsScrollArea" name="scrollArea_1">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
         <horstretch>0</horstretch>
@@ -138,7 +138,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QScrollArea" name="scrollArea_2">
+     <widget class="QgsScrollArea" name="scrollArea_2">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
         <horstretch>0</horstretch>
@@ -222,7 +222,7 @@
      <number>2</number>
     </property>
     <item>
-     <widget class="QScrollArea" name="scrollArea_3">
+     <widget class="QgsScrollArea" name="scrollArea_3">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
         <horstretch>0</horstretch>
@@ -505,6 +505,11 @@
   </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgis.gui</header>
+  </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>

--- a/python/plugins/processing/ui/widgetParametersPanel.ui
+++ b/python/plugins/processing/ui/widgetParametersPanel.ui
@@ -21,7 +21,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -88,6 +88,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>

--- a/src/app/composer/qgsattributeselectiondialog.cpp
+++ b/src/app/composer/qgsattributeselectiondialog.cpp
@@ -29,7 +29,6 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
-#include <QScrollArea>
 #include <QSpinBox>
 #include <QSortFilterProxyModel>
 

--- a/src/customwidgets/CMakeLists.txt
+++ b/src/customwidgets/CMakeLists.txt
@@ -32,6 +32,7 @@ SET (QGIS_CUSTOMWIDGETS_SRCS
   qgsrelationreferencewidgetplugin.cpp
   qgsscalerangewidgetplugin.cpp
   qgsscalewidgetplugin.cpp
+  qgsscrollareawidgetplugin.cpp
   qgsspinboxplugin.cpp
 )
 
@@ -57,6 +58,7 @@ SET (QGIS_CUSTOMWIDGETS_MOC_HDRS
   qgsrelationreferencewidgetplugin.h
   qgsscalerangewidgetplugin.h
   qgsscalewidgetplugin.h
+  qgsscrollareawidgetplugin.h
   qgsspinboxplugin.h
 )
 

--- a/src/customwidgets/qgsscrollareawidgetplugin.cpp
+++ b/src/customwidgets/qgsscrollareawidgetplugin.cpp
@@ -1,0 +1,95 @@
+/***************************************************************************
+   qgsscrollareawidgetplugin.cpp
+    --------------------------------------
+   Date                 : March 2017
+   Copyright            : (C) 2017 Nyall Dawson
+   Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+
+#include "qgiscustomwidgets.h"
+#include "qgsscrollareawidgetplugin.h"
+#include "qgsscrollarea.h"
+
+
+QgsScrollAreaWidgetPlugin::QgsScrollAreaWidgetPlugin( QObject *parent )
+  : QObject( parent )
+{}
+
+QString QgsScrollAreaWidgetPlugin::name() const
+{
+  return "QgsScrollArea";
+}
+
+QString QgsScrollAreaWidgetPlugin::group() const
+{
+  return QgisCustomWidgets::groupName();
+}
+
+QString QgsScrollAreaWidgetPlugin::includeFile() const
+{
+  return "qgsscrollarea.h";
+}
+
+QIcon QgsScrollAreaWidgetPlugin::icon() const
+{
+  return QIcon( ":/images/icons/qgis-icon-60x60.png" );
+}
+
+bool QgsScrollAreaWidgetPlugin::isContainer() const
+{
+  return true;
+}
+
+QWidget *QgsScrollAreaWidgetPlugin::createWidget( QWidget *parent )
+{
+  return new QgsScrollArea( parent );
+}
+
+bool QgsScrollAreaWidgetPlugin::isInitialized() const
+{
+  return mInitialized;
+}
+
+void QgsScrollAreaWidgetPlugin::initialize( QDesignerFormEditorInterface *core )
+{
+  Q_UNUSED( core );
+  if ( mInitialized )
+    return;
+  mInitialized = true;
+}
+
+
+QString QgsScrollAreaWidgetPlugin::toolTip() const
+{
+  return tr( "Scroll area" );
+}
+
+QString QgsScrollAreaWidgetPlugin::whatsThis() const
+{
+  return "";
+}
+
+QString QgsScrollAreaWidgetPlugin::domXml() const
+{
+  return QString( "<ui language=\"c++\">\n"
+                  " <widget class=\"%1\" name=\"mScrollArea\">\n"
+                  "  <property name=\"geometry\">\n"
+                  "   <rect>\n"
+                  "    <x>0</x>\n"
+                  "    <y>0</y>\n"
+                  "    <width>300</width>\n"
+                  "    <height>100</height>\n"
+                  "   </rect>\n"
+                  "  </property>\n"
+                  " </widget>\n"
+                  "</ui>\n" )
+         .arg( name() );
+}

--- a/src/customwidgets/qgsscrollareawidgetplugin.h
+++ b/src/customwidgets/qgsscrollareawidgetplugin.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+   qgsscrollareawidgetplugin.h
+    --------------------------------------
+   Date                 : March 2017
+   Copyright            : (C) 2017 Nyall Dawson
+   Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSSCROLLAREAWIDGETPLUGIN_H
+#define QGSSCROLLAREAWIDGETPLUGIN_H
+
+
+#include <QtGlobal>
+#include <QtUiPlugin/QDesignerCustomWidgetInterface>
+#include <QtUiPlugin/QDesignerExportWidget>
+#include "qgis_customwidgets.h"
+
+class CUSTOMWIDGETS_EXPORT QgsScrollAreaWidgetPlugin : public QObject, public QDesignerCustomWidgetInterface
+{
+    Q_OBJECT
+    Q_INTERFACES( QDesignerCustomWidgetInterface )
+
+  public:
+    explicit QgsScrollAreaWidgetPlugin( QObject *parent = 0 );
+
+  private:
+    bool mInitialized = false;
+
+    // QDesignerCustomWidgetInterface interface
+  public:
+    QString name() const override;
+    QString group() const override;
+    QString includeFile() const override;
+    QIcon icon() const override;
+    bool isContainer() const override;
+    QWidget *createWidget( QWidget *parent ) override;
+    bool isInitialized() const override;
+    void initialize( QDesignerFormEditorInterface *core ) override;
+    QString toolTip() const override;
+    QString whatsThis() const override;
+    QString domXml() const override;
+};
+#endif // QGSSCROLLAREAWIDGETPLUGIN_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -296,6 +296,7 @@ SET(QGIS_GUI_SRCS
   qgsscalerangewidget.cpp
   qgsscalevisibilitydialog.cpp
   qgsscalewidget.cpp
+  qgsscrollarea.cpp
   qgssearchquerybuilder.cpp
   qgsshortcutsmanager.cpp
   qgsslider.cpp
@@ -442,6 +443,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsscalerangewidget.h
   qgsscalevisibilitydialog.h
   qgsscalewidget.h
+  qgsscrollarea.h
   qgssearchquerybuilder.h
   qgsshortcutsmanager.h
   qgsslider.h

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -28,6 +28,7 @@
 #include "qgsorganizetablecolumnsdialog.h"
 #include "qgseditorwidgetregistry.h"
 #include "qgssettings.h"
+#include "qgsscrollarea.h"
 
 #include <QClipboard>
 #include <QDialog>
@@ -95,7 +96,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   mAttributeForm = new QgsAttributeForm( mLayer, QgsFeature(), mEditorContext );
   if ( !context.parentContext() )
   {
-    mAttributeEditorScrollArea = new QScrollArea();
+    mAttributeEditorScrollArea = new QgsScrollArea();
     mAttributeEditorScrollArea->setWidgetResizable( true );
     mAttributeEditor->layout()->addWidget( mAttributeEditorScrollArea );
     mAttributeEditorScrollArea->setWidget( mAttributeForm );

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -29,7 +29,7 @@
 class QgsFeatureRequest;
 class QSignalMapper;
 class QgsMapLayerAction;
-class QScrollArea;
+class QgsScrollArea;
 
 /** \ingroup gui
  * This widget is used to show the attributes of a set of features of a {@link QgsVectorLayer}.
@@ -351,7 +351,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     QgsDistanceArea mDistanceArea;
     QString mDisplayExpression;
     QgsAttributeTableConfig mConfig;
-    QScrollArea *mAttributeEditorScrollArea = nullptr;
+    QgsScrollArea *mAttributeEditorScrollArea = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
 
     friend class TestQgsDualView;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -31,6 +31,7 @@
 #include "qgslogger.h"
 #include "qgstabwidget.h"
 #include "qgssettings.h"
+#include "qgsscrollarea.h"
 
 #include <QDir>
 #include <QTextStream>
@@ -42,7 +43,6 @@
 #include <QKeyEvent>
 #include <QLabel>
 #include <QPushButton>
-#include <QScrollArea>
 #include <QUiLoader>
 #include <QMessageBox>
 #include <QToolButton>
@@ -1210,7 +1210,7 @@ void QgsAttributeForm::init()
     if ( mContext.formMode() != QgsAttributeEditorContext::Embed )
     {
       // put the form into a scroll area to nicely handle cases with lots of attributes
-      QScrollArea *scrollArea = new QScrollArea( this );
+      QgsScrollArea *scrollArea = new QgsScrollArea( this );
       scrollArea->setWidget( formWidget );
       scrollArea->setWidgetResizable( true );
       scrollArea->setFrameShape( QFrame::NoFrame );
@@ -1599,7 +1599,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
         if ( context.formMode() != QgsAttributeEditorContext::Embed )
         {
-          QScrollArea *scrollArea = new QScrollArea( parent );
+          QgsScrollArea *scrollArea = new QgsScrollArea( parent );
 
           scrollArea->setWidget( myContainer );
           scrollArea->setWidgetResizable( true );

--- a/src/gui/qgsattributetypeloaddialog.cpp
+++ b/src/gui/qgsattributetypeloaddialog.cpp
@@ -29,7 +29,6 @@
 #include <QComboBox>
 #include <QLabel>
 #include <QFrame>
-#include <QScrollArea>
 #include <QCompleter>
 #include <QSpinBox>
 #include <QPushButton>

--- a/src/gui/qgsscrollarea.cpp
+++ b/src/gui/qgsscrollarea.cpp
@@ -1,0 +1,127 @@
+/***************************************************************************
+    qgsscrollarea.cpp
+    -----------------
+    begin                : March 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QEvent>
+#include <QMouseEvent>
+#include "qgsscrollarea.h"
+
+// milliseconds to swallow child wheel events for after a scroll occurs
+#define TIMEOUT 1000
+
+QgsScrollArea::QgsScrollArea( QWidget *parent )
+  : QScrollArea( parent )
+  , mFilter( new ScrollAreaFilter( this, viewport() ) )
+{
+  viewport()->installEventFilter( mFilter );
+}
+
+void QgsScrollArea::wheelEvent( QWheelEvent *e )
+{
+  //scroll occurred, reset timer
+  scrollOccurred();
+  QScrollArea::wheelEvent( e );
+}
+
+void QgsScrollArea::scrollOccurred()
+{
+  mTimer.setSingleShot( true );
+  mTimer.start( TIMEOUT );
+}
+
+bool QgsScrollArea::hasScrolled() const
+{
+  return mTimer.isActive();
+}
+
+///@cond PRIVATE
+
+ScrollAreaFilter::ScrollAreaFilter( QgsScrollArea *parent, QWidget *viewPort )
+  : QObject( parent )
+  , mScrollAreaWidget( parent )
+  , mViewPort( viewPort )
+{}
+
+bool ScrollAreaFilter::eventFilter( QObject *obj, QEvent *event )
+{
+  switch ( event->type() )
+  {
+    case QEvent::ChildAdded:
+    {
+      // need to install filter on all child widgets as well
+      QChildEvent *ce = static_cast<QChildEvent *>( event );
+      addChild( ce->child() );
+      break;
+    }
+
+    case QEvent::ChildRemoved:
+    {
+      QChildEvent *ce = static_cast<QChildEvent *>( event );
+      removeChild( ce->child() );
+      break;
+    }
+
+    case QEvent::Wheel:
+    {
+      if ( obj == mViewPort )
+      {
+        // scrolling scroll area - kick off the timer to block wheel events in children
+        mScrollAreaWidget->scrollOccurred();
+      }
+      else
+      {
+        if ( mScrollAreaWidget->hasScrolled() )
+        {
+          // swallow wheel events for children shortly after scroll occurs
+          return true;
+        }
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+  return QObject::eventFilter( obj, event );
+}
+
+void ScrollAreaFilter::addChild( QObject *child )
+{
+  if ( child && child->isWidgetType() )
+  {
+    child->installEventFilter( this );
+
+    // also install filter on existing children
+    Q_FOREACH ( QObject *c, child->children() )
+    {
+      addChild( c );
+    }
+  }
+}
+
+void ScrollAreaFilter::removeChild( QObject *child )
+{
+  if ( child && child->isWidgetType() )
+  {
+    child->removeEventFilter( this );
+
+    // also remove filter on existing children
+    Q_FOREACH ( QObject *c, child->children() )
+    {
+      removeChild( c );
+    }
+  }
+}
+
+///@endcond PRIVATE

--- a/src/gui/qgsscrollarea.h
+++ b/src/gui/qgsscrollarea.h
@@ -1,0 +1,100 @@
+/***************************************************************************
+    qgsscrollarea.h
+    ---------------
+    begin                : March 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSCROLLAREA_H
+#define QGSSCROLLAREA_H
+
+#include <QScrollArea>
+#include "qgis_gui.h"
+#include <QTimer>
+class ScrollAreaFilter;
+
+/**
+ * \class QgsScrollArea
+ * \ingroup gui
+ * A QScrollArea subclass with improved scrolling behavior.
+ *
+ * QgsScrollArea should be used instead of QScrollArea widgets.
+ * In most cases the use is identical, however QgsScrollArea
+ * has extra logic to avoid wheel events changing child widget
+ * values when the mouse cursor is temporarily located over
+ * a child widget during a scroll event.
+ *
+ * All QGIS code and plugins should use QgsScrollArea in place
+ * of QScrollArea.
+ *
+ * \note added in QGIS 3.0
+ */
+class GUI_EXPORT QgsScrollArea : public QScrollArea
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsScrollArea.
+     */
+    explicit QgsScrollArea( QWidget *parent = nullptr );
+
+    /**
+     * Should be called when a scroll occurs on with the
+     * QScrollArea itself or its child viewport().
+     */
+    void scrollOccurred();
+
+    /**
+     * Returns true if a scroll recently occurred within
+     * the QScrollArea or its child viewport()
+     */
+    bool hasScrolled() const;
+
+  protected:
+    void wheelEvent( QWheelEvent *event ) override;
+
+  private:
+    QTimer mTimer;
+    ScrollAreaFilter *mFilter = nullptr;
+};
+
+///@cond PRIVATE
+
+/**
+ * \class ScrollAreaFilter
+ * Swallows wheel events for QScrollArea children for a short period
+ * following a scroll.
+ */
+class ScrollAreaFilter : public QObject
+{
+    Q_OBJECT
+  public:
+
+    ScrollAreaFilter( QgsScrollArea *parent = nullptr,
+                      QWidget *viewPort = nullptr );
+
+  protected:
+    bool eventFilter( QObject *obj, QEvent *event ) override;
+
+  private:
+    QgsScrollArea *mScrollAreaWidget = nullptr;
+    QWidget *mViewPort = nullptr;
+
+    void addChild( QObject *child );
+    void removeChild( QObject *child );
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSSCROLLAREA_H

--- a/src/plugins/evis/eventbrowser/evisimagedisplaywidget.cpp
+++ b/src/plugins/evis/eventbrowser/evisimagedisplaywidget.cpp
@@ -27,6 +27,7 @@
 #include "evisimagedisplaywidget.h"
 
 #include "qgsapplication.h"
+#include "qgsscrollarea.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -76,7 +77,7 @@ eVisImageDisplayWidget::eVisImageDisplayWidget( QWidget *parent, Qt::WindowFlags
   myButtonBar->setLayout( myButtonBarLayout );
 
   //setup display area
-  mDisplayArea = new QScrollArea();
+  mDisplayArea = new QgsScrollArea();
 
   QVBoxLayout *myLayout = new QVBoxLayout;
   myLayout->addWidget( myButtonBar );

--- a/src/plugins/evis/eventbrowser/evisimagedisplaywidget.h
+++ b/src/plugins/evis/eventbrowser/evisimagedisplaywidget.h
@@ -29,11 +29,11 @@
 
 #include <QLabel>
 #include <QWidget>
-#include <QScrollArea>
 #include <QPushButton>
 #include <QBuffer>
-
 #include <QResizeEvent>
+
+class QgsScrollArea;
 
 /**
 * \class eVisGenericEventBrowserGui
@@ -81,7 +81,7 @@ class eVisImageDisplayWidget : public QWidget
     int mCurrentZoomStep;
 
     //! \brief widget to display the image in
-    QScrollArea *mDisplayArea = nullptr;
+    QgsScrollArea *mDisplayArea = nullptr;
 
     //! \brief Method that actually display the image in the widget
     void displayImage();

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
@@ -37,6 +37,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsvectorfilewriter.h"
 #include "qgssettings.h"
+#include "qgsscrollarea.h"
 
 QString QgsGeometryCheckerResultTab::sSettingsGroup = QStringLiteral( "/geometry_checker/default_fix_methods/" );
 
@@ -550,7 +551,7 @@ void QgsGeometryCheckerResultTab::setDefaultResolutionMethods()
 
   QVBoxLayout *layout = new QVBoxLayout( &dialog );
 
-  QScrollArea *scrollArea = new QScrollArea( &dialog );
+  QgsScrollArea *scrollArea = new QgsScrollArea( &dialog );
   scrollArea->setFrameShape( QFrame::NoFrame );
   layout->setContentsMargins( 0, 0, 0, 0 );
   layout->addWidget( scrollArea );

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.ui
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.ui
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -401,6 +401,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>tableWidgetErrors</tabstop>

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckersetuptab.ui
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckersetuptab.ui
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -723,6 +723,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>

--- a/src/plugins/grass/qgsgrassmoduleoptions.cpp
+++ b/src/plugins/grass/qgsgrassmoduleoptions.cpp
@@ -16,8 +16,6 @@
 
 #include <QDomElement>
 #include <QFileDialog>
-#include <QMessageBox>
-#include <QScrollArea>
 #include <QTextCodec>
 
 #include "qgisinterface.h"
@@ -30,6 +28,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
+#include "qgsscrollarea.h"
 
 #include "qgsgrass.h"
 #include "qgsgrassmodule.h"
@@ -90,7 +89,7 @@ QgsGrassModuleStandardOptions::QgsGrassModuleStandardOptions(
   //
   QVBoxLayout *mypOuterLayout = new QVBoxLayout( this );
   mypOuterLayout->setContentsMargins( 0, 0, 0, 0 );
-  QScrollArea *mypScrollArea = new QScrollArea();
+  QgsScrollArea *mypScrollArea = new QgsScrollArea();
   //transfers scroll area ownership so no need to call delete
   mypOuterLayout->addWidget( mypScrollArea );
   QFrame *mypInnerFrame = new QFrame();

--- a/src/providers/grass/qgsgrassoptionsbase.ui
+++ b/src/providers/grass/qgsgrassoptionsbase.ui
@@ -228,7 +228,7 @@
          <widget class="QWidget" name="mModulesPage">
           <layout class="QVBoxLayout" name="verticalLayout_7">
            <item>
-            <widget class="QScrollArea" name="mModulesScrollArea">
+            <widget class="QgsScrollArea" name="mModulesScrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -329,7 +329,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mBrowserScrollArea">
+            <widget class="QgsScrollArea" name="mBrowserScrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -567,6 +567,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
@@ -580,8 +586,8 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../images/images.qrc"/>
   <include location="../../plugins/grass/qgsgrass_plugin.qrc"/>
+  <include location="../../../images/images.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/ui/composer/qgsatlascompositionwidgetbase.ui
+++ b/src/ui/composer/qgsatlascompositionwidgetbase.ui
@@ -96,7 +96,7 @@
        </spacer>
       </item>
       <item row="1" column="0" colspan="3">
-       <widget class="QScrollArea" name="scrollArea">
+       <widget class="QgsScrollArea" name="scrollArea">
         <property name="focusPolicy">
          <enum>Qt::WheelFocus</enum>
         </property>
@@ -316,15 +316,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
    <header location="global">qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsFieldComboBox</class>

--- a/src/ui/composer/qgscomposerarrowwidgetbase.ui
+++ b/src/ui/composer/qgscomposerarrowwidgetbase.ui
@@ -46,7 +46,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -285,21 +285,27 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/composer/qgscomposerattributetablewidgetbase.ui
+++ b/src/ui/composer/qgscomposerattributetablewidgetbase.ui
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -769,9 +769,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -783,6 +783,12 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/composer/qgscomposerbase.ui
+++ b/src/ui/composer/qgscomposerbase.ui
@@ -21,7 +21,16 @@
     <bool>true</bool>
    </property>
    <layout class="QGridLayout" name="gridLayout">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item row="0" column="0">
@@ -35,7 +44,7 @@
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
       </property>
-      <widget class="QScrollArea" name="scrollArea">
+      <widget class="QgsScrollArea" name="scrollArea">
        <property name="geometry">
         <rect>
          <x>280</x>
@@ -1100,6 +1109,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/composer/qgscomposerhtmlwidgetbase.ui
+++ b/src/ui/composer/qgscomposerhtmlwidgetbase.ui
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -282,9 +282,16 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -292,10 +299,9 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/composer/qgscomposerlabelwidgetbase.ui
+++ b/src/ui/composer/qgscomposerlabelwidgetbase.ui
@@ -43,7 +43,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -330,15 +330,21 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/composer/qgscomposerlegendwidgetbase.ui
+++ b/src/ui/composer/qgscomposerlegendwidgetbase.ui
@@ -52,7 +52,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
      </property>
@@ -1029,15 +1029,22 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -1050,15 +1057,14 @@
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsComposerItemComboBox</class>
    <extends>QComboBox</extends>
    <header>qgscomposeritemcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLayerTreeView</class>

--- a/src/ui/composer/qgscomposermapgridwidgetbase.ui
+++ b/src/ui/composer/qgscomposermapgridwidgetbase.ui
@@ -36,7 +36,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -737,9 +737,21 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -756,12 +768,6 @@
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/composer/qgscomposermapwidgetbase.ui
+++ b/src/ui/composer/qgscomposermapwidgetbase.ui
@@ -43,7 +43,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
      </property>
@@ -780,9 +780,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -796,6 +802,11 @@
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsComposerItemComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgscomposeritemcombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
@@ -804,11 +815,6 @@
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsComposerItemComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscomposeritemcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>

--- a/src/ui/composer/qgscomposerpicturewidgetbase.ui
+++ b/src/ui/composer/qgscomposerpicturewidgetbase.ui
@@ -52,7 +52,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -549,15 +549,22 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -565,15 +572,14 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsComposerItemComboBox</class>
    <extends>QComboBox</extends>
    <header>qgscomposeritemcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/composer/qgscomposerpolygonwidgetbase.ui
+++ b/src/ui/composer/qgscomposerpolygonwidgetbase.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -37,7 +46,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -97,9 +106,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/composer/qgscomposerpolylinewidgetbase.ui
+++ b/src/ui/composer/qgscomposerpolylinewidgetbase.ui
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -84,9 +84,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/composer/qgscomposerscalebarwidgetbase.ui
+++ b/src/ui/composer/qgscomposerscalebarwidgetbase.ui
@@ -52,7 +52,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -693,15 +693,22 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -714,20 +721,19 @@
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPenJoinStyleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspenstylecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsComposerItemComboBox</class>
    <extends>QComboBox</extends>
    <header>qgscomposeritemcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPenJoinStyleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspenstylecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPenCapStyleComboBox</class>

--- a/src/ui/composer/qgscomposershapewidgetbase.ui
+++ b/src/ui/composer/qgscomposershapewidgetbase.ui
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -123,9 +123,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/composer/qgscomposertablewidgetbase.ui
+++ b/src/ui/composer/qgscomposertablewidgetbase.ui
@@ -46,7 +46,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -455,9 +455,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -469,6 +469,12 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/composer/qgscompositionwidgetbase.ui
+++ b/src/ui/composer/qgscompositionwidgetbase.ui
@@ -36,7 +36,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>
@@ -664,15 +664,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsVariableEditorWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">qgsvariableeditorwidget.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -700,6 +700,12 @@
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsVariableEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">qgsvariableeditorwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="4" column="0">
-    <widget class="QScrollArea" name="mHelpScrollArea">
+    <widget class="QgsScrollArea" name="mHelpScrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -251,6 +251,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>mFieldFormatComboBox</tabstop>
   <tabstop>mFieldFormatEdit</tabstop>

--- a/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
+++ b/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
@@ -34,7 +34,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -459,14 +459,20 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -488,7 +494,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="mStorageButtonGroup"/>
   <buttongroup name="mRelativeButtonGroup"/>
+  <buttongroup name="mStorageButtonGroup"/>
  </buttongroups>
 </ui>

--- a/src/ui/qgscharacterselectdialogbase.ui
+++ b/src/ui/qgscharacterselectdialogbase.ui
@@ -45,7 +45,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QScrollArea" name="mCharSelectScrollArea">
+    <widget class="QgsScrollArea" name="mCharSelectScrollArea">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -85,6 +85,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/src/ui/qgscustomprojectiondialogbase.ui
+++ b/src/ui/qgscustomprojectiondialogbase.ui
@@ -30,7 +30,7 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="focusPolicy">
       <enum>Qt::NoFocus</enum>
      </property>
@@ -309,6 +309,12 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -291,7 +291,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QScrollArea" name="scrollArea">
+               <widget class="QgsScrollArea" name="scrollArea">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -527,7 +527,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QScrollArea" name="scrollArea_4">
+               <widget class="QgsScrollArea" name="scrollArea_4">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -1118,7 +1118,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QScrollArea" name="scrollArea_5">
+               <widget class="QgsScrollArea" name="scrollArea_5">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -1434,7 +1434,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QScrollArea" name="scrollArea_6">
+               <widget class="QgsScrollArea" name="scrollArea_6">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -1860,7 +1860,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QScrollArea" name="scrollArea_7">
+               <widget class="QgsScrollArea" name="scrollArea_7">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -2079,7 +2079,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QScrollArea" name="scrollArea_2">
+               <widget class="QgsScrollArea" name="scrollArea_2">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -2170,9 +2170,38 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPropertyOverrideButton</class>
@@ -2186,32 +2215,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsFieldExpressionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfieldexpressionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsScaleRangeWidget</class>
    <extends>QWidget</extends>
    <header>qgsscalerangewidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -255,7 +255,7 @@ gray = no data
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QScrollArea" name="scrollArea_2">
+        <widget class="QgsScrollArea" name="scrollArea_2">
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -639,14 +639,23 @@ gray = no data
      <widget class="QWidget" name="stackedWidgetPage3"/>
      <widget class="QWidget" name="stackedWidgetPage4">
       <layout class="QGridLayout" name="gridLayout_5">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <property name="verticalSpacing">
         <number>6</number>
        </property>
        <item row="0" column="0">
-        <widget class="QScrollArea" name="scrollArea">
+        <widget class="QgsScrollArea" name="scrollArea">
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
@@ -1180,6 +1189,14 @@ gray = no data
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>mBtnCloseFeature</tabstop>
   <tabstop>mBtnAddVertex</tabstop>

--- a/src/ui/qgsgradientcolorrampdialogbase.ui
+++ b/src/ui/qgsgradientcolorrampdialogbase.ui
@@ -135,7 +135,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -331,15 +331,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgslabelingrulepropswidget.ui
+++ b/src/ui/qgslabelingrulepropswidget.ui
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -157,6 +157,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsScaleRangeWidget</class>
    <extends>QWidget</extends>
    <header>qgsscalerangewidget.h</header>
@@ -171,6 +177,8 @@
   <tabstop>groupScale</tabstop>
   <tabstop>groupSettings</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/qgslabelpropertydialogbase.ui
+++ b/src/ui/qgslabelpropertydialogbase.ui
@@ -29,7 +29,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -624,15 +624,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsnewgeopackagelayerdialogbase.ui
+++ b/src/ui/qgsnewgeopackagelayerdialogbase.ui
@@ -46,7 +46,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -126,7 +126,7 @@
              <string>Add to fields list</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../images/images.qrc">
               <normaloff>:/images/themes/default/mActionNewAttribute.svg</normaloff>:/images/themes/default/mActionNewAttribute.svg</iconset>
             </property>
             <property name="toolButtonStyle">
@@ -376,7 +376,7 @@
              <string>Remove field</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../images/images.qrc">
               <normaloff>:/images/themes/default/mActionDeleteAttribute.svg</normaloff>:/images/themes/default/mActionDeleteAttribute.svg</iconset>
             </property>
             <property name="toolButtonStyle">
@@ -437,9 +437,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
-   <header location="global">qgsprojectionselectionwidget.h</header>
+   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -462,7 +468,9 @@
   <tabstop>mAttributeView</tabstop>
   <tabstop>mRemoveAttributeButton</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/src/ui/qgsnewspatialitelayerdialogbase.ui
+++ b/src/ui/qgsnewspatialitelayerdialogbase.ui
@@ -36,7 +36,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -335,7 +335,7 @@
              <string>Add to fields list</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../images/images.qrc">
               <normaloff>:/images/themes/default/mActionNewAttribute.svg</normaloff>:/images/themes/default/mActionNewAttribute.svg</iconset>
             </property>
             <property name="toolButtonStyle">
@@ -409,7 +409,7 @@
              <string>Remove field</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../images/images.qrc">
               <normaloff>:/images/themes/default/mActionDeleteAttribute.svg</normaloff>:/images/themes/default/mActionDeleteAttribute.svg</iconset>
             </property>
             <property name="toolButtonStyle">
@@ -437,6 +437,14 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>mPointRadioButton</tabstop>
@@ -458,7 +466,9 @@
   <tabstop>mAttributeView</tabstop>
   <tabstop>mRemoveAttributeButton</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -311,7 +311,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>13</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -328,7 +328,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_01">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_01">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -340,8 +340,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>680</height>
+                <width>856</width>
+                <height>679</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1014,7 +1014,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_03">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_03">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1026,8 +1026,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>541</width>
-                <height>1065</height>
+                <width>839</width>
+                <height>1009</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1544,7 +1544,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_11">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_11">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1556,8 +1556,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>495</width>
-                <height>685</height>
+                <width>856</width>
+                <height>679</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1912,7 +1912,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_04">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_04">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1924,8 +1924,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>674</width>
-                <height>936</height>
+                <width>839</width>
+                <height>827</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -2663,7 +2663,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea">
+            <widget class="QgsScrollArea" name="scrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -2675,8 +2675,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>142</width>
-                <height>239</height>
+                <width>112</width>
+                <height>219</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -2814,7 +2814,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_06">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_06">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -2826,8 +2826,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>501</width>
-                <height>316</height>
+                <width>453</width>
+                <height>281</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3157,7 +3157,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_05">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_05">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -3169,8 +3169,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>604</width>
-                <height>589</height>
+                <width>506</width>
+                <height>533</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3601,7 +3601,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_12">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_12">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -3613,8 +3613,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>480</width>
-                <height>571</height>
+                <width>393</width>
+                <height>530</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -3870,7 +3870,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_07">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_07">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -3882,8 +3882,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>543</width>
-                <height>696</height>
+                <width>488</width>
+                <height>612</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4448,7 +4448,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_02">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_02">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -4460,8 +4460,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>412</width>
-                <height>368</height>
+                <width>345</width>
+                <height>350</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4587,7 +4587,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_08">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_08">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -4599,8 +4599,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>408</width>
-                <height>531</height>
+                <width>332</width>
+                <height>499</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -4800,7 +4800,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_09">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_09">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -4812,8 +4812,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>273</width>
-                <height>236</height>
+                <width>221</width>
+                <height>201</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -4909,7 +4909,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="mOptionsScrollArea_10">
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_10">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -4921,8 +4921,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>689</height>
+                <width>856</width>
+                <height>679</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5435,6 +5435,12 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsPasswordLineEdit</class>
    <extends>QLineEdit</extends>

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -569,7 +569,7 @@
                <number>0</number>
               </property>
               <item>
-               <widget class="QScrollArea" name="scrollArea">
+               <widget class="QgsScrollArea" name="scrollArea">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -959,9 +959,10 @@ p, li { white-space: pre-wrap; }
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsWebView</class>
-   <extends>QWidget</extends>
-   <header>qgswebview.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
@@ -973,6 +974,11 @@ p, li { white-space: pre-wrap; }
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsWebView</class>
+   <extends>QWidget</extends>
+   <header>qgswebview.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -247,7 +247,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_2">
+            <widget class="QgsScrollArea" name="scrollArea_2">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -737,7 +737,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea">
+            <widget class="QgsScrollArea" name="scrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -796,7 +796,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_3">
+            <widget class="QgsScrollArea" name="scrollArea_3">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -882,7 +882,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_4">
+            <widget class="QgsScrollArea" name="scrollArea_4">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1349,7 +1349,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_5">
+            <widget class="QgsScrollArea" name="scrollArea_5">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -2429,7 +2429,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_6">
+            <widget class="QgsScrollArea" name="scrollArea_6">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -2586,6 +2586,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
@@ -2598,15 +2604,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorSchemeList</class>
-   <extends>QWidget</extends>
-   <header location="global">qgscolorschemelist.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsVariableEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">qgsvariableeditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorSchemeList</class>
+   <extends>QWidget</extends>
+   <header location="global">qgscolorschemelist.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -229,7 +229,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_3">
+            <widget class="QgsScrollArea" name="scrollArea_3">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -500,7 +500,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea">
+            <widget class="QgsScrollArea" name="scrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1131,7 +1131,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_2">
+            <widget class="QgsScrollArea" name="scrollArea_2">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1547,7 +1547,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_5">
+            <widget class="QgsScrollArea" name="scrollArea_5">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1717,7 +1717,7 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_6">
+            <widget class="QgsScrollArea" name="scrollArea_6">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1776,7 +1776,7 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_4">
+            <widget class="QgsScrollArea" name="scrollArea_4">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -2244,6 +2244,12 @@ p, li { white-space: pre-wrap; }
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
@@ -2254,6 +2260,11 @@ p, li { white-space: pre-wrap; }
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -2271,11 +2282,6 @@ p, li { white-space: pre-wrap; }
    <extends>QWidget</extends>
    <header>qgslayertreeembeddedconfigwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsBlendModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsblendmodecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsrasterlayersaveasdialogbase.ui
+++ b/src/ui/qgsrasterlayersaveasdialogbase.ui
@@ -174,7 +174,7 @@ datasets with maximum width and height specified below.</string>
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="mScrollArea">
+    <widget class="QgsScrollArea" name="mScrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -682,21 +682,27 @@ datasets with maximum width and height specified below.</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsExtentGroupBox</class>
-   <extends>QgsCollapsibleGroupBox</extends>
-   <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -100,7 +100,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QScrollArea" name="scrollArea_mPreview">
+           <widget class="QgsScrollArea" name="scrollArea_mPreview">
             <property name="verticalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOn</enum>
             </property>
@@ -608,7 +608,7 @@
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QScrollArea" name="scrollArea">
+                   <widget class="QgsScrollArea" name="scrollArea">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
                     </property>
@@ -1431,7 +1431,7 @@ font-style: italic;</string>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QScrollArea" name="scrollArea_5">
+                   <widget class="QgsScrollArea" name="scrollArea_5">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
                     </property>
@@ -2066,7 +2066,7 @@ font-style: italic;</string>
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QScrollArea" name="scrollArea_7">
+                   <widget class="QgsScrollArea" name="scrollArea_7">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
                     </property>
@@ -2452,7 +2452,7 @@ font-style: italic;</string>
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QScrollArea" name="scrollArea_2">
+                   <widget class="QgsScrollArea" name="scrollArea_2">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
                     </property>
@@ -3288,7 +3288,7 @@ font-style: italic;</string>
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QScrollArea" name="scrollArea_8">
+                   <widget class="QgsScrollArea" name="scrollArea_8">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
                     </property>
@@ -3793,7 +3793,7 @@ font-style: italic;</string>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QScrollArea" name="scrollArea_3">
+                   <widget class="QgsScrollArea" name="scrollArea_3">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
                     </property>
@@ -5431,7 +5431,7 @@ font-style: italic;</string>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QScrollArea" name="scrollArea_4">
+                   <widget class="QgsScrollArea" name="scrollArea_4">
                     <property name="frameShape">
                      <enum>QFrame::NoFrame</enum>
                     </property>
@@ -6428,9 +6428,9 @@ font-style: italic;</string>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -6440,14 +6440,10 @@ font-style: italic;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
@@ -6456,9 +6452,9 @@ font-style: italic;</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSpinBox</class>
@@ -6466,10 +6462,9 @@ font-style: italic;</string>
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>
@@ -6480,6 +6475,17 @@ font-style: italic;</string>
    <class>QgsPenJoinStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsTextPreview</class>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -299,7 +299,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea">
+            <widget class="QgsScrollArea" name="scrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -604,7 +604,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_3">
+            <widget class="QgsScrollArea" name="scrollArea_3">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -705,7 +705,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_5">
+            <widget class="QgsScrollArea" name="scrollArea_5">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -765,7 +765,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_19">
+            <widget class="QgsScrollArea" name="scrollArea_19">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1082,7 +1082,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_6">
+            <widget class="QgsScrollArea" name="scrollArea_6">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1148,7 +1148,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_7">
+            <widget class="QgsScrollArea" name="scrollArea_7">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1317,7 +1317,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_2">
+            <widget class="QgsScrollArea" name="scrollArea_2">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -1871,15 +1871,27 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsVariableEditorWidget</class>
+   <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
-   <header location="global">qgsvariableeditorwidget.h</header>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsLayerTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qgslayertreeview.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1889,14 +1901,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScaleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsscalecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsFieldExpressionWidget</class>
+   <class>QgsVariableEditorWidget</class>
    <extends>QWidget</extends>
-   <header>qgsfieldexpressionwidget.h</header>
+   <header location="global">qgsvariableeditorwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1905,10 +1912,9 @@
    <header>qgsscalerangewidget.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsLayerTreeView</class>
-   <extends>QTreeView</extends>
-   <header>qgslayertreeview.h</header>
-   <container>1</container>
+   <class>QgsScaleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsscalecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -98,7 +98,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -446,21 +446,27 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsExtentGroupBox</class>
-   <extends>QgsCollapsibleGroupBox</extends>
-   <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QgsCollapsibleGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/styledock/qgsrenderercontainerbase.ui
+++ b/src/ui/styledock/qgsrenderercontainerbase.ui
@@ -55,7 +55,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -76,8 +76,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QStackedWidget" name="mStackedWidget">
-        </widget>
+        <widget class="QStackedWidget" name="mStackedWidget"/>
        </item>
       </layout>
      </widget>
@@ -85,6 +84,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -346,7 +346,7 @@
    <item row="10" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0" rowspan="2">
-      <widget class="QScrollArea" name="scrollArea">
+      <widget class="QgsScrollArea" name="scrollArea">
        <widget class="QWidget" name="scrollAreaWidgetContents">
         <property name="geometry">
          <rect>
@@ -454,15 +454,16 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -470,15 +471,20 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPenJoinStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/templates/qgsoptionsdialog_template.ui
+++ b/src/ui/templates/qgsoptionsdialog_template.ui
@@ -118,7 +118,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea">
+            <widget class="QgsScrollArea" name="scrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
@@ -209,6 +209,14 @@
  <resources>
   <include location="../../../images/images.qrc"/>
  </resources>
+ <customwidgets>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <connections>
   <connection>
    <sender>mOptionsListWidget</sender>


### PR DESCRIPTION
Here's a different approach to swallowing up scroll events to prevent accidental widget changes. This one sets a time out, so that any wheel events which occur up to 1 sec after a scroll wont change a child widget's value. This still allows the handy hover-and-scroll-wheel-to-change-value shortcut, just not directly after a scroll has occurred. Fixes the issue for me...