### PR TITLE
fix ArcGIS Feature/Map Server connect()

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4643,7 +4643,7 @@ void QgisApp::addAfsLayer()
   }
   afss->setCurrentExtentAndCrs( mapCanvas()->extent(), mapCanvas()->mapSettings().destinationCrs() );
   connect( afss, &QgsSourceSelectDialog::addLayer,
-           this, [ = ] { addAfsLayer(); } );
+  this, [ = ]( const QString & uri, const QString & typeName ) { addAfsLayer( uri, typeName ); } );
 
   bool wasFrozen = mapCanvas()->isFrozen();
   freezeCanvases();
@@ -4677,7 +4677,7 @@ void QgisApp::addAmsLayer()
   }
   amss->setCurrentExtentAndCrs( mapCanvas()->extent(), mapCanvas()->mapSettings().destinationCrs() );
   connect( amss, &QgsSourceSelectDialog::addLayer,
-           this, [ = ] { addAmsLayer(); } );
+  this, [ = ]( const QString & uri, const QString & typeName ) { addAmsLayer( uri, typeName ); } );
 
   bool wasFrozen = mapCanvas()->isFrozen();
   freezeCanvases();


### PR DESCRIPTION
## Description
This PR fixes a connect() issue with regards to addition of ArcGIS Feature/Map Server connection via the source selection dialog. The regression was caused by a connect() style update in commit bd179997.

_(Just making sure the commit is green before pushing)_

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
