### PR TITLE
sipify qgscolorbutton and qgscolorrampbutton

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -337,8 +337,6 @@ gui/qgscodeeditorhtml.sip
 gui/qgscodeeditorcss.sip
 gui/qgscharacterselectdialog.sip
 gui/qgscolorbrewercolorrampdialog.sip
-gui/qgscolorbutton.sip
-gui/qgscolorrampbutton.sip
 gui/qgscolordialog.sip
 gui/qgscolorschemelist.sip
 gui/qgscolorswatchgrid.sip

--- a/python/gui/qgscolorbutton.sip
+++ b/python/gui/qgscolorbutton.sip
@@ -30,17 +30,14 @@ class QgsColorButton : QToolButton
 
     QgsColorButton( QWidget *parent /TransferThis/ = 0, const QString &cdt = "", QgsColorSchemeRegistry *registry = 0 );
 %Docstring
- Construct a new color button.
- \param parent The parent QWidget for the dialog
- \param cdt The title to show in the color chooser dialog
- \param registry a color scheme registry for color swatch grids to show in the drop down menu. If not
- specified, the button will use the global color scheme registry
+ Construct a new color ramp button.
+ Use ``parent`` to attach a parent QWidget to the dialog.
+ Use ``cdt`` string to define the title to show in the color ramp dialog
+ Use a color scheme ``registry`` for color swatch grids to show in the drop down menu. If not specified,
+ the button will use the global color scheme registry instead
 %End
 
     virtual QSize sizeHint() const;
-%Docstring
- :rtype: QSize
-%End
 
     QColor color() const;
 %Docstring
@@ -350,9 +347,6 @@ class QgsColorButton : QToolButton
   protected:
 
     bool event( QEvent *e );
-%Docstring
- :rtype: bool
-%End
     void changeEvent( QEvent *e );
     void showEvent( QShowEvent *e );
     void resizeEvent( QResizeEvent *event );

--- a/python/gui/qgscolorbutton.sip
+++ b/python/gui/qgscolorbutton.sip
@@ -1,329 +1,409 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscolorbutton.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
 
-/** \ingroup gui
- * \class QgsColorButton
- * A cross platform button subclass for selecting colors. Will open a color chooser dialog when clicked.
- * Offers live updates to button from color chooser dialog. An attached drop down menu allows for copying
- * and pasting colors, picking colors from the screen, and selecting colors from color swatch grids.
- * \note Added in version 2.5
- */
+
 
 class QgsColorButton : QToolButton
 {
-%TypeHeaderCode
-#include <qgscolorbutton.h>
+%Docstring
+ A cross platform button subclass for selecting colors. Will open a color chooser dialog when clicked.
+ Offers live updates to button from color chooser dialog. An attached drop down menu allows for copying
+ and pasting colors, picking colors from the screen, and selecting colors from color swatch grids.
+.. versionadded:: 2.5
 %End
 
+%TypeHeaderCode
+#include "qgscolorbutton.h"
+%End
   public:
 
-    /** Specifies the behavior when the button is clicked
-     */
     enum Behavior
     {
-      ShowDialog, /*!< show a color picker dialog when clicked */
-      SignalOnly /*!< emit colorClicked signal only, no dialog */
+      ShowDialog,
+      SignalOnly
     };
 
-    /** Construct a new color button.
-     * @param parent The parent QWidget for the dialog
-     * @param cdt The title to show in the color chooser dialog
-     * @param registry a color scheme registry for color swatch grids to show in the drop down menu. If not
-     * specified, the button will use the global color scheme registry
-     */
-    QgsColorButton( QWidget *parent /TransferThis/ = 0, const QString& cdt = "", QgsColorSchemeRegistry* registry = 0 );
-
-    virtual ~QgsColorButton();
+    QgsColorButton( QWidget *parent /TransferThis/ = 0, const QString &cdt = "", QgsColorSchemeRegistry *registry = 0 );
+%Docstring
+ Construct a new color button.
+ \param parent The parent QWidget for the dialog
+ \param cdt The title to show in the color chooser dialog
+ \param registry a color scheme registry for color swatch grids to show in the drop down menu. If not
+ specified, the button will use the global color scheme registry
+%End
 
     virtual QSize sizeHint() const;
+%Docstring
+ :rtype: QSize
+%End
 
-    /** Return the currently selected color.
-     * @returns currently selected color
-     * @see setColor
-     */
     QColor color() const;
+%Docstring
+ Return the currently selected color.
+ :return: currently selected color
+ \see setColor
+ :rtype: QColor
+%End
 
-    /** Sets whether alpha modification (transparency) is permitted
-     * for the color. Defaults to false.
-     * @param allowAlpha set to true to allow alpha modification
-     * @see allowAlpha
-     */
     void setAllowAlpha( const bool allowAlpha );
+%Docstring
+ Sets whether alpha modification (transparency) is permitted
+ for the color. Defaults to false.
+ \param allowAlpha set to true to allow alpha modification
+ \see allowAlpha
+%End
 
-    /** Returns whether alpha modification (transparency) is permitted
-     * for the color.
-     * @returns true if alpha modification is allowed
-     * @see setAllowAlpha
-     */
     bool allowAlpha() const;
+%Docstring
+ Returns whether alpha modification (transparency) is permitted
+ for the color.
+ :return: true if alpha modification is allowed
+ \see setAllowAlpha
+ :rtype: bool
+%End
 
-    /** Set the title for the color chooser dialog window.
-     * @param title Title for the color chooser dialog
-     * @see colorDialogTitle
-     */
-    void setColorDialogTitle( const QString& title );
+    void setColorDialogTitle( const QString &title );
+%Docstring
+ Set the title for the color chooser dialog window.
+ \param title Title for the color chooser dialog
+ \see colorDialogTitle
+%End
 
-    /** Returns the title for the color chooser dialog window.
-     * @returns title for the color chooser dialog
-     * @see setColorDialogTitle
-     */
     QString colorDialogTitle() const;
+%Docstring
+ Returns the title for the color chooser dialog window.
+ :return: title for the color chooser dialog
+ \see setColorDialogTitle
+ :rtype: str
+%End
 
-    /** Returns whether the button accepts live updates from QColorDialog.
-     * @returns true if the button will be accepted immediately when the dialog's color changes
-     * @see setAcceptLiveUpdates
-     */
     bool acceptLiveUpdates() const;
+%Docstring
+ Returns whether the button accepts live updates from QColorDialog.
+ :return: true if the button will be accepted immediately when the dialog's color changes
+ \see setAcceptLiveUpdates
+ :rtype: bool
+%End
 
-    /** Sets whether the button accepts live updates from QColorDialog. Live updates may cause changes
-     * that are not undoable on QColorDialog cancel.
-     * @param accept set to true to enable live updates
-     * @see acceptLiveUpdates
-     */
     void setAcceptLiveUpdates( const bool accept );
+%Docstring
+ Sets whether the button accepts live updates from QColorDialog. Live updates may cause changes
+ that are not undoable on QColorDialog cancel.
+ \param accept set to true to enable live updates
+ \see acceptLiveUpdates
+%End
 
-    /** Sets whether the drop down menu should be shown for the button. The default behavior is to
-     * show the menu.
-     * @param showMenu set to false to hide the drop down menu
-     * @see showMenu
-     */
     void setShowMenu( const bool showMenu );
+%Docstring
+ Sets whether the drop down menu should be shown for the button. The default behavior is to
+ show the menu.
+ \param showMenu set to false to hide the drop down menu
+ \see showMenu
+%End
 
-    /** Returns whether the drop down menu is shown for the button.
-     * @returns true if drop down menu is shown
-     * @see setShowMenu
-     */
     bool showMenu() const;
+%Docstring
+ Returns whether the drop down menu is shown for the button.
+ :return: true if drop down menu is shown
+ \see setShowMenu
+ :rtype: bool
+%End
 
-    /** Sets the behavior for when the button is clicked. The default behavior is to show
-     * a color picker dialog.
-     * @param behavior behavior when button is clicked
-     * @see behavior
-     */
     void setBehavior( const Behavior behavior );
+%Docstring
+ Sets the behavior for when the button is clicked. The default behavior is to show
+ a color picker dialog.
+ \param behavior behavior when button is clicked
+ \see behavior
+%End
 
-    /** Returns the behavior for when the button is clicked.
-     * @returns behavior when button is clicked
-     * @see setBehavior
-     */
     Behavior behavior() const;
+%Docstring
+ Returns the behavior for when the button is clicked.
+ :return: behavior when button is clicked
+ \see setBehavior
+ :rtype: Behavior
+%End
 
-    /** Sets the default color for the button, which is shown in the button's drop down menu for the
-     * "default color" option.
-     * @param color default color for the button. Set to an invalid QColor to disable the default color
-     * option.
-     * @see defaultColor
-     */
-    void setDefaultColor( const QColor& color );
+    void setDefaultColor( const QColor &color );
+%Docstring
+ Sets the default color for the button, which is shown in the button's drop down menu for the
+ "default color" option.
+ \param color default color for the button. Set to an invalid QColor to disable the default color
+ option.
+ \see defaultColor
+%End
 
-    /** Returns the default color for the button, which is shown in the button's drop down menu for the
-     * "default color" option.
-     * @returns default color for the button. Returns an invalid QColor if the default color
-     * option is disabled.
-     * @see setDefaultColor
-     */
     QColor defaultColor() const;
+%Docstring
+ Returns the default color for the button, which is shown in the button's drop down menu for the
+ "default color" option.
+ :return: default color for the button. Returns an invalid QColor if the default color
+ option is disabled.
+ \see setDefaultColor
+ :rtype: QColor
+%End
 
-    /** Sets whether the "no color" option should be shown in the button's drop down menu. If selected,
-     * the "no color" option sets the color button's color to a totally transparent color.
-     * @param showNoColorOption set to true to show the no color option. This is disabled by default.
-     * @see showNoColor
-     * @see setNoColorString
-     * @note The "no color" option is only shown if the color button is set to show an alpha channel in the color
-     * dialog (see setColorDialogOptions)
-     */
     void setShowNoColor( const bool showNoColorOption );
+%Docstring
+ Sets whether the "no color" option should be shown in the button's drop down menu. If selected,
+ the "no color" option sets the color button's color to a totally transparent color.
+ \param showNoColorOption set to true to show the no color option. This is disabled by default.
+ \see showNoColor
+ \see setNoColorString
+.. note::
 
-    /** Returns whether the "no color" option is shown in the button's drop down menu. If selected,
-     * the "no color" option sets the color button's color to a totally transparent color.
-     * @returns true if the no color option is shown.
-     * @see setShowNoColor
-     * @see noColorString
-     * @note The "no color" option is only shown if the color button is set to show an alpha channel in the color
-     * dialog (see setColorDialogOptions)
-     */
+   The "no color" option is only shown if the color button is set to show an alpha channel in the color
+ dialog (see setColorDialogOptions)
+%End
+
     bool showNoColor() const;
+%Docstring
+ Returns whether the "no color" option is shown in the button's drop down menu. If selected,
+ the "no color" option sets the color button's color to a totally transparent color.
+ :return: true if the no color option is shown.
+ \see setShowNoColor
+ \see noColorString
+.. note::
 
-    /** Sets the string to use for the "no color" option in the button's drop down menu.
-     * @param noColorString string to use for the "no color" menu option
-     * @see noColorString
-     * @see setShowNoColor
-     * @note The "no color" option is only shown if the color button is set to show an alpha channel in the color
-     * dialog (see setColorDialogOptions)
-     */
-    void setNoColorString( const QString& noColorString );
+   The "no color" option is only shown if the color button is set to show an alpha channel in the color
+ dialog (see setColorDialogOptions)
+ :rtype: bool
+%End
 
-     /** Sets whether a set to null (clear) option is shown in the button's drop down menu.
-     * @param showNull set to true to show a null option
-     * @note added in QGIS 2.16
-     * @see showNull()
-     * @see isNull()
-     */
+    void setNoColorString( const QString &noColorString );
+%Docstring
+ Sets the string to use for the "no color" option in the button's drop down menu.
+ \param noColorString string to use for the "no color" menu option
+ \see noColorString
+ \see setShowNoColor
+.. note::
+
+   The "no color" option is only shown if the color button is set to show an alpha channel in the color
+ dialog (see setColorDialogOptions)
+%End
+
     void setShowNull( bool showNull );
+%Docstring
+ Sets whether a set to null (clear) option is shown in the button's drop down menu.
+ \param showNull set to true to show a null option
+.. versionadded:: 2.16
+ \see showNull()
+ \see isNull()
+%End
 
-    /** Returns whether the set to null (clear) option is shown in the button's drop down menu.
-     * @note added in QGIS 2.16
-     * @see setShowNull()
-     * @see isNull()
-     */
     bool showNull() const;
+%Docstring
+ Returns whether the set to null (clear) option is shown in the button's drop down menu.
+.. versionadded:: 2.16
+ \see setShowNull()
+ \see isNull()
+ :rtype: bool
+%End
 
-    /** Returns true if the current color is null.
-     * @note added in QGIS 2.16
-     * @see setShowNull()
-     * @see showNull()
-     */
     bool isNull() const;
+%Docstring
+ Returns true if the current color is null.
+.. versionadded:: 2.16
+ \see setShowNull()
+ \see showNull()
+ :rtype: bool
+%End
 
-    /** Returns the string used for the "no color" option in the button's drop down menu.
-     * @returns string used for the "no color" menu option
-     * @see setNoColorString
-     * @see showNoColor
-     * @note The "no color" option is only shown if the color button is set to show an alpha channel in the color
-     * dialog (see setColorDialogOptions)
-     */
     QString noColorString() const;
+%Docstring
+ Returns the string used for the "no color" option in the button's drop down menu.
+ :return: string used for the "no color" menu option
+ \see setNoColorString
+ \see showNoColor
+.. note::
 
-    /** Sets the context string for the color button. The context string is passed to all color swatch
-     * grids shown in the button's drop down menu, to allow them to customise their display colors
-     * based on the context.
-     * @param context context string for the color button's color swatch grids
-     * @see context
-     */
-    void setContext( const QString& context );
+   The "no color" option is only shown if the color button is set to show an alpha channel in the color
+ dialog (see setColorDialogOptions)
+ :rtype: str
+%End
 
-    /** Returns the context string for the color button. The context string is passed to all color swatch
-     * grids shown in the button's drop down menu, to allow them to customise their display colors
-     * based on the context.
-     * @returns context string for the color button's color swatch grids
-     * @see setContext
-     */
+    void setContext( const QString &context );
+%Docstring
+ Sets the context string for the color button. The context string is passed to all color swatch
+ grids shown in the button's drop down menu, to allow them to customise their display colors
+ based on the context.
+ \param context context string for the color button's color swatch grids
+ \see context
+%End
+
     QString context() const;
+%Docstring
+ Returns the context string for the color button. The context string is passed to all color swatch
+ grids shown in the button's drop down menu, to allow them to customise their display colors
+ based on the context.
+ :return: context string for the color button's color swatch grids
+ \see setContext
+ :rtype: str
+%End
 
-    /** Sets the color scheme registry for the button, which controls the color swatch grids
-     * that are shown in the button's drop down menu.
-     * @param registry color scheme registry for the button. Set to 0 to hide all color
-     * swatch grids from the button's drop down menu.
-     * @see colorSchemeRegistry
-     */
-    void setColorSchemeRegistry( QgsColorSchemeRegistry* registry );
+    void setColorSchemeRegistry( QgsColorSchemeRegistry *registry );
+%Docstring
+ Sets the color scheme registry for the button, which controls the color swatch grids
+ that are shown in the button's drop down menu.
+ \param registry color scheme registry for the button. Set to 0 to hide all color
+ swatch grids from the button's drop down menu.
+ \see colorSchemeRegistry
+%End
 
-    /** Returns the color scheme registry for the button, which controls the color swatch grids
-     * that are shown in the button's drop down menu.
-     * @returns color scheme registry for the button. If returned value is 0 then all color
-     * swatch grids are hidden from the button's drop down menu.
-     * @see setColorSchemeRegistry
-     */
-    QgsColorSchemeRegistry* colorSchemeRegistry();
+    QgsColorSchemeRegistry *colorSchemeRegistry();
+%Docstring
+ Returns the color scheme registry for the button, which controls the color swatch grids
+ that are shown in the button's drop down menu.
+ :return: color scheme registry for the button. If returned value is 0 then all color
+ swatch grids are hidden from the button's drop down menu.
+ \see setColorSchemeRegistry
+ :rtype: QgsColorSchemeRegistry
+%End
 
   public slots:
 
-    /** Sets the current color for the button. Will emit a colorChanged signal if the color is different
-     * to the previous color.
-     * @param color new color for the button
-     * @see color
-     */
     void setColor( const QColor &color );
+%Docstring
+ Sets the current color for the button. Will emit a colorChanged signal if the color is different
+ to the previous color.
+ \param color new color for the button
+ \see color
+%End
 
-    /** Sets the background pixmap for the button based upon color and transparency.
-     * Call directly to update background after adding/removing QColorDialog::ShowAlphaChannel option
-     * but the color has not changed, i.e. setColor() wouldn't update button and
-     * you want the button to retain the set color's alpha component regardless
-     * @param color Color for button background. If no color is specified, the button's current
-     * color will be used
-     */
     void setButtonBackground( const QColor &color = QColor() );
+%Docstring
+ Sets the background pixmap for the button based upon color and transparency.
+ Call directly to update background after adding/removing QColorDialog.ShowAlphaChannel option
+ but the color has not changed, i.e. setColor() wouldn't update button and
+ you want the button to retain the set color's alpha component regardless
+ \param color Color for button background. If no color is specified, the button's current
+ color will be used
+%End
 
-    /** Copies the current color to the clipboard
-     * @see pasteColor
-     */
     void copyColor();
+%Docstring
+ Copies the current color to the clipboard
+ \see pasteColor
+%End
 
-    /** Pastes a color from the clipboard to the color button. If clipboard does not contain a valid
-     * color or string representation of a color, then no change is applied.
-     * @see copyColor
-     */
     void pasteColor();
+%Docstring
+ Pastes a color from the clipboard to the color button. If clipboard does not contain a valid
+ color or string representation of a color, then no change is applied.
+ \see copyColor
+%End
 
-    /** Activates the color picker tool, which allows for sampling a color from anywhere on the screen
-     */
     void activatePicker();
+%Docstring
+ Activates the color picker tool, which allows for sampling a color from anywhere on the screen
+%End
 
-    /** Sets color to a totally transparent color.
-     * @note If the color button is not set to show an alpha channel in the color
-     * dialog (see setColorDialogOptions) then the color will not be changed.
-     */
     void setToNoColor();
+%Docstring
+ Sets color to a totally transparent color.
+.. note::
 
-    /** Sets color to the button's default color, if set.
-     * @see setDefaultColor
-     * @see defaultColor
-     */
+   If the color button is not set to show an alpha channel in the color
+ dialog (see setColorDialogOptions) then the color will not be changed.
+ \see setToNull()
+%End
+
     void setToDefaultColor();
+%Docstring
+ Sets color to the button's default color, if set.
+ \see setDefaultColor
+ \see defaultColor
+ \see setToNull()
+%End
 
-    /** Sets color to null.
-     * @see setToDefaultColor()
-     * @see setToNoColor()
-     * @note added in QGIS 2.16
-     */
     void setToNull();
+%Docstring
+ Sets color to null.
+ \see setToDefaultColor()
+ \see setToNoColor()
+.. versionadded:: 2.16
+%End
 
   signals:
 
-    /** Is emitted whenever a new color is set for the button. The color is always valid.
-     * In case the new color is the same no signal is emitted, to avoid infinite loops.
-     * @param color New color
-     */
     void colorChanged( const QColor &color );
+%Docstring
+ Is emitted whenever a new color is set for the button. The color is always valid.
+ In case the new color is the same no signal is emitted, to avoid infinite loops.
+ \param color New color
+%End
 
-    /** Emitted when the button is clicked, if the button's behavior is set to SignalOnly
-     * @param color button color
-     * @see setBehavior
-     * @see behavior
-     */
     void colorClicked( const QColor &color );
+%Docstring
+ Emitted when the button is clicked, if the button's behavior is set to SignalOnly
+ \param color button color
+ \see setBehavior
+ \see behavior
+%End
 
   protected:
 
-    void changeEvent( QEvent* e );
-    void showEvent( QShowEvent* e );
+    bool event( QEvent *e );
+%Docstring
+ :rtype: bool
+%End
+    void changeEvent( QEvent *e );
+    void showEvent( QShowEvent *e );
     void resizeEvent( QResizeEvent *event );
 
-    /** Returns a checkboard pattern pixmap for use as a background to transparent colors
-     */
-    static const QPixmap& transparentBackground();
+    static const QPixmap &transparentBackground();
+%Docstring
+ Returns a checkboard pattern pixmap for use as a background to transparent colors
+ :rtype: QPixmap
+%End
 
-    /**
-     * Reimplemented to detect right mouse button clicks on the color button and allow dragging colors
-     */
-    void mousePressEvent( QMouseEvent* e );
+    void mousePressEvent( QMouseEvent *e );
+%Docstring
+ Reimplemented to detect right mouse button clicks on the color button and allow dragging colors
+%End
 
-    /**
-     * Reimplemented to allow dragging colors from button
-     */
     void mouseMoveEvent( QMouseEvent *e );
+%Docstring
+ Reimplemented to allow dragging colors from button
+%End
 
-    /**
-     * Reimplemented to allow color picking
-     */
     void mouseReleaseEvent( QMouseEvent *e );
+%Docstring
+ Reimplemented to allow color picking
+%End
 
-    /**
-     * Reimplemented to allow canceling color pick via keypress, and sample via space bar press
-     */
     void keyPressEvent( QKeyEvent *e );
+%Docstring
+ Reimplemented to allow canceling color pick via keypress, and sample via space bar press
+%End
 
-    /**
-     * Reimplemented to accept dragged colors
-     */
-    void dragEnterEvent( QDragEnterEvent * e );
+    void dragEnterEvent( QDragEnterEvent *e );
+%Docstring
+ Reimplemented to accept dragged colors
+%End
 
-    /**
-     * Reimplemented to reset button appearance after drag leave
-     */
     void dragLeaveEvent( QDragLeaveEvent *e );
+%Docstring
+ Reimplemented to reset button appearance after drag leave
+%End
 
-    /**
-     * Reimplemented to accept dropped colors
-     */
     void dropEvent( QDropEvent *e );
+%Docstring
+ Reimplemented to accept dropped colors
+%End
 
 };
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscolorbutton.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgscolorrampbutton.sip
+++ b/python/gui/qgscolorrampbutton.sip
@@ -27,16 +27,13 @@ class QgsColorRampButton : QToolButton
     QgsColorRampButton( QWidget *parent /TransferThis/ = 0, const QString &dialogTitle = QString() );
 %Docstring
  Construct a new color ramp button.
- \param parent The parent QWidget for the dialog
- \param dialogTitle The title to show in the color ramp dialog
+ Use ``parent`` to attach a parent QWidget to the dialog.
+ Use ``dialogTitle`` string  to define the title to show in the color ramp dialog
 %End
 
     virtual ~QgsColorRampButton();
 
     virtual QSize sizeHint() const;
-%Docstring
- :rtype: QSize
-%End
 
     QgsColorRamp *colorRamp() const /Factory/;
 %Docstring
@@ -261,9 +258,6 @@ class QgsColorRampButton : QToolButton
   protected:
 
     bool event( QEvent *e );
-%Docstring
- :rtype: bool
-%End
     void changeEvent( QEvent *e );
     void showEvent( QShowEvent *e );
     void resizeEvent( QResizeEvent *event );

--- a/python/gui/qgscolorrampbutton.sip
+++ b/python/gui/qgscolorrampbutton.sip
@@ -1,220 +1,284 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscolorrampbutton.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
 
-/** \ingroup gui
- * \class QgsColorRampButton
- * A cross platform button subclass for selecting color ramps. Will open color ramp dialogs when clicked.
- * Offers live updates to button from color ramp dialog. An attached drop down menu allows for access to
- * saved color ramps, as well as option to invert the current color ramp and create new ramps.
- * \note Added in version 3.0
- */
+
+
+
 
 class QgsColorRampButton : QToolButton
 {
-%TypeHeaderCode
-#include <qgscolorrampbutton.h>
+%Docstring
+ A cross platform button subclass for selecting color ramps. Will open color ramp dialogs when clicked.
+ Offers live updates to button from color ramp dialog. An attached drop down menu allows for access to
+ saved color ramps, as well as option to invert the current color ramp and create new ramps.
+.. versionadded:: 3.0
 %End
 
+%TypeHeaderCode
+#include "qgscolorrampbutton.h"
+%End
   public:
 
-    /** Construct a new color ramp button.
-     * @param parent The parent QWidget for the dialog
-     * @param dialogTitle The title to show in the color ramp dialog
-     */
-    QgsColorRampButton( QWidget *parent = nullptr, const QString& dialogTitle = QString() );
+    QgsColorRampButton( QWidget *parent /TransferThis/ = 0, const QString &dialogTitle = QString() );
+%Docstring
+ Construct a new color ramp button.
+ \param parent The parent QWidget for the dialog
+ \param dialogTitle The title to show in the color ramp dialog
+%End
 
     virtual ~QgsColorRampButton();
 
     virtual QSize sizeHint() const;
+%Docstring
+ :rtype: QSize
+%End
 
-    /** Return a copy of the current color ramp.
-     * @see setColorRamp()
-     */
-    QgsColorRamp* colorRamp() const /Factory/;
+    QgsColorRamp *colorRamp() const /Factory/;
+%Docstring
+ Return a copy of the current color ramp.
+ \see setColorRamp()
+ :rtype: QgsColorRamp
+%End
 
-    /** Set the title for the color ramp dialog window.
-     * @param title Title for the color ramp dialog
-     * @see colorRampDialogTitle
-     */
-    void setColorRampDialogTitle( const QString& title );
+    void setColorRampDialogTitle( const QString &title );
+%Docstring
+ Set the title for the color ramp dialog window.
+ \param title Title for the color ramp dialog
+ \see colorRampDialogTitle
+%End
 
-    /** Returns the title for the color ramp dialog window.
-     * @returns title for the color ramp dialog
-     * @see setColorRampDialogTitle
-     */
     QString colorRampDialogTitle() const;
+%Docstring
+ Returns the title for the color ramp dialog window.
+ :return: title for the color ramp dialog
+ \see setColorRampDialogTitle
+ :rtype: str
+%End
 
-    /** Returns whether the button accepts live updates from QgsColorRampDialog.
-     * @returns true if the button will be accepted immediately when the dialog's color ramp changes
-     * @see setAcceptLiveUpdates
-     */
     bool acceptLiveUpdates() const;
+%Docstring
+ Returns whether the button accepts live updates from QgsColorRampDialog.
+ :return: true if the button will be accepted immediately when the dialog's color ramp changes
+ \see setAcceptLiveUpdates
+ :rtype: bool
+%End
 
-    /** Sets whether the button accepts live updates from QgsColorRampDialog. Live updates may cause changes
-     * that are not undoable on QColorRampDialog cancel.
-     * @param accept set to true to enable live updates
-     * @see acceptLiveUpdates
-     */
     void setAcceptLiveUpdates( const bool accept );
+%Docstring
+ Sets whether the button accepts live updates from QgsColorRampDialog. Live updates may cause changes
+ that are not undoable on QColorRampDialog cancel.
+ \param accept set to true to enable live updates
+ \see acceptLiveUpdates
+%End
 
-    /** Sets whether the drop down menu should be shown for the button. The default behavior is to
-     * show the menu.
-     * @param showMenu set to false to hide the drop down menu
-     * @see showMenu
-     */
     void setShowMenu( const bool showMenu );
+%Docstring
+ Sets whether the drop down menu should be shown for the button. The default behavior is to
+ show the menu.
+ \param showMenu set to false to hide the drop down menu
+ \see showMenu
+%End
 
-    /** Returns whether the drop down menu is shown for the button.
-     * @returns true if drop down menu is shown
-     * @see setShowMenu
-     */
     bool showMenu() const;
+%Docstring
+ Returns whether the drop down menu is shown for the button.
+ :return: true if drop down menu is shown
+ \see setShowMenu
+ :rtype: bool
+%End
 
-    /** Sets the default color ramp for the button, which is shown in the button's drop down menu for the
-     * "default color ramp" option.
-     * @param colorramp default color ramp for the button. Set to a null pointer to disable the default color
-     * ramp option. The ramp will be cloned and ownership is not transferred.
-     * @see defaultColorRamp
-     */
-    void setDefaultColorRamp( QgsColorRamp* colorramp );
+    void setDefaultColorRamp( QgsColorRamp *colorramp );
+%Docstring
+ Sets the default color ramp for the button, which is shown in the button's drop down menu for the
+ "default color ramp" option.
+ \param colorramp default color ramp for the button. Set to a null pointer to disable the default color
+ ramp option. The ramp will be cloned and ownership is not transferred.
+ \see defaultColorRamp
+%End
 
-    /** Returns a copy of the default color ramp for the button, which is shown in the button's drop down menu for the
-     * "default color ramp" option.
-     * @returns default color ramp for the button. Returns a null pointer if the default color ramp
-     * option is disabled.
-     * @see setDefaultColorRamp
-     */
-    QgsColorRamp* defaultColorRamp() const /Factory/;
+    QgsColorRamp *defaultColorRamp() const /Factory/;
+%Docstring
+ Returns a copy of the default color ramp for the button, which is shown in the button's drop down menu for the
+ "default color ramp" option.
+ :return: default color ramp for the button. Returns a null pointer if the default color ramp
+ option is disabled.
+ \see setDefaultColorRamp
+ :rtype: QgsColorRamp
+%End
 
-    /** Sets whether a random colors option is shown in the button's drop down menu.
-     * @param showNull set to true to show a null option
-     * @see showRandom()
-     */
     void setShowRandomColorRamp( bool showRandom );
+%Docstring
+ Sets whether a random colors option is shown in the button's drop down menu.
+ \param showRandom set to true to show a random colors option
+ \see showRandom()
+%End
 
-    /** Returns whether random colors option is shown in the button's drop down menu.
-     * @see setShowRandom()
-     */
     bool showRandomColorRamp() const;
+%Docstring
+ Returns whether random colors option is shown in the button's drop down menu.
+ \see setShowRandom()
+ :rtype: bool
+%End
 
-    /** Returns true if the current color is null.
-     * @see setShowNull()
-     * @see showNull()
-     */
     bool isRandomColorRamp() const;
+%Docstring
+ Returns true if the current color is null.
+ \see setShowNull()
+ \see showNull()
+ :rtype: bool
+%End
 
-    /** Sets whether a set to null (clear) option is shown in the button's drop down menu.
-     * @param showNull set to true to show a null option
-     * @see showNull()
-     * @see isNull()
-     */
     void setShowNull( bool showNull );
+%Docstring
+ Sets whether a set to null (clear) option is shown in the button's drop down menu.
+ \param showNull set to true to show a null option
+ \see showNull()
+ \see isNull()
+%End
 
-    /** Returns whether the set to null (clear) option is shown in the button's drop down menu.
-     * @see setShowNull()
-     * @see isNull()
-     */
     bool showNull() const;
+%Docstring
+ Returns whether the set to null (clear) option is shown in the button's drop down menu.
+ \see setShowNull()
+ \see isNull()
+ :rtype: bool
+%End
 
-    /** Returns true if the current color is null.
-     * @see setShowNull()
-     * @see showNull()
-     */
     bool isNull() const;
+%Docstring
+ Returns true if the current color is null.
+ \see setShowNull()
+ \see showNull()
+ :rtype: bool
+%End
 
-    /** Sets the context string for the color ramp button. The context string is passed to all color ramp
-     * preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
-     * based on the context.
-     * @param context context string for the color dialog button's color ramp preview icons
-     * @see context
-     */
-    void setContext( const QString& context );
+    void setContext( const QString &context );
+%Docstring
+ Sets the context string for the color ramp button. The context string is passed to all color ramp
+ preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
+ based on the context.
+ \param context context string for the color dialog button's color ramp preview icons
+ \see context
+%End
 
-    /** Returns the context string for the color ramp button. The context string is passed to all color ramp
-     * preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
-     * based on the context.
-     * @returns context context string for the color dialog button's color ramp preview icons
-     * @see setContext
-     */
     QString context() const;
+%Docstring
+ Returns the context string for the color ramp button. The context string is passed to all color ramp
+ preview icons shown in the button's drop down menu, to (eventually) allow them to customise their display colors
+ based on the context.
+ :return: context context string for the color dialog button's color ramp preview icons
+ \see setContext
+ :rtype: str
+%End
 
-    /** Sets whether the color ramp button only shows gradient type ramps
-     * @param gradientonly set to true to show only gradient type ramps
-     * @see showGradientOnly
-     */
     void setShowGradientOnly( bool gradientonly );
+%Docstring
+ Sets whether the color ramp button only shows gradient type ramps
+ \param gradientonly set to true to show only gradient type ramps
+ \see showGradientOnly
+%End
 
-    /** Returns true if the color ramp button only shows gradient type ramps
-     * @see setShowGradientOnly
-     */
     bool showGradientOnly() const;
+%Docstring
+ Returns true if the color ramp button only shows gradient type ramps
+ \see setShowGradientOnly
+ :rtype: bool
+%End
 
-    /** Sets the name of the current color ramp when it's available in the style manager
-     * @param name Name of the saved color ramp
-     * @see colorRampName
-     */
-    void setColorRampName( QString name );
+    void setColorRampName( const QString &name );
+%Docstring
+ Sets the name of the current color ramp when it's available in the style manager
+ \param name Name of the saved color ramp
+ \see colorRampName
+%End
 
-    /** Returns the name of the current color ramp when it's available in the style manager
-     * @see setColorRampName
-     */
     QString colorRampName() const;
+%Docstring
+ Returns the name of the current color ramp when it's available in the style manager
+ \see setColorRampName
+ :rtype: str
+%End
 
   public slots:
 
-    /** Sets the current color ramp for the button. Will emit a colorRampChanged() signal if the color ramp is different
-     * to the previous color ramp.
-     * @param colorramp New color ramp for the button. The ramp will be cloned and ownership is not transferred.
-     * @see setRandomColorRamp, setColorRampFromName, colorRamp
-     */
-    void setColorRamp( QgsColorRamp* colorramp );
+    void setColorRamp( QgsColorRamp *colorramp );
+%Docstring
+ Sets the current color ramp for the button. Will emit a colorRampChanged() signal if the color ramp is different
+ to the previous color ramp.
+ \param colorramp New color ramp for the button. The ramp will be cloned and ownership is not transferred.
+ \see setRandomColorRamp, setColorRampFromName, colorRamp
+%End
 
-    /** Sets the current color ramp for the button to random colors. Will emit a colorRampChanged() signal
-     * if the color ramp is different to the previous color ramp.
-     * @see setColorRamp, setColorRampFromName, colorRamp
-     */
     void setRandomColorRamp();
+%Docstring
+ Sets the current color ramp for the button to random colors. Will emit a colorRampChanged() signal
+ if the color ramp is different to the previous color ramp.
+ \see setColorRamp, setColorRampFromName, colorRamp
+%End
 
-    /** Sets the current color ramp for the button using a saved color ramp name. Will emit a colorRampChanged() signal
-     * if the color ramp is different to the previous color ramp.
-     * @param name Name of saved color ramp
-     * @see setColorRamp, setRandomColorRamp, colorRamp
-     */
-    void setColorRampFromName( const QString& name = QString() );
+    void setColorRampFromName( const QString &name = QString() );
+%Docstring
+ Sets the current color ramp for the button using a saved color ramp name. Will emit a colorRampChanged() signal
+ if the color ramp is different to the previous color ramp.
+ \param name Name of saved color ramp
+ \see setColorRamp, setRandomColorRamp, colorRamp
+%End
 
-    /** Sets the background pixmap for the button based upon current color ramp.
-     * @param colorramp Color ramp for button background. If no color ramp is specified, the button's current
-     * color ramp will be used
-     */
-    void setButtonBackground( QgsColorRamp* colorramp = nullptr );
+    void setButtonBackground( QgsColorRamp *colorramp = 0 );
+%Docstring
+ Sets the background pixmap for the button based upon current color ramp.
+ \param colorramp Color ramp for button background. If no color ramp is specified, the button's current
+ color ramp will be used
+%End
 
-    /** Sets color ramp to the button's default color ramp, if set.
-     * @see setDefaultColorRamp
-     * @see defaultColorRamp
-     * @see setToNull()
-     */
     void setToDefaultColorRamp();
+%Docstring
+ Sets color ramp to the button's default color ramp, if set.
+ \see setDefaultColorRamp
+ \see defaultColorRamp
+ \see setToNull()
+%End
 
-    /** Sets color ramp to null.
-     * @see setToDefaultColorRamp()
-     */
     void setToNull();
+%Docstring
+ Sets color ramp to null.
+ \see setToDefaultColorRamp()
+%End
 
   signals:
 
-    /** Emitted whenever a new color ramp is set for the button. The color ramp is always valid.
-     * In case the new color ramp is the same, no signal is emitted to avoid infinite loops.
-     */
     void colorRampChanged();
+%Docstring
+ Emitted whenever a new color ramp is set for the button. The color ramp is always valid.
+ In case the new color ramp is the same, no signal is emitted to avoid infinite loops.
+%End
 
   protected:
 
     bool event( QEvent *e );
-    void changeEvent( QEvent* e );
-    void showEvent( QShowEvent* e );
+%Docstring
+ :rtype: bool
+%End
+    void changeEvent( QEvent *e );
+    void showEvent( QShowEvent *e );
     void resizeEvent( QResizeEvent *event );
 
-    /**
-     * Reimplemented to detect right mouse button clicks on the color ramp button
-     */
-    void mousePressEvent( QMouseEvent* e );
+    void mousePressEvent( QMouseEvent *e );
+%Docstring
+ Reimplemented to detect right mouse button clicks on the color ramp button
+%End
 
 };
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscolorrampbutton.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -38,7 +38,7 @@
 #include <QGridLayout>
 #include <QPushButton>
 
-QgsColorButton::QgsColorButton( QWidget *parent, const QString &cdt, QgsColorSchemeRegistry *registry )
+QgsColorButton::QgsColorButton( QWidget *parent SIP_TRANSFERTHIS, const QString &cdt, QgsColorSchemeRegistry *registry )
   : QToolButton( parent )
   , mBehavior( QgsColorButton::ShowDialog )
   , mColorDialogTitle( cdt.isEmpty() ? tr( "Select Color" ) : cdt )

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -57,11 +57,11 @@ class GUI_EXPORT QgsColorButton : public QToolButton
       SignalOnly //!< Emit colorClicked signal only, no dialog
     };
 
-    /** Construct a new color button.
-     * \param parent The parent QWidget for the dialog
-     * \param cdt The title to show in the color chooser dialog
-     * \param registry a color scheme registry for color swatch grids to show in the drop down menu. If not
-     * specified, the button will use the global color scheme registry
+    /** Construct a new color ramp button.
+     * Use \a parent to attach a parent QWidget to the dialog.
+     * Use \a cdt string to define the title to show in the color ramp dialog
+     * Use a color scheme \a registry for color swatch grids to show in the drop down menu. If not specified,
+     * the button will use the global color scheme registry instead
      */
     QgsColorButton( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QString &cdt = "", QgsColorSchemeRegistry *registry = nullptr );
 

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -19,6 +19,7 @@
 #include <QToolButton>
 #include <QTemporaryFile>
 #include "qgis_gui.h"
+#include "qgis.h"
 
 class QMimeData;
 class QgsColorSchemeRegistry;
@@ -31,7 +32,6 @@ class QgsPanelWidget;
  * and pasting colors, picking colors from the screen, and selecting colors from color swatch grids.
  * \since QGIS 2.5
  */
-
 class GUI_EXPORT QgsColorButton : public QToolButton
 {
     Q_OBJECT
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * \param registry a color scheme registry for color swatch grids to show in the drop down menu. If not
      * specified, the button will use the global color scheme registry
      */
-    QgsColorButton( QWidget *parent = nullptr, const QString &cdt = "", QgsColorSchemeRegistry *registry = nullptr );
+    QgsColorButton( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QString &cdt = "", QgsColorSchemeRegistry *registry = nullptr );
 
     virtual QSize sizeHint() const override;
 

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -36,7 +36,7 @@
 #include <QPushButton>
 #include <QWidget>
 
-QgsColorRampButton::QgsColorRampButton( QWidget *parent, const QString &dialogTitle )
+QgsColorRampButton::QgsColorRampButton( QWidget *parent SIP_TRANSFERTHIS, const QString &dialogTitle )
   : QToolButton( parent )
   , mColorRampDialogTitle( dialogTitle.isEmpty() ? tr( "Select Color Ramp" ) : dialogTitle )
   , mShowGradientOnly( false )

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -22,6 +22,7 @@
 
 #include <QToolButton>
 #include "qgis_gui.h"
+#include "qgis.h"
 
 class QgsPanelWidget;
 
@@ -32,7 +33,6 @@ class QgsPanelWidget;
  * saved color ramps, as well as option to invert the current color ramp and create new ramps.
  * \since QGIS 3.0
  */
-
 class GUI_EXPORT QgsColorRampButton : public QToolButton
 {
     Q_OBJECT
@@ -48,7 +48,7 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      * \param parent The parent QWidget for the dialog
      * \param dialogTitle The title to show in the color ramp dialog
      */
-    QgsColorRampButton( QWidget *parent = nullptr, const QString &dialogTitle = QString() );
+    QgsColorRampButton( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QString &dialogTitle = QString() );
 
     virtual ~QgsColorRampButton();
 
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
     /** Return a copy of the current color ramp.
      * \see setColorRamp()
      */
-    QgsColorRamp *colorRamp() const;
+    QgsColorRamp *colorRamp() const SIP_FACTORY;
 
     /** Set the title for the color ramp dialog window.
      * \param title Title for the color ramp dialog
@@ -111,7 +111,7 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      * option is disabled.
      * \see setDefaultColorRamp
      */
-    QgsColorRamp *defaultColorRamp() const { return mDefaultColorRamp ? mDefaultColorRamp->clone() : nullptr ; }
+    QgsColorRamp *defaultColorRamp() const SIP_FACTORY { return mDefaultColorRamp ? mDefaultColorRamp->clone() : nullptr ; }
 
     /** Sets whether a random colors option is shown in the button's drop down menu.
      * \param showRandom set to true to show a random colors option
@@ -227,16 +227,16 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      */
     void setToNull();
 
-  private slots:
-
-    void rampWidgetUpdated();
-
   signals:
 
     /** Emitted whenever a new color ramp is set for the button. The color ramp is always valid.
      * In case the new color ramp is the same, no signal is emitted to avoid infinite loops.
      */
     void colorRampChanged();
+
+  private slots:
+
+    void rampWidgetUpdated();
 
   protected:
 

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -45,8 +45,8 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
   public:
 
     /** Construct a new color ramp button.
-     * \param parent The parent QWidget for the dialog
-     * \param dialogTitle The title to show in the color ramp dialog
+     * Use \a parent to attach a parent QWidget to the dialog.
+     * Use \a dialogTitle string  to define the title to show in the color ramp dialog
      */
     QgsColorRampButton( QWidget *parent SIP_TRANSFERTHIS = nullptr, const QString &dialogTitle = QString() );
 


### PR DESCRIPTION
## Description
This PR enables sipify for the QgsColorButton and QgsColorRampButton classes. 

@nyalldawson , looking good? I noticed the documentation for the QgsColorButton::Behavior is gone, should that happen or something needs to be changed there to preserve strings?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
