### PR TITLE
[attributetable] Fix "Move selection to top": for 2.18 regression fixes #15803

### DIFF
--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -196,13 +196,8 @@ void QgsAttributeTableConfig::readXml( const QDomNode& node )
   }
 
   mSortExpression = configNode.toElement().attribute( "sortExpression" );
-  mSortOrder = static_cast<Qt::SortOrder>( configNode.toElement().attribute( "sortOrder" ).toInt() );
-  // fix https://hub.qgis.org/issues/15803
-  // because static_cast give umpredictable value if value is not in the enum range
-  if ( mSortOrder != Qt::AscendingOrder && mSortOrder != Qt::DescendingOrder )
-  {
-    mSortOrder = Qt::AscendingOrder;
-  }
+  Qt::SortOrder sortOrder = static_cast<Qt::SortOrder>( configNode.toElement().attribute( "sortOrder" ).toInt() );
+  setSortOrder( sortOrder );
 }
 
 QString QgsAttributeTableConfig::sortExpression() const

--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -197,6 +197,12 @@ void QgsAttributeTableConfig::readXml( const QDomNode& node )
 
   mSortExpression = configNode.toElement().attribute( "sortExpression" );
   mSortOrder = static_cast<Qt::SortOrder>( configNode.toElement().attribute( "sortOrder" ).toInt() );
+  // fix https://hub.qgis.org/issues/15803
+  // because static_cast give umpredictable value if value is not in the enum range
+  if ( mSortOrder != Qt::AscendingOrder && mSortOrder != Qt::DescendingOrder )
+  {
+    mSortOrder = Qt::AscendingOrder;
+  }
 }
 
 QString QgsAttributeTableConfig::sortExpression() const
@@ -241,7 +247,15 @@ Qt::SortOrder QgsAttributeTableConfig::sortOrder() const
 
 void QgsAttributeTableConfig::setSortOrder( const Qt::SortOrder& sortOrder )
 {
-  mSortOrder = sortOrder;
+  // fix https://hub.qgis.org/issues/15803
+  if ( sortOrder != Qt::AscendingOrder && sortOrder != Qt::DescendingOrder )
+  {
+    mSortOrder = Qt::AscendingOrder;
+  }
+  else
+  {
+    mSortOrder = sortOrder;
+  }
 }
 
 void QgsAttributeTableConfig::writeXml( QDomNode& node ) const

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -63,6 +63,9 @@ bool QgsAttributeTableFilterModel::lessThan( const QModelIndex &left, const QMod
 
 void QgsAttributeTableFilterModel::sort( int column, Qt::SortOrder order )
 {
+  if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
+    order = Qt::AscendingOrder;
+
   int myColumn = mColumnMapping.at( column );
   masterModel()->prefetchColumnData( myColumn );
   QSortFilterProxyModel::sort( myColumn, order );
@@ -210,6 +213,9 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
 
 void QgsAttributeTableFilterModel::sort( QString expression, Qt::SortOrder order )
 {
+  if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
+    order = Qt::AscendingOrder;
+
   QSortFilterProxyModel::sort( -1 );
   masterModel()->prefetchSortData( expression );
   QSortFilterProxyModel::sort( 0, order ) ;
@@ -225,11 +231,17 @@ void QgsAttributeTableFilterModel::setSelectedOnTop( bool selectedOnTop )
   if ( mSelectedOnTop != selectedOnTop )
   {
     mSelectedOnTop = selectedOnTop;
+    int column = sortColumn();
+    Qt::SortOrder order = sortOrder();
 
-    if ( sortColumn() == -1 )
-    {
-      sort( 0 );
-    }
+    // set default sort values if they are not correctly set
+    if ( column < 0 )
+      column = 0;
+
+    if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
+      order = Qt::AscendingOrder;
+
+    sort( column, order );
     invalidate();
   }
 }


### PR DESCRIPTION
the reason that sortColumn() normally was set to it's initial value -1 in:
QSortFilterProxyModel but, somewere in qgis code (probably in the init
of QgsMapLayerProxyModel)  already set a sortColumn => the normal flow
skip default call to sort(0) during first open or during trigger of selectOnTop pushButton