### PR TITLE
[plugin manager] fix QGIS startup crash (fixes #16439)

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1536,7 +1536,7 @@ void QgsPluginManager::updateWindowTitle()
   if ( curitem )
   {
     QString title = QStringLiteral( "%1 | %2" ).arg( tr( "Plugins" ), curitem->text() );
-    if ( mOptionsListWidget->currentRow() < mOptionsListWidget->count() - 1 )
+    if ( mOptionsListWidget->currentRow() < mOptionsListWidget->count() - 1 && mModelPlugins )
     {
       // if it's not the Settings tab, add the plugin count
       title += QStringLiteral( " (%3)" ).arg( mModelProxy->countWithCurrentStatus() );


### PR DESCRIPTION
## Description
If users close the plugin manager while viewing its Settings section, QGIS will upon subsequent startup crash during launch. This is caused by the plugin manager having only two stacks used for its four panels, which lead QgsOptionsDialogBase to wrongly save and restore the stack and its associated option list indexes, which leads to a scenario where mModelPlugins is being accessed prior to being created.

This PR adds a check to insure mModelPlugins exists before accessing it. It'll need backporting to 2.18 (and current LTR)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
