### PR TITLE
disable export button if we try to export a raster layer

### DIFF
--- a/python/plugins/db_manager/db_manager.py
+++ b/python/plugins/db_manager/db_manager.py
@@ -31,7 +31,7 @@ from qgis.PyQt.QtWidgets import QMainWindow, QApplication, QMenu, QTabWidget, QG
 from qgis.PyQt.QtGui import QIcon, QKeySequence
 
 from qgis.gui import QgsMessageBar
-from qgis.core import QgsSettings
+from qgis.core import QgsSettings, QgsMapLayer
 from .info_viewer import InfoViewer
 from .table_viewer import TableViewer
 from .layer_preview import LayerPreview
@@ -175,6 +175,11 @@ class DBManager(QMainWindow):
             return
 
         inLayer = table.toMapLayer()
+        if inLayer.type() != QgsMapLayer.VectorLayer:
+            self.infoBar.pushMessage(
+                self.tr("Select a vector or a tabular layer you want export."),
+                QgsMessageBar.WARNING, self.iface.messageTimeout())
+            return
 
         from .dlg_export_vector import DlgExportVector
 


### PR DESCRIPTION
## Description

In the DBManager, the export button is enabled for every layers. But for now, the export function works only with QgsVectorLayer.

it would be good to be able to export rasters (from geopackage, postgis) to a file.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
