### PR TITLE
[FEATURE] Add a secondary stroke color to QgsRubberBand

### DIFF
--- a/python/gui/qgsrubberband.sip
+++ b/python/gui/qgsrubberband.sip
@@ -6,206 +6,79 @@ class QgsRubberBand: QgsMapCanvasItem
 
   public:
 
-    /** Icons */
     enum IconType
     {
-      /**
-       * No icon is used
-       */
       ICON_NONE,
-      /**
-       * A cross is used to highlight points (+)
-       */
       ICON_CROSS,
-      /**
-       * A cross is used to highlight points (x)
-       */
       ICON_X,
-      /**
-       * A box is used to highlight points (□)
-       */
       ICON_BOX,
-      /**
-       * A circle is used to highlight points (○)
-       */
       ICON_CIRCLE,
-      /**
-       * A full box is used to highlight points (■)
-       */
       ICON_FULL_BOX
     };
 
-    /**
-     * Creates a new RubberBand.
-     *  @param mapCanvas The map canvas to draw onto. It's CRS will be used map points onto screen coordinates.
-     *  @param geometryType Defines how the data should be drawn onto the screen. (Use QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry or QgsWkbTypes::PointGeometry)
-     */
     QgsRubberBand( QgsMapCanvas* mapCanvas /TransferThis/, QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry );
     ~QgsRubberBand();
 
-    /**
-     * Set the color for the rubberband
-     *  @param color  The color used to render this rubberband
-     */
     void setColor( const QColor & color );
 
-    /**
-     * Set the fill color for the rubberband
-     *  @param color  The color used to render this rubberband
-     *  @note Added in 2.6
-     */
     void setFillColor( const QColor & color );
 
-    /**
-     * Set the stroke color for the rubberband
-     *  @param color  The color used to render this rubberband
-     *  @note Added in 2.6
-     */
+    QColor fillColor() const;
+
     void setStrokeColor( const QColor & color );
 
-    /**
-     * Set the width of the line. Stroke width for polygon.
-     *  @param width The width for any lines painted for this rubberband
-     */
+    QColor strokeColor() const;
+
+    void setSecondaryStrokeColor( const QColor &color );
+
+    QColor secondaryStrokeColor() const;
+
     void setWidth( int width );
 
-    /**
-     * Set the icon type to highlight point geometries.
-     *  @param icon The icon to visualize point geometries
-     */
+    int width() const;
+
     void setIcon( IconType icon );
 
-    /**
-     * Set the size of the point icons
-     */
+    IconType icon() const;
+
     void setIconSize( int iconSize );
 
-    /**
-     * Set the style of the line
-     */
+    int iconSize() const;
+
     void setLineStyle( Qt::PenStyle penStyle );
 
-    /**
-     * Set the style of the brush
-     */
     void setBrushStyle( Qt::BrushStyle brushStyle );
 
-    /**
-     * Clears all the geometries in this rubberband.
-     * Sets the representation type according to geometryType.
-     *  @param geometryType Defines how the data should be drawn onto the screen. (Use QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry or QgsWkbTypes::PointGeometry)
-     */
     void reset( QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry );
 
-    /**
-     * Add a vertex to the rubberband and update canvas.
-     * The rendering of the vertex depends on the current GeometryType and icon.
-     * If adding more points consider using update=false for better performance
-     *  @param p             The vertex/point to add
-     *  @param doUpdate      Should the map canvas be updated immediately?
-     *  @param geometryIndex The index of the feature part (in case of multipart geometries)
-     */
     void addPoint( const QgsPoint & p, bool doUpdate = true, int geometryIndex = 0 );
 
-    /** Ensures that a polygon geometry is closed and that the last vertex equals the
-     * first vertex.
-     * @param doUpdate set to true to update the map canvas immediately
-     * @param geometryIndex index of the feature part (in case of multipart geometries)
-     * @note added in QGIS 2.16
-     */
     void closePoints( bool doUpdate = true, int geometryIndex = 0 );
 
-    /**
-     * Remove a vertex from the rubberband and (optionally) update canvas.
-     * @param index The index of the vertex/point to remove, negative indexes start at end
-     * @param doUpdate Should the map canvas be updated immediately?
-     * @param geometryIndex The index of the feature part (in case of multipart geometries)
-     */
     void removePoint( int index = 0, bool doUpdate = true, int geometryIndex = 0 );
 
-    /**
-     * Removes the last point. Most useful in connection with undo operations
-     */
     void removeLastPoint( int geometryIndex = 0, bool doUpdate = true );
 
-    /**
-     * Moves the rubber band point specified by index. Note that if the rubber band is
-     * not used to track the last mouse position, the first point of the rubber band has two vertices
-     */
     void movePoint( const QgsPoint & p, int geometryIndex = 0 );
 
-    /**
-     * Moves the rubber band point specified by index. Note that if the rubber band is
-     * not used to track the last mouse position, the first point of the rubber band has two vertices
-     */
     void movePoint( int index, const QgsPoint& p, int geometryIndex = 0 );
 
-    /**
-     * Returns number of vertices in feature part
-     *  @param geometryIndex The index of the feature part (in case of multipart geometries)
-     *  @return number of vertices
-     */
     int partSize( int geometryIndex ) const;
 
-    /**
-     * Sets this rubber band to the geometry of an existing feature.
-     * This is useful for feature highlighting.
-     * In contrast to {@link addGeometry}, this method does also change the geometry type of the rubberband.
-     *  @param geom the geometry object
-     *  @param layer the layer containing the feature, used for coord transformation to map
-     *               crs. In case of 0 pointer, the coordinates are not going to be transformed.
-     */
     void setToGeometry( const QgsGeometry& geom, QgsVectorLayer* layer );
 
-    /**
-     * Sets this rubber band to a map canvas rectangle
-     *  @param rect rectangle in canvas coordinates
-     */
     void setToCanvasRectangle( QRect rect );
 
-    /**
-     * Add the geometry of an existing feature to a rubberband
-     * This is useful for multi feature highlighting.
-     * As of 2.0, this method does not change the GeometryType any more. You need to set the GeometryType
-     * of the rubberband explicitly by calling {@link reset} or {@link setToGeometry} with appropriate arguments.
-     * {@link setToGeometry} is also to be preferred for backwards-compatibility.
-     *
-     *  @param geom the geometry object. Will be treated as a collection of vertices.
-     *  @param layer the layer containing the feature, used for coord transformation to map
-     *               crs. In case of 0 pointer, the coordinates are not going to be transformed.
-     */
     void addGeometry( const QgsGeometry& geom, QgsVectorLayer* layer );
 
-    /**
-     * Adds translation to original coordinates (all in map coordinates)
-     *  @param dx  x translation
-     *  @param dy  y translation
-     */
     void setTranslationOffset( double dx, double dy );
 
-    /**
-     * Returns number of geometries
-     *  @return number of geometries
-     */
     int size() const;
 
-    /**
-     * Returns count of vertices in all lists of mPoint
-     *  @return The total number of vertices
-     */
     int numberOfVertices() const;
 
-    /**
-     * Return vertex
-     *  @param i   The geometry index
-     *  @param j   The vertex index within geometry i
-     */
     const QgsPoint *getPoint( int i, int j = 0 ) const;
 
-    /**
-     * Returns the rubberband as a Geometry.
-     *  @return A geometry object which reflects the current state of the rubberband.
-     */
     QgsGeometry asGeometry() const;
 
     virtual void updatePosition();
@@ -213,7 +86,8 @@ class QgsRubberBand: QgsMapCanvasItem
   protected:
     virtual void paint( QPainter* p );
 
-    //! recalculates needed rectangle
+    void drawShape( QPainter *p, QVector<QPointF> &pts );
+
     void updateRect();
 
 };

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -53,6 +53,8 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
 
   mExtentRubberBand = new QgsRubberBand( mMapCanvas, QgsWkbTypes::PolygonGeometry );
   mExtentRubberBand->setStrokeColor( Qt::red );
+  mExtentRubberBand->setSecondaryStrokeColor( QColor( 255, 255, 255, 225 ) );
+  mExtentRubberBand->setFillColor( Qt::transparent );
 
   mPanTool = new QgsMapToolPan( mMapCanvas );
   mMapCanvas->setMapTool( mPanTool );

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -77,49 +77,88 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     QgsRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry );
 
     /**
-     * Set the color for the rubberband
+     * Sets the color for the rubberband
      *  @param color  The color used to render this rubberband
      */
     void setColor( const QColor &color );
 
     /**
-     * Set the fill color for the rubberband
+     * Sets the fill color for the rubberband
      *  @param color  The color used to render this rubberband
      *  @note Added in 2.6
      */
     void setFillColor( const QColor &color );
 
     /**
-     * Set the stroke color for the rubberband
+     * Returns the current fill color.
+     */
+    QColor fillColor() const { return mBrush.color(); }
+
+    /**
+     * Sets the stroke color for the rubberband
      *  @param color  The color used to render this rubberband
      *  @note Added in 2.6
      */
     void setStrokeColor( const QColor &color );
 
     /**
-     * Set the width of the line. Stroke width for polygon.
+     * Returns the current stroke color.
+     */
+    QColor strokeColor() const { return mPen.color(); }
+
+    /**
+     * Sets a secondary stroke color for the rubberband which will be drawn under the main stroke color.
+     * Set to an invalid color to avoid drawing the secondary stroke.
+     *  @param color  The color used to render a secondary stroke color to this rubberband
+     *  @note Added in 3.0
+     */
+    void setSecondaryStrokeColor( const QColor &color );
+
+    /**
+     * Returns the current secondary stroke color.
+     */
+    QColor secondaryStrokeColor() const { return mSecondaryPen.color(); }
+
+    /**
+     * Sets the width of the line. Stroke width for polygon.
      *  @param width The width for any lines painted for this rubberband
      */
     void setWidth( int width );
 
     /**
-     * Set the icon type to highlight point geometries.
+     * Returns the current width of the line or stroke width for polygon.
+     */
+    int width() const { return mPen.width(); }
+
+    /**
+     * Sets the icon type to highlight point geometries.
      *  @param icon The icon to visualize point geometries
      */
     void setIcon( IconType icon );
 
+
     /**
-     * Set the size of the point icons
+     * Returns the current icon type to highlight point geometries.
+     */
+    IconType icon() const { return mIconType; }
+
+    /**
+     * Sets the size of the point icons
      */
     void setIconSize( int iconSize );
 
     /**
-     * Set the style of the line
+     * Returns the current icon size of the point icons.
+     */
+    int iconSize() const { return mIconSize; }
+
+    /**
+     * Sets the style of the line
      */
     void setLineStyle( Qt::PenStyle penStyle );
 
     /**
-     * Set the style of the brush
+     * Sets the style of the brush
      */
     void setBrushStyle( Qt::BrushStyle brushStyle );
 
@@ -131,7 +170,7 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     void reset( QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry );
 
     /**
-     * Add a vertex to the rubberband and update canvas.
+     * Adds a vertex to the rubberband and update canvas.
      * The rendering of the vertex depends on the current GeometryType and icon.
      * If adding more points consider using update=false for better performance
      *  @param p             The vertex/point to add
@@ -149,7 +188,7 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     void closePoints( bool doUpdate = true, int geometryIndex = 0 );
 
     /**
-     * Remove a vertex from the rubberband and (optionally) update canvas.
+     * Removes a vertex from the rubberband and (optionally) updates canvas.
      * @param index The index of the vertex/point to remove, negative indexes start at end
      * @param doUpdate Should the map canvas be updated immediately?
      * @param geometryIndex The index of the feature part (in case of multipart geometries)
@@ -197,7 +236,7 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     void setToCanvasRectangle( QRect rect );
 
     /**
-     * Add the geometry of an existing feature to a rubberband
+     * Adds the geometry of an existing feature to a rubberband
      * This is useful for multi feature highlighting.
      * As of 2.0, this method does not change the GeometryType any more. You need to set the GeometryType
      * of the rubberband explicitly by calling {@link reset} or {@link setToGeometry} with appropriate arguments.
@@ -229,14 +268,14 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     int numberOfVertices() const;
 
     /**
-     * Return vertex
+     * Returns a vertex
      *  @param i   The geometry index
      *  @param j   The vertex index within geometry i
      */
     const QgsPoint *getPoint( int i, int j = 0 ) const;
 
     /**
-     * Returns the rubberband as a Geometry.
+     * Returns the rubberband as a Geometry
      *  @return A geometry object which reflects the current state of the rubberband.
      */
     QgsGeometry asGeometry() const;
@@ -244,14 +283,27 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     virtual void updatePosition() override;
 
   protected:
+
+    /**
+     * Paints the rubber band in response to an update event.
+     *  @param p The QPainter object
+     */
     virtual void paint( QPainter *p ) override;
 
-    //! recalculates needed rectangle
+    /**
+     * Draws shape of the rubber band.
+     *  @param p The QPainter object
+     *  @param pts A list of points used to draw the shape
+     */
+    void drawShape( QPainter *p, QVector<QPointF> &pts );
+
+    //! Recalculates needed rectangle
     void updateRect();
 
   private:
     QBrush mBrush;
     QPen mPen;
+    QPen mSecondaryPen;
 
     //! The size of the icon for points.
     int mIconSize;


### PR DESCRIPTION
## Description
This feature comes in handy when in need of insure visibility of a marker/line/polygon overlay over both light and dark areas. 

The PR  also updates the map view's extent to make use of a secondary stroke color instead of a semi-transparent fill:
![untitled](https://cloud.githubusercontent.com/assets/1728657/24279903/4b8f525a-107f-11e7-9493-e762b8a859ad.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
