### PR TITLE
Wrap and expose system tray notifications

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11621,7 +11621,7 @@ void QgisApp::onTaskCompleteShowNotify( long taskId, int status )
     QgsTask *task = QgsApplication::taskManager()->task( taskId );
     if ( task )
     {
-      notifyUser( tr( "Task complete" ), task->description() );
+      showSystemNotification( tr( "Task complete" ), task->description() );
     }
   }
 }
@@ -12335,7 +12335,8 @@ QMenu *QgisApp::createPopupMenu()
   return menu;
 }
 
-void QgisApp::notifyUser( QString title, QString message )
+
+void QgisApp::showSystemNotification( const QString title, const QString message )
 {
 #ifdef Q_OS_MAC
   // Menubar icon is hidden on macOS, by default. Show to enable notification bubbles

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11621,16 +11621,7 @@ void QgisApp::onTaskCompleteShowNotify( long taskId, int status )
     QgsTask *task = QgsApplication::taskManager()->task( taskId );
     if ( task )
     {
-      QString description = task->description();
-#ifdef Q_OS_MAC
-      // Menubar icon is hidden on macOS, by default. Show to enable notification bubbles
-      mTray->show();
-#endif
-      mTray->showMessage( "Task Complete", description );
-#ifdef Q_OS_MAC
-      // Re-hide menubar icon
-      mTray->hide();
-#endif
+      notifyUser( tr( "Task complete" ), task->description() );
     }
   }
 }
@@ -12342,6 +12333,19 @@ QMenu *QgisApp::createPopupMenu()
   }
 
   return menu;
+}
+
+void QgisApp::notifyUser( QString title, QString message )
+{
+#ifdef Q_OS_MAC
+  // Menubar icon is hidden on macOS, by default. Show to enable notification bubbles
+  mTray->show();
+#endif
+  mTray->showMessage( title, message );
+#ifdef Q_OS_MAC
+  // Re-hide menubar icon
+  mTray->hide();
+#endif
 }
 
 void QgisApp::osmDownloadDialog()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -358,7 +358,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * @param title
      * @param message
      */
-    void notifyUser( QString title, QString message );
+    void showSystemNotification( const QString title, const QString message );
 
 
     //! Actions to be inserted in menus and toolbars

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -349,6 +349,18 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     QgsVectorLayerTools *vectorLayerTools() { return mVectorLayerTools; }
 
+    /** Notify the user by using the system tray notifications
+     *
+     * @note usage of the system tray notifications should be limited
+     *       to long running tasks and to when the user needs to be notified
+     *       about interaction with OS services, like the password manager.
+     *
+     * @param title
+     * @param message
+     */
+    void notifyUser( QString title, QString message );
+
+
     //! Actions to be inserted in menus and toolbars
     QAction *actionNewProject() { return mActionNewProject; }
     QAction *actionOpenProject() { return mActionOpenProject; }


### PR DESCRIPTION
## Description
As discussed with @NathanW2 we want to expose the system tray notifications, currently used only by the task manager.
The use of this kind of notifications has limited use cases, specifically:
- long running task completion (already implemented)
- unattended interaction with OS services by the auth system (password manager: PR coming soon)

The preferred method for sending non-blocking messages to the user must remain the message bar.

## Longer explanation

the auth system kicks in different scenarios, where the active window can be:
- the main window (accessing an authenticated layer)
- plugin manager
- authentication tab in option dialog
- modal dialogs for adding new connections (postgis, OGC etc.)

From a UX/UI perspective, message bar notifications do not play well when the active window is a modal dialog, the message could be hidden by the dialog, and may time out before the user can even see it: we did some user tests and this appeared to be happening quite often, moreover, the user cannot click on the timeout icon to interrupt it because it's currently in a modal dialog.

While a standard information modal dialog could be appropriate for most use cases, it is not in case of OS operations like access to the password manager/wallet that has the main purpose of not blocking the user with a master password request (or with additional annoying modals). At the same time, the user must be notified about the successfull (or unsuccessful) insertion of the master password from the password manager.


