### PR TITLE
[bugfix] Fix unit of sizes when reading a SLD file (uom attribute from SLD 1.1 version is supported)

### DIFF
--- a/python/core/symbology-ng/qgssymbollayerutils.sip
+++ b/python/core/symbology-ng/qgssymbollayerutils.sip
@@ -90,6 +90,14 @@ class QgsSymbolLayerUtils
      */
     static QgsUnitTypes::RenderUnit decodeSldUom( const QString &str, double *scaleFactor );
 
+    /** Returns the size scaled in pixels according to the uom attribute.
+     * \param uom The uom attribute from SLD 1.1 version
+     * \param size The original size
+     * \returns the size in pixels
+     * \since QGIS 3.0
+     */
+    static double sizeInPixelsFromSldUom( const QString &uom, double size );
+
     static QString encodeScaleMethod( QgsSymbol::ScaleMethod scaleMethod );
     static QgsSymbol::ScaleMethod decodeScaleMethod( const QString &str );
 

--- a/src/core/symbology-ng/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayer.cpp
@@ -451,6 +451,10 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
   if ( !QgsSymbolLayerUtils::wellKnownMarkerFromSld( graphicElem, name, fillColor, strokeColor, strokeStyle, strokeWidth, size ) )
     return nullptr;
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  size = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, size );
+  strokeWidth = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, strokeWidth );
+
   double angle = 0.0;
   QString angleFunc;
   if ( QgsSymbolLayerUtils::rotationFromSldElement( graphicElem, angleFunc ) )
@@ -462,6 +466,7 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
   }
 
   QgsEllipseSymbolLayer *m = new QgsEllipseSymbolLayer();
+  m->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   m->setSymbolName( name );
   m->setFillColor( fillColor );
   m->setStrokeColor( strokeColor );

--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -381,7 +381,13 @@ QgsSymbolLayer *QgsSimpleFillSymbolLayer::createFromSld( QDomElement &element )
   QPointF offset;
   QgsSymbolLayerUtils::displacementFromSldElement( element, offset );
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  offset.setX( QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset.x() ) );
+  offset.setY( QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset.y() ) );
+  strokeWidth = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, strokeWidth );
+
   QgsSimpleFillSymbolLayer *sl = new QgsSimpleFillSymbolLayer( color, fillStyle, strokeColor, strokeStyle, strokeWidth );
+  sl->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   sl->setOffset( offset );
   return sl;
 }
@@ -2134,6 +2140,10 @@ QgsSymbolLayer *QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
 
   QgsSymbolLayerUtils::lineFromSld( graphicElem, penStyle, strokeColor, strokeWidth );
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  size = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, size );
+  strokeWidth = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, strokeWidth );
+
   double angle = 0.0;
   QString angleFunc;
   if ( QgsSymbolLayerUtils::rotationFromSldElement( graphicElem, angleFunc ) )
@@ -2145,6 +2155,7 @@ QgsSymbolLayer *QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
   }
 
   QgsSVGFillSymbolLayer *sl = new QgsSVGFillSymbolLayer( path, size, angle );
+  sl->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   sl->setSvgFillColor( fillColor );
   sl->setSvgStrokeColor( strokeColor );
   sl->setSvgStrokeWidth( strokeWidth );
@@ -2950,7 +2961,12 @@ QgsSymbolLayer *QgsLinePatternFillSymbolLayer::createFromSld( QDomElement &eleme
     offset = sqrt( pow( vectOffset.x(), 2 ) + pow( vectOffset.y(), 2 ) );
   }
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  size = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, size );
+  lineWidth = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, lineWidth );
+
   QgsLinePatternFillSymbolLayer *sl = new QgsLinePatternFillSymbolLayer();
+  sl->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   sl->setColor( lineColor );
   sl->setLineWidth( lineWidth );
   sl->setLineAngle( angle );

--- a/src/core/symbology-ng/qgslinesymbollayer.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayer.cpp
@@ -462,7 +462,12 @@ QgsSymbolLayer *QgsSimpleLineSymbolLayer::createFromSld( QDomElement &element )
       offset = d;
   }
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  width = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, width );
+  offset = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset );
+
   QgsSimpleLineSymbolLayer *l = new QgsSimpleLineSymbolLayer( color, width, penStyle );
+  l->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   l->setOffset( offset );
   l->setPenJoinStyle( penJoinStyle );
   l->setPenCapStyle( penCapStyle );
@@ -1518,7 +1523,12 @@ QgsSymbolLayer *QgsMarkerLineSymbolLayer::createFromSld( QDomElement &element )
       offset = d;
   }
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  interval = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, interval );
+  offset = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset );
+
   QgsMarkerLineSymbolLayer *x = new QgsMarkerLineSymbolLayer( rotateMarker );
+  x->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   x->setPlacement( placement );
   x->setInterval( interval );
   x->setSubSymbol( marker.release() );

--- a/src/core/symbology-ng/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayer.cpp
@@ -1194,7 +1194,13 @@ QgsSymbolLayer *QgsSimpleMarkerSymbolLayer::createFromSld( QDomElement &element 
 
   Shape shape = decodeShape( name );
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  size = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, size );
+  offset.setX( QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset.x() ) );
+  offset.setY( QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset.y() ) );
+
   QgsSimpleMarkerSymbolLayer *m = new QgsSimpleMarkerSymbolLayer( shape, size );
+  m->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   m->setColor( color );
   m->setStrokeColor( strokeColor );
   m->setAngle( angle );
@@ -2217,6 +2223,9 @@ QgsSymbolLayer *QgsSvgMarkerSymbolLayer::createFromSld( QDomElement &element )
   if ( !QgsSymbolLayerUtils::externalGraphicFromSld( graphicElem, path, mimeType, fillColor, size ) )
     return nullptr;
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  size = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, size );
+
   if ( mimeType != QLatin1String( "image/svg+xml" ) )
     return nullptr;
 
@@ -2234,6 +2243,7 @@ QgsSymbolLayer *QgsSvgMarkerSymbolLayer::createFromSld( QDomElement &element )
   QgsSymbolLayerUtils::displacementFromSldElement( graphicElem, offset );
 
   QgsSvgMarkerSymbolLayer *m = new QgsSvgMarkerSymbolLayer( path, size );
+  m->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   m->setFillColor( fillColor );
   //m->setStrokeColor( strokeColor );
   //m->setStrokeWidth( strokeWidth );
@@ -2874,7 +2884,13 @@ QgsSymbolLayer *QgsFontMarkerSymbolLayer::createFromSld( QDomElement &element )
   QPointF offset;
   QgsSymbolLayerUtils::displacementFromSldElement( graphicElem, offset );
 
+  QString uom = element.attribute( QStringLiteral( "uom" ), "" );
+  offset.setX( QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset.x() ) );
+  offset.setY( QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, offset.y() ) );
+  size = QgsSymbolLayerUtils::sizeInPixelsFromSldUom( uom, size );
+
   QgsMarkerSymbolLayer *m = new QgsFontMarkerSymbolLayer( fontFamily, chr, size, color );
+  m->setOutputUnit( QgsUnitTypes::RenderUnit::RenderPixels );
   m->setAngle( angle );
   m->setOffset( offset );
   return m;

--- a/src/core/symbology-ng/qgssymbollayerutils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerutils.cpp
@@ -4036,3 +4036,23 @@ void QgsSymbolLayerUtils::mergeScaleDependencies( int mScaleMinDenom, int mScale
       props[ QStringLiteral( "scaleMaxDenom" )] = QString::number( qMin( parentScaleMaxDenom, mScaleMaxDenom ) );
   }
 }
+
+double QgsSymbolLayerUtils::sizeInPixelsFromSldUom( const QString &uom, double size )
+{
+  double scale = 1.0;
+
+  if ( uom == QLatin1String( "http://www.opengeospatial.org/se/units/metre" ) )
+  {
+    scale = 1.0 / 0.00028; // from meters to pixels
+  }
+  else if ( uom == QLatin1String( "http://www.opengeospatial.org/se/units/foot" ) )
+  {
+    scale = 304.8 / 0.28; // from feet to pixels
+  }
+  else
+  {
+    scale = 1.0; // from pixels to pixels (default unit)
+  }
+
+  return size * scale;
+}

--- a/src/core/symbology-ng/qgssymbollayerutils.h
+++ b/src/core/symbology-ng/qgssymbollayerutils.h
@@ -137,6 +137,14 @@ class CORE_EXPORT QgsSymbolLayerUtils
      */
     static QgsUnitTypes::RenderUnit decodeSldUom( const QString &str, double *scaleFactor );
 
+    /** Returns the size scaled in pixels according to the uom attribute.
+     * \param uom The uom attribute from SLD 1.1 version
+     * \param size The original size
+     * \returns the size in pixels
+     * \since QGIS 3.0
+     */
+    static double sizeInPixelsFromSldUom( const QString &uom, double size );
+
     static QString encodeScaleMethod( QgsSymbol::ScaleMethod scaleMethod );
     static QgsSymbol::ScaleMethod decodeScaleMethod( const QString &str );
 

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -26,11 +26,23 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 import os
+from qgis.PyQt.QtXml import QDomDocument
 from qgis.testing import start_app, unittest
 from qgis.core import (QgsVectorLayer,
                        QgsFeature,
                        QgsGeometry,
-                       QgsPoint
+                       QgsUnitTypes,
+                       QgsPoint,
+                       QgsSvgMarkerSymbolLayer,
+                       QgsEllipseSymbolLayer,
+                       QgsSimpleFillSymbolLayer,
+                       QgsSVGFillSymbolLayer,
+                       QgsSvgMarkerSymbolLayer,
+                       QgsLinePatternFillSymbolLayer,
+                       QgsSimpleLineSymbolLayer,
+                       QgsMarkerLineSymbolLayer,
+                       QgsSimpleMarkerSymbolLayer,
+                       QgsFontMarkerSymbolLayer
                        )
 from qgis.testing.mocked import get_iface
 from utilities import unitTestDataPath
@@ -49,6 +61,28 @@ def createLayerWithOneLine():
     one.setGeometry(QgsGeometry.fromPolyline([QgsPoint(-7, 38), QgsPoint(-8, 42)]))
     linelayer.dataProvider().addFeatures([one])
     return linelayer
+
+
+def createLayerWithOnePoint():
+    layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer",
+                           "addfeat", "memory")
+    pr = layer.dataProvider()
+    f = QgsFeature()
+    f.setAttributes(["test", 123])
+    f.setGeometry(QgsGeometry.fromPoint(QgsPoint(100, 200)))
+    assert pr.addFeatures([f])
+    assert layer.pendingFeatureCount() == 1
+    return layer
+
+
+def createLayerWithOnePolygon():
+    layer = QgsVectorLayer("Polygon?crs=epsg:3111&field=pk:int", "vl", "memory")
+    assert layer.isValid()
+    f1 = QgsFeature(layer.dataProvider().fields(), 1)
+    f1.setAttribute("pk", 1)
+    f1.setGeometry(QgsGeometry.fromPolygon([[QgsPoint(2484588, 2425722), QgsPoint(2482767, 2398853), QgsPoint(2520109, 2397715), QgsPoint(2520792, 2425494), QgsPoint(2484588, 2425722)]]))
+    assert layer.dataProvider().addFeatures([f1])
+    return layer
 
 
 class TestQgsSymbolLayerReadSld(unittest.TestCase):
@@ -110,6 +144,264 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         layer.loadSldStyle(mFilePath)
         props = layer.renderer().symbol().symbolLayers()[0].properties()
         self.assertEqual(props['angle'], '50')
+
+    def testSymbolSizeUom(self):
+        # create a layer
+        layer = createLayerWithOnePoint()
+
+        # load a sld with marker size without uom attribute (pixels)
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+
+        # load a sld with marker size with uom attribute in pixel
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerUomPixel.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+
+        # load a sld with marker size with uom attribute in meter
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerUomMetre.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12 / (0.28 * 0.001)
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertAlmostEqual(size, sld_size_px, delta=0.1)
+
+        # load a sld with marker size with uom attribute in foot
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerUomFoot.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12 * (304.8 / 0.28)
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertAlmostEqual(size, sld_size_px, delta=0.1)
+
+    def testSymbolSize(self):
+        # create a layers
+        layer = createLayerWithOnePoint()
+        player = createLayerWithOnePolygon()
+
+        # size test for QgsEllipseSymbolLayer
+        sld = 'symbol_layer/QgsEllipseSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 7
+        sld_stroke_width_px = 1
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.symbolWidth()
+        stroke_width = sl.strokeWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsEllipseSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(stroke_width, sld_stroke_width_px)
+
+        # size test for QgsVectorFieldSymbolLayer
+        # createFromSld not implemented
+
+        # size test for QgsSimpleFillSymbolLayer
+        sld = 'symbol_layer/QgsSimpleFillSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_stroke_width_px = 0.26
+
+        sl = player.renderer().symbol().symbolLayers()[0]
+        stroke_width = sl.strokeWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSimpleFillSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(stroke_width, sld_stroke_width_px)
+
+        # size test for QgsSVGFillSymbolLayer
+        sld = 'symbol_layer/QgsSVGFillSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_size_px = 6
+        sld_stroke_width_px = 3
+
+        sl = player.renderer().symbol().symbolLayers()[0]
+        size = sl.patternWidth()
+        stroke_width = sl.svgStrokeWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSVGFillSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(stroke_width, sld_stroke_width_px)
+
+        # size test for QgsSvgMarkerSymbolLayer
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSvgMarkerSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+
+        # size test for QgsPointPatternFillSymbolLayer
+        # createFromSld not implemented
+
+        # size test for QgsLinePatternFillSymbolLayer
+        sld = 'symbol_layer/QgsLinePatternFillSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_size_px = 4
+        sld_stroke_width_px = 1.5
+
+        sl = player.renderer().symbol().symbolLayers()[0]
+        size = sl.distance()
+        stroke_width = sl.lineWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsLinePatternFillSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(stroke_width, sld_stroke_width_px)
+
+        # test size for QgsSimpleLineSymbolLayer
+        sld = 'symbol_layer/QgsSimpleLineSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_stroke_width_px = 1.26
+
+        sl = player.renderer().symbol().symbolLayers()[0]
+        stroke_width = sl.width()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSimpleLineSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(stroke_width, sld_stroke_width_px)
+
+        # test size for QgsMarkerLineSymbolLayer
+        sld = 'symbol_layer/QgsMarkerLineSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_interval_px = 3.3
+        sld_offset_px = 6.6
+
+        sl = player.renderer().symbol().symbolLayers()[0]
+        interval = sl.interval()
+        offset = sl.offset()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsMarkerLineSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(interval, sld_interval_px)
+        self.assertEqual(offset, sld_offset_px)
+
+        # test size for QgsSimpleMarkerSymbolLayer
+        sld = 'symbol_layer/QgsSimpleMarkerSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 6
+        sld_displacement_x_px = 3.3
+        sld_displacement_y_px = 6.6
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        offset = sl.offset()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSimpleMarkerSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(offset.x(), sld_displacement_x_px)
+        self.assertEqual(offset.y(), sld_displacement_y_px)
+
+        # test size for QgsSVGMarkerSymbolLayer
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        self.assertTrue(isinstance(sl, QgsSvgMarkerSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+
+        # test size for QgsFontMarkerSymbolLayer
+        sld = 'symbol_layer/QgsFontMarkerSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 6.23
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        size = sl.size()
+        self.assertTrue(isinstance(sl, QgsFontMarkerSymbolLayer))
+        self.assertEqual(unit, QgsUnitTypes.RenderPixels)
+        self.assertEqual(size, sld_size_px)
+
+    def testSymbolSizeAfterReload(self):
+        # create a layer
+        layer = createLayerWithOnePoint()
+
+        # load a sld with marker size
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        # get the size and unit of the symbol
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        first_size = sl.size()
+        first_unit = sl.outputUnit()  # in pixels
+
+        # export sld into a qdomdocument with namespace processing activated
+        doc = QDomDocument()
+        msg = ""
+        layer.exportSldStyle(doc, msg)
+        doc.setContent(doc.toString(), True)
+        self.assertTrue(msg == "")
+
+        # reload the same sld
+        root = doc.firstChildElement("StyledLayerDescriptor")
+        el = root.firstChildElement("NamedLayer")
+        layer.readSld(el, msg)
+
+        # extract the size and unit of symbol
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        second_size = sl.size()
+        second_unit = sl.outputUnit()
+
+        # size and unit should be the same after export and reload the same
+        # sld description
+        self.assertEqual(first_size, second_size)
+        self.assertEqual(first_unit, second_unit)
 
 
 if __name__ == '__main__':

--- a/tests/testdata/symbol_layer/QgsMarkerLineSymbolLayer.sld
+++ b/tests/testdata/symbol_layer/QgsMarkerLineSymbolLayer.sld
@@ -11,6 +11,8 @@
             <VendorOption name="placement">centralPoint</VendorOption>
             <se:Stroke>
               <se:GraphicStroke>
+                <se:Gap>3.3</se:Gap>
+                <se:PerpendicularOffset>6.6</se:PerpendicularOffset>
                 <se:Graphic>
                   <se:Mark>
                     <se:WellKnownName>circle</se:WellKnownName>

--- a/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomFoot.sld
+++ b/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomFoot.sld
@@ -7,24 +7,15 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Single symbol</se:Name>
-          <se:PointSymbolizer>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/foot">
             <se:Graphic>
-              <se:Displacement>
-                <se:DisplacementX>3.3</se:DisplacementX>
-                <se:DisplacementY>6.6</se:DisplacementY>
-              </se:Displacement>
-              <se:Mark>
-                <se:WellKnownName>pentagon</se:WellKnownName>
-                <se:Fill>
-                  <se:SvgParameter name="fill">#68a0f4</se:SvgParameter>
-                </se:Fill>
-                <se:Stroke>
-                  <se:SvgParameter name="stroke">#5500ff</se:SvgParameter>
-                </se:Stroke>
-              </se:Mark>
-              <se:Size>6</se:Size>
+              <se:ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="file:///gpsicons/skull.svg"/>
+                <Format>image/svg+xml</Format>
+              </se:ExternalGraphic>
+              <se:Size>12</se:Size>
               <se:Rotation>
-                <ogc:Literal>10</ogc:Literal>
+                <ogc:Literal>45</ogc:Literal>
               </se:Rotation>
             </se:Graphic>
           </se:PointSymbolizer>

--- a/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomMetre.sld
+++ b/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomMetre.sld
@@ -7,24 +7,15 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Single symbol</se:Name>
-          <se:PointSymbolizer>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
             <se:Graphic>
-              <se:Displacement>
-                <se:DisplacementX>3.3</se:DisplacementX>
-                <se:DisplacementY>6.6</se:DisplacementY>
-              </se:Displacement>
-              <se:Mark>
-                <se:WellKnownName>pentagon</se:WellKnownName>
-                <se:Fill>
-                  <se:SvgParameter name="fill">#68a0f4</se:SvgParameter>
-                </se:Fill>
-                <se:Stroke>
-                  <se:SvgParameter name="stroke">#5500ff</se:SvgParameter>
-                </se:Stroke>
-              </se:Mark>
-              <se:Size>6</se:Size>
+              <se:ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="file:///gpsicons/skull.svg"/>
+                <Format>image/svg+xml</Format>
+              </se:ExternalGraphic>
+              <se:Size>12</se:Size>
               <se:Rotation>
-                <ogc:Literal>10</ogc:Literal>
+                <ogc:Literal>45</ogc:Literal>
               </se:Rotation>
             </se:Graphic>
           </se:PointSymbolizer>

--- a/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomPixel.sld
+++ b/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomPixel.sld
@@ -7,24 +7,15 @@
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:Name>Single symbol</se:Name>
-          <se:PointSymbolizer>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">
             <se:Graphic>
-              <se:Displacement>
-                <se:DisplacementX>3.3</se:DisplacementX>
-                <se:DisplacementY>6.6</se:DisplacementY>
-              </se:Displacement>
-              <se:Mark>
-                <se:WellKnownName>pentagon</se:WellKnownName>
-                <se:Fill>
-                  <se:SvgParameter name="fill">#68a0f4</se:SvgParameter>
-                </se:Fill>
-                <se:Stroke>
-                  <se:SvgParameter name="stroke">#5500ff</se:SvgParameter>
-                </se:Stroke>
-              </se:Mark>
-              <se:Size>6</se:Size>
+              <se:ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="file:///gpsicons/skull.svg"/>
+                <Format>image/svg+xml</Format>
+              </se:ExternalGraphic>
+              <se:Size>12</se:Size>
               <se:Rotation>
-                <ogc:Literal>10</ogc:Literal>
+                <ogc:Literal>45</ogc:Literal>
               </se:Rotation>
             </se:Graphic>
           </se:PointSymbolizer>


### PR DESCRIPTION
## Description

I noticed an issue by playing with the Save/Load style in/from SLD files functionality.

For example, if I save my current symbology into a SLD file:

![bugfixsld_0](https://cloud.githubusercontent.com/assets/9266424/25522453/3b951750-2c03-11e7-9485-93498e276f41.png)

Then, if  I reload the same SLD file just previously saved, my symbology has changed:

![bugfixsld_1](https://cloud.githubusercontent.com/assets/9266424/25522490/6215afac-2c03-11e7-92d0-cec053d4f8d7.png)

It's because the default unit in SLD files is pixels. However, it's considered as millimeters when layers of symbols are created from the SLD file. 

So:
- this PR changes the default unit in pixels for layers of symbols created from a SLD file
- the uom attribute coming with the SLD 1.1 version is supported (allow to indicate if the unit is in meter, pixel of feet)
- some unit tests are added to validate the behavior

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
