### PR TITLE
MetaSearch: set 4326 as default CRS, use WKT to feed polygon geometry

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -392,7 +392,10 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         """set bounding box from map extent"""
 
         crs = self.map.mapSettings().destinationCrs()
-        crsid = int(crs.authid().split(':')[1])
+        try:
+            crsid = int(crs.authid().split(':')[1])
+        except IndexError:  # no projection
+            crsid = 4326
 
         extent = self.map.extent()
 
@@ -570,7 +573,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             if points is not None:
                 src = QgsCoordinateReferenceSystem(4326)
                 dst = self.map.mapSettings().destinationCrs()
-                geom = QgsGeometry.fromPolygon(points)
+                geom = QgsGeometry.fromWkt(points)
                 if src.postgisSrid() != dst.postgisSrid():
                     ctr = QgsCoordinateTransform(src, dst)
                     try:
@@ -953,11 +956,6 @@ def bbox_to_polygon(bbox):
         maxx = float(bbox.maxx)
         maxy = float(bbox.maxy)
 
-        return [[
-            QgsPoint(minx, miny),
-            QgsPoint(minx, maxy),
-            QgsPoint(maxx, maxy),
-            QgsPoint(maxx, miny)
-        ]]
+        return 'POLYGON((%.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f))' % (minx, miny, minx, maxy, maxx, maxy, maxx, miny, minx, miny)  # noqa
     else:
         return None


### PR DESCRIPTION
## Description
Minor fixes to ensure map projection and polygons coordinates are safely set.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
