### PR TITLE
Add QgsStackTrace class

### DIFF
--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -26,14 +26,14 @@
 #ifdef Q_OS_WIN
 LONG WINAPI QgsCrashHandler::handle( struct _EXCEPTION_POINTERS *ExceptionInfo )
 {
-  QVector<QgsStackTrace::StackLine> stack = QgsStackTrace::trace( ExceptionInfo );
+  QgsStackLines stack = QgsStackTrace::trace( ExceptionInfo );
   showCrashDialog( stack );
 
   return EXCEPTION_EXECUTE_HANDLER;
 }
 #endif
 
-void QgsCrashHandler::showCrashDialog( const QVector<QgsStackTrace::StackLine> &stack )
+void QgsCrashHandler::showCrashDialog( const QgsStackLines &stack )
 {
 
   QgsCrashDialog dlg( QApplication::activeWindow() );

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -21,104 +21,19 @@
 #include "qgsproject.h"
 #include "qgscrashdialog.h"
 #include "qgscrashreport.h"
+#include "qgsstacktrace.h"
 
 #ifdef Q_OS_WIN
 LONG WINAPI QgsCrashHandler::handle( struct _EXCEPTION_POINTERS *ExceptionInfo )
 {
-  HANDLE process = GetCurrentProcess();
-  // TOOD Pull symbols from symbol server.
-  // TOOD Move this logic to generic stack trace class to handle each
-  // platform.
-  SymInitialize( process, NULL, TRUE );
-
-  // StackWalk64() may modify context record passed to it, so we will
-  // use a copy.
-  CONTEXT context_record = *ExceptionInfo->ContextRecord;
-  // Initialize stack walking.
-  STACKFRAME64 stack_frame;
-  memset( &stack_frame, 0, sizeof( stack_frame ) );
-#if defined(_WIN64)
-  int machine_type = IMAGE_FILE_MACHINE_AMD64;
-  stack_frame.AddrPC.Offset = context_record.Rip;
-  stack_frame.AddrFrame.Offset = context_record.Rbp;
-  stack_frame.AddrStack.Offset = context_record.Rsp;
-#else
-  int machine_type = IMAGE_FILE_MACHINE_I386;
-  stack_frame.AddrPC.Offset = context_record.Eip;
-  stack_frame.AddrFrame.Offset = context_record.Ebp;
-  stack_frame.AddrStack.Offset = context_record.Esp;
-#endif
-  stack_frame.AddrPC.Mode = AddrModeFlat;
-  stack_frame.AddrFrame.Mode = AddrModeFlat;
-  stack_frame.AddrStack.Mode = AddrModeFlat;
-
-  SYMBOL_INFO *symbol = ( SYMBOL_INFO * ) qgsMalloc( sizeof( SYMBOL_INFO ) + MAX_SYM_NAME );
-  symbol->SizeOfStruct = sizeof( SYMBOL_INFO );
-  symbol->MaxNameLen = MAX_SYM_NAME;
-
-  IMAGEHLP_LINE *line = ( IMAGEHLP_LINE * ) qgsMalloc( sizeof( IMAGEHLP_LINE ) );
-  line->SizeOfStruct = sizeof( IMAGEHLP_LINE );
-
-  IMAGEHLP_MODULE *module = ( IMAGEHLP_MODULE * ) qgsMalloc( sizeof( IMAGEHLP_MODULE ) );
-  module->SizeOfStruct = sizeof( IMAGEHLP_MODULE );
-
-  QList<QgsCrashReport::StackLine> stack;
-  while ( StackWalk64( machine_type,
-                       GetCurrentProcess(),
-                       GetCurrentThread(),
-                       &stack_frame,
-                       &context_record,
-                       NULL,
-                       &SymFunctionTableAccess64,
-                       &SymGetModuleBase64,
-                       NULL ) )
-  {
-
-    DWORD64 displacement = 0;
-
-    if ( SymFromAddr( process, ( DWORD64 )stack_frame.AddrPC.Offset, &displacement, symbol ) )
-    {
-      DWORD dwDisplacement;
-      QString fileName;
-      QString lineNumber;
-      QString moduleName;
-      if ( SymGetLineFromAddr( process, ( DWORD )( stack_frame.AddrPC.Offset ), &dwDisplacement, line ) )
-      {
-        fileName = QString( line->FileName );
-        lineNumber = QString::number( line->LineNumber );
-      }
-      else
-      {
-        fileName = "(unknown file)";
-        lineNumber = "(unknown line)";
-      }
-      if ( SymGetModuleInfo( process, ( DWORD )( stack_frame.AddrPC.Offset ), module ) )
-      {
-        moduleName = QString( module->ModuleName );
-      }
-      else
-      {
-        moduleName = "(unknown module)";
-      }
-      QgsCrashReport::StackLine stackline;
-      stackline.moduleName = moduleName;
-      stackline.fileName = fileName;
-      stackline.lineNumber = lineNumber;
-      stackline.symbolName = QString( symbol->Name );
-      stack.append( stackline );
-    }
-  }
-
-  qgsFree( symbol );
-  qgsFree( line );
-  qgsFree( module );
-
+  QVector<QgsStackTrace::StackLine> stack = QgsStackTrace::trace( ExceptionInfo );
   showCrashDialog( stack );
 
   return EXCEPTION_EXECUTE_HANDLER;
 }
+#endif
 
-void QgsCrashHandler::showCrashDialog( const QList<QgsCrashReport::StackLine> &stack )
+void QgsCrashHandler::showCrashDialog( const QVector<QgsStackTrace::StackLine> &stack )
 {
 
   QgsCrashDialog dlg( QApplication::activeWindow() );
@@ -141,4 +56,3 @@ void QgsCrashHandler::restartApplication()
   QProcess::startDetached( path, arguments, QDir::toNativeSeparators( QCoreApplication::applicationDirPath() ) );
 
 }
-#endif

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -40,7 +40,7 @@ class APP_EXPORT QgsCrashHandler
      * Show the crash dialog.
      * @param stack The current stack of the crash point.
      */
-    static void showCrashDialog( const QList<QgsCrashReport::StackLine> &stack );
+    static void showCrashDialog( const QVector<QgsStackTrace::StackLine> &stack );
 
     /**
      * Restart the application.

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -40,7 +40,7 @@ class APP_EXPORT QgsCrashHandler
      * Show the crash dialog.
      * @param stack The current stack of the crash point.
      */
-    static void showCrashDialog( const QVector<QgsStackTrace::StackLine> &stack );
+    static void showCrashDialog( const QgsStackLines &stack );
 
     /**
      * Restart the application.

--- a/src/app/qgscrashreport.cpp
+++ b/src/app/qgscrashreport.cpp
@@ -119,7 +119,7 @@ const QString QgsCrashReport::toString() const
 const QString QgsCrashReport::crashID() const
 {
   if ( mStackTrace.isEmpty() )
-    return "ID not generated due to missing information";
+    return "ID not generated due to missing information\n\n Your version of QGIS install might not have debug information included.";
 
   QString data = QString::null;
 

--- a/src/app/qgscrashreport.cpp
+++ b/src/app/qgscrashreport.cpp
@@ -124,7 +124,7 @@ const QString QgsCrashReport::crashID() const
   QString data = QString::null;
 
   // Hashes the full stack.
-  Q_FOREACH ( QgsStackTrace::StackLine line, mStackTrace )
+  Q_FOREACH ( const QgsStackTrace::StackLine &line, mStackTrace )
   {
     QFileInfo fileInfo( line.fileName );
     QString filename( fileInfo.fileName() );

--- a/src/app/qgscrashreport.cpp
+++ b/src/app/qgscrashreport.cpp
@@ -49,7 +49,7 @@ const QString QgsCrashReport::toString() const
     }
     else
     {
-      Q_FOREACH ( const QgsCrashReport::StackLine &line, mStackTrace )
+      Q_FOREACH ( const QgsStackTrace::StackLine &line, mStackTrace )
       {
         QFileInfo fileInfo( line.fileName );
         QString filename( fileInfo.fileName() );
@@ -124,7 +124,7 @@ const QString QgsCrashReport::crashID() const
   QString data = QString::null;
 
   // Hashes the full stack.
-  Q_FOREACH ( QgsCrashReport::StackLine line, mStackTrace )
+  Q_FOREACH ( QgsStackTrace::StackLine line, mStackTrace )
   {
     QFileInfo fileInfo( line.fileName );
     QString filename( fileInfo.fileName() );
@@ -136,17 +136,4 @@ const QString QgsCrashReport::crashID() const
 
   QString hash = QString( QCryptographicHash::hash( data.toAscii(), QCryptographicHash::Sha1 ).toHex() );
   return hash;
-}
-
-bool QgsCrashReport::StackLine::isQgisModule() const
-{
-  return moduleName.toLower().contains( "qgis" );
-}
-
-bool QgsCrashReport::StackLine::isValid() const
-{
-  return !( fileName.toLower().contains( "exe_common" ) ||
-            fileName.toLower().contains( "unknown" ) ||
-            lineNumber.toLower().contains( "unknown" ) );
-
 }

--- a/src/app/qgscrashreport.h
+++ b/src/app/qgscrashreport.h
@@ -17,8 +17,10 @@
 #define QGSCRASHREPORT_H
 
 #include "qgis_app.h"
+#include "qgsstacktrace.h"
 
 #include <QObject>
+#include <QVector>
 
 
 /**
@@ -27,30 +29,6 @@
 class APP_EXPORT QgsCrashReport
 {
   public:
-
-    /**
-     * Represents a line from a stack trace.
-     */
-    struct StackLine
-    {
-      QString moduleName;
-      QString symbolName;
-      QString fileName;
-      QString lineNumber;
-
-      /**
-       * Check if this stack line is part of QGIS.
-       * \return True if part of QGIS.
-       */
-      bool isQgisModule() const;
-
-      /**
-       * Check if this stack line is valid.  Considered valid when the filename and line
-       * number are known.
-       * \return True of the line is valid.
-       */
-      bool isValid() const;
-    };
 
     /**
      * Include information to generate user friendly crash report for QGIS.
@@ -73,13 +51,13 @@ class APP_EXPORT QgsCrashReport
      * Sets the stack trace for the crash report.
      * \param value A string list for each line in the stack trace.
      */
-    void setStackTrace( const QList<QgsCrashReport::StackLine> &value ) { mStackTrace = value; }
+    void setStackTrace( const QVector<QgsStackTrace::StackLine> &value ) { mStackTrace = value; }
 
     /**
      * Returns the stack trace for this report.
      * \return A string list for each line in the stack trace.
      */
-    QList<QgsCrashReport::StackLine> StackTrace() const { return mStackTrace; }
+    QVector<QgsStackTrace::StackLine> StackTrace() const { return mStackTrace; }
 
     /**
      * Set the flags to mark which features are included in this crash report.
@@ -107,7 +85,7 @@ class APP_EXPORT QgsCrashReport
 
   private:
     Flags mFlags;
-    QList<QgsCrashReport::StackLine> mStackTrace;
+    QVector<QgsStackTrace::StackLine> mStackTrace;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsCrashReport::Flags )

--- a/src/app/qgscrashreport.h
+++ b/src/app/qgscrashreport.h
@@ -51,13 +51,13 @@ class APP_EXPORT QgsCrashReport
      * Sets the stack trace for the crash report.
      * \param value A string list for each line in the stack trace.
      */
-    void setStackTrace( const QVector<QgsStackTrace::StackLine> &value ) { mStackTrace = value; }
+    void setStackTrace( const QgsStackLines &value ) { mStackTrace = value; }
 
     /**
      * Returns the stack trace for this report.
      * \return A string list for each line in the stack trace.
      */
-    QVector<QgsStackTrace::StackLine> StackTrace() const { return mStackTrace; }
+    QgsStackLines StackTrace() const { return mStackTrace; }
 
     /**
      * Set the flags to mark which features are included in this crash report.
@@ -85,7 +85,7 @@ class APP_EXPORT QgsCrashReport
 
   private:
     Flags mFlags;
-    QVector<QgsStackTrace::StackLine> mStackTrace;
+    QgsStackLines mStackTrace;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsCrashReport::Flags )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -268,6 +268,7 @@ SET(QGIS_CORE_SRCS
   qgsmapthemecollection.cpp
   qgsxmlutils.cpp
   qgssettings.cpp
+  qgsstacktrace.cpp
 
   composer/qgsaddremoveitemcommand.cpp
   composer/qgsaddremovemultiframecommand.cpp
@@ -463,6 +464,7 @@ IF (WITH_INTERNAL_QEXTSERIALPORT)
       gps/qextserialport/win_qextserialport.cpp
     )
     ADD_DEFINITIONS(-D_TTY_WIN_)
+
   ELSE(WIN32)
     SET(QGIS_CORE_SRCS ${QGIS_CORE_SRCS}
       gps/qextserialport/posix_qextserialport.cpp
@@ -1061,7 +1063,7 @@ ADD_DEPENDENCIES(qgis_core version)
 # because of htonl
 IF (WIN32)
   FIND_LIBRARY(SETUPAPI_LIBRARY NAMES setupapi PATHS $ENV{LIB})
-  TARGET_LINK_LIBRARIES(qgis_core wsock32 ${SETUPAPI_LIBRARY})
+  TARGET_LINK_LIBRARIES(qgis_core wsock32 ${SETUPAPI_LIBRARY} DbgHelp)
 ENDIF (WIN32)
 
 IF(APPLE)

--- a/src/core/qgsstacktrace.cpp
+++ b/src/core/qgsstacktrace.cpp
@@ -36,6 +36,7 @@ QVector<QgsStackTrace::StackLine> QgsStackTrace::trace(_EXCEPTION_POINTERS *Exce
 
   HANDLE process = GetCurrentProcess();
   // TOOD Pull symbols from symbol server.
+  SymSetOptions( SYMOPT_DEFERRED_LOADS | SYMOPT_INCLUDE_32BIT_MODULES | SYMOPT_UNDNAME );
   SymInitialize( process, NULL, TRUE );
 
   // StackWalk64() may modify context record passed to it, so we will

--- a/src/core/qgsstacktrace.cpp
+++ b/src/core/qgsstacktrace.cpp
@@ -27,7 +27,7 @@
 ///@cond PRIVATE
 
 #ifdef Q_OS_WIN
-QVector<QgsStackTrace::StackLine> QgsStackTrace::trace(_EXCEPTION_POINTERS *ExceptionInfo)
+QVector<QgsStackTrace::StackLine> QgsStackTrace::trace( _EXCEPTION_POINTERS *ExceptionInfo )
 {
   QgsStackLines stack;
 #ifndef QGISDEBUG
@@ -126,6 +126,7 @@ QVector<QgsStackTrace::StackLine> QgsStackTrace::trace(_EXCEPTION_POINTERS *Exce
 
 QVector<QgsStackTrace::StackLine> QgsStackTrace::trace( unsigned int maxFrames )
 {
+  Q_UNUSED( maxFrames );
   QgsStackLines stack;
 #ifndef QGISDEBUG
   return stack;

--- a/src/core/qgsstacktrace.cpp
+++ b/src/core/qgsstacktrace.cpp
@@ -24,10 +24,12 @@
 
 #include "qgis.h"
 
+///@cond PRIVATE
+
 #ifdef Q_OS_WIN
 QVector<QgsStackTrace::StackLine> QgsStackTrace::trace(_EXCEPTION_POINTERS *ExceptionInfo)
 {
-  QVector<QgsStackTrace::StackLine> stack;
+  QgsStackLines stack;
 #ifndef QGISDEBUG
   return stack;
 #endif
@@ -123,7 +125,7 @@ QVector<QgsStackTrace::StackLine> QgsStackTrace::trace(_EXCEPTION_POINTERS *Exce
 
 QVector<QgsStackTrace::StackLine> QgsStackTrace::trace( unsigned int maxFrames )
 {
-  QVector<QgsStackTrace::StackLine> stack;
+  QgsStackLines stack;
 #ifndef QGISDEBUG
   return stack;
 #endif
@@ -151,3 +153,4 @@ bool QgsStackTrace::StackLine::isValid() const
             lineNumber.toLower().contains( "unknown" ) );
 
 }
+///@endcond

--- a/src/core/qgsstacktrace.cpp
+++ b/src/core/qgsstacktrace.cpp
@@ -1,0 +1,153 @@
+/***************************************************************************
+  qgsstacktrace.cpp - QgsStackTrace
+
+ ---------------------
+ begin                : 24.4.2017
+ copyright            : (C) 2017 by Nathan Woodrow
+ email                : woodrow.nathan@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsstacktrace.h"
+
+#include <QVector>
+
+#ifdef WIN32
+#include <windows.h>
+#include <dbghelp.h>
+#endif
+
+#include "qgis.h"
+
+#ifdef Q_OS_WIN
+QVector<QgsStackTrace::StackLine> QgsStackTrace::trace(_EXCEPTION_POINTERS *ExceptionInfo)
+{
+  QVector<QgsStackTrace::StackLine> stack;
+#ifndef QGISDEBUG
+  return stack;
+#endif
+
+  HANDLE process = GetCurrentProcess();
+  // TOOD Pull symbols from symbol server.
+  SymInitialize( process, NULL, TRUE );
+
+  // StackWalk64() may modify context record passed to it, so we will
+  // use a copy.
+  CONTEXT context_record = *ExceptionInfo->ContextRecord;
+  // Initialize stack walking.
+  STACKFRAME64 stack_frame;
+  memset( &stack_frame, 0, sizeof( stack_frame ) );
+#if defined(_WIN64)
+  int machine_type = IMAGE_FILE_MACHINE_AMD64;
+  stack_frame.AddrPC.Offset = context_record.Rip;
+  stack_frame.AddrFrame.Offset = context_record.Rbp;
+  stack_frame.AddrStack.Offset = context_record.Rsp;
+#else
+  int machine_type = IMAGE_FILE_MACHINE_I386;
+  stack_frame.AddrPC.Offset = context_record.Eip;
+  stack_frame.AddrFrame.Offset = context_record.Ebp;
+  stack_frame.AddrStack.Offset = context_record.Esp;
+#endif
+  stack_frame.AddrPC.Mode = AddrModeFlat;
+  stack_frame.AddrFrame.Mode = AddrModeFlat;
+  stack_frame.AddrStack.Mode = AddrModeFlat;
+
+  SYMBOL_INFO *symbol = ( SYMBOL_INFO * ) qgsMalloc( sizeof( SYMBOL_INFO ) + MAX_SYM_NAME );
+  symbol->SizeOfStruct = sizeof( SYMBOL_INFO );
+  symbol->MaxNameLen = MAX_SYM_NAME;
+
+  IMAGEHLP_LINE *line = ( IMAGEHLP_LINE * ) qgsMalloc( sizeof( IMAGEHLP_LINE ) );
+  line->SizeOfStruct = sizeof( IMAGEHLP_LINE );
+
+  IMAGEHLP_MODULE *module = ( IMAGEHLP_MODULE * ) qgsMalloc( sizeof( IMAGEHLP_MODULE ) );
+  module->SizeOfStruct = sizeof( IMAGEHLP_MODULE );
+
+  while ( StackWalk64( machine_type,
+                       GetCurrentProcess(),
+                       GetCurrentThread(),
+                       &stack_frame,
+                       &context_record,
+                       NULL,
+                       &SymFunctionTableAccess64,
+                       &SymGetModuleBase64,
+                       NULL ) )
+  {
+
+    DWORD64 displacement = 0;
+
+    if ( SymFromAddr( process, ( DWORD64 )stack_frame.AddrPC.Offset, &displacement, symbol ) )
+    {
+      DWORD dwDisplacement;
+      QString fileName;
+      QString lineNumber;
+      QString moduleName;
+      if ( SymGetLineFromAddr( process, ( DWORD )( stack_frame.AddrPC.Offset ), &dwDisplacement, line ) )
+      {
+        fileName = QString( line->FileName );
+        lineNumber = QString::number( line->LineNumber );
+      }
+      else
+      {
+        fileName = "(unknown file)";
+        lineNumber = "(unknown line)";
+      }
+      if ( SymGetModuleInfo( process, ( DWORD )( stack_frame.AddrPC.Offset ), module ) )
+      {
+        moduleName = QString( module->ModuleName );
+      }
+      else
+      {
+        moduleName = "(unknown module)";
+      }
+      QgsStackTrace::StackLine stackline;
+      stackline.moduleName = moduleName;
+      stackline.fileName = fileName;
+      stackline.lineNumber = lineNumber;
+      stackline.symbolName = QString( symbol->Name );
+      stack.append( stackline );
+    }
+  }
+
+  qgsFree( symbol );
+  qgsFree( line );
+  qgsFree( module );
+  return stack;
+
+}
+#endif
+
+QVector<QgsStackTrace::StackLine> QgsStackTrace::trace( unsigned int maxFrames )
+{
+  QVector<QgsStackTrace::StackLine> stack;
+#ifndef QGISDEBUG
+  return stack;
+#endif
+
+#ifdef Q_OS_LINUX
+  // TODO Add linux stack trace support. Pull it from main.cpp
+#endif
+  return stack;
+}
+
+QgsStackTrace::QgsStackTrace()
+{
+
+}
+
+bool QgsStackTrace::StackLine::isQgisModule() const
+{
+  return moduleName.toLower().contains( "qgis" );
+}
+
+bool QgsStackTrace::StackLine::isValid() const
+{
+  return !( fileName.toLower().contains( "exe_common" ) ||
+            fileName.toLower().contains( "unknown" ) ||
+            lineNumber.toLower().contains( "unknown" ) );
+
+}

--- a/src/core/qgsstacktrace.h
+++ b/src/core/qgsstacktrace.h
@@ -60,16 +60,17 @@ class CORE_EXPORT QgsStackTrace
     };
 
 #ifdef Q_OS_WIN
+
     /**
      * Return a demangled stack backtrace of the caller function.
      *
      * \note Added in QGIS 3.0
      */
-    static QVector<QgsStackTrace::StackLine> trace(  struct _EXCEPTION_POINTERS *ExceptionInfo );
+    static QVector<QgsStackTrace::StackLine> trace( struct _EXCEPTION_POINTERS *ExceptionInfo );
 #endif
 
     /**
-     * Return a demangled stack backtrace of the caller function.
+    * Return a demangled stack backtrace of the caller function.
      *
      * \note Added in QGIS 3.0
      */

--- a/src/core/qgsstacktrace.h
+++ b/src/core/qgsstacktrace.h
@@ -1,0 +1,82 @@
+/***************************************************************************
+  qgsstacktrace.h - QgsStackTrace
+
+ ---------------------
+ begin                : 24.4.2017
+ copyright            : (C) 2017 by Nathan Woodrow
+ email                : woodrow.nathan@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSSTACKTRACE_H
+#define QGSSTACKTRACE_H
+
+#include "qgis_core.h"
+
+#include <QStringList>
+
+/**
+* \ingroup core
+* The QgsStacktrace class provides an interface to generate a stack trace for
+* displaying additional debug information when things go wrong.
+*
+* \note Not available in python
+* \note Added in QGIS 3.0
+*/
+class CORE_EXPORT QgsStackTrace
+{
+  public:
+
+    /**
+     * Represents a line from a stack trace.
+     */
+    struct StackLine
+    {
+      QString moduleName;
+      QString symbolName;
+      QString fileName;
+      QString lineNumber;
+
+      /**
+       * Check if this stack line is part of QGIS.
+       * \return True if part of QGIS.
+       */
+      bool isQgisModule() const;
+
+      /**
+       * Check if this stack line is valid.  Considered valid when the filename and line
+       * number are known.
+       * \return True of the line is valid.
+       */
+      bool isValid() const;
+    };
+
+#ifdef Q_OS_WIN
+    /**
+     * Return a demangled stack backtrace of the caller function.
+     *
+     * \note Not available in python
+     * \note Added in QGIS 3.0
+     */
+    static QVector<QgsStackTrace::StackLine> trace(  struct _EXCEPTION_POINTERS *ExceptionInfo );
+#endif
+
+    /**
+     * Return a demangled stack backtrace of the caller function.
+     *
+     * \note Not available in python
+     * \note Added in QGIS 3.0
+     */
+    static QVector<QgsStackTrace::StackLine> trace( unsigned int maxFrames = 63 );
+
+  private:
+    QgsStackTrace();
+
+};
+
+#endif // QGSSTACKTRACE_H

--- a/src/core/qgsstacktrace.h
+++ b/src/core/qgsstacktrace.h
@@ -20,6 +20,9 @@
 
 #include <QStringList>
 
+///@cond PRIVATE
+
+
 /**
 * \ingroup core
 * The QgsStacktrace class provides an interface to generate a stack trace for
@@ -60,7 +63,6 @@ class CORE_EXPORT QgsStackTrace
     /**
      * Return a demangled stack backtrace of the caller function.
      *
-     * \note Not available in python
      * \note Added in QGIS 3.0
      */
     static QVector<QgsStackTrace::StackLine> trace(  struct _EXCEPTION_POINTERS *ExceptionInfo );
@@ -69,7 +71,6 @@ class CORE_EXPORT QgsStackTrace
     /**
      * Return a demangled stack backtrace of the caller function.
      *
-     * \note Not available in python
      * \note Added in QGIS 3.0
      */
     static QVector<QgsStackTrace::StackLine> trace( unsigned int maxFrames = 63 );
@@ -78,5 +79,9 @@ class CORE_EXPORT QgsStackTrace
     QgsStackTrace();
 
 };
+
+typedef QVector<QgsStackTrace::StackLine> QgsStackLines;
+
+///@endcond
 
 #endif // QGSSTACKTRACE_H


### PR DESCRIPTION
## Description
Adds a new `QgsStackTrace` class to abstract getting a call stack trace for each platform.   Not exposed to Python or in the API docs. Only in core so that it can be used by server if needed.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
