### PR TITLE
[processing] GRASS 7.2 support: use SQL compatible output names

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -515,7 +515,7 @@ class Grass7Algorithm(GeoAlgorithm):
                     filename = orgFilename
             else:
                 filename = orgFilename
-        destFilename = self.getTempFilename()
+        destFilename = 'a' + os.path.basename(self.getTempFilename())
         self.exportedLayers[orgFilename] = destFilename
         command = 'v.in.ogr'
         min_area = self.getParameterValue(self.GRASS_MIN_AREA_PARAMETER)
@@ -549,7 +549,7 @@ class Grass7Algorithm(GeoAlgorithm):
                 Grass7Utils.projectionSet = True
 
     def exportRasterLayer(self, layer):
-        destFilename = self.getTempFilename()
+        destFilename = 'a' + os.path.basename(self.getTempFilename())
         self.exportedLayers[layer] = destFilename
         command = 'r.external'
         command += ' input="' + layer + '"'


### PR DESCRIPTION
## Description
@alexbruy , @volaya , @nyalldawson , the GRASS7 algorithm provider relies on temporary output names that aren't always compatible with GRASS >= 7.2, with SQL-compatible output name requirement enforced on those versions.

The two temporary output name issues this PR fixes are:
- to be SQL compatible, the name must start with a letter
- the "/" character is not allowed

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
