### PR TITLE
Fix build of dxf2shp plugin with GDAL 2.2

### DIFF
--- a/src/plugins/dxf2shp_converter/CMakeLists.txt
+++ b/src/plugins/dxf2shp_converter/CMakeLists.txt
@@ -8,6 +8,8 @@ SET (dxf2shpconverter_SRCS
      builder.cpp
      dxflib/src/dl_dxf.cpp
      dxflib/src/dl_writer_ascii.cpp
+     shapelib-1.2.10/dbfopen.c
+     shapelib-1.2.10/shpopen.c
      )
 
 SET (dxf2shpconverter_UIS dxf2shpconvertergui.ui)
@@ -32,6 +34,7 @@ ADD_LIBRARY (dxf2shpconverterplugin MODULE ${dxf2shpconverter_SRCS} ${dxf2shpcon
 
 INCLUDE_DIRECTORIES(
      ${CMAKE_CURRENT_BINARY_DIR}
+     ${GDAL_INCLUDE_DIR}
      ../../core
      ../../core/geometry
      ../../core/raster

--- a/src/plugins/dxf2shp_converter/shapelib-1.2.10/shapefil.h
+++ b/src/plugins/dxf2shp_converter/shapelib-1.2.10/shapefil.h
@@ -116,9 +116,60 @@
 
 #include <stdio.h>
 
+#include "cpl_vsi.h"
+
 #ifdef USE_DBMALLOC
 #include <dbmalloc.h>
 #endif
+
+#define SHPOpen qgis_SHPOpen
+#define SHPCreate qgis_SHPCreate
+#define SHPGetInfo qgis_SHPGetInfo
+#define SHPReadObject qgis_SHPReadObject
+#define SHPWriteObject qgis_SHPWriteObject
+#define SHPDestroyObject qgis_SHPDestroyObject
+#define SHPComputeExtents qgis_SHPComputeExtents
+#define SHPCreateObject qgis_SHPCreateObject
+#define SHPCreateSimpleObject qgis_SHPCreateSimpleObject
+#define SHPRewindObject qgis_SHPRewindObject
+#define SHPClose qgis_SHPClose
+#define SHPTypeName qgis_SHPTypeName
+#define SHPPartTypeName qgis_SHPPartTypeName
+#define SHPCreateTree qgis_SHPCreateTree
+#define SHPDestroyTree qgis_SHPDestroyTree
+#define SHPWriteTree qgis_SHPWriteTree
+#define SHPReadTree qgis_SHPReadTree
+#define SHPTreeAddObject qgis_SHPTreeAddObject
+#define SHPTreeAddShapeId qgis_SHPTreeAddShapeId
+#define SHPTreeRemoveShapeId qgis_SHPTreeRemoveShapeId
+#define SHPTreeTrimExtraNodes qgis_SHPTreeTrimExtraNodes
+#define SHPTreeFindLikelyShapes qgis_SHPTreeFindLikelyShapes
+#define SHPCheckBoundsOverlap qgis_SHPCheckBoundsOverlap
+#define DBFOpen qgis_DBFOpen
+#define DBFCreate qgis_DBFCreate
+#define DBFGetFieldCount qgis_DBFGetFieldCount
+#define DBFGetRecordCount qgis_DBFGetRecordCount
+#define DBFAddField qgis_DBFAddField
+#define DBFFieldType qgis_DBFFieldType
+#define DBFGetFieldInfo qgis_DBFGetFieldInfo
+#define DBFGetFieldIndex qgis_DBFGetFieldIndex
+#define DBFReadIntegerAttribute qgis_DBFReadIntegerAttribute
+#define DBFReadDoubleAttribute qgis_DBFReadDoubleAttribute
+#define DBFReadStringAttribute qgis_DBFReadStringAttribute
+#define DBFReadLogicalAttribute qgis_DBFReadLogicalAttribute
+#define DBFIsAttributeNULL qgis_DBFIsAttributeNULL
+#define DBFWriteIntegerAttribute qgis_DBFWriteIntegerAttribute
+#define DBFWriteDoubleAttribute qgis_DBFWriteDoubleAttribute
+#define DBFWriteStringAttribute qgis_DBFWriteStringAttribute
+#define DBFWriteNULLAttribute qgis_DBFWriteNULLAttribute
+#define DBFWriteLogicalAttribute qgis_DBFWriteLogicalAttribute
+#define DBFWriteAttributeDirectly qgis_DBFWriteAttributeDirectly
+#define DBFReadTuple qgis_DBFReadTuple
+#define DBFWriteTuple qgis_DBFWriteTuple
+#define DBFCloneEmpty qgis_DBFCloneEmpty
+#define DBFClose qgis_DBFClose
+#define DBFGetNativeFieldType qgis_DBFGetNativeFieldType
+
 
 #ifdef __cplusplus
 extern "C"
@@ -189,8 +240,8 @@ extern "C"
   /************************************************************************/
   typedef struct
   {
-    FILE        *fpSHP;
-    FILE *fpSHX;
+    VSILFILE        *fpSHP;
+    VSILFILE *fpSHX;
 
     int  nShapeType;    /* SHPT_* */
 
@@ -382,7 +433,7 @@ extern "C"
   /************************************************************************/
   typedef struct
   {
-    FILE *fp;
+    VSILFILE *fp;
 
     int         nRecords;
 


### PR DESCRIPTION
Up to know the plugin relied on the fact that GDAL exported the symbols of
its internal shapelib. Since GDAL 2.2 this is no longer the case. So build
the internal copy of shapelib in the plugin, but to avoid symbol name clashes,
prefix the shapelib symbols with qgis_. And also use GDAL VSI large API for I/O
so that on Windows on particular non ASCII filenames are properly handled.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
