### PR TITLE
Add QgsDataProvider::uri property

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -4,7 +4,6 @@ core/qgis.sip
 core/qgsdataitem.sip
 core/qgsdataitemprovider.sip
 core/qgsdataitemproviderregistry.sip
-core/qgsdataprovider.sip
 core/qgsdbfilterproxymodel.sip
 core/qgseditformconfig.sip
 core/qgseditorwidgetsetup.sip

--- a/python/core/qgsdataprovider.sip
+++ b/python/core/qgsdataprovider.sip
@@ -1,28 +1,52 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsdataprovider.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+
 
 
 class QgsDataProvider : QObject
 {
+%Docstring
+ Abstract base class for spatial data provider implementations.
+
+ This object needs to inherit from QObject to enable event
+ processing in the Postgres/PostGIS provider (QgsPostgresProvider).
+ It is called *here* so that this vtable and the vtable for
+ QgsPostgresProvider don't get misaligned -
+ the QgsVectorLayer class factory (which refers
+ to generic QgsVectorDataProvider's) depends on it.
+%End
+
 %TypeHeaderCode
-#include <qgsdataprovider.h>
+#include "qgsdataprovider.h"
 %End
 
 %ConvertToSubClassCode
-    if (sipCpp->inherits("QgsVectorDataProvider"))
+    if ( qobject_cast<QgsVectorDataProvider *>( sipCpp ) )
     {
-        sipType = sipType_QgsVectorDataProvider;
+      sipType = sipType_QgsVectorDataProvider;
     }
-    else if (sipCpp->inherits("QgsRasterDataProvider"))
+    else if ( qobject_cast<QgsRasterDataProvider *>( sipCpp ) )
     {
-	sipType = sipType_QgsRasterDataProvider;
+      sipType = sipType_QgsRasterDataProvider;
     }
     else
     {
-        sipType = 0;
+      sipType = 0;
     }
 %End
-
-
   public:
+
 
     enum DataCapability
     {
@@ -33,304 +57,353 @@ class QgsDataProvider : QObject
       Net
     };
 
-    /**
-     * Properties are used to pass custom configuration options into data providers.
-     * This enum defines a list of custom properties which can be used on different
-     * providers. It depends on the provider, which properties are supported.
-     * In addition to these default properties, providers can add their custom properties
-     * starting from CustomData.
-     */
     enum ProviderProperty
     {
-      EvaluateDefaultValues,       //!< Evaluate default values on provider side when calling QgsVectorDataProvider::defaultValue( int index ) rather than on commit.
-      CustomData   = 3000          //!< Custom properties for 3rd party providers or very provider-specific properties which are not expected to be of interest for other providers can be added starting from this value up.
+      EvaluateDefaultValues,
+      CustomData
     };
 
-    QgsDataProvider( const QString & uri = "" );
+    QgsDataProvider( const QString &uri = QString() );
+%Docstring
+ Create a new dataprovider with the specified in the ``uri``.
+%End
 
-    /**
-     * We need this so the subclass destructors get called
-     */
-    virtual ~QgsDataProvider();
-
-
-    /* Returns the coordinate system for the data source.
-     * If the provider isn't capable of returning its projection then an invalid
-     * QgsCoordinateReferenceSystem will be returned.
-     */
     virtual QgsCoordinateReferenceSystem crs() const = 0;
+%Docstring
+ Returns the coordinate system for the data source.
+ If the provider isn't capable of returning its projection then an invalid
+ QgsCoordinateReferenceSystem will be returned.
+ :rtype: QgsCoordinateReferenceSystem
+%End
 
 
-    /**
-     * Set the data source specification. This may be a path or database
-     * connection string
-     * @param uri source specification
-     */
-    virtual void setDataSourceUri( const QString & uri );
+    virtual void setDataSourceUri( const QString &uri );
+%Docstring
+ Set the data source specification. This may be a path or database
+ connection string
+ \param uri source specification
+%End
 
-    /**
-     * Get the data source specification. This may be a path or database
-     * connection string
-     * @param expandAuthConfig Whether to expand any assigned authentication configuration
-     * @return data source specification
-     * @note The default authentication configuration expansion is FALSE. This keeps credentials
-     * out of layer data source URIs and project files. Expansion should be specifically done
-     * only when needed within a provider
-     */
-    virtual QString dataSourceUri( bool expandAuthConfig = true ) const;
+    virtual QString dataSourceUri( bool expandAuthConfig = false ) const;
+%Docstring
+ Get the data source specification. This may be a path or database
+ connection string
+ \param expandAuthConfig Whether to expand any assigned authentication configuration
+ :return: data source specification
+.. note::
 
+   The default authentication configuration expansion is FALSE. This keeps credentials
+ out of layer data source URIs and project files. Expansion should be specifically done
+ only when needed within a provider
+ :rtype: str
+%End
 
-    /**
-     * Returns the extent of the layer.
-     * @return QgsRectangle containing the extent of the layer
-     */
+    void setUri( const QgsDataSourceUri &uri );
+%Docstring
+ Set the data source specification.
+
+.. versionadded:: 3.0
+%End
+
+    QgsDataSourceUri uri() const;
+%Docstring
+ Get the data source specification.
+
+.. versionadded:: 3.0
+ :rtype: QgsDataSourceUri
+%End
+
     virtual QgsRectangle extent() const = 0;
+%Docstring
+ Returns the extent of the layer
+ :return: QgsRectangle containing the extent of the layer
+ :rtype: QgsRectangle
+%End
 
 
-    /**
-     * Returns true if this is a valid layer. It is up to individual providers
-     * to determine what constitutes a valid layer.
-     */
     virtual bool isValid() const = 0;
+%Docstring
+ Returns true if this is a valid layer. It is up to individual providers
+ to determine what constitutes a valid layer.
+ :rtype: bool
+%End
 
 
-    /**
-     * Update the extents of the layer. Not implemented by default.
-     */
     virtual void updateExtents();
+%Docstring
+ Update the extents of the layer. Not implemented by default.
+%End
 
 
-    /**
-     * Set the subset string used to create a subset of features in
-     * the layer. This may be a sql where clause or any other string
-     * that can be used by the data provider to create a subset.
-     * Must be implemented in the dataprovider.
-     */
-    virtual bool setSubsetString( const QString& subset, bool updateFeatureCount = true );
+    virtual bool setSubsetString( const QString &subset, bool updateFeatureCount = true );
+%Docstring
+ Set the subset string used to create a subset of features in
+ the layer. This may be a sql where clause or any other string
+ that can be used by the data provider to create a subset.
+ Must be implemented in the dataprovider.
+ :rtype: bool
+%End
 
-    /** Returns true if the provider supports setting of subset strings. */
+
     virtual bool supportsSubsetString() const;
+%Docstring
+ Returns true if the provider supports setting of subset strings.
+ :rtype: bool
+%End
 
-    /**
-     * Returns the subset definition string (typically sql) currently in
-     * use by the layer and used by the provider to limit the feature set.
-     * Must be overridden in the dataprovider, otherwise returns a null
-     * QString.
-     */
     virtual QString subsetString() const;
+%Docstring
+ Returns the subset definition string (typically sql) currently in
+ use by the layer and used by the provider to limit the feature set.
+ Must be overridden in the dataprovider, otherwise returns a null
+ QString.
+ :rtype: str
+%End
 
 
-    /**
-     * Sub-layers handled by this provider, in order from bottom to top
-     *
-     * Sub-layers are used when the provider's source can combine layers
-     * it knows about in some way before it hands them off to the provider.
-     */
     virtual QStringList subLayers() const;
+%Docstring
+ Sub-layers handled by this provider, in order from bottom to top
+
+ Sub-layers are used when the provider's source can combine layers
+ it knows about in some way before it hands them off to the provider.
+ :rtype: list of str
+%End
 
 
-    /**
-     * Sub-layer styles for each sub-layer handled by this provider,
-     * in order from bottom to top
-     *
-     * Sub-layer styles are used to abstract the way the provider's source can symbolise
-     * layers in some way at the server, before it serves them to the provider.
-     */
     virtual QStringList subLayerStyles() const;
+%Docstring
+ Sub-layer styles for each sub-layer handled by this provider,
+ in order from bottom to top
+
+ Sub-layer styles are used to abstract the way the provider's source can symbolise
+ layers in some way at the server, before it serves them to the provider.
+ :rtype: list of str
+%End
 
 
-    /**
-     * return the number of layers for the current data source
-     */
     virtual uint subLayerCount() const;
+%Docstring
+ return the number of layers for the current data source
+ :rtype: uint
+%End
 
 
-    /**
-     * Reorder the list of layer names to be rendered by this provider
-     * (in order from bottom to top)
-     * \note   layers must have been previously added.
-     */
     virtual void setLayerOrder( const QStringList &layers );
+%Docstring
+ Reorder the list of layer names to be rendered by this provider
+ (in order from bottom to top)
+.. note::
+
+     layers must have been previously added.
+%End
 
 
-    /**
-     * Set the visibility of the given sublayer name
-     */
     virtual void setSubLayerVisibility( const QString &name, bool vis );
+%Docstring
+ Set the visibility of the given sublayer name
+%End
 
 
-    /** Return a provider name
-     *
-     * Essentially just returns the provider key.  Should be used to build file
-     * dialogs so that providers can be shown with their supported types. Thus
-     * if more than one provider supports a given format, the user is able to
-     * select a specific provider to open that file.
-     *
-     * @note
-     *
-     * Instead of being pure virtual, might be better to generalize this
-     * behavior and presume that none of the sub-classes are going to do
-     * anything strange with regards to their name or description?
-     *
-     */
     virtual QString name() const = 0;
+%Docstring
+ Return a provider name
+
+ Essentially just returns the provider key.  Should be used to build file
+ dialogs so that providers can be shown with their supported types. Thus
+ if more than one provider supports a given format, the user is able to
+ select a specific provider to open that file.
+
+ \note
+
+ Instead of being pure virtual, might be better to generalize this
+ behavior and presume that none of the sub-classes are going to do
+ anything strange with regards to their name or description?
+ :rtype: str
+%End
 
 
-    /** Return description
-     *
-     * Return a terse string describing what the provider is.
-     *
-     * @note
-     *
-     * Instead of being pure virtual, might be better to generalize this
-     * behavior and presume that none of the sub-classes are going to do
-     * anything strange with regards to their name or description?
-     *
-     */
     virtual QString description() const = 0;
+%Docstring
+ Return description
+
+ Return a terse string describing what the provider is.
+
+ \note
+
+ Instead of being pure virtual, might be better to generalize this
+ behavior and presume that none of the sub-classes are going to do
+ anything strange with regards to their name or description?
+ :rtype: str
+%End
 
 
-    /** Return vector file filter string
-     *
-     * Returns a string suitable for a QFileDialog of vector file formats
-     * supported by the data provider.  Naturally this will be an empty string
-     * for those data providers that do not deal with plain files, such as
-     * databases and servers.
-     *
-     * @note It'd be nice to eventually be raster/vector neutral.
-     *
-     */
     virtual QString fileVectorFilters() const;
+%Docstring
+ Return vector file filter string
+
+ Returns a string suitable for a QFileDialog of vector file formats
+ supported by the data provider.  Naturally this will be an empty string
+ for those data providers that do not deal with plain files, such as
+ databases and servers.
+
+.. note::
+
+   It'd be nice to eventually be raster/vector neutral.
+ :rtype: str
+%End
 
 
-    /** Return raster file filter string
-     *
-     * Returns a string suitable for a QFileDialog of raster file formats
-     * supported by the data provider.  Naturally this will be an empty string
-     * for those data providers that do not deal with plain files, such as
-     * databases and servers.
-     *
-     * @note It'd be nice to eventually be raster/vector neutral.
-     */
     virtual QString fileRasterFilters() const;
+%Docstring
+ Return raster file filter string
 
-    /** Reloads the data from the source. Needs to be implemented by providers with data caches to
-      synchronize with changes in the data source*/
+ Returns a string suitable for a QFileDialog of raster file formats
+ supported by the data provider.  Naturally this will be an empty string
+ for those data providers that do not deal with plain files, such as
+ databases and servers.
+
+.. note::
+
+   It'd be nice to eventually be raster/vector neutral.
+ :rtype: str
+%End
+
     virtual void reloadData();
+%Docstring
+ Reloads the data from the source. Needs to be implemented by providers with data caches to
+ synchronize with changes in the data source
+%End
 
-    /** Time stamp of data source in the moment when data/metadata were loaded by provider */
     virtual QDateTime timestamp() const;
+%Docstring
+Time stamp of data source in the moment when data/metadata were loaded by provider
+ :rtype: QDateTime
+%End
 
-    /** Current time stamp of data source */
     virtual QDateTime dataTimestamp() const;
+%Docstring
+Current time stamp of data source
+ :rtype: QDateTime
+%End
 
-    /** Get current status error. This error describes some principal problem
-     *  for which provider cannot work and thus is not valid. It is not last error
-     *  after accessing data by block(), identify() etc.
-     */
     virtual QgsError error() const;
+%Docstring
+ Get current status error. This error describes some principal problem
+  for which provider cannot work and thus is not valid. It is not last error
+  after accessing data by block(), identify() etc.
+ :rtype: QgsError
+%End
 
-    /** Invalidate connections corresponding to specified name
-     * @note added in QGIS 2.16
-     */
-    virtual void invalidateConnections( const QString& connection );
+    virtual void invalidateConnections( const QString &connection );
+%Docstring
+ Invalidate connections corresponding to specified name
+.. versionadded:: 2.16
+%End
 
-    /** Enter update mode.
-     *
-     * This is aimed at providers that can open differently the connection to
-     * the datasource, according it to be in update mode or in read-only mode.
-     * A call to this method shall be balanced with a call to leaveUpdateMode(),
-     * if this method returns true.
-     *
-     * Most providers will have an empty implementation for that method.
-     *
-     * For backward compatibility, providers that implement enterUpdateMode() should
-     * still make sure to allow editing operations to work even if enterUpdateMode()
-     * is not explicitly called.
-     *
-     * Several successive calls to enterUpdateMode() can be done. So there is
-     * a concept of stack of calls that must be handled by the provider. Only the first
-     * call to enterUpdateMode() will really turn update mode on.
-     *
-     * @return true in case of success (or no-op implementation), false in case of failure
-     *
-     * @note added in QGIS 2.16
-     */
     virtual bool enterUpdateMode();
+%Docstring
+ Enter update mode.
 
-    /** Leave update mode.
-     *
-     * This is aimed at providers that can open differently the connection to
-     * the datasource, according it to be in update mode or in read-only mode.
-     * This method shall be balanced with a successful call to enterUpdateMode().
-     *
-     * Most providers will have an empty implementation for that method.
-     *
-     * Several successive calls to enterUpdateMode() can be done. So there is
-     * a concept of stack of calls that must be handled by the provider. Only the last
-     * call to leaveUpdateMode() will really turn update mode off.
-     *
-     * @return true in case of success (or no-op implementation), false in case of failure
-     *
-     * @note added in QGIS 2.16
-     */
+ This is aimed at providers that can open differently the connection to
+ the datasource, according it to be in update mode or in read-only mode.
+ A call to this method shall be balanced with a call to leaveUpdateMode(),
+ if this method returns true.
+
+ Most providers will have an empty implementation for that method.
+
+ For backward compatibility, providers that implement enterUpdateMode() should
+ still make sure to allow editing operations to work even if enterUpdateMode()
+ is not explicitly called.
+
+ Several successive calls to enterUpdateMode() can be done. So there is
+ a concept of stack of calls that must be handled by the provider. Only the first
+ call to enterUpdateMode() will really turn update mode on.
+
+ :return: true in case of success (or no-op implementation), false in case of failure.
+
+.. versionadded:: 2.16
+ :rtype: bool
+%End
+
     virtual bool leaveUpdateMode();
+%Docstring
+ Leave update mode.
 
-    /**
-     * Allows setting arbitrary properties on the provider.
-     * It depends on the provider which properties are supported.
-     *
-     * @note added in 2.16
-     */
-    void setProviderProperty( ProviderProperty property, const QVariant& value );
+ This is aimed at providers that can open differently the connection to
+ the datasource, according it to be in update mode or in read-only mode.
+ This method shall be balanced with a successful call to enterUpdateMode().
 
-    /**
-     * Allows setting arbitrary properties on the provider.
-     * It depends on the provider which properties are supported.
-     *
-     * @note added in 2.16
-     */
-    // void setProviderProperty( int property, const QVariant& value );
+ Most providers will have an empty implementation for that method.
 
-    /**
-     * Get the current value of a certain provider property.
-     * It depends on the provider which properties are supported.
-     *
-     * @note added in 2.16
-     */
-    QVariant providerProperty( ProviderProperty property, const QVariant& defaultValue = QVariant() ) const;
+ Several successive calls to enterUpdateMode() can be done. So there is
+ a concept of stack of calls that must be handled by the provider. Only the last
+ call to leaveUpdateMode() will really turn update mode off.
 
-    /**
-     * Get the current value of a certain provider property.
-     * It depends on the provider which properties are supported.
-     *
-     * @note added in 2.16
-     */
-    // QVariant providerProperty( int property , const QVariant& defaultValue ) const;
+ :return: true in case of success (or no-op implementation), false in case of failure.
+
+.. versionadded:: 2.16
+ :rtype: bool
+%End
+
+    void setProviderProperty( ProviderProperty property, const QVariant &value );
+%Docstring
+ Allows setting arbitrary properties on the provider.
+ It depends on the provider which properties are supported.
+
+.. versionadded:: 2.16
+%End
+
+
+    QVariant providerProperty( ProviderProperty property, const QVariant &defaultValue = QVariant() ) const;
+%Docstring
+ Get the current value of a certain provider property.
+ It depends on the provider which properties are supported.
+
+.. versionadded:: 2.16
+ :rtype: QVariant
+%End
+
 
   signals:
 
-    /**
-     *   This is emitted whenever the worker thread has fully calculated the
-     *   PostGIS extents for this layer, and its event has been received by this
-     *   provider.
-     */
     void fullExtentCalculated();
+%Docstring
+   This is emitted whenever the worker thread has fully calculated the
+   PostGIS extents for this layer, and its event has been received by this
+   provider.
+%End
 
-    /**
-     *   This is emitted whenever an asynchronous operation has finished
-     *   and the data should be redrawn
-     *
-     *   When emitted from a QgsVectorDataProvider, any cached information such as
-     *   feature ids should be invalidated.
-     */
     void dataChanged();
+%Docstring
+   This is emitted whenever an asynchronous operation has finished
+   and the data should be redrawn
+
+   When emitted from a QgsVectorDataProvider, any cached information such as
+   feature ids should be invalidated.
+%End
 
   protected:
 
-    /** Add error message */
-    void appendError( const QgsErrorMessage & message );
 
-    /** Set error message */
-    void setError( const QgsError & error );
+
+    void appendError( const QgsErrorMessage &message );
+%Docstring
+Add error message
+%End
+
+    void setError( const QgsError &error );
+%Docstring
+Set error message
+%End
+
 };
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsdataprovider.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/scripts/sipdiff
+++ b/scripts/sipdiff
@@ -29,7 +29,7 @@ for file in $*; do
 
   if ! grep -Fxq "$d/$f.sip" python/auto_sip.blacklist; then
     echo -e "\033[0;31m$d/$f.sip is an automatically generated SIP file\033[0m"
-    echo -e "  g) \x1B[4mg\x1B[0menerate the SIP file \033[0;32m./sripts/sipify.pl $header > $d/$f.sip\033[0m"
+    echo -e "  g) \x1B[4mg\x1B[0menerate the SIP file \033[0;32m./scripts/sipify.pl $header > python/$d/$f.sip\033[0m"
     echo -e "  s) \x1B[4ms\x1B[0mhow the diff"
     SHOW=NO
     while read -n 1 n; do
@@ -37,7 +37,9 @@ for file in $*; do
       case $n in
         g)
           echo "Generating the SIP file ..."
-          ${DIR}/scripts/sipify.pl ${DIR}/$header > ${DIR}/python/$d/$f.sip
+          pushd ${DIR}
+          ./scripts/sipify.pl $header > python/$d/$f.sip
+          popd
           break
           ;;
         s)

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -26,7 +26,7 @@
 #include "qgsdatasourceuri.h"
 #include "qgserror.h"
 
-typedef int dataCapabilities_t();
+typedef int dataCapabilities_t(); // SIP_SKIP
 
 class QgsRectangle;
 class QgsCoordinateReferenceSystem;
@@ -46,6 +46,23 @@ class QgsCoordinateReferenceSystem;
 
 class CORE_EXPORT QgsDataProvider : public QObject
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsVectorDataProvider *>( sipCpp ) )
+    {
+      sipType = sipType_QgsVectorDataProvider;
+    }
+    else if ( qobject_cast<QgsRasterDataProvider *>( sipCpp ) )
+    {
+      sipType = sipType_QgsRasterDataProvider;
+    }
+    else
+    {
+      sipType = 0;
+    }
+    SIP_END
+#endif
     Q_OBJECT
 
   public:
@@ -74,7 +91,10 @@ class CORE_EXPORT QgsDataProvider : public QObject
       CustomData   = 3000          //!< Custom properties for 3rd party providers or very provider-specific properties which are not expected to be of interest for other providers can be added starting from this value up.
     };
 
-    QgsDataProvider( QString const &uri = "" )
+    /**
+     * Create a new dataprovider with the specified in the \a uri.
+     */
+    QgsDataProvider( const QString &uri = QString() )
       : mDataSourceURI( uri )
     {}
 
@@ -117,6 +137,25 @@ class CORE_EXPORT QgsDataProvider : public QObject
       }
     }
 
+    /**
+     * Set the data source specification.
+     *
+     * \since QGIS 3.0
+     */
+    void setUri( const QgsDataSourceUri &uri )
+    {
+      mDataSourceURI = uri.uri( true );
+    }
+
+    /**
+     * Get the data source specification.
+     *
+     * \since QGIS 3.0
+     */
+    QgsDataSourceUri uri() const
+    {
+      return QgsDataSourceUri( mDataSourceURI );
+    }
 
     /**
      * Returns the extent of the layer
@@ -373,7 +412,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * \since QGIS 2.16
      */
-    void setProviderProperty( int property, const QVariant &value );
+    void setProviderProperty( int property, const QVariant &value ); // SIP_SKIP
 
     /**
      * Get the current value of a certain provider property.
@@ -389,7 +428,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * \since QGIS 2.16
      */
-    QVariant providerProperty( int property, const QVariant &defaultValue ) const;
+    QVariant providerProperty( int property, const QVariant &defaultValue ) const; // SIP_SKIP
 
   signals:
 
@@ -420,7 +459,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
     QgsError mError;
 
     //! Add error message
-    void appendError( const QgsErrorMessage &message ) { mError.append( message );}
+    void appendError( const QgsErrorMessage &message ) { mError.append( message ); }
 
     //! Set error message
     void setError( const QgsError &error ) { mError = error;}


### PR DESCRIPTION
Mainly for the purpose of not having to create this manually every single time it's used in a plugin for something.

But it might as well be saved as such to reduce the parsing overhead.