### PR TITLE
Add invalid geometry handling to QgsFeatureRequest/QgsVectorLayerFeatureIterator

### DIFF
--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -26,6 +26,14 @@ class QgsFeatureRequest
       FilterFids        //!< Filter using feature IDs
     };
 
+    //! Handling of features with invalid geometries
+    enum InvalidGeometryCheck
+    {
+      GeometryNoCheck,
+      GeometrySkipInvalid,
+      GeometryAbortOnInvalid,
+    };
+
     /**
      * The OrderByClause class represents an order by clause for a QgsFeatureRequest.
      *
@@ -195,6 +203,22 @@ class QgsFeatureRequest
     QgsFeatureRequest& setFilterFids( const QgsFeatureIds& fids );
     //! Get feature IDs that should be fetched.
     const QgsFeatureIds& filterFids() const;
+
+    /**
+     * Sets invalid geometry checking behavior.
+     * \note Invalid geometry checking is not performed when retrieving features
+     * directly from a QgsVectorDataProvider.
+     * \see invalidGeometryCheck()
+     * \since QGIS 3.0
+     */
+    QgsFeatureRequest &setInvalidGeometryCheck( InvalidGeometryCheck check );
+
+    /**
+     * Returns the invalid geometry checking behavior.
+     * \see setInvalidGeometryCheck()
+     * \since QGIS 3.0
+     */
+    InvalidGeometryCheck invalidGeometryCheck() const;
 
     /** Set the filter expression. {@see QgsExpression}
      * @param expression expression string

--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -220,6 +220,35 @@ class QgsFeatureRequest
      */
     InvalidGeometryCheck invalidGeometryCheck() const;
 
+    /**
+     * Sets a callback function to use when encountering an invalid geometry and
+     * invalidGeometryCheck() is set to GeometryAbortOnInvalid. This function will be
+     * called using the feature with invalid geometry as a parameter.
+     * \since QGIS 3.0
+     * \see invalidGeometryCallback()
+     */
+    QgsFeatureRequest &setInvalidGeometryCallback( SIP_PYCALLABLE /AllowNone/ );
+%MethodCode
+        Py_BEGIN_ALLOW_THREADS
+
+        sipRes = new QgsFeatureRequest( sipCpp->setInvalidGeometryCallback([a0](const QgsFeature &arg) {
+            SIP_BLOCK_THREADS
+            Py_XDECREF( sipCallMethod(NULL, a0, "N", new QgsFeature(arg), sipType_QgsFeature, NULL) );
+            SIP_UNBLOCK_THREADS
+        }) );
+
+        Py_END_ALLOW_THREADS
+%End
+
+    /**
+     * Returns the callback function to use when encountering an invalid geometry and
+     * invalidGeometryCheck() is set to GeometryAbortOnInvalid.
+     * \since QGIS 3.0
+     * \note not available in Python bindings
+     * \see setInvalidGeometryCallback()
+     */
+    // std::function< void( const QgsFeature & ) > invalidGeometryCallback() const;
+
     /** Set the filter expression. {@see QgsExpression}
      * @param expression expression string
      * @see filterExpression

--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -233,7 +233,7 @@ class QgsFeatureRequest
 
         sipCpp->setInvalidGeometryCallback([a0](const QgsFeature &arg) {
             SIP_BLOCK_THREADS
-            Py_XDECREF( sipCallMethod(NULL, a0, "D", arg, sipType_QgsFeature, NULL) );
+            Py_XDECREF( sipCallMethod(NULL, a0, "D", &arg, sipType_QgsFeature, NULL) );
             SIP_UNBLOCK_THREADS
         });
 

--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -231,11 +231,13 @@ class QgsFeatureRequest
 %MethodCode
         Py_BEGIN_ALLOW_THREADS
 
-        sipRes = new QgsFeatureRequest( sipCpp->setInvalidGeometryCallback([a0](const QgsFeature &arg) {
+        sipCpp->setInvalidGeometryCallback([a0](const QgsFeature &arg) {
             SIP_BLOCK_THREADS
-            Py_XDECREF( sipCallMethod(NULL, a0, "N", new QgsFeature(arg), sipType_QgsFeature, NULL) );
+            Py_XDECREF( sipCallMethod(NULL, a0, "N", new QgsFeature( arg ), sipType_QgsFeature, NULL) );
             SIP_UNBLOCK_THREADS
-        }) );
+        });
+
+        sipRes = sipCpp;
 
         Py_END_ALLOW_THREADS
 %End

--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -233,7 +233,7 @@ class QgsFeatureRequest
 
         sipCpp->setInvalidGeometryCallback([a0](const QgsFeature &arg) {
             SIP_BLOCK_THREADS
-            Py_XDECREF( sipCallMethod(NULL, a0, "N", new QgsFeature( arg ), sipType_QgsFeature, NULL) );
+            Py_XDECREF( sipCallMethod(NULL, a0, "D", arg, sipType_QgsFeature, NULL) );
             SIP_UNBLOCK_THREADS
         });
 

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -111,6 +111,12 @@ QgsFeatureRequest &QgsFeatureRequest::setInvalidGeometryCheck( QgsFeatureRequest
   return *this;
 }
 
+QgsFeatureRequest &QgsFeatureRequest::setInvalidGeometryCallback( std::function<void ( const QgsFeature & )> callback )
+{
+  mInvalidGeometryCallback = callback;
+  return *this;
+}
+
 QgsFeatureRequest &QgsFeatureRequest::setFilterExpression( const QString &expression )
 {
   mFilter = FilterExpression;

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -76,6 +76,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   {
     mFilterExpression.reset( nullptr );
   }
+  mInvalidGeometryFilter = rh.mInvalidGeometryFilter;
   mExpressionContext = rh.mExpressionContext;
   mAttrs = rh.mAttrs;
   mSimplifyMethod = rh.mSimplifyMethod;
@@ -101,6 +102,12 @@ QgsFeatureRequest &QgsFeatureRequest::setFilterFids( const QgsFeatureIds &fids )
 {
   mFilter = FilterFids;
   mFilterFids = fids;
+  return *this;
+}
+
+QgsFeatureRequest &QgsFeatureRequest::setInvalidGeometryCheck( QgsFeatureRequest::InvalidGeometryCheck check )
+{
+  mInvalidGeometryFilter = check;
   return *this;
 }
 

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -77,6 +77,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
     mFilterExpression.reset( nullptr );
   }
   mInvalidGeometryFilter = rh.mInvalidGeometryFilter;
+  mInvalidGeometryCallback = rh.mInvalidGeometryCallback;
   mExpressionContext = rh.mExpressionContext;
   mAttrs = rh.mAttrs;
   mSimplifyMethod = rh.mSimplifyMethod;

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -294,6 +294,25 @@ class CORE_EXPORT QgsFeatureRequest
      */
     InvalidGeometryCheck invalidGeometryCheck() const { return mInvalidGeometryFilter; }
 
+    /**
+     * Sets a callback function to use when encountering an invalid geometry and
+     * invalidGeometryCheck() is set to GeometryAbortOnInvalid. This function will be
+     * called using the feature with invalid geometry as a parameter.
+     * \since QGIS 3.0
+     * \note not available in Python bindings
+     * \see invalidGeometryCallback()
+     */
+    QgsFeatureRequest &setInvalidGeometryCallback( std::function< void( const QgsFeature & ) > callback );
+
+    /**
+     * Returns the callback function to use when encountering an invalid geometry and
+     * invalidGeometryCheck() is set to GeometryAbortOnInvalid.
+     * \since QGIS 3.0
+     * \note not available in Python bindings
+     * \see setInvalidGeometryCallback()
+     */
+    std::function< void( const QgsFeature & ) > invalidGeometryCallback() const { return mInvalidGeometryCallback; }
+
     /** Set the filter expression. {\see QgsExpression}
      * \param expression expression string
      * \see filterExpression
@@ -440,6 +459,7 @@ class CORE_EXPORT QgsFeatureRequest
     long mLimit = -1;
     OrderBy mOrderBy;
     InvalidGeometryCheck mInvalidGeometryFilter = GeometryNoCheck;
+    std::function< void( const QgsFeature & ) > mInvalidGeometryCallback;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureRequest::Flags )

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -85,6 +85,14 @@ class CORE_EXPORT QgsFeatureRequest
       FilterFids        //!< Filter using feature IDs
     };
 
+    //! Handling of features with invalid geometries
+    enum InvalidGeometryCheck
+    {
+      GeometryNoCheck = 0, //!< No invalid geometry checking
+      GeometrySkipInvalid = 1, //!< Skip any features with invalid geometry. This requires a slow geometry validity check for every feature.
+      GeometryAbortOnInvalid = 2, //!< Close iterator on encountering any features with invalid geometry. This requires a slow geometry validity check for every feature.
+    };
+
     /** \ingroup core
      * The OrderByClause class represents an order by clause for a QgsFeatureRequest.
      *
@@ -270,6 +278,22 @@ class CORE_EXPORT QgsFeatureRequest
     //! Get feature IDs that should be fetched.
     const QgsFeatureIds &filterFids() const { return mFilterFids; }
 
+    /**
+     * Sets invalid geometry checking behavior.
+     * \note Invalid geometry checking is not performed when retrieving features
+     * directly from a QgsVectorDataProvider.
+     * \see invalidGeometryCheck()
+     * \since QGIS 3.0
+     */
+    QgsFeatureRequest &setInvalidGeometryCheck( InvalidGeometryCheck check );
+
+    /**
+     * Returns the invalid geometry checking behavior.
+     * \see setInvalidGeometryCheck()
+     * \since QGIS 3.0
+     */
+    InvalidGeometryCheck invalidGeometryCheck() const { return mInvalidGeometryFilter; }
+
     /** Set the filter expression. {\see QgsExpression}
      * \param expression expression string
      * \see filterExpression
@@ -415,6 +439,7 @@ class CORE_EXPORT QgsFeatureRequest
     QgsSimplifyMethod mSimplifyMethod;
     long mLimit = -1;
     OrderBy mOrderBy;
+    InvalidGeometryCheck mInvalidGeometryFilter = GeometryNoCheck;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureRequest::Flags )

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -299,7 +299,6 @@ class CORE_EXPORT QgsFeatureRequest
      * invalidGeometryCheck() is set to GeometryAbortOnInvalid. This function will be
      * called using the feature with invalid geometry as a parameter.
      * \since QGIS 3.0
-     * \note not available in Python bindings
      * \see invalidGeometryCallback()
      */
     QgsFeatureRequest &setInvalidGeometryCallback( std::function< void( const QgsFeature & ) > callback );

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -698,8 +698,12 @@ bool QgsVectorLayerFeatureIterator::checkGeometry( const QgsFeature &feature )
     case QgsFeatureRequest::GeometryAbortOnInvalid:
       if ( !feature.geometry().isGeosValid() )
       {
-        QgsMessageLog::logMessage( QObject::tr( "Geometry error: One or more input features have invalid geometry." ), QString(), QgsMessageLog::CRITICAL);
+        QgsMessageLog::logMessage( QObject::tr( "Geometry error: One or more input features have invalid geometry." ), QString(), QgsMessageLog::CRITICAL );
         close();
+        if ( mRequest.invalidGeometryCallback() )
+        {
+          mRequest.invalidGeometryCallback()( feature );
+        }
         return false;
       }
       break;

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -242,7 +242,7 @@ bool QgsVectorLayerFeatureIterator::fetchFeature( QgsFeature &f )
     if ( mFetchedFid )
       return false;
     bool res = nextFeatureFid( f );
-    if ( res && checkGeometry( f ) )
+    if ( res && testFeature( f ) )
     {
       mFetchedFid = true;
       return res;
@@ -313,7 +313,7 @@ bool QgsVectorLayerFeatureIterator::fetchFeature( QgsFeature &f )
     if ( !( mRequest.flags() & QgsFeatureRequest::NoGeometry ) )
       updateFeatureGeometry( f );
 
-    if ( !checkGeometry( f ) )
+    if ( !testFeature( f ) )
       continue;
 
     return true;
@@ -377,7 +377,7 @@ bool QgsVectorLayerFeatureIterator::fetchNextAddedFeature( QgsFeature &f )
       // skip features which are not accepted by the filter
       continue;
 
-    if ( !checkGeometry( *mFetchAddedFeaturesIt ) )
+    if ( !testFeature( *mFetchAddedFeaturesIt ) )
       continue;
 
     useAddedFeature( *mFetchAddedFeaturesIt, f );
@@ -430,7 +430,7 @@ bool QgsVectorLayerFeatureIterator::fetchNextChangedGeomFeature( QgsFeature &f )
 
     useChangedAttributeFeature( fid, *mFetchChangedGeomIt, f );
 
-    if ( checkGeometry( f ) )
+    if ( testFeature( f ) )
     {
       // return complete feature
       mFetchChangedGeomIt++;
@@ -457,7 +457,7 @@ bool QgsVectorLayerFeatureIterator::fetchNextChangedAttributeFeature( QgsFeature
       addVirtualAttributes( f );
 
     mRequest.expressionContext()->setFeature( f );
-    if ( mRequest.filterExpression()->evaluate( mRequest.expressionContext() ).toBool() && checkGeometry( f ) )
+    if ( mRequest.filterExpression()->evaluate( mRequest.expressionContext() ).toBool() && testFeature( f ) )
     {
       return true;
     }
@@ -675,7 +675,13 @@ void QgsVectorLayerFeatureIterator::createOrderedJoinList()
   }
 }
 
-bool QgsVectorLayerFeatureIterator::checkGeometry( const QgsFeature &feature )
+bool QgsVectorLayerFeatureIterator::testFeature( const QgsFeature &feature )
+{
+  bool result = checkGeometryValidity( feature );
+  return result;
+}
+
+bool QgsVectorLayerFeatureIterator::checkGeometryValidity( const QgsFeature &feature )
 {
   if ( !feature.hasGeometry() )
     return true;

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -221,6 +221,11 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     virtual bool providerCanSimplify( QgsSimplifyMethod::MethodType methodType ) const override;
 
     void createOrderedJoinList();
+
+    /**
+     * Performs any geometry validity checking.
+     */
+    bool checkGeometry( const QgsFeature &feature );
 };
 
 #endif // QGSVECTORLAYERFEATUREITERATOR_H

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -223,9 +223,14 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     void createOrderedJoinList();
 
     /**
-     * Performs any geometry validity checking.
+     * Performs any feature based validity checking, e.g. checking for geometry validity.
      */
-    bool checkGeometry( const QgsFeature &feature );
+    bool testFeature( const QgsFeature &feature );
+
+    /**
+     * Checks a feature's geometry for validity, if requested in feature request.
+     */
+    bool checkGeometryValidity( const QgsFeature &feature );
 };
 
 #endif // QGSVECTORLAYERFEATUREITERATOR_H

--- a/tests/src/python/test_qgsfeatureiterator.py
+++ b/tests/src/python/test_qgsfeatureiterator.py
@@ -308,6 +308,23 @@ class TestQgsFeatureIterator(unittest.TestCase):
                layer.getFeatures(QgsFeatureRequest().setInvalidGeometryCheck(QgsFeatureRequest.GeometryAbortOnInvalid))]
         self.assertEqual(res, ['a'])
 
+        # with callback
+        self.callback_feature_val = None
+
+        def callback(feature):
+            self.callback_feature_val = feature['x']
+
+        res = [f['x'] for f in
+               layer.getFeatures(QgsFeatureRequest().setInvalidGeometryCheck(
+                   QgsFeatureRequest.GeometryAbortOnInvalid).setInvalidGeometryCallback(callback))]
+        self.assertEqual(res, ['a'])
+        self.assertEqual(self.callback_feature_val, 'b')
+        # clear callback
+        res = [f['x'] for f in
+               layer.getFeatures(QgsFeatureRequest().setInvalidGeometryCheck(
+                   QgsFeatureRequest.GeometryAbortOnInvalid).setInvalidGeometryCallback(None))]
+        self.assertEqual(res, ['a'])
+
         # check with filter fids
         res = [f['x'] for f in
                layer.getFeatures(QgsFeatureRequest().setFilterFid(f2.id()).setInvalidGeometryCheck(QgsFeatureRequest.GeometryNoCheck))]


### PR DESCRIPTION
This PR copies the handling of invalid geometries from processing to QgsFeatureRequest/QgsVectorLayerFeatureIterator. It allows specifying the behaviour to follow when invalid geometries are encountered while iterating a layer.

An optional callback can be specified which is called when the iterator has been aborted as a result of encountering invalid geometries. I've used a callback here instead of a signal as I don't want to make QgsVectorLayerFeatureIterator a QObject.