### PR TITLE
[Processing] Zonal Statistics - Mode computation with masked arrays and Scipy version

### DIFF
--- a/python/plugins/processing/algs/qgis/ZonalStatistics.py
+++ b/python/plugins/processing/algs/qgis/ZonalStatistics.py
@@ -263,7 +263,8 @@ class ZonalStatistics(GeoAlgorithm):
             v = float(numpy.ma.median(masked))
             attrs.insert(idxMedian, None if numpy.isnan(v) else v)
             if hasSciPy:
-                attrs.insert(idxMode, float(mode(masked, axis=None)[0][0]))
+                v = float(mode(masked, axis=None)[0])
+                attrs.insert(idxMode, v if numpy.isscalar(v) else v[0])
 
             outFeat.setAttributes(attrs)
             writer.addFeature(outFeat)


### PR DESCRIPTION
## Description
Hi team,

I found a bug related to mode computation with masked arrays in ZonalStatistics. Depending on which version of Scipy you are using the function ```mstats.mode``` returns a diferent object (and ZonalStatistics can crash). Examples of mstats.mode with different versions of Scipy:

- Last versions of Scipy (tested with 0.18):
```python
import numpy as np
from scipy.stats import mstats

a = np.array([[6, 8, 3, 0],
              [3, 2, 1, 7],
              [8, 1, 8, 4],
              [5, 3, 0, 5],
              [4, 7, 5, 9]])

mstats.mode(a,axis=None)

# Outcome is an array:
>>> ModeResult(mode=array([ 3.]), count=array([ 3.]))

```

- Older versions of Scipy (tested with 0.11):
```python
import numpy as np
from scipy.stats import mstats

a = np.array([[6, 8, 3, 0],
              [3, 2, 1, 7],
              [8, 1, 8, 4],
              [5, 3, 0, 5],
              [4, 7, 5, 9]])

mstats.mode(a,axis=None)

# Outcome is a scalar:
>>> (masked_array(data = 3.0,
             mask = False,
       fill_value = 1e+20)
, masked_array(data = 3,
             mask = False,
       fill_value = 999999)
)

```

On Unix-like OS the tool ZonalStatistics works fine, but for Windows users this issue is a big problem, because QGIS is bundled with an old version of Scipy.

With this PR I solved this bug using a retrocompatibility point of view.

Thanks for all!

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
