### PR TITLE
More use of weak layer references in composer templates

### DIFF
--- a/src/core/composer/qgscomposerattributetablev2.cpp
+++ b/src/core/composer/qgscomposerattributetablev2.cpp
@@ -51,7 +51,6 @@ bool QgsComposerAttributeTableCompareV2::operator()( const QgsComposerTableRow &
 QgsComposerAttributeTableV2::QgsComposerAttributeTableV2( QgsComposition *composition, bool createUndoCommands )
   : QgsComposerTableV2( composition, createUndoCommands )
   , mSource( LayerAttributes )
-  , mVectorLayer( nullptr )
   , mCurrentAtlasLayer( nullptr )
   , mComposerMap( nullptr )
   , mMaximumNumberOfFeatures( 30 )
@@ -69,7 +68,7 @@ QgsComposerAttributeTableV2::QgsComposerAttributeTableV2( QgsComposition *compos
     QgsVectorLayer *vl = dynamic_cast<QgsVectorLayer *>( mapIt.value() );
     if ( vl )
     {
-      mVectorLayer = vl;
+      mVectorLayer.setLayer( vl );
       break;
     }
   }
@@ -77,7 +76,7 @@ QgsComposerAttributeTableV2::QgsComposerAttributeTableV2( QgsComposition *compos
   {
     resetColumns();
     //listen for modifications to layer and refresh table when they occur
-    connect( mVectorLayer, &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
+    connect( &mVectorLayer, &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
   }
 
   if ( mComposition )
@@ -103,14 +102,14 @@ QString QgsComposerAttributeTableV2::displayName() const
 
 void QgsComposerAttributeTableV2::setVectorLayer( QgsVectorLayer *layer )
 {
-  if ( layer == mVectorLayer )
+  if ( layer == &mVectorLayer )
   {
     //no change
     return;
   }
 
   QgsVectorLayer *prevLayer = sourceLayer();
-  mVectorLayer = layer;
+  mVectorLayer.setLayer( layer );
 
   if ( mSource == QgsComposerAttributeTableV2::LayerAttributes && layer != prevLayer )
   {
@@ -124,7 +123,7 @@ void QgsComposerAttributeTableV2::setVectorLayer( QgsVectorLayer *layer )
     resetColumns();
 
     //listen for modifications to layer and refresh table when they occur
-    connect( mVectorLayer, &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
+    connect( &mVectorLayer, &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
   }
 
   refreshAttributes();
@@ -539,7 +538,7 @@ QgsExpressionContext QgsComposerAttributeTableV2::createExpressionContext() cons
 
   if ( mSource == LayerAttributes )
   {
-    context.appendScope( QgsExpressionContextUtils::layerScope( mVectorLayer ) );
+    context.appendScope( QgsExpressionContextUtils::layerScope( &mVectorLayer ) );
   }
 
   return context;
@@ -563,7 +562,7 @@ QgsVectorLayer *QgsComposerAttributeTableV2::sourceLayer()
     case QgsComposerAttributeTableV2::AtlasFeature:
       return mComposition->atlasComposition().coverageLayer();
     case QgsComposerAttributeTableV2::LayerAttributes:
-      return mVectorLayer;
+      return &mVectorLayer;
     case QgsComposerAttributeTableV2::RelationChildren:
     {
       QgsRelation relation = mComposition->project()->relationManager()->relation( mRelationId );
@@ -579,7 +578,7 @@ void QgsComposerAttributeTableV2::removeLayer( const QString &layerId )
   {
     if ( layerId == mVectorLayer->id() )
     {
-      mVectorLayer = nullptr;
+      mVectorLayer.setLayer( nullptr );
       //remove existing columns
       qDeleteAll( mColumns );
       mColumns.clear();
@@ -657,7 +656,10 @@ bool QgsComposerAttributeTableV2::writeXml( QDomElement &elem, QDomDocument &doc
   }
   if ( mVectorLayer )
   {
-    composerTableElem.setAttribute( QStringLiteral( "vectorLayer" ), mVectorLayer->id() );
+    composerTableElem.setAttribute( QStringLiteral( "vectorLayer" ), mVectorLayer.layerId );
+    composerTableElem.setAttribute( QStringLiteral( "vectorLayerName" ), mVectorLayer.name );
+    composerTableElem.setAttribute( QStringLiteral( "vectorLayerSource" ), mVectorLayer.source );
+    composerTableElem.setAttribute( QStringLiteral( "vectorLayerProvider" ), mVectorLayer.provider );
   }
 
   bool ok = QgsComposerTableV2::writeXml( composerTableElem, doc, ignoreFrames );
@@ -726,19 +728,12 @@ bool QgsComposerAttributeTableV2::readXml( const QDomElement &itemElem, const QD
   }
 
   //vector layer
-  QString layerId = itemElem.attribute( QStringLiteral( "vectorLayer" ), QStringLiteral( "not_existing" ) );
-  if ( layerId == QLatin1String( "not_existing" ) )
-  {
-    mVectorLayer = nullptr;
-  }
-  else
-  {
-    QgsMapLayer *ml = mComposition->project()->mapLayer( layerId );
-    if ( ml )
-    {
-      mVectorLayer = dynamic_cast<QgsVectorLayer *>( ml );
-    }
-  }
+  QString layerId = itemElem.attribute( QStringLiteral( "vectorLayer" ) );
+  QString layerName = itemElem.attribute( QStringLiteral( "vectorLayerName" ) );
+  QString layerSource = itemElem.attribute( QStringLiteral( "vectorLayerSource" ) );
+  QString layerProvider = itemElem.attribute( QStringLiteral( "vectorLayerProvider" ) );
+  mVectorLayer = QgsVectorLayerRef( layerId, layerName, layerSource, layerProvider );
+  mVectorLayer.resolveWeakly( mComposition->project() );
 
   //connect to new layer
   connect( sourceLayer(), &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );

--- a/src/core/composer/qgscomposerattributetablev2.cpp
+++ b/src/core/composer/qgscomposerattributetablev2.cpp
@@ -76,7 +76,7 @@ QgsComposerAttributeTableV2::QgsComposerAttributeTableV2( QgsComposition *compos
   {
     resetColumns();
     //listen for modifications to layer and refresh table when they occur
-    connect( &mVectorLayer, &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
+    connect( mVectorLayer.get(), &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
   }
 
   if ( mComposition )
@@ -102,7 +102,7 @@ QString QgsComposerAttributeTableV2::displayName() const
 
 void QgsComposerAttributeTableV2::setVectorLayer( QgsVectorLayer *layer )
 {
-  if ( layer == &mVectorLayer )
+  if ( layer == mVectorLayer.get() )
   {
     //no change
     return;
@@ -123,7 +123,7 @@ void QgsComposerAttributeTableV2::setVectorLayer( QgsVectorLayer *layer )
     resetColumns();
 
     //listen for modifications to layer and refresh table when they occur
-    connect( &mVectorLayer, &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
+    connect( mVectorLayer.get(), &QgsVectorLayer::layerModified, this, &QgsComposerTableV2::refreshAttributes );
   }
 
   refreshAttributes();
@@ -538,7 +538,7 @@ QgsExpressionContext QgsComposerAttributeTableV2::createExpressionContext() cons
 
   if ( mSource == LayerAttributes )
   {
-    context.appendScope( QgsExpressionContextUtils::layerScope( &mVectorLayer ) );
+    context.appendScope( QgsExpressionContextUtils::layerScope( mVectorLayer.get() ) );
   }
 
   return context;
@@ -562,7 +562,7 @@ QgsVectorLayer *QgsComposerAttributeTableV2::sourceLayer()
     case QgsComposerAttributeTableV2::AtlasFeature:
       return mComposition->atlasComposition().coverageLayer();
     case QgsComposerAttributeTableV2::LayerAttributes:
-      return &mVectorLayer;
+      return mVectorLayer.get();
     case QgsComposerAttributeTableV2::RelationChildren:
     {
       QgsRelation relation = mComposition->project()->relationManager()->relation( mRelationId );

--- a/src/core/composer/qgscomposerattributetablev2.h
+++ b/src/core/composer/qgscomposerattributetablev2.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgscomposertablev2.h"
+#include "qgsvectorlayerref.h"
 
 class QgsComposerMap;
 class QgsVectorLayer;
@@ -119,7 +120,7 @@ class CORE_EXPORT QgsComposerAttributeTableV2: public QgsComposerTableV2
      * \returns attribute table's current vector layer
      * \see setVectorLayer
      */
-    QgsVectorLayer *vectorLayer() const { return mVectorLayer; }
+    QgsVectorLayer *vectorLayer() const { return &mVectorLayer; }
 
     /** Sets the relation id from which to display child features
      * \param relationId id for relation to display child features from
@@ -303,7 +304,7 @@ class CORE_EXPORT QgsComposerAttributeTableV2: public QgsComposerTableV2
     //! Attribute source
     ContentSource mSource;
     //! Associated vector layer
-    QgsVectorLayer *mVectorLayer = nullptr;
+    QgsVectorLayerRef mVectorLayer;
     //! Relation id, if in relation children mode
     QString mRelationId;
 

--- a/src/core/composer/qgscomposerattributetablev2.h
+++ b/src/core/composer/qgscomposerattributetablev2.h
@@ -120,7 +120,7 @@ class CORE_EXPORT QgsComposerAttributeTableV2: public QgsComposerTableV2
      * \returns attribute table's current vector layer
      * \see setVectorLayer
      */
-    QgsVectorLayer *vectorLayer() const { return &mVectorLayer; }
+    QgsVectorLayer *vectorLayer() const { return mVectorLayer.get(); }
 
     /** Sets the relation id from which to display child features
      * \param relationId id for relation to display child features from

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -1532,7 +1532,7 @@ void QgsComposerMap::storeCurrentLayerStyles()
   mLayerStyleOverrides.clear();
   Q_FOREACH ( const QgsMapLayerRef &layerRef, mLayers )
   {
-    if ( QgsMapLayer *layer = &layerRef )
+    if ( QgsMapLayer *layer = layerRef.get() )
     {
       QgsMapLayerStyle style;
       style.readFromLayer( layer );

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -24,6 +24,7 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrendercontext.h"
 #include "qgsmaplayer.h"
+#include "qgsmaplayerref.h"
 #include <QFont>
 #include <QGraphicsRectItem>
 
@@ -541,7 +542,7 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     bool mKeepLayerSet = false;
 
     //! Stored layer list (used if layer live-link mKeepLayerSet is disabled)
-    QgsWeakMapLayerPointerList mLayers;
+    QList< QgsMapLayerRef > mLayers;
 
     bool mKeepLayerStyles = false;
     //! Stored style names (value) to be used with particular layer IDs (key) instead of default style

--- a/src/core/layertree/qgslayertreelayer.cpp
+++ b/src/core/layertree/qgslayertreelayer.cpp
@@ -48,25 +48,18 @@ void QgsLayerTreeLayer::resolveReferences( const QgsProject *project, bool loose
   if ( mRef.layer )
     return;  // already assigned
 
-  QgsMapLayer *layer = project->mapLayer( mRef.layerId );
-
-  if ( !layer && looseMatching && !mRef.name.isEmpty() )
+  if ( !looseMatching )
   {
-    Q_FOREACH ( QgsMapLayer *l, project->mapLayersByName( mRef.name ) )
-    {
-      if ( mRef.layerMatchesSource( l ) )
-      {
-        layer = l;
-        break;
-      }
-    }
+    mRef.resolve( project );
+  }
+  else
+  {
+    mRef.resolveWeakly( project );
   }
 
-  if ( !layer )
+  if ( !mRef.layer )
     return;
 
-  mRef.layer = layer;
-  mRef.layerId = layer->id();
   attachToLayer();
   emit layerLoaded();
 }

--- a/src/core/layertree/qgslayertreelayer.cpp
+++ b/src/core/layertree/qgslayertreelayer.cpp
@@ -45,7 +45,7 @@ QgsLayerTreeLayer::QgsLayerTreeLayer( const QgsLayerTreeLayer &other )
 
 void QgsLayerTreeLayer::resolveReferences( const QgsProject *project, bool looseMatching )
 {
-  if ( mRef.layer )
+  if ( mRef )
     return;  // already assigned
 
   if ( !looseMatching )
@@ -57,7 +57,7 @@ void QgsLayerTreeLayer::resolveReferences( const QgsProject *project, bool loose
     mRef.resolveWeakly( project );
   }
 
-  if ( !mRef.layer )
+  if ( !mRef )
     return;
 
   attachToLayer();
@@ -66,7 +66,7 @@ void QgsLayerTreeLayer::resolveReferences( const QgsProject *project, bool loose
 
 void QgsLayerTreeLayer::attachToLayer()
 {
-  if ( !mRef.layer )
+  if ( !mRef )
     return;
 
   connect( mRef.layer, &QgsMapLayer::nameChanged, this, &QgsLayerTreeLayer::layerNameChanged );
@@ -76,16 +76,16 @@ void QgsLayerTreeLayer::attachToLayer()
 
 QString QgsLayerTreeLayer::name() const
 {
-  return mRef.layer ? mRef.layer->name() : mLayerName;
+  return mRef ? mRef->name() : mLayerName;
 }
 
 void QgsLayerTreeLayer::setName( const QString &n )
 {
-  if ( mRef.layer )
+  if ( mRef )
   {
-    if ( mRef.layer->name() == n )
+    if ( mRef->name() == n )
       return;
-    mRef.layer->setName( n );
+    mRef->setName( n );
     // no need to emit signal: we will be notified from layer's nameChanged() signal
   }
   else
@@ -136,10 +136,10 @@ void QgsLayerTreeLayer::writeXml( QDomElement &parentElement )
   elem.setAttribute( QStringLiteral( "id" ), layerId() );
   elem.setAttribute( QStringLiteral( "name" ), name() );
 
-  if ( mRef.layer )
+  if ( mRef )
   {
-    elem.setAttribute( "source", mRef.layer->publicSource() );
-    elem.setAttribute( "providerKey", mRef.layer->dataProvider() ? mRef.layer->dataProvider()->name() : QString() );
+    elem.setAttribute( "source", mRef->publicSource() );
+    elem.setAttribute( "providerKey", mRef->dataProvider() ? mRef->dataProvider()->name() : QString() );
   }
 
   elem.setAttribute( QStringLiteral( "checked" ), mChecked ? QStringLiteral( "Qt::Checked" ) : QStringLiteral( "Qt::Unchecked" ) );
@@ -162,9 +162,9 @@ QgsLayerTreeLayer *QgsLayerTreeLayer::clone() const
 
 void QgsLayerTreeLayer::layerWillBeDeleted()
 {
-  Q_ASSERT( mRef.layer );
+  Q_ASSERT( mRef );
 
-  mLayerName = mRef.layer->name();
+  mLayerName = mRef->name();
   // in theory we do not even need to do this - the weak ref should clear itself
   mRef.layer.clear();
   // layerId stays in the reference
@@ -175,6 +175,6 @@ void QgsLayerTreeLayer::layerWillBeDeleted()
 
 void QgsLayerTreeLayer::layerNameChanged()
 {
-  Q_ASSERT( mRef.layer );
-  emit nameChanged( this, mRef.layer->name() );
+  Q_ASSERT( mRef );
+  emit nameChanged( this, mRef->name() );
 }

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -54,7 +54,7 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     QString layerId() const { return mRef.layerId; }
 
-    QgsMapLayer *layer() const { return &mRef; }
+    QgsMapLayer *layer() const { return mRef.get(); }
 
     /**
      * Returns the layer's name.

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -54,7 +54,7 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     QString layerId() const { return mRef.layerId; }
 
-    QgsMapLayer *layer() const { return mRef.get(); }
+    QgsMapLayer *layer() const { return &mRef; }
 
     /**
      * Returns the layer's name.

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -54,7 +54,7 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     QString layerId() const { return mRef.layerId; }
 
-    QgsMapLayer *layer() const { return mRef.layer.data(); }
+    QgsMapLayer *layer() const { return mRef.get(); }
 
     /**
      * Returns the layer's name.

--- a/src/core/qgsmaplayerlistutils.h
+++ b/src/core/qgsmaplayerlistutils.h
@@ -47,7 +47,7 @@ inline QList<QgsMapLayer *> _qgis_listRefToRaw( const QList< QgsMapLayerRef > &l
   Q_FOREACH ( const QgsMapLayerRef &layer, layers )
   {
     if ( layer )
-      lst.append( &layer );
+      lst.append( layer.get() );
   }
   return lst;
 }
@@ -69,7 +69,7 @@ inline void _qgis_removeLayers( QList< QgsMapLayerRef > &list, QList< QgsMapLaye
   while ( it.hasNext() )
   {
     QgsMapLayerRef &ref = it.next();
-    if ( layersToRemove.contains( &ref ) )
+    if ( layersToRemove.contains( ref.get() ) )
       it.remove();
   }
 }

--- a/src/core/qgsmaplayerlistutils.h
+++ b/src/core/qgsmaplayerlistutils.h
@@ -13,6 +13,7 @@
 #include <QPointer>
 
 #include "qgsmaplayer.h"
+#include "qgsmaplayerref.h"
 
 /// @cond PRIVATE
 
@@ -37,6 +38,40 @@ inline QgsWeakMapLayerPointerList _qgis_listRawToQPointer( const QList<QgsMapLay
     lst.append( layer );
   }
   return lst;
+}
+
+inline QList<QgsMapLayer *> _qgis_listRefToRaw( const QList< QgsMapLayerRef > &layers )
+{
+  QList<QgsMapLayer *> lst;
+  lst.reserve( layers.count() );
+  Q_FOREACH ( const QgsMapLayerRef &layer, layers )
+  {
+    if ( layer )
+      lst.append( &layer );
+  }
+  return lst;
+}
+
+inline QList< QgsMapLayerRef > _qgis_listRawToRef( const QList<QgsMapLayer *> &layers )
+{
+  QList< QgsMapLayerRef > lst;
+  lst.reserve( layers.count() );
+  Q_FOREACH ( QgsMapLayer *layer, layers )
+  {
+    lst.append( QgsMapLayerRef( layer ) );
+  }
+  return lst;
+}
+
+inline void _qgis_removeLayers( QList< QgsMapLayerRef > &list, QList< QgsMapLayer *> layersToRemove )
+{
+  QMutableListIterator<QgsMapLayerRef> it( list );
+  while ( it.hasNext() )
+  {
+    QgsMapLayerRef &ref = it.next();
+    if ( layersToRemove.contains( &ref ) )
+      it.remove();
+  }
 }
 
 inline QStringList _qgis_listQPointerToIDs( const QgsWeakMapLayerPointerList &layers )

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -68,10 +68,30 @@ struct _LayerRef
   }
 
   /**
+   * Returns true if the layer reference is resolved and contains a reference to an existing
+   * map layer.
+   */
+  operator bool() const
+  {
+    return static_cast< bool >( layer.data() );
+  }
+
+  /**
+   * Forwards the to map layer.
+   */
+  TYPE *operator->() const
+  {
+    return layer.data();
+  }
+
+  /**
    * Returns a pointer to the layer, or nullptr if the reference has not yet been matched
    * to a layer.
    */
-  TYPE *get() const { return layer.data(); }
+  TYPE *operator &() const
+  {
+    return layer.data();
+  }
 
   //! Weak pointer to map layer
   QPointer<TYPE> layer;

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -88,7 +88,7 @@ struct _LayerRef
    * Returns a pointer to the layer, or nullptr if the reference has not yet been matched
    * to a layer.
    */
-  TYPE *operator &() const
+  TYPE *get() const
   {
     return layer.data();
   }

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -19,10 +19,7 @@
 #include <QPointer>
 
 #include "qgsmaplayer.h"
-#include "qgsvectorlayer.h"
-#include "qgsvectordataprovider.h"
-#include "raster/qgsrasterlayer.h"
-#include "raster/qgsrasterdataprovider.h"
+#include "qgsdataprovider.h"
 
 /** Internal structure to keep weak pointer to QgsMapLayer or layerId
  *  if the layer is not available yet.
@@ -31,7 +28,19 @@
 template<typename TYPE>
 struct _LayerRef
 {
-  _LayerRef( TYPE *l = nullptr ): layer( l ), layerId( l ? l->id() : QString() ) {}
+
+  /**
+   * Constructor for a layer reference from an existing map layer.
+   * The layerId, source, name and provider members will automatically
+   * be populated from this layer.
+   */
+  _LayerRef( TYPE *l = nullptr )
+    : layer( l )
+    , layerId( l ? l->id() : QString() )
+    , source( l ? l->publicSource() : QString() )
+    , name( l ? l->name() : QString() )
+    , provider( l && l->dataProvider() ? l->dataProvider()->name() : QString() )
+  {}
 
   /**
    * Constructor for a weak layer reference, using a combination of layer ID,
@@ -45,7 +54,16 @@ struct _LayerRef
     , provider( provider )
   {}
 
+  /**
+   * Returns a pointer to the layer, or nullptr if the reference has not yet been matched
+   * to a layer.
+   */
+  TYPE *get() const { return layer.data(); }
+
+  //! Weak pointer to map layer
   QPointer<TYPE> layer;
+
+  //! Original layer ID
   QString layerId;
 
   //! Weak reference to layer public source

--- a/src/core/qgsvectorlayerjoininfo.h
+++ b/src/core/qgsvectorlayerjoininfo.h
@@ -27,7 +27,7 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
     //! Sets weak reference to the joined layer
     void setJoinLayer( QgsVectorLayer *layer ) { mJoinLayerRef = QgsVectorLayerRef( layer ); }
     //! Returns joined layer (may be null if the reference was set by layer ID and not resolved yet)
-    QgsVectorLayer *joinLayer() const { return mJoinLayerRef.layer.data(); }
+    QgsVectorLayer *joinLayer() const { return mJoinLayerRef.get(); }
 
     //! Sets ID of the joined layer. It will need to be overwritten by setJoinLayer() to a reference to real layer
     void setJoinLayerId( const QString &layerId ) { mJoinLayerRef = QgsVectorLayerRef( layerId ); }

--- a/src/core/qgsvectorlayerjoininfo.h
+++ b/src/core/qgsvectorlayerjoininfo.h
@@ -27,7 +27,7 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
     //! Sets weak reference to the joined layer
     void setJoinLayer( QgsVectorLayer *layer ) { mJoinLayerRef = QgsVectorLayerRef( layer ); }
     //! Returns joined layer (may be null if the reference was set by layer ID and not resolved yet)
-    QgsVectorLayer *joinLayer() const { return &mJoinLayerRef; }
+    QgsVectorLayer *joinLayer() const { return mJoinLayerRef.get(); }
 
     //! Sets ID of the joined layer. It will need to be overwritten by setJoinLayer() to a reference to real layer
     void setJoinLayerId( const QString &layerId ) { mJoinLayerRef = QgsVectorLayerRef( layerId ); }

--- a/src/core/qgsvectorlayerjoininfo.h
+++ b/src/core/qgsvectorlayerjoininfo.h
@@ -27,7 +27,7 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
     //! Sets weak reference to the joined layer
     void setJoinLayer( QgsVectorLayer *layer ) { mJoinLayerRef = QgsVectorLayerRef( layer ); }
     //! Returns joined layer (may be null if the reference was set by layer ID and not resolved yet)
-    QgsVectorLayer *joinLayer() const { return mJoinLayerRef.get(); }
+    QgsVectorLayer *joinLayer() const { return &mJoinLayerRef; }
 
     //! Sets ID of the joined layer. It will need to be overwritten by setJoinLayer() to a reference to real layer
     void setJoinLayerId( const QString &layerId ) { mJoinLayerRef = QgsVectorLayerRef( layerId ); }

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -162,7 +162,7 @@ void TestQgsMapLayer::layerRef()
 {
   // construct from layer
   QgsVectorLayerRef ref( mpLayer );
-  QCOMPARE( &ref, mpLayer );
+  QCOMPARE( ref.get(), mpLayer );
   QCOMPARE( ref.layer.data(), mpLayer );
   QCOMPARE( ref.layerId, mpLayer->id() );
   QCOMPARE( ref.name, QStringLiteral( "points" ) );
@@ -180,7 +180,7 @@ void TestQgsMapLayer::layerRef()
   // create a weak reference
   QgsVectorLayerRef ref2( mpLayer->id(), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "ogr" ) );
   QVERIFY( !ref2 );
-  QVERIFY( !&ref2 );
+  QVERIFY( !ref2.get() );
   QVERIFY( !ref2.layer.data() );
   QCOMPARE( ref2.layerId, mpLayer->id() );
   QCOMPARE( ref2.name, QStringLiteral( "points" ) );
@@ -193,7 +193,7 @@ void TestQgsMapLayer::layerRef()
   // resolve layer using project
   QCOMPARE( ref2.resolve( QgsProject::instance() ), mpLayer );
   QVERIFY( ref2 );
-  QCOMPARE( &ref2, mpLayer );
+  QCOMPARE( ref2.get(), mpLayer );
   QCOMPARE( ref2.layer.data(), mpLayer );
   QCOMPARE( ref2.layerId, mpLayer->id() );
   QCOMPARE( ref2.name, QStringLiteral( "points" ) );
@@ -202,9 +202,9 @@ void TestQgsMapLayer::layerRef()
 
   // setLayer
   QgsVectorLayerRef ref3;
-  QVERIFY( !&ref3 );
+  QVERIFY( !ref3.get() );
   ref3.setLayer( mpLayer );
-  QCOMPARE( &ref3, mpLayer );
+  QCOMPARE( ref3.get(), mpLayer );
   QCOMPARE( ref3.layer.data(), mpLayer );
   QCOMPARE( ref3.layerId, mpLayer->id() );
   QCOMPARE( ref3.name, QStringLiteral( "points" ) );
@@ -213,10 +213,10 @@ void TestQgsMapLayer::layerRef()
 
   // weak resolve
   QgsVectorLayerRef ref4( QStringLiteral( "badid" ), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "ogr" ) );
-  QVERIFY( !&ref4 );
+  QVERIFY( !ref4 );
   QVERIFY( !ref4.resolve( QgsProject::instance() ) );
   QCOMPARE( ref4.resolveWeakly( QgsProject::instance() ), mpLayer );
-  QCOMPARE( &ref4, mpLayer );
+  QCOMPARE( ref4.get(), mpLayer );
   QCOMPARE( ref4.layer.data(), mpLayer );
   QCOMPARE( ref4.layerId, mpLayer->id() );
   QCOMPARE( ref4.name, QStringLiteral( "points" ) );
@@ -225,7 +225,7 @@ void TestQgsMapLayer::layerRef()
 
   // try resolving a bad reference
   QgsVectorLayerRef ref5( QStringLiteral( "badid" ), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "xxx" ) );
-  QVERIFY( !&ref5 );
+  QVERIFY( !ref5.get() );
   QVERIFY( !ref5.resolve( QgsProject::instance() ) );
   QVERIFY( !ref5.resolveWeakly( QgsProject::instance() ) );
 }
@@ -240,8 +240,8 @@ void TestQgsMapLayer::layerRefListUtils()
   listRawSource << vlA << vlB;
 
   QList< QgsMapLayerRef > refs = _qgis_listRawToRef( listRawSource );
-  QCOMPARE( &refs.at( 0 ), vlA );
-  QCOMPARE( &refs.at( 1 ), vlB );
+  QCOMPARE( refs.at( 0 ).get(), vlA );
+  QCOMPARE( refs.at( 1 ).get(), vlB );
 
   QList<QgsMapLayer *> raw = _qgis_listRefToRaw( refs );
   QCOMPARE( raw, QList< QgsMapLayer *>() << vlA << vlB );
@@ -253,8 +253,8 @@ void TestQgsMapLayer::layerRefListUtils()
 
   _qgis_removeLayers( refs, QList< QgsMapLayer *>() << vlB << vlD );
   QCOMPARE( refs.size(), 2 );
-  QCOMPARE( &refs.at( 0 ), vlA );
-  QCOMPARE( &refs.at( 1 ), vlC );
+  QCOMPARE( refs.at( 0 ).get(), vlA );
+  QCOMPARE( refs.at( 1 ).get(), vlC );
 
 
 }

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -26,6 +26,7 @@
 #include <qgsapplication.h>
 #include <qgsproviderregistry.h>
 #include "qgsvectorlayerref.h"
+#include "qgsmaplayerlistutils.h"
 
 class TestSignalReceiver : public QObject
 {
@@ -70,6 +71,7 @@ class TestQgsMapLayer : public QObject
     void isInScaleRange();
 
     void layerRef();
+    void layerRefListUtils();
 
 
   private:
@@ -226,6 +228,35 @@ void TestQgsMapLayer::layerRef()
   QVERIFY( !&ref5 );
   QVERIFY( !ref5.resolve( QgsProject::instance() ) );
   QVERIFY( !ref5.resolveWeakly( QgsProject::instance() ) );
+}
+
+void TestQgsMapLayer::layerRefListUtils()
+{
+  // conversion utils
+  QgsVectorLayer *vlA = new QgsVectorLayer( "Point", "a", "memory" );
+  QgsVectorLayer *vlB = new QgsVectorLayer( "Point", "b", "memory" );
+
+  QList<QgsMapLayer *> listRawSource;
+  listRawSource << vlA << vlB;
+
+  QList< QgsMapLayerRef > refs = _qgis_listRawToRef( listRawSource );
+  QCOMPARE( &refs.at( 0 ), vlA );
+  QCOMPARE( &refs.at( 1 ), vlB );
+
+  QList<QgsMapLayer *> raw = _qgis_listRefToRaw( refs );
+  QCOMPARE( raw, QList< QgsMapLayer *>() << vlA << vlB );
+
+  //remove layers
+  QgsVectorLayer *vlC = new QgsVectorLayer( "Point", "c", "memory" );
+  QgsVectorLayer *vlD = new QgsVectorLayer( "Point", "d", "memory" );
+  refs << QgsMapLayerRef( vlC ) << QgsMapLayerRef( vlD );
+
+  _qgis_removeLayers( refs, QList< QgsMapLayer *>() << vlB << vlD );
+  QCOMPARE( refs.size(), 2 );
+  QCOMPARE( &refs.at( 0 ), vlA );
+  QCOMPARE( &refs.at( 1 ), vlC );
+
+
 }
 
 QGSTEST_MAIN( TestQgsMapLayer )

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -97,11 +97,12 @@ void TestQgsMapLayer::init()
   QFileInfo myMapFileInfo( myFileName );
   mpLayer = new QgsVectorLayer( myMapFileInfo.filePath(),
                                 myMapFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+  QgsProject::instance()->addMapLayer( mpLayer );
 }
 
 void TestQgsMapLayer::cleanup()
 {
-  delete mpLayer;
+  QgsProject::instance()->removeAllMapLayers();
 }
 
 void TestQgsMapLayer::cleanupTestCase()
@@ -180,6 +181,44 @@ void TestQgsMapLayer::layerRef()
 
   // verify that weak reference matches layer
   QVERIFY( ref2.layerMatchesSource( mpLayer ) );
+
+  // resolve layer using project
+  QCOMPARE( ref2.resolve( QgsProject::instance() ), mpLayer );
+  QCOMPARE( ref2.get(), mpLayer );
+  QCOMPARE( ref2.layer.data(), mpLayer );
+  QCOMPARE( ref2.layerId, mpLayer->id() );
+  QCOMPARE( ref2.name, QStringLiteral( "points" ) );
+  QCOMPARE( ref2.source, mpLayer->publicSource() );
+  QCOMPARE( ref2.provider, QStringLiteral( "ogr" ) );
+
+  // setLayer
+  QgsVectorLayerRef ref3;
+  QVERIFY( !ref3.get() );
+  ref3.setLayer( mpLayer );
+  QCOMPARE( ref3.get(), mpLayer );
+  QCOMPARE( ref3.layer.data(), mpLayer );
+  QCOMPARE( ref3.layerId, mpLayer->id() );
+  QCOMPARE( ref3.name, QStringLiteral( "points" ) );
+  QCOMPARE( ref3.source, mpLayer->publicSource() );
+  QCOMPARE( ref3.provider, QStringLiteral( "ogr" ) );
+
+  // weak resolve
+  QgsVectorLayerRef ref4( QStringLiteral( "badid" ), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "ogr" ) );
+  QVERIFY( !ref4.get() );
+  QVERIFY( !ref4.resolve( QgsProject::instance() ) );
+  QCOMPARE( ref4.resolveWeakly( QgsProject::instance() ), mpLayer );
+  QCOMPARE( ref4.get(), mpLayer );
+  QCOMPARE( ref4.layer.data(), mpLayer );
+  QCOMPARE( ref4.layerId, mpLayer->id() );
+  QCOMPARE( ref4.name, QStringLiteral( "points" ) );
+  QCOMPARE( ref4.source, mpLayer->publicSource() );
+  QCOMPARE( ref4.provider, QStringLiteral( "ogr" ) );
+
+  // try resolving a bad reference
+  QgsVectorLayerRef ref5( QStringLiteral( "badid" ), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "xxx" ) );
+  QVERIFY( !ref5.get() );
+  QVERIFY( !ref5.resolve( QgsProject::instance() ) );
+  QVERIFY( !ref5.resolveWeakly( QgsProject::instance() ) );
 }
 
 QGSTEST_MAIN( TestQgsMapLayer )

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -160,19 +160,25 @@ void TestQgsMapLayer::layerRef()
 {
   // construct from layer
   QgsVectorLayerRef ref( mpLayer );
-  QCOMPARE( ref.get(), mpLayer );
+  QCOMPARE( &ref, mpLayer );
   QCOMPARE( ref.layer.data(), mpLayer );
   QCOMPARE( ref.layerId, mpLayer->id() );
   QCOMPARE( ref.name, QStringLiteral( "points" ) );
   QCOMPARE( ref.source, mpLayer->publicSource() );
   QCOMPARE( ref.provider, QStringLiteral( "ogr" ) );
 
+  // bool operator
+  QVERIFY( ref );
+  // -> operator
+  QCOMPARE( ref->id(), mpLayer->id() );
+
   // verify that layer matches layer
   QVERIFY( ref.layerMatchesSource( mpLayer ) );
 
   // create a weak reference
   QgsVectorLayerRef ref2( mpLayer->id(), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "ogr" ) );
-  QVERIFY( !ref2.get() );
+  QVERIFY( !ref2 );
+  QVERIFY( !&ref2 );
   QVERIFY( !ref2.layer.data() );
   QCOMPARE( ref2.layerId, mpLayer->id() );
   QCOMPARE( ref2.name, QStringLiteral( "points" ) );
@@ -184,7 +190,8 @@ void TestQgsMapLayer::layerRef()
 
   // resolve layer using project
   QCOMPARE( ref2.resolve( QgsProject::instance() ), mpLayer );
-  QCOMPARE( ref2.get(), mpLayer );
+  QVERIFY( ref2 );
+  QCOMPARE( &ref2, mpLayer );
   QCOMPARE( ref2.layer.data(), mpLayer );
   QCOMPARE( ref2.layerId, mpLayer->id() );
   QCOMPARE( ref2.name, QStringLiteral( "points" ) );
@@ -193,9 +200,9 @@ void TestQgsMapLayer::layerRef()
 
   // setLayer
   QgsVectorLayerRef ref3;
-  QVERIFY( !ref3.get() );
+  QVERIFY( !&ref3 );
   ref3.setLayer( mpLayer );
-  QCOMPARE( ref3.get(), mpLayer );
+  QCOMPARE( &ref3, mpLayer );
   QCOMPARE( ref3.layer.data(), mpLayer );
   QCOMPARE( ref3.layerId, mpLayer->id() );
   QCOMPARE( ref3.name, QStringLiteral( "points" ) );
@@ -204,10 +211,10 @@ void TestQgsMapLayer::layerRef()
 
   // weak resolve
   QgsVectorLayerRef ref4( QStringLiteral( "badid" ), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "ogr" ) );
-  QVERIFY( !ref4.get() );
+  QVERIFY( !&ref4 );
   QVERIFY( !ref4.resolve( QgsProject::instance() ) );
   QCOMPARE( ref4.resolveWeakly( QgsProject::instance() ), mpLayer );
-  QCOMPARE( ref4.get(), mpLayer );
+  QCOMPARE( &ref4, mpLayer );
   QCOMPARE( ref4.layer.data(), mpLayer );
   QCOMPARE( ref4.layerId, mpLayer->id() );
   QCOMPARE( ref4.name, QStringLiteral( "points" ) );
@@ -216,7 +223,7 @@ void TestQgsMapLayer::layerRef()
 
   // try resolving a bad reference
   QgsVectorLayerRef ref5( QStringLiteral( "badid" ), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "xxx" ) );
-  QVERIFY( !ref5.get() );
+  QVERIFY( !&ref5 );
   QVERIFY( !ref5.resolve( QgsProject::instance() ) );
   QVERIFY( !ref5.resolveWeakly( QgsProject::instance() ) );
 }

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -25,6 +25,7 @@
 #include <qgsvectorlayer.h>
 #include <qgsapplication.h>
 #include <qgsproviderregistry.h>
+#include "qgsvectorlayerref.h"
 
 class TestSignalReceiver : public QObject
 {
@@ -68,9 +69,11 @@ class TestQgsMapLayer : public QObject
     void isInScaleRange_data();
     void isInScaleRange();
 
+    void layerRef();
+
 
   private:
-    QgsMapLayer *mpLayer = nullptr;
+    QgsVectorLayer *mpLayer = nullptr;
 };
 
 void TestQgsMapLayer::initTestCase()
@@ -150,6 +153,33 @@ void TestQgsMapLayer::isInScaleRange()
   mpLayer->setScaleBasedVisibility( false );
   QCOMPARE( mpLayer->isInScaleRange( scale ), true );
 
+}
+
+void TestQgsMapLayer::layerRef()
+{
+  // construct from layer
+  QgsVectorLayerRef ref( mpLayer );
+  QCOMPARE( ref.get(), mpLayer );
+  QCOMPARE( ref.layer.data(), mpLayer );
+  QCOMPARE( ref.layerId, mpLayer->id() );
+  QCOMPARE( ref.name, QStringLiteral( "points" ) );
+  QCOMPARE( ref.source, mpLayer->publicSource() );
+  QCOMPARE( ref.provider, QStringLiteral( "ogr" ) );
+
+  // verify that layer matches layer
+  QVERIFY( ref.layerMatchesSource( mpLayer ) );
+
+  // create a weak reference
+  QgsVectorLayerRef ref2( mpLayer->id(), QStringLiteral( "points" ), mpLayer->publicSource(), QStringLiteral( "ogr" ) );
+  QVERIFY( !ref2.get() );
+  QVERIFY( !ref2.layer.data() );
+  QCOMPARE( ref2.layerId, mpLayer->id() );
+  QCOMPARE( ref2.name, QStringLiteral( "points" ) );
+  QCOMPARE( ref2.source, mpLayer->publicSource() );
+  QCOMPARE( ref2.provider, QStringLiteral( "ogr" ) );
+
+  // verify that weak reference matches layer
+  QVERIFY( ref2.layerMatchesSource( mpLayer ) );
 }
 
 QGSTEST_MAIN( TestQgsMapLayer )


### PR DESCRIPTION
Contains fixes for restoring composer templates in projects other than the project in which the template was created.

This PR allows attribute tables and composer maps with fixed layer sets to correctly load and reattach to matching layers when the template is loaded in a project with different layer IDs.

On behalf of Faunalia, sponsored by ENEL

@wonder-sk quite a few changes here to QgsMapLayerRef you may be interested in....

