### PR TITLE
Catch geos exception in main event loop

### DIFF
--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -250,42 +250,14 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
 
 /// @cond PRIVATE
 
-class GEOSException // clazy:exclude=rule-of-three
+
+class GEOSException : public std::runtime_error
 {
   public:
     explicit GEOSException( const QString &message )
+      : std::runtime_error( message.toUtf8().constData() )
     {
-      if ( message == QLatin1String( "Unknown exception thrown" ) && lastMsg().isNull() )
-      {
-        msg = message;
-      }
-      else
-      {
-        msg = message;
-        lastMsg() = msg;
-      }
     }
-
-    // copy constructor
-    GEOSException( const GEOSException &rhs )
-    {
-      *this = rhs;
-    }
-
-    ~GEOSException()
-    {
-      if ( lastMsg() == msg )
-        lastMsg() = QString::null;
-    }
-
-    QString what()
-    {
-      return msg;
-    }
-
-  private:
-    QString msg;
-    static QString &lastMsg() { static QString sLastMsg; return sLastMsg; }
 };
 
 /// @endcond

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -37,7 +37,6 @@
 #include "qgsmessagelog.h"
 #include "qgsannotationregistry.h"
 #include "qgssettings.h"
-#include "qgsgeos.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -311,12 +310,6 @@ bool QgsApplication::notify( QObject *receiver, QEvent *event )
   catch ( QgsException &e )
   {
     QgsDebugMsg( "Caught unhandled QgsException: " + e.what() );
-    if ( qApp->thread() == QThread::currentThread() )
-      QMessageBox::critical( activeWindow(), tr( "Exception" ), e.what() );
-  }
-  catch ( GEOSException &e )
-  {
-    QgsDebugMsg( "Caught unhandled GEOSException: " + e.what() );
     if ( qApp->thread() == QThread::currentThread() )
       QMessageBox::critical( activeWindow(), tr( "Exception" ), e.what() );
   }

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -37,6 +37,7 @@
 #include "qgsmessagelog.h"
 #include "qgsannotationregistry.h"
 #include "qgssettings.h"
+#include "qgsgeos.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -310,6 +311,12 @@ bool QgsApplication::notify( QObject *receiver, QEvent *event )
   catch ( QgsException &e )
   {
     QgsDebugMsg( "Caught unhandled QgsException: " + e.what() );
+    if ( qApp->thread() == QThread::currentThread() )
+      QMessageBox::critical( activeWindow(), tr( "Exception" ), e.what() );
+  }
+  catch ( GEOSException &e )
+  {
+    QgsDebugMsg( "Caught unhandled GEOSException: " + e.what() );
     if ( qApp->thread() == QThread::currentThread() )
       QMessageBox::critical( activeWindow(), tr( "Exception" ), e.what() );
   }

--- a/src/core/qgstracer.cpp
+++ b/src/core/qgstracer.cpp
@@ -550,7 +550,7 @@ bool QgsTracer::initGraph()
 
     mHasTopologyProblem = true;
 
-    QgsDebugMsg( "Tracer Noding Exception: " + e.what() );
+    QgsDebugMsg( QString( "Tracer Noding Exception: %1" ).arg( e.what() ) );
   }
 #endif
 


### PR DESCRIPTION
If something fails to catch a geos exception, at least there will be more information in the message box.

I hope to get more information next time I run into this *reshape tool shows "Unknown Exception" message possibly related to CRS and snapping but not sure and cannot reproduce* error.

I am not sure what exactly the reason was for GEOSException implementing a static `lastMsg` variable. It looks like this is only assigned but never used and is some really old code.