### PR TITLE
Implement Metadata store (WP2 for QEP-91) (part 1)

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -63,6 +63,7 @@ IF(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/core/geometry
       ${CMAKE_SOURCE_DIR}/src/core/gps
       ${CMAKE_SOURCE_DIR}/src/core/layertree
+      ${CMAKE_SOURCE_DIR}/src/core/metadata
       ${CMAKE_SOURCE_DIR}/src/core/pal
       ${CMAKE_SOURCE_DIR}/src/core/processing
       ${CMAKE_SOURCE_DIR}/src/core/raster

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -105,6 +105,7 @@ INCLUDE_DIRECTORIES(
   ../src/core/geometry
   ../src/core/gps
   ../src/core/layertree
+  ../src/core/metadata
   ../src/core/processing
   ../src/core/raster
   ../src/core/scalebar

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -149,7 +149,6 @@ SET(SIP_CORE_CPP_FILES ${cpp_files})
 INCLUDE_DIRECTORIES(
   ../src/gui
   ../src/gui/symbology-ng
-  ../src/gui/effects
   ../src/plugins
   ${CMAKE_BINARY_DIR}/src/gui
   ${CMAKE_BINARY_DIR}/src/ui

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -276,6 +276,8 @@
 %Include layertree/qgslayertreeregistrybridge.sip
 %Include layertree/qgslayertreeutils.sip
 
+%Include metadata/qgslayermetadata.sip
+
 %Include processing/qgsprocessingalgorithm.sip
 %Include processing/qgsprocessingcontext.sip
 %Include processing/qgsprocessingfeedback.sip

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -277,6 +277,7 @@
 %Include layertree/qgslayertreeutils.sip
 
 %Include metadata/qgslayermetadata.sip
+%Include metadata/qgslayermetadatavalidator.sip
 
 %Include processing/qgsprocessingalgorithm.sip
 %Include processing/qgsprocessingcontext.sip

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -44,6 +44,62 @@ class QgsLayerMetadata
 
     typedef QMap< QString, QStringList > KeywordMap;
 
+    struct SpatialExtent
+    {
+
+      QgsCoordinateReferenceSystem extentCrs;
+%Docstring
+ Coordinate reference system for spatial extent.
+ \see spatial
+%End
+
+      QgsBox3d bounds;
+%Docstring
+ Geospatial extent of the resource. X and Y coordinates are in the
+ CRS defined by the metadata (see extentCrs).
+
+ While the spatial extent can include a Z dimension, this is not
+ compulsory.
+ \see extentCrs
+%End
+    };
+
+    struct Extent
+    {
+      public:
+
+        QList< QgsLayerMetadata::SpatialExtent > spatialExtents() const;
+%Docstring
+ Spatial extents of the resource.
+ \see setSpatialExtents()
+ :rtype: list of QgsLayerMetadata.SpatialExtent
+%End
+
+        void setSpatialExtents( const QList< QgsLayerMetadata::SpatialExtent > &extents );
+%Docstring
+ Sets the spatial ``extents`` of the resource.
+ \see spatialExtents()
+%End
+
+        QList< QgsDateTimeRange > temporalExtents() const;
+%Docstring
+ Temporal extents of the resource. Use QgsDateTimeRange.isInstant() to determine
+ whether the temporal extent is a range or a single point in time.
+ If QgsDateTimeRange.isInfinite() returns true then the temporal extent
+ is considered to be indeterminate and continuous.
+ \see setTemporalExtents()
+ :rtype: list of QgsDateTimeRange
+%End
+
+        void setTemporalExtents( const QList< QgsDateTimeRange > &extents );
+%Docstring
+ Sets the temporal ``extents`` of the resource.
+ \see temporalExtents()
+%End
+
+
+    };
+
     struct Constraint
     {
 
@@ -394,6 +450,20 @@ class QgsLayerMetadata
  \see encoding()
 %End
 
+
+    QgsLayerMetadata::Extent &extent();
+%Docstring
+ Returns the spatial and temporal extents associated with the resource.
+ \see setExtent()
+ :rtype: QgsLayerMetadata.Extent
+%End
+
+    void setExtent( const QgsLayerMetadata::Extent &extent );
+%Docstring
+ Sets the spatial and temporal extents associated with the resource.
+ \see setExtent()
+%End
+
     QgsCoordinateReferenceSystem crs() const;
 %Docstring
  Returns the coordinate reference system described by the layer's metadata.
@@ -546,8 +616,6 @@ class QgsLayerMetadata
 %End
 
 };
-
-
 
 
 /************************************************************************

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsLayerMetadata
 {
 %Docstring
@@ -37,6 +38,8 @@ class QgsLayerMetadata
 %End
   public:
 
+    typedef QMap< QString, QStringList > KeywordMap;
+
     struct Constraint
     {
 
@@ -56,6 +59,9 @@ class QgsLayerMetadata
  Free-form constraint string.
 %End
     };
+
+    typedef QList< QgsLayerMetadata::Constraint > ConstraintList;
+
 
     struct Address
     {
@@ -150,6 +156,9 @@ class QgsLayerMetadata
 %End
     };
 
+    typedef QList< QgsLayerMetadata::Contact > ContactList;
+
+
     struct Link
     {
 
@@ -194,6 +203,8 @@ class QgsLayerMetadata
  Estimated size (in bytes) of the online resource response.
 %End
     };
+
+    typedef QList< QgsLayerMetadata::Link > LinkList;
 
     QgsLayerMetadata();
 %Docstring
@@ -304,14 +315,14 @@ class QgsLayerMetadata
  \see fees()
 %End
 
-    QList< QgsLayerMetadata::Constraint > constraints() const;
+    QgsLayerMetadata::ConstraintList constraints() const;
 %Docstring
  Returns a list of constraints associated with using the resource.
  \see setConstraints()
- :rtype: list of QgsLayerMetadata.Constraint
+ :rtype: QgsLayerMetadata.ConstraintList
 %End
 
-    void setConstraints( const QList<QgsLayerMetadata::Constraint> &constraints );
+    void setConstraints( const QgsLayerMetadata::ConstraintList &constraints );
 %Docstring
  Sets the list of constraints associated with using the resource.
  \see constraints()
@@ -374,7 +385,7 @@ class QgsLayerMetadata
  \see setCrs()
 %End
 
-    QMap<QString, QStringList> keywords() const;
+    KeywordMap keywords() const;
 %Docstring
  Returns the keywords map, which is a set of descriptive keywords associated with the resource.
 
@@ -385,10 +396,10 @@ class QgsLayerMetadata
 
  \see setKeywords()
  \see keywordVocabularies()
- :rtype: QMap<str, list of str>
+ :rtype: KeywordMap
 %End
 
-    void setKeywords( const QMap<QString, QStringList> &keywords );
+    void setKeywords( const KeywordMap &keywords );
 %Docstring
  Sets the keywords map, which is a set of descriptive keywords associated with the resource.
 
@@ -438,14 +449,14 @@ class QgsLayerMetadata
  :rtype: list of str
 %End
 
-    QList<QgsLayerMetadata::Contact> contacts() const;
+    QgsLayerMetadata::ContactList contacts() const;
 %Docstring
  Returns a list of contact persons or entities associated with the resource.
  \see setContacts()
- :rtype: list of QgsLayerMetadata.Contact
+ :rtype: QgsLayerMetadata.ContactList
 %End
 
-    void setContacts( const QList<QgsLayerMetadata::Contact> &contacts );
+    void setContacts( const QgsLayerMetadata::ContactList &contacts );
 %Docstring
  Sets the list of contacts or entities associated with the resource. Any existing contacts
  will be replaced.
@@ -460,14 +471,14 @@ class QgsLayerMetadata
  \see setContacts()
 %End
 
-    QList<QgsLayerMetadata::Link> links() const;
+    QgsLayerMetadata::LinkList links() const;
 %Docstring
  Returns a list of online resources associated with the resource.
  \see setLinks()
- :rtype: list of QgsLayerMetadata.Link
+ :rtype: QgsLayerMetadata.LinkList
 %End
 
-    void setLinks( const QList<QgsLayerMetadata::Link> &links );
+    void setLinks( const QgsLayerMetadata::LinkList &links );
 %Docstring
  Sets the list of online resources associated with the resource. Any existing links
  will be replaced.
@@ -482,7 +493,22 @@ class QgsLayerMetadata
  \see setLinks()
 %End
 
+    void saveToLayer( QgsMapLayer *layer ) const;
+%Docstring
+ Saves the metadata to a layer's custom properties (see QgsMapLayer.setCustomProperty() ).
+ \see readFromLayer()
+%End
+
+    void readFromLayer( const QgsMapLayer *layer );
+%Docstring
+ Reads the metadata state from a layer's custom properties (see QgsMapLayer.customProperty() ).
+ \see saveToLayer()
+%End
+
 };
+
+
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -1,0 +1,92 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/metadata/qgslayermetadata.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsLayerMetadata
+{
+
+%TypeHeaderCode
+#include "qgslayermetadata.h"
+%End
+  public:
+
+    QgsLayerMetadata();
+
+    virtual ~QgsLayerMetadata();
+
+
+    QString identifier() const;
+%Docstring
+ :rtype: str
+%End
+    void setIdentifier( const QString &identifier );
+
+    QString parentIdentifier() const;
+%Docstring
+ Returns an empty string if no parent identifier is set.
+ :rtype: str
+%End
+
+
+    void setParentIdentifier( const QString &parentIdentifier );
+
+    QString type() const;
+%Docstring
+ :rtype: str
+%End
+    void setType( const QString &type );
+
+    QString title() const;
+%Docstring
+ :rtype: str
+%End
+    void setTitle( const QString &title );
+
+    QString abstract() const;
+%Docstring
+ :rtype: str
+%End
+    void setAbstract( const QString &abstract );
+
+    QString fees() const;
+%Docstring
+ Returns an empty string if no fees are set.
+ :rtype: str
+%End
+    void setFees( const QString &fees );
+
+    QStringList constraints() const;
+%Docstring
+ :rtype: list of str
+%End
+    void setConstraints( const QStringList &constraints );
+
+    QStringList rights() const;
+%Docstring
+ :rtype: list of str
+%End
+    void setRights( const QStringList &rights );
+
+    QString encoding() const;
+%Docstring
+ Returns an empty string if no encoding is set.
+ :rtype: str
+%End
+    void setEncoding( const QString &encoding );
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/metadata/qgslayermetadata.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -253,7 +253,7 @@ class QgsLayerMetadata
 
     void setLanguage( const QString &language );
 %Docstring
- Sets the human language associated with the resource. While a formal vocabulary is not imposed,
+ Sets the human ``language`` associated with the resource. While a formal vocabulary is not imposed,
  ideally values should be taken from the ISO 639.2 or ISO 3166 specifications,
  e.g. 'ENG' or 'SPA' (ISO 639.2) or 'EN-AU' (ISO 3166).
  \see language()
@@ -269,7 +269,7 @@ class QgsLayerMetadata
 
     void setType( const QString &type );
 %Docstring
- Sets the type (nature) of the resource.  While a formal vocabulary is not imposed, it is advised
+ Sets the ``type`` (nature) of the resource.  While a formal vocabulary is not imposed, it is advised
  to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
  \see type()
 %End
@@ -283,7 +283,7 @@ class QgsLayerMetadata
 
     void setTitle( const QString &title );
 %Docstring
- Sets the human readable title (name) of the resource, typically displayed in search results.
+ Sets the human readable ``title`` (name) of the resource, typically displayed in search results.
  \see title()
 %End
 
@@ -296,7 +296,7 @@ class QgsLayerMetadata
 
     void setAbstract( const QString &abstract );
 %Docstring
- Sets a free-form abstract (description) of the resource.
+ Sets a free-form ``abstract`` (description) of the resource.
  \see abstract()
 %End
 
@@ -310,7 +310,7 @@ class QgsLayerMetadata
 
     void setFees( const QString &fees );
 %Docstring
- Sets the fees associated with using the resource.
+ Sets the ``fees`` associated with using the resource.
  Use an empty string if no fees are set.
  \see fees()
 %End
@@ -324,7 +324,7 @@ class QgsLayerMetadata
 
     void setConstraints( const QgsLayerMetadata::ConstraintList &constraints );
 %Docstring
- Sets the list of constraints associated with using the resource.
+ Sets the list of ``constraints`` associated with using the resource.
  \see constraints()
 %End
 
@@ -337,7 +337,7 @@ class QgsLayerMetadata
 
     void setRights( const QStringList &rights );
 %Docstring
- Sets a list of rights (attribution or copyright strings) associated with the resource.
+ Sets a list of ``rights`` (attribution or copyright strings) associated with the resource.
  \see rights()
 %End
 
@@ -350,7 +350,7 @@ class QgsLayerMetadata
 
     void setEncoding( const QString &encoding );
 %Docstring
- Sets the character encoding of the data in the resource. Use an empty string if no encoding is set.
+ Sets the character ``encoding`` of the data in the resource. Use an empty string if no encoding is set.
  \see encoding()
 %End
 
@@ -401,7 +401,7 @@ class QgsLayerMetadata
 
     void setKeywords( const KeywordMap &keywords );
 %Docstring
- Sets the keywords map, which is a set of descriptive keywords associated with the resource.
+ Sets the ``keywords`` map, which is a set of descriptive keywords associated with the resource.
 
  The map key is the vocabulary string and map value is a list of keywords for that vocabulary.
  Calling this replaces any existing keyword vocabularies.
@@ -415,7 +415,7 @@ class QgsLayerMetadata
 
     void addKeywords( const QString &vocabulary, const QStringList &keywords );
 %Docstring
- Adds a list of descriptive keywords for a specified vocabulary. Any existing
+ Adds a list of descriptive ``keywords`` for a specified ``vocabulary``. Any existing
  keywords for the same vocabulary will be replaced. Other vocabularies
  will not be affected.
 
@@ -438,7 +438,7 @@ class QgsLayerMetadata
 
     QStringList keywords( const QString &vocabulary ) const;
 %Docstring
- Returns a list of keywords for the specified vocabulary.
+ Returns a list of keywords for the specified ``vocabulary``.
  If the vocabulary is not contained in the metadata, an empty
  list will be returned.
 
@@ -458,7 +458,7 @@ class QgsLayerMetadata
 
     void setContacts( const QgsLayerMetadata::ContactList &contacts );
 %Docstring
- Sets the list of contacts or entities associated with the resource. Any existing contacts
+ Sets the list of ``contacts`` or entities associated with the resource. Any existing contacts
  will be replaced.
  \see contacts()
  \see addContact()
@@ -466,7 +466,7 @@ class QgsLayerMetadata
 
     void addContact( const QgsLayerMetadata::Contact &contact );
 %Docstring
- Adds an individual contact to the existing contacts.
+ Adds an individual ``contact`` to the existing contacts.
  \see contacts()
  \see setContacts()
 %End
@@ -488,20 +488,20 @@ class QgsLayerMetadata
 
     void addLink( const QgsLayerMetadata::Link &link );
 %Docstring
- Adds an individual link to the existing links.
+ Adds an individual ``link`` to the existing links.
  \see links()
  \see setLinks()
 %End
 
     void saveToLayer( QgsMapLayer *layer ) const;
 %Docstring
- Saves the metadata to a layer's custom properties (see QgsMapLayer.setCustomProperty() ).
+ Saves the metadata to a ``layer``'s custom properties (see QgsMapLayer.setCustomProperty() ).
  \see readFromLayer()
 %End
 
     void readFromLayer( const QgsMapLayer *layer );
 %Docstring
- Reads the metadata state from a layer's custom properties (see QgsMapLayer.customProperty() ).
+ Reads the metadata state from a ``layer``'s custom properties (see QgsMapLayer.customProperty() ).
  \see saveToLayer()
 %End
 

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -355,6 +355,28 @@ class QgsLayerMetadata
  \see licenses()
 %End
 
+    QStringList history() const;
+%Docstring
+ Returns a freeform description of the history or lineage of the resource.
+ \see setHistory()
+ :rtype: list of str
+%End
+
+    void setHistory( const QStringList &history );
+%Docstring
+ Sets the freeform description of the ``history`` or lineage of the resource.
+ Any existing history items will be overwritten.
+ \see addHistoryItem()
+ \see history()
+%End
+
+    void addHistoryItem( const QString &text );
+%Docstring
+ Adds a single history ``text`` to the end of the existing history list.
+ \see history()
+ \see setHistory()
+%End
+
     QString encoding() const;
 %Docstring
  Returns the character encoding of the data in the resource. An empty string will be returned if no encoding is set.

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -30,6 +30,10 @@ class QgsLayerMetadata
  the schema definition available at resources/qgis-resource-metadata.xsd
  within the QGIS source code.
 
+ Metadata can be validated through the use of QgsLayerMetadataValidator
+ subclasses. E.g. validating against the native QGIS metadata schema can be performed
+ using QgsNativeMetadataValidator.
+
 .. versionadded:: 3.0
 %End
 

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -11,75 +11,476 @@
 
 class QgsLayerMetadata
 {
+%Docstring
+ A structured metadata store for a map layer.
+
+ QgsLayerMetadata handles storage and management of the metadata
+ for a QgsMapLayer. This class is an internal QGIS format with a common
+ metadata structure, which allows for code to access the metadata properties for
+ layers in a uniform way.
+
+ The metadata store is designed to be compatible with the Dublin Core metadata
+ specifications, and will be expanded to allow compatibility with ISO specifications
+ in future releases. However, the QGIS internal schema does not represent a superset
+ of all existing metadata schemas and accordingly conversion from specific
+ metadata formats to QgsLayerMetadata may result in a loss of information.
+
+ This class is designed to follow the specifications detailed in
+ the schema definition available at resources/qgis-resource-metadata.xsd
+ within the QGIS source code.
+
+.. versionadded:: 3.0
+%End
 
 %TypeHeaderCode
 #include "qgslayermetadata.h"
 %End
   public:
 
+    struct Constraint
+    {
+
+      Constraint( const QString &constraint = QString(), const QString &type = QString() );
+%Docstring
+ Constructor for Constraint.
+%End
+
+      QString type;
+%Docstring
+ Constraint type. Standard values include 'access' and 'other', however any
+ string can be used for the type.
+%End
+
+      QString constraint;
+%Docstring
+ Free-form constraint string.
+%End
+    };
+
+    struct Address
+    {
+
+      Address( const QString &type = QString(), const QString &address = QString(), const QString &city = QString(), const QString &administrativeArea = QString(), const QString &postalCode = QString(), const QString &country = QString() );
+%Docstring
+ Constructor for Address.
+%End
+
+      QString type;
+%Docstring
+ Type of address, e.g. 'postal'.
+%End
+
+      QString address;
+%Docstring
+ Free-form physical address component, e.g. '221B Baker St' or 'P.O. Box 196'.
+%End
+
+      QString city;
+%Docstring
+ City or locality name.
+%End
+
+      QString administrativeArea;
+%Docstring
+ Administrative area (state, provice/territory, etc.).
+%End
+
+      QString postalCode;
+%Docstring
+ Postal (or ZIP) code.
+%End
+
+      QString country;
+%Docstring
+ Free-form country string.
+%End
+    };
+
+    struct Contact
+    {
+
+      Contact( const QString &name = QString() );
+%Docstring
+ Constructor for Contact.
+%End
+
+      QString name;
+%Docstring
+ Name of contact.
+%End
+
+      QString organization;
+%Docstring
+ Organization contact belongs to/represents.
+%End
+
+      QString position;
+%Docstring
+ Position/title of contact.
+%End
+
+      QList< QgsLayerMetadata::Address > addresses;
+%Docstring
+ List of addresses associated with this contact.
+%End
+
+      QString voice;
+%Docstring
+ Voice telephone.
+%End
+
+      QString fax;
+%Docstring
+ Facsimile telephone.
+%End
+
+      QString email;
+%Docstring
+ Electronic mail address.
+.. note::
+
+   Do not include mailto: protocol as part of the email address.
+%End
+
+      QString role;
+%Docstring
+ Role of contact. Acceptable values are those from the ISO 19115 CI_RoleCode specifications
+ (see http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml).
+ E.g. 'custodian', 'owner', 'distributor', etc.
+%End
+    };
+
+    struct Link
+    {
+
+      Link( const QString &name = QString(), const QString &type = QString(), const QString &url = QString() );
+%Docstring
+ Constructor for Link.
+%End
+
+      QString name;
+%Docstring
+ Short link name. E.g. WMS layer name.
+%End
+
+      QString type;
+%Docstring
+ Link type. It is strongly suggested to use values from the 'identifier'
+ column in https://github.com/OSGeo/Cat-Interop/blob/master/LinkPropertyLookupTable.csv
+%End
+
+      QString description;
+%Docstring
+ Abstract text about link.
+%End
+
+      QString url;
+%Docstring
+ Link url.  If the URL is an OWS server, specify the *base* URL only without parameters like service=xxx....
+%End
+
+      QString format;
+%Docstring
+ Format specification of online resource. It is strongly suggested to use GDAL/OGR format values.
+%End
+
+      QString mimeType;
+%Docstring
+ MIME type representative of the online resource response (image/png, application/json, etc.)
+%End
+
+      QString size;
+%Docstring
+ Estimated size (in bytes) of the online resource response.
+%End
+    };
+
     QgsLayerMetadata();
+%Docstring
+ Constructor for QgsLayerMetadata.
+%End
 
     virtual ~QgsLayerMetadata();
 
-
     QString identifier() const;
 %Docstring
+ A reference, URI, URL or some other mechanism to identify the resource.
+ \see setIdentifier()
  :rtype: str
 %End
+
     void setIdentifier( const QString &identifier );
+%Docstring
+ Sets the reference, URI, URL or some other mechanism to identify the resource.
+ \see identifier()
+%End
 
     QString parentIdentifier() const;
 %Docstring
+ A reference, URI, URL or some other mechanism to identify the parent resource that this resource is a part (child) of.
  Returns an empty string if no parent identifier is set.
+ \see setParentIdentifier()
  :rtype: str
 %End
 
-
     void setParentIdentifier( const QString &parentIdentifier );
+%Docstring
+ Sets a reference, URI, URL or some other mechanism to identify the parent resource that this resource is a part (child) of.
+ Set an empty string if no parent identifier is required.
+ \see parentIdentifier()
+%End
+
+    QString language() const;
+%Docstring
+ Returns the human language associated with the resource. Usually the returned string
+ will follow either the ISO 639.2 or ISO 3166 specifications, e.g. 'ENG' or 'SPA', however
+ this is not a hard requirement and the caller must account for non compliant
+ values.
+ \see setLanguage()
+ :rtype: str
+%End
+
+    void setLanguage( const QString &language );
+%Docstring
+ Sets the human language associated with the resource. While a formal vocabulary is not imposed,
+ ideally values should be taken from the ISO 639.2 or ISO 3166 specifications,
+ e.g. 'ENG' or 'SPA' (ISO 639.2) or 'EN-AU' (ISO 3166).
+ \see language()
+%End
 
     QString type() const;
 %Docstring
+ Returns the nature of the resource.  While a formal vocabulary is not imposed, it is advised
+ to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
+ \see setType()
  :rtype: str
 %End
+
     void setType( const QString &type );
+%Docstring
+ Sets the type (nature) of the resource.  While a formal vocabulary is not imposed, it is advised
+ to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
+ \see type()
+%End
 
     QString title() const;
 %Docstring
+ Returns the human readable name of the resource, typically displayed in search results.
+ \see setTitle()
  :rtype: str
 %End
+
     void setTitle( const QString &title );
+%Docstring
+ Sets the human readable title (name) of the resource, typically displayed in search results.
+ \see title()
+%End
 
     QString abstract() const;
 %Docstring
+ Returns a free-form description of the resource.
+ \see setAbstract()
  :rtype: str
 %End
+
     void setAbstract( const QString &abstract );
+%Docstring
+ Sets a free-form abstract (description) of the resource.
+ \see abstract()
+%End
 
     QString fees() const;
 %Docstring
- Returns an empty string if no fees are set.
+ Returns any fees associated with using the resource.
+ An empty string will be returned if no fees are set.
+ \see setFees()
  :rtype: str
 %End
-    void setFees( const QString &fees );
 
-    QStringList constraints() const;
+    void setFees( const QString &fees );
 %Docstring
- :rtype: list of str
+ Sets the fees associated with using the resource.
+ Use an empty string if no fees are set.
+ \see fees()
 %End
-    void setConstraints( const QStringList &constraints );
+
+    QList< QgsLayerMetadata::Constraint > constraints() const;
+%Docstring
+ Returns a list of constraints associated with using the resource.
+ \see setConstraints()
+ :rtype: list of QgsLayerMetadata.Constraint
+%End
+
+    void setConstraints( const QList<QgsLayerMetadata::Constraint> &constraints );
+%Docstring
+ Sets the list of constraints associated with using the resource.
+ \see constraints()
+%End
 
     QStringList rights() const;
 %Docstring
+ Returns a list of attribution or copyright strings associated with the resource.
+ \see setRights()
  :rtype: list of str
 %End
+
     void setRights( const QStringList &rights );
+%Docstring
+ Sets a list of rights (attribution or copyright strings) associated with the resource.
+ \see rights()
+%End
 
     QString encoding() const;
 %Docstring
- Returns an empty string if no encoding is set.
+ Returns the character encoding of the data in the resource. An empty string will be returned if no encoding is set.
+ \see setEncoding()
  :rtype: str
 %End
+
     void setEncoding( const QString &encoding );
+%Docstring
+ Sets the character encoding of the data in the resource. Use an empty string if no encoding is set.
+ \see encoding()
+%End
+
+    QgsCoordinateReferenceSystem crs() const;
+%Docstring
+ Returns the coordinate reference system described by the layer's metadata.
+
+ Note that this has no link to QgsMapLayer.crs(). While in most cases these
+ two systems are likely to be identical, it is possible to have a layer
+ with a different CRS described by it's accompanying metadata versus the
+ CRS which is actually used to display and manipulate the layer within QGIS.
+ This may be the case when a layer has an incorrect CRS within its metadata
+ and a user has manually overridden the layer's CRS within QGIS.
+ \see setCrs()
+ :rtype: QgsCoordinateReferenceSystem
+%End
+
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+ Sets the coordinate reference system for the layer's metadata.
+
+ Note that this has no link to QgsMapLayer.setCrs(). Setting the layer's
+ CRS via QgsMapLayer.setCrs() does not affect the layer's metadata CRS,
+ and changing the CRS from the metadata will not change the layer's
+ CRS or how it is projected within QGIS.
+
+ While ideally these two systems are likely to be identical, it is possible to have a layer
+ with a different CRS described by it's accompanying metadata versus the
+ CRS which is actually used to display and manipulate the layer within QGIS.
+ This may be the case when a layer has an incorrect CRS within its metadata
+ and a user has manually overridden the layer's CRS within QGIS.
+ \see setCrs()
+%End
+
+    QMap<QString, QStringList> keywords() const;
+%Docstring
+ Returns the keywords map, which is a set of descriptive keywords associated with the resource.
+
+ The map key is the vocabulary string and map value is a list of keywords for that vocabulary.
+
+ The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+ associated with keyword list.
+
+ \see setKeywords()
+ \see keywordVocabularies()
+ :rtype: QMap<str, list of str>
+%End
+
+    void setKeywords( const QMap<QString, QStringList> &keywords );
+%Docstring
+ Sets the keywords map, which is a set of descriptive keywords associated with the resource.
+
+ The map key is the vocabulary string and map value is a list of keywords for that vocabulary.
+ Calling this replaces any existing keyword vocabularies.
+
+ The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+ associated with keyword list.
+
+ \see keywords()
+ \see addKeywords()
+%End
+
+    void addKeywords( const QString &vocabulary, const QStringList &keywords );
+%Docstring
+ Adds a list of descriptive keywords for a specified vocabulary. Any existing
+ keywords for the same vocabulary will be replaced. Other vocabularies
+ will not be affected.
+
+ The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+ associated with keyword list.
+
+ \see setKeywords()
+%End
+
+    QStringList keywordVocabularies() const;
+%Docstring
+ Returns a list of keyword vocabularies contained in the metadata.
+
+ The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+ associated with keyword list.
+
+ \see keywords()
+ :rtype: list of str
+%End
+
+    QStringList keywords( const QString &vocabulary ) const;
+%Docstring
+ Returns a list of keywords for the specified vocabulary.
+ If the vocabulary is not contained in the metadata, an empty
+ list will be returned.
+
+ The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+ associated with keyword list.
+
+ \see keywordVocabularies()
+ :rtype: list of str
+%End
+
+    QList<QgsLayerMetadata::Contact> contacts() const;
+%Docstring
+ Returns a list of contact persons or entities associated with the resource.
+ \see setContacts()
+ :rtype: list of QgsLayerMetadata.Contact
+%End
+
+    void setContacts( const QList<QgsLayerMetadata::Contact> &contacts );
+%Docstring
+ Sets the list of contacts or entities associated with the resource. Any existing contacts
+ will be replaced.
+ \see contacts()
+ \see addContact()
+%End
+
+    void addContact( const QgsLayerMetadata::Contact &contact );
+%Docstring
+ Adds an individual contact to the existing contacts.
+ \see contacts()
+ \see setContacts()
+%End
+
+    QList<QgsLayerMetadata::Link> links() const;
+%Docstring
+ Returns a list of online resources associated with the resource.
+ \see setLinks()
+ :rtype: list of QgsLayerMetadata.Link
+%End
+
+    void setLinks( const QList<QgsLayerMetadata::Link> &links );
+%Docstring
+ Sets the list of online resources associated with the resource. Any existing links
+ will be replaced.
+ \see links()
+ \see addLink()
+%End
+
+    void addLink( const QgsLayerMetadata::Link &link );
+%Docstring
+ Adds an individual link to the existing links.
+ \see links()
+ \see setLinks()
+%End
 
 };
 

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -341,6 +341,20 @@ class QgsLayerMetadata
  \see rights()
 %End
 
+    QStringList licenses() const;
+%Docstring
+ Returns a list of licenses associated with the resource (examples: http://opendefinition.org/licenses/).
+ \see setLicenses()
+ :rtype: list of str
+%End
+
+    void setLicenses( const QStringList &licenses );
+%Docstring
+ Sets a list of ``licenses`` associated with the resource.
+ (examples: http://opendefinition.org/licenses/).
+ \see licenses()
+%End
+
     QString encoding() const;
 %Docstring
  Returns the character encoding of the data in the resource. An empty string will be returned if no encoding is set.

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -50,7 +50,7 @@ class QgsLayerMetadata
       QgsCoordinateReferenceSystem extentCrs;
 %Docstring
  Coordinate reference system for spatial extent.
- \see spatial
+.. seealso:: spatial
 %End
 
       QgsBox3d bounds;
@@ -60,7 +60,7 @@ class QgsLayerMetadata
 
  While the spatial extent can include a Z dimension, this is not
  compulsory.
- \see extentCrs
+.. seealso:: extentCrs
 %End
     };
 
@@ -71,14 +71,14 @@ class QgsLayerMetadata
         QList< QgsLayerMetadata::SpatialExtent > spatialExtents() const;
 %Docstring
  Spatial extents of the resource.
- \see setSpatialExtents()
+.. seealso:: setSpatialExtents()
  :rtype: list of QgsLayerMetadata.SpatialExtent
 %End
 
         void setSpatialExtents( const QList< QgsLayerMetadata::SpatialExtent > &extents );
 %Docstring
  Sets the spatial ``extents`` of the resource.
- \see spatialExtents()
+.. seealso:: spatialExtents()
 %End
 
         QList< QgsDateTimeRange > temporalExtents() const;
@@ -87,14 +87,14 @@ class QgsLayerMetadata
  whether the temporal extent is a range or a single point in time.
  If QgsDateTimeRange.isInfinite() returns true then the temporal extent
  is considered to be indeterminate and continuous.
- \see setTemporalExtents()
+.. seealso:: setTemporalExtents()
  :rtype: list of QgsDateTimeRange
 %End
 
         void setTemporalExtents( const QList< QgsDateTimeRange > &extents );
 %Docstring
  Sets the temporal ``extents`` of the resource.
- \see temporalExtents()
+.. seealso:: temporalExtents()
 %End
 
 
@@ -276,21 +276,21 @@ class QgsLayerMetadata
     QString identifier() const;
 %Docstring
  A reference, URI, URL or some other mechanism to identify the resource.
- \see setIdentifier()
+.. seealso:: setIdentifier()
  :rtype: str
 %End
 
     void setIdentifier( const QString &identifier );
 %Docstring
  Sets the reference, URI, URL or some other mechanism to identify the resource.
- \see identifier()
+.. seealso:: identifier()
 %End
 
     QString parentIdentifier() const;
 %Docstring
  A reference, URI, URL or some other mechanism to identify the parent resource that this resource is a part (child) of.
  Returns an empty string if no parent identifier is set.
- \see setParentIdentifier()
+.. seealso:: setParentIdentifier()
  :rtype: str
 %End
 
@@ -298,7 +298,7 @@ class QgsLayerMetadata
 %Docstring
  Sets a reference, URI, URL or some other mechanism to identify the parent resource that this resource is a part (child) of.
  Set an empty string if no parent identifier is required.
- \see parentIdentifier()
+.. seealso:: parentIdentifier()
 %End
 
     QString language() const;
@@ -307,7 +307,7 @@ class QgsLayerMetadata
  will follow either the ISO 639.2 or ISO 3166 specifications, e.g. 'ENG' or 'SPA', however
  this is not a hard requirement and the caller must account for non compliant
  values.
- \see setLanguage()
+.. seealso:: setLanguage()
  :rtype: str
 %End
 
@@ -316,14 +316,14 @@ class QgsLayerMetadata
  Sets the human ``language`` associated with the resource. While a formal vocabulary is not imposed,
  ideally values should be taken from the ISO 639.2 or ISO 3166 specifications,
  e.g. 'ENG' or 'SPA' (ISO 639.2) or 'EN-AU' (ISO 3166).
- \see language()
+.. seealso:: language()
 %End
 
     QString type() const;
 %Docstring
  Returns the nature of the resource.  While a formal vocabulary is not imposed, it is advised
  to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
- \see setType()
+.. seealso:: setType()
  :rtype: str
 %End
 
@@ -331,40 +331,40 @@ class QgsLayerMetadata
 %Docstring
  Sets the ``type`` (nature) of the resource.  While a formal vocabulary is not imposed, it is advised
  to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
- \see type()
+.. seealso:: type()
 %End
 
     QString title() const;
 %Docstring
  Returns the human readable name of the resource, typically displayed in search results.
- \see setTitle()
+.. seealso:: setTitle()
  :rtype: str
 %End
 
     void setTitle( const QString &title );
 %Docstring
  Sets the human readable ``title`` (name) of the resource, typically displayed in search results.
- \see title()
+.. seealso:: title()
 %End
 
     QString abstract() const;
 %Docstring
  Returns a free-form description of the resource.
- \see setAbstract()
+.. seealso:: setAbstract()
  :rtype: str
 %End
 
     void setAbstract( const QString &abstract );
 %Docstring
  Sets a free-form ``abstract`` (description) of the resource.
- \see abstract()
+.. seealso:: abstract()
 %End
 
     QString fees() const;
 %Docstring
  Returns any fees associated with using the resource.
  An empty string will be returned if no fees are set.
- \see setFees()
+.. seealso:: setFees()
  :rtype: str
 %End
 
@@ -372,39 +372,39 @@ class QgsLayerMetadata
 %Docstring
  Sets the ``fees`` associated with using the resource.
  Use an empty string if no fees are set.
- \see fees()
+.. seealso:: fees()
 %End
 
     QgsLayerMetadata::ConstraintList constraints() const;
 %Docstring
  Returns a list of constraints associated with using the resource.
- \see setConstraints()
+.. seealso:: setConstraints()
  :rtype: QgsLayerMetadata.ConstraintList
 %End
 
     void setConstraints( const QgsLayerMetadata::ConstraintList &constraints );
 %Docstring
  Sets the list of ``constraints`` associated with using the resource.
- \see constraints()
+.. seealso:: constraints()
 %End
 
     QStringList rights() const;
 %Docstring
  Returns a list of attribution or copyright strings associated with the resource.
- \see setRights()
+.. seealso:: setRights()
  :rtype: list of str
 %End
 
     void setRights( const QStringList &rights );
 %Docstring
  Sets a list of ``rights`` (attribution or copyright strings) associated with the resource.
- \see rights()
+.. seealso:: rights()
 %End
 
     QStringList licenses() const;
 %Docstring
  Returns a list of licenses associated with the resource (examples: http://opendefinition.org/licenses/).
- \see setLicenses()
+.. seealso:: setLicenses()
  :rtype: list of str
 %End
 
@@ -412,13 +412,13 @@ class QgsLayerMetadata
 %Docstring
  Sets a list of ``licenses`` associated with the resource.
  (examples: http://opendefinition.org/licenses/).
- \see licenses()
+.. seealso:: licenses()
 %End
 
     QStringList history() const;
 %Docstring
  Returns a freeform description of the history or lineage of the resource.
- \see setHistory()
+.. seealso:: setHistory()
  :rtype: list of str
 %End
 
@@ -426,42 +426,42 @@ class QgsLayerMetadata
 %Docstring
  Sets the freeform description of the ``history`` or lineage of the resource.
  Any existing history items will be overwritten.
- \see addHistoryItem()
- \see history()
+.. seealso:: addHistoryItem()
+.. seealso:: history()
 %End
 
     void addHistoryItem( const QString &text );
 %Docstring
  Adds a single history ``text`` to the end of the existing history list.
- \see history()
- \see setHistory()
+.. seealso:: history()
+.. seealso:: setHistory()
 %End
 
     QString encoding() const;
 %Docstring
  Returns the character encoding of the data in the resource. An empty string will be returned if no encoding is set.
- \see setEncoding()
+.. seealso:: setEncoding()
  :rtype: str
 %End
 
     void setEncoding( const QString &encoding );
 %Docstring
  Sets the character ``encoding`` of the data in the resource. Use an empty string if no encoding is set.
- \see encoding()
+.. seealso:: encoding()
 %End
 
 
     QgsLayerMetadata::Extent &extent();
 %Docstring
  Returns the spatial and temporal extents associated with the resource.
- \see setExtent()
+.. seealso:: setExtent()
  :rtype: QgsLayerMetadata.Extent
 %End
 
     void setExtent( const QgsLayerMetadata::Extent &extent );
 %Docstring
  Sets the spatial and temporal extents associated with the resource.
- \see setExtent()
+.. seealso:: setExtent()
 %End
 
     QgsCoordinateReferenceSystem crs() const;
@@ -474,7 +474,7 @@ class QgsLayerMetadata
  CRS which is actually used to display and manipulate the layer within QGIS.
  This may be the case when a layer has an incorrect CRS within its metadata
  and a user has manually overridden the layer's CRS within QGIS.
- \see setCrs()
+.. seealso:: setCrs()
  :rtype: QgsCoordinateReferenceSystem
 %End
 
@@ -492,7 +492,7 @@ class QgsLayerMetadata
  CRS which is actually used to display and manipulate the layer within QGIS.
  This may be the case when a layer has an incorrect CRS within its metadata
  and a user has manually overridden the layer's CRS within QGIS.
- \see setCrs()
+.. seealso:: setCrs()
 %End
 
     KeywordMap keywords() const;
@@ -504,8 +504,8 @@ class QgsLayerMetadata
  The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
  associated with keyword list.
 
- \see setKeywords()
- \see keywordVocabularies()
+.. seealso:: setKeywords()
+.. seealso:: keywordVocabularies()
  :rtype: KeywordMap
 %End
 
@@ -519,8 +519,8 @@ class QgsLayerMetadata
  The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
  associated with keyword list.
 
- \see keywords()
- \see addKeywords()
+.. seealso:: keywords()
+.. seealso:: addKeywords()
 %End
 
     void addKeywords( const QString &vocabulary, const QStringList &keywords );
@@ -532,7 +532,7 @@ class QgsLayerMetadata
  The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
  associated with keyword list.
 
- \see setKeywords()
+.. seealso:: setKeywords()
 %End
 
     QStringList keywordVocabularies() const;
@@ -542,7 +542,7 @@ class QgsLayerMetadata
  The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
  associated with keyword list.
 
- \see keywords()
+.. seealso:: keywords()
  :rtype: list of str
 %End
 
@@ -555,14 +555,14 @@ class QgsLayerMetadata
  The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
  associated with keyword list.
 
- \see keywordVocabularies()
+.. seealso:: keywordVocabularies()
  :rtype: list of str
 %End
 
     QgsLayerMetadata::ContactList contacts() const;
 %Docstring
  Returns a list of contact persons or entities associated with the resource.
- \see setContacts()
+.. seealso:: setContacts()
  :rtype: QgsLayerMetadata.ContactList
 %End
 
@@ -570,21 +570,21 @@ class QgsLayerMetadata
 %Docstring
  Sets the list of ``contacts`` or entities associated with the resource. Any existing contacts
  will be replaced.
- \see contacts()
- \see addContact()
+.. seealso:: contacts()
+.. seealso:: addContact()
 %End
 
     void addContact( const QgsLayerMetadata::Contact &contact );
 %Docstring
  Adds an individual ``contact`` to the existing contacts.
- \see contacts()
- \see setContacts()
+.. seealso:: contacts()
+.. seealso:: setContacts()
 %End
 
     QgsLayerMetadata::LinkList links() const;
 %Docstring
  Returns a list of online resources associated with the resource.
- \see setLinks()
+.. seealso:: setLinks()
  :rtype: QgsLayerMetadata.LinkList
 %End
 
@@ -592,27 +592,27 @@ class QgsLayerMetadata
 %Docstring
  Sets the list of online resources associated with the resource. Any existing links
  will be replaced.
- \see links()
- \see addLink()
+.. seealso:: links()
+.. seealso:: addLink()
 %End
 
     void addLink( const QgsLayerMetadata::Link &link );
 %Docstring
  Adds an individual ``link`` to the existing links.
- \see links()
- \see setLinks()
+.. seealso:: links()
+.. seealso:: setLinks()
 %End
 
     void saveToLayer( QgsMapLayer *layer ) const;
 %Docstring
  Saves the metadata to a ``layer``'s custom properties (see QgsMapLayer.setCustomProperty() ).
- \see readFromLayer()
+.. seealso:: readFromLayer()
 %End
 
     void readFromLayer( const QgsMapLayer *layer );
 %Docstring
  Reads the metadata state from a ``layer``'s custom properties (see QgsMapLayer.customProperty() ).
- \see saveToLayer()
+.. seealso:: saveToLayer()
 %End
 
 };

--- a/python/core/metadata/qgslayermetadatavalidator.sip
+++ b/python/core/metadata/qgslayermetadatavalidator.sip
@@ -1,0 +1,96 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/metadata/qgslayermetadatavalidator.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsMetadataValidator
+{
+%Docstring
+ Abstract base class for metadata validators.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgslayermetadatavalidator.h"
+%End
+  public:
+
+    struct ValidationResult
+    {
+
+      ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() );
+%Docstring
+ Constructor for ValidationResult.
+%End
+
+      QString section;
+%Docstring
+Metadata section which failed the validation
+%End
+
+      QVariant identifier;
+%Docstring
+ Optional identifier for the failed metadata item.
+ For instance, in list type metadata elements this
+ will be set to the list index of the failed metadata
+ item.
+%End
+
+      QString note;
+%Docstring
+The reason behind the validation failure.
+%End
+    };
+
+    virtual ~QgsMetadataValidator();
+
+    virtual bool validate( const QgsLayerMetadata &metadata, QList< QgsMetadataValidator::ValidationResult > &results /Out/ ) const = 0;
+%Docstring
+ Validates a ``metadata`` object, and returns true if the
+ metadata is considered valid.
+ If validation fails, the ``results`` list will be filled with a list of
+ items describing why the validation failed and what needs to be rectified
+ to fix the metadata.
+ :rtype: bool
+%End
+
+};
+
+
+
+class QgsNativeMetadataValidator : QgsMetadataValidator
+{
+%Docstring
+ A validator for the native QGIS metadata schema definition.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgslayermetadatavalidator.h"
+%End
+  public:
+
+    QgsNativeMetadataValidator();
+%Docstring
+ Constructor for QgsNativeMetadataValidator.
+%End
+
+    virtual bool validate( const QgsLayerMetadata &metadata, QList< QgsMetadataValidator::ValidationResult > &results /Out/ ) const;
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/metadata/qgslayermetadatavalidator.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/metadata/qgslayermetadatavalidator.sip
+++ b/python/core/metadata/qgslayermetadatavalidator.sip
@@ -85,6 +85,7 @@ class QgsNativeMetadataValidator : QgsMetadataValidator
 
     virtual bool validate( const QgsLayerMetadata &metadata, QList< QgsMetadataValidator::ValidationResult > &results /Out/ ) const;
 
+
 };
 
 /************************************************************************

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -822,8 +822,8 @@ Return pointer to layer's undo stack
 %Docstring
  Returns a reference to the layer's metadata store.
 .. versionadded:: 3.0
- \see setMetadata()
- \see metadataChanged()
+.. seealso:: setMetadata()
+.. seealso:: metadataChanged()
  :rtype: QgsLayerMetadata
 %End
 
@@ -831,8 +831,8 @@ Return pointer to layer's undo stack
 %Docstring
  Sets the layer's ``metadata`` store.
 .. versionadded:: 3.0
- \see metadata()
- \see metadataChanged()
+.. seealso:: metadata()
+.. seealso:: metadataChanged()
 %End
 
     virtual QString htmlMetadata() const;
@@ -1010,8 +1010,8 @@ Signal emitted when the blend mode is changed, through QgsMapLayer.setBlendMode(
     void metadataChanged();
 %Docstring
  Emitted when the layer's metadata is changed.
- \see setMetadata()
- \see metadata()
+.. seealso:: setMetadata()
+.. seealso:: metadata()
 .. versionadded:: 3.0
 %End
 

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -829,7 +829,7 @@ Return pointer to layer's undo stack
 
     virtual void setMetadata( const QgsLayerMetadata &metadata );
 %Docstring
- Sets the layer's metadata store.
+ Sets the layer's ``metadata`` store.
 .. versionadded:: 3.0
  \see metadata()
  \see metadataChanged()

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -818,6 +818,23 @@ Return pointer to layer's undo stack
 .. seealso:: setAutoRefreshInterval()
 %End
 
+    virtual const QgsLayerMetadata &metadata() const;
+%Docstring
+ Returns a reference to the layer's metadata store.
+.. versionadded:: 3.0
+ \see setMetadata()
+ \see metadataChanged()
+ :rtype: QgsLayerMetadata
+%End
+
+    virtual void setMetadata( const QgsLayerMetadata &metadata );
+%Docstring
+ Sets the layer's metadata store.
+.. versionadded:: 3.0
+ \see metadata()
+ \see metadataChanged()
+%End
+
     virtual QString htmlMetadata() const;
 %Docstring
  Obtain a formatted HTML string containing assorted metadata for this layer.
@@ -987,6 +1004,14 @@ Signal emitted when the blend mode is changed, through QgsMapLayer.setBlendMode(
 %Docstring
  Emitted when the auto refresh interval changes.
 .. seealso:: setAutoRefreshInterval()
+.. versionadded:: 3.0
+%End
+
+    void metadataChanged();
+%Docstring
+ Emitted when the layer's metadata is changed.
+ \see setMetadata()
+ \see metadata()
 .. versionadded:: 3.0
 %End
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -991,6 +991,7 @@ INCLUDE_DIRECTORIES(
   fieldformatter
   geometry
   layertree
+  metadata
   pal
   processing
   raster

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -72,6 +72,7 @@ SET(QGIS_CORE_SRCS
   layertree/qgslayertree.cpp
 
   metadata/qgslayermetadata.cpp
+  metadata/qgslayermetadatavalidator.cpp
 
   auth/qgsauthcertutils.cpp
   auth/qgsauthconfig.cpp
@@ -858,6 +859,7 @@ SET(QGIS_CORE_HDRS
   composer/qgspaperitem.h
 
   metadata/qgslayermetadata.h
+  metadata/qgslayermetadatavalidator.h
 
   processing/qgsprocessingalgorithm.h
   processing/qgsprocessingcontext.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -71,6 +71,8 @@ SET(QGIS_CORE_SRCS
   layertree/qgslayertreeutils.cpp
   layertree/qgslayertree.cpp
 
+  metadata/qgslayermetadata.cpp
+
   auth/qgsauthcertutils.cpp
   auth/qgsauthconfig.cpp
   auth/qgsauthcrypto.cpp
@@ -854,6 +856,8 @@ SET(QGIS_CORE_HDRS
   composer/qgscomposermultiframecommand.h
   composer/qgscomposertexttable.h
   composer/qgspaperitem.h
+
+  metadata/qgslayermetadata.h
 
   processing/qgsprocessingalgorithm.h
   processing/qgsprocessingcontext.h

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -215,6 +215,7 @@ void QgsLayerMetadata::saveToLayer( QgsMapLayer *layer ) const
   layer->setCustomProperty( QStringLiteral( "metadata/language" ), mLanguage );
   layer->setCustomProperty( QStringLiteral( "metadata/type" ), mType );
   layer->setCustomProperty( QStringLiteral( "metadata/title" ), mTitle );
+  layer->setCustomProperty( QStringLiteral( "metadata/extent" ), QVariant::fromValue( mExtent ) );
   layer->setCustomProperty( QStringLiteral( "metadata/abstract" ), mAbstract );
   layer->setCustomProperty( QStringLiteral( "metadata/fees" ), mFees );
   layer->setCustomProperty( QStringLiteral( "metadata/rights" ), mRights );
@@ -243,8 +244,44 @@ void QgsLayerMetadata::readFromLayer( const QgsMapLayer *layer )
   mEncoding = layer->customProperty( QStringLiteral( "metadata/encoding" ) ).toString();
   QString crsAuthId = layer->customProperty( QStringLiteral( "metadata/crs" ) ).toString();
   mCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsAuthId );
+  mExtent = layer->customProperty( QStringLiteral( "metadata/extent" ) ).value<Extent>();
   mConstraints = layer->customProperty( QStringLiteral( "metadata/constraints" ) ).value<ConstraintList>();
   mKeywords = layer->customProperty( QStringLiteral( "metadata/keywords" ) ).value<KeywordMap>();
   mContacts = layer->customProperty( QStringLiteral( "metadata/contacts" ) ).value<ContactList>();
   mLinks = layer->customProperty( QStringLiteral( "metadata/links" ) ).value<LinkList>();
+}
+
+const QgsLayerMetadata::Extent &QgsLayerMetadata::extent() const
+{
+  return mExtent;
+}
+
+QgsLayerMetadata::Extent &QgsLayerMetadata::extent()
+{
+  return mExtent;
+}
+
+void QgsLayerMetadata::setExtent( const Extent &extent )
+{
+  mExtent = extent;
+}
+
+QList<QgsLayerMetadata::SpatialExtent> QgsLayerMetadata::Extent::spatialExtents() const
+{
+  return mSpatialExtents;
+}
+
+void QgsLayerMetadata::Extent::setSpatialExtents( const QList<QgsLayerMetadata::SpatialExtent> &spatialExtents )
+{
+  mSpatialExtents = spatialExtents;
+}
+
+QList<QgsDateTimeRange> QgsLayerMetadata::Extent::temporalExtents() const
+{
+  return mTemporalExtents;
+}
+
+void QgsLayerMetadata::Extent::setTemporalExtents( const QList<QgsDateTimeRange> &temporalExtents )
+{
+  mTemporalExtents = temporalExtents;
 }

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -98,6 +98,16 @@ void QgsLayerMetadata::setRights( const QStringList &rights )
   mRights = rights;
 }
 
+QStringList QgsLayerMetadata::licenses() const
+{
+  return mLicenses;
+}
+
+void QgsLayerMetadata::setLicenses( const QStringList &licenses )
+{
+  mLicenses = licenses;
+}
+
 QString QgsLayerMetadata::encoding() const
 {
   return mEncoding;
@@ -193,6 +203,7 @@ void QgsLayerMetadata::saveToLayer( QgsMapLayer *layer ) const
   layer->setCustomProperty( QStringLiteral( "metadata/abstract" ), mAbstract );
   layer->setCustomProperty( QStringLiteral( "metadata/fees" ), mFees );
   layer->setCustomProperty( QStringLiteral( "metadata/rights" ), mRights );
+  layer->setCustomProperty( QStringLiteral( "metadata/licenses" ), mLicenses );
   layer->setCustomProperty( QStringLiteral( "metadata/encoding" ), mEncoding );
   layer->setCustomProperty( QStringLiteral( "metadata/crs" ), mCrs.authid() );
   layer->setCustomProperty( QStringLiteral( "metadata/constraints" ), QVariant::fromValue( mConstraints ) );
@@ -211,6 +222,7 @@ void QgsLayerMetadata::readFromLayer( const QgsMapLayer *layer )
   mAbstract = layer->customProperty( QStringLiteral( "metadata/abstract" ) ).toString();
   mFees = layer->customProperty( QStringLiteral( "metadata/fees" ) ).toString();
   mRights = layer->customProperty( QStringLiteral( "metadata/rights" ) ).toStringList();
+  mLicenses = layer->customProperty( QStringLiteral( "metadata/licenses" ) ).toStringList();
   mEncoding = layer->customProperty( QStringLiteral( "metadata/encoding" ) ).toString();
   QString crsAuthId = layer->customProperty( QStringLiteral( "metadata/crs" ) ).toString();
   mCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsAuthId );

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgslayermetadata.h"
+#include "qgsmaplayer.h"
 
 QString QgsLayerMetadata::identifier() const
 {
@@ -180,4 +181,41 @@ QString QgsLayerMetadata::language() const
 void QgsLayerMetadata::setLanguage( const QString &language )
 {
   mLanguage = language;
+}
+
+void QgsLayerMetadata::saveToLayer( QgsMapLayer *layer ) const
+{
+  layer->setCustomProperty( QStringLiteral( "metadata/identifier" ), mIdentifier );
+  layer->setCustomProperty( QStringLiteral( "metadata/parentIdentifier" ), mParentIdentifier );
+  layer->setCustomProperty( QStringLiteral( "metadata/language" ), mLanguage );
+  layer->setCustomProperty( QStringLiteral( "metadata/type" ), mType );
+  layer->setCustomProperty( QStringLiteral( "metadata/title" ), mTitle );
+  layer->setCustomProperty( QStringLiteral( "metadata/abstract" ), mAbstract );
+  layer->setCustomProperty( QStringLiteral( "metadata/fees" ), mFees );
+  layer->setCustomProperty( QStringLiteral( "metadata/rights" ), mRights );
+  layer->setCustomProperty( QStringLiteral( "metadata/encoding" ), mEncoding );
+  layer->setCustomProperty( QStringLiteral( "metadata/crs" ), mCrs.authid() );
+  layer->setCustomProperty( QStringLiteral( "metadata/constraints" ), QVariant::fromValue( mConstraints ) );
+  layer->setCustomProperty( QStringLiteral( "metadata/keywords" ), QVariant::fromValue( mKeywords ) );
+  layer->setCustomProperty( QStringLiteral( "metadata/contacts" ), QVariant::fromValue( mContacts ) );
+  layer->setCustomProperty( QStringLiteral( "metadata/links" ), QVariant::fromValue( mLinks ) );
+}
+
+void QgsLayerMetadata::readFromLayer( const QgsMapLayer *layer )
+{
+  mIdentifier = layer->customProperty( QStringLiteral( "metadata/identifier" ) ).toString();
+  mParentIdentifier = layer->customProperty( QStringLiteral( "metadata/parentIdentifier" ) ).toString();
+  mLanguage = layer->customProperty( QStringLiteral( "metadata/language" ) ).toString();
+  mType = layer->customProperty( QStringLiteral( "metadata/type" ) ).toString();
+  mTitle = layer->customProperty( QStringLiteral( "metadata/title" ) ).toString();
+  mAbstract = layer->customProperty( QStringLiteral( "metadata/abstract" ) ).toString();
+  mFees = layer->customProperty( QStringLiteral( "metadata/fees" ) ).toString();
+  mRights = layer->customProperty( QStringLiteral( "metadata/rights" ) ).toStringList();
+  mEncoding = layer->customProperty( QStringLiteral( "metadata/encoding" ) ).toString();
+  QString crsAuthId = layer->customProperty( QStringLiteral( "metadata/crs" ) ).toString();
+  mCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsAuthId );
+  mConstraints = layer->customProperty( QStringLiteral( "metadata/constraints" ) ).value<ConstraintList>();
+  mKeywords = layer->customProperty( QStringLiteral( "metadata/keywords" ) ).value<KeywordMap>();
+  mContacts = layer->customProperty( QStringLiteral( "metadata/contacts" ) ).value<ContactList>();
+  mLinks = layer->customProperty( QStringLiteral( "metadata/links" ) ).value<LinkList>();
 }

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -1,0 +1,108 @@
+/***************************************************************************
+                             qgslayermetadata.cpp
+                             --------------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayermetadata.h"
+
+QString QgsLayerMetadata::identifier() const
+{
+  return mIdentifier;
+}
+
+void QgsLayerMetadata::setIdentifier( const QString &identifier )
+{
+  mIdentifier = identifier;
+}
+
+QString QgsLayerMetadata::parentIdentifier() const
+{
+  return mParentIdentifier;
+}
+
+void QgsLayerMetadata::setParentIdentifier( const QString &parentIdentifier )
+{
+  mParentIdentifier = parentIdentifier;
+}
+
+QString QgsLayerMetadata::type() const
+{
+  return mType;
+}
+
+void QgsLayerMetadata::setType( const QString &type )
+{
+  mType = type;
+}
+
+QString QgsLayerMetadata::title() const
+{
+  return mTitle;
+}
+
+void QgsLayerMetadata::setTitle( const QString &title )
+{
+  mTitle = title;
+}
+
+QString QgsLayerMetadata::abstract() const
+{
+  return mAbstract;
+}
+
+void QgsLayerMetadata::setAbstract( const QString &abstract )
+{
+  mAbstract = abstract;
+}
+
+QString QgsLayerMetadata::fees() const
+{
+  return mFees;
+}
+
+void QgsLayerMetadata::setFees( const QString &fees )
+{
+  mFees = fees;
+}
+
+QStringList QgsLayerMetadata::constraints() const
+{
+  return mConstraints;
+}
+
+void QgsLayerMetadata::setConstraints( const QStringList &constraints )
+{
+  mConstraints = constraints;
+}
+
+QStringList QgsLayerMetadata::rights() const
+{
+  return mRights;
+}
+
+void QgsLayerMetadata::setRights( const QStringList &rights )
+{
+  mRights = rights;
+}
+
+QString QgsLayerMetadata::encoding() const
+{
+  return mEncoding;
+}
+
+void QgsLayerMetadata::setEncoding( const QString &encoding )
+{
+  mEncoding = encoding;
+}

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -108,6 +108,21 @@ void QgsLayerMetadata::setLicenses( const QStringList &licenses )
   mLicenses = licenses;
 }
 
+QStringList QgsLayerMetadata::history() const
+{
+  return mHistory;
+}
+
+void QgsLayerMetadata::setHistory( const QStringList &history )
+{
+  mHistory = history;
+}
+
+void QgsLayerMetadata::addHistoryItem( const QString &text )
+{
+  mHistory << text;
+}
+
 QString QgsLayerMetadata::encoding() const
 {
   return mEncoding;
@@ -204,6 +219,7 @@ void QgsLayerMetadata::saveToLayer( QgsMapLayer *layer ) const
   layer->setCustomProperty( QStringLiteral( "metadata/fees" ), mFees );
   layer->setCustomProperty( QStringLiteral( "metadata/rights" ), mRights );
   layer->setCustomProperty( QStringLiteral( "metadata/licenses" ), mLicenses );
+  layer->setCustomProperty( QStringLiteral( "metadata/history" ), mHistory );
   layer->setCustomProperty( QStringLiteral( "metadata/encoding" ), mEncoding );
   layer->setCustomProperty( QStringLiteral( "metadata/crs" ), mCrs.authid() );
   layer->setCustomProperty( QStringLiteral( "metadata/constraints" ), QVariant::fromValue( mConstraints ) );
@@ -223,6 +239,7 @@ void QgsLayerMetadata::readFromLayer( const QgsMapLayer *layer )
   mFees = layer->customProperty( QStringLiteral( "metadata/fees" ) ).toString();
   mRights = layer->customProperty( QStringLiteral( "metadata/rights" ) ).toStringList();
   mLicenses = layer->customProperty( QStringLiteral( "metadata/licenses" ) ).toStringList();
+  mHistory = layer->customProperty( QStringLiteral( "metadata/history" ) ).toStringList();
   mEncoding = layer->customProperty( QStringLiteral( "metadata/encoding" ) ).toString();
   QString crsAuthId = layer->customProperty( QStringLiteral( "metadata/crs" ) ).toString();
   mCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsAuthId );

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -77,12 +77,12 @@ void QgsLayerMetadata::setFees( const QString &fees )
   mFees = fees;
 }
 
-QStringList QgsLayerMetadata::constraints() const
+QList<QgsLayerMetadata::Constraint> QgsLayerMetadata::constraints() const
 {
   return mConstraints;
 }
 
-void QgsLayerMetadata::setConstraints( const QStringList &constraints )
+void QgsLayerMetadata::setConstraints( const QList<Constraint> &constraints )
 {
   mConstraints = constraints;
 }
@@ -105,4 +105,79 @@ QString QgsLayerMetadata::encoding() const
 void QgsLayerMetadata::setEncoding( const QString &encoding )
 {
   mEncoding = encoding;
+}
+
+QgsCoordinateReferenceSystem QgsLayerMetadata::crs() const
+{
+  return mCrs;
+}
+
+void QgsLayerMetadata::setCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  mCrs = crs;
+}
+
+QMap<QString, QStringList> QgsLayerMetadata::keywords() const
+{
+  return mKeywords;
+}
+
+void QgsLayerMetadata::setKeywords( const QMap<QString, QStringList> &keywords )
+{
+  mKeywords = keywords;
+}
+
+void QgsLayerMetadata::addKeywords( const QString &vocabulary, const QStringList &keywords )
+{
+  mKeywords.insert( vocabulary, keywords );
+}
+
+QStringList QgsLayerMetadata::keywordVocabularies() const
+{
+  return mKeywords.keys();
+}
+
+QStringList QgsLayerMetadata::keywords( const QString &vocabulary ) const
+{
+  return mKeywords.value( vocabulary );
+}
+
+QList<QgsLayerMetadata::Contact> QgsLayerMetadata::contacts() const
+{
+  return mContacts;
+}
+
+void QgsLayerMetadata::setContacts( const QList<Contact> &contacts )
+{
+  mContacts = contacts;
+}
+
+void QgsLayerMetadata::addContact( const QgsLayerMetadata::Contact &contact )
+{
+  mContacts << contact;
+}
+
+QList<QgsLayerMetadata::Link> QgsLayerMetadata::links() const
+{
+  return mLinks;
+}
+
+void QgsLayerMetadata::setLinks( const QList<QgsLayerMetadata::Link> &links )
+{
+  mLinks = links;
+}
+
+void QgsLayerMetadata::addLink( const QgsLayerMetadata::Link &link )
+{
+  mLinks << link;
+}
+
+QString QgsLayerMetadata::language() const
+{
+  return mLanguage;
+}
+
+void QgsLayerMetadata::setLanguage( const QString &language )
+{
+  mLanguage = language;
 }

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+                             qgslayermetadata.h
+                             -------------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERMETADATA_H
+#define QGSLAYERMETADATA_H
+
+#include "qgis.h"
+#include "qgis_core.h"
+
+class CORE_EXPORT QgsLayerMetadata
+{
+  public:
+
+    QgsLayerMetadata() = default;
+
+    virtual ~QgsLayerMetadata() = default;
+
+
+    QString identifier() const;
+    void setIdentifier( const QString &identifier );
+
+    /**
+     * Returns an empty string if no parent identifier is set.
+     */
+    QString parentIdentifier() const;
+
+
+    void setParentIdentifier( const QString &parentIdentifier );
+
+    QString type() const;
+    void setType( const QString &type );
+
+    QString title() const;
+    void setTitle( const QString &title );
+
+    QString abstract() const;
+    void setAbstract( const QString &abstract );
+
+    /**
+     * Returns an empty string if no fees are set.
+     */
+    QString fees() const;
+    void setFees( const QString &fees );
+
+    QStringList constraints() const;
+    void setConstraints( const QStringList &constraints );
+
+    QStringList rights() const;
+    void setRights( const QStringList &rights );
+
+    /**
+     * Returns an empty string if no encoding is set.
+     */
+    QString encoding() const;
+    void setEncoding( const QString &encoding );
+
+  private:
+
+    QString mIdentifier;
+    QString mParentIdentifier;
+    QString mType;
+    QString mTitle;
+    QString mAbstract;
+    QString mFees;
+    QStringList mConstraints;
+    QStringList mRights;
+    QString mEncoding;
+
+
+
+};
+
+#endif // QGSLAYERMETADATA_H

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -383,6 +383,19 @@ class CORE_EXPORT QgsLayerMetadata
     void setRights( const QStringList &rights );
 
     /**
+     * Returns a list of licenses associated with the resource (examples: http://opendefinition.org/licenses/).
+     * \see setLicenses()
+     */
+    QStringList licenses() const;
+
+    /**
+     * Sets a list of \a licenses associated with the resource.
+     * (examples: http://opendefinition.org/licenses/).
+     * \see licenses()
+     */
+    void setLicenses( const QStringList &licenses );
+
+    /**
      * Returns the character encoding of the data in the resource. An empty string will be returned if no encoding is set.
      * \see setEncoding()
      */
@@ -558,6 +571,7 @@ class CORE_EXPORT QgsLayerMetadata
     QString mFees;
     ConstraintList mConstraints;
     QStringList mRights;
+    QStringList mLicenses;
 
     // IMPORTANT - look up before adding anything here!!
 

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -80,8 +80,6 @@ class CORE_EXPORT QgsLayerMetadata
     QStringList mRights;
     QString mEncoding;
 
-
-
 };
 
 #endif // QGSLAYERMETADATA_H

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -22,6 +22,8 @@
 #include "qgis_core.h"
 #include "qgscoordinatereferencesystem.h"
 
+class QgsMapLayer;
+
 /**
  * \ingroup core
  * \class QgsLayerMetadata
@@ -49,6 +51,11 @@ class CORE_EXPORT QgsLayerMetadata
   public:
 
     /**
+     * Map of vocabulary string to keyword list.
+     */
+    typedef QMap< QString, QStringList > KeywordMap;
+
+    /**
      * Metadata constraint structure.
      */
     struct Constraint
@@ -73,6 +80,12 @@ class CORE_EXPORT QgsLayerMetadata
        */
       QString constraint;
     };
+
+    /**
+     * A list of constraints.
+     */
+    typedef QList< QgsLayerMetadata::Constraint > ConstraintList;
+
 
     /**
      * Metadata address structure.
@@ -181,6 +194,12 @@ class CORE_EXPORT QgsLayerMetadata
     };
 
     /**
+     * A list of contacts.
+     */
+    typedef QList< QgsLayerMetadata::Contact > ContactList;
+
+
+    /**
      * Metadata link structure.
      */
     struct Link
@@ -231,6 +250,11 @@ class CORE_EXPORT QgsLayerMetadata
        */
       QString size;
     };
+
+    /**
+     * A list of links.
+     */
+    typedef QList< QgsLayerMetadata::Link > LinkList;
 
     /**
      * Constructor for QgsLayerMetadata.
@@ -338,13 +362,13 @@ class CORE_EXPORT QgsLayerMetadata
      * Returns a list of constraints associated with using the resource.
      * \see setConstraints()
      */
-    QList< QgsLayerMetadata::Constraint > constraints() const;
+    QgsLayerMetadata::ConstraintList constraints() const;
 
     /**
      * Sets the list of \a constraints associated with using the resource.
      * \see constraints()
      */
-    void setConstraints( const QList<QgsLayerMetadata::Constraint> &constraints );
+    void setConstraints( const QgsLayerMetadata::ConstraintList &constraints );
 
     /**
      * Returns a list of attribution or copyright strings associated with the resource.
@@ -411,7 +435,7 @@ class CORE_EXPORT QgsLayerMetadata
      * \see setKeywords()
      * \see keywordVocabularies()
      */
-    QMap<QString, QStringList> keywords() const;
+    KeywordMap keywords() const;
 
     /**
      * Sets the \a keywords map, which is a set of descriptive keywords associated with the resource.
@@ -425,7 +449,7 @@ class CORE_EXPORT QgsLayerMetadata
      * \see keywords()
      * \see addKeywords()
      */
-    void setKeywords( const QMap<QString, QStringList> &keywords );
+    void setKeywords( const KeywordMap &keywords );
 
     /**
      * Adds a list of descriptive \a keywords for a specified \a vocabulary. Any existing
@@ -465,7 +489,7 @@ class CORE_EXPORT QgsLayerMetadata
      * Returns a list of contact persons or entities associated with the resource.
      * \see setContacts()
      */
-    QList<QgsLayerMetadata::Contact> contacts() const;
+    QgsLayerMetadata::ContactList contacts() const;
 
     /**
      * Sets the list of \a contacts or entities associated with the resource. Any existing contacts
@@ -473,7 +497,7 @@ class CORE_EXPORT QgsLayerMetadata
      * \see contacts()
      * \see addContact()
      */
-    void setContacts( const QList<QgsLayerMetadata::Contact> &contacts );
+    void setContacts( const QgsLayerMetadata::ContactList &contacts );
 
     /**
      * Adds an individual \a contact to the existing contacts.
@@ -486,7 +510,7 @@ class CORE_EXPORT QgsLayerMetadata
      * Returns a list of online resources associated with the resource.
      * \see setLinks()
      */
-    QList<QgsLayerMetadata::Link> links() const;
+    QgsLayerMetadata::LinkList links() const;
 
     /**
      * Sets the list of online resources associated with the resource. Any existing links
@@ -494,7 +518,7 @@ class CORE_EXPORT QgsLayerMetadata
      * \see links()
      * \see addLink()
      */
-    void setLinks( const QList<QgsLayerMetadata::Link> &links );
+    void setLinks( const QgsLayerMetadata::LinkList &links );
 
     /**
      * Adds an individual \a link to the existing links.
@@ -502,6 +526,18 @@ class CORE_EXPORT QgsLayerMetadata
      * \see setLinks()
      */
     void addLink( const QgsLayerMetadata::Link &link );
+
+    /**
+     * Saves the metadata to a \a layer's custom properties (see QgsMapLayer::setCustomProperty() ).
+     * \see readFromLayer()
+     */
+    void saveToLayer( QgsMapLayer *layer ) const;
+
+    /**
+     * Reads the metadata state from a \a layer's custom properties (see QgsMapLayer::customProperty() ).
+     * \see saveToLayer()
+     */
+    void readFromLayer( const QgsMapLayer *layer );
 
   private:
 
@@ -520,7 +556,7 @@ class CORE_EXPORT QgsLayerMetadata
     QString mTitle;
     QString mAbstract;
     QString mFees;
-    QList<QgsLayerMetadata::Constraint> mConstraints;
+    ConstraintList mConstraints;
     QStringList mRights;
 
     // IMPORTANT - look up before adding anything here!!
@@ -531,11 +567,11 @@ class CORE_EXPORT QgsLayerMetadata
     /**
      * Keywords map. Key is the vocabulary, value is a list of keywords for that vocabulary.
      */
-    QMap< QString, QStringList > mKeywords;
+    KeywordMap mKeywords;
 
-    QList< Contact > mContacts;
+    ContactList mContacts;
 
-    QList< Link > mLinks;
+    LinkList mLinks;
 
     /*
      * IMPORTANT!!!!!!
@@ -546,5 +582,12 @@ class CORE_EXPORT QgsLayerMetadata
      */
 
 };
+
+Q_DECLARE_METATYPE( QgsLayerMetadata::KeywordMap )
+Q_DECLARE_METATYPE( QgsLayerMetadata::ConstraintList )
+Q_DECLARE_METATYPE( QgsLayerMetadata::ContactList )
+Q_DECLARE_METATYPE( QgsLayerMetadata::LinkList )
+
+
 
 #endif // QGSLAYERMETADATA_H

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -44,6 +44,10 @@ class QgsMapLayer;
  * the schema definition available at resources/qgis-resource-metadata.xsd
  * within the QGIS source code.
  *
+ * Metadata can be validated through the use of QgsLayerMetadataValidator
+ * subclasses. E.g. validating against the native QGIS metadata schema can be performed
+ * using QgsNativeMetadataValidator.
+ *
  * \since QGIS 3.0
  */
 class CORE_EXPORT QgsLayerMetadata

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -396,6 +396,27 @@ class CORE_EXPORT QgsLayerMetadata
     void setLicenses( const QStringList &licenses );
 
     /**
+     * Returns a freeform description of the history or lineage of the resource.
+     * \see setHistory()
+     */
+    QStringList history() const;
+
+    /**
+     * Sets the freeform description of the \a history or lineage of the resource.
+     * Any existing history items will be overwritten.
+     * \see addHistoryItem()
+     * \see history()
+     */
+    void setHistory( const QStringList &history );
+
+    /**
+     * Adds a single history \a text to the end of the existing history list.
+     * \see history()
+     * \see setHistory()
+     */
+    void addHistoryItem( const QString &text );
+
+    /**
      * Returns the character encoding of the data in the resource. An empty string will be returned if no encoding is set.
      * \see setEncoding()
      */
@@ -572,6 +593,7 @@ class CORE_EXPORT QgsLayerMetadata
     ConstraintList mConstraints;
     QStringList mRights;
     QStringList mLicenses;
+    QStringList mHistory;
 
     // IMPORTANT - look up before adding anything here!!
 

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -20,65 +20,530 @@
 
 #include "qgis.h"
 #include "qgis_core.h"
+#include "qgscoordinatereferencesystem.h"
 
+/**
+ * \ingroup core
+ * \class QgsLayerMetadata
+ * \brief A structured metadata store for a map layer.
+ *
+ * QgsLayerMetadata handles storage and management of the metadata
+ * for a QgsMapLayer. This class is an internal QGIS format with a common
+ * metadata structure, which allows for code to access the metadata properties for
+ * layers in a uniform way.
+ *
+ * The metadata store is designed to be compatible with the Dublin Core metadata
+ * specifications, and will be expanded to allow compatibility with ISO specifications
+ * in future releases. However, the QGIS internal schema does not represent a superset
+ * of all existing metadata schemas and accordingly conversion from specific
+ * metadata formats to QgsLayerMetadata may result in a loss of information.
+ *
+ * This class is designed to follow the specifications detailed in
+ * the schema definition available at resources/qgis-resource-metadata.xsd
+ * within the QGIS source code.
+ *
+ * \since QGIS 3.0
+ */
 class CORE_EXPORT QgsLayerMetadata
 {
   public:
 
+    /**
+     * Metadata constraint structure.
+     */
+    struct Constraint
+    {
+
+      /**
+       * Constructor for Constraint.
+       */
+      Constraint( const QString &constraint = QString(), const QString &type = QString() )
+        : type( type )
+        , constraint( constraint )
+      {}
+
+      /**
+       * Constraint type. Standard values include 'access' and 'other', however any
+       * string can be used for the type.
+       */
+      QString type;
+
+      /**
+       * Free-form constraint string.
+       */
+      QString constraint;
+    };
+
+    /**
+     * Metadata address structure.
+     */
+    struct Address
+    {
+
+      /**
+       * Constructor for Address.
+       */
+      Address( const QString &type = QString(), const QString &address = QString(), const QString &city = QString(), const QString &administrativeArea = QString(), const QString &postalCode = QString(), const QString &country = QString() )
+        : type( type )
+        , address( address )
+        , city( city )
+        , administrativeArea( administrativeArea )
+        , postalCode( postalCode )
+        , country( country )
+      {}
+
+      /**
+       * Type of address, e.g. 'postal'.
+       */
+      QString type;
+
+      /**
+       * Free-form physical address component, e.g. '221B Baker St' or 'P.O. Box 196'.
+       */
+      QString address;
+
+      /**
+       * City or locality name.
+       */
+      QString city;
+
+      /**
+       * Administrative area (state, provice/territory, etc.).
+       */
+      QString administrativeArea;
+
+      /**
+       * Postal (or ZIP) code.
+       */
+      QString postalCode;
+
+      /**
+       * Free-form country string.
+       */
+      QString country;
+    };
+
+    /**
+     * Metadata contact structure.
+     */
+    struct Contact
+    {
+
+      /**
+       * Constructor for Contact.
+       */
+      Contact( const QString &name = QString() )
+        : name( name )
+      {}
+
+      /**
+       * Name of contact.
+       */
+      QString name;
+
+      /**
+       * Organization contact belongs to/represents.
+       */
+      QString organization;
+
+      /**
+       * Position/title of contact.
+       */
+      QString position;
+
+      /**
+       * List of addresses associated with this contact.
+       */
+      QList< QgsLayerMetadata::Address > addresses;
+
+      /**
+       * Voice telephone.
+       */
+      QString voice;
+
+      /**
+       * Facsimile telephone.
+       */
+      QString fax;
+
+      /**
+       * Electronic mail address.
+       * \note Do not include mailto: protocol as part of the email address.
+       */
+      QString email;
+
+      /**
+       * Role of contact. Acceptable values are those from the ISO 19115 CI_RoleCode specifications
+       * (see http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml).
+       * E.g. 'custodian', 'owner', 'distributor', etc.
+       */
+      QString role;
+    };
+
+    /**
+     * Metadata link structure.
+     */
+    struct Link
+    {
+
+      /**
+       * Constructor for Link.
+       */
+      Link( const QString &name = QString(), const QString &type = QString(), const QString &url = QString() )
+        : name( name )
+        , type( type )
+        , url( url )
+      {}
+
+      /**
+       * Short link name. E.g. WMS layer name.
+       */
+      QString name;
+
+      /**
+       * Link type. It is strongly suggested to use values from the 'identifier'
+       * column in https://github.com/OSGeo/Cat-Interop/blob/master/LinkPropertyLookupTable.csv
+       */
+      QString type;
+
+      /**
+       * Abstract text about link.
+       */
+      QString description;
+
+      /**
+       * Link url.  If the URL is an OWS server, specify the *base* URL only without parameters like service=xxx....
+       */
+      QString url;
+
+      /**
+       * Format specification of online resource. It is strongly suggested to use GDAL/OGR format values.
+       */
+      QString format;
+
+      /**
+       * MIME type representative of the online resource response (image/png, application/json, etc.)
+       */
+      QString mimeType;
+
+      /**
+       * Estimated size (in bytes) of the online resource response.
+       */
+      QString size;
+    };
+
+    /**
+     * Constructor for QgsLayerMetadata.
+     */
     QgsLayerMetadata() = default;
 
     virtual ~QgsLayerMetadata() = default;
 
-
+    /**
+     * A reference, URI, URL or some other mechanism to identify the resource.
+     * \see setIdentifier()
+     */
     QString identifier() const;
+
+    /**
+     * Sets the reference, URI, URL or some other mechanism to identify the resource.
+     * \see identifier()
+     */
     void setIdentifier( const QString &identifier );
 
     /**
+     * A reference, URI, URL or some other mechanism to identify the parent resource that this resource is a part (child) of.
      * Returns an empty string if no parent identifier is set.
+     * \see setParentIdentifier()
      */
     QString parentIdentifier() const;
 
-
+    /**
+     * Sets a reference, URI, URL or some other mechanism to identify the parent resource that this resource is a part (child) of.
+     * Set an empty string if no parent identifier is required.
+     * \see parentIdentifier()
+     */
     void setParentIdentifier( const QString &parentIdentifier );
 
+    /**
+     * Returns the human language associated with the resource. Usually the returned string
+     * will follow either the ISO 639.2 or ISO 3166 specifications, e.g. 'ENG' or 'SPA', however
+     * this is not a hard requirement and the caller must account for non compliant
+     * values.
+     * \see setLanguage()
+     */
+    QString language() const;
+
+    /**
+     * Sets the human \a language associated with the resource. While a formal vocabulary is not imposed,
+     * ideally values should be taken from the ISO 639.2 or ISO 3166 specifications,
+     * e.g. 'ENG' or 'SPA' (ISO 639.2) or 'EN-AU' (ISO 3166).
+     * \see language()
+     */
+    void setLanguage( const QString &language );
+
+    /**
+     * Returns the nature of the resource.  While a formal vocabulary is not imposed, it is advised
+     * to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
+     * \see setType()
+     */
     QString type() const;
+
+    /**
+     * Sets the \a type (nature) of the resource.  While a formal vocabulary is not imposed, it is advised
+     * to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
+     * \see type()
+     */
     void setType( const QString &type );
 
+    /**
+     * Returns the human readable name of the resource, typically displayed in search results.
+     * \see setTitle()
+     */
     QString title() const;
+
+    /**
+     * Sets the human readable \a title (name) of the resource, typically displayed in search results.
+     * \see title()
+     */
     void setTitle( const QString &title );
 
+    /**
+     * Returns a free-form description of the resource.
+     * \see setAbstract()
+     */
     QString abstract() const;
+
+    /**
+     * Sets a free-form \a abstract (description) of the resource.
+     * \see abstract()
+     */
     void setAbstract( const QString &abstract );
 
     /**
-     * Returns an empty string if no fees are set.
+     * Returns any fees associated with using the resource.
+     * An empty string will be returned if no fees are set.
+     * \see setFees()
      */
     QString fees() const;
+
+    /**
+     * Sets the \a fees associated with using the resource.
+     * Use an empty string if no fees are set.
+     * \see fees()
+     */
     void setFees( const QString &fees );
 
-    QStringList constraints() const;
-    void setConstraints( const QStringList &constraints );
+    /**
+     * Returns a list of constraints associated with using the resource.
+     * \see setConstraints()
+     */
+    QList< QgsLayerMetadata::Constraint > constraints() const;
 
+    /**
+     * Sets the list of \a constraints associated with using the resource.
+     * \see constraints()
+     */
+    void setConstraints( const QList<QgsLayerMetadata::Constraint> &constraints );
+
+    /**
+     * Returns a list of attribution or copyright strings associated with the resource.
+     * \see setRights()
+     */
     QStringList rights() const;
+
+    /**
+     * Sets a list of \a rights (attribution or copyright strings) associated with the resource.
+     * \see rights()
+     */
     void setRights( const QStringList &rights );
 
     /**
-     * Returns an empty string if no encoding is set.
+     * Returns the character encoding of the data in the resource. An empty string will be returned if no encoding is set.
+     * \see setEncoding()
      */
     QString encoding() const;
+
+    /**
+     * Sets the character \a encoding of the data in the resource. Use an empty string if no encoding is set.
+     * \see encoding()
+     */
     void setEncoding( const QString &encoding );
+
+    /**
+     * Returns the coordinate reference system described by the layer's metadata.
+     *
+     * Note that this has no link to QgsMapLayer::crs(). While in most cases these
+     * two systems are likely to be identical, it is possible to have a layer
+     * with a different CRS described by it's accompanying metadata versus the
+     * CRS which is actually used to display and manipulate the layer within QGIS.
+     * This may be the case when a layer has an incorrect CRS within its metadata
+     * and a user has manually overridden the layer's CRS within QGIS.
+     * \see setCrs()
+     */
+    QgsCoordinateReferenceSystem crs() const;
+
+    /**
+     * Sets the coordinate reference system for the layer's metadata.
+     *
+     * Note that this has no link to QgsMapLayer::setCrs(). Setting the layer's
+     * CRS via QgsMapLayer::setCrs() does not affect the layer's metadata CRS,
+     * and changing the CRS from the metadata will not change the layer's
+     * CRS or how it is projected within QGIS.
+     *
+     * While ideally these two systems are likely to be identical, it is possible to have a layer
+     * with a different CRS described by it's accompanying metadata versus the
+     * CRS which is actually used to display and manipulate the layer within QGIS.
+     * This may be the case when a layer has an incorrect CRS within its metadata
+     * and a user has manually overridden the layer's CRS within QGIS.
+     * \see setCrs()
+     */
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Returns the keywords map, which is a set of descriptive keywords associated with the resource.
+     *
+     * The map key is the vocabulary string and map value is a list of keywords for that vocabulary.
+     *
+     * The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+     * associated with keyword list.
+     *
+     * \see setKeywords()
+     * \see keywordVocabularies()
+     */
+    QMap<QString, QStringList> keywords() const;
+
+    /**
+     * Sets the \a keywords map, which is a set of descriptive keywords associated with the resource.
+     *
+     * The map key is the vocabulary string and map value is a list of keywords for that vocabulary.
+     * Calling this replaces any existing keyword vocabularies.
+     *
+     * The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+     * associated with keyword list.
+     *
+     * \see keywords()
+     * \see addKeywords()
+     */
+    void setKeywords( const QMap<QString, QStringList> &keywords );
+
+    /**
+     * Adds a list of descriptive \a keywords for a specified \a vocabulary. Any existing
+     * keywords for the same vocabulary will be replaced. Other vocabularies
+     * will not be affected.
+     *
+     * The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+     * associated with keyword list.
+     *
+     * \see setKeywords()
+     */
+    void addKeywords( const QString &vocabulary, const QStringList &keywords );
+
+    /**
+     * Returns a list of keyword vocabularies contained in the metadata.
+     *
+     * The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+     * associated with keyword list.
+     *
+     * \see keywords()
+     */
+    QStringList keywordVocabularies() const;
+
+    /**
+     * Returns a list of keywords for the specified \a vocabulary.
+     * If the vocabulary is not contained in the metadata, an empty
+     * list will be returned.
+     *
+     * The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
+     * associated with keyword list.
+     *
+     * \see keywordVocabularies()
+     */
+    QStringList keywords( const QString &vocabulary ) const;
+
+    /**
+     * Returns a list of contact persons or entities associated with the resource.
+     * \see setContacts()
+     */
+    QList<QgsLayerMetadata::Contact> contacts() const;
+
+    /**
+     * Sets the list of \a contacts or entities associated with the resource. Any existing contacts
+     * will be replaced.
+     * \see contacts()
+     * \see addContact()
+     */
+    void setContacts( const QList<QgsLayerMetadata::Contact> &contacts );
+
+    /**
+     * Adds an individual \a contact to the existing contacts.
+     * \see contacts()
+     * \see setContacts()
+     */
+    void addContact( const QgsLayerMetadata::Contact &contact );
+
+    /**
+     * Returns a list of online resources associated with the resource.
+     * \see setLinks()
+     */
+    QList<QgsLayerMetadata::Link> links() const;
+
+    /**
+     * Sets the list of online resources associated with the resource. Any existing links
+     * will be replaced.
+     * \see links()
+     * \see addLink()
+     */
+    void setLinks( const QList<QgsLayerMetadata::Link> &links );
+
+    /**
+     * Adds an individual \a link to the existing links.
+     * \see links()
+     * \see setLinks()
+     */
+    void addLink( const QgsLayerMetadata::Link &link );
 
   private:
 
+    /*
+     * IMPORTANT!!!!!!
+     *
+     * Do NOT add anything to this class without also updating the schema
+     * definition located at resources/qgis-resource-metadata.xsd
+     *
+     */
+
     QString mIdentifier;
     QString mParentIdentifier;
+    QString mLanguage;
     QString mType;
     QString mTitle;
     QString mAbstract;
     QString mFees;
-    QStringList mConstraints;
+    QList<QgsLayerMetadata::Constraint> mConstraints;
     QStringList mRights;
+
+    // IMPORTANT - look up before adding anything here!!
+
     QString mEncoding;
+    QgsCoordinateReferenceSystem mCrs;
+
+    /**
+     * Keywords map. Key is the vocabulary, value is a list of keywords for that vocabulary.
+     */
+    QMap< QString, QStringList > mKeywords;
+
+    QList< Contact > mContacts;
+
+    QList< Link > mLinks;
+
+    /*
+     * IMPORTANT!!!!!!
+     *
+     * Do NOT add anything to this class without also updating the schema
+     * definition located at resources/qgis-resource-metadata.xsd
+     *
+     */
 
 };
 

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -21,6 +21,8 @@
 #include "qgis.h"
 #include "qgis_core.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsbox3d.h"
+#include "qgsrange.h"
 
 class QgsMapLayer;
 
@@ -58,6 +60,73 @@ class CORE_EXPORT QgsLayerMetadata
      * Map of vocabulary string to keyword list.
      */
     typedef QMap< QString, QStringList > KeywordMap;
+
+    /**
+     * Metadata spatial extent structure.
+     */
+    struct SpatialExtent
+    {
+
+      /**
+       * Coordinate reference system for spatial extent.
+       * \see spatial
+       */
+      QgsCoordinateReferenceSystem extentCrs;
+
+      /**
+       * Geospatial extent of the resource. X and Y coordinates are in the
+       * CRS defined by the metadata (see extentCrs).
+       *
+       * While the spatial extent can include a Z dimension, this is not
+       * compulsory.
+       * \see extentCrs
+       */
+      QgsBox3d bounds;
+    };
+
+    /**
+     * Metadata extent structure.
+     */
+    struct Extent
+    {
+      public:
+
+        /**
+         * Spatial extents of the resource.
+         * \see setSpatialExtents()
+         */
+        QList< QgsLayerMetadata::SpatialExtent > spatialExtents() const;
+
+        /**
+         * Sets the spatial \a extents of the resource.
+         * \see spatialExtents()
+         */
+        void setSpatialExtents( const QList< QgsLayerMetadata::SpatialExtent > &extents );
+
+        /**
+         * Temporal extents of the resource. Use QgsDateTimeRange::isInstant() to determine
+         * whether the temporal extent is a range or a single point in time.
+         * If QgsDateTimeRange::isInfinite() returns true then the temporal extent
+         * is considered to be indeterminate and continuous.
+         * \see setTemporalExtents()
+         */
+        QList< QgsDateTimeRange > temporalExtents() const;
+
+        /**
+         * Sets the temporal \a extents of the resource.
+         * \see temporalExtents()
+         */
+        void setTemporalExtents( const QList< QgsDateTimeRange > &extents );
+
+#ifndef SIP_RUN
+      private:
+
+        QList< QgsLayerMetadata::SpatialExtent > mSpatialExtents;
+        QList< QgsDateTimeRange > mTemporalExtents;
+
+#endif
+
+    };
 
     /**
      * Metadata constraint structure.
@@ -433,6 +502,24 @@ class CORE_EXPORT QgsLayerMetadata
     void setEncoding( const QString &encoding );
 
     /**
+     * Returns the spatial and temporal extents associated with the resource.
+     * \see setExtent()
+     */
+    SIP_SKIP const QgsLayerMetadata::Extent &extent() const;
+
+    /**
+     * Returns the spatial and temporal extents associated with the resource.
+     * \see setExtent()
+     */
+    QgsLayerMetadata::Extent &extent();
+
+    /**
+     * Sets the spatial and temporal extents associated with the resource.
+     * \see setExtent()
+     */
+    void setExtent( const QgsLayerMetadata::Extent &extent );
+
+    /**
      * Returns the coordinate reference system described by the layer's metadata.
      *
      * Note that this has no link to QgsMapLayer::crs(). While in most cases these
@@ -604,6 +691,8 @@ class CORE_EXPORT QgsLayerMetadata
     QString mEncoding;
     QgsCoordinateReferenceSystem mCrs;
 
+    Extent mExtent;
+
     /**
      * Keywords map. Key is the vocabulary, value is a list of keywords for that vocabulary.
      */
@@ -627,7 +716,6 @@ Q_DECLARE_METATYPE( QgsLayerMetadata::KeywordMap )
 Q_DECLARE_METATYPE( QgsLayerMetadata::ConstraintList )
 Q_DECLARE_METATYPE( QgsLayerMetadata::ContactList )
 Q_DECLARE_METATYPE( QgsLayerMetadata::LinkList )
-
-
+Q_DECLARE_METATYPE( QgsLayerMetadata::Extent )
 
 #endif // QGSLAYERMETADATA_H

--- a/src/core/metadata/qgslayermetadatavalidator.cpp
+++ b/src/core/metadata/qgslayermetadatavalidator.cpp
@@ -65,6 +65,23 @@ bool QgsNativeMetadataValidator::validate( const QgsLayerMetadata &metadata, QLi
     results << ValidationResult( QObject::tr( "crs" ), QObject::tr( "A valid CRS element is required." ) );
   }
 
+  int index = 0;
+  Q_FOREACH ( const QgsLayerMetadata::SpatialExtent &extent, metadata.extent().spatialExtents() )
+  {
+    if ( !extent.extentCrs.isValid() )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "extent" ), QObject::tr( "A valid CRS element for the spatial extent is required." ), index );
+    }
+
+    if ( extent.bounds.width() == 0.0 || extent.bounds.height() == 0.0 )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "extent" ), QObject::tr( "A valid spatial extent is required." ), index );
+    }
+    index++;
+  }
+
   if ( metadata.contacts().isEmpty() )
   {
     result = false;
@@ -80,7 +97,7 @@ bool QgsNativeMetadataValidator::validate( const QgsLayerMetadata &metadata, QLi
   // validate keywords
   QgsLayerMetadata::KeywordMap keywords = metadata.keywords();
   QgsLayerMetadata::KeywordMap::const_iterator keywordIt = keywords.constBegin();
-  int index = 0;
+  index = 0;
   for ( ; keywordIt != keywords.constEnd(); ++keywordIt )
   {
     if ( keywordIt.key().isEmpty() )

--- a/src/core/metadata/qgslayermetadatavalidator.cpp
+++ b/src/core/metadata/qgslayermetadatavalidator.cpp
@@ -1,0 +1,130 @@
+/***************************************************************************
+                             qgslayermetadatavalidator.cpp
+                             -----------------------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayermetadatavalidator.h"
+#include "qgslayermetadata.h"
+
+bool QgsNativeMetadataValidator::validate( const QgsLayerMetadata &metadata, QList<ValidationResult> &results ) const
+{
+  results.clear();
+
+  bool result = true;
+  if ( metadata.identifier().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "identifier" ), QObject::tr( "Identifier element is required." ) );
+  }
+
+  if ( metadata.language().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "language" ), QObject::tr( "Language element is required." ) );
+  }
+
+  if ( metadata.type().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "type" ), QObject::tr( "Type element is required." ) );
+  }
+
+  if ( metadata.title().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "title" ), QObject::tr( "Title element is required." ) );
+  }
+
+  if ( metadata.abstract().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "abstract" ), QObject::tr( "Abstract element is required." ) );
+  }
+
+  //result = result && !metadata.license().isEmpty();
+
+  if ( !metadata.crs().isValid() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "crs" ), QObject::tr( "A valid CRS element is required." ) );
+  }
+
+  if ( metadata.contacts().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "contacts" ), QObject::tr( "At least one contact is required." ) );
+  }
+
+  if ( metadata.links().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "links" ), QObject::tr( "At least one link is required." ) );
+  }
+
+  // validate keywords
+  QgsLayerMetadata::KeywordMap keywords = metadata.keywords();
+  QgsLayerMetadata::KeywordMap::const_iterator keywordIt = keywords.constBegin();
+  int index = 0;
+  for ( ; keywordIt != keywords.constEnd(); ++keywordIt )
+  {
+    if ( keywordIt.key().isEmpty() )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "keywords" ), QObject::tr( "Keyword vocabulary cannot be empty." ), index );
+    }
+    if ( keywordIt.value().isEmpty() )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "keywords" ), QObject::tr( "Keyword list cannot be empty." ), index );
+    }
+    index++;
+  }
+
+  // validate contacts
+  index = 0;
+  Q_FOREACH ( const QgsLayerMetadata::Contact &contact, metadata.contacts() )
+  {
+    if ( contact.name.isEmpty() )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "contacts" ), QObject::tr( "Contact name cannot be empty." ), index );
+    }
+    index++;
+  }
+
+  // validate links
+  index = 0;
+  Q_FOREACH ( const QgsLayerMetadata::Link &link, metadata.links() )
+  {
+    if ( link.name.isEmpty() )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "links" ), QObject::tr( "Link name cannot be empty." ), index );
+    }
+    if ( link.type.isEmpty() )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "links" ), QObject::tr( "Link type cannot be empty." ), index );
+    }
+    if ( link.url.isEmpty() )
+    {
+      result = false;
+      results << ValidationResult( QObject::tr( "links" ), QObject::tr( "Link url cannot be empty." ), index );
+    }
+    index++;
+  }
+
+  return result;
+}

--- a/src/core/metadata/qgslayermetadatavalidator.cpp
+++ b/src/core/metadata/qgslayermetadatavalidator.cpp
@@ -53,7 +53,11 @@ bool QgsNativeMetadataValidator::validate( const QgsLayerMetadata &metadata, QLi
     results << ValidationResult( QObject::tr( "abstract" ), QObject::tr( "Abstract element is required." ) );
   }
 
-  //result = result && !metadata.license().isEmpty();
+  if ( metadata.licenses().isEmpty() )
+  {
+    result = false;
+    results << ValidationResult( QObject::tr( "license" ), QObject::tr( "At least one license is required." ) );
+  }
 
   if ( !metadata.crs().isValid() )
   {

--- a/src/core/metadata/qgslayermetadatavalidator.h
+++ b/src/core/metadata/qgslayermetadatavalidator.h
@@ -1,0 +1,104 @@
+/***************************************************************************
+                             qgslayermetadatavalidator.h
+                             ---------------------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERMETADATAVALIDATOR_H
+#define QGSLAYERMETADATAVALIDATOR_H
+
+#include "qgis.h"
+#include "qgis_core.h"
+
+class QgsLayerMetadata;
+
+/**
+ * \ingroup core
+ * \class QgsMetadataValidator
+ * \brief Abstract base class for metadata validators.
+ * \since QGIS 3.0
+ */
+
+class CORE_EXPORT QgsMetadataValidator
+{
+
+  public:
+
+    /**
+     * Contains the parameters describing a metadata validation
+     * failure.
+     */
+    struct ValidationResult
+    {
+
+      /**
+       * Constructor for ValidationResult.
+       */
+      ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() )
+        : section( section )
+        , identifier( identifier )
+        , note( note )
+      {}
+
+      //! Metadata section which failed the validation
+      QString section;
+
+      /**
+       * Optional identifier for the failed metadata item.
+       * For instance, in list type metadata elements this
+       * will be set to the list index of the failed metadata
+       * item.
+       */
+      QVariant identifier;
+
+      //! The reason behind the validation failure.
+      QString note;
+    };
+
+    virtual ~QgsMetadataValidator() = default;
+
+    /**
+     * Validates a \a metadata object, and returns true if the
+     * metadata is considered valid.
+     * If validation fails, the \a results list will be filled with a list of
+     * items describing why the validation failed and what needs to be rectified
+     * to fix the metadata.
+     */
+    virtual bool validate( const QgsLayerMetadata &metadata, QList< QgsMetadataValidator::ValidationResult > &results SIP_OUT ) const = 0;
+
+};
+
+
+/**
+ * \ingroup core
+ * \class QgsNativeMetadataValidator
+ * \brief A validator for the native QGIS metadata schema definition.
+ * \since QGIS 3.0
+ */
+
+class CORE_EXPORT QgsNativeMetadataValidator : public QgsMetadataValidator
+{
+
+  public:
+
+    /**
+     * Constructor for QgsNativeMetadataValidator.
+     */
+    QgsNativeMetadataValidator() = default;
+
+    bool validate( const QgsLayerMetadata &metadata, QList< QgsMetadataValidator::ValidationResult > &results SIP_OUT ) const override;
+
+};
+
+#endif // QGSLAYERMETADATAVALIDATOR_H

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1621,6 +1621,12 @@ void QgsMapLayer::triggerRepaint( bool deferredUpdate )
   emit repaintRequested( deferredUpdate );
 }
 
+void QgsMapLayer::setMetadata( const QgsLayerMetadata &metadata )
+{
+  mMetadata = metadata;
+  emit metadataChanged();
+}
+
 QString QgsMapLayer::htmlMetadata() const
 {
   return QString();

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -506,6 +506,8 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, const QgsPathRe
 
   readCustomProperties( layerElement );
 
+  mMetadata.readFromLayer( this );
+
   return true;
 } // bool QgsMapLayer::readLayerXML
 
@@ -1624,6 +1626,7 @@ void QgsMapLayer::triggerRepaint( bool deferredUpdate )
 void QgsMapLayer::setMetadata( const QgsLayerMetadata &metadata )
 {
   mMetadata = metadata;
+  mMetadata.saveToLayer( this );
   emit metadataChanged();
 }
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -34,6 +34,7 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrendercontext.h"
 #include "qgsmaplayerdependency.h"
+#include "metadata/qgslayermetadata.h"
 
 class QgsDataProvider;
 class QgsMapLayerLegend;
@@ -56,6 +57,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
     Q_PROPERTY( int autoRefreshInterval READ autoRefreshInterval WRITE setAutoRefreshInterval NOTIFY autoRefreshIntervalChanged )
+    Q_PROPERTY( QgsLayerMetadata metadata READ metadata WRITE setMetadata NOTIFY metadataChanged )
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
@@ -733,6 +735,22 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void setAutoRefreshEnabled( bool enabled );
 
     /**
+     * Returns a reference to the layer's metadata store.
+     * \since QGIS 3.0
+     * \see setMetadata()
+     * \see metadataChanged()
+     */
+    virtual const QgsLayerMetadata &metadata() const { return mMetadata; }
+
+    /**
+     * Sets the layer's \a metadata store.
+     * \since QGIS 3.0
+     * \see metadata()
+     * \see metadataChanged()
+     */
+    virtual void setMetadata( const QgsLayerMetadata &metadata );
+
+    /**
      * Obtain a formatted HTML string containing assorted metadata for this layer.
      * \since QGIS 3.0
      */
@@ -879,6 +897,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void autoRefreshIntervalChanged( int interval );
 
+    /**
+     * Emitted when the layer's metadata is changed.
+     * \see setMetadata()
+     * \see metadata()
+     * \since QGIS 3.0
+     */
+    void metadataChanged();
+
   protected:
     //! Set the extent
     virtual void setExtent( const QgsRectangle &rect );
@@ -1018,6 +1044,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! Timer for triggering automatic refreshes of the layer
     QTimer mRefreshTimer;
+
+    QgsLayerMetadata mMetadata;
 
 };
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -747,6 +747,7 @@ INCLUDE_DIRECTORIES(
   ../core/fieldformatter
   ../core/geometry
   ../core/layertree
+  ../core/metadata
   ../core/raster
   ../core/scalebar
   ../core/symbology-ng

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/effects
   ${CMAKE_SOURCE_DIR}/src/core/layertree
+  ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/processing
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/scalebar

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -71,6 +71,7 @@ ADD_PYTHON_TEST(PyQgsLayerTreeMapCanvasBridge test_qgslayertreemapcanvasbridge.p
 ADD_PYTHON_TEST(PyQgsLayerTree test_qgslayertree.py)
 ADD_PYTHON_TEST(PyQgsLayoutManager test_qgslayoutmanager.py)
 ADD_PYTHON_TEST(PyQgsLineSymbolLayers test_qgslinesymbollayers.py)
+ADD_PYTHON_TEST(PyQgsLayerMetadata test_qgslayermetadata.py)
 ADD_PYTHON_TEST(PyQgsMapCanvas test_qgsmapcanvas.py)
 ADD_PYTHON_TEST(PyQgsMapCanvasAnnotationItem test_qgsmapcanvasannotationitem.py)
 ADD_PYTHON_TEST(PyQgsMapLayer test_qgsmaplayer.py)

--- a/tests/src/python/test_qgslayermetadata.py
+++ b/tests/src/python/test_qgslayermetadata.py
@@ -59,6 +59,13 @@ class TestQgsLayerMetadata(unittest.TestCase):
         m.setLicenses(['l a', 'l b'])
         self.assertEqual(m.licenses(), ['l a', 'l b'])
 
+        m.setHistory(['loaded into QGIS'])
+        self.assertEqual(m.history(), ['loaded into QGIS'])
+        m.setHistory(['accidentally deleted some features'])
+        self.assertEqual(m.history(), ['accidentally deleted some features'])
+        m.addHistoryItem('panicked and deleted more')
+        self.assertEqual(m.history(), ['accidentally deleted some features', 'panicked and deleted more'])
+
         m.setEncoding('encoding')
         self.assertEqual(m.encoding(), 'encoding')
 
@@ -192,6 +199,7 @@ class TestQgsLayerMetadata(unittest.TestCase):
         m.setConstraints([QgsLayerMetadata.Constraint('None', 'access')])
         m.setRights(['Copyright foo 2017'])
         m.setLicenses(['WTFPL'])
+        m.setHistory(['history a', 'history b'])
         m.setKeywords({'GEMET': ['kw1', 'kw2']})
         m.setEncoding('utf-8')
         m.setCrs(QgsCoordinateReferenceSystem.fromOgcWmsCrs('EPSG:4326'))
@@ -254,6 +262,7 @@ class TestQgsLayerMetadata(unittest.TestCase):
         self.assertEqual(m.constraints()[0].type, 'access')
         self.assertEqual(m.rights(), ['Copyright foo 2017'])
         self.assertEqual(m.licenses(), ['WTFPL'])
+        self.assertEqual(m.history(), ['history a', 'history b'])
         self.assertEqual(m.encoding(), 'utf-8')
         self.assertEqual(m.keywords(), {'GEMET': ['kw1', 'kw2']})
         self.assertEqual(m.crs().authid(), 'EPSG:4326')

--- a/tests/src/python/test_qgslayermetadata.py
+++ b/tests/src/python/test_qgslayermetadata.py
@@ -15,7 +15,8 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 from qgis.core import (QgsLayerMetadata,
-                       QgsCoordinateReferenceSystem)
+                       QgsCoordinateReferenceSystem,
+                       QgsVectorLayer)
 from qgis.testing import start_app, unittest
 
 start_app()
@@ -282,6 +283,22 @@ class TestQgsLayerMetadata(unittest.TestCase):
     def testStandard(self):
         m = self.createTestMetadata()
         self.checkExpectedMetadata(m)
+
+    def testSaveReadFromLayer(self):
+        """
+        Test saving and reading metadata from a layer
+        """
+        vl = QgsVectorLayer('Point', 'test', 'memory')
+        self.assertTrue(vl.isValid())
+
+        # save metadata to layer
+        m = self.createTestMetadata()
+        m.saveToLayer(vl)
+
+        # read back from layer and check result
+        m2 = QgsLayerMetadata()
+        m2.readFromLayer(vl)
+        self.checkExpectedMetadata(m2)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgslayermetadata.py
+++ b/tests/src/python/test_qgslayermetadata.py
@@ -56,6 +56,9 @@ class TestQgsLayerMetadata(unittest.TestCase):
         m.setRights(['right a', 'right b'])
         self.assertEqual(m.rights(), ['right a', 'right b'])
 
+        m.setLicenses(['l a', 'l b'])
+        self.assertEqual(m.licenses(), ['l a', 'l b'])
+
         m.setEncoding('encoding')
         self.assertEqual(m.encoding(), 'encoding')
 
@@ -188,6 +191,7 @@ class TestQgsLayerMetadata(unittest.TestCase):
         m.setFees('None')
         m.setConstraints([QgsLayerMetadata.Constraint('None', 'access')])
         m.setRights(['Copyright foo 2017'])
+        m.setLicenses(['WTFPL'])
         m.setKeywords({'GEMET': ['kw1', 'kw2']})
         m.setEncoding('utf-8')
         m.setCrs(QgsCoordinateReferenceSystem.fromOgcWmsCrs('EPSG:4326'))
@@ -249,6 +253,7 @@ class TestQgsLayerMetadata(unittest.TestCase):
         self.assertEqual(m.constraints()[0].constraint, 'None')
         self.assertEqual(m.constraints()[0].type, 'access')
         self.assertEqual(m.rights(), ['Copyright foo 2017'])
+        self.assertEqual(m.licenses(), ['WTFPL'])
         self.assertEqual(m.encoding(), 'utf-8')
         self.assertEqual(m.keywords(), {'GEMET': ['kw1', 'kw2']})
         self.assertEqual(m.crs().authid(), 'EPSG:4326')
@@ -343,6 +348,12 @@ class TestQgsLayerMetadata(unittest.TestCase):
         res, list = v.validate(m)
         self.assertFalse(res)
         self.assertEqual(list[0].section, 'abstract')
+
+        m = self.createTestMetadata()
+        m.setLicenses([])
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'license')
 
         m = self.createTestMetadata()
         m.setCrs(QgsCoordinateReferenceSystem())

--- a/tests/src/python/test_qgslayermetadata.py
+++ b/tests/src/python/test_qgslayermetadata.py
@@ -16,7 +16,8 @@ import qgis  # NOQA
 
 from qgis.core import (QgsLayerMetadata,
                        QgsCoordinateReferenceSystem,
-                       QgsVectorLayer)
+                       QgsVectorLayer,
+                       QgsNativeMetadataValidator)
 from qgis.testing import start_app, unittest
 
 start_app()
@@ -299,6 +300,117 @@ class TestQgsLayerMetadata(unittest.TestCase):
         m2 = QgsLayerMetadata()
         m2.readFromLayer(vl)
         self.checkExpectedMetadata(m2)
+
+    def testValidateNative(self):  # spellok
+        """
+        Test validating metadata against QGIS native schema
+        """
+
+        m = self.createTestMetadata()
+        v = QgsNativeMetadataValidator()
+
+        res, list = v.validate(m)
+        self.assertTrue(res)
+        self.assertFalse(list)
+
+        # corrupt metadata piece by piece...
+        m = self.createTestMetadata()
+        m.setIdentifier('')
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'identifier')
+
+        m = self.createTestMetadata()
+        m.setLanguage('')
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'language')
+
+        m = self.createTestMetadata()
+        m.setType('')
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'type')
+
+        m = self.createTestMetadata()
+        m.setTitle('')
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'title')
+
+        m = self.createTestMetadata()
+        m.setAbstract('')
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'abstract')
+
+        m = self.createTestMetadata()
+        m.setCrs(QgsCoordinateReferenceSystem())
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'crs')
+
+        m = self.createTestMetadata()
+        m.setContacts([])
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'contacts')
+
+        m = self.createTestMetadata()
+        m.setLinks([])
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'links')
+
+        m = self.createTestMetadata()
+        m.setKeywords({'': ['kw1', 'kw2']})
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'keywords')
+        self.assertEqual(list[0].identifier, 0)
+
+        m = self.createTestMetadata()
+        m.setKeywords({'AA': []})
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'keywords')
+        self.assertEqual(list[0].identifier, 0)
+
+        m = self.createTestMetadata()
+        c = m.contacts()[0]
+        c.name = ''
+        m.setContacts([c])
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'contacts')
+        self.assertEqual(list[0].identifier, 0)
+
+        m = self.createTestMetadata()
+        l = m.links()[0]
+        l.name = ''
+        m.setLinks([l])
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'links')
+        self.assertEqual(list[0].identifier, 0)
+
+        m = self.createTestMetadata()
+        l = m.links()[0]
+        l.type = ''
+        m.setLinks([l])
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'links')
+        self.assertEqual(list[0].identifier, 0)
+
+        m = self.createTestMetadata()
+        l = m.links()[0]
+        l.url = ''
+        m.setLinks([l])
+        res, list = v.validate(m)
+        self.assertFalse(res)
+        self.assertEqual(list[0].section, 'links')
+        self.assertEqual(list[0].identifier, 0)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgslayermetadata.py
+++ b/tests/src/python/test_qgslayermetadata.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for QgsLayerMetadata.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Nyall Dawson'
+__date__ = '11/04/2017'
+__copyright__ = 'Copyright 2017, The QGIS Project'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+import qgis  # NOQA
+
+from qgis.core import (QgsLayerMetadata,
+                       QgsCoordinateReferenceSystem)
+from qgis.testing import start_app, unittest
+
+start_app()
+
+
+class TestQgsLayerMetadata(unittest.TestCase):
+
+    def testGettersSetters(self):
+        m = QgsLayerMetadata()
+
+        m.setIdentifier('identifier')
+        self.assertEqual(m.identifier(), 'identifier')
+
+        m.setParentIdentifier('parent identifier')
+        self.assertEqual(m.parentIdentifier(), 'parent identifier')
+
+        m.setLanguage('en-us')
+        self.assertEqual(m.language(), 'en-us')
+
+        m.setType('type')
+        self.assertEqual(m.type(), 'type')
+
+        m.setTitle('title')
+        self.assertEqual(m.title(), 'title')
+
+        m.setAbstract('abstract')
+        self.assertEqual(m.abstract(), 'abstract')
+
+        m.setFees('fees')
+        self.assertEqual(m.fees(), 'fees')
+
+        m.setConstraints([QgsLayerMetadata.Constraint('constraint a'), QgsLayerMetadata.Constraint('constraint b')])
+        self.assertEqual(m.constraints()[0].constraint, 'constraint a')
+        self.assertEqual(m.constraints()[1].constraint, 'constraint b')
+
+        m.setRights(['right a', 'right b'])
+        self.assertEqual(m.rights(), ['right a', 'right b'])
+
+        m.setEncoding('encoding')
+        self.assertEqual(m.encoding(), 'encoding')
+
+        m.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(3111))
+        self.assertEqual(m.crs().authid(), 'EPSG:3111')
+
+    def testKeywords(self):
+        m = QgsLayerMetadata()
+
+        m.setKeywords({'vocab a': ['keyword a', 'other a'],
+                       'vocab b': ['keyword b', 'other b']})
+        self.assertEqual(m.keywords(), {'vocab a': ['keyword a', 'other a'],
+                                        'vocab b': ['keyword b', 'other b']})
+        self.assertEqual(m.keywordVocabularies(), ['vocab a', 'vocab b'])
+        self.assertEqual(m.keywords('vocab a'), ['keyword a', 'other a'])
+        self.assertEqual(m.keywords('vocab b'), ['keyword b', 'other b'])
+        self.assertEqual(m.keywords('not valid'), [])
+
+        m.addKeywords('vocab c', ['keyword c'])
+        self.assertEqual(m.keywords(), {'vocab a': ['keyword a', 'other a'],
+                                        'vocab b': ['keyword b', 'other b'],
+                                        'vocab c': ['keyword c']})
+        # replace existing using addKeywords
+        m.addKeywords('vocab c', ['c'])
+        self.assertEqual(m.keywords(), {'vocab a': ['keyword a', 'other a'],
+                                        'vocab b': ['keyword b', 'other b'],
+                                        'vocab c': ['c']})
+        # replace existing using setKeywords
+        m.setKeywords({'x': ['x'], 'y': ['y']})
+        self.assertEqual(m.keywords(), {'x': ['x'],
+                                        'y': ['y']})
+
+    def testAddress(self):
+        a = QgsLayerMetadata.Address()
+        a.type = 'postal'
+        a.address = '13 north rd'
+        a.city = 'huxleys haven'
+        a.administrativeArea = 'land of the queens'
+        a.postalCode = '4123'
+        a.country = 'straya!'
+        self.assertEqual(a.type, 'postal')
+        self.assertEqual(a.address, '13 north rd')
+        self.assertEqual(a.city, 'huxleys haven')
+        self.assertEqual(a.administrativeArea, 'land of the queens')
+        self.assertEqual(a.postalCode, '4123')
+        self.assertEqual(a.country, 'straya!')
+
+    def testContact(self):
+        c = QgsLayerMetadata.Contact()
+        c.name = 'Prince Gristle'
+        c.organization = 'Bergen co'
+        c.position = 'prince'
+        c.voice = '1500 515 555'
+        c.fax = 'who the f*** still uses fax?'
+        c.email = 'limpbiskitrulez69@hotmail.com'
+        c.role = 'person to blame when all goes wrong'
+        a = QgsLayerMetadata.Address()
+        a.type = 'postal'
+        a2 = QgsLayerMetadata.Address()
+        a2.type = 'street'
+        c.addresses = [a, a2]
+        self.assertEqual(c.name, 'Prince Gristle')
+        self.assertEqual(c.organization, 'Bergen co')
+        self.assertEqual(c.position, 'prince')
+        self.assertEqual(c.voice, '1500 515 555')
+        self.assertEqual(c.fax, 'who the f*** still uses fax?')
+        self.assertEqual(c.email, 'limpbiskitrulez69@hotmail.com')
+        self.assertEqual(c.role, 'person to blame when all goes wrong')
+        self.assertEqual(c.addresses[0].type, 'postal')
+        self.assertEqual(c.addresses[1].type, 'street')
+
+        m = QgsLayerMetadata()
+        c2 = QgsLayerMetadata.Contact(c)
+        c2.name = 'Bridgette'
+
+        m.setContacts([c, c2])
+        self.assertEqual(m.contacts()[0].name, 'Prince Gristle')
+        self.assertEqual(m.contacts()[1].name, 'Bridgette')
+
+        # add contact
+        c3 = QgsLayerMetadata.Contact(c)
+        c3.name = 'Princess Poppy'
+        m.addContact(c3)
+        self.assertEqual(len(m.contacts()), 3)
+        self.assertEqual(m.contacts()[2].name, 'Princess Poppy')
+
+    def testLinks(self):
+        l = QgsLayerMetadata.Link()
+        l.name = 'Trashbat'
+        l.type = 'fashion'
+        l.description = 'registered in the cook islands!'
+        l.url = 'http://trashbat.co.uk'
+        l.format = 'whois'
+        l.mimeType = 'text/string'
+        l.size = '112'
+        self.assertEqual(l.name, 'Trashbat')
+        self.assertEqual(l.type, 'fashion')
+        self.assertEqual(l.description, 'registered in the cook islands!')
+        self.assertEqual(l.url, 'http://trashbat.co.uk')
+        self.assertEqual(l.format, 'whois')
+        self.assertEqual(l.mimeType, 'text/string')
+        self.assertEqual(l.size, '112')
+
+        m = QgsLayerMetadata()
+        l2 = QgsLayerMetadata.Link(l)
+        l2.name = 'Trashbat2'
+
+        m.setLinks([l, l2])
+        self.assertEqual(m.links()[0].name, 'Trashbat')
+        self.assertEqual(m.links()[1].name, 'Trashbat2')
+
+        # add link
+        l3 = QgsLayerMetadata.Link(l)
+        l3.name = 'Trashbat3'
+        m.addLink(l3)
+        self.assertEqual(len(m.links()), 3)
+        self.assertEqual(m.links()[2].name, 'Trashbat3')
+
+    def createTestMetadata(self):
+        """
+        Returns a standard metadata which can be tested with checkExpectedMetadata
+        """
+        m = QgsLayerMetadata()
+        m.setIdentifier('1234')
+        m.setParentIdentifier('xyz')
+        m.setLanguage('en-CA')
+        m.setType('dataset')
+        m.setTitle('roads')
+        m.setAbstract('my roads')
+        m.setFees('None')
+        m.setConstraints([QgsLayerMetadata.Constraint('None', 'access')])
+        m.setRights(['Copyright foo 2017'])
+        m.setKeywords({'GEMET': ['kw1', 'kw2']})
+        m.setEncoding('utf-8')
+        m.setCrs(QgsCoordinateReferenceSystem.fromOgcWmsCrs('EPSG:4326'))
+
+        c = QgsLayerMetadata.Contact()
+        c.name = 'John Smith'
+        c.organization = 'ACME'
+        c.position = 'staff'
+        c.voice = '1500 515 555'
+        c.fax = 'xx.xxx.xxx.xxxx'
+        c.email = 'foo@example.org'
+        c.role = 'pointOfContact'
+        address = QgsLayerMetadata.Address()
+        address.type = 'postal'
+        address.address = '123 Main Street'
+        address.city = 'anycity'
+        address.administrativeArea = 'anyprovince'
+        address.postalCode = '90210'
+        address.country = 'Canada'
+        c.addresses = [address]
+        m.setContacts([c])
+
+        l = QgsLayerMetadata.Link()
+        l.name = 'geonode:roads'
+        l.type = 'OGC:WMS'
+        l.description = 'my GeoNode road layer'
+        l.url = 'http://example.org/wms'
+
+        l2 = QgsLayerMetadata.Link()
+        l2.name = 'geonode:roads'
+        l2.type = 'OGC:WFS'
+        l2.description = 'my GeoNode road layer'
+        l2.url = 'http://example.org/wfs'
+
+        l3 = QgsLayerMetadata.Link()
+        l3.name = 'roads'
+        l3.type = 'WWW:LINK'
+        l3.description = 'full dataset download'
+        l3.url = 'http://example.org/roads.tgz'
+        l3.format = 'ESRI Shapefile'
+        l3.mimeType = 'application/gzip'
+        l3.size = '283676'
+
+        m.setLinks([l, l2, l3])
+
+        return m
+
+    def checkExpectedMetadata(self, m):
+        """
+        Checks that a metadata object matches that returned by createTestMetadata
+        """
+        self.assertEqual(m.identifier(), '1234')
+        self.assertEqual(m.parentIdentifier(), 'xyz')
+        self.assertEqual(m.language(), 'en-CA')
+        self.assertEqual(m.type(), 'dataset')
+        self.assertEqual(m.title(), 'roads')
+        self.assertEqual(m.abstract(), 'my roads')
+        self.assertEqual(m.fees(), 'None')
+        self.assertEqual(m.constraints()[0].constraint, 'None')
+        self.assertEqual(m.constraints()[0].type, 'access')
+        self.assertEqual(m.rights(), ['Copyright foo 2017'])
+        self.assertEqual(m.encoding(), 'utf-8')
+        self.assertEqual(m.keywords(), {'GEMET': ['kw1', 'kw2']})
+        self.assertEqual(m.crs().authid(), 'EPSG:4326')
+        self.assertEqual(m.contacts()[0].name, 'John Smith')
+        self.assertEqual(m.contacts()[0].organization, 'ACME')
+        self.assertEqual(m.contacts()[0].position, 'staff')
+        self.assertEqual(m.contacts()[0].voice, '1500 515 555')
+        self.assertEqual(m.contacts()[0].fax, 'xx.xxx.xxx.xxxx')
+        self.assertEqual(m.contacts()[0].email, 'foo@example.org')
+        self.assertEqual(m.contacts()[0].role, 'pointOfContact')
+        self.assertEqual(m.contacts()[0].addresses[0].type, 'postal')
+        self.assertEqual(m.contacts()[0].addresses[0].address, '123 Main Street')
+        self.assertEqual(m.contacts()[0].addresses[0].city, 'anycity')
+        self.assertEqual(m.contacts()[0].addresses[0].administrativeArea, 'anyprovince')
+        self.assertEqual(m.contacts()[0].addresses[0].postalCode, '90210')
+        self.assertEqual(m.contacts()[0].addresses[0].country, 'Canada')
+        self.assertEqual(m.links()[0].name, 'geonode:roads')
+        self.assertEqual(m.links()[0].type, 'OGC:WMS')
+        self.assertEqual(m.links()[0].description, 'my GeoNode road layer')
+        self.assertEqual(m.links()[0].url, 'http://example.org/wms')
+        self.assertEqual(m.links()[1].name, 'geonode:roads')
+        self.assertEqual(m.links()[1].type, 'OGC:WFS')
+        self.assertEqual(m.links()[1].description, 'my GeoNode road layer')
+        self.assertEqual(m.links()[1].url, 'http://example.org/wfs')
+        self.assertEqual(m.links()[2].name, 'roads')
+        self.assertEqual(m.links()[2].type, 'WWW:LINK')
+        self.assertEqual(m.links()[2].description, 'full dataset download')
+        self.assertEqual(m.links()[2].url, 'http://example.org/roads.tgz')
+        self.assertEqual(m.links()[2].format, 'ESRI Shapefile')
+        self.assertEqual(m.links()[2].mimeType, 'application/gzip')
+        self.assertEqual(m.links()[2].size, '283676')
+
+    def testStandard(self):
+        m = self.createTestMetadata()
+        self.checkExpectedMetadata(m)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
This PR partly implements Work Package 2 from QEP-91 - implementing a metadata store in QGIS.

It implements a new class "QgsLayerMetadata". QgsLayerMetadata handles storage and management of the metadata for a QgsMapLayer. This class is an internal QGIS format with a common metadata structure, which allows for code to access the metadata properties for layers in a uniform way.

The metadata store is designed to be compatible with the Dublin Core metadata specifications, and will be expanded to allow compatibility with ISO specifications in future releases. However, the QGIS internal schema does not represent a superset of all existing metadata schemas and accordingly conversion from specific metadata formats to QgsLayerMetadata may result in a loss of information.

This class follows the schema defined in https://github.com/qgis/QGIS/pull/4330. #4330 is a prerequisite before this can be merged.

Note 1: please do not comment on the metadata schema here - those comments must be directed to #4330. Feedback on this PR should be limited to the API/code only.

Note 2: this PR does not implement the extent component of the schema - that is blocked by #4349 and #4353.

Note 3: this PR does not implement persistent storage and parsing of metadata. That will be implemented in a follow up package as part of QEP-91. To workaround this limitation, I've temporarily added (limited) support for storing QgsLayerMetadata in a layer's custom properties, allowing persistence of the metadata within a single project. **I consider this a temporary hack, and this support WILL be removed when the proper storage handling component of QEP-91 is implemented**

Note 4: The redundant API calls from QgsMapLayer (eg QgsMapLayer::abstract(), keywordList(), attribution(), title() ) will be removed following merge of this PR.

## Checklist

> Reviewing is a process done by magic fairies, mostly on a bribery basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
