### PR TITLE
Adding Metadata schema for WP1 for QEP-91

### DIFF
--- a/resources/qgis-resource-metadata.xml
+++ b/resources/qgis-resource-metadata.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ResourceMetadata xmlns="http://qgis.org/resource-metadata/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" xsi:schemaLocation="http://qgis.org/resource-metadata/1.0 qgis-resource-metadata.xsd">
+    <identifier>1234</identifier>
+    <parentidentifier>xyz</parentidentifier>
+    <language>en-CA</language>
+    <type>dataset</type>
+    <title>roads</title>
+    <abstract>my roads</abstract>
+    <keywords vocabulary="GEMET">
+        <keyword>kw1</keyword>
+        <keyword>kw2</keyword>
+    </keywords>
+    <fees>None</fees>
+    <accessconstraints>None<accessconstraints>
+    <encoding>utf-8</encoding>
+    <crs>EPSG:4326</crs>
+    <extent>
+        <spatial dimensions="2" crs="EPSG:4326" minx="-180" miny="-90" maxx="180" maxy="90"/>
+        <temporal>
+            <instant>2001-12-17T09:30:47Z</instant>
+        </temporal>
+    </extent>
+    <contact>
+        <name>John Smith</name>
+        <organization>ACME</organization>
+        <position>staff</position>
+        <address>
+            <type>postal</type>
+            <address>123 Main Street</address>
+            <city>anycity</city>
+            <administrativearea>anyprovince</administrativearea>
+            <postalcode>90210</postalcode>
+            <country>Canada</country>
+        </address>
+        <voice>xx.xxx.xxx.xxxx</voice>
+        <fax>xx.xxx.xxx.xxxx</fax>
+        <email>foo@example.org</email>
+        <role>pointOfContact</role>
+    </contact>
+    <links>
+        <link name="geonode:roads" type="OGC:WMS" description="my GeoNode road layer" url="http://example.org/wms"/>
+        <link name="geonode:roads" type="OGC:WFS" description="my GeoNode road layer" url="http://example.org/wfs"/>
+        <link name="roads" type="WWW:LINK" description="full dataset download" url="http://example.org/roads.tgz" format="ESRI Shapefile" mimeType="application/gzip" size="283676"/>
+    </links>
+</ResourceMetadata>

--- a/resources/qgis-resource-metadata.xml
+++ b/resources/qgis-resource-metadata.xml
@@ -12,6 +12,7 @@
     </keywords>
     <fees>None</fees>
     <constraints type="access">None<constraints>
+    <rights>Copyright foo 2017</rights>
     <encoding>utf-8</encoding>
     <crs>EPSG:4326</crs>
     <extent>

--- a/resources/qgis-resource-metadata.xml
+++ b/resources/qgis-resource-metadata.xml
@@ -11,7 +11,7 @@
         <keyword>kw2</keyword>
     </keywords>
     <fees>None</fees>
-    <accessconstraints>None<accessconstraints>
+    <constraints type="access">None<constraints>
     <encoding>utf-8</encoding>
     <crs>EPSG:4326</crs>
     <extent>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:rm="http://qgis.org/resource-metadata/1.0" targetNamespace="http://qgis.org/resource-metadata/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+    <xs:element name="ResourceMetadata" type="rm:ResourceMetadataType">
+        <xs:annotation>
+            <xs:documentation>Comment describing your root element</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="ResourceMetadataType">
+        <xs:sequence>
+            <xs:element name="identifier" type="xs:string"/>
+            <xs:element name="parentidentifier" type="xs:string" minOccurs="0"/>
+            <xs:element name="language" type="xs:string"/>
+            <xs:element name="type" type="xs:string"/>
+            <xs:element name="title" type="xs:string"/>
+            <xs:element name="abstract" type="xs:string"/>
+            <xs:element name="keywords" type="rm:keywordsType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="fees" type="xs:string" minOccurs="0"/>
+            <xs:element name="constraints" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="rights" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="encoding" type="xs:string" minOccurs="0"/>
+            <xs:element name="crs" type="xs:string"/>
+            <xs:element name="extent" type="rm:extentType" maxOccurs="1"/>
+            <xs:element name="contact" type="rm:contactType" maxOccurs="unbounded"/>
+            <xs:element name="links" type="rm:linksType"/>
+        </xs:sequence>
+        <xs:attribute name="version" use="required" fixed="1.0"/>
+    </xs:complexType>
+    <xs:complexType name="keywordsType">
+        <xs:sequence>
+            <xs:element name="keyword" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="vocabulary" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="extentType">
+            <xs:sequence>
+                <xs:element name="spatial" type="rm:spatialType" maxOccurs="unbounded"/>
+                <xs:element name="temporal" type="rm:temporalType" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="spatialType">
+        <xs:attribute name="dimensions" type="xs:integer" default="2"/>
+        <xs:attribute name="crs" type="xs:string" use="required"/>
+        <xs:attribute name="minx" type="xs:decimal" use="required"/>
+        <xs:attribute name="miny" type="xs:decimal" use="required"/>
+        <xs:attribute name="minz" type="xs:decimal" use="optional"/>
+        <xs:attribute name="maxx" type="xs:decimal" use="required"/>
+        <xs:attribute name="maxy" type="xs:decimal" use="required"/>
+        <xs:attribute name="maxz" type="xs:decimal" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="temporalType">
+        <xs:choice>
+            <xs:element name="instant" type="xs:dateTime"/>
+            <xs:element name="period" type="rm:periodType"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="periodType">
+        <xs:sequence>
+            <xs:element name="start" type="xs:dateTime"/>
+            <xs:element name="end" type="xs:dateTime" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="indeterminatePosition" type="xs:boolean"/>
+    </xs:complexType>
+    <xs:complexType name="contactType">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+            <xs:element name="organization" type="xs:string" minOccurs="0"/>
+            <xs:element name="position" type="xs:string" minOccurs="0"/>
+            <xs:element name="address" type="rm:addressType" minOccurs="0"/>
+            <xs:element name="voice" type="xs:string" minOccurs="0"/>
+            <xs:element name="fax" type="xs:string" minOccurs="0"/>
+            <xs:element name="email" type="xs:string" minOccurs="0"/>
+            <xs:element name="role" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="addressType">
+        <xs:sequence>
+            <xs:element name="type" type="xs:string" minOccurs="0"/>
+            <xs:element name="address" type="xs:string" minOccurs="0"/>
+            <xs:element name="city" type="xs:string" minOccurs="0"/>
+            <xs:element name="administrativearea" type="xs:string" minOccurs="0"/>
+            <xs:element name="postalcode" type="xs:string" minOccurs="0"/>
+            <xs:element name="country" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="linksType">
+        <xs:sequence>
+            <xs:element name="link" type="rm:linkType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="linkType">
+        <xs:attributeGroup ref="rm:linkAttrs"/>
+    </xs:complexType>
+    <xs:attributeGroup name="linkAttrs">
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string"/>
+        <xs:attribute name="description" type="xs:string" use="optional"/>
+        <xs:attribute name="url" type="xs:anyURI" use="required"/>
+        <xs:attribute name="format" type="xs:string" use="optional"/>
+        <xs:attribute name="mimeType" type="xs:string" use="optional"/>
+        <xs:attribute name="size" type="xs:string" use="optional"/>
+    </xs:attributeGroup>
+</xs:schema>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -39,7 +39,7 @@
             <xs:element name="abstract" type="xs:string"/>
             <xs:element name="keywords" type="rm:keywordsType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="fees" type="xs:string" minOccurs="0"/>
-            <xs:element name="constraints" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="constraints" type="rm:constraintsType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="rights" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="encoding" type="xs:string" minOccurs="0"/>
             <xs:element name="crs" type="xs:string"/>
@@ -49,6 +49,13 @@
         </xs:sequence>
         <xs:attribute name="version" use="required" fixed="1.0"/>
     </xs:complexType>
+    <xs:complexType name="constraintsType">
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute name="type" type="xs:string"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>  
     <xs:complexType name="keywordsType">
         <xs:sequence>
             <xs:element name="keyword" maxOccurs="unbounded"/>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -96,7 +96,7 @@
             <xs:element name="name" type="xs:string"/>
             <xs:element name="organization" type="xs:string" minOccurs="0"/>
             <xs:element name="position" type="xs:string" minOccurs="0"/>
-            <xs:element name="address" type="rm:addressType" minOccurs="0"/>
+            <xs:element name="address" type="rm:addressType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="voice" type="xs:string" minOccurs="0"/>
             <xs:element name="fax" type="xs:string" minOccurs="0"/>
             <xs:element name="email" type="xs:string" minOccurs="0"/>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -22,112 +22,319 @@
 ###############################################################################
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:rm="http://qgis.org/resource-metadata/1.0" targetNamespace="http://qgis.org/resource-metadata/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
-    <xs:element name="ResourceMetadata" type="rm:ResourceMetadataType">
-        <xs:annotation>
-            <xs:appinfo>QGIS Resource Metadata Schema</xs:appinfo>
-            <xs:documentation>Copyright (C) 2017 Tom Kralidis (tomkralidis@gmail.com)</xs:documentation>
-            <xs:documentation>Copyright (C) 2017 Angelos Tzotsos (gcpp.kalxas@gmail.com)</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:complexType name="ResourceMetadataType">
-        <xs:sequence>
-            <xs:element name="identifier" type="xs:string"/>
-            <xs:element name="parentidentifier" type="xs:string" minOccurs="0"/>
-            <xs:element name="language" type="xs:string"/>
-            <xs:element name="type" type="xs:string"/>
-            <xs:element name="title" type="xs:string"/>
-            <xs:element name="abstract" type="xs:string"/>
-            <xs:element name="keywords" type="rm:keywordsType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="fees" type="xs:string" minOccurs="0"/>
-            <xs:element name="constraints" type="rm:constraintsType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="rights" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="encoding" type="xs:string" minOccurs="0"/>
-            <xs:element name="crs" type="xs:string"/>
-            <xs:element name="extent" type="rm:extentType" maxOccurs="1"/>
-            <xs:element name="contact" type="rm:contactType" maxOccurs="unbounded"/>
-            <xs:element name="links" type="rm:linksType"/>
-        </xs:sequence>
-        <xs:attribute name="version" use="required" fixed="1.0"/>
-    </xs:complexType>
-    <xs:complexType name="constraintsType">
-      <xs:simpleContent>
-        <xs:extension base="xs:string">
-          <xs:attribute name="type" type="xs:string"/>
-        </xs:extension>
-      </xs:simpleContent>
-    </xs:complexType>  
-    <xs:complexType name="keywordsType">
-        <xs:sequence>
-            <xs:element name="keyword" maxOccurs="unbounded"/>
-        </xs:sequence>
-        <xs:attribute name="vocabulary" type="xs:string"/>
-    </xs:complexType>
-    <xs:complexType name="extentType">
-            <xs:sequence>
-                <xs:element name="spatial" type="rm:spatialType" maxOccurs="unbounded"/>
-                <xs:element name="temporal" type="rm:temporalType" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="spatialType">
-        <xs:attribute name="dimensions" type="xs:integer" default="2"/>
-        <xs:attribute name="crs" type="xs:string" use="required"/>
-        <xs:attribute name="minx" type="xs:decimal" use="required"/>
-        <xs:attribute name="miny" type="xs:decimal" use="required"/>
-        <xs:attribute name="minz" type="xs:decimal" use="optional"/>
-        <xs:attribute name="maxx" type="xs:decimal" use="required"/>
-        <xs:attribute name="maxy" type="xs:decimal" use="required"/>
-        <xs:attribute name="maxz" type="xs:decimal" use="optional"/>
-    </xs:complexType>
-    <xs:complexType name="temporalType">
-        <xs:choice>
-            <xs:element name="instant" type="xs:dateTime"/>
-            <xs:element name="period" type="rm:periodType"/>
-        </xs:choice>
-    </xs:complexType>
-    <xs:complexType name="periodType">
-        <xs:sequence>
-            <xs:element name="start" type="xs:dateTime"/>
-            <xs:element name="end" type="xs:dateTime" minOccurs="0"/>
-        </xs:sequence>
-        <xs:attribute name="indeterminatePosition" type="xs:boolean"/>
-    </xs:complexType>
-    <xs:complexType name="contactType">
-        <xs:sequence>
-            <xs:element name="name" type="xs:string"/>
-            <xs:element name="organization" type="xs:string" minOccurs="0"/>
-            <xs:element name="position" type="xs:string" minOccurs="0"/>
-            <xs:element name="address" type="rm:addressType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="voice" type="xs:string" minOccurs="0"/>
-            <xs:element name="fax" type="xs:string" minOccurs="0"/>
-            <xs:element name="email" type="xs:string" minOccurs="0"/>
-            <xs:element name="role" type="xs:string" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="addressType">
-        <xs:sequence>
-            <xs:element name="type" type="xs:string" minOccurs="0"/>
-            <xs:element name="address" type="xs:string" minOccurs="0"/>
-            <xs:element name="city" type="xs:string" minOccurs="0"/>
-            <xs:element name="administrativearea" type="xs:string" minOccurs="0"/>
-            <xs:element name="postalcode" type="xs:string" minOccurs="0"/>
-            <xs:element name="country" type="xs:string" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="linksType">
-        <xs:sequence>
-            <xs:element name="link" type="rm:linkType" maxOccurs="unbounded"/>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="linkType">
-        <xs:attributeGroup ref="rm:linkAttrs"/>
-    </xs:complexType>
-    <xs:attributeGroup name="linkAttrs">
-        <xs:attribute name="name" type="xs:string"/>
-        <xs:attribute name="type" type="xs:string"/>
-        <xs:attribute name="description" type="xs:string" use="optional"/>
-        <xs:attribute name="url" type="xs:anyURI" use="required"/>
-        <xs:attribute name="format" type="xs:string" use="optional"/>
-        <xs:attribute name="mimeType" type="xs:string" use="optional"/>
-        <xs:attribute name="size" type="xs:string" use="optional"/>
-    </xs:attributeGroup>
+	<xs:element name="ResourceMetadata" type="rm:ResourceMetadataType">
+		<xs:annotation>
+			<xs:appinfo>QGIS Resource Metadata Schema</xs:appinfo>
+			<xs:documentation>Copyright (C) 2017 Tom Kralidis (tomkralidis@gmail.com)</xs:documentation>
+			<xs:documentation>Copyright (C) 2017 Angelos Tzotsos (gcpp.kalxas@gmail.com)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="ResourceMetadataType">
+		<xs:sequence>
+			<xs:element name="identifier" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>A Reference, URI, URL or some other mechanism to identify a given resource. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="parentidentifier" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A Refernece, URI, URL or some other mechanism that that a given resource is a part of (child).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="language" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Human language associated with a given resource.  While a formal vocabulary is not imposed, it is advised to use ISO 3166/ISO 639.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="type" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Nature of a given resource.  While a formal vocabulary is not imposed, it is advised to use the ISO 19115 MD_ScopeCode.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="title" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Human readable name of a given resource typically displayed in search results.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="abstract" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Description of a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="keywords" type="rm:keywordsType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Set of descriptive keywords associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="fees" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Any fees associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="constraints" type="rm:constraintsType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>List of constraints associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="rights" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Attribution or copyright associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="encoding" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Character encoding of the data of a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="crs" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Coordinate reference system associated with the data of a given resource.  Examples:
+						* EPSG:EPSGCODE
+						* http://www.opengis.net/def/crs/EPSG/0/EPSGCODE (URI Style 1)
+						* http://www.opengis.net/gml/srs/epsg.xml#EPSGCODE (URI Style 2)
+						* urn:EPSG:geographicCRS:EPSGCODE
+						* urn:ogc:def:crs:EPSG::EPSGCODE
+						* urn:ogc:def:crs:EPSG:EPSGCODE
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="extent" type="rm:extentType" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Spatial and temporal extents associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="contact" type="rm:contactType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Contact person/entity associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="links" type="rm:linksType">
+				<xs:annotation>
+					<xs:documentation>Set of online resources associated with a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="version" use="required" fixed="1.0">
+			<xs:annotation>
+				<xs:documentation>Version of QGIS Resource Metadata schema used. </xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="constraintsType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="type" type="xs:string">
+					<xs:annotation>
+						<xs:documentation>Type of constraint.  Suggested types are 'access', 'other'.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="keywordsType">
+		<xs:sequence>
+			<xs:element name="keyword" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Descriptive keyword associated with a resource.  While a formal vocabulary is not imposed, it is advised to use rm:keywords/@vocabulary to identify a codelist or applicable vocabulary.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="vocabulary" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>Reference (URI/URL preferred) to a codelist or vocabulary associated with keyword list.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="extentType">
+		<xs:sequence>
+			<xs:element name="spatial" type="rm:spatialType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Geospatial Extent of a given resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="temporal" type="rm:temporalType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Temporal extent associated with a given resource.  It is advised to use ISO 8601 for consistency.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="spatialType">
+		<xs:attribute name="dimensions" type="xs:integer" default="2"/>
+		<xs:attribute name="crs" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>Coordinate refernece system.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="minx" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation>Minimum x value according to crs.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="miny" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation>Minimum y value according to crs.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="minz" type="xs:decimal" use="optional">
+			<xs:annotation>
+				<xs:documentation>Minimum z value according to crs.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="maxx" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation>Maximum x value according to crs.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="maxy" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation>Maximum y value according to crs.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="maxz" type="xs:decimal" use="optional">
+			<xs:annotation>
+				<xs:documentation>Maximum z value according to crs.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="temporalType">
+		<xs:choice>
+			<xs:element name="instant" type="xs:dateTime">
+				<xs:annotation>
+					<xs:documentation>Single point in time.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="period" type="rm:periodType">
+				<xs:annotation>
+					<xs:documentation>Time period or envelope.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="periodType">
+		<xs:sequence>
+			<xs:element name="start" type="xs:dateTime">
+				<xs:annotation>
+					<xs:documentation>Begin date/time.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="end" type="xs:dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>End date/time.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="indeterminatePosition" type="xs:boolean">
+			<xs:annotation>
+				<xs:documentation>Whether resource has no end date/time (i.e. continuous acquisition).</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="contactType">
+		<xs:sequence>
+			<xs:element name="name" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Name of contact.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="organization" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Organization contact belongs to/represents.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="position" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Position/title of contact.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="address" type="rm:addressType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Address associated with a given contact.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="voice" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Voice telephone.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="fax" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Facsimile telephone.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="email" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Electronic mail address (note, do not include mailto: protocol as part of the email address).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="role" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Role of contact. While no vocabulary is imposed, it is advised to use ISO 19115 CI_RoleCode.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="addressType">
+		<xs:sequence>
+			<xs:element name="type" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Type of address (e.g. 'postal').</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="address" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Physical address.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="city" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>City.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="administrativearea" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Administrative area (state, provice/territory, etc.).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="postalcode" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Postal code.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="country" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Country.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="linksType">
+		<xs:sequence>
+			<xs:element name="link" type="rm:linkType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Online resource associated with a given resource.  Attribute definitions:
+						* name: short name (like WMS layer name)
+						* type: link type.  Strongly suggested to use values from the 'identifier' column in https://github.com/OSGeo/Cat-Interop/blob/master/LinkPropertyLookupTable.csv
+						* description: abstract text about link
+						* url: endpoint.  If the URL is an OWS server, specify the *base* URL only without parameters like service=xxx.....
+						* format: format specification of online resource.  Strongly suggested to use GDAL/OGR format values
+						* mimeType: MIME type represenative of the online resource response (image/png, application/json, etc.)
+						* size: estimated size (in bytes) of the online resource response
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="linkType">
+		<xs:attributeGroup ref="rm:linkAttrs"/>
+	</xs:complexType>
+	<xs:attributeGroup name="linkAttrs">
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="type" type="xs:string"/>
+		<xs:attribute name="description" type="xs:string" use="optional"/>
+		<xs:attribute name="url" type="xs:anyURI" use="required"/>
+		<xs:attribute name="format" type="xs:string" use="optional"/>
+		<xs:attribute name="mimeType" type="xs:string" use="optional"/>
+		<xs:attribute name="size" type="xs:string" use="optional"/>
+	</xs:attributeGroup>
 </xs:schema>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -1,8 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+###############################################################################
+#
+# Copyright (C) 2017 Tom Kralidis (tomkralidis@gmail.com)
+# Copyright (C) 2017 Angelos Tzotsos (gcpp.kalxas@gmail.com)
+#
+# This source is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 2 of the License, or (at your option)
+# any later version.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+###############################################################################
+-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:rm="http://qgis.org/resource-metadata/1.0" targetNamespace="http://qgis.org/resource-metadata/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
     <xs:element name="ResourceMetadata" type="rm:ResourceMetadataType">
         <xs:annotation>
-            <xs:documentation>Comment describing your root element</xs:documentation>
+            <xs:appinfo>QGIS Resource Metadata Schema</xs:appinfo>
+            <xs:documentation>Copyright (C) 2017 Tom Kralidis (tomkralidis@gmail.com)</xs:documentation>
+            <xs:documentation>Copyright (C) 2017 Angelos Tzotsos (gcpp.kalxas@gmail.com)</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:complexType name="ResourceMetadataType">

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -118,6 +118,11 @@
 					<xs:documentation>Set of online resources associated with a given resource.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+      <xs:element name="history" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+    	    <xs:documentation>Freeform description of the history or lineage of the resource.</xs:documentation>
+        </xs:annotation>
+      </xs:element> 
 		</xs:sequence>
 		<xs:attribute name="version" use="required" fixed="1.0">
 			<xs:annotation>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -81,6 +81,11 @@
 					<xs:documentation>Attribution or copyright associated with a given resource.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+      <xs:element name="license" type="xs:string" minOccurs="1" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>License associated with a given resource (examples: http://opendefinition.org/licenses/).</xs:documentation>
+				</xs:annotation>        
+      </xs:element>
 			<xs:element name="encoding" type="xs:string" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Character encoding of the data of a given resource.</xs:documentation>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -33,12 +33,12 @@
 		<xs:sequence>
 			<xs:element name="identifier" type="xs:string">
 				<xs:annotation>
-					<xs:documentation>A Reference, URI, URL or some other mechanism to identify a given resource. </xs:documentation>
+					<xs:documentation>Reference, URI, URL or some other mechanism to identify a given resource. </xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="parentidentifier" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>A Reference, URI, URL or some other mechanism that that a given resource is a part of (child).</xs:documentation>
+					<xs:documentation>Reference, URI, URL or some other mechanism that that a given resource is a part of (child).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="language" type="xs:string">

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -163,7 +163,7 @@
 		<xs:attribute name="dimensions" type="xs:integer" default="2"/>
 		<xs:attribute name="crs" type="xs:string" use="required">
 			<xs:annotation>
-				<xs:documentation>Coordinate refernece system.</xs:documentation>
+				<xs:documentation>Coordinate reference system.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="minx" type="xs:decimal" use="required">
@@ -318,7 +318,7 @@
 						* description: abstract text about link
 						* url: endpoint.  If the URL is an OWS server, specify the *base* URL only without parameters like service=xxx.....
 						* format: format specification of online resource.  Strongly suggested to use GDAL/OGR format values
-						* mimeType: MIME type represenative of the online resource response (image/png, application/json, etc.)
+						* mimeType: MIME type representative of the online resource response (image/png, application/json, etc.)
 						* size: estimated size (in bytes) of the online resource response
 					</xs:documentation>
 				</xs:annotation>

--- a/resources/qgis-resource-metadata.xsd
+++ b/resources/qgis-resource-metadata.xsd
@@ -38,7 +38,7 @@
 			</xs:element>
 			<xs:element name="parentidentifier" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>A Refernece, URI, URL or some other mechanism that that a given resource is a part of (child).</xs:documentation>
+					<xs:documentation>A Reference, URI, URL or some other mechanism that that a given resource is a part of (child).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="language" type="xs:string">


### PR DESCRIPTION
## Description
This PR introduces a QGIS metadata schema as part of WP1 of [QEP-91](https://github.com/qgis/QGIS-Enhancement-Proposals/issues/91).

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
