### PR TITLE
Use weak layer references and loose matching for composer legend customisation

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -218,7 +218,6 @@ core/fieldformatter/qgsrelationreferencefieldformatter.sip
 core/fieldformatter/qgsvaluemapfieldformatter.sip
 core/fieldformatter/qgsvaluerelationfieldformatter.sip
 core/layertree/qgslayertree.sip
-core/layertree/qgslayertreelayer.sip
 core/layertree/qgslayertreemodel.sip
 core/layertree/qgslayertreemodellegendnode.sip
 core/layertree/qgslayertreenode.sip

--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -218,7 +218,6 @@ core/fieldformatter/qgsrelationreferencefieldformatter.sip
 core/fieldformatter/qgsvaluemapfieldformatter.sip
 core/fieldformatter/qgsvaluerelationfieldformatter.sip
 core/layertree/qgslayertree.sip
-core/layertree/qgslayertreegroup.sip
 core/layertree/qgslayertreelayer.sip
 core/layertree/qgslayertreemodel.sip
 core/layertree/qgslayertreemodellegendnode.sip

--- a/python/core/annotations/qgshtmlannotation.sip
+++ b/python/core/annotations/qgshtmlannotation.sip
@@ -31,7 +31,7 @@ class QgsHtmlAnnotation: QgsAnnotation
 
     ~QgsHtmlAnnotation();
 
-    QSizeF minimumFrameSize() const;
+    virtual QSizeF minimumFrameSize() const;
 
     void setSourceFile( const QString &htmlFile );
 %Docstring
@@ -49,7 +49,7 @@ class QgsHtmlAnnotation: QgsAnnotation
     virtual void writeXml( QDomElement &elem, QDomDocument &doc ) const;
     virtual void readXml( const QDomElement &itemElem, const QDomDocument &doc );
 
-    void setAssociatedFeature( const QgsFeature &feature );
+    virtual void setAssociatedFeature( const QgsFeature &feature );
 
     static QgsHtmlAnnotation *create() /Factory/;
 %Docstring
@@ -59,7 +59,7 @@ class QgsHtmlAnnotation: QgsAnnotation
 
   protected:
 
-    void renderAnnotation( QgsRenderContext &context, QSizeF size ) const;
+    virtual void renderAnnotation( QgsRenderContext &context, QSizeF size ) const;
 
 };
 

--- a/python/core/annotations/qgssvgannotation.sip
+++ b/python/core/annotations/qgssvgannotation.sip
@@ -50,7 +50,7 @@ class QgsSvgAnnotation: QgsAnnotation
 
   protected:
 
-    void renderAnnotation( QgsRenderContext &context, QSizeF size ) const;
+    virtual void renderAnnotation( QgsRenderContext &context, QSizeF size ) const;
 
 };
 

--- a/python/core/annotations/qgstextannotation.sip
+++ b/python/core/annotations/qgstextannotation.sip
@@ -52,7 +52,7 @@ class QgsTextAnnotation: QgsAnnotation
 
   protected:
 
-    void renderAnnotation( QgsRenderContext &context, QSizeF size ) const;
+    virtual void renderAnnotation( QgsRenderContext &context, QSizeF size ) const;
 
 };
 

--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -79,8 +79,11 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     virtual QgsLayerTreeGroup* clone() const /Factory/;
 
     //! Calls resolveReferences() on child tree nodes
-    //! @note added in 3.0
-    virtual void resolveReferences( const QgsProject* project );
+    //! \since QGIS 3.0
+    virtual void resolveReferences( const QgsProject *project, bool looseMatching = false );
+
+    //! Check or uncheck a node and all its children (taking into account exclusion rules)
+    virtual void setItemVisibilityCheckedRecursive( bool checked );
 
     //! Return whether the group is mutually exclusive (only one child can be checked at a time)
     //! @note added in 2.12

--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -1,107 +1,227 @@
-/**
- * Layer tree group node serves as a container for layers and further groups.
- *
- * Group names do not need to be unique within one tree nor within one parent.
- *
- * @note added in 2.4
- */
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layertree/qgslayertreegroup.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
 class QgsLayerTreeGroup : QgsLayerTreeNode
 {
-%TypeHeaderCode
-#include <qgslayertreegroup.h>
+%Docstring
+ Layer tree group node serves as a container for layers and further groups.
+
+ Group names do not need to be unique within one tree nor within one parent.
+
+.. versionadded:: 2.4
 %End
 
+%TypeHeaderCode
+#include "qgslayertreegroup.h"
+%End
   public:
-    QgsLayerTreeGroup( const QString& name = QString(), Qt::CheckState checked = Qt::Checked );
 
-    //! Get group's name
+    QgsLayerTreeGroup( const QString &name = QString(), bool checked = true );
+%Docstring
+ Constructor
+%End
+
+
     QString name() const;
-    //! Set group's name
-    void setName( const QString& n );
+%Docstring
+ Returns the group's name.
+ :rtype: str
+%End
 
-    //! Insert a new group node with given name at specified position. Newly created node is owned by this group.
-    QgsLayerTreeGroup* insertGroup( int index, const QString& name );
-    //! Append a new group node with given name. Newly created node is owned by this group.
-    QgsLayerTreeGroup* addGroup( const QString& name );
-    //! Insert a new layer node for given map layer at specified position. Newly created node is owned by this group.
-    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer );
-    //! Append a new layer node for given map layer. Newly created node is owned by this group.
-    QgsLayerTreeLayer* addLayer( QgsMapLayer* layer );
+    void setName( const QString &n );
+%Docstring
+ Sets the group's name.
+%End
 
-    //! Insert existing nodes at specified position. The nodes must not have a parent yet. The nodes will be owned by this group.
-    void insertChildNodes( int index, const QList<QgsLayerTreeNode*>& nodes /Transfer/ );
-    //! Insert existing node at specified position. The node must not have a parent yet. The node will be owned by this group.
-    void insertChildNode( int index, QgsLayerTreeNode* node /Transfer/ );
-    //! Append an existing node. The node must not have a parent yet. The node will be owned by this group.
-    void addChildNode( QgsLayerTreeNode* node /Transfer/ );
+    QgsLayerTreeGroup *insertGroup( int index, const QString &name );
+%Docstring
+ Insert a new group node with given name at specified position. The newly created node is owned by this group.
+ :rtype: QgsLayerTreeGroup
+%End
 
-    //! Remove a child node from this group. The node will be deleted.
-    void removeChildNode( QgsLayerTreeNode* node );
-    //! Remove map layer's node from this group. The node will be deleted.
-    void removeLayer( QgsMapLayer* layer );
-    //! Remove child nodes from index "from". The nodes will be deleted.
+    QgsLayerTreeGroup *addGroup( const QString &name );
+%Docstring
+ Append a new group node with given name. Newly created node is owned by this group.
+ :rtype: QgsLayerTreeGroup
+%End
+
+    QgsLayerTreeLayer *insertLayer( int index, QgsMapLayer *layer );
+%Docstring
+ Insert a new layer node for given map layer at specified position. The newly created node is owned by this group.
+ :rtype: QgsLayerTreeLayer
+%End
+
+    QgsLayerTreeLayer *addLayer( QgsMapLayer *layer );
+%Docstring
+ Append a new layer node for given map layer. The newly created node is owned by this group.
+ :rtype: QgsLayerTreeLayer
+%End
+
+    void insertChildNodes( int index, const QList<QgsLayerTreeNode *> &nodes /Transfer/ );
+%Docstring
+ Insert existing nodes at specified position. The nodes must not have a parent yet. The nodes will be owned by this group.
+%End
+
+    void insertChildNode( int index, QgsLayerTreeNode *node /Transfer/ );
+%Docstring
+ Insert existing node at specified position. The node must not have a parent yet. The node will be owned by this group.
+%End
+
+    void addChildNode( QgsLayerTreeNode *node /Transfer/ );
+%Docstring
+ Append an existing node. The node must not have a parent yet. The node will be owned by this group.
+%End
+
+    void removeChildNode( QgsLayerTreeNode *node );
+%Docstring
+ Remove a child node from this group. The node will be deleted.
+%End
+
+    void removeLayer( QgsMapLayer *layer );
+%Docstring
+ Remove map layer's node from this group. The node will be deleted.
+%End
+
     void removeChildren( int from, int count );
-    //! Remove all child group nodes without layers. The groupnodes will be deleted.
+%Docstring
+ Remove child nodes from index "from". The nodes will be deleted.
+%End
+
     void removeChildrenGroupWithoutLayers();
-    //! Remove all child nodes. The nodes will be deleted.
+%Docstring
+ Remove all child group nodes without layers. The groupnodes will be deleted.
+%End
+
     void removeAllChildren();
+%Docstring
+ Remove all child nodes. The nodes will be deleted.
+%End
 
-    //! Find layer node representing the map layer. Searches recursively the whole sub-tree.
-    //! @note added in 3.0
-    QgsLayerTreeLayer* findLayer( QgsMapLayer* layer ) const;
-    //! Find layer node representing the map layer specified by its ID. Searches recursively the whole sub-tree.
-    QgsLayerTreeLayer* findLayer( const QString& layerId );
-    //! Find all layer nodes. Searches recursively the whole sub-tree.
-    QList<QgsLayerTreeLayer*> findLayers() const;
-    //! Find layer IDs used in all layer nodes. Searches recursively the whole sub-tree.
+    QgsLayerTreeLayer *findLayer( QgsMapLayer *layer ) const;
+%Docstring
+ Find layer node representing the map layer. Searches recursively the whole sub-tree.
+.. versionadded:: 3.0
+ :rtype: QgsLayerTreeLayer
+%End
+
+    QgsLayerTreeLayer *findLayer( const QString &layerId ) const;
+%Docstring
+ Find layer node representing the map layer specified by its ID. Searches recursively the whole sub-tree.
+ :rtype: QgsLayerTreeLayer
+%End
+
+    QList<QgsLayerTreeLayer *> findLayers() const;
+%Docstring
+ Find all layer nodes. Searches recursively the whole sub-tree.
+ :rtype: list of QgsLayerTreeLayer
+%End
+
     QStringList findLayerIds() const;
-    //! Find group node with specified name. Searches recursively the whole sub-tree.
-    QgsLayerTreeGroup* findGroup( const QString& name );
+%Docstring
+ Find layer IDs used in all layer nodes. Searches recursively the whole sub-tree.
+ :rtype: list of str
+%End
 
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
-    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
-    static QgsLayerTreeGroup* readXml( QDomElement& element ) /Factory/;
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
-    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
-    //! @note added in 3.0
-    static QgsLayerTreeGroup* readXml( QDomElement& element, const QgsProject* project ) /Factory/;
+    QgsLayerTreeGroup *findGroup( const QString &name );
+%Docstring
+ Find group node with specified name. Searches recursively the whole sub-tree.
+ :rtype: QgsLayerTreeGroup
+%End
 
-    //! Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
-    virtual void writeXml( QDomElement& parentElement );
-    //! Read children from XML and append them to the group.
-    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
-    void readChildrenFromXml( QDomElement& element );
+    static QgsLayerTreeGroup *readXml( QDomElement &element ) /Factory/;
+%Docstring
+ Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+ Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+ :rtype: QgsLayerTreeGroup
+%End
 
-    //! Return text representation of the tree. For debugging purposes only.
+    static QgsLayerTreeGroup *readXml( QDomElement &element, const QgsProject *project ) /Factory/;
+%Docstring
+ Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+ Also resolves textual references to layers from the project (calls resolveReferences() internally).
+.. versionadded:: 3.0
+ :rtype: QgsLayerTreeGroup
+%End
+
+    virtual void writeXml( QDomElement &parentElement );
+%Docstring
+ Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
+%End
+
+    void readChildrenFromXml( QDomElement &element );
+%Docstring
+ Read children from XML and append them to the group.
+ Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+%End
+
     virtual QString dump() const;
+%Docstring
+ Return text representation of the tree. For debugging purposes only.
+ :rtype: str
+%End
 
-    //! Return a clone of the group. The children are cloned too.
-    virtual QgsLayerTreeGroup* clone() const /Factory/;
+    virtual QgsLayerTreeGroup *clone() const /Factory/;
+%Docstring
+ Return a clone of the group. The children are cloned too.
+ :rtype: QgsLayerTreeGroup
+%End
 
-    //! Calls resolveReferences() on child tree nodes
-    //! \since QGIS 3.0
     virtual void resolveReferences( const QgsProject *project, bool looseMatching = false );
+%Docstring
+ Calls resolveReferences() on child tree nodes
+.. versionadded:: 3.0
+%End
 
-    //! Check or uncheck a node and all its children (taking into account exclusion rules)
     virtual void setItemVisibilityCheckedRecursive( bool checked );
+%Docstring
+ Check or uncheck a node and all its children (taking into account exclusion rules)
+%End
 
-    //! Return whether the group is mutually exclusive (only one child can be checked at a time)
-    //! @note added in 2.12
     bool isMutuallyExclusive() const;
-    //! Set whether the group is mutually exclusive (only one child can be checked at a time).
-    //! The initial child index determines which child should be initially checked. The default value
-    //! of -1 will determine automatically (either first one currently checked or none)
-    //! @note added in 2.12
+%Docstring
+ Return whether the group is mutually exclusive (only one child can be checked at a time)
+.. versionadded:: 2.12
+ :rtype: bool
+%End
+
     void setIsMutuallyExclusive( bool enabled, int initialChildIndex = -1 );
+%Docstring
+ Set whether the group is mutually exclusive (only one child can be checked at a time).
+ The initial child index determines which child should be initially checked. The default value
+ of -1 will determine automatically (either first one currently checked or none)
+.. versionadded:: 2.12
+%End
 
   protected slots:
-    void nodeVisibilityChanged( QgsLayerTreeNode* node );
+    void nodeVisibilityChanged( QgsLayerTreeNode *node );
 
   protected:
 
-    //! Set check state of children - if mutually exclusive
     void updateChildVisibilityMutuallyExclusive();
+%Docstring
+ Set check state of children - if mutually exclusive
+%End
+
+
+
 
   private:
-    QgsLayerTreeGroup( const QgsLayerTreeGroup& other );
+    QgsLayerTreeGroup( const QgsLayerTreeGroup &other );
 };
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layertree/qgslayertreegroup.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -30,13 +30,13 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
 %End
 
 
-    QString name() const;
+    virtual QString name() const;
 %Docstring
  Returns the group's name.
  :rtype: str
 %End
 
-    void setName( const QString &n );
+    virtual void setName( const QString &n );
 %Docstring
  Sets the group's name.
 %End
@@ -213,8 +213,13 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
 
 
 
+
   private:
+
     QgsLayerTreeGroup( const QgsLayerTreeGroup &other );
+%Docstring
+ Copies are not allowed
+%End
 };
 
 

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -49,8 +49,9 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
     virtual QgsLayerTreeLayer* clone() const /Factory/;
 
     //! Resolves reference to layer from stored layer ID (if it has not been resolved already)
-    //! @note added in 3.0
-    virtual void resolveReferences( const QgsProject* project );
+    //! \since QGIS 3.0
+    virtual void resolveReferences( const QgsProject *project, bool looseMatching = false );
+
 
   signals:
     //! emitted when a previously unavailable layer got loaded

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -34,6 +34,9 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
 
 
     explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() );
+%Docstring
+ Constructor for QgsLayerTreeLayer using weak references to layer ID, name, public source, and provider key.
+%End
 
     QString layerId() const;
 %Docstring

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -1,69 +1,123 @@
-/**
- * Layer tree node points to a map layer.
- *
- * The node can exist also without a valid instance of a layer (just ID). That
- * means the referenced layer does not need to be loaded in order to use it
- * in layer tree. In such case, resolveReferences() method can be called
- * once the layer is loaded.
- *
- * A map layer is supposed to be present in one layer tree just once. It is
- * however possible that temporarily a layer exists in one tree more than just
- * once, e.g. while reordering items with drag and drop.
- *
- * @note added in 2.4
- */
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layertree/qgslayertreelayer.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
 class QgsLayerTreeLayer : QgsLayerTreeNode
 {
-%TypeHeaderCode
-#include <qgslayertreelayer.h>
+%Docstring
+ Layer tree node points to a map layer.
+
+ The node can exist also without a valid instance of a layer (just ID). That
+ means the referenced layer does not need to be loaded in order to use it
+ in layer tree. In such case, resolveReferences() method can be called
+ once the layer is loaded.
+
+ A map layer is supposed to be present in one layer tree just once. It is
+ however possible that temporarily a layer exists in one tree more than just
+ once, e.g. while reordering items with drag and drop.
+
+.. versionadded:: 2.4
 %End
 
+%TypeHeaderCode
+#include "qgslayertreelayer.h"
+%End
   public:
-    explicit QgsLayerTreeLayer( QgsMapLayer* layer );
+    explicit QgsLayerTreeLayer( QgsMapLayer *layer );
 
-    explicit QgsLayerTreeLayer( const QString& layerId, const QString& name = QString() );
+
+    explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() );
 
     QString layerId() const;
+%Docstring
+ :rtype: str
+%End
 
-    QgsMapLayer* layer() const;
+    QgsMapLayer *layer() const;
+%Docstring
+ :rtype: QgsMapLayer
+%End
 
-    //! Get layer's name
-    //! @note added in 3.0
     QString name() const;
-    //! Set layer's name
-    //! @note added in 3.0
-    void setName( const QString& n );
+%Docstring
+ Returns the layer's name.
+.. versionadded:: 3.0
+ :rtype: str
+%End
 
-    //! Read layer node from XML. Returns new instance.
-    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
-    static QgsLayerTreeLayer* readXml( QDomElement& element ) /Factory/;
-    //! Read layer node from XML. Returns new instance.
-    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
-    //! @note added in 3.0
-    static QgsLayerTreeLayer* readXml( QDomElement& element, const QgsProject* project ) /Factory/;
+    void setName( const QString &n );
+%Docstring
+ Sets the layer's name.
+.. versionadded:: 3.0
+%End
 
-    virtual void writeXml( QDomElement& parentElement );
+    static QgsLayerTreeLayer *readXml( QDomElement &element ) /Factory/;
+%Docstring
+ Read layer node from XML. Returns new instance.
+ Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+ :rtype: QgsLayerTreeLayer
+%End
+
+    static QgsLayerTreeLayer *readXml( QDomElement &element, const QgsProject *project ) /Factory/;
+%Docstring
+ Read layer node from XML. Returns new instance.
+ Also resolves textual references to layers from the project (calls resolveReferences() internally).
+.. versionadded:: 3.0
+ :rtype: QgsLayerTreeLayer
+%End
+
+    virtual void writeXml( QDomElement &parentElement );
 
     virtual QString dump() const;
+%Docstring
+ :rtype: str
+%End
 
-    virtual QgsLayerTreeLayer* clone() const /Factory/;
+    virtual QgsLayerTreeLayer *clone() const /Factory/;
+%Docstring
+ :rtype: QgsLayerTreeLayer
+%End
 
-    //! Resolves reference to layer from stored layer ID (if it has not been resolved already)
-    //! \since QGIS 3.0
     virtual void resolveReferences( const QgsProject *project, bool looseMatching = false );
-
+%Docstring
+ Resolves reference to layer from stored layer ID (if it has not been resolved already)
+.. versionadded:: 3.0
+%End
 
   signals:
-    //! emitted when a previously unavailable layer got loaded
+
     void layerLoaded();
-    //! emitted when a previously available layer got unloaded (from layer registry)
-    //! @note added in 2.6
+%Docstring
+ Emitted when a previously unavailable layer got loaded.
+%End
+
     void layerWillBeUnloaded();
+%Docstring
+ Emitted when a previously available layer got unloaded (from layer registry).
+.. versionadded:: 2.6
+%End
 
   protected:
     void attachToLayer();
 
-  private:
-    QgsLayerTreeLayer( const QgsLayerTreeLayer& other );
 
+  private:
+    QgsLayerTreeLayer( const QgsLayerTreeLayer &other );
 };
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layertree/qgslayertreelayer.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/layertree/qgslayertreelayer.sip
+++ b/python/core/layertree/qgslayertreelayer.sip
@@ -35,7 +35,7 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
 
     explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() );
 %Docstring
- Constructor for QgsLayerTreeLayer using weak references to layer ID, name, public source, and provider key.
+ Constructor for QgsLayerTreeLayer using weak references to layer ID, ``name``, public ``source``, and ``provider`` key.
 %End
 
     QString layerId() const;
@@ -48,14 +48,14 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
  :rtype: QgsMapLayer
 %End
 
-    QString name() const;
+    virtual QString name() const;
 %Docstring
  Returns the layer's name.
 .. versionadded:: 3.0
  :rtype: str
 %End
 
-    void setName( const QString &n );
+    virtual void setName( const QString &n );
 %Docstring
  Sets the layer's name.
 .. versionadded:: 3.0
@@ -79,14 +79,8 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
     virtual void writeXml( QDomElement &parentElement );
 
     virtual QString dump() const;
-%Docstring
- :rtype: str
-%End
 
     virtual QgsLayerTreeLayer *clone() const /Factory/;
-%Docstring
- :rtype: QgsLayerTreeLayer
-%End
 
     virtual void resolveReferences( const QgsProject *project, bool looseMatching = false );
 %Docstring
@@ -112,7 +106,11 @@ class QgsLayerTreeLayer : QgsLayerTreeNode
 
 
   private:
+
     QgsLayerTreeLayer( const QgsLayerTreeLayer &other );
+%Docstring
+ Copies are not allowed
+%End
 };
 
 

--- a/python/core/layertree/qgslayertreenode.sip
+++ b/python/core/layertree/qgslayertreenode.sip
@@ -102,10 +102,16 @@ class QgsLayerTreeNode : QObject
     //! Create a copy of the node. Returns new instance
     virtual QgsLayerTreeNode *clone() const = 0 /Factory/;
 
-    //! Turn textual references to layers into map layer object from project.
-    //! This method should be called after readXml()
-    //! @note added in 3.0
-    virtual void resolveReferences( const QgsProject* project ) = 0;
+    /**
+     * Turn textual references to layers into map layer object from project.
+     * This method should be called after readXml()
+     * If \a looseMatching is true then a looser match will be used, where a layer
+     * will match if the name, public source, and data provider match. This can be
+     * used to match legend customisation from different projects where layers
+     * will have different layer IDs.
+     * \since QGIS 3.0
+     */
+    virtual void resolveReferences( const QgsProject *project, bool looseMatching = false ) = 0;
 
     //! Returns whether a node is really visible (ie checked and all its ancestors checked as well)
     //! @note added in 3.0

--- a/python/core/qgscolorramp.sip
+++ b/python/core/qgscolorramp.sip
@@ -302,7 +302,7 @@ class QgsLimitedRandomColorRamp : QgsColorRamp
     virtual QString type() const;
     virtual QgsLimitedRandomColorRamp *clone() const /Factory/;
     virtual QgsStringMap properties() const;
-    int count() const;
+    virtual int count() const;
 
     static QList<QColor> randomColors( int count,
                                        int hueMax = DEFAULT_RANDOM_HUE_MAX, int hueMin = DEFAULT_RANDOM_HUE_MIN,
@@ -420,11 +420,11 @@ class QgsRandomColorRamp: QgsColorRamp
   public:
     QgsRandomColorRamp();
 
-    int count() const;
+    virtual int count() const;
 
-    double value( int index ) const;
+    virtual double value( int index ) const;
 
-    QColor color( double value ) const;
+    virtual QColor color( double value ) const;
 
     virtual void setTotalColorCount( const int colorCount );
 %Docstring
@@ -435,7 +435,7 @@ class QgsRandomColorRamp: QgsColorRamp
 .. versionadded:: 2.5
 %End
 
-    QString type() const;
+    virtual QString type() const;
 
     virtual QgsRandomColorRamp *clone() const /Factory/;
 
@@ -483,7 +483,7 @@ class QgsPresetSchemeColorRamp : QgsColorRamp, QgsColorScheme
  :rtype: QgsColorRamp
 %End
 
-    bool setColors( const QgsNamedColorList &colors, const QString & = QString(), const QColor & = QColor() );
+    virtual bool setColors( const QgsNamedColorList &colors, const QString & = QString(), const QColor & = QColor() );
 %Docstring
  Sets the list of colors used by the ramp.
  \param colors list of colors
@@ -499,25 +499,16 @@ class QgsPresetSchemeColorRamp : QgsColorRamp, QgsColorScheme
 %End
 
     virtual double value( int index ) const;
-%Docstring
-QgsColorRamp interface
- :rtype: float
-%End
     virtual QColor color( double value ) const;
     virtual QString type() const;
     virtual void invert();
     virtual QgsPresetSchemeColorRamp *clone() const /Factory/;
     virtual QgsStringMap properties() const;
-    int count() const;
+    virtual int count() const;
 
-    QString schemeName() const;
-%Docstring
-QgsColorScheme interface
- :rtype: str
-%End
-    QgsNamedColorList fetchColors( const QString &context = QString(),
-                                   const QColor &baseColor = QColor() );
-    bool isEditable() const;
+    virtual QString schemeName() const;
+    virtual QgsNamedColorList fetchColors( const QString &context = QString(), const QColor &baseColor = QColor() );
+    virtual bool isEditable() const;
 
 };
 

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -95,6 +95,13 @@ Returns the layer's unique ID, which is used to access this layer from QgsProjec
  :rtype: str
 %End
 
+    virtual QgsDataProvider *dataProvider();
+%Docstring
+ Returns the layer's data provider.
+ :rtype: QgsDataProvider
+%End
+
+
     QString originalName() const;
 %Docstring
  Returns the original name of the layer.

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -383,12 +383,7 @@ Returns a comment for the data in the layer
  :rtype: str
 %End
 
-    QgsVectorDataProvider *dataProvider();
-%Docstring
-Returns the data provider
- :rtype: QgsVectorDataProvider
-%End
-
+    virtual QgsVectorDataProvider *dataProvider();
 
     void setProviderEncoding( const QString &encoding );
 %Docstring

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -772,7 +772,7 @@ Return the provider type for this layer
  :rtype: str
 %End
 
-    bool readSymbology( const QDomNode &layerNode, QString &errorMessage );
+    virtual bool readSymbology( const QDomNode &layerNode, QString &errorMessage );
 %Docstring
  Read the symbology for the current layer from the Dom node supplied.
  \param layerNode node that will contain the symbology definition for this layer.
@@ -781,7 +781,7 @@ Return the provider type for this layer
  :rtype: bool
 %End
 
-    bool readStyle( const QDomNode &node, QString &errorMessage );
+    virtual bool readStyle( const QDomNode &node, QString &errorMessage );
 %Docstring
  Read the style for the current layer from the Dom node supplied.
  \param node node that will contain the style definition for this layer.
@@ -790,7 +790,7 @@ Return the provider type for this layer
  :rtype: bool
 %End
 
-    bool writeSymbology( QDomNode &node, QDomDocument &doc, QString &errorMessage ) const;
+    virtual bool writeSymbology( QDomNode &node, QDomDocument &doc, QString &errorMessage ) const;
 %Docstring
  Write the symbology for the layer into the docment provided.
   \param node the node that will have the style element added to it.
@@ -800,7 +800,7 @@ Return the provider type for this layer
  :rtype: bool
 %End
 
-    bool writeStyle( QDomNode &node, QDomDocument &doc, QString &errorMessage ) const;
+    virtual bool writeStyle( QDomNode &node, QDomDocument &doc, QString &errorMessage ) const;
 %Docstring
  Write just the style information for the layer into the document
   \param node the node that will have the style element added to it.
@@ -821,7 +821,7 @@ Return the provider type for this layer
  :rtype: bool
 %End
 
-    bool readSld( const QDomNode &node, QString &errorMessage );
+    virtual bool readSld( const QDomNode &node, QString &errorMessage );
 
     long featureCount( const QString &legendKey ) const;
 %Docstring
@@ -1099,7 +1099,7 @@ Synchronises with changes in the datasource
  :rtype: QgsMapLayerRenderer
 %End
 
-    QgsRectangle extent() const;
+    virtual QgsRectangle extent() const;
 %Docstring
 Return the extent of the layer
  :rtype: QgsRectangle
@@ -1627,7 +1627,7 @@ Returns the current transparency for the vector layer
  :rtype: int
 %End
 
-    QString htmlMetadata() const;
+    virtual QString htmlMetadata() const;
 
 
     void setSimplifyMethod( const QgsVectorSimplifyMethod &simplifyMethod );
@@ -1695,7 +1695,7 @@ Returns the current transparency for the vector layer
 .. versionadded:: 3.0
 %End
 
-    QgsExpressionContext createExpressionContext() const;
+    virtual QgsExpressionContext createExpressionContext() const;
 
     QgsEditFormConfig editFormConfig() const;
 %Docstring
@@ -2041,7 +2041,7 @@ Signal emitted when setLayerTransparency() is called
 
 
   protected:
-    void setExtent( const QgsRectangle &rect );
+    virtual void setExtent( const QgsRectangle &rect );
 %Docstring
 Set the extent
 %End

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -103,12 +103,12 @@ class QgsRasterLayer : QgsMapLayer
     QString bandName( int bandNoInt ) const;
 
     /** Returns the data provider */
-    QgsRasterDataProvider* dataProvider();
+    virtual QgsRasterDataProvider* dataProvider();
 
     /** Returns the data provider in a const-correct manner
       @note available in python bindings as constDataProvider()
      */
-    const QgsRasterDataProvider* dataProvider() const /PyName=constDataProvider/;
+    virtual const QgsRasterDataProvider* dataProvider() const /PyName=constDataProvider/;
 
     /** Synchronises with changes in the datasource */
     virtual void reload();

--- a/python/gui/qgscolorbutton.sip
+++ b/python/gui/qgscolorbutton.sip
@@ -346,10 +346,10 @@ class QgsColorButton : QToolButton
 
   protected:
 
-    bool event( QEvent *e );
-    void changeEvent( QEvent *e );
-    void showEvent( QShowEvent *e );
-    void resizeEvent( QResizeEvent *event );
+    virtual bool event( QEvent *e );
+    virtual void changeEvent( QEvent *e );
+    virtual void showEvent( QShowEvent *e );
+    virtual void resizeEvent( QResizeEvent *event );
 
     static const QPixmap &transparentBackground();
 %Docstring
@@ -357,37 +357,37 @@ class QgsColorButton : QToolButton
  :rtype: QPixmap
 %End
 
-    void mousePressEvent( QMouseEvent *e );
+    virtual void mousePressEvent( QMouseEvent *e );
 %Docstring
  Reimplemented to detect right mouse button clicks on the color button and allow dragging colors
 %End
 
-    void mouseMoveEvent( QMouseEvent *e );
+    virtual void mouseMoveEvent( QMouseEvent *e );
 %Docstring
  Reimplemented to allow dragging colors from button
 %End
 
-    void mouseReleaseEvent( QMouseEvent *e );
+    virtual void mouseReleaseEvent( QMouseEvent *e );
 %Docstring
  Reimplemented to allow color picking
 %End
 
-    void keyPressEvent( QKeyEvent *e );
+    virtual void keyPressEvent( QKeyEvent *e );
 %Docstring
  Reimplemented to allow canceling color pick via keypress, and sample via space bar press
 %End
 
-    void dragEnterEvent( QDragEnterEvent *e );
+    virtual void dragEnterEvent( QDragEnterEvent *e );
 %Docstring
  Reimplemented to accept dragged colors
 %End
 
-    void dragLeaveEvent( QDragLeaveEvent *e );
+    virtual void dragLeaveEvent( QDragLeaveEvent *e );
 %Docstring
  Reimplemented to reset button appearance after drag leave
 %End
 
-    void dropEvent( QDropEvent *e );
+    virtual void dropEvent( QDropEvent *e );
 %Docstring
  Reimplemented to accept dropped colors
 %End

--- a/python/gui/qgscolorrampbutton.sip
+++ b/python/gui/qgscolorrampbutton.sip
@@ -257,12 +257,12 @@ class QgsColorRampButton : QToolButton
 
   protected:
 
-    bool event( QEvent *e );
-    void changeEvent( QEvent *e );
-    void showEvent( QShowEvent *e );
-    void resizeEvent( QResizeEvent *event );
+    virtual bool event( QEvent *e );
+    virtual void changeEvent( QEvent *e );
+    virtual void showEvent( QShowEvent *e );
+    virtual void resizeEvent( QResizeEvent *event );
 
-    void mousePressEvent( QMouseEvent *e );
+    virtual void mousePressEvent( QMouseEvent *e );
 %Docstring
  Reimplemented to detect right mouse button clicks on the color ramp button
 %End

--- a/python/gui/qgsmessagelogviewer.sip
+++ b/python/gui/qgsmessagelogviewer.sip
@@ -35,8 +35,8 @@ class QgsMessageLogViewer: QDialog
 %End
 
   protected:
-    void closeEvent( QCloseEvent *e );
-    void reject();
+    virtual void closeEvent( QCloseEvent *e );
+    virtual void reject();
 
 };
 

--- a/python/gui/symbology-ng/characterwidget.sip
+++ b/python/gui/symbology-ng/characterwidget.sip
@@ -27,7 +27,7 @@ class CharacterWidget : QWidget
  Constructor for CharacterWidget.
 %End
 
-    QSize sizeHint() const;
+    virtual QSize sizeHint() const;
 
     int columns() const;
 %Docstring
@@ -101,9 +101,9 @@ class CharacterWidget : QWidget
 %End
 
   protected:
-    void mouseMoveEvent( QMouseEvent *event );
-    void mousePressEvent( QMouseEvent *event );
-    void paintEvent( QPaintEvent *event );
+    virtual void mouseMoveEvent( QMouseEvent *event );
+    virtual void mousePressEvent( QMouseEvent *event );
+    virtual void paintEvent( QPaintEvent *event );
 
 };
 

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -318,6 +318,12 @@ while(!eof $header){
         # remove keywords
         if ( $line =~ m/\boverride\b/){
             $is_override = 1;
+            if ( $line !~ m/^(\s*)virtual\b(.*)$/ ){
+                #sip often requires the virtual keyword to be present, or it chokes on covariant return types
+                #in overridden methods
+                $line =~ m/^(\s*?)\b(.*)$/;
+                $line = "$1virtual $2\n";
+            }
         }
         $line =~ s/\s*\boverride\b//;
         $line =~ s/^(\s*)?(const )?(virtual |static )?inline /$1$2$3/;

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -489,7 +489,7 @@ bool QgsComposerLegend::readXml( const QDomElement &itemElem, const QDomDocument
   {
     std::unique_ptr< QgsLayerTree > tree( QgsLayerTree::readXml( layerTreeElem ) );
     if ( mComposition )
-      tree->resolveReferences( mComposition->project() );
+      tree->resolveReferences( mComposition->project(), true );
     setCustomLayerTree( tree.release() );
   }
   else

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -336,10 +336,10 @@ QgsLayerTreeGroup *QgsLayerTreeGroup::clone() const
   return new QgsLayerTreeGroup( *this );
 }
 
-void QgsLayerTreeGroup::resolveReferences( const QgsProject *project )
+void QgsLayerTreeGroup::resolveReferences( const QgsProject *project, bool looseMatching )
 {
   Q_FOREACH ( QgsLayerTreeNode *node, mChildren )
-    node->resolveReferences( project );
+    node->resolveReferences( project, looseMatching );
 }
 
 static bool _nodeIsChecked( QgsLayerTreeNode *node )

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -103,7 +103,7 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 
     //! Calls resolveReferences() on child tree nodes
     //! \since QGIS 3.0
-    virtual void resolveReferences( const QgsProject *project ) override;
+    virtual void resolveReferences( const QgsProject *project, bool looseMatching = false ) override;
 
     //! Check or uncheck a node and all its children (taking into account exclusion rules)
     virtual void setItemVisibilityCheckedRecursive( bool checked ) override;

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -215,13 +215,20 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 
     //! Whether the group is mutually exclusive (i.e. only one child can be checked at a time)
     bool mMutuallyExclusive;
-    //! Keeps track which child has been most recently selected
-    //! (so if the whole group is unchecked and checked again, we know which child to check)
+
+    /**
+     * Keeps track which child has been most recently selected
+     * (so if the whole group is unchecked and checked again, we know which child to check)
+     */
     int mMutuallyExclusiveChildIndex;
 
   private:
 
 #ifdef SIP_RUN
+
+    /**
+     * Copies are not allowed
+     */
     QgsLayerTreeGroup( const QgsLayerTreeGroup &other );
 #endif
 

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -17,6 +17,7 @@
 #define QGSLAYERTREEGROUP_H
 
 #include "qgis_core.h"
+#include "qgis.h"
 #include "qgslayertreenode.h"
 
 class QgsMapLayer;
@@ -33,88 +34,169 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 {
     Q_OBJECT
   public:
-    //! Constructor
-    QgsLayerTreeGroup( const QString &name = QString(), bool checked = true );
-    QgsLayerTreeGroup( const QgsLayerTreeGroup &other );
 
-    //! Get group's name
+    /**
+     * Constructor
+     */
+    QgsLayerTreeGroup( const QString &name = QString(), bool checked = true );
+
+#ifndef SIP_RUN
+    QgsLayerTreeGroup( const QgsLayerTreeGroup &other );
+#endif
+
+    /**
+     * Returns the group's name.
+     */
     QString name() const override;
-    //! Set group's name
+
+    /**
+     * Sets the group's name.
+     */
     void setName( const QString &n ) override;
 
-    //! Insert a new group node with given name at specified position. Newly created node is owned by this group.
+    /**
+     * Insert a new group node with given name at specified position. The newly created node is owned by this group.
+     */
     QgsLayerTreeGroup *insertGroup( int index, const QString &name );
-    //! Append a new group node with given name. Newly created node is owned by this group.
+
+    /**
+     * Append a new group node with given name. Newly created node is owned by this group.
+     */
     QgsLayerTreeGroup *addGroup( const QString &name );
-    //! Insert a new layer node for given map layer at specified position. Newly created node is owned by this group.
+
+    /**
+     * Insert a new layer node for given map layer at specified position. The newly created node is owned by this group.
+     */
     QgsLayerTreeLayer *insertLayer( int index, QgsMapLayer *layer );
-    //! Append a new layer node for given map layer. Newly created node is owned by this group.
+
+    /**
+     * Append a new layer node for given map layer. The newly created node is owned by this group.
+     */
     QgsLayerTreeLayer *addLayer( QgsMapLayer *layer );
 
-    //! Insert existing nodes at specified position. The nodes must not have a parent yet. The nodes will be owned by this group.
-    void insertChildNodes( int index, const QList<QgsLayerTreeNode *> &nodes );
-    //! Insert existing node at specified position. The node must not have a parent yet. The node will be owned by this group.
-    void insertChildNode( int index, QgsLayerTreeNode *node );
-    //! Append an existing node. The node must not have a parent yet. The node will be owned by this group.
-    void addChildNode( QgsLayerTreeNode *node );
+    /**
+     * Insert existing nodes at specified position. The nodes must not have a parent yet. The nodes will be owned by this group.
+     */
+    void insertChildNodes( int index, const QList<QgsLayerTreeNode *> &nodes SIP_TRANSFER );
 
-    //! Remove a child node from this group. The node will be deleted.
+    /**
+     * Insert existing node at specified position. The node must not have a parent yet. The node will be owned by this group.
+     */
+    void insertChildNode( int index, QgsLayerTreeNode *node SIP_TRANSFER );
+
+    /**
+     * Append an existing node. The node must not have a parent yet. The node will be owned by this group.
+     */
+    void addChildNode( QgsLayerTreeNode *node SIP_TRANSFER );
+
+    /**
+     * Remove a child node from this group. The node will be deleted.
+     */
     void removeChildNode( QgsLayerTreeNode *node );
-    //! Remove map layer's node from this group. The node will be deleted.
+
+    /**
+     * Remove map layer's node from this group. The node will be deleted.
+     */
     void removeLayer( QgsMapLayer *layer );
-    //! Remove child nodes from index "from". The nodes will be deleted.
+
+    /**
+     * Remove child nodes from index "from". The nodes will be deleted.
+     */
     void removeChildren( int from, int count );
-    //! Remove all child group nodes without layers. The groupnodes will be deleted.
+
+    /**
+     * Remove all child group nodes without layers. The groupnodes will be deleted.
+     */
     void removeChildrenGroupWithoutLayers();
-    //! Remove all child nodes. The nodes will be deleted.
+
+    /**
+     * Remove all child nodes. The nodes will be deleted.
+     */
     void removeAllChildren();
 
-    //! Find layer node representing the map layer. Searches recursively the whole sub-tree.
-    //! \since QGIS 3.0
+    /**
+     * Find layer node representing the map layer. Searches recursively the whole sub-tree.
+     * \since QGIS 3.0
+     */
     QgsLayerTreeLayer *findLayer( QgsMapLayer *layer ) const;
-    //! Find layer node representing the map layer specified by its ID. Searches recursively the whole sub-tree.
+
+    /**
+     * Find layer node representing the map layer specified by its ID. Searches recursively the whole sub-tree.
+     */
     QgsLayerTreeLayer *findLayer( const QString &layerId ) const;
-    //! Find all layer nodes. Searches recursively the whole sub-tree.
+
+    /**
+     * Find all layer nodes. Searches recursively the whole sub-tree.
+     */
     QList<QgsLayerTreeLayer *> findLayers() const;
-    //! Find layer IDs used in all layer nodes. Searches recursively the whole sub-tree.
+
+    /**
+     * Find layer IDs used in all layer nodes. Searches recursively the whole sub-tree.
+     */
     QStringList findLayerIds() const;
-    //! Find group node with specified name. Searches recursively the whole sub-tree.
+
+    /**
+     * Find group node with specified name. Searches recursively the whole sub-tree.
+     */
     QgsLayerTreeGroup *findGroup( const QString &name );
 
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
-    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
-    static QgsLayerTreeGroup *readXml( QDomElement &element );
-    //! Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
-    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
-    //! \since QGIS 3.0
-    static QgsLayerTreeGroup *readXml( QDomElement &element, const QgsProject *project );
+    /**
+     * Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+     * Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+     */
+    static QgsLayerTreeGroup *readXml( QDomElement &element ) SIP_FACTORY;
 
-    //! Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
+    /**
+     * Read group (tree) from XML element <layer-tree-group> and return the newly created group (or null on error).
+     * Also resolves textual references to layers from the project (calls resolveReferences() internally).
+     * \since QGIS 3.0
+     */
+    static QgsLayerTreeGroup *readXml( QDomElement &element, const QgsProject *project ) SIP_FACTORY;
+
+    /**
+     * Write group (tree) as XML element <layer-tree-group> and add it to the given parent element
+     */
     virtual void writeXml( QDomElement &parentElement ) override;
-    //! Read children from XML and append them to the group.
-    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+
+    /**
+     * Read children from XML and append them to the group.
+     * Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+     */
     void readChildrenFromXml( QDomElement &element );
 
-    //! Return text representation of the tree. For debugging purposes only.
+    /**
+     * Return text representation of the tree. For debugging purposes only.
+     */
     virtual QString dump() const override;
 
-    //! Return a clone of the group. The children are cloned too.
-    virtual QgsLayerTreeGroup *clone() const override;
+    /**
+     * Return a clone of the group. The children are cloned too.
+     */
+    virtual QgsLayerTreeGroup *clone() const override SIP_FACTORY;
 
-    //! Calls resolveReferences() on child tree nodes
-    //! \since QGIS 3.0
+    /**
+     * Calls resolveReferences() on child tree nodes
+     * \since QGIS 3.0
+     */
     virtual void resolveReferences( const QgsProject *project, bool looseMatching = false ) override;
 
-    //! Check or uncheck a node and all its children (taking into account exclusion rules)
+    /**
+     * Check or uncheck a node and all its children (taking into account exclusion rules)
+     */
     virtual void setItemVisibilityCheckedRecursive( bool checked ) override;
 
-    //! Return whether the group is mutually exclusive (only one child can be checked at a time)
-    //! \since QGIS 2.12
+    /**
+     * Return whether the group is mutually exclusive (only one child can be checked at a time)
+     * \since QGIS 2.12
+     */
     bool isMutuallyExclusive() const;
-    //! Set whether the group is mutually exclusive (only one child can be checked at a time).
-    //! The initial child index determines which child should be initially checked. The default value
-    //! of -1 will determine automatically (either first one currently checked or none)
-    //! \since QGIS 2.12
+
+    /**
+     * Set whether the group is mutually exclusive (only one child can be checked at a time).
+     * The initial child index determines which child should be initially checked. The default value
+     * of -1 will determine automatically (either first one currently checked or none)
+     * \since QGIS 2.12
+     */
     void setIsMutuallyExclusive( bool enabled, int initialChildIndex = -1 );
 
   protected slots:
@@ -122,10 +204,11 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 
   protected:
 
-    //! Set check state of children - if mutually exclusive
+    /**
+     * Set check state of children - if mutually exclusive
+     */
     void updateChildVisibilityMutuallyExclusive();
 
-  protected:
     QString mName;
 
     bool mChangingChildVisibility;
@@ -135,6 +218,13 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     //! Keeps track which child has been most recently selected
     //! (so if the whole group is unchecked and checked again, we know which child to check)
     int mMutuallyExclusiveChildIndex;
+
+  private:
+
+#ifdef SIP_RUN
+    QgsLayerTreeGroup( const QgsLayerTreeGroup &other );
+#endif
+
 };
 
 

--- a/src/core/layertree/qgslayertreelayer.cpp
+++ b/src/core/layertree/qgslayertreelayer.cpp
@@ -146,25 +146,7 @@ void QgsLayerTreeLayer::writeXml( QDomElement &parentElement )
   if ( mRef.layer )
   {
     elem.setAttribute( "source", mRef.layer->publicSource() );
-    QString providerKey;
-    switch ( mRef.layer->type() )
-    {
-      case QgsMapLayer::VectorLayer:
-      {
-        QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( mRef.layer );
-        providerKey = vl->dataProvider()->name();
-        break;
-      }
-      case QgsMapLayer::RasterLayer:
-      {
-        QgsRasterLayer *rl = qobject_cast< QgsRasterLayer * >( mRef.layer );
-        providerKey = rl->dataProvider()->name();
-        break;
-      }
-      case QgsMapLayer::PluginLayer:
-        break;
-    }
-    elem.setAttribute( "providerKey", providerKey );
+    elem.setAttribute( "providerKey", mRef.layer->dataProvider() ? mRef.layer->dataProvider()->name() : QString() );
   }
 
   elem.setAttribute( QStringLiteral( "checked" ), mChecked ? QStringLiteral( "Qt::Checked" ) : QStringLiteral( "Qt::Unchecked" ) );

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -47,6 +47,9 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     QgsLayerTreeLayer( const QgsLayerTreeLayer &other );
 #endif
 
+    /**
+     * Constructor for QgsLayerTreeLayer using weak references to layer ID, \a name, public \a source, and \a provider key.
+     */
     explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() );
 
     QString layerId() const { return mRef.layerId; }

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -17,6 +17,7 @@
 #define QGSLAYERTREELAYER_H
 
 #include "qgis_core.h"
+#include "qgis.h"
 #include "qgslayertreenode.h"
 #include "qgsmaplayerref.h"
 
@@ -41,7 +42,10 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     Q_OBJECT
   public:
     explicit QgsLayerTreeLayer( QgsMapLayer *layer );
+
+#ifndef SIP_RUN
     QgsLayerTreeLayer( const QgsLayerTreeLayer &other );
+#endif
 
     explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() );
 
@@ -49,44 +53,54 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     QgsMapLayer *layer() const { return mRef.layer.data(); }
 
-    //! Get layer's name
-    //! \since QGIS 3.0
+    /**
+     * Returns the layer's name.
+     * \since QGIS 3.0
+     */
     QString name() const override;
-    //! Set layer's name
-    //! \since QGIS 3.0
+
+    /**
+     * Sets the layer's name.
+     * \since QGIS 3.0
+     */
     void setName( const QString &n ) override;
 
-    //! Read layer node from XML. Returns new instance.
-    //! Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
-    static QgsLayerTreeLayer *readXml( QDomElement &element );
-    //! Read layer node from XML. Returns new instance.
-    //! Also resolves textual references to layers from the project (calls resolveReferences() internally).
-    //! \since QGIS 3.0
-    static QgsLayerTreeLayer *readXml( QDomElement &element, const QgsProject *project );
+    /**
+     * Read layer node from XML. Returns new instance.
+     * Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
+     */
+    static QgsLayerTreeLayer *readXml( QDomElement &element ) SIP_FACTORY;
+
+    /**
+     * Read layer node from XML. Returns new instance.
+     * Also resolves textual references to layers from the project (calls resolveReferences() internally).
+     * \since QGIS 3.0
+     */
+    static QgsLayerTreeLayer *readXml( QDomElement &element, const QgsProject *project ) SIP_FACTORY;
 
     virtual void writeXml( QDomElement &parentElement ) override;
 
     virtual QString dump() const override;
 
-    virtual QgsLayerTreeLayer *clone() const override;
+    virtual QgsLayerTreeLayer *clone() const override SIP_FACTORY;
 
-    //! Resolves reference to layer from stored layer ID (if it has not been resolved already)
-    //! \since QGIS 3.0
+    /**
+     * Resolves reference to layer from stored layer ID (if it has not been resolved already)
+     * \since QGIS 3.0
+     */
     virtual void resolveReferences( const QgsProject *project, bool looseMatching = false ) override;
 
-  private slots:
-    //! Emits a nameChanged() signal if layer's name has changed
-    //! \since QGIS 3.0
-    void layerNameChanged();
-    //! Handles the event of deletion of the referenced layer
-    //! \since QGIS 3.0
-    void layerWillBeDeleted();
-
   signals:
-    //! emitted when a previously unavailable layer got loaded
+
+    /**
+     * Emitted when a previously unavailable layer got loaded.
+     */
     void layerLoaded();
-    //! emitted when a previously available layer got unloaded (from layer registry)
-    //! \since QGIS 2.6
+
+    /**
+     * Emitted when a previously available layer got unloaded (from layer registry).
+     * \since QGIS 2.6
+     */
     void layerWillBeUnloaded();
 
   protected:
@@ -96,6 +110,26 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     QgsMapLayerRef mRef;
     //! Layer name - only used if layer does not exist
     QString mLayerName;
+
+  private slots:
+
+    /**
+     * Emits a nameChanged() signal if layer's name has changed
+     * \since QGIS 3.0
+     */
+    void layerNameChanged();
+
+    /**
+     * Handles the event of deletion of the referenced layer
+     * \since QGIS 3.0
+     */
+    void layerWillBeDeleted();
+
+  private:
+
+#ifdef SIP_RUN
+    QgsLayerTreeLayer( const QgsLayerTreeLayer &other );
+#endif
 };
 
 

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
     explicit QgsLayerTreeLayer( QgsMapLayer *layer );
     QgsLayerTreeLayer( const QgsLayerTreeLayer &other );
 
-    explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString() );
+    explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() );
 
     QString layerId() const { return mRef.layerId; }
 
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     //! Resolves reference to layer from stored layer ID (if it has not been resolved already)
     //! \since QGIS 3.0
-    virtual void resolveReferences( const QgsProject *project ) override;
+    virtual void resolveReferences( const QgsProject *project, bool looseMatching = false ) override;
 
   private slots:
     //! Emits a nameChanged() signal if layer's name has changed

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -131,6 +131,10 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
   private:
 
 #ifdef SIP_RUN
+
+    /**
+     * Copies are not allowed
+     */
     QgsLayerTreeLayer( const QgsLayerTreeLayer &other );
 #endif
 };

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -113,10 +113,16 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     //! Create a copy of the node. Returns new instance
     virtual QgsLayerTreeNode *clone() const = 0;
 
-    //! Turn textual references to layers into map layer object from project.
-    //! This method should be called after readXml()
-    //! \since QGIS 3.0
-    virtual void resolveReferences( const QgsProject *project ) = 0;
+    /**
+     * Turn textual references to layers into map layer object from project.
+     * This method should be called after readXml()
+     * If \a looseMatching is true then a looser match will be used, where a layer
+     * will match if the name, public source, and data provider match. This can be
+     * used to match legend customisation from different projects where layers
+     * will have different layer IDs.
+     * \since QGIS 3.0
+     */
+    virtual void resolveReferences( const QgsProject *project, bool looseMatching = false ) = 0;
 
     //! Returns whether a node is really visible (ie checked and all its ancestors checked as well)
     //! \since QGIS 3.0

--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -450,7 +450,6 @@ class CORE_EXPORT QgsPresetSchemeColorRamp : public QgsColorRamp, public QgsColo
      */
     QList< QColor > colors() const;
 
-    // QgsColorRamp interface
     virtual double value( int index ) const override;
     virtual QColor color( double value ) const override;
     virtual QString type() const override { return QStringLiteral( "preset" ); }
@@ -459,10 +458,8 @@ class CORE_EXPORT QgsPresetSchemeColorRamp : public QgsColorRamp, public QgsColo
     virtual QgsStringMap properties() const override;
     int count() const override;
 
-    // QgsColorScheme interface
     QString schemeName() const override { return QStringLiteral( "preset" ); }
-    QgsNamedColorList fetchColors( const QString &context = QString(),
-                                   const QColor &baseColor = QColor() ) override;
+    QgsNamedColorList fetchColors( const QString &context = QString(), const QColor &baseColor = QColor() ) override;
     bool isEditable() const override { return true; }
 
   private:

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -35,6 +35,7 @@
 #include "qgsrendercontext.h"
 #include "qgsmaplayerdependency.h"
 
+class QgsDataProvider;
 class QgsMapLayerLegend;
 class QgsMapLayerRenderer;
 class QgsMapLayerStyleManager;
@@ -127,6 +128,17 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see setName()
      */
     QString name() const;
+
+    /**
+     * Returns the layer's data provider.
+     */
+    virtual QgsDataProvider *dataProvider() { return nullptr; }
+
+    /**
+     * Returns the layer's data provider in a const-correct manner
+     * \note not available in Python bindings
+     */
+    virtual const QgsDataProvider *dataProvider() const SIP_SKIP { return nullptr; }
 
     /** Returns the original name of the layer.
      * \returns the original layer name

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -98,11 +98,7 @@ bool QgsMapLayerProxyModel::filterAcceptsRow( int source_row, const QModelIndex 
   if ( mExceptList.contains( layer ) )
     return false;
 
-  QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
-  if ( vl && mExcludedProviders.contains( vl->dataProvider()->name() ) )
-    return false;
-  QgsRasterLayer *rl = qobject_cast<QgsRasterLayer *>( layer );
-  if ( rl && mExcludedProviders.contains( rl->dataProvider()->name() ) )
+  if ( mExcludedProviders.contains( layer->dataProvider()->name() ) )
     return false;
 
   if ( mFilters.testFlag( WritableLayer ) && layer->readOnly() )
@@ -122,7 +118,7 @@ bool QgsMapLayerProxyModel::filterAcceptsRow( int source_row, const QModelIndex 
                         mFilters.testFlag( HasGeometry );
   if ( detectGeometry && layer->type() == QgsMapLayer::VectorLayer )
   {
-    if ( vl )
+    if ( QgsVectorLayer *vl = qobject_cast< QgsVectorLayer *>( layer ) )
     {
       if ( mFilters.testFlag( HasGeometry ) && vl->hasGeometryType() )
         return true;

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -19,6 +19,10 @@
 #include <QPointer>
 
 #include "qgsmaplayer.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataprovider.h"
+#include "raster/qgsrasterlayer.h"
+#include "raster/qgsrasterdataprovider.h"
 
 /** Internal structure to keep weak pointer to QgsMapLayer or layerId
  *  if the layer is not available yet.
@@ -28,10 +32,61 @@ template<typename TYPE>
 struct _LayerRef
 {
   _LayerRef( TYPE *l = nullptr ): layer( l ), layerId( l ? l->id() : QString() ) {}
-  _LayerRef( const QString &id ): layer(), layerId( id ) {}
+
+  /**
+   * Constructor for a weak layer reference, using a combination of layer ID,
+   * \a name, public \a source and \a provider key.
+   */
+  _LayerRef( const QString &id, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() )
+    : layer()
+    , layerId( id )
+    , source( source )
+    , name( name )
+    , provider( provider )
+  {}
 
   QPointer<TYPE> layer;
   QString layerId;
+
+  //! Weak reference to layer public source
+  QString source;
+  //! Weak reference to layer name
+  QString name;
+  //! Weak reference to layer provider
+  QString provider;
+
+  /**
+   * Returns true if a layer matches the weak references to layer public source,
+   * layer name and data provider contained in this layer reference.
+   */
+  bool layerMatchesSource( QgsMapLayer *layer ) const
+  {
+    if ( layer->publicSource() != source ||
+         layer->name() != name )
+      return false;
+
+    switch ( layer->type() )
+    {
+      case QgsMapLayer::VectorLayer:
+      {
+        QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( layer );
+        if ( vl->dataProvider()->name() != provider )
+          return false;
+        break;
+      }
+      case QgsMapLayer::RasterLayer:
+      {
+        QgsRasterLayer *rl = qobject_cast< QgsRasterLayer * >( layer );
+        if ( rl->dataProvider()->name() != provider )
+          return false;
+        break;
+      }
+      case QgsMapLayer::PluginLayer:
+        break;
+
+    }
+    return true;
+  }
 };
 
 typedef _LayerRef<QgsMapLayer> QgsMapLayerRef;

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -65,26 +65,9 @@ struct _LayerRef
          layer->name() != name )
       return false;
 
-    switch ( layer->type() )
-    {
-      case QgsMapLayer::VectorLayer:
-      {
-        QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( layer );
-        if ( vl->dataProvider()->name() != provider )
-          return false;
-        break;
-      }
-      case QgsMapLayer::RasterLayer:
-      {
-        QgsRasterLayer *rl = qobject_cast< QgsRasterLayer * >( layer );
-        if ( rl->dataProvider()->name() != provider )
-          return false;
-        break;
-      }
-      case QgsMapLayer::PluginLayer:
-        break;
+    if ( layer->dataProvider()->name() != provider )
+      return false;
 
-    }
     return true;
   }
 };

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -108,23 +108,21 @@ static void _addLayerTreeNodeToUriList( QgsLayerTreeNode *node, QgsMimeDataUtils
   else if ( QgsLayerTree::isLayer( node ) )
   {
     QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
-    if ( !nodeLayer->layer() )
+    QgsMapLayer *layer = nodeLayer->layer();
+    if ( !layer )
       return;
 
     QgsMimeDataUtils::Uri uri;
-    if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() ) )
+    uri.name = layer->name();
+    uri.uri = layer->dataProvider()->dataSourceUri();
+    uri.providerKey = layer->dataProvider()->name();
+    if ( layer->type() == QgsMapLayer::VectorLayer )
     {
       uri.layerType = QStringLiteral( "vector" );
-      uri.name = vlayer->name();
-      uri.providerKey = vlayer->dataProvider()->name();
-      uri.uri = vlayer->dataProvider()->dataSourceUri();
     }
-    else if ( QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( nodeLayer->layer() ) )
+    else if ( layer->type() == QgsMapLayer::RasterLayer )
     {
       uri.layerType = QStringLiteral( "raster" );
-      uri.name = rlayer->name();
-      uri.providerKey = rlayer->dataProvider()->name();
-      uri.uri = rlayer->dataProvider()->dataSourceUri();
     }
     else
     {

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -525,14 +525,14 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * Get metadata, dependent on the provider type, that will be display in the metadata tab of the layer properties.
      * \returns The provider metadata
      */
-    virtual QVariantMap metadata() const { return QVariantMap(); };
+    virtual QVariantMap metadata() const { return QVariantMap(); }
 
     /**
      * Get the translated metadata key.
      * \param mdKey The metadata key
      * \returns The translated metadata value
      */
-    virtual QString translateMetadataKey( const QString &mdKey ) const { return mdKey; };
+    virtual QString translateMetadataKey( const QString &mdKey ) const { return mdKey; }
 
     /**
      * Get the translated metadata value.
@@ -540,7 +540,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * \param value The metadata value
      * \returns The translated metadata value
      */
-    virtual QString translateMetadataValue( const QString &mdKey, const QVariant &value ) const { Q_UNUSED( mdKey ); return value.toString(); };
+    virtual QString translateMetadataValue( const QString &mdKey, const QVariant &value ) const { Q_UNUSED( mdKey ); return value.toString(); }
 
   signals:
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -33,6 +33,7 @@
 #include "qgsfeaturerequest.h"
 #include "qgsfields.h"
 #include "qgssnapper.h"
+#include "qgsvectordataprovider.h"
 #include "qgsvectorsimplifymethod.h"
 #include "qgseditformconfig.h"
 #include "qgsattributetableconfig.h"
@@ -63,7 +64,6 @@ class QgsRelation;
 class QgsRelationManager;
 class QgsSingleSymbolRenderer;
 class QgsSymbol;
-class QgsVectorDataProvider;
 class QgsVectorLayerJoinInfo;
 class QgsVectorLayerEditBuffer;
 class QgsVectorLayerJoinBuffer;
@@ -437,13 +437,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     QString displayExpression() const;
 
-    //! Returns the data provider
-    QgsVectorDataProvider *dataProvider();
-
-    /** Returns the data provider in a const-correct manner
-     * \note not available in Python bindings
-     */
-    const QgsVectorDataProvider *dataProvider() const SIP_SKIP;
+    QgsVectorDataProvider *dataProvider() override;
+    const QgsVectorDataProvider *dataProvider() const override SIP_SKIP;
 
     //! Sets the textencoding of the data provider
     void setProviderEncoding( const QString &encoding );

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -32,6 +32,7 @@
 #include "qgis.h"
 #include "qgsmaplayer.h"
 #include "qgsraster.h"
+#include "qgsrasterdataprovider.h"
 #include "qgsrasterpipe.h"
 #include "qgsrasterviewport.h"
 #include "qgsrasterminmaxorigin.h"
@@ -247,13 +248,12 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     //! \brief Get the name of a band given its number
     QString bandName( int bandNoInt ) const;
 
-    //! Returns the data provider
-    QgsRasterDataProvider *dataProvider();
+    QgsRasterDataProvider *dataProvider() override;
 
     /** Returns the data provider in a const-correct manner
       \note available in Python bindings as constDataProvider()
      */
-    const QgsRasterDataProvider *dataProvider() const;
+    const QgsRasterDataProvider *dataProvider() const override;
 
     //! Synchronises with changes in the datasource
     virtual void reload() override;

--- a/tests/scripts/sipifyheader.expected.sip
+++ b/tests/scripts/sipifyheader.expected.sip
@@ -129,7 +129,7 @@ Factory annotation
  :rtype: SomeObject
 %End
 
-    SomeObject *createAnother2() /Factory/;
+    virtual SomeObject *createAnother2() /Factory/;
 
     void LongDocStringMethod();
 %Docstring
@@ -202,6 +202,8 @@ Removing function body with virtual const reference
 
 
     virtual int overriddenProperty();
+    virtual int overrideWithoutVirtual();
+
     QString returnTypeString() const;
 %Docstring
  :rtype: str

--- a/tests/scripts/sipifyheader.h
+++ b/tests/scripts/sipifyheader.h
@@ -216,6 +216,8 @@ class CORE_EXPORT QgsSipifyHeader : public QtClass<QVariant>, private Ui::QgsBas
 
     virtual int overriddenProperty() override { return 42; } // if in doubt, comment it out
 
+    int overrideWithoutVirtual() override;
+
     QString returnTypeString() const;
 
     double returnTypeDouble() const;

--- a/tests/src/core/testqgscomposition.cpp
+++ b/tests/src/core/testqgscomposition.cpp
@@ -720,7 +720,6 @@ void TestQgsComposition::legendRestoredFromTemplate()
   QCOMPARE( layerNode2->layer(), layer );
   QCOMPARE( model2->data( model->node2index( layerNode2 ), Qt::DisplayRole ).toString(), QString( "new title!" ) );
 
-#if 0 //expected failure (#2738)
   QString oldId = layer->id();
   // new test
   // remove existing layer
@@ -749,7 +748,6 @@ void TestQgsComposition::legendRestoredFromTemplate()
   QVERIFY( layerNode3 );
   QCOMPARE( layerNode3->layer(), layer2 );
   QCOMPARE( model3->data( model->node2index( layerNode3 ), Qt::DisplayRole ).toString(), QString( "new title!" ) );
-#endif
 }
 
 void TestQgsComposition::legendRestoredFromTemplateAutoUpdate()


### PR DESCRIPTION
Allows legend customisation to be restored when loading a composer
template

Fix #2738

This is an updated fix based on the fix used for 2.18 (https://github.com/qgis/QGIS/pull/4054), which addresses partially the comments from https://github.com/qgis/QGIS-Enhancement-Proposals/issues/87#issuecomment-275611243

I plan on extending this approach to allow resolving references to map layers within composer maps which have been set to locked layers, to allow templates with locked layers to be restored in different projects correctly.