### PR TITLE
fix tab order in qgsvectorlayer properties dialog

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4124,7 +4124,7 @@ QString QgsVectorLayer::htmlMetadata() const
   myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Legend URL" ) % QLatin1String( "</td><td>" ) % legendUrl() % QLatin1String( "</td></tr>\n" );
   myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Legend Format" ) % QLatin1String( "</td><td>" ) % legendUrlFormat() % QLatin1String( "</td></tr>\n" );
 
-  myMetadata += QStringLiteral( "</body>\n</html>\n" );
+  myMetadata += QStringLiteral( "</table>\n</body>\n</html>\n" );
   return myMetadata;
 }
 

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -2027,10 +2027,37 @@ border-radius: 2px;</string>
  </customwidgets>
  <tabstops>
   <tabstop>mOptionsListWidget</tabstop>
+  <tabstop>mSearchLineEdit</tabstop>
+  <tabstop>teMetadataViewer</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mLayerOrigNameLineEdit</tabstop>
+  <tabstop>txtDisplayName</tabstop>
+  <tabstop>mLayerShortNameLineEdit</tabstop>
+  <tabstop>mLayerTitleLineEdit</tabstop>
+  <tabstop>mLayerAbstractTextEdit</tabstop>
+  <tabstop>mLayerKeywordListLineEdit</tabstop>
+  <tabstop>mLayerDataUrlLineEdit</tabstop>
+  <tabstop>mLayerDataUrlFormatComboBox</tabstop>
+  <tabstop>mLayerAttributionLineEdit</tabstop>
+  <tabstop>mLayerAttributionUrlLineEdit</tabstop>
+  <tabstop>mLayerMetadataUrlLineEdit</tabstop>
+  <tabstop>mLayerMetadataUrlTypeComboBox</tabstop>
+  <tabstop>mLayerMetadataUrlFormatComboBox</tabstop>
+  <tabstop>mLayerLegendUrlLineEdit</tabstop>
+  <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
+  <tabstop>scrollArea_4</tabstop>
+  <tabstop>cboProviderEncoding</tabstop>
+  <tabstop>indexGroupBox_2</tabstop>
+  <tabstop>mCrsSelector</tabstop>
+  <tabstop>pbnIndex</tabstop>
+  <tabstop>pbnUpdateExtents</tabstop>
+  <tabstop>txtSubsetSQL</tabstop>
+  <tabstop>pbnQueryBuilder</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>scrollArea_19</tabstop>
+  <tabstop>mScaleVisibilityGroupBox</tabstop>
+  <tabstop>mScaleRangeWidget</tabstop>
   <tabstop>mSimplifyDrawingGroupBox</tabstop>
   <tabstop>mSimplifyDrawingSpinBox</tabstop>
   <tabstop>mSimplifyAlgorithmComboBox</tabstop>
@@ -2040,15 +2067,15 @@ border-radius: 2px;</string>
   <tabstop>mRefreshLayerCheckBox</tabstop>
   <tabstop>mRefreshLayerIntervalSpinBox</tabstop>
   <tabstop>mDisplayExpressionWidget</tabstop>
-  <tabstop>mMapTipExpressionFieldWidget</tabstop>
-  <tabstop>mInsertExpressionButton</tabstop>
   <tabstop>scrollArea_6</tabstop>
-  <tabstop>scrollArea_7</tabstop>
-  <tabstop>mButtonAddJoin</tabstop>
-  <tabstop>mButtonRemoveJoin</tabstop>
-  <tabstop>mButtonEditJoin</tabstop>
   <tabstop>mJoinTreeWidget</tabstop>
   <tabstop>mLayersDependenciesTreeView</tabstop>
+  <tabstop>mButtonRemoveJoin</tabstop>
+  <tabstop>scrollArea_7</tabstop>
+  <tabstop>mButtonAddJoin</tabstop>
+  <tabstop>mInsertExpressionButton</tabstop>
+  <tabstop>mButtonEditJoin</tabstop>
+  <tabstop>mMapTipExpressionFieldWidget</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
## Description

Fixing the focus order when we use the tab key in the vector properties dialog.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
