### PR TITLE
Fix layer drawing order in server to also work in complex projects and with custom drawing order

### DIFF
--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -1216,7 +1216,7 @@ bool QgsServerProjectParser::findUseLayerIDs() const
 void QgsServerProjectParser::layerFromLegendLayer( const QDomElement& legendLayerElem, QMap< int, QgsMapLayer*>& layers, bool useCache ) const
 {
   QString id = legendLayerElem.firstChild().firstChild().toElement().attribute( "layerid" );
-  int drawingOrder = updateLegendDrawingOrder() ? -1 : mCustomLayerOrder.indexOf( id );
+  int drawingOrder = updateLegendDrawingOrder() ? mCustomLayerOrder.indexOf( id ) : -1;
 
   QHash< QString, QDomElement >::const_iterator layerIt = mProjectLayerElementsById.find( id );
   if ( layerIt != mProjectLayerElementsById.constEnd() )

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -203,7 +203,7 @@ QList<QgsMapLayer*> QgsWMSProjectParser::mapLayerFromStyle( const QString& lName
   if ( !groupElement.isNull() )
   {
     addLayersFromGroup( groupElement, layers, useCache );
-    return QgsConfigParserUtils::layerMapToList( layers, mProjectParser->updateLegendDrawingOrder() );
+    return QgsConfigParserUtils::layerMapToList( layers, false );
   }
 
   //still not found. Check if it is a single embedded layer (embedded layers are not contained in mProjectLayerElementsByName)


### PR DESCRIPTION
This PR fixes the drawing order in 2.18 server (was not correct for complex projects if custom drawing order was used)
