### PR TITLE
fix undeclared identifier on MAC in composer

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3336,17 +3336,6 @@ void QgsComposer::resizeEvent( QResizeEvent *e )
   saveWindowState();
 }
 
-#ifdef Q_OS_MAC
-void QgsComposer::showEvent( QShowEvent *event )
-{
-  // add to menu if (re)opening window (event not due to unminimize)
-  if ( !event->spontaneous() )
-  {
-    mQgis->addWindow( mWindowAction );
-  }
-}
-#endif
-
 void QgsComposer::saveWindowState()
 {
   QgsSettings settings;

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -142,10 +142,6 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Resize event
     virtual void resizeEvent( QResizeEvent * ) override;
 
-#ifdef Q_OS_MAC
-    virtual void showEvent( QShowEvent *event ) override;
-#endif
-
   signals:
     //! Is emitted every time the view zoom has changed
     void zoomLevelChanged();


### PR DESCRIPTION
## Description

The build is broken on mac because of undeclared identifier.
I don't think it's the solution to delete this block. At least we can compile on mac, it might be a temporary hack.
Can you check @nyalldawson @dakcarto ?
Thanks

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit