### PR TITLE
Server: Restore body() accessor in QgsRequestHandler

### DIFF
--- a/python/server/qgsrequesthandler.sip
+++ b/python/server/qgsrequesthandler.sip
@@ -27,18 +27,18 @@ class QgsRequestHandler  /Abstract/
   public:
 
     /** Allow plugins to return a QgsServerException*/
-    void setServiceException( const QgsServerException& ex );
+    void setServiceException( const QgsServerException &ex );
 
     /** Set an HTTP header*/
     void setHeader( const QString &name, const QString &value );
 
     //! Retrieve header value
-    QString getHeader( const QString& name ) const;
+    QString getHeader( const QString &name ) const;
 
     //! Return the list of all header keys
     QList<QString> headerKeys() const;
 
-   /** Remove an HTTP header*/
+    /** Remove an HTTP header*/
     void removeHeader( const QString &name );
 
     /** Delete all HTTP headers*/
@@ -52,6 +52,12 @@ class QgsRequestHandler  /Abstract/
 
     /** Pointer to last raised exception*/
     bool exceptionRaised() const;
+
+    /** Clear response buffer */
+    void clearBody();
+
+    /** Return body data */
+    QByteArray body() const;
 
     /** Return a copy of the parsed parameters as a key-value pair, to modify
      * a parameter setParameter( const QString &key, const QString &value)

--- a/python/server/qgsserverresponse.sip
+++ b/python/server/qgsserverresponse.sip
@@ -40,18 +40,18 @@ class QgsServerResponse
      *  Add Header entry to the response
      *  Note that it is usually an error to set Header after writing data
      */
-    virtual void setHeader( const QString& key, const QString& value ) = 0;
+    virtual void setHeader( const QString &key, const QString &value ) = 0;
 
     /**
      * Clear header
      * Undo a previous 'set_header' call
      */
-    virtual void clearHeader( const QString& key ) = 0;
+    virtual void clearHeader( const QString &key ) = 0;
 
     /**
      * Return the header value
      */
-    virtual QString getHeader( const QString& key ) const = 0;
+    virtual QString getHeader( const QString &key ) const = 0;
 
     /**
      * Return the list of all header keys
@@ -75,14 +75,14 @@ class QgsServerResponse
      * @param code HTTP return code value
      * @param message An informative error message
      */
-    virtual void sendError( int code,  const QString& message ) = 0;
+    virtual void sendError( int code,  const QString &message ) = 0;
 
     /**
      * Write string
      * This is a convenient method that will write directly
      * to the underlying I/O device
      */
-    virtual void write( const QString& data );
+    virtual void write( const QString &data );
 
     /**
      * Write chunk of data
@@ -90,17 +90,17 @@ class QgsServerResponse
      * underlying I/O device
      * @return the number of bytes that were actually written
      */
-    virtual qint64 write( const QByteArray& byteArray );
+    virtual qint64 write( const QByteArray &byteArray );
 
     /**
      * Write server exception
      */
-    virtual void write( const QgsServerException& ex );
+    virtual void write( const QgsServerException &ex );
 
     /**
      * Return the underlying QIODevice
      */
-    virtual QIODevice* io() = 0;
+    virtual QIODevice *io() = 0;
 
     /**
      * End the transaction
@@ -120,5 +120,14 @@ class QgsServerResponse
      */
     virtual void clear() = 0;
 
+    /**
+     * Get the data written so far
+     */
+    virtual QByteArray data() const = 0;
+
+    /**
+     * Truncate internal buffer
+     */
+    virtual void truncate() = 0;
 };
 

--- a/src/server/qgsbufferserverresponse.cpp
+++ b/src/server/qgsbufferserverresponse.cpp
@@ -130,6 +130,18 @@ void QgsBufferServerResponse::clear()
 }
 
 
+QByteArray QgsBufferServerResponse::data() const
+{
+  return mBuffer.data();
+}
+
+
+void QgsBufferServerResponse::truncate()
+{
+  mBuffer.seek( 0 );
+  mBuffer.buffer().clear();
+}
+
 //QgsBufferServerRequest
 //
 QgsBufferServerRequest::QgsBufferServerRequest( const QString &url, Method method, QByteArray *data )

--- a/src/server/qgsbufferserverresponse.h
+++ b/src/server/qgsbufferserverresponse.h
@@ -38,27 +38,31 @@ class QgsBufferServerResponse: public QgsServerResponse
     QgsBufferServerResponse();
     ~QgsBufferServerResponse();
 
-    virtual void setHeader( const QString &key, const QString &value ) override;
+    void setHeader( const QString &key, const QString &value ) override;
 
-    virtual void clearHeader( const QString &key ) override;
+    void clearHeader( const QString &key ) override;
 
-    virtual QString getHeader( const QString &key ) const override;
+    QString getHeader( const QString &key ) const override;
 
-    virtual QList<QString> headerKeys() const override;
+    QList<QString> headerKeys() const override;
 
-    virtual bool headersSent() const override;
+    bool headersSent() const override;
 
-    virtual void setReturnCode( int code ) override;
+    void setReturnCode( int code ) override;
 
-    virtual void sendError( int code,  const QString &message ) override;
+    void sendError( int code,  const QString &message ) override;
 
-    virtual QIODevice *io() override;
+    QIODevice *io() override;
 
-    virtual void finish() override;
+    void finish() override;
 
-    virtual void flush() override;
+    void flush() override;
 
-    virtual void clear() override;
+    void clear() override;
+
+    QByteArray data() const override;
+
+    void truncate() override;
 
     /**
      * Return body

--- a/src/server/qgsfcgiserverresponse.cpp
+++ b/src/server/qgsfcgiserverresponse.cpp
@@ -160,6 +160,20 @@ void QgsFcgiServerResponse::clear()
   setDefaultHeaders();
 }
 
+
+QByteArray QgsFcgiServerResponse::data() const
+{
+  return mBuffer.data();
+}
+
+
+void QgsFcgiServerResponse::truncate()
+{
+  mBuffer.seek( 0 );
+  mBuffer.buffer().clear();
+}
+
+
 void QgsFcgiServerResponse::setDefaultHeaders()
 {
   setHeader( QStringLiteral( "Server" ), QStringLiteral( " Qgis FCGI server - QGis version %1" ).arg( Qgis::QGIS_VERSION ) );

--- a/src/server/qgsfcgiserverresponse.h
+++ b/src/server/qgsfcgiserverresponse.h
@@ -36,27 +36,31 @@ class SERVER_EXPORT QgsFcgiServerResponse: public QgsServerResponse
     QgsFcgiServerResponse( QgsServerRequest::Method method = QgsServerRequest::GetMethod );
     ~QgsFcgiServerResponse();
 
-    virtual void setHeader( const QString &key, const QString &value ) override;
+    void setHeader( const QString &key, const QString &value ) override;
 
-    virtual void clearHeader( const QString &key ) override;
+    void clearHeader( const QString &key ) override;
 
-    virtual QString getHeader( const QString &key ) const override;
+    QString getHeader( const QString &key ) const override;
 
-    virtual QList<QString> headerKeys() const override;
+    QList<QString> headerKeys() const override;
 
-    virtual bool headersSent() const override;
+    bool headersSent() const override;
 
-    virtual void setReturnCode( int code ) override;
+    void setReturnCode( int code ) override;
 
-    virtual void sendError( int code,  const QString &message ) override;
+    void sendError( int code,  const QString &message ) override;
 
-    virtual QIODevice *io() override;
+    QIODevice *io() override;
 
-    virtual void finish() override;
+    void finish() override;
 
-    virtual void flush() override;
+    void flush() override;
 
-    virtual void clear() override;
+    void clear() override;
+
+    QByteArray data() const override;
+
+    void truncate() override;
 
     /**
      * Set the default headers

--- a/src/server/qgsfilterresponsedecorator.h
+++ b/src/server/qgsfilterresponsedecorator.h
@@ -63,7 +63,9 @@ class QgsFilterResponseDecorator: public QgsServerResponse
 
     void clear() override { mResponse.clear(); }
 
+    QByteArray data() const override { return mResponse.data(); }
 
+    void truncate() override { mResponse.truncate(); }
 
   private:
     QgsServerFiltersMap  mFilters;

--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -89,6 +89,16 @@ void QgsRequestHandler::appendBody( const QByteArray &body )
   mResponse.write( body );
 }
 
+void QgsRequestHandler::clearBody()
+{
+  mResponse.truncate();
+}
+
+QByteArray QgsRequestHandler::body() const
+{
+  return mResponse.data();
+}
+
 void QgsRequestHandler::sendResponse()
 {
   // Send data to output

--- a/src/server/qgsrequesthandler.h
+++ b/src/server/qgsrequesthandler.h
@@ -85,6 +85,12 @@ class SERVER_EXPORT QgsRequestHandler
     //! Pointer to last raised exception
     bool exceptionRaised() const;
 
+    //! Clear response buffer
+    void clearBody();
+
+    //! Return body data
+    QByteArray body() const;
+
     /** Return the parsed parameters as a key-value pair, to modify
      * a parameter setParameter( const QString &key, const QString &value)
      * and removeParameter(const QString &key) must be used

--- a/src/server/qgsserverresponse.h
+++ b/src/server/qgsserverresponse.h
@@ -157,6 +157,24 @@ class SERVER_EXPORT QgsServerResponse
      * Reset all headers and content for this response
      */
     virtual void clear() = 0;
+
+    /**
+     * Get the data written so far
+     *
+     * This is implementation dependent: some implementations may not
+     * give access to the underlyng and return an empty array.
+     *
+     * Note that each call to 'flush' may empty the buffer and in case
+     * of streaming process you may get partial content
+     */
+    virtual QByteArray data() const = 0;
+
+    /**
+     * Truncate data
+     *
+     * Clear internal buffer
+     */
+    virtual void truncate() = 0;
 };
 
 #endif


### PR DESCRIPTION
 
## Description
Restore body() accessor and clearBody() method in QgsRequestHandler. This feature was removed
and thus was preventing replacing/editing response body in server plugins.

