### PR TITLE
[OGR] fix feature count issue for OSM datasets (fixes #16402)

### DIFF
--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -58,6 +58,17 @@ class QgsVectorDataProvider : QgsDataProvider
     static const int EditingCapabilities;
 
     /**
+     * Enumeration of feature count states
+     */
+    enum FeatureCountState
+    {
+      //! Feature count not yet computed
+      Uncounted = -2,
+      //! Provider returned an unknown feature count
+      UnknownCount = -1,
+    };
+
+    /**
      * Constructor of the vector provider
      * @param uri  uniform resource locator (URI) for a dataset
      */

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -113,6 +113,17 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
                                            RenameAttributes;
 
     /**
+     * Enumeration of feature count states
+     */
+    enum FeatureCountState
+    {
+      //! Feature count not yet computed
+      Uncounted = -2,
+      //! Provider returned an unknown feature count
+      UnknownCount = -1,
+    };
+
+    /**
      * Constructor of the vector provider
      * \param uri  uniform resource locator (URI) for a dataset
      */

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -378,7 +378,7 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri )
   , ogrDriver( nullptr )
   , mValid( false )
   , mOGRGeomType( wkbUnknown )
-  , mFeaturesCounted( -1 )
+  , mFeaturesCounted( QgsVectorDataProvider::Uncounted )
   , mWriteAccess( false )
   , mWriteAccessPossible( false )
   , mDynamicWriteAccess( false )
@@ -450,7 +450,7 @@ bool QgsOgrProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
   if ( !ogrDataSource )
     return false;
 
-  if ( theSQL == mSubsetString && mFeaturesCounted >= 0 )
+  if ( theSQL == mSubsetString && mFeaturesCounted != QgsVectorDataProvider::Uncounted )
     return true;
 
   OGRLayerH prevLayer = ogrLayer;
@@ -3300,7 +3300,7 @@ void QgsOgrProvider::recalculateFeatureCount()
 {
   if ( !ogrLayer )
   {
-    mFeaturesCounted = 0;
+    mFeaturesCounted = QgsVectorDataProvider::Uncounted;
     return;
   }
 
@@ -3316,6 +3316,10 @@ void QgsOgrProvider::recalculateFeatureCount()
   if ( mOgrGeometryTypeFilter == wkbUnknown )
   {
     mFeaturesCounted = OGR_L_GetFeatureCount( ogrLayer, true );
+    if ( mFeaturesCounted == -1 )
+    {
+      mFeaturesCounted = QgsVectorDataProvider::UnknownCount;
+    }
   }
   else
   {


### PR DESCRIPTION
## Description
Some OGR drivers will return -1 when calling GetFeatureCount() when the count is not known (for flat file drivers, such as OSM, it appears). This didn't play well with our provider code, which uses the -1 value to indicate that a feature count has not been called yet.

The above can lead to QGIS going into infinite loops (such as hub issue #16402). This PR update the OGR provider code to fix this.

@rouault , @nyalldawson , does this look good to you guys? 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
