### PR TITLE
Update decorators to avoid relying on map canvas when rendering

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -82,6 +82,7 @@
 %Include qgslegendsettings.sip
 %Include qgslegendstyle.sip
 %Include qgslogger.sip
+%Include qgsmapdecoration.sip
 %Include qgsmaphittest.sip
 %Include qgsmaplayer.sip
 %Include qgsmaplayerdependency.sip

--- a/python/core/qgsmapdecoration.sip
+++ b/python/core/qgsmapdecoration.sip
@@ -1,0 +1,46 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsmapdecoration.h                                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsMapDecoration
+{
+%Docstring
+ Interface for map decorations.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsmapdecoration.h"
+%End
+  public:
+
+    QgsMapDecoration();
+%Docstring
+ Constructor for QgsMapDecoration.
+%End
+
+    virtual ~QgsMapDecoration();
+
+    virtual void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) = 0;
+%Docstring
+ Renders a map decoration.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsmapdecoration.h                                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3483,9 +3483,12 @@ void QgisApp::createDecorations()
 
 void QgisApp::renderDecorationItems( QPainter *p )
 {
+  QgsRenderContext context = QgsRenderContext::fromMapSettings( mMapCanvas->mapSettings() );
+  context.setPainter( p );
+
   Q_FOREACH ( QgsDecorationItem *item, mDecorationItems )
   {
-    item->render( p );
+    item->render( mMapCanvas->mapSettings(), context );
   }
 }
 

--- a/src/app/qgsdecorationcopyright.cpp
+++ b/src/app/qgsdecorationcopyright.cpp
@@ -91,14 +91,15 @@ void QgsDecorationCopyright::run()
 }
 
 
-void QgsDecorationCopyright::render( QPainter *theQPainter )
+void QgsDecorationCopyright::render( const QgsMapSettings &mapSettings, QgsRenderContext &context )
 {
+  Q_UNUSED( mapSettings );
   //Large IF statement to enable/disable copyright label
   if ( enabled() )
   {
     // need width/height of paint device
-    int myHeight = theQPainter->device()->height();
-    int myWidth = theQPainter->device()->width();
+    int myHeight = context.painter()->device()->height();
+    int myWidth = context.painter()->device()->width();
 
     QTextDocument text;
     text.setDefaultFont( mQFont );
@@ -115,8 +116,8 @@ void QgsDecorationCopyright::render( QPainter *theQPainter )
     {
       case QgsUnitTypes::RenderMillimeters:
       {
-        int myPixelsInchX = theQPainter->device()->logicalDpiX();
-        int myPixelsInchY = theQPainter->device()->logicalDpiY();
+        int myPixelsInchX = context.painter()->device()->logicalDpiX();
+        int myPixelsInchY = context.painter()->device()->logicalDpiY();
         myXOffset = myPixelsInchX * INCHES_TO_MM * mMarginHorizontal;
         myYOffset = myPixelsInchY * INCHES_TO_MM * mMarginVertical;
         break;
@@ -156,11 +157,11 @@ void QgsDecorationCopyright::render( QPainter *theQPainter )
     }
 
     //Paint label to canvas
-    QMatrix worldMatrix = theQPainter->worldMatrix();
-    theQPainter->translate( myXOffset, myYOffset );
-    text.drawContents( theQPainter );
+    QMatrix worldMatrix = context.painter()->worldMatrix();
+    context.painter()->translate( myXOffset, myYOffset );
+    text.drawContents( context.painter() );
     // Put things back how they were
-    theQPainter->setWorldMatrix( worldMatrix );
+    context.painter()->setWorldMatrix( worldMatrix );
   }
 }
 

--- a/src/app/qgsdecorationcopyright.h
+++ b/src/app/qgsdecorationcopyright.h
@@ -47,7 +47,7 @@ class APP_EXPORT QgsDecorationCopyright : public QgsDecorationItem
     //! Show the dialog box
     void run() override;
     //! render the copyright label
-    void render( QPainter * ) override;
+    void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
 
   private:
     //! This is the font that will be used for the copyright label

--- a/src/app/qgsdecorationgrid.h
+++ b/src/app/qgsdecorationgrid.h
@@ -146,7 +146,7 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
     void saveToProject() override;
 
     //! this does the meaty bit of the work
-    void render( QPainter * ) override;
+    void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
     //! Show the dialog box
     void run() override;
 
@@ -212,11 +212,12 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
 
     /** Returns the grid lines with associated coordinate value
         \returns 0 in case of success*/
-    int xGridLines( QList< QPair< qreal, QLineF > > &lines ) const;
+    int xGridLines( const QgsMapSettings &mapSettings, QList< QPair< qreal, QLineF > > &lines ) const;
 
     /** Returns the grid lines for the y-coordinates. Not vertical in case of rotation
         \returns 0 in case of success*/
-    int yGridLines( QList< QPair< qreal, QLineF > > &lines ) const;
+    int yGridLines( const QgsMapSettings &mapSettings, QList< QPair< qreal, QLineF > > &lines ) const;
+
     //! Returns the item border of a point (in item coordinates)
     Border borderForLineCoord( QPointF point, QPainter *p ) const;
 

--- a/src/app/qgsdecorationitem.cpp
+++ b/src/app/qgsdecorationitem.cpp
@@ -21,6 +21,7 @@
 #include "qgisapp.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
+#include "qgsmapdecoration.h"
 #include "qgsmaplayer.h"
 #include "qgsmaptopixel.h"
 #include "qgspoint.h"

--- a/src/app/qgsdecorationitem.h
+++ b/src/app/qgsdecorationitem.h
@@ -19,6 +19,8 @@
 #define QGSDECORATIONITEM_H
 
 #include <QObject>
+
+#include "qgsmapdecoration.h"
 #include "qgsunittypes.h"
 #include "qgis_app.h"
 
@@ -26,9 +28,10 @@ class QPainter;
 
 #define INCHES_TO_MM 0.0393700787402
 
-class APP_EXPORT QgsDecorationItem: public QObject
+class APP_EXPORT QgsDecorationItem : public QObject, public QgsMapDecoration
 {
     Q_OBJECT
+
   public:
 
     //! Item placements
@@ -67,8 +70,6 @@ class APP_EXPORT QgsDecorationItem: public QObject
     //! save values to the project
     virtual void saveToProject();
 
-    //! this does the meaty bit of the work
-    virtual void render( QPainter * ) {}
     //! Show the dialog box
     virtual void run() {}
 

--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -25,11 +25,11 @@ email                : tim@linfiniti.com
 #include "qgsdecorationnortharrowdialog.h"
 
 #include "qgisapp.h"
+#include "qgsbearingutils.h"
 #include "qgscoordinatetransform.h"
 #include "qgsmaplayer.h"
 #include "qgsproject.h"
 #include "qgslogger.h"
-#include "qgsmapcanvas.h"
 #include "qgscsexception.h"
 
 // qt includes
@@ -95,7 +95,7 @@ void QgsDecorationNorthArrow::run()
   dlg.exec();
 }
 
-void QgsDecorationNorthArrow::render( QPainter *theQPainter )
+void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRenderContext &context )
 {
 
   //Large IF statement controlled by enable check box
@@ -110,7 +110,7 @@ void QgsDecorationNorthArrow::render( QPainter *theQPainter )
       double centerXDouble = myQPixmap.width() / 2.0;
       double centerYDouble = myQPixmap.height() / 2.0;
       //save the current canvas rotation
-      theQPainter->save();
+      context.painter()->save();
       //
       //work out how to shift the image so that it rotates
       //           properly about its center
@@ -120,7 +120,10 @@ void QgsDecorationNorthArrow::render( QPainter *theQPainter )
       // could move this call to somewhere else so that it is only
       // called when the projection or map extent changes
       if ( mAutomatic )
-        calculateNorthDirection();
+      {
+        mRotationInt = QgsBearingUtils:: bearingTrueNorth( mapSettings.destinationCrs(), context.extent().center() );
+        mRotationInt += mapSettings.rotation();
+      }
 
       double myRadiansDouble = mRotationInt * M_PI / 180.0;
       int xShift = static_cast<int>( (
@@ -133,8 +136,8 @@ void QgsDecorationNorthArrow::render( QPainter *theQPainter )
                                      ) - centerYDouble );
 
       // need width/height of paint device
-      int myHeight = theQPainter->device()->height();
-      int myWidth = theQPainter->device()->width();
+      int myHeight = context.painter()->device()->height();
+      int myWidth = context.painter()->device()->width();
 
       //QgsDebugMsg("Rendering north arrow at " + mPlacementLabels.at(mPlacementIndex));
 
@@ -145,8 +148,8 @@ void QgsDecorationNorthArrow::render( QPainter *theQPainter )
       {
         case QgsUnitTypes::RenderMillimeters:
         {
-          int myPixelsInchX = theQPainter->device()->logicalDpiX();
-          int myPixelsInchY = theQPainter->device()->logicalDpiY();
+          int myPixelsInchX = context.painter()->device()->logicalDpiX();
+          int myPixelsInchY = context.painter()->device()->logicalDpiY();
           myXOffset = myPixelsInchX * INCHES_TO_MM * mMarginHorizontal;
           myYOffset = myPixelsInchY * INCHES_TO_MM * mMarginVertical;
           break;
@@ -169,17 +172,17 @@ void QgsDecorationNorthArrow::render( QPainter *theQPainter )
       switch ( mPlacement )
       {
         case BottomLeft:
-          theQPainter->translate( myXOffset, myHeight - myYOffset - myQPixmap.height() );
+          context.painter()->translate( myXOffset, myHeight - myYOffset - myQPixmap.height() );
           break;
         case TopLeft:
-          theQPainter->translate( myXOffset, myYOffset );
+          context.painter()->translate( myXOffset, myYOffset );
           break;
         case TopRight:
-          theQPainter->translate( myWidth - myXOffset - myQPixmap.width(), myYOffset );
+          context.painter()->translate( myWidth - myXOffset - myQPixmap.width(), myYOffset );
           break;
         case BottomRight:
-          theQPainter->translate( myWidth - myXOffset - myQPixmap.width(),
-                                  myHeight - myYOffset - myQPixmap.height() );
+          context.painter()->translate( myWidth - myXOffset - myQPixmap.width(),
+                                        myHeight - myYOffset - myQPixmap.height() );
           break;
         default:
         {
@@ -188,136 +191,21 @@ void QgsDecorationNorthArrow::render( QPainter *theQPainter )
       }
 
       //rotate the canvas by the north arrow rotation amount
-      theQPainter->rotate( mRotationInt );
+      context.painter()->rotate( mRotationInt );
       //Now we can actually do the drawing, and draw a smooth north arrow even when rotated
-      theQPainter->setRenderHint( QPainter::SmoothPixmapTransform );
-      theQPainter->drawPixmap( xShift, yShift, myQPixmap );
+      context.painter()->setRenderHint( QPainter::SmoothPixmapTransform );
+      context.painter()->drawPixmap( xShift, yShift, myQPixmap );
 
       //unrotate the canvas again
-      theQPainter->restore();
+      context.painter()->restore();
     }
     else
     {
       QFont myQFont( QStringLiteral( "time" ), 12, QFont::Bold );
-      theQPainter->setFont( myQFont );
-      theQPainter->setPen( Qt::black );
-      theQPainter->drawText( 10, 20, tr( "North arrow pixmap not found" ) );
+      context.painter()->setFont( myQFont );
+      context.painter()->setPen( Qt::black );
+      context.painter()->drawText( 10, 20, tr( "North arrow pixmap not found" ) );
     }
   }
 
-}
-
-bool QgsDecorationNorthArrow::calculateNorthDirection()
-{
-  QgsMapCanvas *mapCanvas = QgisApp::instance()->mapCanvas();
-
-  bool goodDirn = false;
-
-  // Get the shown extent...
-  QgsRectangle canvasExtent = mapCanvas->extent();
-  // ... and all layers extent, ...
-  QgsRectangle fullExtent = mapCanvas->fullExtent();
-  // ... and combine
-  QgsRectangle extent = canvasExtent.intersect( & fullExtent );
-
-  // If no layers are added or shown, we can't get any direction
-  if ( mapCanvas->layerCount() > 0 && ! extent.isEmpty() )
-  {
-    QgsCoordinateReferenceSystem outputCRS = mapCanvas->mapSettings().destinationCrs();
-
-    if ( outputCRS.isValid() && !outputCRS.isGeographic() )
-    {
-      // Use a geographic CRS to get lat/long to work out direction
-      QgsCoordinateReferenceSystem ourCRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( GEO_EPSG_CRS_AUTHID );
-      assert( ourCRS.isValid() );
-
-      QgsCoordinateTransform transform( outputCRS, ourCRS );
-
-      QgsPoint p1( extent.center() );
-      // A point a bit above p1. XXX assumes that y increases up!!
-      // May need to involve the maptopixel transform if this proves
-      // to be a problem.
-      QgsPoint p2( p1.x(), p1.y() + extent.height() * 0.25 );
-
-      // project p1 and p2 to geographic coords
-      try
-      {
-        p1 = transform.transform( p1 );
-        p2 = transform.transform( p2 );
-      }
-      catch ( QgsCsException &e )
-      {
-        Q_UNUSED( e );
-        // just give up
-        QgsDebugMsg( "North Arrow: Transformation error, quitting" );
-        return false;
-      }
-
-      // Work out the value of the initial heading one takes to go
-      // from point p1 to point p2. The north direction is then that
-      // many degrees anti-clockwise or vertical.
-
-      // Take some care to not divide by zero, etc, and ensure that we
-      // get sensible results for all possible values for p1 and p2.
-
-      goodDirn = true;
-      double angle = 0.0;
-
-      // convert to radians for the equations below
-      p1.multiply( M_PI / 180.0 );
-      p2.multiply( M_PI / 180.0 );
-
-      double y = sin( p2.x() - p1.x() ) * cos( p2.y() );
-      double x = cos( p1.y() ) * sin( p2.y() ) -
-                 sin( p1.y() ) * cos( p2.y() ) * cos( p2.x() - p1.x() );
-
-      // Use TOL to decide if the quotient is big enough.
-      // Both x and y can be very small, if heavily zoomed
-      // For small y/x, we set directly angle 0. Not sure
-      // if this is needed.
-      if ( y > 0.0 )
-      {
-        if ( x > 0.0 && ( y / x ) > TOL )
-          angle = atan( y / x );
-        else if ( x < 0.0 && ( y / x ) < -TOL )
-          angle = M_PI - atan( -y / x );
-        else
-          angle = 0.5 * M_PI;
-      }
-      else if ( y < 0.0 )
-      {
-        if ( x > 0.0 && ( y / x ) < -TOL )
-          angle = -atan( -y / x );
-        else if ( x < 0.0 && ( y / x ) > TOL )
-          angle = atan( y / x ) - M_PI;
-        else
-          angle = 1.5 * M_PI;
-      }
-      else
-      {
-        if ( x > TOL )
-          angle = 0.0;
-        else if ( x < -TOL )
-          angle = M_PI;
-        else
-        {
-          angle = 0.0; // p1 = p2
-          goodDirn = false;
-        }
-      }
-      // And set the angle of the north arrow. Perhaps do something
-      // different if goodDirn = false.
-      mRotationInt = qRound( fmod( 360.0 - angle * 180.0 / M_PI, 360.0 ) );
-    }
-    else
-    {
-      // For geographic CRS and for when there are no layers, set the
-      // direction back to the default
-      mRotationInt = 0;
-    }
-  }
-
-  mRotationInt += mapCanvas->mapSettings().rotation();
-
-  return goodDirn;
 }

--- a/src/app/qgsdecorationnortharrow.h
+++ b/src/app/qgsdecorationnortharrow.h
@@ -47,13 +47,7 @@ class APP_EXPORT QgsDecorationNorthArrow: public QgsDecorationItem
     //! Show the dialog box
     void run() override;
     //! draw some arbitrary text to the screen
-    void render( QPainter * ) override;
-
-    //! try to calculate the direction for the north arrow. Sets the
-    //! private class rotation variable. If unable to calculate the
-    //! direction, the function returns false and leaves the rotation
-    //! variable as is.
-    bool calculateNorthDirection();
+    void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
 
   private:
 

--- a/src/app/qgsdecorationscalebar.h
+++ b/src/app/qgsdecorationscalebar.h
@@ -45,7 +45,7 @@ class APP_EXPORT QgsDecorationScaleBar: public QgsDecorationItem
     void saveToProject() override;
 
     //! this does the meaty bit of the work
-    void render( QPainter * ) override;
+    void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
     //! Show the dialog box
     void run() override;
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -732,6 +732,7 @@ SET(QGIS_CORE_HDRS
   qgslegendsettings.h
   qgslegendstyle.h
   qgslogger.h
+  qgsmapdecoration.h
   qgsmaplayerref.h
   qgsmaphittest.h
   qgsmaplayerdependency.h

--- a/src/core/qgsmapdecoration.h
+++ b/src/core/qgsmapdecoration.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+                          qgsmapdecoration.h
+                          ----------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPDECORATION_H
+#define QGSMAPDECORATION_H
+
+#include "qgis_core.h"
+#include "qgsmapsettings.h"
+#include "qgsrendercontext.h"
+
+/**
+ * \ingroup core
+ * \class QgsMapDecoration
+ * \brief Interface for map decorations.
+ *
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsMapDecoration
+{
+
+  public:
+
+    /**
+     * Constructor for QgsMapDecoration.
+     */
+    QgsMapDecoration() {}
+
+    virtual ~QgsMapDecoration() = default;
+
+    /**
+     * Renders a map decoration.
+     */
+    virtual void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) = 0;
+
+};
+
+#endif //QGSMAPDECORATION_H


### PR DESCRIPTION
## Description
This PR updates the decorators to rely on QgsMapSettings & QgsRenderContext when rendering. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
