### PR TITLE
added minimal gdal_runtime logic to master.

### DIFF
--- a/python/core/qgis.sip
+++ b/python/core/qgis.sip
@@ -30,25 +30,46 @@ class Qgis
   public:
     // Version constants
     //
-    // Version string
+    //! Version string
     static const QString QGIS_VERSION;
-    // Version number used for comparing versions using the "Check QGIS Version" function
+    //! Version number used for comparing versions using the "Check QGIS Version" function
     static const int QGIS_VERSION_INT;
-    // Release name
+    //! Release name
     static const QString QGIS_RELEASE_NAME;
-    // The development version
-    static const char* QGIS_DEV_VERSION;
-    // Gdal Version string at build/compile time
+    //! The development version
+    static const char *QGIS_DEV_VERSION;
+    //! Gdal Version string at build/compile time
     static QString GDAL_BUILD_VERSION;
+    //! Gdal major-version as integer (taken from Version string) at build/compile time
     static const int GDAL_BUILD_VERSION_MAJOR;
+    //! Gdal minor-version as integer (taken from Version string) at build/compile time
     static const int GDAL_BUILD_VERSION_MINOR;
+    //! Gdal revision-version as integer (taken from Version string) at build/compile time
     static const int GDAL_BUILD_VERSION_REV;
-    // Gdal Version string runtime
+    //! Gdal Version string runtime
     static QString GDAL_RUNTIME_VERSION;
+    //! Gdal major-version as integer (taken from Version string) while application is running
     static int GDAL_RUNTIME_VERSION_MAJOR;
+    //! Gdal minor-version as integer (taken from Version string) while application is running
     static int GDAL_RUNTIME_VERSION_MINOR;
+    //! Gdal revision-version as integer (taken from Version string) while application is running
     static int GDAL_RUNTIME_VERSION_REV;
-    static int GDAL_OGR_RUNTIME_SUPPORTED;
+    //! true or false the if Gdal runtime version is supported
+    static bool GDAL_OGR_RUNTIME_SUPPORTED;
+    /**
+     * Check if the gdal/ogr version running is supported
+     * @note
+     * For the moment, will be used to prevent QGIS3 from starting if running against a gdal 1 version
+     * In the future it may be useful when  gdal evolves in a way, that at the moment cannot be for seen.
+     * and it may be considered desirable that gdal 2 sub-versions no longer be supported
+     * This checking is done once in
+     * - QGis::ogrRuntimeSupport()
+     * and matches the conditions set in cmake (GDAL_VERSION_MAJOR)
+     * GDAL_RUNTIME_VERSION_MINOR and GDAL_RUNTIME_VERSION_REV
+      *  are available to check against the corresponding GDAL_BUILD_VERSION_ values.
+     * @return if the running version of gdal/ogr is supported
+     */
+    static bool ogrRuntimeSupport();
 
     // Enumerations
     //

--- a/python/core/qgis.sip
+++ b/python/core/qgis.sip
@@ -38,6 +38,17 @@ class Qgis
     static const QString QGIS_RELEASE_NAME;
     // The development version
     static const char* QGIS_DEV_VERSION;
+    // Gdal Version string at build/compile time
+    static QString GDAL_BUILD_VERSION;
+    static const int GDAL_BUILD_VERSION_MAJOR;
+    static const int GDAL_BUILD_VERSION_MINOR;
+    static const int GDAL_BUILD_VERSION_REV;
+    // Gdal Version string runtime
+    static QString GDAL_RUNTIME_VERSION;
+    static int GDAL_RUNTIME_VERSION_MAJOR;
+    static int GDAL_RUNTIME_VERSION_MINOR;
+    static int GDAL_RUNTIME_VERSION_REV;
+    static int GDAL_OGR_RUNTIME_SUPPORTED;
 
     // Enumerations
     //

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -502,6 +502,12 @@ int main( int argc, char *argv[] )
   // initialize random number seed
   qsrand( time( nullptr ) );
 
+  if ( !Qgis::QGISRuntimeChecks() )
+  {
+    QMessageBox::critical( 0, QObject::tr( "QGIS runtime checks failed" ), QObject::tr( "Libraries that QGIS requires are currently missing or have not been loaded correctly" ) );
+    exit( 1 ); //exit due to missing components
+  }
+
   /////////////////////////////////////////////////////////////////
   // Command line options 'behavior' flag setup
   ////////////////////////////////////////////////////////////////

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -630,6 +630,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   }
 
   sInstance = this;
+  Qgis::ogrRuntimeSupport();
   QgsRuntimeProfiler *profiler = QgsApplication::profiler();
 
   namSetup();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -630,7 +630,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   }
 
   sInstance = this;
-  Qgis::ogrRuntimeSupport();
   QgsRuntimeProfiler *profiler = QgsApplication::profiler();
 
   namSetup();

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -88,7 +88,7 @@ bool Qgis::QGISRuntimeChecks()
 {
   if ( !Qgis::ogrRuntimeSupport() )
   {
-    std::cerr << QObject::tr( "QGIS does not support theis version of GDAL.\nGDAL[%1]\nPlease install a GDAL 2 version.\n" ).arg( Qgis::GDAL_RUNTIME_VERSION ).toUtf8().constData();
+    std::cerr << QObject::tr( "QGIS does not support this version of GDAL.\nGDAL[%1]\nPlease install a GDAL 2 version.\n" ).arg( Qgis::GDAL_RUNTIME_VERSION ).toUtf8().constData();
     return false;
   }
   return true;

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -67,15 +67,15 @@ bool Qgis::ogrRuntimeSupport()
     QString gdalVersionInfo = Qgis::GDAL_RUNTIME_VERSION;
     gdalVersionInfo.remove( QRegExp( QString::fromUtf8( "[-`~!@#$%^&*()_—+=|:;<>«»,?/{a-zA-Z}\'\"\\[\\]\\\\]" ) ) );
     QStringList saSplit = gdalVersionInfo.split( '.' );
-    if ( if ( !saSplit.isEmpty() ) )
-      {
-        // setting gdal-runtime version
-        Qgis::GDAL_RUNTIME_VERSION_MAJOR = saSplit[0].toInt();
-        if ( sa_split.size() > 1 )
-          Qgis::GDAL_RUNTIME_VERSION_MINOR = saSplit[1].toInt();
-        if ( sa_split.size() > 2 )
-          Qgis::GDAL_RUNTIME_VERSION_REV = saSplit[2].toInt();
-      }
+    if ( ( !saSplit.isEmpty() ) )
+    {
+      // setting gdal-runtime version
+      Qgis::GDAL_RUNTIME_VERSION_MAJOR = saSplit[0].toInt();
+      if ( saSplit.size() > 1 )
+        Qgis::GDAL_RUNTIME_VERSION_MINOR = saSplit[1].toInt();
+      if ( saSplit.size() > 2 )
+        Qgis::GDAL_RUNTIME_VERSION_REV = saSplit[2].toInt();
+    }
     if ( Qgis::GDAL_RUNTIME_VERSION_MAJOR >= Qgis::GDAL_BUILD_VERSION_MAJOR )
     {
       // Deprecated gdal major-versions that are less than the major-version
@@ -88,11 +88,7 @@ bool Qgis::QGISRuntimeChecks()
 {
   if ( !Qgis::ogrRuntimeSupport() )
   {
-    std::cerr << QObject::tr(
-                QString( "QGIS does not support theis version of GDAL.\n"
-                         "GDAL[%1]\n"
-                         "Please install a GDAL 2 version.\n" ).arg( Qgis::GDAL_RUNTIME_VERSION )
-              ).toUtf8().constData();
+    std::cerr << QObject::tr( QString( "QGIS does not support theis version of GDAL.\nGDAL[%1]\nPlease install a GDAL 2 version.\n" ).arg( Qgis::GDAL_RUNTIME_VERSION ) ).toUtf8().constData();
     return false;
   }
   return true;

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -88,7 +88,7 @@ bool Qgis::QGISRuntimeChecks()
 {
   if ( !Qgis::ogrRuntimeSupport() )
   {
-    std::cerr << QObject::tr( QString( "QGIS does not support theis version of GDAL.\nGDAL[%1]\nPlease install a GDAL 2 version.\n" ).arg( Qgis::GDAL_RUNTIME_VERSION ) ).toUtf8().constData();
+    std::cerr << QObject::tr( "QGIS does not support theis version of GDAL.\nGDAL[%1]\nPlease install a GDAL 2 version.\n" ).arg( Qgis::GDAL_RUNTIME_VERSION ).toUtf8().constData();
     return false;
   }
   return true;

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -46,6 +46,48 @@ const int Qgis::QGIS_VERSION_INT = VERSION_INT;
 
 // Release name
 const QString Qgis::QGIS_RELEASE_NAME( QStringLiteral( RELEASE_NAME ) );
+// Gdal Version string at build/compile time
+QString Qgis::GDAL_BUILD_VERSION( QString::fromUtf8( GDAL_RELEASE_NAME ) );
+const int Qgis::GDAL_BUILD_VERSION_MAJOR = GDAL_VERSION_MAJOR;
+const int Qgis::GDAL_BUILD_VERSION_MINOR = GDAL_VERSION_MINOR;
+const int Qgis::GDAL_BUILD_VERSION_REV = GDAL_VERSION_REV;
+QString Qgis::GDAL_RUNTIME_VERSION = QString::null;
+int Qgis::GDAL_RUNTIME_VERSION_MAJOR = -1;
+int Qgis::GDAL_RUNTIME_VERSION_MINOR = -1;
+int Qgis::GDAL_RUNTIME_VERSION_REV = -1;
+int Qgis::GDAL_OGR_RUNTIME_SUPPORTED = 0;
+bool Qgis::ogrRuntimeSupport()
+{
+  // Called in QgisApp and tested in QgsOgrProvider constructor
+  if ( Qgis::GDAL_RUNTIME_VERSION.isNull() )
+  {
+    // do this only once
+    Qgis::GDAL_RUNTIME_VERSION = QString( "%1" ).arg( GDALVersionInfo( "RELEASE_NAME" ) );
+    // Remove non-numeric characters (with the excetion of '.') : '2.2.0dev' to '2.2.0'
+    QString s_GdalVersionInfo = Qgis::GDAL_RUNTIME_VERSION;
+    s_GdalVersionInfo.remove( QRegExp( QString::fromUtf8( "[-`~!@#$%^&*()_—+=|:;<>«»,?/{a-zA-Z}\'\"\\[\\]\\\\]" ) ) );
+    QStringList sa_split = s_GdalVersionInfo.split( '.' );
+    if ( sa_split.size() > 0 )
+    {
+      // setting gdal-runtime version
+      Qgis::GDAL_RUNTIME_VERSION_MAJOR = sa_split[0].toInt();
+      if ( sa_split.size() > 1 )
+        Qgis::GDAL_RUNTIME_VERSION_MINOR = sa_split[1].toInt();
+      if ( sa_split.size() > 2 )
+        Qgis::GDAL_RUNTIME_VERSION_REV = sa_split[2].toInt();
+    }
+    // QgsOgrProvider constructor [with Layer is not valid] returns before QgsApplication::registerOgrDrivers is called when not 1
+    // - tested in QgsApplication::registerOgrDrivers, QgisApp::about()
+    //  --> QgisApp::about() will report version as 'Deprecated'
+    // -> QgisApp::addVectorLayers should return 'is not a valid or recognized data source'
+    if ( Qgis::GDAL_RUNTIME_VERSION_MAJOR >= Qgis::GDAL_BUILD_VERSION_MAJOR )
+    {
+      // Deprecated gdal major-versions that are less than the major-version
+      Qgis::GDAL_OGR_RUNTIME_SUPPORTED = 1;
+    }
+  }
+  return ( bool )Qgis::GDAL_OGR_RUNTIME_SUPPORTED;
+}
 
 const QString GEOPROJ4 = QStringLiteral( "+proj=longlat +datum=WGS84 +no_defs" );
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -51,42 +51,51 @@ QString Qgis::GDAL_BUILD_VERSION( QString::fromUtf8( GDAL_RELEASE_NAME ) );
 const int Qgis::GDAL_BUILD_VERSION_MAJOR = GDAL_VERSION_MAJOR;
 const int Qgis::GDAL_BUILD_VERSION_MINOR = GDAL_VERSION_MINOR;
 const int Qgis::GDAL_BUILD_VERSION_REV = GDAL_VERSION_REV;
-QString Qgis::GDAL_RUNTIME_VERSION = QString::null;
+QString Qgis::GDAL_RUNTIME_VERSION = QString();
 int Qgis::GDAL_RUNTIME_VERSION_MAJOR = -1;
 int Qgis::GDAL_RUNTIME_VERSION_MINOR = -1;
 int Qgis::GDAL_RUNTIME_VERSION_REV = -1;
-int Qgis::GDAL_OGR_RUNTIME_SUPPORTED = 0;
+bool Qgis::GDAL_OGR_RUNTIME_SUPPORTED = false;
 bool Qgis::ogrRuntimeSupport()
 {
   // Called in QgisApp and tested in QgsOgrProvider constructor
-  if ( Qgis::GDAL_RUNTIME_VERSION.isNull() )
+  if ( Qgis::GDAL_RUNTIME_VERSION.isEmpty() )
   {
     // do this only once
     Qgis::GDAL_RUNTIME_VERSION = QString( "%1" ).arg( GDALVersionInfo( "RELEASE_NAME" ) );
     // Remove non-numeric characters (with the excetion of '.') : '2.2.0dev' to '2.2.0'
-    QString s_GdalVersionInfo = Qgis::GDAL_RUNTIME_VERSION;
-    s_GdalVersionInfo.remove( QRegExp( QString::fromUtf8( "[-`~!@#$%^&*()_—+=|:;<>«»,?/{a-zA-Z}\'\"\\[\\]\\\\]" ) ) );
-    QStringList sa_split = s_GdalVersionInfo.split( '.' );
-    if ( sa_split.size() > 0 )
-    {
-      // setting gdal-runtime version
-      Qgis::GDAL_RUNTIME_VERSION_MAJOR = sa_split[0].toInt();
-      if ( sa_split.size() > 1 )
-        Qgis::GDAL_RUNTIME_VERSION_MINOR = sa_split[1].toInt();
-      if ( sa_split.size() > 2 )
-        Qgis::GDAL_RUNTIME_VERSION_REV = sa_split[2].toInt();
-    }
-    // QgsOgrProvider constructor [with Layer is not valid] returns before QgsApplication::registerOgrDrivers is called when not 1
-    // - tested in QgsApplication::registerOgrDrivers, QgisApp::about()
-    //  --> QgisApp::about() will report version as 'Deprecated'
-    // -> QgisApp::addVectorLayers should return 'is not a valid or recognized data source'
+    QString gdalVersionInfo = Qgis::GDAL_RUNTIME_VERSION;
+    gdalVersionInfo.remove( QRegExp( QString::fromUtf8( "[-`~!@#$%^&*()_—+=|:;<>«»,?/{a-zA-Z}\'\"\\[\\]\\\\]" ) ) );
+    QStringList saSplit = gdalVersionInfo.split( '.' );
+    if ( if ( !saSplit.isEmpty() ) )
+      {
+        // setting gdal-runtime version
+        Qgis::GDAL_RUNTIME_VERSION_MAJOR = saSplit[0].toInt();
+        if ( sa_split.size() > 1 )
+          Qgis::GDAL_RUNTIME_VERSION_MINOR = saSplit[1].toInt();
+        if ( sa_split.size() > 2 )
+          Qgis::GDAL_RUNTIME_VERSION_REV = saSplit[2].toInt();
+      }
     if ( Qgis::GDAL_RUNTIME_VERSION_MAJOR >= Qgis::GDAL_BUILD_VERSION_MAJOR )
     {
       // Deprecated gdal major-versions that are less than the major-version
-      Qgis::GDAL_OGR_RUNTIME_SUPPORTED = 1;
+      Qgis::GDAL_OGR_RUNTIME_SUPPORTED = true;
     }
   }
-  return ( bool )Qgis::GDAL_OGR_RUNTIME_SUPPORTED;
+  return Qgis::GDAL_OGR_RUNTIME_SUPPORTED;
+}
+bool Qgis::QGISRuntimeChecks()
+{
+  if ( !Qgis::ogrRuntimeSupport() )
+  {
+    std::cerr << QObject::tr(
+                QString( "QGIS does not support theis version of GDAL.\n"
+                         "GDAL[%1]\n"
+                         "Please install a GDAL 2 version.\n" ).arg( Qgis::GDAL_RUNTIME_VERSION )
+              ).toUtf8().constData();
+    return false;
+  }
+  return true;
 }
 
 const QString GEOPROJ4 = QStringLiteral( "+proj=longlat +datum=WGS84 +no_defs" );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -51,6 +51,23 @@ class CORE_EXPORT Qgis
     static const QString QGIS_RELEASE_NAME;
     //! The development version
     static const char *QGIS_DEV_VERSION;
+    // Gdal Version string at build/compile time
+    static QString GDAL_BUILD_VERSION;
+    static const int GDAL_BUILD_VERSION_MAJOR;
+    static const int GDAL_BUILD_VERSION_MINOR;
+    static const int GDAL_BUILD_VERSION_REV;
+    // Gdal Version string runtime
+    static QString GDAL_RUNTIME_VERSION;
+    static int GDAL_RUNTIME_VERSION_MAJOR;
+    static int GDAL_RUNTIME_VERSION_MINOR;
+    static int GDAL_RUNTIME_VERSION_REV;
+    static int GDAL_OGR_RUNTIME_SUPPORTED;
+
+    /** Set, when needed, the gdal Runtime Version
+     * Determine if the runtime version should be supported
+     * @returns true if QgsOgrProvider supports the runtime Version of gdal/ogr
+     */
+    static bool ogrRuntimeSupport();
 
     // Enumerations
     //

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -51,23 +51,52 @@ class CORE_EXPORT Qgis
     static const QString QGIS_RELEASE_NAME;
     //! The development version
     static const char *QGIS_DEV_VERSION;
-    // Gdal Version string at build/compile time
+    //! Gdal Version string at build/compile time
     static QString GDAL_BUILD_VERSION;
+    //! Gdal major-version as integer (taken from Version string) at build/compile time
     static const int GDAL_BUILD_VERSION_MAJOR;
+    //! Gdal minor-version as integer (taken from Version string) at build/compile time
     static const int GDAL_BUILD_VERSION_MINOR;
+    //! Gdal revision-version as integer (taken from Version string) at build/compile time
     static const int GDAL_BUILD_VERSION_REV;
-    // Gdal Version string runtime
+    //! Gdal Version string runtime
     static QString GDAL_RUNTIME_VERSION;
+    //! Gdal major-version as integer (taken from Version string) while application is running
     static int GDAL_RUNTIME_VERSION_MAJOR;
+    //! Gdal minor-version as integer (taken from Version string) while application is running
     static int GDAL_RUNTIME_VERSION_MINOR;
+    //! Gdal revision-version as integer (taken from Version string) while application is running
     static int GDAL_RUNTIME_VERSION_REV;
-    static int GDAL_OGR_RUNTIME_SUPPORTED;
+    //! true or false if the Gdal runtime version is supported
+    static bool GDAL_OGR_RUNTIME_SUPPORTED;
 
-    /** Set, when needed, the gdal Runtime Version
-     * Determine if the runtime version should be supported
-     * @returns true if QgsOgrProvider supports the runtime Version of gdal/ogr
+    /**
+     * Check if the gdal/ogr version running is supported
+     * @note
+     * For the moment, will be used to prevent QGIS3 from starting if running against a gdal 1 version
+     * In the future it may be useful when  gdal evolves in a way, that at the moment cannot be for seen.
+     * and it may be considered desirable that gdal 2 sub-versions no longer be supported
+     * This checking is done once in
+     * - QGis::ogrRuntimeSupport()
+     * and matches the conditions set in cmake (GDAL_VERSION_MAJOR)
+     * GDAL_RUNTIME_VERSION_MINOR and GDAL_RUNTIME_VERSION_REV
+     *  are available to check against the corresponding GDAL_BUILD_VERSION_ values.
+     * \since QGIS 3.0
+     * @return if the running version of gdal/ogr is supported
      */
     static bool ogrRuntimeSupport();
+
+    /**
+     * General checks for components needed for QGIS
+     * @note
+     * Called during main()
+     * - Application will exit if any tests faile
+     * @note not available in Python bindings
+     * \since QGIS 3.0
+     * @see main()
+     * @return false if any of the needed component-tests fail
+     */
+    static bool QGISRuntimeChecks();
 
     // Enumerations
     //

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1025,9 +1025,13 @@ QString QgsApplication::reportStyleSheet()
 
 void QgsApplication::registerOgrDrivers()
 {
-  if ( 0 >= OGRGetDriverCount() )
+  if ( Qgis::ogrRuntimeSupport() )
   {
-    OGRRegisterAll();
+    // allow only if running gdal version is supported
+    if ( 0 >= OGRGetDriverCount() )
+    {
+      OGRRegisterAll();
+    }
   }
 }
 


### PR DESCRIPTION
## Description
A minimal version of the gdal_runtime logic initially added to following pull:
https://github.com/qgis/QGIS/pull/4341

for further discussion if this should be added at all.

For the moment, this can be used to prevent QGIS3 from starting 
* if running against a gdal 1 version

In the future it may be useful when (not if) gdal evolves in a way (that at the moment cannot be for seen) 
* and it may be considered desirable that gdal 2 sub-versions no longer be supported

This checking is done once in
* **QGis::ogrRuntimeSupport()**

which matches the conditions set in cmake (**GDAL_VERSION_MAJOR**)
* **GDAL_RUNTIME_VERSION_MINOR** and
* **GDAL_RUNTIME_VERSION_REV**

are available to check against the corresponding **GDAL_BUILD_VERSION_** values.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
