### PR TITLE
set checked by default if we have some selected features in save as dialog

### DIFF
--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -64,7 +64,9 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, i
     mScaleSpinBox->hide();
   }
 
-  mSelectedOnly->setEnabled( layer && layer->selectedFeatureCount() != 0 );
+  bool enableSelectedOnly = layer && layer->selectedFeatureCount() != 0;
+  mSelectedOnly->setEnabled( enableSelectedOnly );
+  mSelectedOnly->setChecked( enableSelectedOnly );
   buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
 }
 


### PR DESCRIPTION
## Description

Usually, when we use the save as dialog with some selected features, we want to save the selection only.
But we often forget to check this option in the dialog.

If accepted, can I backport it to 2.X ?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
