### PR TITLE
[needs-docs] use QgsPasswordLineEdit in the master password dialog

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -349,7 +349,6 @@ gui/qgscomposerruler.sip
 gui/qgscomposerview.sip
 gui/qgscompoundcolorwidget.sip
 gui/qgsconfigureshortcutsdialog.sip
-gui/qgscredentialdialog.sip
 gui/qgscustomdrophandler.sip
 gui/qgscurveeditorwidget.sip
 gui/qgsdetaileditemdata.sip

--- a/python/gui/qgscredentialdialog.sip
+++ b/python/gui/qgscredentialdialog.sip
@@ -21,18 +21,15 @@ class QgsCredentialDialog : QDialog, QgsCredentials
 %End
   public:
     QgsCredentialDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
+%Docstring
+QgsCredentialDialog constructor
+%End
 
 
   protected:
     virtual bool request( const QString &realm, QString &username /In,Out/, QString &password /In,Out/, const QString &message = QString::null );
-%Docstring
- :rtype: bool
-%End
 
     virtual bool requestMasterPassword( QString &password /In,Out/, bool stored = false );
-%Docstring
- :rtype: bool
-%End
 
 };
 

--- a/python/gui/qgscredentialdialog.sip
+++ b/python/gui/qgscredentialdialog.sip
@@ -1,18 +1,45 @@
-/** \ingroup gui
- * A generic dialog for requesting credentials
- */
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscredentialdialog.h                                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
 class QgsCredentialDialog : QDialog, QgsCredentials
 {
-%TypeHeaderCode
-#include <qgscredentialdialog.h>
+%Docstring
+ A generic dialog for requesting credentials
 %End
 
+%TypeHeaderCode
+#include "qgscredentialdialog.h"
+%End
   public:
-    QgsCredentialDialog( QWidget *parent /TransferThis/ = 0, const Qt::WindowFlags& fl = QgisGui::ModalDialogFlags );
-    ~QgsCredentialDialog();
+    QgsCredentialDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
+
 
   protected:
-    virtual bool request( const QString& realm, QString &username /In,Out/, QString &password /In,Out/, const QString& message = QString::null );
+    virtual bool request( const QString &realm, QString &username /In,Out/, QString &password /In,Out/, const QString &message = QString::null );
+%Docstring
+ :rtype: bool
+%End
 
     virtual bool requestMasterPassword( QString &password /In,Out/, bool stored = false );
+%Docstring
+ :rtype: bool
+%End
+
 };
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscredentialdialog.h                                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -208,7 +208,6 @@ void QgsCredentialDialog::requestCredentialsMasterPassword( QString *password, b
 
   // don't leave master password in singleton's text field, or the ability to show it
   leMasterPass->clear();
-  chkMasterPassShow->setChecked( false );
   leMasterPassVerify->clear();
 
   chkbxEraseAuthDb->setChecked( false );
@@ -224,12 +223,6 @@ void QgsCredentialDialog::requestCredentialsMasterPassword( QString *password, b
   {
     close();
   }
-}
-
-void QgsCredentialDialog::on_chkMasterPassShow_stateChanged( int state )
-{
-  leMasterPass->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
-  leMasterPassVerify->setEchoMode( ( state > 0 ) ? QLineEdit::Normal : QLineEdit::Password );
 }
 
 void QgsCredentialDialog::on_leMasterPass_textChanged( const QString &pass )

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -34,6 +34,7 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
 {
     Q_OBJECT
   public:
+    //! QgsCredentialDialog constructor
     QgsCredentialDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
 #ifndef SIP_RUN

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -48,7 +48,6 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
 
     void requestCredentialsMasterPassword( QString *password, bool stored, bool *ok );
 
-    void on_chkMasterPassShow_stateChanged( int state );
     void on_leMasterPass_textChanged( const QString &pass );
     void on_leMasterPassVerify_textChanged( const QString &pass );
     void on_chkbxEraseAuthDb_toggled( bool checked );

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -22,6 +22,7 @@
 #include "qgscredentials.h"
 
 #include <QString>
+#include "qgis.h"
 #include "qgis_gui.h"
 
 class QPushButton;
@@ -33,8 +34,9 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
 {
     Q_OBJECT
   public:
-    QgsCredentialDialog( QWidget *parent = nullptr, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
+    QgsCredentialDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
+#ifndef SIP_RUN
   signals:
 
     //! \note not available in Python bindings
@@ -42,6 +44,7 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
 
     //! \note not available in Python bindings
     void credentialsRequestedMasterPassword( QString *, bool, bool * );
+#endif
 
   private slots:
     void requestCredentials( const QString &, QString *, QString *, const QString &, bool * );
@@ -53,9 +56,9 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
     void on_chkbxEraseAuthDb_toggled( bool checked );
 
   protected:
-    virtual bool request( const QString &realm, QString &username, QString &password, const QString &message = QString::null ) override;
+    virtual bool request( const QString &realm, QString &username SIP_INOUT, QString &password SIP_INOUT, const QString &message = QString::null ) override;
 
-    virtual bool requestMasterPassword( QString &password, bool stored = false ) override;
+    virtual bool requestMasterPassword( QString &password SIP_INOUT, bool stored = false ) override;
 
   private:
     QPushButton *mOkButton = nullptr;

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -121,29 +121,16 @@
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="0">
-          <widget class="QLineEdit" name="leMasterPass">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QgsPasswordLineEdit" name="leMasterPass">
            <property name="echoMode">
             <enum>QLineEdit::Password</enum>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="chkMasterPassShow">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Show</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLineEdit" name="leMasterPassVerify">
+         <item>
+          <widget class="QgsPasswordLineEdit" name="leMasterPassVerify">
            <property name="echoMode">
             <enum>QLineEdit::Password</enum>
            </property>
@@ -239,7 +226,6 @@ font-style: italic;
   <tabstop>lePassword</tabstop>
   <tabstop>leMasterPass</tabstop>
   <tabstop>leMasterPassVerify</tabstop>
-  <tabstop>chkMasterPassShow</tabstop>
   <tabstop>chkbxEraseAuthDb</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Replaces ordinal QLineEdit with QgsPasswordLineEdit

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
