### PR TITLE
UTF8 support for QgsRasterDataProvider::cStringList2Q_

### DIFF
--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -233,7 +233,7 @@ QStringList QgsRasterDataProvider::cStringList2Q_( char **stringList )
   // presume null terminated string list
   for ( qgssize i = 0; stringList[i]; ++i )
   {
-    strings.append( stringList[i] );
+    strings.append( QString::fromUtf8(stringList[i]) );
   }
 
   return strings;

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -233,7 +233,7 @@ QStringList QgsRasterDataProvider::cStringList2Q_( char **stringList )
   // presume null terminated string list
   for ( qgssize i = 0; stringList[i]; ++i )
   {
-    strings.append( QString::fromUtf8(stringList[i]) );
+    strings.append( QString::fromUtf8( stringList[i] ) );
   }
 
   return strings;


### PR DESCRIPTION
## Description

UTF8 support for QgsRasterDataProvider::cStringList2Q_
* resolves https://hub.qgis.org/issues/15978

