### PR TITLE
[FEATURE][needs-docs] Add to Browser panel XYZ connection to provide default OpenStreetMap tiles

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -921,6 +921,16 @@ int main( int argc, char *argv[] )
     }
   }
 
+  QString osmTitle = QStringLiteral( "OpenStreetMap" );
+  QString osmUrl = QStringLiteral( "http://a.tile.openstreetmap.org/{z}/{x}/{y}.png" );
+  if ( !mySettings.contains( QStringLiteral( "qgis/connections-xyz/%1/url" ).arg( osmTitle ) ) )
+  {
+    QgsDebugMsg( QString( "OpenStreetMap default connection settings added" ) );
+    mySettings.setValue( QStringLiteral( "qgis/connections-xyz/%1/url" ).arg( osmTitle ), osmUrl );
+    mySettings.setValue( QStringLiteral( "qgis/connections-xyz/%1/zmax" ).arg( osmTitle ), 19 );
+    mySettings.setValue( QStringLiteral( "qgis/connections-xyz/%1/zmin" ).arg( osmTitle ), 0 );
+  }
+
   // custom environment variables
   QMap<QString, QString> systemEnvVars = QgsApplication::systemEnvVars();
   bool useCustomVars = mySettings.value( QStringLiteral( "qgis/customEnvVarsUse" ), QVariant( false ) ).toBool();

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -151,6 +151,7 @@ ADD_PYTHON_TEST(PyQgsVersionCompare test_versioncompare.py)
 ADD_PYTHON_TEST(PyQgsDBManagerGpkg test_db_manager_gpkg.py)
 ADD_PYTHON_TEST(PyQgsFileDownloader test_qgsfiledownloader.py)
 ADD_PYTHON_TEST(PyQgsSettings test_qgssettings.py)
+ADD_PYTHON_TEST(PyQgsOpenStreetMapConnection test_openstreetmap_connection.py)
 
 IF (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_openstreetmap_connection.py
+++ b/tests/src/python/test_openstreetmap_connection.py
@@ -28,7 +28,6 @@ from qgis.core import (QgsApplication, QgsSettings, QgsRaster, QgsRasterLayer, Q
 
 QGISAPP = start_app()
 
-
 def createLayerFromSettings(url='http://a.tile.openstreetmap.org/{z}/{x}/{y}.png', type='xyz', zmax=19, zmin=0):
     # urlWithParams = 'type=xyz&url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0'
     # rlayer = QgsRasterLayer(urlWithParams, 'some layer name', 'wms')
@@ -39,7 +38,6 @@ def createLayerFromSettings(url='http://a.tile.openstreetmap.org/{z}/{x}/{y}.png
     uri = 'type=%s&url=%s&zmax=%d&zmin=%d' % (type, url, zmax, zmin)
     rlayer = QgsRasterLayer(uri, 'OpenStreetMap', 'wms')
     return rlayer
-
 
 class PyQgsOpenStreetMapConnection(unittest.TestCase):
     """

--- a/tests/src/python/test_openstreetmap_connection.py
+++ b/tests/src/python/test_openstreetmap_connection.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    test_openstreetmap_connection.py
+    ---------------------
+    Date                 : April 2017
+    Copyright            : (C) 2017, Jorge Gustavo Rocha
+    Email                : jgr at di dot uminho dot pt
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Jorge Gustavo Rocha'
+__date__ = 'January 2017'
+__copyright__ = '(C) 2017, Jorge Gustavo Rocha'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+from qgis.testing import start_app, unittest
+from qgis.core import (QgsApplication, QgsSettings, QgsRaster, QgsRasterLayer, QgsProject)
+
+QGISAPP = start_app()
+
+
+def createLayerFromSettings(url='http://a.tile.openstreetmap.org/{z}/{x}/{y}.png', type='xyz', zmax=19, zmin=0):
+    # urlWithParams = 'type=xyz&url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0'
+    # rlayer = QgsRasterLayer(urlWithParams, 'some layer name', 'wms')
+    # if not rlayer.isValid():
+    #     print( "Layer failed to load!" )
+    # QgsProject.instance().addMapLayer(rlayer)
+
+    uri = 'type=%s&url=%s&zmax=%d&zmin=%d' % (type, url, zmax, zmin)
+    rlayer = QgsRasterLayer(uri, 'OpenStreetMap', 'wms')
+    return rlayer
+
+
+class PyQgsOpenStreetMapConnection(unittest.TestCase):
+    """
+    This class checks if OpenStreetMap connection is properly created
+    """
+
+    def setUp(self):
+        self.osmTitle = "OpenStreetMap"
+
+    def tearDown(self):
+        QgsProject.instance().removeAllMapLayers()
+
+    def test_OpenStreepMapConnectionSettings(self):
+        # settings are not available
+        # self.settings = QgsSettings()
+        # # print( self.settings.childGroups() )
+        # # print( self.settings.allKeys() )
+        # self.osmUrl = self.settings.value('qgis/connections-xyz/%s/url' % self.osmTitle)
+        # self.osmZMax = self.settings.value('qgis/connections-xyz/%s/zmax' % self.osmTitle)
+        # self.osmZMin = self.settings.value('qgis/connections-xyz/%s/zmin' % self.osmTitle)
+        # # print(self.osmUrl, self.osmZMax, self.osmZMin)
+        self.assertTrue(True)
+
+    def test_LayerCreatedFromSettings(self):
+        self.layer = createLayerFromSettings()
+        self.assertTrue(self.layer.isValid())
+        QgsProject.instance().addMapLayer(self.layer)
+        self.assertEqual(len(QgsProject.instance().mapLayersByName(self.osmTitle)), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

This PR adds a default XYZ connection to the Browser panel. No layer is added to the map. 
With this connection available, users can add the OpenStreetMap as a new layer with just one double click on it.

This feature was discusssed on the mailing list. The [thread](https://lists.osgeo.org/pipermail/qgis-developer/2017-March/047716.html) was started by @pcav.

The result is illustrated in the following screen shot:

![openstreetmap xyz connection](https://cloud.githubusercontent.com/assets/163681/24884625/31296aec-1e42-11e7-9d6d-7d226aa5bf32.png)

### UserAgent

The [OpenStreetMap Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) regarding the use of a valid HTTP User-Agent identifying the application is respected. Even if the user changes the UserAgent in settings, the string QGIS/version is always added to the UserAgent defined. For this development version, the default userAgent string is `Mozilla/5.0 QGIS/2.99.0-Master`.

XYZ requests to another server (running MapProxy under Apache) were logged to confirm the valid userAgent:
```
a.geomaster.pt:80 188.250.64.156 - - [09/Apr/2017:22:44:25 +0000] "GET /mapproxy/wmts/osmpb/osm_grid/13/3897/3091.png HTTP/1.1" 200 10269 "-" "Mozilla/5.0 QGIS/2.99.0-Master"
a.geomaster.pt:80 188.250.64.156 - - [09/Apr/2017:22:44:25 +0000] "GET /mapproxy/wmts/osmpb/osm_grid/13/3899/3091.png HTTP/1.1" 200 8980 "-" "Mozilla/5.0 QGIS/2.99.0-Master"
```
### Unit test

I was not able to have QgsSettings filled with the settings on the unit test. I've wrote this initial unit test, but it should be improved once the QgsSettings usage is more stable.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
