### PR TITLE
Block use of the Adwaita themes if we can avoid them

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -29,6 +29,7 @@
 #include <QString>
 #include <QStringList>
 #include <QStyle>
+#include <QStyleFactory>
 #include <QDesktopWidget>
 #include <QTranslator>
 #include <QImageReader>
@@ -954,13 +955,31 @@ int main( int argc, char *argv[] )
 
   // Set the application style.  If it's not set QT will use the platform style except on Windows
   // as it looks really ugly so we use QPlastiqueStyle.
-  QString style = mySettings.value( QStringLiteral( "qgis/style" ) ).toString();
-  if ( !style.isNull() )
+  QString presetStyle = mySettings.value( QStringLiteral( "qgis/style" ) ).toString();
+  QString activeStyleName = presetStyle;
+  if ( activeStyleName.isEmpty() ) // not set, using default style
   {
-    QApplication::setStyle( style );
+    //not set, check default
+    activeStyleName = QApplication::style()->metaObject()->className() ;
+  }
+  if ( activeStyleName.contains( QStringLiteral( "adwaita" ), Qt::CaseInsensitive ) )
+  {
+    //never allow Adwaita themes - the Qt variants of these are VERY broken
+    //for apps like QGIS. E.g. oversized controls like spinbox widgets prevent actually showing
+    //any content in these widgets, leaving a very bad impression of QGIS
+
+    //note... we only do this if there's a known good style available (fusion), as SOME
+    //style choices can cause Qt apps to crash...
+    if ( QStyleFactory::keys().contains( QStringLiteral( "fusion" ), Qt::CaseInsensitive ) )
+    {
+      presetStyle = QStringLiteral( "fusion" );
+    }
+  }
+  if ( !presetStyle.isEmpty() )
+  {
+    QApplication::setStyle( presetStyle );
     mySettings.setValue( QStringLiteral( "qgis/style" ), QApplication::style()->objectName() );
   }
-
   /* Translation file for QGIS.
    */
   QString i18nPath = QgsApplication::i18nPath();

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -101,7 +101,22 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   connect( this, &QDialog::rejected, this, &QgsOptions::rejectOptions );
 
   QStringList styles = QStyleFactory::keys();
-  cmbStyle->addItems( styles );
+  QStringList filteredStyles = styles;
+  for ( int i = filteredStyles.count() - 1; i >= 0; --i )
+  {
+    // filter out the broken adwaita styles - see note in main.cpp
+    if ( filteredStyles.at( i ).contains( QStringLiteral( "adwaita" ), Qt::CaseInsensitive ) )
+    {
+      filteredStyles.removeAt( i );
+    }
+  }
+  if ( filteredStyles.isEmpty() )
+  {
+    //oops - none left!.. have to let user use a broken style
+    filteredStyles = styles;
+  }
+
+  cmbStyle->addItems( filteredStyles );
 
   QStringList themes = QgsApplication::uiThemes().keys();
   cmbUITheme->addItems( themes );


### PR DESCRIPTION
The Qt variants of these GTK themes are VERY broken for apps like QGIS. E.g. oversized controls like
spinbox widgets prevent showing any actual CONTENT in these widgets, leaving a very bad impression of QGIS

Here's what a default QGIS install looks like on Fedora:

![image](https://cloud.githubusercontent.com/assets/1829991/25318585/950890f4-28d5-11e7-8ee7-52dbde3d761e.png)

With this patch Fedora users will instead use the "fusion" theme by default:

![image](https://cloud.githubusercontent.com/assets/1829991/25318594/bbdcc0ce-28d5-11e7-81f1-c14ec69f5aa1.png)


Keeping a consistent DE theme is nice and all, but if it leaves QGIS in an unusable state then it's misguided.




*Blame resides with gnome's obsession with "touch friendly" tablet style widgets
