### PR TITLE
Fix incorrect project CRS when loading project (fix #16149)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5191,6 +5191,9 @@ bool QgisApp::addProject( const QString &projectFile )
   // close the previous opened project if any
   closeProject();
 
+  bool autoSetupOnFirstLayer = mLayerTreeCanvasBridge->autoSetupOnFirstLayer();
+  mLayerTreeCanvasBridge->setAutoSetupOnFirstLayer( false );
+
   if ( !QgsProject::instance()->read( projectFile ) )
   {
     QString backupFile = projectFile + "~";
@@ -5306,6 +5309,9 @@ bool QgisApp::addProject( const QString &projectFile )
   saveRecentProjectPath( projectFile, false );
 
   QApplication::restoreOverrideCursor();
+
+  if ( autoSetupOnFirstLayer )
+    mLayerTreeCanvasBridge->setAutoSetupOnFirstLayer( true );
 
   mMapCanvas->freeze( false );
   mMapCanvas->refresh();


### PR DESCRIPTION
This commit fixes a situation where loading a project results in incorrect project & canvas CRS. The bug is trigerred whenever something in the project load calls a processEvents() call, eg restoring a project with layer count enabled on a layer or with a composer html item.

When this occurs, the "auto-set CRS to first added layer" code would kick in early and replace the project's CRS with that of the first layer loaded.

To avoid this disable the "auto-set CRS" code when loading layers from a project.
