### PR TITLE
Fix crash when OGR layer is removed when source is stored

### DIFF
--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -343,7 +343,7 @@ class QgsAbstractFeatureSource
      * @param request The request
      * @return A feature iterator
      */
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) = 0;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) = 0;
 
   protected:
     void iteratorOpened( QgsAbstractFeatureIterator* it );

--- a/python/core/qgsvectorlayerfeatureiterator.sip
+++ b/python/core/qgsvectorlayerfeatureiterator.sip
@@ -2,6 +2,23 @@
 // abstract feature iterator implementations are not part of public API
 
 
+class QgsVectorLayerFeatureSource : QgsAbstractFeatureSource
+{
+%TypeHeaderCode
+#include <qgsvectorlayerfeatureiterator.h>
+%End
+  public:
+
+    /** Constructor for QgsVectorLayerFeatureSource.
+     * \param layer source layer
+     */
+    explicit QgsVectorLayerFeatureSource( const QgsVectorLayer *layer );
+
+    ~QgsVectorLayerFeatureSource();
+
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() );
+};
+
 class QgsVectorLayerFeatureIterator : QgsAbstractFeatureIterator
 {
 %TypeHeaderCode

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -437,7 +437,7 @@ class CORE_EXPORT QgsAbstractFeatureSource
      * \param request The request
      * \returns A feature iterator
      */
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) = 0;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) = 0;
 
   protected:
     void iteratorOpened( QgsAbstractFeatureIterator *it );

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -36,7 +36,6 @@ class QgsVectorLayerFeatureIterator;
 
 /** \ingroup core
  * Partial snapshot of vector layer's state (only the members necessary for access to features)
- * \note not available in Python bindings
 */
 class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
 {
@@ -49,7 +48,7 @@ class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
 
     ~QgsVectorLayerFeatureSource();
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) override;
 
     friend class QgsVectorLayerFeatureIterator;
 

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -25,7 +25,6 @@ SET (AFS_SRCS
 SET (AFS_MOC_HDRS
   qgsarcgisrestutils.h
   qgsafsdataitems.h
-  qgsafsfeatureiterator.h
   qgsafsprovider.h
   qgsafssourceselect.h
 )

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -39,9 +39,7 @@ QgsAfsProvider *QgsAfsFeatureSource::provider() const
 
 QgsAfsFeatureIterator::QgsAfsFeatureIterator( QgsAfsFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsAfsFeatureSource>( source, ownSource, request )
-{
-  mFeatureIterator = 0;
-}
+{}
 
 QgsAfsFeatureIterator::~QgsAfsFeatureIterator()
 {

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.h
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.h
@@ -21,17 +21,13 @@ class QgsAfsProvider;
 class QgsSpatialIndex;
 
 
-class QgsAfsFeatureSource : public QObject, public QgsAbstractFeatureSource
+class QgsAfsFeatureSource : public QgsAbstractFeatureSource
 {
-    Q_OBJECT
 
   public:
     QgsAfsFeatureSource( const QgsAfsProvider *provider );
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
     QgsAfsProvider *provider() const;
-
-  signals:
-    void extentRequested( const QgsRectangle & );
 
   protected:
     QgsAfsProvider *mProvider = nullptr;

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.h
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.h
@@ -47,7 +47,7 @@ class QgsAfsFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsAfs
     bool fetchFeature( QgsFeature &f ) override;
 
   private:
-    QgsFeatureId mFeatureIterator;
+    QgsFeatureId mFeatureIterator = 0;
 };
 
 #endif // QGSAFSFEATUREITERATOR_H

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -32,7 +32,6 @@ QgsDb2FeatureIterator::QgsDb2FeatureIterator( QgsDb2FeatureSource *source, bool 
   : QgsAbstractFeatureIteratorFromSource<QgsDb2FeatureSource>( source, ownSource, request )
 {
   mClosed = false;
-  mFetchCount = 0;
 
   BuildStatement( request );
 
@@ -446,15 +445,14 @@ bool QgsDb2FeatureIterator::close()
 QgsDb2FeatureSource::QgsDb2FeatureSource( const QgsDb2Provider *p )
   : mFields( p->mAttributeFields )
   , mFidColName( p->mFidColName )
+  , mSRId( p->mSRId )
   , mGeometryColName( p->mGeometryColName )
   , mGeometryColType( p->mGeometryColType )
   , mSchemaName( p->mSchemaName )
   , mTableName( p->mTableName )
   , mConnInfo( p->mConnInfo )
   , mSqlWhereClause( p->mSqlWhereClause )
-{
-  mSRId = p->mSRId;
-}
+{}
 
 QgsDb2FeatureSource::~QgsDb2FeatureSource()
 {

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -32,7 +32,6 @@ QgsDb2FeatureIterator::QgsDb2FeatureIterator( QgsDb2FeatureSource *source, bool 
   : QgsAbstractFeatureIteratorFromSource<QgsDb2FeatureSource>( source, ownSource, request )
 {
   mClosed = false;
-  mQuery = nullptr;
   mFetchCount = 0;
 
   BuildStatement( request );
@@ -48,7 +47,7 @@ QgsDb2FeatureIterator::QgsDb2FeatureIterator( QgsDb2FeatureSource *source, bool 
   }
 
   // create sql query
-  mQuery = new QSqlQuery( mDatabase );
+  mQuery.reset( new QSqlQuery( mDatabase ) );
 
   // start selection
   rewind();
@@ -428,7 +427,7 @@ bool QgsDb2FeatureIterator::close()
     {
       mQuery->finish();
     }
-    delete mQuery;
+    mQuery.reset();
   }
 
   if ( mDatabase.isOpen() )

--- a/src/providers/db2/qgsdb2featureiterator.h
+++ b/src/providers/db2/qgsdb2featureiterator.h
@@ -34,7 +34,7 @@ class QgsDb2FeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
     QgsFields mFields;
     QString mFidColName;
     long mSRId;

--- a/src/providers/db2/qgsdb2featureiterator.h
+++ b/src/providers/db2/qgsdb2featureiterator.h
@@ -99,7 +99,7 @@ class QgsDb2FeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsDb2
     bool mExpressionCompiled;
     bool mOrderByCompiled;
 
-    int mFetchCount;
+    int mFetchCount = 0;
 };
 
 #endif // QGSDB2FEATUREITERATOR_H

--- a/src/providers/db2/qgsdb2featureiterator.h
+++ b/src/providers/db2/qgsdb2featureiterator.h
@@ -85,7 +85,7 @@ class QgsDb2FeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsDb2
     QString mOrderByClause;
 
     // The current sql query
-    QSqlQuery *mQuery = nullptr;
+    std::unique_ptr< QSqlQuery > mQuery;
 
     // The current sql statement
     QString mStatement;

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -28,8 +28,7 @@
 
 QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTextFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsDelimitedTextFeatureSource>( source, ownSource, request )
-  , mNextId( 0 )
-  , mTestGeometryExact( false )
+  , mTestSubset( mSource->mSubsetExpression )
 {
 
   // Determine mode to use based on request...
@@ -38,14 +37,6 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   // Does the layer have geometry - will revise later to determine if we actually need to
   // load it.
   bool hasGeometry = mSource->mGeomRep != QgsDelimitedTextProvider::GeomNone;
-
-  // Does the layer have an explicit or implicit subset (implicit subset is if we have geometry which can
-  // be invalid)
-
-  mTestSubset = mSource->mSubsetExpression;
-  mTestGeometry = false;
-
-  mMode = FileScan;
 
   if ( !request.filterRect().isNull() && hasGeometry )
   {

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -271,7 +271,7 @@ bool QgsDelimitedTextFeatureIterator::nextFeatureInternal( QgsFeature &feature )
 {
   QStringList tokens;
 
-  QgsDelimitedTextFile *file = mSource->mFile;
+  QgsDelimitedTextFile *file = mSource->mFile.get();
 
   // If the iterator is not scanning the file, then it will have requested a specific
   // record, so only need to load that one.
@@ -506,7 +506,7 @@ QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimited
     url.removeQueryItem( QStringLiteral( "watchFile" ) );
   }
 
-  mFile = new QgsDelimitedTextFile();
+  mFile.reset( new QgsDelimitedTextFile() );
   mFile->setFromUrl( url );
 
   mExpressionContext << QgsExpressionContextUtils::globalScope()
@@ -517,8 +517,6 @@ QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimited
 QgsDelimitedTextFeatureSource::~QgsDelimitedTextFeatureSource()
 {
   delete mSubsetExpression;
-  delete mSpatialIndex;
-  delete mFile;
 }
 
 QgsFeatureIterator QgsDelimitedTextFeatureSource::getFeatures( const QgsFeatureRequest &request )

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -30,7 +30,7 @@ class QgsDelimitedTextFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
     QgsDelimitedTextProvider::GeomRepresentationType mGeomRep;
     QgsExpression *mSubsetExpression = nullptr;
     QgsExpressionContext mExpressionContext;
@@ -77,6 +77,8 @@ class QgsDelimitedTextFeatureIterator : public QgsAbstractFeatureIteratorFromSou
 
   protected:
     virtual bool fetchFeature( QgsFeature &feature ) override;
+
+  private:
 
     bool setNextFeatureId( qint64 fid );
 

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -88,12 +88,12 @@ class QgsDelimitedTextFeatureIterator : public QgsAbstractFeatureIteratorFromSou
     void fetchAttribute( QgsFeature &feature, int fieldIdx, const QStringList &tokens );
 
     QList<QgsFeatureId> mFeatureIds;
-    IteratorMode mMode;
-    long mNextId;
-    bool mTestSubset;
-    bool mTestGeometry;
-    bool mTestGeometryExact;
-    bool mLoadGeometry;
+    IteratorMode mMode = FileScan;
+    long mNextId = 0;
+    bool mTestSubset = false;
+    bool mTestGeometry = false;
+    bool mTestGeometryExact = false;
+    bool mLoadGeometry = false;
 };
 
 

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -36,10 +36,10 @@ class QgsDelimitedTextFeatureSource : public QgsAbstractFeatureSource
     QgsExpressionContext mExpressionContext;
     QgsRectangle mExtent;
     bool mUseSpatialIndex;
-    QgsSpatialIndex *mSpatialIndex = nullptr;
+    std::unique_ptr< QgsSpatialIndex > mSpatialIndex;
     bool mUseSubsetIndex;
     QList<quintptr> mSubsetIndex;
-    QgsDelimitedTextFile *mFile = nullptr;
+    std::unique_ptr< QgsDelimitedTextFile > mFile;
     QgsFields mFields;
     int mFieldCount;  // Note: this includes field count for wkt field
     int mXFieldIndex;

--- a/src/providers/gpx/qgsgpxfeatureiterator.cpp
+++ b/src/providers/gpx/qgsgpxfeatureiterator.cpp
@@ -27,7 +27,6 @@
 
 QgsGPXFeatureIterator::QgsGPXFeatureIterator( QgsGPXFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsGPXFeatureSource>( source, ownSource, request )
-  , mFetchedFid( false )
 {
   rewind();
 }

--- a/src/providers/gpx/qgsgpxfeatureiterator.h
+++ b/src/providers/gpx/qgsgpxfeatureiterator.h
@@ -31,7 +31,7 @@ class QgsGPXFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
     QString mFileName;
     QgsGPXProvider::DataType mFeatureType;
     QgsGPSData *data = nullptr;
@@ -56,6 +56,8 @@ class QgsGPXFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsGPX
 
     virtual bool fetchFeature( QgsFeature &feature ) override;
 
+  private:
+
     bool readFid( QgsFeature &feature );
 
     bool readWaypoint( const QgsWaypoint &wpt, QgsFeature &feature );
@@ -69,8 +71,6 @@ class QgsGPXFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsGPX
     void readAttributes( QgsFeature &feature, const QgsWaypoint &wpt );
     void readAttributes( QgsFeature &feature, const QgsRoute &rte );
     void readAttributes( QgsFeature &feature, const QgsTrack &trk );
-
-  protected:
 
     //! Current waypoint iterator
     QgsGPSData::WaypointIterator mWptIter;

--- a/src/providers/gpx/qgsgpxfeatureiterator.h
+++ b/src/providers/gpx/qgsgpxfeatureiterator.h
@@ -79,7 +79,7 @@ class QgsGPXFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsGPX
     //! Current track iterator
     QgsGPSData::TrackIterator mTrkIter;
 
-    bool mFetchedFid;
+    bool mFetchedFid = false;
 };
 
 #endif // QGSGPXFEATUREITERATOR_H

--- a/src/providers/grass/qgsgrassfeatureiterator.cpp
+++ b/src/providers/grass/qgsgrassfeatureiterator.cpp
@@ -69,9 +69,6 @@ void copy_boxlist_and_destroy( struct boxlist *blist, struct ilist *list )
 
 QgsGrassFeatureIterator::QgsGrassFeatureIterator( QgsGrassFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsGrassFeatureSource>( source, ownSource, request )
-  , mCanceled( false )
-  , mNextCidx( 0 )
-  , mNextLid( 1 )
 {
 
   // WARNING: the iterater cannot use mutex lock for its whole life, because QgsVectorLayerFeatureIterator is opening

--- a/src/providers/grass/qgsgrassfeatureiterator.h
+++ b/src/providers/grass/qgsgrassfeatureiterator.h
@@ -32,7 +32,7 @@ class GRASS_LIB_EXPORT QgsGrassFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
 #if 0
     enum Selection
     {
@@ -79,19 +79,24 @@ class GRASS_LIB_EXPORT QgsGrassFeatureIterator : public QObject, public QgsAbstr
     virtual bool rewind() override;
     virtual bool close() override;
 
-    // create QgsFeatureId from GRASS geometry object id, cat and layer number (editing)
-    static QgsFeatureId makeFeatureId( int grassId, int cat, int layer = 0 );
-
-    // Get layer number from QGIS fid
-    static int layerFromFid( QgsFeatureId fid );
-
-    // Get GRASS line id from QGIS fid
+    /**
+     * Get GRASS line id from a QGIS \a fid.
+     */
     static int lidFromFid( QgsFeatureId fid );
 
-    // Get GRASS cat from QGIS fid
+    /**
+     * Get GRASS cat from QGIS \a fid.
+     */
     static int catFromFid( QgsFeatureId fid );
 
-    // get attribute value to be used in different layer when it is edited
+    /**
+     * Get layer number from QGIS \a fid.
+     */
+    static int layerFromFid( QgsFeatureId fid );
+
+    /**
+     * Get attribute value to be used in different layer when it is edited.
+     */
     static QVariant nonEditableValue( int layerNumber );
 
   public slots:
@@ -102,7 +107,11 @@ class GRASS_LIB_EXPORT QgsGrassFeatureIterator : public QObject, public QgsAbstr
 
     void doClose();
 
-  protected:
+  private:
+
+    // create QgsFeatureId from GRASS geometry object id, cat and layer number (editing)
+    static QgsFeatureId makeFeatureId( int grassId, int cat, int layer = 0 );
+
     //void lock();
     //void unlock();
 

--- a/src/providers/grass/qgsgrassfeatureiterator.h
+++ b/src/providers/grass/qgsgrassfeatureiterator.h
@@ -136,18 +136,16 @@ class GRASS_LIB_EXPORT QgsGrassFeatureIterator : public QObject, public QgsAbstr
     void setFeatureAttributes( int cat, QgsFeature *feature, const QgsAttributeList &attlist, QgsGrassVectorMap::TopoSymbol symbol );
 
     //! Canceled -> close when possible
-    bool mCanceled;
+    bool mCanceled = false;
 
     //! Selection array
     QBitArray mSelection; // !UPDATE!
 
     // Edit mode is using mNextLid + mNextCidx
     // Next index in cidxFieldIndex to be read in standard mode or next index of line Cats in editing mode
-    int mNextCidx;
+    int mNextCidx = 0;
     // Next topology line/node id to be read in topo mode or next line id in edit mode, starts from 1
-    int mNextLid;
-
-
+    int mNextLid = 1;
 
     static QMutex sMutex;
 };

--- a/src/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -221,11 +221,6 @@ QgsMemoryFeatureSource::QgsMemoryFeatureSource( const QgsMemoryProvider *p )
   mExpressionContext.setFields( mFields );
 }
 
-QgsMemoryFeatureSource::~QgsMemoryFeatureSource()
-{
-  delete mSpatialIndex;
-}
-
 QgsFeatureIterator QgsMemoryFeatureSource::getFeatures( const QgsFeatureRequest &request )
 {
   return QgsFeatureIterator( new QgsMemoryFeatureIterator( this, false, request ) );

--- a/src/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -25,8 +25,6 @@
 
 QgsMemoryFeatureIterator::QgsMemoryFeatureIterator( QgsMemoryFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsMemoryFeatureSource>( source, ownSource, request )
-  , mSelectRectGeom( nullptr )
-  , mSubsetExpression( nullptr )
 {
   if ( !mSource->mSubsetString.isEmpty() )
   {

--- a/src/providers/memory/qgsmemoryfeatureiterator.h
+++ b/src/providers/memory/qgsmemoryfeatureiterator.h
@@ -31,14 +31,13 @@ class QgsMemoryFeatureSource : public QgsAbstractFeatureSource
 {
   public:
     explicit QgsMemoryFeatureSource( const QgsMemoryProvider *p );
-    ~QgsMemoryFeatureSource();
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
   private:
     QgsFields mFields;
     QgsFeatureMap mFeatures;
-    QgsSpatialIndex *mSpatialIndex = nullptr;
+    std::unique_ptr< QgsSpatialIndex > mSpatialIndex;
     QString mSubsetString;
     QgsExpressionContext mExpressionContext;
 

--- a/src/providers/memory/qgsmemoryfeatureiterator.h
+++ b/src/providers/memory/qgsmemoryfeatureiterator.h
@@ -35,7 +35,7 @@ class QgsMemoryFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
     QgsFields mFields;
     QgsFeatureMap mFeatures;
     QgsSpatialIndex *mSpatialIndex = nullptr;
@@ -60,6 +60,7 @@ class QgsMemoryFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Qgs
 
     virtual bool fetchFeature( QgsFeature &feature ) override;
 
+  private:
     bool nextFeatureUsingList( QgsFeature &feature );
     bool nextFeatureTraverseAll( QgsFeature &feature );
 

--- a/src/providers/memory/qgsmemoryfeatureiterator.h
+++ b/src/providers/memory/qgsmemoryfeatureiterator.h
@@ -65,7 +65,7 @@ class QgsMemoryFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Qgs
 
     QgsGeometry mSelectRectGeom;
     QgsFeatureMap::const_iterator mSelectIterator;
-    bool mUsingFeatureIdList;
+    bool mUsingFeatureIdList = false;
     QList<QgsFeatureId> mFeatureIdList;
     QList<QgsFeatureId>::const_iterator mFeatureIdListIterator;
     QgsExpression *mSubsetExpression = nullptr;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -32,7 +32,6 @@ QgsMssqlFeatureIterator::QgsMssqlFeatureIterator( QgsMssqlFeatureSource *source,
   , mOrderByCompiled( false )
 {
   mClosed = false;
-  mQuery = nullptr;
 
   mParser.IsGeography = mSource->mIsGeography;
 
@@ -49,7 +48,7 @@ QgsMssqlFeatureIterator::QgsMssqlFeatureIterator( QgsMssqlFeatureSource *source,
   }
 
   // create sql query
-  mQuery = new QSqlQuery( mDatabase );
+  mQuery.reset( new QSqlQuery( mDatabase ) );
 
   // start selection
   rewind();
@@ -399,8 +398,7 @@ bool QgsMssqlFeatureIterator::rewind()
   if ( !result )
   {
     QgsDebugMsg( mQuery->lastError().text() );
-    delete mQuery;
-    mQuery = nullptr;
+    mQuery.reset();
     if ( mDatabase.isOpen() )
       mDatabase.close();
 
@@ -429,11 +427,7 @@ bool QgsMssqlFeatureIterator::close()
     mQuery->finish();
   }
 
-  if ( mQuery )
-  {
-    delete mQuery;
-    mQuery = nullptr;
-  }
+  mQuery.reset();
 
   if ( mDatabase.isOpen() )
     mDatabase.close();

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -28,8 +28,6 @@
 
 QgsMssqlFeatureIterator::QgsMssqlFeatureIterator( QgsMssqlFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsMssqlFeatureSource>( source, ownSource, request )
-  , mExpressionCompiled( false )
-  , mOrderByCompiled( false )
 {
   mClosed = false;
 
@@ -443,6 +441,8 @@ bool QgsMssqlFeatureIterator::close()
 QgsMssqlFeatureSource::QgsMssqlFeatureSource( const QgsMssqlProvider *p )
   : mFields( p->mAttributeFields )
   , mFidColName( p->mFidColName )
+  , mSRId( p->mSRId )
+  , mIsGeography( p->mParser.IsGeography )
   , mGeometryColName( p->mGeometryColName )
   , mGeometryColType( p->mGeometryColType )
   , mSchemaName( p->mSchemaName )
@@ -453,10 +453,7 @@ QgsMssqlFeatureSource::QgsMssqlFeatureSource( const QgsMssqlProvider *p )
   , mDatabaseName( p->mDatabaseName )
   , mHost( p->mHost )
   , mSqlWhereClause( p->mSqlWhereClause )
-{
-  mSRId = p->mSRId;
-  mIsGeography = p->mParser.IsGeography;
-}
+{}
 
 QgsFeatureIterator QgsMssqlFeatureSource::getFeatures( const QgsFeatureRequest &request )
 {

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -95,7 +95,7 @@ class QgsMssqlFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsM
     QSqlDatabase mDatabase;
 
     // The current sql query
-    QSqlQuery *mQuery = nullptr;
+    std::unique_ptr< QSqlQuery > mQuery;
 
     // The current sql statement
     QString mStatement;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -34,7 +34,7 @@ class QgsMssqlFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
     QgsFields mFields;
     QString mFidColName;
     long mSRId;
@@ -79,10 +79,13 @@ class QgsMssqlFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsM
     virtual bool close() override;
 
   protected:
-    void BuildStatement( const QgsFeatureRequest &request );
 
     virtual bool fetchFeature( QgsFeature &feature ) override;
     bool nextFeatureFilterExpression( QgsFeature &f ) override;
+
+  private:
+    void BuildStatement( const QgsFeatureRequest &request );
+
 
   private:
 

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -40,7 +40,7 @@ class QgsMssqlFeatureSource : public QgsAbstractFeatureSource
     long mSRId;
 
     /* sql geo type */
-    bool mIsGeography;
+    bool mIsGeography = false;
 
     QString mGeometryColName;
     QString mGeometryColType;
@@ -104,7 +104,7 @@ class QgsMssqlFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsM
     QString mFallbackStatement;
 
     // Field index of FID column
-    long mFidCol;
+    long mFidCol = -1;
 
     // List of attribute indices to fetch with nextFeature calls
     QgsAttributeList mAttributesToFetch;
@@ -112,8 +112,8 @@ class QgsMssqlFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsM
     // for parsing sql geometries
     QgsMssqlGeometryParser mParser;
 
-    bool mExpressionCompiled;
-    bool mOrderByCompiled;
+    bool mExpressionCompiled = false;
+    bool mOrderByCompiled = false;
 };
 
 #endif // QGSMSSQLFEATUREITERATOR_H

--- a/src/providers/ogr/qgsogrexpressioncompiler.cpp
+++ b/src/providers/ogr/qgsogrexpressioncompiler.cpp
@@ -86,7 +86,7 @@ QgsSqlExpressionCompiler::Result QgsOgrExpressionCompiler::compileNode( const Qg
 
 QString QgsOgrExpressionCompiler::quotedIdentifier( const QString &identifier )
 {
-  return mSource->mProvider->quotedIdentifier( identifier.toUtf8() );
+  return QgsOgrProviderUtils::quotedIdentifier( identifier.toUtf8(), mSource->mDriverName );
 }
 
 QString QgsOgrExpressionCompiler::quotedValue( const QVariant &value, bool &ok )

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -353,18 +353,18 @@ bool QgsOgrFeatureIterator::readFeature( OGRFeatureH fet, QgsFeature &feature ) 
 
 
 QgsOgrFeatureSource::QgsOgrFeatureSource( const QgsOgrProvider *p )
+  : mDataSource( p->dataSourceUri() )
+  , mLayerName( p->layerName() )
+  , mLayerIndex( p->layerIndex() )
+  , mSubsetString( p->mSubsetString )
+  , mEncoding( p->textEncoding() ) // no copying - this is a borrowed pointer from Qt
+  , mFields( p->mAttributeFields )
+  , mFirstFieldIsFid( p->mFirstFieldIsFid )
+  , mOgrGeometryTypeFilter( QgsOgrProvider::ogrWkbSingleFlatten( p->mOgrGeometryTypeFilter ) )
+  , mDriverName( p->ogrDriverName )
 {
-  mDataSource = p->dataSourceUri();
-  mLayerName = p->layerName();
-  mLayerIndex = p->layerIndex();
-  mSubsetString = p->mSubsetString;
-  mEncoding = p->textEncoding(); // no copying - this is a borrowed pointer from Qt
-  mFields = p->mAttributeFields;
   for ( int i = ( p->mFirstFieldIsFid ) ? 1 : 0; i < mFields.size(); i++ )
     mFieldsWithoutFid.append( mFields.at( i ) );
-  mDriverName = p->ogrDriverName;
-  mFirstFieldIsFid = p->mFirstFieldIsFid;
-  mOgrGeometryTypeFilter = QgsOgrProvider::ogrWkbSingleFlatten( p->mOgrGeometryTypeFilter );
   QgsOgrConnPool::instance()->ref( mDataSource );
 }
 

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -47,7 +47,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   , mFilterFids( mRequest.filterFids() )
   , mFilterFidsIt( mFilterFids.constBegin() )
 {
-  mConn = QgsOgrConnPool::instance()->acquireConnection( mSource->mProvider->dataSourceUri() );
+  mConn = QgsOgrConnPool::instance()->acquireConnection( mSource->mDataSource );
   if ( !mConn->ds )
   {
     return;
@@ -353,7 +353,6 @@ bool QgsOgrFeatureIterator::readFeature( OGRFeatureH fet, QgsFeature &feature ) 
 
 
 QgsOgrFeatureSource::QgsOgrFeatureSource( const QgsOgrProvider *p )
-  : mProvider( p )
 {
   mDataSource = p->dataSourceUri();
   mLayerName = p->layerName();

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -38,7 +38,6 @@
 
 QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsOgrFeatureSource>( source, ownSource, request )
-  , mFeatureFetched( false )
   , mConn( nullptr )
   , ogrLayer( nullptr )
   , mSubsetStringSet( false )

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -69,8 +69,6 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
     //! Get an attribute associated with a feature
     void getFeatureAttribute( OGRFeatureH ogrFet, QgsFeature &f, int attindex ) const;
 
-    bool mFeatureFetched;
-
     QgsOgrConn *mConn = nullptr;
     OGRLayerH ogrLayer;
 

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -33,7 +33,6 @@ class QgsOgrFeatureSource : public QgsAbstractFeatureSource
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
   protected:
-    const QgsOgrProvider *mProvider = nullptr;
     QString mDataSource;
     QString mLayerName;
     int mLayerIndex;

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -32,7 +32,7 @@ class QgsOgrFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
     QString mDataSource;
     QString mLayerName;
     int mLayerIndex;
@@ -62,6 +62,8 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
     virtual bool fetchFeature( QgsFeature &feature ) override;
     bool nextFeatureFilterExpression( QgsFeature &f ) override;
 
+  private:
+
     bool readFeature( OGRFeatureH fet, QgsFeature &feature ) const;
 
     //! Get an attribute associated with a feature
@@ -77,7 +79,6 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
     //! Set to true, if geometry is in the requested columns
     bool mFetchGeometry;
 
-  private:
     bool mExpressionCompiled;
     QgsFeatureIds mFilterFids;
     QgsFeatureIds::const_iterator mFilterFidsIt;

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -799,6 +799,7 @@ void QgsPostgresFeatureIterator::getFeatureAttribute( int idx, QgsPostgresResult
 QgsPostgresFeatureSource::QgsPostgresFeatureSource( const QgsPostgresProvider *p )
   : mConnInfo( p->mUri.connectionInfo( false ) )
   , mGeometryColumn( p->mGeometryColumn )
+  , mSqlWhereClause( p->filterWhereClause() )
   , mFields( p->mAttributeFields )
   , mSpatialColType( p->mSpatialColType )
   , mRequestedSrid( p->mRequestedSrid )
@@ -811,8 +812,6 @@ QgsPostgresFeatureSource::QgsPostgresFeatureSource( const QgsPostgresProvider *p
   , mQuery( p->mQuery )
   , mShared( p->mShared )
 {
-  mSqlWhereClause = p->filterWhereClause();
-
   if ( mSqlWhereClause.startsWith( QLatin1String( " WHERE " ) ) )
     mSqlWhereClause = mSqlWhereClause.mid( 7 );
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -34,7 +34,7 @@ class QgsPostgresFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
 
     QString mConnInfo;
 
@@ -83,6 +83,8 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
     bool nextFeatureFilterExpression( QgsFeature &f ) override;
     virtual bool prepareSimplification( const QgsSimplifyMethod &simplifyMethod ) override;
 
+  private:
+
     QgsPostgresConn *mConn = nullptr;
 
 
@@ -110,7 +112,6 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
 
     bool mIsTransactionConnection;
 
-  private:
     virtual bool providerCanSimplify( QgsSimplifyMethod::MethodType methodType ) const override;
 
     virtual bool prepareOrderBy( const QList<QgsFeatureRequest::OrderByClause> &orderBys ) override;

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -34,7 +34,7 @@ class QgsSpatiaLiteFeatureSource : public QgsAbstractFeatureSource
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
     QString mGeometryColumn;
     QString mSubsetString;
     QgsFields mFields;
@@ -67,6 +67,8 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIteratorFromSource
     virtual bool fetchFeature( QgsFeature &feature ) override;
     bool nextFeatureFilterExpression( QgsFeature &f ) override;
 
+  private:
+
     QString whereClauseRect();
     QString whereClauseFid();
     QString whereClauseFids();
@@ -95,7 +97,6 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIteratorFromSource
     bool mHasPrimaryKey;
     QgsFeatureId mRowNumber;
 
-  private:
     bool prepareOrderBy( const QList<QgsFeatureRequest::OrderByClause> &orderBys ) override;
 
     bool mOrderByCompiled;

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -29,43 +29,52 @@ static QString quotedColumn( QString name )
 QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsVirtualLayerFeatureSource>( source, ownSource, request )
 {
+
+  // NOTE: this is really bad and should be removed.
+  // it's only here to guard mSource->mSqlite - because if the provider is removed
+  // then mSqlite will be meaningless.
+  // this needs to be totally reworked so that mSqlite no longer depends on the provider
+  // and can be fully encapsulated in the source
+  if ( !mSource->mProvider )
+  {
+    close();
+    return;
+  }
+
   try
   {
-    mSqlite = mSource->provider()->mSqlite.get();
-    mDefinition = mSource->provider()->mDefinition;
-
-    QString tableName = mSource->provider()->mTableName;
+    QString tableName = mSource->mTableName;
 
     QStringList wheres;
-    QString subset = mSource->provider()->mSubset;
+    QString subset = mSource->mSubset;
     if ( !subset.isNull() )
     {
       wheres << subset;
     }
 
-    if ( !mDefinition.uid().isNull() )
+    if ( !mSource->mDefinition.uid().isNull() )
     {
       // filters are only available when a column with unique id exists
-      if ( mDefinition.hasDefinedGeometry() && !request.filterRect().isNull() )
+      if ( mSource->mDefinition.hasDefinedGeometry() && !request.filterRect().isNull() )
       {
         bool do_exact = request.flags() & QgsFeatureRequest::ExactIntersect;
         QgsRectangle rect( request.filterRect() );
         QString mbr = QStringLiteral( "%1,%2,%3,%4" ).arg( rect.xMinimum() ).arg( rect.yMinimum() ).arg( rect.xMaximum() ).arg( rect.yMaximum() );
-        wheres << quotedColumn( mDefinition.geometryField() ) + " is not null";
+        wheres << quotedColumn( mSource->mDefinition.geometryField() ) + " is not null";
         wheres <<  QStringLiteral( "%1Intersects(%2,BuildMbr(%3))" )
                .arg( do_exact ? "" : "Mbr",
-                     quotedColumn( mDefinition.geometryField() ),
+                     quotedColumn( mSource->mDefinition.geometryField() ),
                      mbr );
       }
       else if ( request.filterType() == QgsFeatureRequest::FilterFid )
       {
         wheres << QStringLiteral( "%1=%2" )
-               .arg( quotedColumn( mDefinition.uid() ) )
+               .arg( quotedColumn( mSource->mDefinition.uid() ) )
                .arg( request.filterFid() );
       }
       else if ( request.filterType() == QgsFeatureRequest::FilterFids )
       {
-        QString values = quotedColumn( mDefinition.uid() ) + " IN (";
+        QString values = quotedColumn( mSource->mDefinition.uid() ) + " IN (";
         bool first = true;
         Q_FOREACH ( QgsFeatureId v, request.filterFids() )
         {
@@ -81,7 +90,6 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
       }
     }
 
-    mFields = mSource->provider()->fields();
     if ( request.flags() & QgsFeatureRequest::SubsetOfAttributes )
     {
       // copy only selected fields
@@ -95,7 +103,7 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
       {
         Q_FOREACH ( const QString &field, request.filterExpression()->referencedColumns() )
         {
-          int attrIdx = mFields.lookupField( field );
+          int attrIdx = mSource->mFields.lookupField( field );
           if ( !mAttributes.contains( attrIdx ) )
             mAttributes << attrIdx;
         }
@@ -103,15 +111,15 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
     }
     else
     {
-      mAttributes = mFields.allAttributesList();
+      mAttributes = mSource->mFields.allAttributesList();
     }
 
     QString columns;
     {
       // the first column is always the uid (or 0)
-      if ( !mDefinition.uid().isNull() )
+      if ( !mSource->mDefinition.uid().isNull() )
       {
-        columns = quotedColumn( mDefinition.uid() );
+        columns = quotedColumn( mSource->mDefinition.uid() );
       }
       else
       {
@@ -120,16 +128,16 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
       Q_FOREACH ( int i, mAttributes )
       {
         columns += QLatin1String( "," );
-        QString cname = mFields.at( i ).name().toLower();
+        QString cname = mSource->mFields.at( i ).name().toLower();
         columns += quotedColumn( cname );
       }
     }
     // the last column is the geometry, if any
     if ( ( !( request.flags() & QgsFeatureRequest::NoGeometry )
            || ( request.filterType() == QgsFeatureRequest::FilterExpression && request.filterExpression()->needsGeometry() ) )
-         && !mDefinition.geometryField().isNull() && mDefinition.geometryField() != QLatin1String( "*no*" ) )
+         && !mSource->mDefinition.geometryField().isNull() && mSource->mDefinition.geometryField() != QLatin1String( "*no*" ) )
     {
-      columns += "," + quotedColumn( mDefinition.geometryField() );
+      columns += "," + quotedColumn( mSource->mDefinition.geometryField() );
     }
 
     mSqlQuery = "SELECT " + columns + " FROM " + tableName;
@@ -138,7 +146,7 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
       mSqlQuery += " WHERE " + wheres.join( QStringLiteral( " AND " ) );
     }
 
-    mQuery.reset( new Sqlite::Query( mSqlite, mSqlQuery ) );
+    mQuery.reset( new Sqlite::Query( mSource->mSqlite, mSqlQuery ) );
 
     mFid = 0;
   }
@@ -193,9 +201,9 @@ bool QgsVirtualLayerFeatureIterator::fetchFeature( QgsFeature &feature )
     return false;
   }
 
-  feature.setFields( mFields, /* init */ true );
+  feature.setFields( mSource->mFields, /* init */ true );
 
-  if ( mDefinition.uid().isNull() )
+  if ( mSource->mDefinition.uid().isNull() )
   {
     // no id column => autoincrement
     feature.setId( mFid++ );
@@ -246,6 +254,11 @@ bool QgsVirtualLayerFeatureIterator::fetchFeature( QgsFeature &feature )
 
 QgsVirtualLayerFeatureSource::QgsVirtualLayerFeatureSource( const QgsVirtualLayerProvider *p )
   : mProvider( p )
+  , mDefinition( p->mDefinition )
+  , mFields( p->fields() )
+  , mSqlite( p->mSqlite.get() )
+  , mTableName( p->mTableName )
+  , mSubset( p->mSubset )
 {
 }
 

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -262,10 +262,6 @@ QgsVirtualLayerFeatureSource::QgsVirtualLayerFeatureSource( const QgsVirtualLaye
 {
 }
 
-QgsVirtualLayerFeatureSource::~QgsVirtualLayerFeatureSource()
-{
-}
-
 QgsFeatureIterator QgsVirtualLayerFeatureSource::getFeatures( const QgsFeatureRequest &request )
 {
   return QgsFeatureIterator( new QgsVirtualLayerFeatureIterator( this, false, request ) );

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
@@ -27,7 +27,6 @@ class QgsVirtualLayerFeatureSource : public QgsAbstractFeatureSource
 {
   public:
     QgsVirtualLayerFeatureSource( const QgsVirtualLayerProvider *p );
-    ~QgsVirtualLayerFeatureSource();
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
@@ -63,6 +63,8 @@ class QgsVirtualLayerFeatureIterator : public QgsAbstractFeatureIteratorFromSour
 
     virtual bool fetchFeature( QgsFeature &feature ) override;
 
+  private:
+
     std::unique_ptr<Sqlite::Query> mQuery;
 
     QgsAttributeList mAttributes;

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -113,7 +113,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     bool createIt();
     bool loadSourceLayers();
 
-    friend class QgsVirtualLayerFeatureIterator;
+    friend class QgsVirtualLayerFeatureSource;
 
   private slots:
     void invalidateStatistics();

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -255,7 +255,7 @@ class QgsWFSFeatureSource : public QgsAbstractFeatureSource
 
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
 
-  protected:
+  private:
 
     std::shared_ptr<QgsWFSSharedData> mShared;  //!< Mutable data shared between provider and feature sources
 


### PR DESCRIPTION
There's some bad behaviour in QgsOgrFeatureSource where the provider is stored and accessed in the feature source. This causes a crash if the layer is removed when a source has been created for it.

I.e. when removing a layer while a background map render is relying on it.

I've also added a test to the provider conformance suite to guard against this... let's see if any other providers have the same issue...