### PR TITLE
expose image compression in the layer metadata (fix #15702)

### DIFF
--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -286,6 +286,15 @@ QString QgsGdalProvider::metadata()
     QgsDebugMsg( "dataset has no metadata" );
   }
 
+  // compression
+  QString compression = QString( GDALGetMetadataItem( mGdalDataset, "COMPRESSION", "IMAGE_STRUCTURE" ) );
+  if ( !compression.isEmpty() )
+  {
+    myMetadata += QLatin1String( "<p>" );
+    myMetadata += tr( "COMPRESSION=%1" ).arg( compression );
+    myMetadata += QLatin1String( "</p>\n" );
+  }
+
   for ( int i = 1; i <= GDALGetRasterCount( mGdalDataset ); ++i )
   {
     myMetadata += "<p class=\"glossy\">" + tr( "Band %1" ).arg( i ) + "</p>\n";


### PR DESCRIPTION
Display information about raster compression in the metadata field. Fixes https://hub.qgis.org/issues/15702
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
