### PR TITLE
[postgis] Native boolean support

### DIFF
--- a/src/gui/editorwidgets/qgscheckboxconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgscheckboxconfigdlg.cpp
@@ -22,6 +22,15 @@ QgsCheckBoxConfigDlg::QgsCheckBoxConfigDlg( QgsVectorLayer *vl, int fieldIdx, QW
 
   connect( leCheckedState, &QLineEdit::textEdited, this, &QgsEditorConfigWidget::changed );
   connect( leUncheckedState, &QLineEdit::textEdited, this, &QgsEditorConfigWidget::changed );
+
+  if ( vl->fields().at( fieldIdx ).type() == QVariant::Bool )
+  {
+    leCheckedState->setEnabled( false );
+    leUncheckedState->setEnabled( false );
+
+    leCheckedState->setPlaceholderText( QStringLiteral( "TRUE" ) );
+    leUncheckedState->setPlaceholderText( QStringLiteral( "FALSE" ) );
+  }
 }
 
 QVariantMap QgsCheckBoxConfigDlg::config()
@@ -36,6 +45,9 @@ QVariantMap QgsCheckBoxConfigDlg::config()
 
 void QgsCheckBoxConfigDlg::setConfig( const QVariantMap &config )
 {
-  leCheckedState->setText( config.value( QStringLiteral( "CheckedState" ) ).toString() );
-  leUncheckedState->setText( config.value( QStringLiteral( "UncheckedState" ) ).toString() );
+  if ( layer()->fields().at( field() ).type() != QVariant::Bool )
+  {
+    leCheckedState->setText( config.value( QStringLiteral( "CheckedState" ) ).toString() );
+    leUncheckedState->setText( config.value( QStringLiteral( "UncheckedState" ) ).toString() );
+  }
 }

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -27,12 +27,21 @@ QVariant QgsCheckboxWidgetWrapper::value() const
 {
   QVariant v;
 
-  if ( mGroupBox )
-    v = mGroupBox->isChecked() ? config( QStringLiteral( "CheckedState" ) ) : config( QStringLiteral( "UncheckedState" ) );
+  if ( field().type() == QVariant::Bool )
+  {
+    if ( mGroupBox )
+      v = mGroupBox->isChecked();
+    else if ( mCheckBox )
+      v = mCheckBox->isChecked();
+  }
+  else
+  {
+    if ( mGroupBox )
+      v = mGroupBox->isChecked() ? config( QStringLiteral( "CheckedState" ) ) : config( QStringLiteral( "UncheckedState" ) );
 
-  if ( mCheckBox )
-    v = mCheckBox->isChecked() ? config( QStringLiteral( "CheckedState" ) ) : config( QStringLiteral( "UncheckedState" ) );
-
+    else if ( mCheckBox )
+      v = mCheckBox->isChecked() ? config( QStringLiteral( "CheckedState" ) ) : config( QStringLiteral( "UncheckedState" ) );
+  }
 
   return v;
 }
@@ -68,7 +77,16 @@ bool QgsCheckboxWidgetWrapper::valid() const
 
 void QgsCheckboxWidgetWrapper::setValue( const QVariant &value )
 {
-  bool state = ( value == config( QStringLiteral( "CheckedState" ) ) );
+  bool state = false;
+
+  if ( field().type() == QVariant::Bool )
+  {
+    state = value.toBool();
+  }
+  else
+  {
+    state = ( value == config( QStringLiteral( "CheckedState" ) ) );
+  }
   if ( mGroupBox )
   {
     mGroupBox->setChecked( state );

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -132,6 +132,21 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertIsInstance(f.attributes()[datetime_idx], QDateTime)
         self.assertEqual(f.attributes()[datetime_idx], QDateTime(QDate(2004, 3, 4), QTime(13, 41, 52)))
 
+    def testBooleanType(self):
+        vl = QgsVectorLayer('{} table="qgis_test"."boolean_table" sql='.format(self.dbconn), "testbool", "postgres")
+        self.assertTrue(vl.isValid())
+
+        fields = vl.dataProvider().fields()
+        self.assertEqual(fields.at(fields.indexFromName('fld1')).type(), QVariant.Bool)
+
+        values = {feat['id']: feat['fld1'] for feat in vl.getFeatures()}
+        expected = {
+            1: True,
+            2: False,
+            3: NULL
+        }
+        self.assertEqual(values, expected)
+
     def testQueryLayers(self):
         def test_query(dbconn, query, key):
             ql = QgsVectorLayer('%s srid=4326 table="%s" (geom) key=\'%s\' sql=' % (dbconn, query.replace('"', '\\"'), key), "testgeom", "postgres")

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -459,6 +459,20 @@ CREATE TABLE qgis_test.widget_styles(
 INSERT INTO qgis_editor_widget_styles VALUES
 ('qgis_test', 'widget_styles', 'fld1', 'FooEdit', '<config type="Map"><Option name="param1" value="value1" type="QString"/><Option name="param2" value="2" type="QString"/></config>');
 
+--------------------------------------
+-- Table for boolean
+--
+
+CREATE TABLE qgis_test.boolean_table
+(
+  id int PRIMARY KEY,
+  fld1 BOOLEAN
+);
+
+INSERT INTO qgis_test.boolean_table VALUES
+(1, TRUE),
+(2, FALSE),
+(3, NULL);
 
 -----------------------------
 -- Table for constraint tests


### PR DESCRIPTION
Reports boolean columns from postgis as `QVariant::Bool`.

The checkbox widget will properly handle `QVariant::Bool` columns without additional mapping.