### PR TITLE
Avoid calling start/stopRender multiple times on the same symbol in categorised renderer

### DIFF
--- a/src/core/symbology-ng/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrenderer.cpp
@@ -400,11 +400,6 @@ void QgsCategorizedSymbolRenderer::startRender( QgsRenderContext &context, const
   {
     cat.symbol()->startRender( context, fields );
   }
-
-  Q_FOREACH ( QgsSymbol *sym, mSymbolHash.values() )
-  {
-    sym->startRender( context, fields );
-  }
 }
 
 void QgsCategorizedSymbolRenderer::stopRender( QgsRenderContext &context )
@@ -413,12 +408,6 @@ void QgsCategorizedSymbolRenderer::stopRender( QgsRenderContext &context )
   {
     cat.symbol()->stopRender( context );
   }
-
-  Q_FOREACH ( QgsSymbol *sym, mSymbolHash.values() )
-  {
-    sym->stopRender( context );
-  }
-
   mExpression.reset();
 }
 


### PR DESCRIPTION
Calling stopRender multiple times can cause a crash.

@jef-n you made this change in 4b7432cf15c304ba7c63b9aec8f1381835349ece and c7c52442f71a6a17ea1ad97e741b2b4b6d51f698 - but I'm not sure what situation led to those commits. Calling start/stopRender on the hash should not be required as the symbols in the hash are not clones, but rather just pointers to the same symbols contained in mCategories

I've experienced some inconsistent crashes with the categorized renderer today and this change seemed to fix them. There's also discussion on the user list recently which describes similar crashes.
