### PR TITLE
Add better crash dialog

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -557,6 +557,7 @@
         <file>themes/default/mActionNewMap.svg</file>
         <file>themes/default/mActionMapSettings.svg</file>
         <file>themes/default/mActionLockExtent.svg</file>
+        <file>icons/qgis_icon.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -178,6 +178,7 @@ SET(QGIS_APP_SRCS
 
   qgssettingstree.cpp
   qgsvariantdelegate.cpp
+  qgscrashdialog.cpp
 )
 
 SET (QGIS_APP_MOC_HDRS
@@ -348,6 +349,7 @@ SET (QGIS_APP_MOC_HDRS
 
   qgssettingstree.h
   qgsvariantdelegate.h
+  qgscrashdialog.h
   )
 
 SET (WITH_QWTPOLAR FALSE CACHE BOOL "Determines whether QwtPolar should be built")

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4725,8 +4725,6 @@ void QgisApp::fileExit()
 
 void QgisApp::fileNew()
 {
-  QgsRuntimeProfiler *profile;
-  profile->clear();
   fileNew( true ); // prompts whether to save project
 } // fileNew()
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4725,8 +4725,8 @@ void QgisApp::fileExit()
 
 void QgisApp::fileNew()
 {
-    QgsRuntimeProfiler* profile;
-    profile->clear();
+  QgsRuntimeProfiler *profile;
+  profile->clear();
   fileNew( true ); // prompts whether to save project
 } // fileNew()
 
@@ -12529,9 +12529,15 @@ LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
   }
 
   QgsCrashDialog dlg;
-  dlg.setWindowTitle("Oh. Snap!");
-  dlg.exec();
-  //QMessageBox::critical( 0, QObject::tr( "Crash dumped" ), msg );
+  if ( dlg.exec() )
+  {
+    QStringList arguments;
+    arguments = QCoreApplication::arguments();
+    QString path = arguments.at( 0 );
+    arguments.removeFirst();
+    arguments << QgsProject::instance()->fileName();
+    QProcess::startDetached( path, arguments, QDir::toNativeSeparators( QCoreApplication::applicationDirPath() ) );
+  }
 
   return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12494,39 +12494,41 @@ void QgisApp::transactionGroupCommitError( const QString &error )
 #ifdef Q_OS_WIN
 LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
 {
-  QString dumpName = QDir::toNativeSeparators(
-                       QString( "%1\\qgis-%2-%3-%4-%5.dmp" )
-                       .arg( QDir::tempPath() )
-                       .arg( QDateTime::currentDateTime().toString( "yyyyMMdd-hhmmss" ) )
-                       .arg( GetCurrentProcessId() )
-                       .arg( GetCurrentThreadId() )
-                       .arg( Qgis::QGIS_DEV_VERSION )
-                     );
+  // Crash dump creation will be move to a new class in the near future.
 
-  QString msg;
-  HANDLE hDumpFile = CreateFile( dumpName.toLocal8Bit(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0 );
-  if ( hDumpFile != INVALID_HANDLE_VALUE )
-  {
-    MINIDUMP_EXCEPTION_INFORMATION ExpParam;
-    ExpParam.ThreadId = GetCurrentThreadId();
-    ExpParam.ExceptionPointers = ExceptionInfo;
-    ExpParam.ClientPointers = TRUE;
+//  QString dumpName = QDir::toNativeSeparators(
+//                       QString( "%1\\qgis-%2-%3-%4-%5.dmp" )
+//                       .arg( QDir::tempPath() )
+//                       .arg( QDateTime::currentDateTime().toString( "yyyyMMdd-hhmmss" ) )
+//                       .arg( GetCurrentProcessId() )
+//                       .arg( GetCurrentThreadId() )
+//                       .arg( Qgis::QGIS_DEV_VERSION )
+//                     );
 
-    if ( MiniDumpWriteDump( GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpWithDataSegs, ExceptionInfo ? &ExpParam : nullptr, nullptr, nullptr ) )
-    {
-      msg = QObject::tr( "minidump written to %1" ).arg( dumpName );
-    }
-    else
-    {
-      msg = QObject::tr( "writing of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
-    }
+//  QString msg;
+//  HANDLE hDumpFile = CreateFile( dumpName.toLocal8Bit(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0 );
+//  if ( hDumpFile != INVALID_HANDLE_VALUE )
+//  {
+//    MINIDUMP_EXCEPTION_INFORMATION ExpParam;
+//    ExpParam.ThreadId = GetCurrentThreadId();
+//    ExpParam.ExceptionPointers = ExceptionInfo;
+//    ExpParam.ClientPointers = TRUE;
 
-    CloseHandle( hDumpFile );
-  }
-  else
-  {
-    msg = QObject::tr( "creation of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
-  }
+//    if ( MiniDumpWriteDump( GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpWithDataSegs, ExceptionInfo ? &ExpParam : nullptr, nullptr, nullptr ) )
+//    {
+//      msg = QObject::tr( "minidump written to %1" ).arg( dumpName );
+//    }
+//    else
+//    {
+//      msg = QObject::tr( "writing of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
+//    }
+
+//    CloseHandle( hDumpFile );
+//  }
+//  else
+//  {
+//    msg = QObject::tr( "creation of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
+//  }
 
   QgsCrashDialog dlg( QApplication::activeWindow() );
   if ( dlg.exec() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4725,6 +4725,8 @@ void QgisApp::fileExit()
 
 void QgisApp::fileNew()
 {
+  QgsRuntimeProfiler *profile;
+  profile->clear();
   fileNew( true ); // prompts whether to save project
 } // fileNew()
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12528,7 +12528,7 @@ LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
     msg = QObject::tr( "creation of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
   }
 
-  QgsCrashDialog dlg;
+  QgsCrashDialog dlg( QApplication::activeWindow() );
   if ( dlg.exec() )
   {
     QStringList arguments;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -110,6 +110,7 @@
 // QGIS Specific Includes
 //
 
+#include "qgscrashdialog.h"
 #include "qgisapp.h"
 #include "qgisappinterface.h"
 #include "qgisappstylesheet.h"
@@ -4724,6 +4725,8 @@ void QgisApp::fileExit()
 
 void QgisApp::fileNew()
 {
+    QgsRuntimeProfiler* profile;
+    profile->clear();
   fileNew( true ); // prompts whether to save project
 } // fileNew()
 
@@ -12525,7 +12528,10 @@ LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
     msg = QObject::tr( "creation of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
   }
 
-  QMessageBox::critical( 0, QObject::tr( "Crash dumped" ), msg );
+  QgsCrashDialog dlg;
+  dlg.setWindowTitle("Oh. Snap!");
+  dlg.exec();
+  //QMessageBox::critical( 0, QObject::tr( "Crash dumped" ), msg );
 
   return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12494,39 +12494,41 @@ LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
 {
   // Crash dump creation will be move to a new class in the near future.
 
-//  QString dumpName = QDir::toNativeSeparators(
-//                       QString( "%1\\qgis-%2-%3-%4-%5.dmp" )
-//                       .arg( QDir::tempPath() )
-//                       .arg( QDateTime::currentDateTime().toString( "yyyyMMdd-hhmmss" ) )
-//                       .arg( GetCurrentProcessId() )
-//                       .arg( GetCurrentThreadId() )
-//                       .arg( Qgis::QGIS_DEV_VERSION )
-//                     );
+#if 0
+  QString dumpName = QDir::toNativeSeparators(
+                       QString( "%1\\qgis-%2-%3-%4-%5.dmp" )
+                       .arg( QDir::tempPath() )
+                       .arg( QDateTime::currentDateTime().toString( "yyyyMMdd-hhmmss" ) )
+                       .arg( GetCurrentProcessId() )
+                       .arg( GetCurrentThreadId() )
+                       .arg( Qgis::QGIS_DEV_VERSION )
+                     );
 
-//  QString msg;
-//  HANDLE hDumpFile = CreateFile( dumpName.toLocal8Bit(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0 );
-//  if ( hDumpFile != INVALID_HANDLE_VALUE )
-//  {
-//    MINIDUMP_EXCEPTION_INFORMATION ExpParam;
-//    ExpParam.ThreadId = GetCurrentThreadId();
-//    ExpParam.ExceptionPointers = ExceptionInfo;
-//    ExpParam.ClientPointers = TRUE;
+  QString msg;
+  HANDLE hDumpFile = CreateFile( dumpName.toLocal8Bit(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE | FILE_SHARE_READ, 0, CREATE_ALWAYS, 0, 0 );
+  if ( hDumpFile != INVALID_HANDLE_VALUE )
+  {
+    MINIDUMP_EXCEPTION_INFORMATION ExpParam;
+    ExpParam.ThreadId = GetCurrentThreadId();
+    ExpParam.ExceptionPointers = ExceptionInfo;
+    ExpParam.ClientPointers = TRUE;
 
-//    if ( MiniDumpWriteDump( GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpWithDataSegs, ExceptionInfo ? &ExpParam : nullptr, nullptr, nullptr ) )
-//    {
-//      msg = QObject::tr( "minidump written to %1" ).arg( dumpName );
-//    }
-//    else
-//    {
-//      msg = QObject::tr( "writing of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
-//    }
+    if ( MiniDumpWriteDump( GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpWithDataSegs, ExceptionInfo ? &ExpParam : nullptr, nullptr, nullptr ) )
+    {
+      msg = QObject::tr( "minidump written to %1" ).arg( dumpName );
+    }
+    else
+    {
+      msg = QObject::tr( "writing of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
+    }
 
-//    CloseHandle( hDumpFile );
-//  }
-//  else
-//  {
-//    msg = QObject::tr( "creation of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
-//  }
+    CloseHandle( hDumpFile );
+  }
+  else
+  {
+    msg = QObject::tr( "creation of minidump to %1 failed (%2)" ).arg( dumpName ).arg( GetLastError(), 0, 16 );
+  }
+#endif
 
   QgsCrashDialog dlg( QApplication::activeWindow() );
   if ( dlg.exec() )

--- a/src/app/qgscrashdialog.cpp
+++ b/src/app/qgscrashdialog.cpp
@@ -17,8 +17,12 @@
 
 #include "qgscrashdialog.h"
 
-QgsCrashDialog::QgsCrashDialog()
+QgsCrashDialog::QgsCrashDialog( QWidget *parent )
+  : QDialog( parent )
 {
   setupUi( this );
   setWindowTitle( tr( "Oh. Snap!" ) );
+  mHelpLabel->setText( tr( "Keen to help us fix? <br> <a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\"> Follow the steps to help devs.<a>" ) );
+  mHelpLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
+  mHelpLabel->setOpenExternalLinks( true );
 }

--- a/src/app/qgscrashdialog.cpp
+++ b/src/app/qgscrashdialog.cpp
@@ -25,4 +25,7 @@ QgsCrashDialog::QgsCrashDialog( QWidget *parent )
   mHelpLabel->setText( tr( "Keen to help us fix? <br> <a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\"> Follow the steps to help devs.<a>" ) );
   mHelpLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
   mHelpLabel->setOpenExternalLinks( true );
+
+  mCrashHeaderMessage->setText( tr( "Ouch!" ) );
+  mCrashMessage->setText( tr("Sorry it looks like QGIS crashed. \n Something unexpected happened that we didn't handle correctly."));
 }

--- a/src/app/qgscrashdialog.cpp
+++ b/src/app/qgscrashdialog.cpp
@@ -1,6 +1,24 @@
+/***************************************************************************
+                qgscrashdialog.cpp - QgsCrashDialog
+
+ ---------------------
+ begin                : 11.4.2017
+ copyright            : (C) 2017 by Nathan Woodrow
+ email                : woodrow.nathan@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
 #include "qgscrashdialog.h"
 
 QgsCrashDialog::QgsCrashDialog()
 {
   setupUi( this );
+  setWindowTitle( tr( "Oh. Snap!" ) );
 }

--- a/src/app/qgscrashdialog.cpp
+++ b/src/app/qgscrashdialog.cpp
@@ -22,10 +22,11 @@ QgsCrashDialog::QgsCrashDialog( QWidget *parent )
 {
   setupUi( this );
   setWindowTitle( tr( "Oh. Snap!" ) );
-  mHelpLabel->setText( tr( "Keen to help us fix? <br> <a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\"> Follow the steps to help devs.<a>" ) );
-  mHelpLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
-  mHelpLabel->setOpenExternalLinks( true );
 
   mCrashHeaderMessage->setText( tr( "Ouch!" ) );
-  mCrashMessage->setText( tr("Sorry it looks like QGIS crashed. \n Something unexpected happened that we didn't handle correctly."));
+  mCrashMessage->setText( tr("Sorry it looks like QGIS crashed. \nSomething unexpected happened that we didn't handle correctly."));
+
+  mHelpLabel->setText( tr( "Keen to help us fix it? <br> <a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\"> Follow the steps to help devs.<a>" ) );
+  mHelpLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
+  mHelpLabel->setOpenExternalLinks( true );
 }

--- a/src/app/qgscrashdialog.cpp
+++ b/src/app/qgscrashdialog.cpp
@@ -1,0 +1,6 @@
+#include "qgscrashdialog.h"
+
+QgsCrashDialog::QgsCrashDialog()
+{
+  setupUi( this );
+}

--- a/src/app/qgscrashdialog.h
+++ b/src/app/qgscrashdialog.h
@@ -21,11 +21,18 @@
 #include "ui_qgscrashdialog.h"
 #include "qgis_app.h"
 
+/**
+ * A dialog to show a nicer crash dialog to the user.
+ */
 class APP_EXPORT QgsCrashDialog : public QDialog, private Ui::QgsCrashDialog
 {
     Q_OBJECT
   public:
-    QgsCrashDialog( );
+
+    /**
+     * A dialog to show a nicer crash dialog to the user.
+     */
+    QgsCrashDialog( QWidget *parent = nullptr );
 };
 
 #endif // QGSCRASHDIALOG_H

--- a/src/app/qgscrashdialog.h
+++ b/src/app/qgscrashdialog.h
@@ -1,0 +1,15 @@
+#ifndef QGSCRASHDIALOG_H
+#define QGSCRASHDIALOG_H
+
+#include <QDialog>
+#include "ui_qgscrashdialog.h"
+#include "qgis_app.h"
+
+class APP_EXPORT QgsCrashDialog : public QDialog, private Ui::QgsCrashDialog
+{
+    Q_OBJECT
+  public:
+    QgsCrashDialog();
+};
+
+#endif // QGSCRASHDIALOG_H

--- a/src/app/qgscrashdialog.h
+++ b/src/app/qgscrashdialog.h
@@ -1,3 +1,19 @@
+/***************************************************************************
+                qgscrashdialog.h - QgsCrashDialog
+
+ ---------------------
+ begin                : 11.4.2017
+ copyright            : (C) 2017 by Nathan Woodrow
+ email                : woodrow.nathan@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef QGSCRASHDIALOG_H
 #define QGSCRASHDIALOG_H
 
@@ -9,7 +25,7 @@ class APP_EXPORT QgsCrashDialog : public QDialog, private Ui::QgsCrashDialog
 {
     Q_OBJECT
   public:
-    QgsCrashDialog();
+    QgsCrashDialog( );
 };
 
 #endif // QGSCRASHDIALOG_H

--- a/src/ui/qgscrashdialog.ui
+++ b/src/ui/qgscrashdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>571</width>
-    <height>367</height>
+    <width>630</width>
+    <height>362</height>
    </rect>
   </property>
   <property name="palette">
@@ -471,10 +471,15 @@
       <widget class="QLabel" name="label">
        <property name="font">
         <font>
-         <pointsize>22</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
+         <family>MS Shell Dlg 2</family>
+         <pointsize>30</pointsize>
+         <weight>9</weight>
+         <italic>false</italic>
+         <bold>false</bold>
         </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">font: 75 30pt &quot;MS Shell Dlg 2&quot;;</string>
        </property>
        <property name="text">
         <string>Ouch!</string>
@@ -511,15 +516,34 @@
        </property>
        <item>
         <widget class="QPushButton" name="pushButton">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="text">
           <string>Reload QGIS</string>
          </property>
         </widget>
        </item>
        <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <widget class="QPushButton" name="pushButton_2">
          <property name="text">
-          <string>Close</string>
+          <string>Quit</string>
          </property>
         </widget>
        </item>
@@ -539,9 +563,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="mHelpLabel">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;devs&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Keen to help us fix? Follow the steps to help devs.&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string/>
        </property>
       </widget>
      </item>

--- a/src/ui/qgscrashdialog.ui
+++ b/src/ui/qgscrashdialog.ui
@@ -489,7 +489,7 @@
      <item>
       <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Looks lke QGIS has crashed. Something unexpected happend that we didn't handle correctly</string>
+        <string>Looks lke QGIS has crashed. Something unexpected happened that we didn't handle correctly</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>

--- a/src/ui/qgscrashdialog.ui
+++ b/src/ui/qgscrashdialog.ui
@@ -468,7 +468,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="mCrashHeaderMessage">
        <property name="font">
         <font>
          <family>MS Shell Dlg 2</family>
@@ -482,14 +482,14 @@
         <string notr="true">font: 75 30pt &quot;MS Shell Dlg 2&quot;;</string>
        </property>
        <property name="text">
-        <string>Ouch!</string>
+        <string/>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="mCrashMessage">
        <property name="text">
-        <string>Looks lke QGIS has crashed. Something unexpected happened that we didn't handle correctly</string>
+        <string/>
        </property>
        <property name="wordWrap">
         <bool>true</bool>

--- a/src/ui/qgscrashdialog.ui
+++ b/src/ui/qgscrashdialog.ui
@@ -1,0 +1,556 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsCrashDialog</class>
+ <widget class="QDialog" name="QgsCrashDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>571</width>
+    <height>367</height>
+   </rect>
+  </property>
+  <property name="palette">
+   <palette>
+    <active>
+     <colorrole role="WindowText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Button">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Light">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Midlight">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Dark">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>127</red>
+        <green>127</green>
+        <blue>127</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Mid">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>170</red>
+        <green>170</green>
+        <blue>170</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Text">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="BrightText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ButtonText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Base">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Window">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Shadow">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="AlternateBase">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ToolTipBase">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>220</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ToolTipText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </active>
+    <inactive>
+     <colorrole role="WindowText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Button">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Light">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Midlight">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Dark">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>127</red>
+        <green>127</green>
+        <blue>127</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Mid">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>170</red>
+        <green>170</green>
+        <blue>170</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Text">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="BrightText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ButtonText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Base">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Window">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Shadow">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="AlternateBase">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ToolTipBase">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>220</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ToolTipText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </inactive>
+    <disabled>
+     <colorrole role="WindowText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>127</red>
+        <green>127</green>
+        <blue>127</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Button">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Light">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Midlight">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Dark">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>127</red>
+        <green>127</green>
+        <blue>127</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Mid">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>170</red>
+        <green>170</green>
+        <blue>170</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Text">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>127</red>
+        <green>127</green>
+        <blue>127</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="BrightText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ButtonText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>127</red>
+        <green>127</green>
+        <blue>127</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Base">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Window">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="Shadow">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="AlternateBase">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ToolTipBase">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>255</red>
+        <green>255</green>
+        <blue>220</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="ToolTipText">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </disabled>
+   </palette>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../../images/images.qrc">:/images/icons/qgis_icon.svg</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <pointsize>22</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Ouch!</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Looks lke QGIS has crashed. Something unexpected happend that we didn't handle correctly</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="pushButton">
+         <property name="text">
+          <string>Reload QGIS</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_2">
+         <property name="text">
+          <string>Close</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;devs&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Keen to help us fix? Follow the steps to help devs.&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/ui/qgscrashdialog.ui
+++ b/src/ui/qgscrashdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
-    <height>362</height>
+    <width>603</width>
+    <height>346</height>
    </rect>
   </property>
   <property name="palette">

--- a/src/ui/qgscrashdialog.ui
+++ b/src/ui/qgscrashdialog.ui
@@ -482,17 +482,24 @@
         <string notr="true">font: 75 30pt &quot;MS Shell Dlg 2&quot;;</string>
        </property>
        <property name="text">
-        <string/>
+        <string>Header</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="mCrashMessage">
        <property name="text">
-        <string/>
+        <string>Message</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="mHelpLabel">
+       <property name="text">
+        <string>Help Message</string>
        </property>
       </widget>
      </item>
@@ -548,26 +555,6 @@
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="mHelpLabel">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/src/ui/qgscrashdialog.ui
+++ b/src/ui/qgscrashdialog.ui
@@ -552,5 +552,38 @@
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>pushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>QgsCrashDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>352</x>
+     <y>257</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>468</x>
+     <y>-36</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_2</sender>
+   <signal>clicked()</signal>
+   <receiver>QgsCrashDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>486</x>
+     <y>246</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>457</x>
+     <y>-30</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
## Description

Adds a nicer crash dialog for better UX. Crashing sucks so best to handle it well if we can. Showing a crash dumped dialog before was a bit raw so this is attempt at doing something a bit nicer.

@nirvn can I have a cool "sad" QGIS logo :) 

Things to do:

- [ ] Funny error message
- [ ] Cool crash image
- [x] Wire up buttons
- [x] Write dev guide (maybe we should just have this link to online someplace)


![image](https://cloud.githubusercontent.com/assets/381660/24912699/3b12a26e-1f12-11e7-8472-2fc4c1ce2286.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
