### PR TITLE
Add QgsCrashHandler for single place for all platforms

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -181,6 +181,7 @@ SET(QGIS_APP_SRCS
   qgssettingstree.cpp
   qgsvariantdelegate.cpp
   qgscrashdialog.cpp
+  qgscrashhandler.cpp
 )
 
 SET (QGIS_APP_MOC_HDRS

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -96,6 +96,7 @@ typedef SInt32 SRefCon;
 #include "qgsmapthemes.h"
 #include "qgsvectorlayer.h"
 #include "qgis_app.h"
+#include "qgscrashhandler.h"
 
 /** Print usage text
  */
@@ -468,7 +469,7 @@ int main( int argc, char *argv[] )
 #endif
 
 #ifdef Q_OS_WIN
-  SetUnhandledExceptionFilter( QgisApp::qgisCrashDump );
+  SetUnhandledExceptionFilter( QgsCrashHandler::handle );
 #endif
 
   // initialize random number seed

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -111,8 +111,8 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 // QGIS Specific Includes
 //
 
-#include "qgscrashdialog.h"
-#include "qgscrashreport.h"
+#include "qgscrashhandler.h"
+
 #include "qgisapp.h"
 #include "qgisappinterface.h"
 #include "qgisappstylesheet.h"
@@ -11753,7 +11753,7 @@ void QgisApp::keyPressEvent( QKeyEvent *e )
 #if defined(Q_OS_WIN) && defined(QGISDEBUG)
   else if ( e->key() == Qt::Key_Backslash && e->modifiers() & Qt::ControlModifier )
   {
-    qgisCrashDump( 0 );
+    QgsCrashHandler::handle( 0 );
   }
 #endif
   else
@@ -12582,112 +12582,3 @@ void QgisApp::transactionGroupCommitError( const QString &error )
 {
   displayMessage( tr( "Transaction" ), error, QgsMessageBar::CRITICAL );
 }
-
-#ifdef Q_OS_WIN
-LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
-{
-  HANDLE process = GetCurrentProcess();
-  // TOOD Pull symbols from symbol server.
-  // TOOD Move this logic to generic stack trace class to handle each
-  // platform.
-  SymInitialize( process, NULL, TRUE );
-
-  // StackWalk64() may modify context record passed to it, so we will
-  // use a copy.
-  CONTEXT context_record = *ExceptionInfo->ContextRecord;
-  // Initialize stack walking.
-  STACKFRAME64 stack_frame;
-  memset( &stack_frame, 0, sizeof( stack_frame ) );
-#if defined(_WIN64)
-  int machine_type = IMAGE_FILE_MACHINE_AMD64;
-  stack_frame.AddrPC.Offset = context_record.Rip;
-  stack_frame.AddrFrame.Offset = context_record.Rbp;
-  stack_frame.AddrStack.Offset = context_record.Rsp;
-#else
-  int machine_type = IMAGE_FILE_MACHINE_I386;
-  stack_frame.AddrPC.Offset = context_record.Eip;
-  stack_frame.AddrFrame.Offset = context_record.Ebp;
-  stack_frame.AddrStack.Offset = context_record.Esp;
-#endif
-  stack_frame.AddrPC.Mode = AddrModeFlat;
-  stack_frame.AddrFrame.Mode = AddrModeFlat;
-  stack_frame.AddrStack.Mode = AddrModeFlat;
-
-  SYMBOL_INFO *symbol = ( SYMBOL_INFO * ) qgsMalloc( sizeof( SYMBOL_INFO ) + MAX_SYM_NAME );
-  symbol->SizeOfStruct = sizeof( SYMBOL_INFO );
-  symbol->MaxNameLen = MAX_SYM_NAME;
-
-  IMAGEHLP_LINE *line = ( IMAGEHLP_LINE * ) qgsMalloc( sizeof( IMAGEHLP_LINE ) );
-  line->SizeOfStruct = sizeof( IMAGEHLP_LINE );
-
-  IMAGEHLP_MODULE *module = ( IMAGEHLP_MODULE * ) qgsMalloc( sizeof( IMAGEHLP_MODULE ) );
-  module->SizeOfStruct = sizeof( IMAGEHLP_MODULE );
-
-  QList<QgsCrashReport::StackLine> stack;
-  while ( StackWalk64( machine_type,
-                       GetCurrentProcess(),
-                       GetCurrentThread(),
-                       &stack_frame,
-                       &context_record,
-                       NULL,
-                       &SymFunctionTableAccess64,
-                       &SymGetModuleBase64,
-                       NULL ) )
-  {
-
-    DWORD64 displacement = 0;
-
-    if ( SymFromAddr( process, ( DWORD64 )stack_frame.AddrPC.Offset, &displacement, symbol ) )
-    {
-      DWORD dwDisplacement;
-      QString fileName;
-      QString lineNumber;
-      QString moduleName;
-      if ( SymGetLineFromAddr( process, ( DWORD )( stack_frame.AddrPC.Offset ), &dwDisplacement, line ) )
-      {
-        fileName = QString( line->FileName );
-        lineNumber = QString::number( line->LineNumber );
-      }
-      else
-      {
-        fileName = "(unknown file)";
-        lineNumber = "(unknown line)";
-      }
-      if ( SymGetModuleInfo( process, ( DWORD )( stack_frame.AddrPC.Offset ), module ) )
-      {
-        moduleName = QString( module->ModuleName );
-      }
-      else
-      {
-        moduleName = "(unknown module)";
-      }
-      QgsCrashReport::StackLine stackline;
-      stackline.ModuleName = moduleName;
-      stackline.FileName = fileName;
-      stackline.LineNumber = lineNumber;
-      stackline.SymbolName = QString( symbol->Name );
-      stack.append( stackline );
-    }
-  }
-
-  qgsFree( symbol );
-  qgsFree( line );
-  qgsFree( module );
-
-  QgsCrashDialog dlg( QApplication::activeWindow() );
-  QgsCrashReport report;
-  report.setStackTrace( stack );
-  dlg.setBugReport( report.toString() );
-  if ( dlg.exec() )
-  {
-    QStringList arguments;
-    arguments = QCoreApplication::arguments();
-    QString path = arguments.at( 0 );
-    arguments.removeFirst();
-    arguments << QgsProject::instance()->fileName();
-    QProcess::startDetached( path, arguments, QDir::toNativeSeparators( QCoreApplication::applicationDirPath() ) );
-  }
-
-  return EXCEPTION_EXECUTE_HANDLER;
-}
-#endif

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -593,10 +593,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! \since QGIS 2.1
     static QString normalizedMenuName( const QString &name ) { return name.normalized( QString::NormalizationForm_KD ).remove( QRegExp( "[^a-zA-Z]" ) ); }
 
-#ifdef Q_OS_WIN
-    static LONG WINAPI qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo );
-#endif
-
     void parseVersionInfo( QNetworkReply *reply, int &latestVersion, QStringList &versionInfo );
 
     //! Register a new tab in the layer properties dialog

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -1,0 +1,143 @@
+/***************************************************************************
+  qgscrashhandler.cpp - QgsCrashHandler
+
+ ---------------------
+ begin                : 23.4.2017
+ copyright            : (C) 2017 by Nathan Woodrow
+ email                : woodrow.nathan@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgscrashhandler.h"
+
+#include <QProcess>
+#include <QDir>
+
+#include "qgsproject.h"
+#include "qgscrashdialog.h"
+#include "qgscrashreport.h"
+
+#ifdef Q_OS_WIN
+LONG WINAPI QgsCrashHandler::handle( struct _EXCEPTION_POINTERS *ExceptionInfo )
+{
+  HANDLE process = GetCurrentProcess();
+  // TOOD Pull symbols from symbol server.
+  // TOOD Move this logic to generic stack trace class to handle each
+  // platform.
+  SymInitialize( process, NULL, TRUE );
+
+  // StackWalk64() may modify context record passed to it, so we will
+  // use a copy.
+  CONTEXT context_record = *ExceptionInfo->ContextRecord;
+  // Initialize stack walking.
+  STACKFRAME64 stack_frame;
+  memset( &stack_frame, 0, sizeof( stack_frame ) );
+#if defined(_WIN64)
+  int machine_type = IMAGE_FILE_MACHINE_AMD64;
+  stack_frame.AddrPC.Offset = context_record.Rip;
+  stack_frame.AddrFrame.Offset = context_record.Rbp;
+  stack_frame.AddrStack.Offset = context_record.Rsp;
+#else
+  int machine_type = IMAGE_FILE_MACHINE_I386;
+  stack_frame.AddrPC.Offset = context_record.Eip;
+  stack_frame.AddrFrame.Offset = context_record.Ebp;
+  stack_frame.AddrStack.Offset = context_record.Esp;
+#endif
+  stack_frame.AddrPC.Mode = AddrModeFlat;
+  stack_frame.AddrFrame.Mode = AddrModeFlat;
+  stack_frame.AddrStack.Mode = AddrModeFlat;
+
+  SYMBOL_INFO *symbol = ( SYMBOL_INFO * ) qgsMalloc( sizeof( SYMBOL_INFO ) + MAX_SYM_NAME );
+  symbol->SizeOfStruct = sizeof( SYMBOL_INFO );
+  symbol->MaxNameLen = MAX_SYM_NAME;
+
+  IMAGEHLP_LINE *line = ( IMAGEHLP_LINE * ) qgsMalloc( sizeof( IMAGEHLP_LINE ) );
+  line->SizeOfStruct = sizeof( IMAGEHLP_LINE );
+
+  IMAGEHLP_MODULE *module = ( IMAGEHLP_MODULE * ) qgsMalloc( sizeof( IMAGEHLP_MODULE ) );
+  module->SizeOfStruct = sizeof( IMAGEHLP_MODULE );
+
+  QList<QgsCrashReport::StackLine> stack;
+  while ( StackWalk64( machine_type,
+                       GetCurrentProcess(),
+                       GetCurrentThread(),
+                       &stack_frame,
+                       &context_record,
+                       NULL,
+                       &SymFunctionTableAccess64,
+                       &SymGetModuleBase64,
+                       NULL ) )
+  {
+
+    DWORD64 displacement = 0;
+
+    if ( SymFromAddr( process, ( DWORD64 )stack_frame.AddrPC.Offset, &displacement, symbol ) )
+    {
+      DWORD dwDisplacement;
+      QString fileName;
+      QString lineNumber;
+      QString moduleName;
+      if ( SymGetLineFromAddr( process, ( DWORD )( stack_frame.AddrPC.Offset ), &dwDisplacement, line ) )
+      {
+        fileName = QString( line->FileName );
+        lineNumber = QString::number( line->LineNumber );
+      }
+      else
+      {
+        fileName = "(unknown file)";
+        lineNumber = "(unknown line)";
+      }
+      if ( SymGetModuleInfo( process, ( DWORD )( stack_frame.AddrPC.Offset ), module ) )
+      {
+        moduleName = QString( module->ModuleName );
+      }
+      else
+      {
+        moduleName = "(unknown module)";
+      }
+      QgsCrashReport::StackLine stackline;
+      stackline.ModuleName = moduleName;
+      stackline.FileName = fileName;
+      stackline.LineNumber = lineNumber;
+      stackline.SymbolName = QString( symbol->Name );
+      stack.append( stackline );
+    }
+  }
+
+  qgsFree( symbol );
+  qgsFree( line );
+  qgsFree( module );
+
+  showCrashDialog( stack );
+
+  return EXCEPTION_EXECUTE_HANDLER;
+}
+
+void QgsCrashHandler::showCrashDialog(const QList<QgsCrashReport::StackLine> &value)
+{
+  QgsCrashDialog dlg( QApplication::activeWindow() );
+  QgsCrashReport report;
+  report.setStackTrace( stack );
+  dlg.setBugReport( report.toString() );
+  if ( dlg.exec() )
+  {
+      restartApplication();
+  }
+}
+
+void QgsCrashHandler::restartApplication()
+{
+    QStringList arguments;
+    arguments = QCoreApplication::arguments();
+    QString path = arguments.at( 0 );
+    arguments.removeFirst();
+    arguments << QgsProject::instance()->fileName();
+    QProcess::startDetached( path, arguments, QDir::toNativeSeparators( QCoreApplication::applicationDirPath() ) );
+
+}
+#endif

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -101,10 +101,10 @@ LONG WINAPI QgsCrashHandler::handle( struct _EXCEPTION_POINTERS *ExceptionInfo )
         moduleName = "(unknown module)";
       }
       QgsCrashReport::StackLine stackline;
-      stackline.ModuleName = moduleName;
-      stackline.FileName = fileName;
-      stackline.LineNumber = lineNumber;
-      stackline.SymbolName = QString( symbol->Name );
+      stackline.moduleName = moduleName;
+      stackline.fileName = fileName;
+      stackline.lineNumber = lineNumber;
+      stackline.symbolName = QString( symbol->Name );
       stack.append( stackline );
     }
   }
@@ -118,7 +118,7 @@ LONG WINAPI QgsCrashHandler::handle( struct _EXCEPTION_POINTERS *ExceptionInfo )
   return EXCEPTION_EXECUTE_HANDLER;
 }
 
-void QgsCrashHandler::showCrashDialog( const QList<QgsCrashReport::StackLine> &value )
+void QgsCrashHandler::showCrashDialog( const QList<QgsCrashReport::StackLine> &stack )
 {
 
   QgsCrashDialog dlg( QApplication::activeWindow() );

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -118,26 +118,27 @@ LONG WINAPI QgsCrashHandler::handle( struct _EXCEPTION_POINTERS *ExceptionInfo )
   return EXCEPTION_EXECUTE_HANDLER;
 }
 
-void QgsCrashHandler::showCrashDialog(const QList<QgsCrashReport::StackLine> &value)
+void QgsCrashHandler::showCrashDialog( const QList<QgsCrashReport::StackLine> &value )
 {
+
   QgsCrashDialog dlg( QApplication::activeWindow() );
   QgsCrashReport report;
   report.setStackTrace( stack );
   dlg.setBugReport( report.toString() );
   if ( dlg.exec() )
   {
-      restartApplication();
+    restartApplication();
   }
 }
 
 void QgsCrashHandler::restartApplication()
 {
-    QStringList arguments;
-    arguments = QCoreApplication::arguments();
-    QString path = arguments.at( 0 );
-    arguments.removeFirst();
-    arguments << QgsProject::instance()->fileName();
-    QProcess::startDetached( path, arguments, QDir::toNativeSeparators( QCoreApplication::applicationDirPath() ) );
+  QStringList arguments;
+  arguments = QCoreApplication::arguments();
+  QString path = arguments.at( 0 );
+  arguments.removeFirst();
+  arguments << QgsProject::instance()->fileName();
+  QProcess::startDetached( path, arguments, QDir::toNativeSeparators( QCoreApplication::applicationDirPath() ) );
 
 }
 #endif

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -31,7 +31,7 @@
 class APP_EXPORT QgsCrashHandler
 {
 
-public:
+  public:
 #ifdef Q_OS_WIN
     static LONG WINAPI handle( struct _EXCEPTION_POINTERS *ExceptionInfo );
 #endif
@@ -48,7 +48,8 @@ public:
      */
     static void restartApplication();
 
-private:
+  private:
+
     /**
      * This class doesn't need to be created by anyone as is only used to handle
      * crashes in the application.

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+  qgscrashhandler.h - QgsCrashHandler
+
+ ---------------------
+ begin                : 23.4.2017
+ copyright            : (C) 2017 by Nathan Woodrow
+ email                : woodrow.nathan@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCRASHHANDLER_H
+#define QGSCRASHHANDLER_H
+
+#include "qgis.h"
+#include "qgis_app.h"
+#include "qgscrashreport.h"
+
+#ifdef WIN32
+#include <windows.h>
+#include <dbghelp.h>
+#endif
+
+/**
+ * Utility object to handle crashes in QGIS.
+ */
+class APP_EXPORT QgsCrashHandler
+{
+
+public:
+#ifdef Q_OS_WIN
+    static LONG WINAPI handle( struct _EXCEPTION_POINTERS *ExceptionInfo );
+#endif
+
+    /**
+     * Show the crash dialog.
+     * @param stack The current stack of the crash point.
+     */
+    static void showCrashDialog( const QList<QgsCrashReport::StackLine> &stack );
+
+    /**
+     * Restart the application.
+     * Restores project and arguments used when application was loaded.
+     */
+    static void restartApplication();
+
+private:
+    /**
+     * This class doesn't need to be created by anyone as is only used to handle
+     * crashes in the application.
+     */
+    QgsCrashHandler() {}
+};
+
+
+#endif // QGSCRASHHANDLER_H

--- a/src/app/qgscrashreport.cpp
+++ b/src/app/qgscrashreport.cpp
@@ -51,9 +51,9 @@ const QString QgsCrashReport::toString() const
     {
       Q_FOREACH ( const QgsCrashReport::StackLine &line, mStackTrace )
       {
-        QFileInfo fileInfo( line.FileName );
+        QFileInfo fileInfo( line.fileName );
         QString filename( fileInfo.fileName() );
-        reportData.append( QString( "(%1) %2 %3:%4" ).arg( line.ModuleName, line.SymbolName, filename, line.LineNumber ) );
+        reportData.append( QString( "(%1) %2 %3:%4" ).arg( line.moduleName, line.symbolName, filename, line.lineNumber ) );
       }
     }
   }
@@ -126,9 +126,9 @@ const QString QgsCrashReport::crashID() const
   // Hashes the full stack.
   Q_FOREACH ( QgsCrashReport::StackLine line, mStackTrace )
   {
-    QFileInfo fileInfo( line.FileName );
+    QFileInfo fileInfo( line.fileName );
     QString filename( fileInfo.fileName() );
-    data += line.ModuleName + line.SymbolName + line.LineNumber + filename;
+    data += line.moduleName + line.symbolName + line.lineNumber + filename;
   }
 
   if ( data.isNull() )
@@ -139,15 +139,15 @@ const QString QgsCrashReport::crashID() const
 
 }
 
-bool QgsCrashReport::StackLine::isQGISModule()
+bool QgsCrashReport::StackLine::isQgisModule() const
 {
-  return ModuleName.toLower().contains( "qgis" );
+  return moduleName.toLower().contains( "qgis" );
 }
 
-bool QgsCrashReport::StackLine::isValid()
+bool QgsCrashReport::StackLine::isValid() const
 {
-  return !( FileName.toLower().contains( "exe_common" ) ||
-            FileName.toLower().contains( "unknown" ) ||
-            LineNumber.toLower().contains( "unknown" ) );
+  return !( fileName.toLower().contains( "exe_common" ) ||
+            fileName.toLower().contains( "unknown" ) ||
+            lineNumber.toLower().contains( "unknown" ) );
 
 }

--- a/src/app/qgscrashreport.h
+++ b/src/app/qgscrashreport.h
@@ -33,23 +33,23 @@ class APP_EXPORT QgsCrashReport
      */
     struct StackLine
     {
-      QString ModuleName;
-      QString SymbolName;
-      QString FileName;
-      QString LineNumber;
+      QString moduleName;
+      QString symbolName;
+      QString fileName;
+      QString lineNumber;
 
       /**
        * Check if this stack line is part of QGIS.
        * \return True if part of QGIS.
        */
-      bool isQGISModule();
+      bool isQgisModule() const;
 
       /**
        * Check if this stack line is valid.  Considered valid when the filename and line
        * number are known.
        * \return True of the line is valid.
        */
-      bool isValid();
+      bool isValid() const;
     };
 
     /**


### PR DESCRIPTION
## Description
Moves the crash handler logic into QgsCrashHandler and out of QGisApp.  I don't have a non-Windows build at the moment so others will need to implement the other platforms to make sure it's handled correctly.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
