### PR TITLE
Backport composer template fixes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -672,6 +672,8 @@ SET(QGIS_CORE_HDRS
   qgslegendsettings.h
   qgslogger.h
   qgsmaphittest.h
+  qgsmaplayerlistutils.h
+  qgsmaplayerref.h
   qgsmaplayerrenderer.h
   qgsmaplayerstylemanager.h
   qgsmapsettings.h
@@ -723,6 +725,7 @@ SET(QGIS_CORE_HDRS
 
   qgsvectordataprovider.h
   qgsvectorlayercache.h
+  qgsvectorlayerref.h
   qgsvectorfilewriter.h
   qgsvectorlayerdiagramprovider.h
   qgsvectorlayereditutils.h

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -35,7 +35,6 @@ QgsAtlasComposition::QgsAtlasComposition( QgsComposition* composition )
     , mEnabled( false )
     , mHideCoverage( false )
     , mFilenamePattern( "'output_'||@atlas_featurenumber" )
-    , mCoverageLayer( nullptr )
     , mSingleFile( false )
     , mSortFeatures( false )
     , mSortAscending( true )
@@ -73,10 +72,10 @@ void QgsAtlasComposition::removeLayers( const QStringList& layers )
 
   Q_FOREACH ( const QString& layerId, layers )
   {
-    if ( layerId == mCoverageLayer->id() )
+    if ( layerId == mCoverageLayer.layerId )
     {
       //current coverage layer removed
-      mCoverageLayer = nullptr;
+      mCoverageLayer.setLayer( nullptr );
       setEnabled( false );
       return;
     }
@@ -85,12 +84,12 @@ void QgsAtlasComposition::removeLayers( const QStringList& layers )
 
 void QgsAtlasComposition::setCoverageLayer( QgsVectorLayer* layer )
 {
-  if ( layer == mCoverageLayer )
+  if ( layer == mCoverageLayer.get() )
   {
     return;
   }
 
-  mCoverageLayer = layer;
+  mCoverageLayer.setLayer( layer );
   emit coverageLayerChanged( layer );
 }
 
@@ -644,7 +643,10 @@ void QgsAtlasComposition::writeXML( QDomElement& elem, QDomDocument& doc ) const
 
   if ( mCoverageLayer )
   {
-    atlasElem.setAttribute( "coverageLayer", mCoverageLayer->id() );
+    atlasElem.setAttribute( "coverageLayer", mCoverageLayer.layerId );
+    atlasElem.setAttribute( "coverageLayerName", mCoverageLayer.name );
+    atlasElem.setAttribute( "coverageLayerSource", mCoverageLayer.source );
+    atlasElem.setAttribute( "coverageLayerProvider", mCoverageLayer.provider );
   }
   else
   {
@@ -682,16 +684,13 @@ void QgsAtlasComposition::readXML( const QDomElement& atlasElem, const QDomDocum
   }
 
   // look for stored layer name
-  mCoverageLayer = nullptr;
-  QMap<QString, QgsMapLayer*> layers = QgsMapLayerRegistry::instance()->mapLayers();
-  for ( QMap<QString, QgsMapLayer*>::const_iterator it = layers.begin(); it != layers.end(); ++it )
-  {
-    if ( it.key() == atlasElem.attribute( "coverageLayer" ) )
-    {
-      mCoverageLayer = dynamic_cast<QgsVectorLayer*>( it.value() );
-      break;
-    }
-  }
+  QString layerId = atlasElem.attribute( "coverageLayer" );
+  QString layerName = atlasElem.attribute( "coverageLayerName" );
+  QString layerSource = atlasElem.attribute( "coverageLayerSource" );
+  QString layerProvider = atlasElem.attribute( "coverageLayerProvider" );
+
+  mCoverageLayer = QgsVectorLayerRef( layerId, layerName, layerSource, layerProvider );
+  mCoverageLayer.resolveWeakly();
 
   mPageNameExpression = atlasElem.attribute( "pageNameExpression", QString() );
   mSingleFile = atlasElem.attribute( "singleFile", "false" ) == "true" ? true : false;

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -19,6 +19,7 @@
 #include "qgscoordinatetransform.h"
 #include "qgsfeature.h"
 #include "qgsgeometry.h"
+#include "qgsvectorlayerref.h"
 
 #include <memory>
 #include <QString>
@@ -101,7 +102,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
      * @returns atlas coverage layer
      * @see setCoverageLayer
      */
-    QgsVectorLayer* coverageLayer() const { return mCoverageLayer; }
+    QgsVectorLayer* coverageLayer() const { return mCoverageLayer.get(); }
 
     /** Sets the coverage layer to use for the atlas features
      * @param layer vector coverage layer
@@ -355,7 +356,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     bool mEnabled;
     bool mHideCoverage;
     QString mFilenamePattern;
-    QgsVectorLayer* mCoverageLayer;
+    QgsVectorLayerRef mCoverageLayer;
     bool mSingleFile;
 
     QString mCurrentFilename;

--- a/src/core/composer/qgscomposerattributetablev2.h
+++ b/src/core/composer/qgscomposerattributetablev2.h
@@ -20,6 +20,7 @@
 
 #include "qgscomposertablev2.h"
 #include "qgscomposerattributetable.h"
+#include "qgsvectorlayerref.h"
 
 class QgsComposerMap;
 class QgsVectorLayer;
@@ -120,7 +121,7 @@ class CORE_EXPORT QgsComposerAttributeTableV2: public QgsComposerTableV2
      * @returns attribute table's current vector layer
      * @see setVectorLayer
      */
-    QgsVectorLayer* vectorLayer() const { return mVectorLayer; }
+    QgsVectorLayer* vectorLayer() const { return mVectorLayer.get(); }
 
     /** Sets the relation id from which to display child features
      * @param relationId id for relation to display child features from
@@ -314,7 +315,7 @@ class CORE_EXPORT QgsComposerAttributeTableV2: public QgsComposerTableV2
     /** Attribute source*/
     ContentSource mSource;
     /** Associated vector layer*/
-    QgsVectorLayer* mVectorLayer;
+    QgsVectorLayerRef mVectorLayer;
     /** Relation id, if in relation children mode*/
     QString mRelationId;
 

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -1351,7 +1351,15 @@ bool QgsComposerMap::writeXML( QDomElement& elem, QDomDocument & doc ) const
     for ( ; styleIt != mLayerStyleOverrides.constEnd(); ++styleIt )
     {
       QDomElement styleElem = doc.createElement( "LayerStyle" );
-      styleElem.setAttribute( "layerid", styleIt.key() );
+
+      QgsMapLayerRef ref( styleIt.key() );
+      ref.resolve();
+
+      styleElem.setAttribute( "layerid", ref.layerId );
+      styleElem.setAttribute( "name", ref.name );
+      styleElem.setAttribute( "source", ref.source );
+      styleElem.setAttribute( "provider", ref.provider );
+
       QgsMapLayerStyle style( styleIt.value() );
       style.writeXml( styleElem );
       stylesElem.appendChild( styleElem );
@@ -1490,9 +1498,15 @@ bool QgsComposerMap::readXML( const QDomElement& itemElem, const QDomDocument& d
     {
       const QDomElement& layerStyleElement = layerStyleNodeList.at( i ).toElement();
       QString layerId = layerStyleElement.attribute( "layerid" );
+      QString layerName = layerStyleElement.attribute( "name" );
+      QString layerSource = layerStyleElement.attribute( "source" );
+      QString layerProvider = layerStyleElement.attribute( "provider" );
+      QgsMapLayerRef ref( layerId, layerName, layerSource, layerProvider );
+      ref.resolveWeakly();
+
       QgsMapLayerStyle style;
       style.readXml( layerStyleElement );
-      mLayerStyleOverrides.insert( layerId, style.xmlData() );
+      mLayerStyleOverrides.insert( ref.layerId, style.xmlData() );
     }
   }
 

--- a/src/core/qgsmaplayerlistutils.h
+++ b/src/core/qgsmaplayerlistutils.h
@@ -1,0 +1,57 @@
+#ifndef QGSMAPLAYERLISTUTILS_H
+#define QGSMAPLAYERLISTUTILS_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#include <QPointer>
+
+#include "qgsmaplayer.h"
+#include "qgsmaplayerref.h"
+
+/// @cond PRIVATE
+
+inline QList<QgsMapLayer *> _qgis_listRefToRaw( const QList< QgsMapLayerRef > &layers )
+{
+  QList<QgsMapLayer *> lst;
+  lst.reserve( layers.count() );
+  Q_FOREACH ( const QgsMapLayerRef &layer, layers )
+  {
+    if ( layer )
+      lst.append( layer.get() );
+  }
+  return lst;
+}
+
+inline QList< QgsMapLayerRef > _qgis_listRawToRef( const QList<QgsMapLayer *> &layers )
+{
+  QList< QgsMapLayerRef > lst;
+  lst.reserve( layers.count() );
+  Q_FOREACH ( QgsMapLayer *layer, layers )
+  {
+    lst.append( QgsMapLayerRef( layer ) );
+  }
+  return lst;
+}
+
+inline void _qgis_removeLayers( QList< QgsMapLayerRef > &list, QList< QgsMapLayer *> layersToRemove )
+{
+  QMutableListIterator<QgsMapLayerRef> it( list );
+  while ( it.hasNext() )
+  {
+    QgsMapLayerRef &ref = it.next();
+    if ( layersToRemove.contains( ref.get() ) )
+      it.remove();
+  }
+}
+
+
+///@endcond
+
+#endif // QGSMAPLAYERLISTUTILS_H

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -1,0 +1,220 @@
+/***************************************************************************
+  qgsmaplayerref.h
+  --------------------------------------
+  Date                 : January 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPLAYERREF_H
+#define QGSMAPLAYERREF_H
+
+#include <QPointer>
+
+#include "qgsmaplayer.h"
+#include "qgsdataprovider.h"
+#include "qgsmaplayerregistry.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataprovider.h"
+#include "qgsrasterlayer.h"
+#include "qgsrasterdataprovider.h"
+
+/** Internal structure to keep weak pointer to QgsMapLayer or layerId
+ *  if the layer is not available yet.
+ *  \note not available in Python bindings
+ */
+template<typename TYPE>
+struct _LayerRef
+{
+
+  /**
+   * Constructor for a layer reference from an existing map layer.
+   * The layerId, source, name and provider members will automatically
+   * be populated from this layer.
+   */
+  _LayerRef( TYPE *l = nullptr )
+      : layer( l )
+      , layerId( l ? l->id() : QString() )
+      , source( l ? l->publicSource() : QString() )
+      , name( l ? l->name() : QString() )
+      , provider( layerProviderName( l ) )
+  {}
+
+  /**
+   * Constructor for a weak layer reference, using a combination of layer ID,
+   * \a name, public \a source and \a provider key.
+   */
+  _LayerRef( const QString &id, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() )
+      : layer()
+      , layerId( id )
+      , source( source )
+      , name( name )
+      , provider( provider )
+  {}
+
+  /**
+   * Sets the reference to point to a specified layer.
+   */
+  void setLayer( TYPE *l )
+  {
+    layer = l;
+    layerId = l ? l->id() : QString();
+    source = l ? l->publicSource() : QString();
+    name = l ? l->name() : QString();
+    provider = layerProviderName( l );
+  }
+
+  /**
+   * Returns true if the layer reference is resolved and contains a reference to an existing
+   * map layer.
+   */
+  operator bool() const
+  {
+    return static_cast< bool >( layer.data() );
+  }
+
+  /**
+   * Forwards the to map layer.
+   */
+  TYPE *operator->() const
+  {
+    return layer.data();
+  }
+
+  /**
+   * Returns a pointer to the layer, or nullptr if the reference has not yet been matched
+   * to a layer.
+   */
+  TYPE *get() const
+  {
+    return layer.data();
+  }
+
+  //! Weak pointer to map layer
+  QPointer<TYPE> layer;
+
+  //! Original layer ID
+  QString layerId;
+
+  //! Weak reference to layer public source
+  QString source;
+  //! Weak reference to layer name
+  QString name;
+  //! Weak reference to layer provider
+  QString provider;
+
+  /**
+   * Returns true if a layer matches the weak references to layer public source,
+   * layer name and data provider contained in this layer reference.
+   * \see resolveWeakly()
+   */
+  bool layerMatchesSource( QgsMapLayer *layer ) const
+  {
+    if ( layer->publicSource() != source ||
+         layer->name() != name )
+      return false;
+
+    if ( layerProviderName( layer ) != provider )
+      return false;
+
+    return true;
+  }
+
+  /**
+   * Resolves the map layer by attempting to find a layer with matching ID
+   * within the map layer registry. If found, this reference will be updated to match
+   * the found layer and the layer will be returned. If no matching layer is
+   * found, a nullptr is returned.
+   * \see resolveWeakly()
+   */
+  TYPE *resolve()
+  {
+    if ( !layerId.isEmpty() )
+    {
+      if ( TYPE *l = qobject_cast<TYPE *>( QgsMapLayerRegistry::instance()->mapLayer( layerId ) ) )
+      {
+        setLayer( l );
+        return l;
+      }
+    }
+    return nullptr;
+  }
+
+  /**
+   * Resolves the map layer by attempting to find a matching layer
+   * in the map layer registry using a weak match.
+   *
+   * First, the layer is attempted to match to registry layers using the
+   * layer's ID (calling this method implicitly calls resolve()).
+   *
+   * Failing a match by layer ID, the layer will be matched by using
+   * the weak references to layer public source, layer name and data
+   * provider contained in this layer reference.
+   *
+   * If a matching layer is found, this reference will be updated to match
+   * the found layer and the layer will be returned. If no matching layer is
+   * found, a nullptr is returned.
+   * \see resolve()
+   * \see layerMatchesSource()
+   */
+  TYPE *resolveWeakly()
+  {
+    // first try matching by layer ID
+    if ( resolve() )
+      return layer;
+
+    if ( !name.isEmpty() )
+    {
+      Q_FOREACH ( QgsMapLayer *l, QgsMapLayerRegistry::instance()->mapLayersByName( name ) )
+      {
+        if ( TYPE *tl = qobject_cast< TYPE *>( l ) )
+        {
+          if ( layerMatchesSource( tl ) )
+          {
+            setLayer( tl );
+            return tl;
+          }
+        }
+      }
+    }
+    return nullptr;
+  }
+
+private:
+
+  static QString layerProviderName( const QgsMapLayer *layer )
+  {
+    if ( !layer )
+      return QString();
+
+    switch ( layer->type() )
+    {
+      case QgsMapLayer::VectorLayer:
+      {
+        const QgsVectorLayer *vl = qobject_cast< const QgsVectorLayer *>( layer );
+        return vl->dataProvider()->name();
+      }
+
+      case QgsMapLayer::RasterLayer:
+      {
+        const QgsRasterLayer *rl = qobject_cast< const QgsRasterLayer *>( layer );
+        return rl->dataProvider()->name();
+      }
+      case QgsMapLayer::PluginLayer:
+        return QString();
+    }
+    return QString();
+
+  }
+};
+
+typedef _LayerRef<QgsMapLayer> QgsMapLayerRef;
+
+#endif // QGSMAPLAYERREF_H

--- a/src/core/qgsvectorlayerref.h
+++ b/src/core/qgsvectorlayerref.h
@@ -1,0 +1,10 @@
+#ifndef QGSVECTORLAYERREF_H
+#define QGSVECTORLAYERREF_H
+
+#include "qgsmaplayerref.h"
+
+#include "qgsvectorlayer.h"
+
+typedef _LayerRef<QgsVectorLayer> QgsVectorLayerRef;
+
+#endif // QGSVECTORLAYERREF_H

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -25,6 +25,8 @@
 #include <qgsvectorlayer.h>
 #include <qgsapplication.h>
 #include <qgsproviderregistry.h>
+#include "qgsvectorlayerref.h"
+#include "qgsmaplayerlistutils.h"
 
 class TestSignalReceiver : public QObject
 {
@@ -68,9 +70,11 @@ class TestQgsMapLayer : public QObject
     void isInScaleRange_data();
     void isInScaleRange();
 
+    void layerRef();
+    void layerRefListUtils();
 
   private:
-    QgsMapLayer * mpLayer;
+    QgsVectorLayer * mpLayer;
 };
 
 void TestQgsMapLayer::initTestCase()
@@ -94,11 +98,12 @@ void TestQgsMapLayer::init()
   QFileInfo myMapFileInfo( myFileName );
   mpLayer = new QgsVectorLayer( myMapFileInfo.filePath(),
                                 myMapFileInfo.completeBaseName(), "ogr" );
+  QgsMapLayerRegistry::instance()->addMapLayer( mpLayer );
 }
 
 void TestQgsMapLayer::cleanup()
 {
-  delete mpLayer;
+  QgsMapLayerRegistry::instance()->removeAllMapLayers();
 }
 
 void TestQgsMapLayer::cleanupTestCase()
@@ -151,6 +156,108 @@ void TestQgsMapLayer::isInScaleRange()
   QCOMPARE( mpLayer->isInScaleRange( scale ), true );
 
 }
+
+void TestQgsMapLayer::layerRef()
+{
+  // construct from layer
+  QgsVectorLayerRef ref( mpLayer );
+  QCOMPARE( ref.get(), mpLayer );
+  QCOMPARE( ref.layer.data(), mpLayer );
+  QCOMPARE( ref.layerId, mpLayer->id() );
+  QCOMPARE( ref.name, QString( "points" ) );
+  QCOMPARE( ref.source, mpLayer->publicSource() );
+  QCOMPARE( ref.provider, QString( "ogr" ) );
+
+  // bool operator
+  QVERIFY( ref );
+  // -> operator
+  QCOMPARE( ref->id(), mpLayer->id() );
+
+  // verify that layer matches layer
+  QVERIFY( ref.layerMatchesSource( mpLayer ) );
+
+  // create a weak reference
+  QgsVectorLayerRef ref2( mpLayer->id(), QString( "points" ), mpLayer->publicSource(), QString( "ogr" ) );
+  QVERIFY( !ref2 );
+  QVERIFY( !ref2.get() );
+  QVERIFY( !ref2.layer.data() );
+  QCOMPARE( ref2.layerId, mpLayer->id() );
+  QCOMPARE( ref2.name, QString( "points" ) );
+  QCOMPARE( ref2.source, mpLayer->publicSource() );
+  QCOMPARE( ref2.provider, QString( "ogr" ) );
+
+  // verify that weak reference matches layer
+  QVERIFY( ref2.layerMatchesSource( mpLayer ) );
+
+  // resolve layer using project
+  QCOMPARE( ref2.resolve(), mpLayer );
+  QVERIFY( ref2 );
+  QCOMPARE( ref2.get(), mpLayer );
+  QCOMPARE( ref2.layer.data(), mpLayer );
+  QCOMPARE( ref2.layerId, mpLayer->id() );
+  QCOMPARE( ref2.name, QString( "points" ) );
+  QCOMPARE( ref2.source, mpLayer->publicSource() );
+  QCOMPARE( ref2.provider, QString( "ogr" ) );
+
+  // setLayer
+  QgsVectorLayerRef ref3;
+  QVERIFY( !ref3.get() );
+  ref3.setLayer( mpLayer );
+  QCOMPARE( ref3.get(), mpLayer );
+  QCOMPARE( ref3.layer.data(), mpLayer );
+  QCOMPARE( ref3.layerId, mpLayer->id() );
+  QCOMPARE( ref3.name, QString( "points" ) );
+  QCOMPARE( ref3.source, mpLayer->publicSource() );
+  QCOMPARE( ref3.provider, QString( "ogr" ) );
+
+  // weak resolve
+  QgsVectorLayerRef ref4( QString( "badid" ), QString( "points" ), mpLayer->publicSource(), QString( "ogr" ) );
+  QVERIFY( !ref4 );
+  QVERIFY( !ref4.resolve() );
+  QCOMPARE( ref4.resolveWeakly(), mpLayer );
+  QCOMPARE( ref4.get(), mpLayer );
+  QCOMPARE( ref4.layer.data(), mpLayer );
+  QCOMPARE( ref4.layerId, mpLayer->id() );
+  QCOMPARE( ref4.name, QString( "points" ) );
+  QCOMPARE( ref4.source, mpLayer->publicSource() );
+  QCOMPARE( ref4.provider, QString( "ogr" ) );
+
+  // try resolving a bad reference
+  QgsVectorLayerRef ref5( QString( "badid" ), QString( "points" ), mpLayer->publicSource(), QString( "xxx" ) );
+  QVERIFY( !ref5.get() );
+  QVERIFY( !ref5.resolve() );
+  QVERIFY( !ref5.resolveWeakly() );
+}
+
+void TestQgsMapLayer::layerRefListUtils()
+{
+  // conversion utils
+  QgsVectorLayer *vlA = new QgsVectorLayer( "Point", "a", "memory" );
+  QgsVectorLayer *vlB = new QgsVectorLayer( "Point", "b", "memory" );
+
+  QList<QgsMapLayer *> listRawSource;
+  listRawSource << vlA << vlB;
+
+  QList< QgsMapLayerRef > refs = _qgis_listRawToRef( listRawSource );
+  QCOMPARE( refs.at( 0 ).get(), vlA );
+  QCOMPARE( refs.at( 1 ).get(), vlB );
+
+  QList<QgsMapLayer *> raw = _qgis_listRefToRaw( refs );
+  QCOMPARE( raw, QList< QgsMapLayer *>() << vlA << vlB );
+
+  //remove layers
+  QgsVectorLayer *vlC = new QgsVectorLayer( "Point", "c", "memory" );
+  QgsVectorLayer *vlD = new QgsVectorLayer( "Point", "d", "memory" );
+  refs << QgsMapLayerRef( vlC ) << QgsMapLayerRef( vlD );
+
+  _qgis_removeLayers( refs, QList< QgsMapLayer *>() << vlB << vlD );
+  QCOMPARE( refs.size(), 2 );
+  QCOMPARE( refs.at( 0 ).get(), vlA );
+  QCOMPARE( refs.at( 1 ).get(), vlC );
+
+
+}
+
 
 QTEST_MAIN( TestQgsMapLayer )
 #include "testqgsmaplayer.moc"


### PR DESCRIPTION
Backport of the recent composer template fixes which handle layer restoration when loading composer templates in projects other then the project in which the template was made.

On behalf of Faunalia, sponsored by ENEL