### PR TITLE
[2.18] OGR data provider: use transactions when changing attributes and geometries (if possible) (#16216)

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1306,6 +1306,8 @@ bool QgsOgrProvider::addFeatures( QgsFeatureList & flist )
 
   setRelevantFields( ogrLayer, true, attributeIndexes() );
 
+  const bool inTransaction = startTransaction();
+
   bool returnvalue = true;
   for ( QgsFeatureList::iterator it = flist.begin(); it != flist.end(); ++it )
   {
@@ -1313,6 +1315,11 @@ bool QgsOgrProvider::addFeatures( QgsFeatureList & flist )
     {
       returnvalue = false;
     }
+  }
+
+  if ( inTransaction )
+  {
+    commitTransaction();
   }
 
   if ( !syncToDisc() )
@@ -1820,6 +1827,8 @@ bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds & id )
   if ( !doInitialActionsForEdition() )
     return false;
 
+  const bool inTransaction = startTransaction();
+
   bool returnvalue = true;
   for ( QgsFeatureIds::const_iterator it = id.begin(); it != id.end(); ++it )
   {
@@ -1827,6 +1836,11 @@ bool QgsOgrProvider::deleteFeatures( const QgsFeatureIds & id )
     {
       returnvalue = false;
     }
+  }
+
+  if ( inTransaction )
+  {
+    commitTransaction();
   }
 
   if ( !syncToDisc() )

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1521,6 +1521,31 @@ bool QgsOgrProvider::renameAttributes( const QgsFieldNameMap& renamedAttributes 
 #endif
 }
 
+bool QgsOgrProvider::startTransaction()
+{
+  bool inTransaction = false;
+  if ( OGR_L_TestCapability( ogrLayer, OLCTransactions ) )
+  {
+    // A transaction might already be active, so be robust on failed
+    // StartTransaction.
+    CPLPushErrorHandler( CPLQuietErrorHandler );
+    inTransaction = ( OGR_L_StartTransaction( ogrLayer ) == OGRERR_NONE );
+    CPLPopErrorHandler();
+  }
+  return inTransaction;
+}
+
+
+bool QgsOgrProvider::commitTransaction()
+{
+  if ( OGR_L_CommitTransaction( ogrLayer ) != OGRERR_NONE )
+  {
+    pushError( tr( "OGR error committing transaction: %1" ).arg( CPLGetLastErrorMsg() ) );
+    return false;
+  }
+  return true;
+}
+
 
 bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_map )
 {
@@ -1533,6 +1558,8 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
   clearMinMaxCache();
 
   setRelevantFields( ogrLayer, true, attributeIndexes() );
+
+  const bool inTransaction = startTransaction();
 
   for ( QgsChangedAttributesMap::const_iterator it = attr_map.begin(); it != attr_map.end(); ++it )
   {
@@ -1649,6 +1676,11 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
     OGR_F_Destroy( of );
   }
 
+  if ( inTransaction )
+  {
+    commitTransaction();
+  }
+
   if ( OGR_L_SyncToDisk( ogrLayer ) != OGRERR_NONE )
   {
     pushError( tr( "OGR error syncing to disk: %1" ).arg( CPLGetLastErrorMsg() ) );
@@ -1663,6 +1695,8 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
     return false;
 
   setRelevantFields( ogrLayer, true, attributeIndexes() );
+
+  const bool inTransaction = startTransaction();
 
   for ( QgsGeometryMap::const_iterator it = geometry_map.constBegin(); it != geometry_map.constEnd(); ++it )
   {
@@ -1731,6 +1765,12 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
 
     OGR_F_Destroy( theOGRFeature );
   }
+
+  if ( inTransaction )
+  {
+    commitTransaction();
+  }
+
   QgsOgrConnPool::instance()->invalidateConnections( dataSourceUri() );
   return syncToDisc();
 }

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -305,6 +305,13 @@ class QgsOgrProvider : public QgsVectorDataProvider
   private:
     unsigned char *getGeometryPointer( OGRFeatureH fet );
     QString ogrWkbGeometryTypeName( OGRwkbGeometryType type ) const;
+
+    //! Starts a transaction if possible and return true in that case
+    bool startTransaction();
+
+    //! Commits a transaction
+    bool commitTransaction();
+
     QgsFields mAttributeFields;
     bool mFirstFieldIsFid;
     OGRDataSourceH ogrDataSource;


### PR DESCRIPTION
Backport t 2.18 of https://github.com/qgis/QGIS/pull/4257