### PR TITLE
Add methods to clone annotations

### DIFF
--- a/python/core/annotations/qgsannotation.sip
+++ b/python/core/annotations/qgsannotation.sip
@@ -25,6 +25,8 @@ class QgsAnnotation : QObject
 
     QgsAnnotation( QObject* parent /TransferThis/ = nullptr );
 
+    virtual QgsAnnotation *clone() const = 0 /Factory/;
+
     bool isVisible() const;
     void setVisible( bool visible );
 
@@ -80,5 +82,7 @@ class QgsAnnotation : QObject
 
     void _writeXml( QDomElement& itemElem, QDomDocument& doc ) const;
     void _readXml( const QDomElement& annotationElem, const QDomDocument& doc );
+
+    void copyCommonProperties( QgsAnnotation *target ) const;
 
 };

--- a/python/core/annotations/qgsannotationmanager.sip
+++ b/python/core/annotations/qgsannotationmanager.sip
@@ -68,6 +68,16 @@ class QgsAnnotationManager : QObject
     QList< QgsAnnotation * > annotations() const;
 %Docstring
  Returns a list of all annotations contained in the manager.
+ \see cloneAnnotations()
+ :rtype: list of QgsAnnotation
+%End
+
+    QList< QgsAnnotation * > cloneAnnotations() const /Factory/;
+%Docstring
+ Returns a list containing clones of all annotations contained
+ in the manager. The caller takes responsibility for deleting
+ all returned annotations.
+ \see annotations()
  :rtype: list of QgsAnnotation
 %End
 

--- a/python/core/annotations/qgshtmlannotation.sip
+++ b/python/core/annotations/qgshtmlannotation.sip
@@ -31,6 +31,8 @@ class QgsHtmlAnnotation: QgsAnnotation
 
     ~QgsHtmlAnnotation();
 
+    virtual QgsHtmlAnnotation *clone() const /Factory/;
+
     virtual QSizeF minimumFrameSize() const;
 
     void setSourceFile( const QString &htmlFile );

--- a/python/core/annotations/qgssvgannotation.sip
+++ b/python/core/annotations/qgssvgannotation.sip
@@ -26,6 +26,8 @@ class QgsSvgAnnotation: QgsAnnotation
  Constructor for QgsSvgAnnotation.
 %End
 
+    virtual QgsSvgAnnotation *clone() const /Factory/;
+
     virtual void writeXml( QDomElement &elem, QDomDocument &doc ) const;
     virtual void readXml( const QDomElement &itemElem, const QDomDocument &doc );
 

--- a/python/core/annotations/qgstextannotation.sip
+++ b/python/core/annotations/qgstextannotation.sip
@@ -26,6 +26,8 @@ class QgsTextAnnotation: QgsAnnotation
  Constructor for QgsTextAnnotation.
 %End
 
+    virtual QgsTextAnnotation *clone() const /Factory/;
+
     const QTextDocument *document() const;
 %Docstring
  Returns the text document which will be rendered

--- a/python/gui/qgsformannotation.sip
+++ b/python/gui/qgsformannotation.sip
@@ -7,6 +7,8 @@ class QgsFormAnnotation : QgsAnnotation
 
     QgsFormAnnotation( QObject* parent /TransferThis/ = nullptr );
 
+    virtual QgsFormAnnotation *clone() const /Factory/;
+
     QSizeF minimumFrameSize() const;
     QSizeF preferredFrameSize() const;
 

--- a/src/core/annotations/qgsannotation.cpp
+++ b/src/core/annotations/qgsannotation.cpp
@@ -431,3 +431,22 @@ void QgsAnnotation::_readXml( const QDomElement &annotationElem, const QDomDocum
   emit mapLayerChanged();
 }
 
+void QgsAnnotation::copyCommonProperties( QgsAnnotation *target ) const
+{
+  target->mVisible = mVisible;
+  target->mHasFixedMapPosition = mHasFixedMapPosition;
+  target->mMapPosition = mMapPosition;
+  target->mMapPositionCrs = mMapPositionCrs;
+  target->mRelativePosition = mRelativePosition;
+  target->mOffsetFromReferencePoint = mOffsetFromReferencePoint;
+  target->mFrameSize = mFrameSize;
+  target->mMarkerSymbol.reset( mMarkerSymbol ? mMarkerSymbol->clone() : nullptr );
+  target->mContentsMargins = mContentsMargins;
+  target->mFillSymbol.reset( mFillSymbol ? mFillSymbol->clone() : nullptr );
+  target->mBalloonSegment = mBalloonSegment;
+  target->mBalloonSegmentPoint1 = mBalloonSegmentPoint1;
+  target->mBalloonSegmentPoint2 = mBalloonSegmentPoint2;
+  target->mMapLayer = mMapLayer;
+  target->mFeature = mFeature;
+}
+

--- a/src/core/annotations/qgsannotation.h
+++ b/src/core/annotations/qgsannotation.h
@@ -58,6 +58,12 @@ class CORE_EXPORT QgsAnnotation : public QObject
     QgsAnnotation( QObject *parent = nullptr );
 
     /**
+     * Clones the annotation, returning a new copy of the annotation
+     * reflecting the annotation's current state.
+     */
+    virtual QgsAnnotation *clone() const = 0;
+
+    /**
      * Returns true if the annotation is visible and should be rendered.
      * \see setVisible()
      */
@@ -292,6 +298,14 @@ class CORE_EXPORT QgsAnnotation : public QObject
      * \see _writeXml()
      */
     void _readXml( const QDomElement &annotationElem, const QDomDocument &doc );
+
+    /**
+     * Copies common annotation properties to the \a targe
+     * annotation.
+     * Can be used within QgsAnnotation::clone() implementations
+     * to assist with creating copies.
+     */
+    void copyCommonProperties( QgsAnnotation *target ) const;
 
   private:
 

--- a/src/core/annotations/qgsannotationmanager.cpp
+++ b/src/core/annotations/qgsannotationmanager.cpp
@@ -73,6 +73,16 @@ QList<QgsAnnotation *> QgsAnnotationManager::annotations() const
   return mAnnotations;
 }
 
+QList<QgsAnnotation *> QgsAnnotationManager::cloneAnnotations() const
+{
+  QList<QgsAnnotation *> results;
+  Q_FOREACH ( const QgsAnnotation *a, mAnnotations )
+  {
+    results << a->clone();
+  }
+  return results;
+}
+
 bool QgsAnnotationManager::readXml( const QDomElement &element, const QDomDocument &doc )
 {
   clear();

--- a/src/core/annotations/qgsannotationmanager.h
+++ b/src/core/annotations/qgsannotationmanager.h
@@ -79,8 +79,17 @@ class CORE_EXPORT QgsAnnotationManager : public QObject
 
     /**
      * Returns a list of all annotations contained in the manager.
+     * \see cloneAnnotations()
      */
     QList< QgsAnnotation * > annotations() const;
+
+    /**
+     * Returns a list containing clones of all annotations contained
+     * in the manager. The caller takes responsibility for deleting
+     * all returned annotations.
+     * \see annotations()
+     */
+    QList< QgsAnnotation * > cloneAnnotations() const SIP_FACTORY;
 
     /**
      * Reads the manager's state from a DOM element, restoring all annotations

--- a/src/core/annotations/qgshtmlannotation.cpp
+++ b/src/core/annotations/qgshtmlannotation.cpp
@@ -47,6 +47,14 @@ QgsHtmlAnnotation::QgsHtmlAnnotation( QObject *parent )
   connect( mWebPage->mainFrame(), &QWebFrame::javaScriptWindowObjectCleared, this, &QgsHtmlAnnotation::javascript );
 }
 
+QgsHtmlAnnotation *QgsHtmlAnnotation::clone() const
+{
+  std::unique_ptr< QgsHtmlAnnotation > c( new QgsHtmlAnnotation() );
+  copyCommonProperties( c.get() );
+  c->setSourceFile( mHtmlFile );
+  return c.release();
+}
+
 void QgsHtmlAnnotation::setSourceFile( const QString &htmlFile )
 {
   QFile file( htmlFile );

--- a/src/core/annotations/qgshtmlannotation.h
+++ b/src/core/annotations/qgshtmlannotation.h
@@ -44,6 +44,8 @@ class CORE_EXPORT QgsHtmlAnnotation: public QgsAnnotation
 
     ~QgsHtmlAnnotation() = default;
 
+    QgsHtmlAnnotation *clone() const override SIP_FACTORY;
+
     QSizeF minimumFrameSize() const override;
 
     /**

--- a/src/core/annotations/qgssvgannotation.cpp
+++ b/src/core/annotations/qgssvgannotation.cpp
@@ -27,6 +27,14 @@ QgsSvgAnnotation::QgsSvgAnnotation( QObject *parent )
 
 }
 
+QgsSvgAnnotation *QgsSvgAnnotation::clone() const
+{
+  std::unique_ptr< QgsSvgAnnotation > c( new QgsSvgAnnotation() );
+  copyCommonProperties( c.get() );
+  c->setFilePath( mFilePath );
+  return c.release();
+}
+
 void QgsSvgAnnotation::writeXml( QDomElement &elem, QDomDocument &doc ) const
 {
   QDomElement svgAnnotationElem = doc.createElement( QStringLiteral( "SVGAnnotationItem" ) );

--- a/src/core/annotations/qgssvgannotation.h
+++ b/src/core/annotations/qgssvgannotation.h
@@ -39,6 +39,8 @@ class CORE_EXPORT QgsSvgAnnotation: public QgsAnnotation
      */
     QgsSvgAnnotation( QObject *parent SIP_TRANSFERTHIS = nullptr );
 
+    QgsSvgAnnotation *clone() const override SIP_FACTORY;
+
     virtual void writeXml( QDomElement &elem, QDomDocument &doc ) const override;
     virtual void readXml( const QDomElement &itemElem, const QDomDocument &doc ) override;
 

--- a/src/core/annotations/qgstextannotation.cpp
+++ b/src/core/annotations/qgstextannotation.cpp
@@ -26,6 +26,14 @@ QgsTextAnnotation::QgsTextAnnotation( QObject *parent )
   mDocument->setUseDesignMetrics( true );
 }
 
+QgsTextAnnotation *QgsTextAnnotation::clone() const
+{
+  std::unique_ptr< QgsTextAnnotation > c( new QgsTextAnnotation() );
+  copyCommonProperties( c.get() );
+  c->setDocument( mDocument ? mDocument->clone() : nullptr );
+  return c.release();
+}
+
 const QTextDocument *QgsTextAnnotation::document() const
 {
   return mDocument.get();

--- a/src/core/annotations/qgstextannotation.h
+++ b/src/core/annotations/qgstextannotation.h
@@ -39,6 +39,8 @@ class CORE_EXPORT QgsTextAnnotation: public QgsAnnotation
      */
     QgsTextAnnotation( QObject *parent SIP_TRANSFERTHIS = nullptr );
 
+    QgsTextAnnotation *clone() const override SIP_FACTORY;
+
     /**
      * Returns the text document which will be rendered
      * within the annotation.

--- a/src/gui/qgsformannotation.cpp
+++ b/src/gui/qgsformannotation.cpp
@@ -40,6 +40,14 @@ QgsFormAnnotation::QgsFormAnnotation( QObject *parent )
   : QgsAnnotation( parent )
 {}
 
+QgsFormAnnotation *QgsFormAnnotation::clone() const
+{
+  std::unique_ptr< QgsFormAnnotation > c( new QgsFormAnnotation() );
+  copyCommonProperties( c.get() );
+  c->setDesignerForm( mDesignerForm );
+  return c.release();
+}
+
 void QgsFormAnnotation::setDesignerForm( const QString &uiFile )
 {
   mDesignerForm = uiFile;

--- a/src/gui/qgsformannotation.h
+++ b/src/gui/qgsformannotation.h
@@ -39,6 +39,8 @@ class GUI_EXPORT QgsFormAnnotation: public QgsAnnotation
      */
     QgsFormAnnotation( QObject *parent = nullptr );
 
+    QgsFormAnnotation *clone() const override SIP_FACTORY;
+
     QSizeF minimumFrameSize() const override;
     //! Returns the optimal frame size
     QSizeF preferredFrameSize() const;
@@ -63,7 +65,7 @@ class GUI_EXPORT QgsFormAnnotation: public QgsAnnotation
     /**
      * Returns a new QgsFormAnnotation object.
      */
-    static QgsFormAnnotation *create() { return new QgsFormAnnotation(); }
+    static QgsFormAnnotation *create() SIP_FACTORY { return new QgsFormAnnotation(); }
 
   protected:
 

--- a/tests/src/python/test_qgsannotation.py
+++ b/tests/src/python/test_qgsannotation.py
@@ -63,6 +63,11 @@ class TestQgsAnnotation(unittest.TestCase):
         im = self.renderAnnotation(a, QPointF(20, 30))
         self.assertTrue(self.imageCheck('text_annotation', 'text_annotation', im))
 
+        # check clone
+        clone = a.clone()
+        im = self.renderAnnotation(a, QPointF(20, 30))
+        self.assertTrue(self.imageCheck('text_annotation', 'text_annotation', im))
+
     def testSvgAnnotation(self):
         """ test rendering a svg annotation"""
         a = QgsSvgAnnotation()
@@ -73,6 +78,11 @@ class TestQgsAnnotation(unittest.TestCase):
         im = self.renderAnnotation(a, QPointF(20, 30))
         self.assertTrue(self.imageCheck('svg_annotation', 'svg_annotation', im))
 
+        # check clone
+        clone = a.clone()
+        im = self.renderAnnotation(a, QPointF(20, 30))
+        self.assertTrue(self.imageCheck('svg_annotation', 'svg_annotation', im))
+
     def testHtmlAnnotation(self):
         """ test rendering a html annotation"""
         a = QgsHtmlAnnotation()
@@ -80,6 +90,11 @@ class TestQgsAnnotation(unittest.TestCase):
         a.setFrameOffsetFromReferencePoint(QPointF(70, 90))
         html = TEST_DATA_DIR + "/test_html.html"
         a.setSourceFile(html)
+        im = self.renderAnnotation(a, QPointF(20, 30))
+        self.assertTrue(self.imageCheck('html_annotation', 'html_annotation', im))
+
+        # check clone
+        clone = a.clone()
         im = self.renderAnnotation(a, QPointF(20, 30))
         self.assertTrue(self.imageCheck('html_annotation', 'html_annotation', im))
 


### PR DESCRIPTION
Allows cloning annotations to allow safe background rendering of maps with annotations.