### PR TITLE
Rename QgsMapLayer::metadata() -> htmlMetadata()

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1391,6 +1391,7 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 - loadNamedStyleFromDb() was renamed to loadNamedStyleFromDatabase()
 - readLayerXml() and writeLayerXml() expect QgsPathResolver reference as the last argument
 - the invalidTransformInput() slot was removed - calling this slot had no effect
+- metadata() was renamed to htmlMetadata()
 
 QgsMapOverviewCanvas        {#qgis_api_break_3_0_QgsMapOverviewCanvas}
 --------------------

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -807,10 +807,10 @@ Return pointer to layer's undo stack
  \see setAutoRefreshInterval()
 %End
 
-    virtual QString metadata() const;
+    virtual QString htmlMetadata() const;
 %Docstring
- Obtain Metadata for this layer
-
+ Obtain a formatted HTML string containing assorted metadata for this layer.
+.. versionadded:: 3.0
  :rtype: str
 %End
 

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1643,7 +1643,7 @@ Returns the current transparency for the vector layer
  :rtype: int
 %End
 
-    QString metadata() const;
+    QString htmlMetadata() const;
 %Docstring
  :rtype: str
 %End

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -128,8 +128,7 @@ class QgsRasterLayer : QgsMapLayer
 
     virtual bool isSpatial() const;
 
-    /** \brief Obtain GDAL Metadata for this layer */
-    QString metadata() const;
+    QString htmlMetadata() const;
 
     /** \brief Get an 100x100 pixmap of the color palette. If the layer has no palette a white pixmap will be returned */
     QPixmap paletteAsPixmap( int bandNumber = 1 );

--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -144,7 +144,7 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
       if ( layer->isValid() )
       {
         layerCrs = layer->crs();
-        layerMetadata = layer->metadata();
+        layerMetadata = layer->htmlMetadata();
       }
       delete layer;
     }
@@ -158,7 +158,7 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
       if ( layer->isValid() )
       {
         layerCrs = layer->crs();
-        layerMetadata = layer->metadata();
+        layerMetadata = layer->htmlMetadata();
       }
       delete layer;
     }

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -785,7 +785,7 @@ void QgsRasterLayerProperties::sync()
   //populate the metadata tab's text browser widget with gdal metadata info
   QString myStyle = QgsApplication::reportStyleSheet();
   txtbMetadata->document()->setDefaultStyleSheet( myStyle );
-  txtbMetadata->setHtml( mRasterLayer->metadata() );
+  txtbMetadata->setHtml( mRasterLayer->htmlMetadata() );
 
   // WMS Name as layer short name
   mLayerShortNameLineEdit->setText( mRasterLayer->shortName() );
@@ -1133,7 +1133,7 @@ void QgsRasterLayerProperties::on_buttonBuildPyramids_clicked()
 
   //populate the metadata tab's text browser widget with gdal metadata info
   QString myStyle = QgsApplication::reportStyleSheet();
-  txtbMetadata->setHtml( mRasterLayer->metadata() );
+  txtbMetadata->setHtml( mRasterLayer->htmlMetadata() );
   txtbMetadata->document()->setDefaultStyleSheet( myStyle );
 }
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -703,7 +703,7 @@ void QgsVectorLayerProperties::on_pbnIndex_clicked()
 
 QString QgsVectorLayerProperties::metadata()
 {
-  return mLayer->metadata();
+  return mLayer->htmlMetadata();
 }
 
 void QgsVectorLayerProperties::on_mLayerOrigNameLineEdit_textEdited( const QString &text )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1621,7 +1621,7 @@ void QgsMapLayer::triggerRepaint( bool deferredUpdate )
   emit repaintRequested( deferredUpdate );
 }
 
-QString QgsMapLayer::metadata() const
+QString QgsMapLayer::htmlMetadata() const
 {
   return QString();
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -720,8 +720,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void setAutoRefreshEnabled( bool enabled );
 
-    //! \brief Obtain Metadata for this layer
-    virtual QString metadata() const;
+    /**
+     * Obtain a formatted HTML string containing assorted metadata for this layer.
+     * \since QGIS 3.0
+     */
+    virtual QString htmlMetadata() const;
 
     //! Time stamp of data source in the moment when data/metadata were loaded by provider
     virtual QDateTime timestamp() const { return QDateTime() ; }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3985,7 +3985,7 @@ void QgsVectorLayer::setDiagramLayerSettings( const QgsDiagramLayerSettings &s )
   *mDiagramLayerSettings = s;
 }
 
-QString QgsVectorLayer::metadata() const
+QString QgsVectorLayer::htmlMetadata() const
 {
   QString myMetadata = QStringLiteral( "<html><body>" );
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1526,7 +1526,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Returns the current transparency for the vector layer
     int layerTransparency() const;
 
-    QString metadata() const override;
+    QString htmlMetadata() const override;
 
     //! \note not available in Python bindings
     inline QgsGeometryCache *cache() SIP_SKIP { return mCache; }

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -287,7 +287,7 @@ QgsLegendColorList QgsRasterLayer::legendSymbologyItems() const
   return symbolList;
 }
 
-QString QgsRasterLayer::metadata() const
+QString QgsRasterLayer::htmlMetadata() const
 {
   QgsRasterDataProvider *provider = const_cast< QgsRasterDataProvider * >( mDataProvider );
   QString myMetadata;

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -273,8 +273,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
     virtual bool isSpatial() const override { return true; }
 
-    //! \brief Obtain GDAL Metadata for this layer
-    QString metadata() const override;
+    QString htmlMetadata() const override;
 
     //! \brief Get an 100x100 pixmap of the color palette. If the layer has no palette a white pixmap will be returned
     QPixmap paletteAsPixmap( int bandNumber = 1 );


### PR DESCRIPTION
Frees up metadata() for use as a structured metadata getter