### PR TITLE
Move labeling engine config to a new class + QgsPalLabeling cleanup

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1577,6 +1577,14 @@ QgsPalLabeling        {#qgis_api_break_3_0_QgsPalLabeling}
 --------------
 
 - all methods implemented from QgsLabelingEngineInterface have been removed: init(), willUseLayer(), clearActiveLayers(), clearActiveLayer(), prepareLayer(), prepareDiagramLayer(), registerFeature(), registerDiagramFeature(), drawLabeling(), exit(), clone(). Labeling is now driven by QgsLabelingEngine.
+- all methods for global labeling engine configuration have been moved to QgsLabelingEngineSettings:
+  - searchMethod(), setSearchMethod(), numCandidatePositions(), setNumCandidatePositions() - methods with the same name in QgsLabelingEngineSettings
+  - isShowingCandidates(), setShowingCandidates() - replaced by DrawCandidates flag
+  - isShowingAllLabels(), setShowingAllLabels() - replaced by UseAllLabels flag
+  - isShowingPartialLabels(), setShowingPartialLabels() - replaced by UsePartialCandidates flag
+  - drawLabelRectOnly(), setDrawLabelRectOnly() - replaced by DrawLabelRectOnly flag
+  - loadEngineSettings(), saveEngineSettings() - replaced by readSettingsFromProject() and writeSettingsToProject()
+  - clearEngineSettings() - replaced by clear() that resets the settings instance (rather than immediately writing to project)
 - init(QgsMapRenderer*) has been removed. Use init(const QgsMapSettings&) instead.
 - prepareGeometry and geometryRequiresPreparation now take geometry references, not pointers.
 - layer() was removed. If direct access to QgsPalLayerSettings is necessary, use QgsPalLayerSettings::fromLayer()
@@ -1586,7 +1594,6 @@ QgsPalLabeling        {#qgis_api_break_3_0_QgsPalLabeling}
 - labelsWithinRect() was removed. Use takeResults() and methods of QgsLabelingResults instead.
 - isStoredWithProject() and setStoredWithProject() had no effect and were removed.
 - staticWillUseLayer(QString) was removed. Use the variant with QgsVectorLayer argument.
-- clearEngineSettings() was replaced by QgsLabelingEngine::clearSettingsInProject().
 
 
 QgsPalLayerSettings        {#qgis_api_break_3_0_QgsPalLayerSettings}

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -77,6 +77,7 @@
 %Include qgsfieldmodel.sip
 %Include qgsfieldproxymodel.sip
 %Include qgsfontutils.sip
+%Include qgslabelingenginesettings.sip
 %Include qgslabelsearchtree.sip
 %Include qgslegendrenderer.sip
 %Include qgslegendsettings.sip

--- a/python/core/qgslabelingenginesettings.sip
+++ b/python/core/qgslabelingenginesettings.sip
@@ -1,0 +1,106 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgslabelingenginesettings.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsLabelingEngineSettings
+{
+%Docstring
+ Stores global configuration for labeling engine
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgslabelingenginesettings.h"
+%End
+  public:
+    enum Flag
+    {
+      UseAllLabels,
+      UsePartialCandidates,
+      RenderOutlineLabels,
+      DrawLabelRectOnly,
+      DrawCandidates,
+    };
+    typedef QFlags<QgsLabelingEngineSettings::Flag> Flags;
+
+    enum Search
+    {
+      Chain,
+      Popmusic_Tabu,
+      Popmusic_Chain,
+      Popmusic_Tabu_Chain,
+      Falp
+    };
+
+    QgsLabelingEngineSettings();
+
+    void clear();
+%Docstring
+Return the configuration to the defaults
+%End
+
+    void setFlags( Flags flags );
+%Docstring
+Set flags of the labeling engine
+%End
+    Flags flags() const;
+%Docstring
+Get flags of the labeling engine
+ :rtype: Flags
+%End
+    bool testFlag( Flag f ) const;
+%Docstring
+Test whether a particular flag is enabled
+ :rtype: bool
+%End
+    void setFlag( Flag f, bool enabled = true );
+%Docstring
+Set whether a particual flag is enabled
+%End
+
+    void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon ) const;
+%Docstring
+Get number of candidate positions that will be generated for each label feature (default to 8)
+%End
+    void setNumCandidatePositions( int candPoint, int candLine, int candPolygon );
+%Docstring
+Set number of candidate positions that will be generated for each label feature
+%End
+
+    void setSearchMethod( Search s );
+%Docstring
+Set which search method to use for removal collisions between labels
+%End
+    Search searchMethod() const;
+%Docstring
+Which search method to use for removal collisions between labels
+ :rtype: Search
+%End
+
+    void readSettingsFromProject( QgsProject *project );
+%Docstring
+Read configuration of the labeling engine from a project
+%End
+    void writeSettingsToProject( QgsProject *project );
+%Docstring
+Write configuration of the labeling engine to a project
+%End
+
+};
+
+QFlags<QgsLabelingEngineSettings::Flag> operator|(QgsLabelingEngineSettings::Flag f1, QFlags<QgsLabelingEngineSettings::Flag> f2);
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgslabelingenginesettings.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/qgslabelingenginesettings.sip
+++ b/python/core/qgslabelingenginesettings.sip
@@ -30,6 +30,7 @@ class QgsLabelingEngineSettings
     };
     typedef QFlags<QgsLabelingEngineSettings::Flag> Flags;
 
+
     enum Search
     {
       Chain,
@@ -97,6 +98,7 @@ Write configuration of the labeling engine to a project
 
 QFlags<QgsLabelingEngineSettings::Flag> operator|(QgsLabelingEngineSettings::Flag f1, QFlags<QgsLabelingEngineSettings::Flag> f2);
 
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
@@ -104,3 +106,4 @@ QFlags<QgsLabelingEngineSettings::Flag> operator|(QgsLabelingEngineSettings::Fla
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/
+

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -239,6 +239,17 @@ class QgsMapSettings
     /** Gets segmentation tolerance type (maximum angle or maximum difference between curve and approximation)*/
     QgsAbstractGeometry::SegmentationToleranceType segmentationToleranceType() const;
 
+    /**
+     * Sets global configuration of the labeling engine
+     * \since QGIS 3.0
+     */
+    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings );
+
+    /**
+     * Returns global configuration of the labeling engine
+     * \since QGIS 3.0
+     */
+    const QgsLabelingEngineSettings &labelingEngineSettings() const;
 
   protected:
 

--- a/python/core/qgspallabeling.sip
+++ b/python/core/qgspallabeling.sip
@@ -514,55 +514,9 @@ class QgsPalLabeling
 
   public:
 
-    QgsPalLabeling();
-    ~QgsPalLabeling();
-
-    void numCandidatePositions( int& candPoint, int& candLine, int& candPolygon );
-    void setNumCandidatePositions( int candPoint, int candLine, int candPolygon );
-
-    enum Search { Chain, Popmusic_Tabu, Popmusic_Chain, Popmusic_Tabu_Chain, Falp };
-
-    void setSearchMethod( Search s );
-    Search searchMethod() const;
-
-    bool isShowingCandidates() const;
-    void setShowingCandidates( bool showing );
-
-    bool isShowingAllLabels() const;
-    void setShowingAllLabels( bool showing );
-
-    bool isShowingPartialsLabels() const;
-    void setShowingPartialsLabels( bool showing );
-
-    //! @note added in 2.4
-    bool isDrawingOutlineLabels() const;
-    void setDrawingOutlineLabels( bool outline );
-
-    /** Returns whether the engine will only draw the outline rectangles of labels,
-     * not the label contents themselves. Used for debugging and testing purposes.
-     * @see setDrawLabelRectOnly
-     * @note added in QGIS 2.12
-     */
-    bool drawLabelRectOnly() const;
-
-    /** Sets whether the engine should only draw the outline rectangles of labels,
-     * not the label contents themselves. Used for debugging and testing purposes.
-     * @param drawRect set to true to enable rect drawing only
-     * @see drawLabelRectOnly
-     * @note added in QGIS 2.12
-     */
-    void setDrawLabelRectOnly( bool drawRect );
-
     //! called to find out whether the layer is used for labeling
-    //! @note added in 2.4
-    static bool staticWillUseLayer( QgsVectorLayer* layer );
-
-    //! @note not available in python bindings
-    // void drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* painter, const QgsMapToPixel* xform );
-
-    //! load/save engine settings to project file
-    void loadEngineSettings();
-    void saveEngineSettings();
+    //! \since QGIS 2.4
+    static bool staticWillUseLayer( QgsVectorLayer *layer );
 
     /** Prepares a geometry for registration with PAL. Handles reprojection, rotation, clipping, etc.
      * @param geometry geometry to prepare
@@ -604,26 +558,24 @@ class QgsPalLabeling
 
   protected:
     // update temporary QgsPalLayerSettings with any data defined text style values
-    void dataDefinedTextStyle( QgsPalLayerSettings& tmpLyr,
-                               const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
+    static void dataDefinedTextStyle( QgsPalLayerSettings& tmpLyr,
+                                      const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
 
     // update temporary QgsPalLayerSettings with any data defined text formatting values
-    void dataDefinedTextFormatting( QgsPalLayerSettings& tmpLyr,
-                                    const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
+    static void dataDefinedTextFormatting( QgsPalLayerSettings& tmpLyr,
+                                           const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
 
     // update temporary QgsPalLayerSettings with any data defined text buffer values
-    void dataDefinedTextBuffer( QgsPalLayerSettings& tmpLyr,
-                                const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
+    static void dataDefinedTextBuffer( QgsPalLayerSettings& tmpLyr,
+                                       const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
 
     // update temporary QgsPalLayerSettings with any data defined shape background values
-    void dataDefinedShapeBackground( QgsPalLayerSettings& tmpLyr,
-                                     const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
+    static void dataDefinedShapeBackground( QgsPalLayerSettings& tmpLyr,
+                                            const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
 
     // update temporary QgsPalLayerSettings with any data defined drop shadow values
-    void dataDefinedDropShadow( QgsPalLayerSettings& tmpLyr,
-                                const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
-
-    void deleteTemporaryData();
+    static void dataDefinedDropShadow( QgsPalLayerSettings& tmpLyr,
+                                       const QMap< QgsPalLayerSettings::Property, QVariant >& ddValues );
 
     /** Checks whether a geometry exceeds the minimum required size for a geometry to be labeled.
      * @param context render context

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -596,6 +596,12 @@ class QgsProject : QObject, QgsExpressionContextGenerator
      */
     void mapThemeCollectionChanged();
 
+    /**
+     * Emitted when global configuration of the labeling engine changes.
+     * \since QGIS 3.0
+     */
+    void labelingEngineSettingsChanged();
+
     //
     // signals from QgsMapLayerRegistry
     //

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -409,6 +409,19 @@ class QgsProject : QObject, QgsExpressionContextGenerator
     void setAvoidIntersectionsLayers( const QList<QgsVectorLayer*>& layers );
     QVariantMap customVariables() const;
     void setCustomVariables( const QVariantMap& customVariables );
+
+    /**
+     * Sets project's global labeling engine settings
+     * \since QGIS 3.0
+     */
+    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings );
+
+    /**
+     * Returns project's global labeling engine settings
+     * \since QGIS 3.0
+     */
+    const QgsLabelingEngineSettings &labelingEngineSettings() const;
+
     int count() const;
 
     QgsMapLayer* mapLayer( const QString& layerId ) const;

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -101,6 +101,8 @@ class QgsMapCanvas : QGraphicsView
     QList< QgsMapCanvasAnnotationItem *> annotationItems() const;
     bool annotationsVisible() const;
     void setAnnotationsVisible( bool visible );
+    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings );
+    const QgsLabelingEngineSettings &labelingEngineSettings() const;
 
   public slots:
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2893,6 +2893,12 @@ void QgisApp::setupConnections()
     mMapCanvas->setDestinationCrs( QgsProject::instance()->crs() );
   } );
 
+  connect( QgsProject::instance(), &QgsProject::labelingEngineSettingsChanged,
+           this, [ = ]
+  {
+    mMapCanvas->setLabelingEngineSettings( QgsProject::instance()->labelingEngineSettings() );
+  } );
+
   // connect legend signals
   connect( mLayerTreeView, &QgsLayerTreeView::currentLayerChanged,
            this, &QgisApp::activateDeactivateLayerRelatedActions );

--- a/src/app/qgslabelengineconfigdialog.cpp
+++ b/src/app/qgslabelengineconfigdialog.cpp
@@ -14,8 +14,7 @@
  ***************************************************************************/
 #include "qgslabelengineconfigdialog.h"
 
-#include "qgspallabeling.h"
-#include "qgslabelingengine.h"
+#include "qgslabelingenginesettings.h"
 #include "qgsproject.h"
 #include <pal/pal.h>
 
@@ -30,44 +29,41 @@ QgsLabelEngineConfigDialog::QgsLabelEngineConfigDialog( QWidget *parent )
   connect( buttonBox->button( QDialogButtonBox::RestoreDefaults ), &QAbstractButton::clicked,
            this, &QgsLabelEngineConfigDialog::setDefaults );
 
-  QgsLabelingEngine engine;
-  engine.readSettingsFromProject( QgsProject::instance() );
+  QgsLabelingEngineSettings engineSettings = QgsProject::instance()->labelingEngineSettings();
 
   // search method
-  cboSearchMethod->setCurrentIndex( engine.searchMethod() );
+  cboSearchMethod->setCurrentIndex( engineSettings.searchMethod() );
 
   // candidate numbers
   int candPoint, candLine, candPolygon;
-  engine.numCandidatePositions( candPoint, candLine, candPolygon );
+  engineSettings.numCandidatePositions( candPoint, candLine, candPolygon );
   spinCandPoint->setValue( candPoint );
   spinCandLine->setValue( candLine );
   spinCandPolygon->setValue( candPolygon );
 
-  chkShowCandidates->setChecked( engine.testFlag( QgsLabelingEngine::DrawCandidates ) );
-  chkShowAllLabels->setChecked( engine.testFlag( QgsLabelingEngine::UseAllLabels ) );
+  chkShowCandidates->setChecked( engineSettings.testFlag( QgsLabelingEngineSettings::DrawCandidates ) );
+  chkShowAllLabels->setChecked( engineSettings.testFlag( QgsLabelingEngineSettings::UseAllLabels ) );
 
-  chkShowPartialsLabels->setChecked( engine.testFlag( QgsLabelingEngine::UsePartialCandidates ) );
-  mDrawOutlinesChkBox->setChecked( engine.testFlag( QgsLabelingEngine::RenderOutlineLabels ) );
+  chkShowPartialsLabels->setChecked( engineSettings.testFlag( QgsLabelingEngineSettings::UsePartialCandidates ) );
+  mDrawOutlinesChkBox->setChecked( engineSettings.testFlag( QgsLabelingEngineSettings::RenderOutlineLabels ) );
 }
 
 
 void QgsLabelEngineConfigDialog::onOK()
 {
-  QgsLabelingEngine engine;
+  QgsLabelingEngineSettings engineSettings;
 
   // save
-  engine.setSearchMethod( ( QgsPalLabeling::Search ) cboSearchMethod->currentIndex() );
+  engineSettings.setSearchMethod( ( QgsLabelingEngineSettings::Search ) cboSearchMethod->currentIndex() );
 
-  engine.setNumCandidatePositions( spinCandPoint->value(),
-                                   spinCandLine->value(),
-                                   spinCandPolygon->value() );
+  engineSettings.setNumCandidatePositions( spinCandPoint->value(), spinCandLine->value(), spinCandPolygon->value() );
 
-  engine.setFlag( QgsLabelingEngine::DrawCandidates, chkShowCandidates->isChecked() );
-  engine.setFlag( QgsLabelingEngine::UseAllLabels, chkShowAllLabels->isChecked() );
-  engine.setFlag( QgsLabelingEngine::UsePartialCandidates, chkShowPartialsLabels->isChecked() );
-  engine.setFlag( QgsLabelingEngine::RenderOutlineLabels, mDrawOutlinesChkBox->isChecked() );
+  engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, chkShowCandidates->isChecked() );
+  engineSettings.setFlag( QgsLabelingEngineSettings::UseAllLabels, chkShowAllLabels->isChecked() );
+  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, chkShowPartialsLabels->isChecked() );
+  engineSettings.setFlag( QgsLabelingEngineSettings::RenderOutlineLabels, mDrawOutlinesChkBox->isChecked() );
 
-  engine.writeSettingsToProject( QgsProject::instance() );
+  QgsProject::instance()->setLabelingEngineSettings( engineSettings );
 
   accept();
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -155,6 +155,7 @@ SET(QGIS_CORE_SRCS
   qgsjsonutils.cpp
   qgslabelfeature.cpp
   qgslabelingengine.cpp
+  qgslabelingenginesettings.cpp
   qgslabelsearchtree.cpp
   qgslayerdefinition.cpp
   qgslegendrenderer.cpp
@@ -729,6 +730,7 @@ SET(QGIS_CORE_HDRS
   qgslayerdefinition.h
   qgslabelfeature.h
   qgslabelingengine.h
+  qgslabelingenginesettings.h
   qgslabelsearchtree.h
   qgslegendrenderer.h
   qgslegendsettings.h

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -194,6 +194,8 @@ QgsMapSettings QgsComposerMap::mapSettings( const QgsRectangle &extent, QSizeF s
 
   jobMapSettings.datumTransformStore().setDestinationCrs( renderCrs );
 
+  jobMapSettings.setLabelingEngineSettings( mComposition->project()->labelingEngineSettings() );
+
   return jobMapSettings;
 }
 

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -966,7 +966,6 @@ void QgsDxfExport::writeEntities()
 
   // label engine
   QgsLabelingEngine engine;
-  engine.readSettingsFromProject( QgsProject::instance() );
   engine.setMapSettings( mMapSettings );
 
   // iterate through the maplayers

--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -17,7 +17,6 @@
 #include "qgslabelingengine.h"
 
 #include "qgslogger.h"
-#include "qgsproject.h"
 
 #include "feature.h"
 #include "labelposition.h"
@@ -72,12 +71,7 @@ class QgsLabelSorter
 
 
 QgsLabelingEngine::QgsLabelingEngine()
-  : mFlags( RenderOutlineLabels | UsePartialCandidates )
-  , mSearchMethod( QgsPalLabeling::Chain )
-  , mCandPoint( 16 )
-  , mCandLine( 50 )
-  , mCandPolygon( 30 )
-  , mResults( new QgsLabelingResults )
+  : mResults( new QgsLabelingResults )
 {}
 
 QgsLabelingEngine::~QgsLabelingEngine()
@@ -192,36 +186,39 @@ void QgsLabelingEngine::processProvider( QgsAbstractLabelProvider *provider, Qgs
 
 void QgsLabelingEngine::run( QgsRenderContext &context )
 {
-  pal::Pal p;
+  const QgsLabelingEngineSettings &settings = mMapSettings.labelingEngineSettings();
 
+  pal::Pal p;
   pal::SearchMethod s;
-  switch ( mSearchMethod )
+  switch ( settings.searchMethod() )
   {
     default:
-    case QgsPalLabeling::Chain:
+    case QgsLabelingEngineSettings::Chain:
       s = pal::CHAIN;
       break;
-    case QgsPalLabeling::Popmusic_Tabu:
+    case QgsLabelingEngineSettings::Popmusic_Tabu:
       s = pal::POPMUSIC_TABU;
       break;
-    case QgsPalLabeling::Popmusic_Chain:
+    case QgsLabelingEngineSettings::Popmusic_Chain:
       s = pal::POPMUSIC_CHAIN;
       break;
-    case QgsPalLabeling::Popmusic_Tabu_Chain:
+    case QgsLabelingEngineSettings::Popmusic_Tabu_Chain:
       s = pal::POPMUSIC_TABU_CHAIN;
       break;
-    case QgsPalLabeling::Falp:
+    case QgsLabelingEngineSettings::Falp:
       s = pal::FALP;
       break;
   }
   p.setSearch( s );
 
   // set number of candidates generated per feature
-  p.setPointP( mCandPoint );
-  p.setLineP( mCandLine );
-  p.setPolyP( mCandPolygon );
+  int candPoint, candLine, candPolygon;
+  settings.numCandidatePositions( candPoint, candLine, candPolygon );
+  p.setPointP( candPoint );
+  p.setLineP( candLine );
+  p.setPolyP( candPolygon );
 
-  p.setShowPartial( mFlags.testFlag( UsePartialCandidates ) );
+  p.setShowPartial( settings.testFlag( QgsLabelingEngineSettings::UsePartialCandidates ) );
 
 
   // for each provider: get labels and register them in PAL
@@ -295,7 +292,7 @@ void QgsLabelingEngine::run( QgsRenderContext &context )
   // this is done before actual solution of the problem
   // before number of candidates gets reduced
   // TODO mCandidates.clear();
-  if ( mFlags.testFlag( DrawCandidates ) && problem )
+  if ( settings.testFlag( QgsLabelingEngineSettings::DrawCandidates ) && problem )
   {
     painter->setBrush( Qt::NoBrush );
     for ( int i = 0; i < problem->getNumFeatures(); i++ )
@@ -310,7 +307,7 @@ void QgsLabelingEngine::run( QgsRenderContext &context )
   }
 
   // find the solution
-  labels = p.solveProblem( problem, mFlags.testFlag( UseAllLabels ) );
+  labels = p.solveProblem( problem, settings.testFlag( QgsLabelingEngineSettings::UseAllLabels ) );
 
   QgsDebugMsgLevel( QString( "LABELING work:  %1 ms ... labels# %2" ).arg( t.elapsed() ).arg( labels->size() ), 4 );
   t.restart();
@@ -357,50 +354,6 @@ QgsLabelingResults *QgsLabelingEngine::takeResults()
 {
   return mResults.release();
 }
-
-
-void QgsLabelingEngine::readSettingsFromProject( QgsProject *prj )
-{
-  bool saved = false;
-  mSearchMethod = static_cast< QgsPalLabeling::Search >( prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ), static_cast< int >( QgsPalLabeling::Chain ), &saved ) );
-  mCandPoint = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ), 16, &saved );
-  mCandLine = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ), 50, &saved );
-  mCandPolygon = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ), 30, &saved );
-
-  mFlags = 0;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), false, &saved ) ) mFlags |= DrawCandidates;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), false, &saved ) ) mFlags |= DrawLabelRectOnly;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), false, &saved ) ) mFlags |= UseAllLabels;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), true, &saved ) ) mFlags |= UsePartialCandidates;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), true, &saved ) ) mFlags |= RenderOutlineLabels;
-}
-
-void QgsLabelingEngine::writeSettingsToProject( QgsProject *project )
-{
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ), static_cast< int >( mSearchMethod ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ), mCandPoint );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ), mCandLine );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ), mCandPolygon );
-
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), mFlags.testFlag( DrawCandidates ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), mFlags.testFlag( DrawLabelRectOnly ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), mFlags.testFlag( UseAllLabels ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), mFlags.testFlag( UsePartialCandidates ) );
-  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), mFlags.testFlag( RenderOutlineLabels ) );
-}
-
-void QgsLabelingEngine::clearSettingsInProject( QgsProject *project )
-{
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ) );
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ) );
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ) );
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ) );
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ) );
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ) );
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ) );
-  project->removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ) );
-}
-
 
 
 ////

--- a/src/core/qgslabelingengine.h
+++ b/src/core/qgslabelingengine.h
@@ -20,8 +20,7 @@
 #include "qgsmapsettings.h"
 
 #include "qgspallabeling.h"
-
-#include <QFlags>
+#include "qgslabelingenginesettings.h"
 
 
 class QgsLabelingEngine;
@@ -130,7 +129,6 @@ class CORE_EXPORT QgsAbstractLabelProvider
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAbstractLabelProvider::Flags )
 
 
-
 /** \ingroup core
  * \brief The QgsLabelingEngine class provides map labeling functionality.
  * The input for the engine is a list of label provider objects and map settings.
@@ -176,20 +174,13 @@ class CORE_EXPORT QgsLabelingEngine
     //! QgsLabelingEngine cannot be copied.
     QgsLabelingEngine &operator=( const QgsLabelingEngine &rh ) = delete;
 
-    enum Flag
-    {
-      UseAllLabels          = 1 << 1,  //!< Whether to draw all labels even if there would be collisions
-      UsePartialCandidates  = 1 << 2,  //!< Whether to use also label candidates that are partially outside of the map view
-      RenderOutlineLabels   = 1 << 3,  //!< Whether to render labels as text or outlines
-      DrawLabelRectOnly     = 1 << 4,  //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
-      DrawCandidates        = 1 << 5,  //!< Whether to draw rectangles of generated candidates (good for debugging)
-    };
-    Q_DECLARE_FLAGS( Flags, Flag )
-
     //! Associate map settings instance
     void setMapSettings( const QgsMapSettings &mapSettings ) { mMapSettings = mapSettings; }
     //! Get associated map settings
     const QgsMapSettings &mapSettings() const { return mMapSettings; }
+
+    //! Get associated labeling engine settings
+    const QgsLabelingEngineSettings &engineSettings() const { return mMapSettings.labelingEngineSettings(); }
 
     /**
      * Returns a list of layers with providers in the engine.
@@ -212,54 +203,21 @@ class CORE_EXPORT QgsLabelingEngine
     //! For internal use by the providers
     QgsLabelingResults *results() const { return mResults.get(); }
 
-    //! Set flags of the labeling engine
-    void setFlags( Flags flags ) { mFlags = flags; }
-    //! Get flags of the labeling engine
-    Flags flags() const { return mFlags; }
-    //! Test whether a particular flag is enabled
-    bool testFlag( Flag f ) const { return mFlags.testFlag( f ); }
-    //! Set whether a particual flag is enabled
-    void setFlag( Flag f, bool enabled = true ) { if ( enabled ) mFlags |= f; else mFlags &= ~f; }
-
-    //! Get number of candidate positions that will be generated for each label feature (default to 8)
-    void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon ) { candPoint = mCandPoint; candLine = mCandLine; candPolygon = mCandPolygon; }
-    //! Set number of candidate positions that will be generated for each label feature
-    void setNumCandidatePositions( int candPoint, int candLine, int candPolygon ) { mCandPoint = candPoint; mCandLine = candLine; mCandPolygon = candPolygon; }
-
-    //! Set which search method to use for removal collisions between labels
-    void setSearchMethod( QgsPalLabeling::Search s ) { mSearchMethod = s; }
-    //! Which search method to use for removal collisions between labels
-    QgsPalLabeling::Search searchMethod() const { return mSearchMethod; }
-
-    //! Read configuration of the labeling engine from a project
-    void readSettingsFromProject( QgsProject *project );
-    //! Write configuration of the labeling engine to a project
-    void writeSettingsToProject( QgsProject *project );
-    //! Clear configuration of the labeling engine in a project
-    static void clearSettingsInProject( QgsProject *project );
-
   protected:
     void processProvider( QgsAbstractLabelProvider *provider, QgsRenderContext &context, pal::Pal &p );  //#spellok
 
   protected:
     //! Associated map settings instance
     QgsMapSettings mMapSettings;
+
     //! List of providers (the are owned by the labeling engine)
     QList<QgsAbstractLabelProvider *> mProviders;
     QList<QgsAbstractLabelProvider *> mSubProviders;
-    //! Flags
-    Flags mFlags;
-    //! search method to use for removal collisions between labels
-    QgsPalLabeling::Search mSearchMethod;
-    //! Number of candedate positions that will be generated for features
-    int mCandPoint, mCandLine, mCandPolygon;
 
     //! Resulting labeling layout
     std::unique_ptr< QgsLabelingResults > mResults;
 
 };
-
-Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLabelingEngine::Flags )
 
 
 /** \ingroup core

--- a/src/core/qgslabelingenginesettings.cpp
+++ b/src/core/qgslabelingenginesettings.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+  qgslabelingenginesettings.cpp
+  --------------------------------------
+  Date                 : April 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslabelingenginesettings.h"
+
+#include "qgsproject.h"
+
+
+QgsLabelingEngineSettings::QgsLabelingEngineSettings()
+  : mFlags( RenderOutlineLabels | UsePartialCandidates )
+  , mSearchMethod( Chain )
+  , mCandPoint( 16 )
+  , mCandLine( 50 )
+  , mCandPolygon( 30 )
+{
+}
+
+void QgsLabelingEngineSettings::clear()
+{
+  *this = QgsLabelingEngineSettings();
+}
+
+void QgsLabelingEngineSettings::readSettingsFromProject( QgsProject *prj )
+{
+  bool saved = false;
+  mSearchMethod = static_cast< Search >( prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ), static_cast< int >( Chain ), &saved ) );
+  mCandPoint = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ), 16, &saved );
+  mCandLine = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ), 50, &saved );
+  mCandPolygon = prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ), 30, &saved );
+
+  mFlags = 0;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), false, &saved ) ) mFlags |= DrawCandidates;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), false, &saved ) ) mFlags |= DrawLabelRectOnly;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), false, &saved ) ) mFlags |= UseAllLabels;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), true, &saved ) ) mFlags |= UsePartialCandidates;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), true, &saved ) ) mFlags |= RenderOutlineLabels;
+}
+
+void QgsLabelingEngineSettings::writeSettingsToProject( QgsProject *project )
+{
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/SearchMethod" ), static_cast< int >( mSearchMethod ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPoint" ), mCandPoint );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesLine" ), mCandLine );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygon" ), mCandPolygon );
+
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), mFlags.testFlag( DrawCandidates ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), mFlags.testFlag( DrawLabelRectOnly ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), mFlags.testFlag( UseAllLabels ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), mFlags.testFlag( UsePartialCandidates ) );
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), mFlags.testFlag( RenderOutlineLabels ) );
+}

--- a/src/core/qgslabelingenginesettings.h
+++ b/src/core/qgslabelingenginesettings.h
@@ -7,13 +7,14 @@
 
 class QgsProject;
 
-/**
+/** \ingroup core
  * Stores global configuration for labeling engine
- * \since in QGIS 3.0
+ * \since QGIS 3.0
  */
 class CORE_EXPORT QgsLabelingEngineSettings
 {
   public:
+    //! Various flags that affect drawing and placement of labels
     enum Flag
     {
       UseAllLabels          = 1 << 1,  //!< Whether to draw all labels even if there would be collisions

--- a/src/core/qgslabelingenginesettings.h
+++ b/src/core/qgslabelingenginesettings.h
@@ -1,0 +1,79 @@
+#ifndef QGSLABELINGENGINESETTINGS_H
+#define QGSLABELINGENGINESETTINGS_H
+
+#include "qgis_core.h"
+
+#include <QFlags>
+
+class QgsProject;
+
+/**
+ * Stores global configuration for labeling engine
+ * \since in QGIS 3.0
+ */
+class CORE_EXPORT QgsLabelingEngineSettings
+{
+  public:
+    enum Flag
+    {
+      UseAllLabels          = 1 << 1,  //!< Whether to draw all labels even if there would be collisions
+      UsePartialCandidates  = 1 << 2,  //!< Whether to use also label candidates that are partially outside of the map view
+      RenderOutlineLabels   = 1 << 3,  //!< Whether to render labels as text or outlines
+      DrawLabelRectOnly     = 1 << 4,  //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
+      DrawCandidates        = 1 << 5,  //!< Whether to draw rectangles of generated candidates (good for debugging)
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    //! Search methods in the PAL library to remove colliding labels
+    //! (methods have different processing speed and number of labels placed)
+    enum Search
+    {
+      Chain,
+      Popmusic_Tabu,
+      Popmusic_Chain,
+      Popmusic_Tabu_Chain,
+      Falp
+    };
+
+    QgsLabelingEngineSettings();
+
+    //! Return the configuration to the defaults
+    void clear();
+
+    //! Set flags of the labeling engine
+    void setFlags( Flags flags ) { mFlags = flags; }
+    //! Get flags of the labeling engine
+    Flags flags() const { return mFlags; }
+    //! Test whether a particular flag is enabled
+    bool testFlag( Flag f ) const { return mFlags.testFlag( f ); }
+    //! Set whether a particual flag is enabled
+    void setFlag( Flag f, bool enabled = true ) { if ( enabled ) mFlags |= f; else mFlags &= ~f; }
+
+    //! Get number of candidate positions that will be generated for each label feature (default to 8)
+    void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon ) const { candPoint = mCandPoint; candLine = mCandLine; candPolygon = mCandPolygon; }
+    //! Set number of candidate positions that will be generated for each label feature
+    void setNumCandidatePositions( int candPoint, int candLine, int candPolygon ) { mCandPoint = candPoint; mCandLine = candLine; mCandPolygon = candPolygon; }
+
+    //! Set which search method to use for removal collisions between labels
+    void setSearchMethod( Search s ) { mSearchMethod = s; }
+    //! Which search method to use for removal collisions between labels
+    Search searchMethod() const { return mSearchMethod; }
+
+    //! Read configuration of the labeling engine from a project
+    void readSettingsFromProject( QgsProject *project );
+    //! Write configuration of the labeling engine to a project
+    void writeSettingsToProject( QgsProject *project );
+
+  private:
+    //! Flags
+    Flags mFlags;
+    //! search method to use for removal collisions between labels
+    Search mSearchMethod;
+    //! Number of candedate positions that will be generated for features
+    int mCandPoint, mCandLine, mCandPolygon;
+
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLabelingEngineSettings::Flags )
+
+#endif // QGSLABELINGENGINESETTINGS_H

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -20,7 +20,6 @@
 #include "qgslogger.h"
 #include "qgsproject.h"
 #include "qgsmaplayerrenderer.h"
-#include "qgspallabeling.h"
 #include "qgsvectorlayer.h"
 #include "qgsrenderer.h"
 #include "qgsmaplayerlistutils.h"
@@ -74,7 +73,6 @@ void QgsMapRendererCustomPainterJob::start()
   if ( mSettings.testFlag( QgsMapSettings::DrawLabeling ) )
   {
     mLabelingEngineV2.reset( new QgsLabelingEngine() );
-    mLabelingEngineV2->readSettingsFromProject( QgsProject::instance() );
     mLabelingEngineV2->setMapSettings( mSettings );
   }
 

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -34,7 +34,6 @@ class QgsLabelingEngine;
 class QgsLabelingResults;
 class QgsMapLayerRenderer;
 class QgsMapRendererCache;
-class QgsPalLabeling;
 class QgsFeatureFilterProvider;
 
 /// @cond PRIVATE

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -19,7 +19,6 @@
 #include "qgslabelingengine.h"
 #include "qgslogger.h"
 #include "qgsmaplayerrenderer.h"
-#include "qgspallabeling.h"
 #include "qgsproject.h"
 #include "qgsmaplayer.h"
 #include "qgsmaplayerlistutils.h"
@@ -54,7 +53,6 @@ void QgsMapRendererParallelJob::start()
   if ( mSettings.testFlag( QgsMapSettings::DrawLabeling ) )
   {
     mLabelingEngineV2.reset( new QgsLabelingEngine() );
-    mLabelingEngineV2->readSettingsFromProject( QgsProject::instance() );
     mLabelingEngineV2->setMapSettings( mSettings );
   }
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -26,6 +26,7 @@
 #include "qgsabstractgeometry.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsdatumtransformstore.h"
+#include "qgslabelingenginesettings.h"
 #include "qgsmaptopixel.h"
 #include "qgsrectangle.h"
 #include "qgsscalecalculator.h"
@@ -291,6 +292,18 @@ class CORE_EXPORT QgsMapSettings
     //! Gets segmentation tolerance type (maximum angle or maximum difference between curve and approximation)
     QgsAbstractGeometry::SegmentationToleranceType segmentationToleranceType() const { return mSegmentationToleranceType; }
 
+    /**
+     * Sets global configuration of the labeling engine
+     * \since QGIS 3.0
+     */
+    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings ) { mLabelingEngineSettings = settings; }
+
+    /**
+     * Returns global configuration of the labeling engine
+     * \since QGIS 3.0
+     */
+    const QgsLabelingEngineSettings &labelingEngineSettings() const { return mLabelingEngineSettings; }
+
   protected:
 
     double mDpi;
@@ -321,6 +334,7 @@ class CORE_EXPORT QgsMapSettings
     double mSegmentationTolerance;
     QgsAbstractGeometry::SegmentationToleranceType mSegmentationToleranceType;
 
+    QgsLabelingEngineSettings mLabelingEngineSettings;
 
     // derived properties
     bool mValid; //!< Whether the actual settings are valid (set in updateDerived())

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2761,16 +2761,6 @@ void QgsPalLayerSettings::parseDropShadow( QgsRenderContext &context )
 
 // -------------
 
-QgsPalLabeling::QgsPalLabeling()
-  : mEngine( new QgsLabelingEngine() )
-{
-}
-
-QgsPalLabeling::~QgsPalLabeling()
-{
-  delete mEngine;
-  mEngine = nullptr;
-}
 
 bool QgsPalLabeling::staticWillUseLayer( QgsVectorLayer *layer )
 {
@@ -3375,80 +3365,6 @@ void QgsPalLabeling::dataDefinedDropShadow( QgsPalLayerSettings &tmpLyr,
 }
 
 
-void QgsPalLabeling::deleteTemporaryData()
-{
-}
-
-void QgsPalLabeling::numCandidatePositions( int &candPoint, int &candLine, int &candPolygon )
-{
-  mEngine->numCandidatePositions( candPoint, candLine, candPolygon );
-}
-
-void QgsPalLabeling::setNumCandidatePositions( int candPoint, int candLine, int candPolygon )
-{
-  mEngine->setNumCandidatePositions( candPoint, candLine, candPolygon );
-}
-
-void QgsPalLabeling::setSearchMethod( QgsPalLabeling::Search s )
-{
-  mEngine->setSearchMethod( s );
-}
-
-QgsPalLabeling::Search QgsPalLabeling::searchMethod() const
-{
-  return mEngine->searchMethod();
-}
-
-bool QgsPalLabeling::isShowingCandidates() const
-{
-  return mEngine->testFlag( QgsLabelingEngine::DrawCandidates );
-}
-
-void QgsPalLabeling::setShowingCandidates( bool showing )
-{
-  mEngine->setFlag( QgsLabelingEngine::DrawCandidates, showing );
-}
-
-bool QgsPalLabeling::isShowingAllLabels() const
-{
-  return mEngine->testFlag( QgsLabelingEngine::UseAllLabels );
-}
-
-void QgsPalLabeling::setShowingAllLabels( bool showing )
-{
-  mEngine->setFlag( QgsLabelingEngine::UseAllLabels, showing );
-}
-
-bool QgsPalLabeling::isShowingPartialsLabels() const
-{
-  return mEngine->testFlag( QgsLabelingEngine::UsePartialCandidates );
-}
-
-void QgsPalLabeling::setShowingPartialsLabels( bool showing )
-{
-  mEngine->setFlag( QgsLabelingEngine::UsePartialCandidates, showing );
-}
-
-bool QgsPalLabeling::isDrawingOutlineLabels() const
-{
-  return mEngine->testFlag( QgsLabelingEngine::RenderOutlineLabels );
-}
-
-void QgsPalLabeling::setDrawingOutlineLabels( bool outline )
-{
-  mEngine->setFlag( QgsLabelingEngine::RenderOutlineLabels, outline );
-}
-
-bool QgsPalLabeling::drawLabelRectOnly() const
-{
-  return mEngine->testFlag( QgsLabelingEngine::DrawLabelRectOnly );
-}
-
-void QgsPalLabeling::setDrawLabelRectOnly( bool drawRect )
-{
-  mEngine->setFlag( QgsLabelingEngine::DrawLabelRectOnly, drawRect );
-}
-
 void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition *lp, QPainter *painter, const QgsMapToPixel *xform, QList<QgsLabelCandidate> *candidates )
 {
   QgsPoint outPt = xform->transform( lp->getX(), lp->getY() );
@@ -3506,18 +3422,6 @@ void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition *lp, QPainter *p
   // show all parts of the multipart label
   if ( lp->getNextPart() )
     drawLabelCandidateRect( lp->getNextPart(), painter, xform, candidates );
-}
-
-// TODO: remove once not used in labeling tests
-void QgsPalLabeling::loadEngineSettings()
-{
-  mEngine->readSettingsFromProject( QgsProject::instance() );
-}
-
-// TODO: remove once not used in labeling tests
-void QgsPalLabeling::saveEngineSettings()
-{
-  mEngine->writeSettingsToProject( QgsProject::instance() );
 }
 
 QgsLabelingResults::QgsLabelingResults()

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -34,6 +34,7 @@
 #include "qgsfeature.h"
 #include "qgsgeometry.h"
 #include "qgsfields.h"
+#include "qgslabelingenginesettings.h"
 #include "qgspoint.h"
 #include "qgsmapunitscale.h"
 #include "qgsstringutils.h"
@@ -705,55 +706,12 @@ class CORE_EXPORT QgsPalLabeling
 {
   public:
 
-    QgsPalLabeling();
-    ~QgsPalLabeling();
-
-    void numCandidatePositions( int &candPoint, int &candLine, int &candPolygon );
-    void setNumCandidatePositions( int candPoint, int candLine, int candPolygon );
-
-    enum Search { Chain, Popmusic_Tabu, Popmusic_Chain, Popmusic_Tabu_Chain, Falp };
-
-    void setSearchMethod( Search s );
-    Search searchMethod() const;
-
-    bool isShowingCandidates() const;
-    void setShowingCandidates( bool showing );
-
-    bool isShowingAllLabels() const;
-    void setShowingAllLabels( bool showing );
-
-    bool isShowingPartialsLabels() const;
-    void setShowingPartialsLabels( bool showing );
-
-    //! \since QGIS 2.4
-    bool isDrawingOutlineLabels() const;
-    void setDrawingOutlineLabels( bool outline );
-
-    /** Returns whether the engine will only draw the outline rectangles of labels,
-     * not the label contents themselves. Used for debugging and testing purposes.
-     * \see setDrawLabelRectOnly
-     * \since QGIS 2.12
-     */
-    bool drawLabelRectOnly() const;
-
-    /** Sets whether the engine should only draw the outline rectangles of labels,
-     * not the label contents themselves. Used for debugging and testing purposes.
-     * \param drawRect set to true to enable rect drawing only
-     * \see drawLabelRectOnly
-     * \since QGIS 2.12
-     */
-    void setDrawLabelRectOnly( bool drawRect );
-
     //! called to find out whether the layer is used for labeling
     //! \since QGIS 2.4
     static bool staticWillUseLayer( QgsVectorLayer *layer );
 
     //! \note not available in Python bindings
     static void drawLabelCandidateRect( pal::LabelPosition *lp, QPainter *painter, const QgsMapToPixel *xform, QList<QgsLabelCandidate> *candidates = nullptr );
-
-    //! load/save engine settings to project file
-    void loadEngineSettings();
-    void saveEngineSettings();
 
     /** Prepares a geometry for registration with PAL. Handles reprojection, rotation, clipping, etc.
      * \param geometry geometry to prepare
@@ -817,8 +775,6 @@ class CORE_EXPORT QgsPalLabeling
     friend class QgsVectorLayerLabelProvider; // to allow calling the static methods above
     friend class QgsDxfExport;                // to allow calling the static methods above
 
-    void deleteTemporaryData();
-
     /** Checks whether a geometry exceeds the minimum required size for a geometry to be labeled.
      * \param context render context
      * \param geom geometry
@@ -827,18 +783,6 @@ class CORE_EXPORT QgsPalLabeling
      * \since QGIS 2.9
      */
     static bool checkMinimumSizeMM( const QgsRenderContext &context, const QgsGeometry *geom, double minSize );
-
-    //! hashtable of label providers, being filled during labeling (key = layer ID)
-    QHash<QString, QgsVectorLayerLabelProvider *> mLabelProviders;
-    //! hashtable of diagram providers (key = layer ID)
-    QHash<QString, QgsVectorLayerDiagramProvider *> mDiagramProviders;
-    QgsPalLayerSettings mInvalidLayerSettings;
-
-    //! New labeling engine to interface with PAL
-    QgsLabelingEngine *mEngine = nullptr;
-
-    // list of candidates from last labeling
-    QList<QgsLabelCandidate> mCandidates;
 
     friend class QgsPalLayerSettings;
 };

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -56,6 +56,7 @@ class QgsVectorLayer;
 class QgsAnnotationManager;
 class QgsLayoutManager;
 class QgsLayerTree;
+class QgsLabelingEngineSettings;
 
 /** \ingroup core
  * Reads and writes project states.
@@ -510,6 +511,18 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     void setCustomVariables( const QVariantMap &customVariables );
 
+    /**
+     * Sets project's global labeling engine settings
+     * \since QGIS 3.0
+     */
+    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings );
+
+    /**
+     * Returns project's global labeling engine settings
+     * \since QGIS 3.0
+     */
+    const QgsLabelingEngineSettings &labelingEngineSettings() const;
+
     //
     // Functionality from QgsMapLayerRegistry
     //
@@ -815,6 +828,12 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     void mapThemeCollectionChanged();
 
+    /**
+     * Emitted when global configuration of the labeling engine changes.
+     * \since QGIS 3.0
+     */
+    void labelingEngineSettingsChanged();
+
     //
     // signals from QgsMapLayerRegistry
     //
@@ -1000,6 +1019,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QMap< QPair< QString, QString>, QgsTransactionGroup *> mTransactionGroups;
 
     std::unique_ptr<QgsMapThemeCollection> mMapThemeCollection;
+
+    std::unique_ptr<QgsLabelingEngineSettings> mLabelingEngineSettings;
 
     QVariantMap mCustomVariables;
 

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -458,7 +458,7 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
 
   QPointF outPt = xform.transform( label->getX(), label->getY() ).toQPointF();
 
-  if ( mEngine->testFlag( QgsLabelingEngine::DrawLabelRectOnly ) )  // TODO: this should get directly to labeling engine
+  if ( mEngine->engineSettings().testFlag( QgsLabelingEngineSettings::DrawLabelRectOnly ) )  // TODO: this should get directly to labeling engine
   {
     //debugging rect
     if ( drawType != QgsTextRenderer::Text )
@@ -596,7 +596,7 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
     component.origin = outPt;
     component.rotation = label->getAlpha();
     QgsTextRenderer::drawTextInternal( drawType, context, tmpLyr.format(), component, multiLineList, labelfm,
-                                       hAlign, mEngine->testFlag( QgsLabelingEngine::RenderOutlineLabels ), QgsTextRenderer::Label );
+                                       hAlign, mEngine->engineSettings().testFlag( QgsLabelingEngineSettings::RenderOutlineLabels ), QgsTextRenderer::Label );
 
   }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2124,3 +2124,13 @@ void QgsMapCanvas::setAnnotationsVisible( bool show )
     item->setVisible( show );
   }
 }
+
+void QgsMapCanvas::setLabelingEngineSettings( const QgsLabelingEngineSettings &settings )
+{
+  mSettings.setLabelingEngineSettings( settings );
+}
+
+const QgsLabelingEngineSettings &QgsMapCanvas::labelingEngineSettings() const
+{
+  return mSettings.labelingEngineSettings();
+}

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -494,6 +494,18 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     void setAnnotationsVisible( bool visible );
 
+    /**
+     * Sets global labeling engine settings in the internal map settings
+     * \since QGIS 3.0
+     */
+    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings );
+
+    /**
+     * Returns global labeling engine settings from the internal map settings
+     * \since QGIS 3.0
+     */
+    const QgsLabelingEngineSettings &labelingEngineSettings() const;
+
   public slots:
 
     //! Repaints the canvas map

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -31,7 +31,6 @@
 #include "qgsproviderregistry.h"
 #include "qgslogger.h"
 #include "qgsmapserviceexception.h"
-#include "qgspallabeling.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsserverlogger.h"
 #include "qgseditorwidgetregistry.h"

--- a/src/server/qgssldconfigparser.h
+++ b/src/server/qgssldconfigparser.h
@@ -19,6 +19,7 @@
 #define QGSSLDCONFIGPARSER_H
 
 #include "qgswmsconfigparser.h"
+#include <QFont>
 
 class QgsFeatureRenderer;
 class QgsVectorLayer;

--- a/src/server/qgswmsconfigparser.h
+++ b/src/server/qgswmsconfigparser.h
@@ -19,7 +19,6 @@
 #define QGSWMSCONFIGPARSER_H
 
 #include "qgsunittypes.h"
-#include "qgspallabeling.h"
 #include "qgsdatumtransformstore.h"
 #include "qgis_server.h"
 
@@ -30,9 +29,11 @@ class QgsComposerLabel;
 class QgsComposerLegend;
 class QgsComposerMap;
 class QgsComposition;
+class QgsGeometry;
 class QgsMapLayer;
 class QgsLegendModel;
 class QgsMapSettings;
+class QgsVectorLayer;
 
 
 class SERVER_EXPORT QgsWmsConfigParser

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -23,7 +23,6 @@
 #include "qgsproject.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsmapserviceexception.h"
-#include "qgspallabeling.h"
 #include "qgsrenderer.h"
 #include "qgsvectorlayer.h"
 #include "qgsmapsettings.h"
@@ -2201,7 +2200,7 @@ void QgsWmsProjectParser::loadLabelSettings() const
 
 void QgsWmsProjectParser::readLabelSettings( int &searchMethod, int &nCandPoint, int &nCandLine, int &nCandPoly, bool &showingCandidates, bool &drawRectOnly, bool &showingShadowRects, bool &showingAllLabels, bool &showingPartialsLabels, bool &drawOutlineLabels ) const
 {
-  searchMethod = static_cast< int >( QgsPalLabeling::Chain );
+  searchMethod = static_cast< int >( QgsLabelingEngineSettings::Chain );
   nCandPoint = 8;
   nCandLine = 8;
   nCandPoly = 8;

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -22,6 +22,8 @@
 #include "qgswmsgetlegendgraphics.h"
 #include "qgswmsrenderer.h"
 
+#include <QImage>
+
 namespace QgsWms
 {
 

--- a/src/server/services/wms/qgswmsgetmap.cpp
+++ b/src/server/services/wms/qgswmsgetmap.cpp
@@ -22,6 +22,8 @@
 #include "qgswmsgetmap.h"
 #include "qgswmsrenderer.h"
 
+#include <QImage>
+
 namespace QgsWms
 {
 

--- a/src/server/services/wms/qgswmsgetschemaextension.cpp
+++ b/src/server/services/wms/qgswmsgetschemaextension.cpp
@@ -21,6 +21,8 @@
 #include "qgswmsutils.h"
 #include "qgswmsgetschemaextension.h"
 
+#include <QFileInfo>
+
 namespace QgsWms
 {
 

--- a/src/server/services/wms/qgswmsutils.h
+++ b/src/server/services/wms/qgswmsutils.h
@@ -27,6 +27,8 @@
 #include "qgswmsconfigparser.h"
 #include "qgswmsserviceexception.h"
 
+class QgsRectangle;
+
 /**
  * \ingroup server
  * WMS implementation

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -35,6 +35,7 @@ from qgis.PyQt.QtGui import QFont, QColor
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsDataSourceUri,
+    QgsLabelingEngineSettings,
     QgsProject,
     QgsMapSettings,
     QgsPalLabeling,
@@ -79,8 +80,6 @@ class TestQgsPalLabeling(unittest.TestCase):
     """:type: QgsMapSettings"""
     _Canvas = None
     """:type: QgsMapCanvas"""
-    _Pal = None
-    """:type: QgsPalLabeling"""
     _BaseSetup = False
 
     @classmethod
@@ -120,9 +119,6 @@ class TestQgsPalLabeling(unittest.TestCase):
         cls._Canvas.setCanvasColor(cls._MapSettings.backgroundColor())
 
         cls.setDefaultEngineSettings()
-        msg = ('\nCould not initialize PAL labeling engine, '
-               'SKIPPING TEST SUITE')
-        assert cls._Pal, msg
 
         cls._BaseSetup = True
 
@@ -138,7 +134,7 @@ class TestQgsPalLabeling(unittest.TestCase):
     @classmethod
     def setDefaultEngineSettings(cls):
         """Restore default settings for pal labeling"""
-        cls._Pal = QgsPalLabeling()
+        cls._MapSettings.setLabelingEngineSettings(QgsLabelingEngineSettings())
 
     @classmethod
     def removeAllLayers(cls):
@@ -226,6 +222,7 @@ class TestQgsPalLabeling(unittest.TestCase):
         ms.setDestinationCrs(oms.destinationCrs())
         ms.setExtent(oms.extent())
         ms.setOutputImageFormat(oms.outputImageFormat())
+        ms.setLabelingEngineSettings(oms.labelingEngineSettings())
 
         ms.setLayers(oms.layers())
         return ms
@@ -429,20 +426,20 @@ class TestPALConfig(TestQgsPalLabeling):
 
     def test_default_partials_labels_enabled(self):
         # Verify ShowingPartialsLabels is enabled for PAL by default
-        pal = QgsPalLabeling()
-        self.assertTrue(pal.isShowingPartialsLabels())
+        engine_settings = QgsLabelingEngineSettings()
+        self.assertTrue(engine_settings.testFlag(QgsLabelingEngineSettings.UsePartialCandidates))
 
     def test_partials_labels_activate(self):
-        pal = QgsPalLabeling()
+        engine_settings = QgsLabelingEngineSettings()
         # Enable partials labels
-        pal.setShowingPartialsLabels(True)
-        self.assertTrue(pal.isShowingPartialsLabels())
+        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates)
+        self.assertTrue(engine_settings.testFlag(QgsLabelingEngineSettings.UsePartialCandidates))
 
     def test_partials_labels_deactivate(self):
-        pal = QgsPalLabeling()
+        engine_settings = QgsLabelingEngineSettings()
         # Disable partials labels
-        pal.setShowingPartialsLabels(False)
-        self.assertFalse(pal.isShowingPartialsLabels())
+        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates, False)
+        self.assertFalse(engine_settings.testFlag(QgsLabelingEngineSettings.UsePartialCandidates))
 
 
 # noinspection PyPep8Naming,PyShadowingNames

--- a/tests/src/python/test_qgspallabeling_composer.py
+++ b/tests/src/python/test_qgspallabeling_composer.py
@@ -100,7 +100,7 @@ class TestComposerBase(TestQgsPalLabeling):
         self._Mismatches.clear()
         self._ColorTols.clear()
 
-    def _set_up_composition(self, width, height, dpi):
+    def _set_up_composition(self, width, height, dpi, engine_settings):
         # set up composition and add map
         self._c = QgsComposition(QgsProject.instance())
         """:type: QgsComposition"""
@@ -126,6 +126,8 @@ class TestComposerBase(TestQgsPalLabeling):
         self._cmap.setNewExtent(self.aoiExtent())
         # self._cmap.updateCachedImage()
         self._c.setPlotStyle(QgsComposition.Print)
+        # composition takes labeling engine settings from project
+        QgsProject.instance().setLabelingEngineSettings(engine_settings)
 
     # noinspection PyUnusedLocal
     def _get_composer_image(self, width, height, dpi):
@@ -271,7 +273,7 @@ class TestComposerBase(TestQgsPalLabeling):
         ms = self._TestMapSettings
         osize = ms.outputSize()
         width, height, dpi = osize.width(), osize.height(), ms.outputDpi()
-        self._set_up_composition(width, height, dpi)
+        self._set_up_composition(width, height, dpi, ms.labelingEngineSettings())
         if kind == OutputKind.Svg:
             return self._get_composer_svg_image(width, height, dpi)
         elif kind == OutputKind.Pdf:

--- a/tests/src/python/test_qgspallabeling_placement.py
+++ b/tests/src/python/test_qgspallabeling_placement.py
@@ -40,9 +40,6 @@ class TestPlacementBase(TestQgsPalLabeling):
     def setUpClass(cls):
         if not cls._BaseSetup:
             TestQgsPalLabeling.setUpClass()
-        engine_settings = QgsLabelingEngineSettings()
-        engine_settings.setFlag(QgsLabelingEngineSettings.DrawLabelRectOnly)
-        cls._MapSettings.setLabelingEngineSettings(engine_settings)
 
     @classmethod
     def tearDownClass(cls):
@@ -56,12 +53,16 @@ class TestPlacementBase(TestQgsPalLabeling):
         self.removeAllLayers()
         self.configTest('pal_placement', 'sp')
         self._TestImage = ''
-        # ensure per test map settings stay encapsulated
-        self._TestMapSettings = self.cloneMapSettings(self._MapSettings)
+
         self._Mismatch = 0
         self._ColorTol = 0
         self._Mismatches.clear()
         self._ColorTols.clear()
+
+        # render only rectangles of the placed labels
+        engine_settings = QgsLabelingEngineSettings()
+        engine_settings.setFlag(QgsLabelingEngineSettings.DrawLabelRectOnly)
+        self._MapSettings.setLabelingEngineSettings(engine_settings)
 
     def checkTest(self, **kwargs):
         self.lyr.writeToLayer(self.layer)

--- a/tests/src/python/test_qgspallabeling_placement.py
+++ b/tests/src/python/test_qgspallabeling_placement.py
@@ -23,7 +23,8 @@ import sys
 
 from qgis.PyQt.QtCore import QThreadPool, qDebug
 
-from qgis.core import (QgsPalLayerSettings,
+from qgis.core import (QgsLabelingEngineSettings,
+                       QgsPalLayerSettings,
                        QgsSingleSymbolRenderer,
                        QgsMarkerSymbol,
                        QgsProperty)
@@ -39,8 +40,9 @@ class TestPlacementBase(TestQgsPalLabeling):
     def setUpClass(cls):
         if not cls._BaseSetup:
             TestQgsPalLabeling.setUpClass()
-        cls._Pal.setDrawLabelRectOnly(True)
-        cls._Pal.saveEngineSettings()
+        engine_settings = QgsLabelingEngineSettings()
+        engine_settings.setFlag(QgsLabelingEngineSettings.DrawLabelRectOnly)
+        cls._MapSettings.setLabelingEngineSettings(engine_settings)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/src/python/test_qgspallabeling_server.py
+++ b/tests/src/python/test_qgspallabeling_server.py
@@ -142,10 +142,13 @@ class TestServerBase(TestQgsPalLabeling):
         """
         Sync custom test QgsMapSettings to Project file
         """
+        pass
+        """
         pal = QgsPalLabeling()
         pal.loadEngineSettings()
         pal.init(self._TestMapSettings)
         pal.saveEngineSettings()
+        """
 
     def checkTest(self, **kwargs):
         self.sync_map_settings()

--- a/tests/src/python/test_qgspallabeling_server.py
+++ b/tests/src/python/test_qgspallabeling_server.py
@@ -138,20 +138,7 @@ class TestServerBase(TestQgsPalLabeling):
         # print params
         return params
 
-    def sync_map_settings(self):
-        """
-        Sync custom test QgsMapSettings to Project file
-        """
-        pass
-        """
-        pal = QgsPalLabeling()
-        pal.loadEngineSettings()
-        pal.init(self._TestMapSettings)
-        pal.saveEngineSettings()
-        """
-
     def checkTest(self, **kwargs):
-        self.sync_map_settings()
         self.lyr.writeToLayer(self.layer)
         # save project file
         self._TestProj.write()

--- a/tests/src/python/test_qgspallabeling_tests.py
+++ b/tests/src/python/test_qgspallabeling_tests.py
@@ -23,7 +23,7 @@ import os
 from qgis.PyQt.QtCore import Qt, QPointF, QSizeF
 from qgis.PyQt.QtGui import QFont
 
-from qgis.core import QgsPalLayerSettings, QgsUnitTypes, QgsTextBackgroundSettings
+from qgis.core import QgsLabelingEngineSettings, QgsPalLayerSettings, QgsUnitTypes, QgsTextBackgroundSettings
 
 from utilities import svgSymbolsPath
 
@@ -37,8 +37,6 @@ class TestPointBase(object):
         """:type: QgsPalLayerSettings"""
         # noinspection PyArgumentList
         self._TestFont = QFont()  # will become a standard test font
-        self._Pal = None
-        """:type: QgsPalLabeling"""
         self._Canvas = None
         """:type: QgsMapCanvas"""
         # custom mismatches per group/test (should not mask any needed anomaly)
@@ -175,8 +173,9 @@ class TestPointBase(object):
         format.setSize(84)
         self.lyr.setFormat(format)
         # Enable partials labels
-        self._Pal.setShowingPartialsLabels(True)
-        self._Pal.saveEngineSettings()
+        engine_settings = QgsLabelingEngineSettings()
+        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates)
+        self._Canvas.setLabelingEngineSettings(engine_settings)
         self._Mismatches['TestCanvasPoint'] = 779
         self._ColorTols['TestComposerPdfPoint'] = 2
         self.checkTest()
@@ -189,8 +188,9 @@ class TestPointBase(object):
         format.setSize(84)
         self.lyr.setFormat(format)
         # Disable partials labels
-        self._Pal.setShowingPartialsLabels(False)
-        self._Pal.saveEngineSettings()
+        engine_settings = QgsLabelingEngineSettings()
+        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates)
+        self._Canvas.setLabelingEngineSettings(engine_settings)
         self.checkTest()
 
     def test_buffer(self):

--- a/tests/src/python/test_qgspallabeling_tests.py
+++ b/tests/src/python/test_qgspallabeling_tests.py
@@ -174,8 +174,8 @@ class TestPointBase(object):
         self.lyr.setFormat(format)
         # Enable partials labels
         engine_settings = QgsLabelingEngineSettings()
-        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates)
-        self._Canvas.setLabelingEngineSettings(engine_settings)
+        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates, True)
+        self._TestMapSettings.setLabelingEngineSettings(engine_settings)
         self._Mismatches['TestCanvasPoint'] = 779
         self._ColorTols['TestComposerPdfPoint'] = 2
         self.checkTest()
@@ -189,8 +189,8 @@ class TestPointBase(object):
         self.lyr.setFormat(format)
         # Disable partials labels
         engine_settings = QgsLabelingEngineSettings()
-        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates)
-        self._Canvas.setLabelingEngineSettings(engine_settings)
+        engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates, False)
+        self._TestMapSettings.setLabelingEngineSettings(engine_settings)
         self.checkTest()
 
     def test_buffer(self):


### PR DESCRIPTION
Another bit to make core library independent from QgsProject::instance(). Until now labeling engine configuration was taken from project singleton.

Removed legacy methods from QgsPalLabeling - the class now does not have any more member variables/methods, it is just a bunch of helper functions.
