### PR TITLE
Qt5 connection with slot as method argument

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -543,7 +543,6 @@ gui/symbology-ng/qgsnullsymbolrendererwidget.sip
 gui/symbology-ng/qgspenstylecombobox.sip
 gui/symbology-ng/qgspointclusterrendererwidget.sip
 gui/symbology-ng/qgspointdisplacementrendererwidget.sip
-gui/symbology-ng/qgsrendererpropertiesdialog.sip
 gui/symbology-ng/qgsrendererwidget.sip
 gui/symbology-ng/qgsrulebasedrendererwidget.sip
 gui/symbology-ng/qgssinglesymbolrendererwidget.sip

--- a/python/gui/symbology-ng/qgsrendererpropertiesdialog.sip
+++ b/python/gui/symbology-ng/qgsrendererpropertiesdialog.sip
@@ -103,7 +103,7 @@ Apply and accept the changes for the dialog.
 
   protected:
 
-    void connectValueChanged( const QList<QWidget *> &widgets, void ( QgsRendererPropertiesDialog::*slot )() );
+    void connectValueChanged( const QList<QWidget *> &widgets, const char *slot );
 %Docstring
  Connect the given slot to the value changed event for the set of widgets
  Each widget is checked for type and the common type of signal is connected
@@ -111,6 +111,23 @@ Apply and accept the changes for the dialog.
 
  \param widgets The list of widgets to check.
  \param slot The slot to connect to the signals.
+%End
+%MethodCode
+#include <QMetaObject>
+    const QMetaObject *metaObject = sipCpp->metaObject();
+    QStringList methods;
+    for ( int i = metaObject->methodOffset(); i < metaObject->methodCount(); ++i )
+    {
+      QMetaMethod m = metaObject->method( i );
+      if ( m.methodType() == QMetaMethod::Slot )
+      {
+        if ( m.methodSignature() == QByteArray(a1) )
+        {
+          sipCpp->connectValueChanged( *a0, reinterpret_cast<void **>(&m) );
+          return;
+        }
+      }
+    }
 %End
 
     void keyPressEvent( QKeyEvent *event );

--- a/python/gui/symbology-ng/qgsrendererpropertiesdialog.sip
+++ b/python/gui/symbology-ng/qgsrendererpropertiesdialog.sip
@@ -1,93 +1,135 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/symbology-ng/qgsrendererpropertiesdialog.h                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+
 class QgsRendererPropertiesDialog : QDialog
 {
+
 %TypeHeaderCode
-#include <qgsrendererpropertiesdialog.h>
+#include "qgsrendererpropertiesdialog.h"
 %End
 
   public:
 
-    /** Constructor for QgsRendererPropertiesDialog.
-     * @param layer associated layer
-     * @param style style collection
-     * @param embedded set to true to indicate that the dialog will be embedded in another widget, rather
-     * than shown as a dialog by itself
-     * @param parent parent widget
-     */
-    QgsRendererPropertiesDialog( QgsVectorLayer* layer, QgsStyle* style, bool embedded = false, QWidget* parent /TransferThis/ = nullptr );
-
+    QgsRendererPropertiesDialog( QgsVectorLayer *layer, QgsStyle *style, bool embedded = false, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+ Constructor for QgsRendererPropertiesDialog.
+ \param layer associated layer
+ \param style style collection
+ \param embedded set to true to indicate that the dialog will be embedded in another widget, rather
+ than shown as a dialog by itself
+ \param parent parent widget
+%End
     ~QgsRendererPropertiesDialog();
 
-    /** Sets the map canvas associated with the dialog. This allows the widget to retrieve the current
-     * map scale and other properties from the canvas.
-     * @param canvas map canvas
-     * @note added in QGIS 2.12
-     */
-    void setMapCanvas( QgsMapCanvas* canvas );
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+ Sets the map canvas associated with the dialog. This allows the widget to retrieve the current
+ map scale and other properties from the canvas.
+ \param canvas map canvas
+.. versionadded:: 2.12
+%End
 
-    /**
-     * Set the widget in dock mode which tells the widget to emit panel
-     * widgets and not open dialogs
-     * @param dockMode True to enable dock mode.
-     */
     void setDockMode( bool dockMode );
+%Docstring
+ Set the widget in dock mode which tells the widget to emit panel
+ widgets and not open dialogs
+ \param dockMode True to enable dock mode.
+%End
 
   signals:
-    /**
-     * Emitted when expression context variables on the associated
-     * vector layers have been changed. Will request the parent dialog
-     * to re-synchronize with the variables.
-     */
+
     void layerVariablesChanged();
+%Docstring
+ Emitted when expression context variables on the associated
+ vector layers have been changed. Will request the parent dialog
+ to re-synchronize with the variables.
+%End
 
-    /**
-     * Emitted when something on the widget has changed.
-     * All widgets will fire this event to notify of an internal change.
-     */
     void widgetChanged();
+%Docstring
+ Emitted when something on the widget has changed.
+ All widgets will fire this event to notify of an internal change.
+%End
 
-    /**
-     * Emit when you require a panel to be show in the interface.
-     * @param panel The panel widget to show.
-     * @note If you are connected to this signal you should also connect
-     * given panels showPanel signal as they can be nested.
-     */
-    void showPanel( QgsPanelWidget* panel );
+    void showPanel( QgsPanelWidget *panel );
+%Docstring
+ Emit when you require a panel to be show in the interface.
+ \param panel The panel widget to show.
+.. note::
+
+   If you are connected to this signal you should also connect
+ given panels showPanel signal as they can be nested.
+%End
 
   public slots:
-    //! called when user changes renderer type
     void rendererChanged();
+%Docstring
+called when user changes renderer type
+%End
 
-    //! Apply the changes from the dialog to the layer.
     void apply();
+%Docstring
+Apply the changes from the dialog to the layer.
+%End
 
-    //! Apply and accept the changes for the dialog.
     void onOK();
+%Docstring
+Apply and accept the changes for the dialog.
+%End
 
-    /**
-     * Open a panel or dialog depending on dock mode setting
-     * If dock mode is true this method will emit the showPanel signal
-     * for connected slots to handle the open event.
-     *
-     * If dock mode is false this method will open a dialog
-     * and block the user.
-     *
-     * @param panel The panel widget to open.
-     */
-    void openPanel( QgsPanelWidget* panel );
+    void openPanel( QgsPanelWidget *panel );
+%Docstring
+ Open a panel or dialog depending on dock mode setting
+ If dock mode is true this method will emit the showPanel signal
+ for connected slots to handle the open event.
+
+ If dock mode is false this method will open a dialog
+ and block the user.
+
+ \param panel The panel widget to open.
+%End
+
 
   protected:
-    /**
-     * Connect the given slot to the value changed event for the set of widgets
-     * Each widget is checked for type and the common type of signal is connected
-     * to the slot.
-     *
-     * @param widgets The list of widgets to check.
-     * @param slot The slot to connect to the signals.
-     */
-    void connectValueChanged( const QList<QWidget *>& widgets, const char *slot );
+
+    void connectValueChanged( const QList<QWidget *> &widgets, void ( QgsRendererPropertiesDialog::*slot )() );
+%Docstring
+ Connect the given slot to the value changed event for the set of widgets
+ Each widget is checked for type and the common type of signal is connected
+ to the slot.
+
+ \param widgets The list of widgets to check.
+ \param slot The slot to connect to the signals.
+%End
+
+    void keyPressEvent( QKeyEvent *event );
+%Docstring
+Reimplements dialog keyPress event so we can ignore it
+%End
 
 
-    //! Reimplements dialog keyPress event so we can ignore it
-    void keyPressEvent( QKeyEvent * event );
+
+
+
 
 };
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/symbology-ng/qgsrendererpropertiesdialog.h                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/gui/symbology-ng/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererpropertiesdialog.cpp
@@ -133,50 +133,50 @@ QgsRendererPropertiesDialog::QgsRendererPropertiesDialog( QgsVectorLayer *layer,
           << mFeatureBlendComboBox
           << mEffectWidget;
 
-  connectValueChanged( widgets, SIGNAL( widgetChanged() ) );
+  connectValueChanged( widgets, &QgsRendererPropertiesDialog::widgetChanged );
   connect( mEffectWidget, &QgsPanelWidget::showPanel, this, &QgsRendererPropertiesDialog::openPanel );
 }
 
-void QgsRendererPropertiesDialog::connectValueChanged( const QList<QWidget *> &widgets, const char *slot )
+void QgsRendererPropertiesDialog::connectValueChanged( const QList<QWidget *> &widgets, void ( QgsRendererPropertiesDialog::*slot )() )
 {
   Q_FOREACH ( QWidget *widget, widgets )
   {
     if ( QgsPropertyOverrideButton *w = qobject_cast<QgsPropertyOverrideButton *>( widget ) )
     {
-      connect( w, SIGNAL( changed ), this, slot );
+      connect( w, &QgsPropertyOverrideButton::changed, this, slot );
     }
     else if ( QgsFieldExpressionWidget *w = qobject_cast<QgsFieldExpressionWidget *>( widget ) )
     {
-      connect( w, SIGNAL( fieldChanged( QString ) ), this,  slot );
+      connect( w, static_cast < void ( QgsFieldExpressionWidget::* )( const QString & ) > ( &QgsFieldExpressionWidget::fieldChanged ), this,  slot );
     }
     else if ( QComboBox *w =  qobject_cast<QComboBox *>( widget ) )
     {
-      connect( w, SIGNAL( currentIndexChanged( int ) ), this, slot );
+      connect( w, static_cast < void ( QComboBox::* )( int ) > ( &QComboBox::currentIndexChanged ), this, slot );
     }
     else if ( QSpinBox *w =  qobject_cast<QSpinBox *>( widget ) )
     {
-      connect( w, SIGNAL( valueChanged( int ) ), this, slot );
+      connect( w, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, slot );
     }
     else if ( QDoubleSpinBox *w =  qobject_cast<QDoubleSpinBox *>( widget ) )
     {
-      connect( w, SIGNAL( valueChanged( double ) ), this, slot );
+      connect( w, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, slot );
     }
     else if ( QgsColorButton *w =  qobject_cast<QgsColorButton *>( widget ) )
     {
-      connect( w, SIGNAL( colorChanged( QColor ) ), this, slot );
+      connect( w, static_cast < void ( QgsColorButton::* )( const QColor & ) > ( &QgsColorButton::colorChanged ), this, slot );
     }
     else if ( QCheckBox *w =  qobject_cast<QCheckBox *>( widget ) )
     {
-      connect( w, SIGNAL( toggled( bool ) ), this, slot );
+      connect( w, static_cast < void ( QCheckBox::* )( bool ) > ( &QCheckBox::toggled ), this, slot );
     }
     else if ( QLineEdit *w =  qobject_cast<QLineEdit *>( widget ) )
     {
-      connect( w, SIGNAL( textEdited( QString ) ), this, slot );
-      connect( w, SIGNAL( textChanged( QString ) ), this, slot );
+      connect( w, static_cast < void ( QLineEdit::* )( const QString & ) > ( &QLineEdit::textEdited ), this, slot );
+      connect( w, static_cast < void ( QLineEdit::* )( const QString & ) > ( &QLineEdit::textChanged ), this, slot );
     }
     else if ( QgsEffectStackCompactWidget *w = qobject_cast<QgsEffectStackCompactWidget *>( widget ) )
     {
-      connect( w, SIGNAL( changed() ), this, slot );
+      connect( w, &QgsEffectStackCompactWidget::changed, this, slot );
     }
   }
 }

--- a/src/gui/symbology-ng/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererpropertiesdialog.cpp
@@ -133,11 +133,11 @@ QgsRendererPropertiesDialog::QgsRendererPropertiesDialog( QgsVectorLayer *layer,
           << mFeatureBlendComboBox
           << mEffectWidget;
 
-  connectValueChanged( widgets, &QgsRendererPropertiesDialog::widgetChanged );
+  //connectValueChanged( widgets, &QgsRendererPropertiesDialog::widgetChanged );
   connect( mEffectWidget, &QgsPanelWidget::showPanel, this, &QgsRendererPropertiesDialog::openPanel );
 }
 
-void QgsRendererPropertiesDialog::connectValueChanged( const QList<QWidget *> &widgets, void ( QgsRendererPropertiesDialog::*slot )() )
+void QgsRendererPropertiesDialog::connectValueChangedImpl( const QList<QWidget *> &widgets, void (QgsRendererPropertiesDialog::*slot)() )
 {
   Q_FOREACH ( QWidget *widget, widgets )
   {

--- a/src/gui/symbology-ng/qgsrendererpropertiesdialog.h
+++ b/src/gui/symbology-ng/qgsrendererpropertiesdialog.h
@@ -21,6 +21,7 @@
 
 #include "ui_qgsrendererv2propsdialogbase.h"
 
+#include "qgis.h"
 #include "qgsfeaturerequest.h"
 #include "qgis_gui.h"
 
@@ -49,7 +50,7 @@ class GUI_EXPORT QgsRendererPropertiesDialog : public QDialog, private Ui::QgsRe
      * than shown as a dialog by itself
      * \param parent parent widget
      */
-    QgsRendererPropertiesDialog( QgsVectorLayer *layer, QgsStyle *style, bool embedded = false, QWidget *parent = nullptr );
+    QgsRendererPropertiesDialog( QgsVectorLayer *layer, QgsStyle *style, bool embedded = false, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsRendererPropertiesDialog();
 
     /** Sets the map canvas associated with the dialog. This allows the widget to retrieve the current
@@ -131,7 +132,11 @@ class GUI_EXPORT QgsRendererPropertiesDialog : public QDialog, private Ui::QgsRe
      * \param widgets The list of widgets to check.
      * \param slot The slot to connect to the signals.
      */
-    void connectValueChanged( const QList<QWidget *> &widgets, const char *slot );
+#ifndef SIP_RUN
+    void connectValueChanged( const QList<QWidget *> &widgets, void ( QgsRendererPropertiesDialog::*slot )() );
+#else
+    void connectValueChanged( const QList<QWidget *> &widgets, void ( QgsRendererPropertiesDialog::*slot )() );
+#endif
 
     // Reimplements dialog keyPress event so we can ignore it
     void keyPressEvent( QKeyEvent *event ) override;


### PR DESCRIPTION
also autosipify the file


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
