### PR TITLE
Expression performance

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -8,7 +8,6 @@ core/qgsdbfilterproxymodel.sip
 core/qgseditformconfig.sip
 core/qgseditorwidgetsetup.sip
 core/qgserror.sip
-core/qgsexpression.sip
 core/qgsexpressioncontext.sip
 core/qgsexpressioncontextgenerator.sip
 core/qgsfeaturefilterprovider.sip

--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -85,7 +85,6 @@ core/qgsruntimeprofiler.sip
 core/qgsscalecalculator.sip
 core/qgsscaleutils.sip
 core/qgssimplifymethod.sip
-core/qgssnapper.sip
 core/qgssnappingutils.sip
 core/qgsspatialindex.sip
 core/qgssqlstatement.sip

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -1134,7 +1134,7 @@ The name of the column.
  :rtype: str
 %End
 
-        virtual NodeType nodeType() const;
+        virtual QgsExpression::NodeType nodeType() const;
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -1,213 +1,371 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsexpression.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
 class QgsExpression
 {
+%Docstring
+Class for parsing and evaluation of expressions (formerly called "search strings").
+The expressions try to follow both syntax and semantics of SQL expressions.
+
+Usage:
+\code{.cpp}
+QgsExpression exp("gid*2 > 10 and type not in ('D','F'));
+if (exp.hasParserError())
+{
+// show error message with parserErrorString() and exit
+}
+QVariant result = exp.evaluate(feature, fields);
+if (exp.hasEvalError())
+{
+// show error message with evalErrorString()
+}
+else
+{
+// examine the result
+}
+\endcode
+
+Three Value Logic
+=================
+
+Similarly to SQL, this class supports three-value logic: true/false/unknown.
+Unknown value may be a result of operations with missing data (NULL). Please note
+that NULL is different value than zero or an empty string. For example
+3 > NULL returns unknown.
+
+There is no special (three-value) 'boolean' type: true/false is represented as
+1/0 integer, unknown value is represented the same way as NULL values: invalid QVariant.
+
+Performance
+===========
+
+For better performance with many evaluations you may first call prepare(fields) function
+to find out indices of columns and then repeatedly call evaluate(feature).
+
+Type conversion
+===============
+
+Operators and functions that expect arguments to be of a particular
+type automatically convert the arguments to that type, e.g. sin('2.1') will convert
+the argument to a double, length(123) will first convert the number to a string.
+Explicit conversion can be achieved with to_int, to_real, to_string functions.
+If implicit or explicit conversion is invalid, the evaluation returns an error.
+Comparison operators do numeric comparison in case both operators are numeric (int/double)
+or they can be converted to numeric types.
+
+Implicit sharing
+================
+
+This class is implicitly shared, copying has a very low overhead.
+It is normally preferable to call `QgsExpression( otherExpression )` instead of
+`QgsExpression( otherExpression.expression() )`. A deep copy will only be made
+when prepare() is called. For usage this means mainly, that you should
+normally keep an unprepared master copy of a QgsExpression and whenever using it
+with a particular QgsFeatureIterator copy it just before and prepare it using the
+same context as the iterator.
+
+Implicit sharing was added in 2.14
+%End
+
 %TypeHeaderCode
 #include "qgsexpression.h"
 %End
-
   public:
-    /**
-     * Creates a new expression based on the provided string.
-     * The string will immediately be parsed. For optimization
-     * {@link prepare()} should alwys be called before every
-     * loop in which this expression is used.
-     */
-    QgsExpression( const QString& expr );
-    /**
-     * Create an empty expression.
-     *
-     * @note Added in QGIS 3.0
-     */
+
+    QgsExpression( const QString &expr );
+%Docstring
+ Creates a new expression based on the provided string.
+ The string will immediately be parsed. For optimization
+ prepare() should always be called before every
+ loop in which this expression is used.
+%End
+
+    QgsExpression( const QgsExpression &other );
+%Docstring
+ Create a copy of this expression. This is preferred
+ over recreating an expression from a string since
+ it does not need to be re-parsed.
+%End
+
+
     QgsExpression();
+%Docstring
+ Create an empty expression.
+
+.. versionadded:: 3.0
+%End
 
     ~QgsExpression();
 
-    /**
-     * Checks if this expression is valid.
-     * A valid expression could be parsed but does not necessarily evaluate properly.
-     *
-     * @note Added in QGIS 3.0
-     */
+    bool operator==( const QgsExpression &other ) const;
+%Docstring
+ Compares two expressions. The operator returns true
+ if the expression string is equal.
+
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
     bool isValid() const;
+%Docstring
+ Checks if this expression is valid.
+ A valid expression could be parsed but does not necessarily evaluate properly.
 
-    //! Returns true if an error occurred when parsing the input expression
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
     bool hasParserError() const;
-    //! Returns parser error
+%Docstring
+Returns true if an error occurred when parsing the input expression
+ :rtype: bool
+%End
     QString parserErrorString() const;
+%Docstring
+Returns parser error
+ :rtype: str
+%End
 
-    //! Returns root node of the expression. Root node is null is parsing has failed
-    const QgsExpression::Node* rootNode() const;
 
-    /** Get the expression ready for evaluation - find out column indexes.
-     * @param context context for preparing expression
-     * @note added in QGIS 2.12
-     */
+    const QgsExpression::Node *rootNode() const;
+%Docstring
+Returns root node of the expression. Root node is null is parsing has failed
+ :rtype: QgsExpression.Node
+%End
+
     bool prepare( const QgsExpressionContext *context );
+%Docstring
+ Get the expression ready for evaluation - find out column indexes.
+ \param context context for preparing expression
+.. versionadded:: 2.12
+ :rtype: bool
+%End
 
-    /**
-     * Get list of columns referenced by the expression.
-     *
-     * @note If the returned list contains the QgsFeatureRequest::AllAttributes constant then
-     * all attributes from the layer are required for evaluation of the expression.
-     * QgsFeatureRequest::setSubsetOfAttributes automatically handles this case.
-     *
-     * @see referencedAttributeIndexes()
-     */
     QSet<QString> referencedColumns() const;
+%Docstring
+ Get list of columns referenced by the expression.
 
-    /**
-     * Return a list of all variables which are used in this expression.
-     */
+.. note::
+
+   If the returned list contains the QgsFeatureRequest.AllAttributes constant then
+ all attributes from the layer are required for evaluation of the expression.
+ QgsFeatureRequest.setSubsetOfAttributes automatically handles this case.
+
+ \see referencedAttributeIndexes()
+ :rtype: set of str
+%End
+
     QSet<QString> referencedVariables() const;
+%Docstring
+ Return a list of all variables which are used in this expression.
+ If the list contains a NULL QString, there is a variable name used
+ which is determined at runtime.
 
-    /**
-     * Return a list of field name indexes obtained from the provided fields.
-     *
-     * @note Added in QGIS 3.0
-     */
-    QSet<int> referencedAttributeIndexes( const QgsFields& fields ) const;
+.. versionadded:: 3.0
+ :rtype: set of str
+%End
 
-    //! Returns true if the expression uses feature geometry for some computation
+    QSet<int> referencedAttributeIndexes( const QgsFields &fields ) const;
+%Docstring
+ Return a list of field name indexes obtained from the provided fields.
+
+.. versionadded:: 3.0
+ :rtype: set of int
+%End
+
     bool needsGeometry() const;
+%Docstring
+Returns true if the expression uses feature geometry for some computation
+ :rtype: bool
+%End
 
-    // evaluation
 
-    /** Evaluate the feature and return the result.
-     * @note this method does not expect that prepare() has been called on this instance
-     * @note added in QGIS 2.12
-     */
     QVariant evaluate();
+%Docstring
+ Evaluate the feature and return the result.
+.. note::
 
-    /** Evaluate the expression against the specified context and return the result.
-     * @param context context for evaluating expression
-     * @note prepare() should be called before calling this method.
-     * @note added in QGIS 2.12
-     */
-    QVariant evaluate( const QgsExpressionContext* context );
+   this method does not expect that prepare() has been called on this instance
+.. versionadded:: 2.12
+ :rtype: QVariant
+%End
 
-    //! Returns true if an error occurred when evaluating last input
+    QVariant evaluate( const QgsExpressionContext *context );
+%Docstring
+ Evaluate the expression against the specified context and return the result.
+ \param context context for evaluating expression
+.. note::
+
+   prepare() should be called before calling this method.
+.. versionadded:: 2.12
+ :rtype: QVariant
+%End
+
     bool hasEvalError() const;
-    //! Returns evaluation error
+%Docstring
+Returns true if an error occurred when evaluating last input
+ :rtype: bool
+%End
     QString evalErrorString() const;
-    //! Set evaluation error (used internally by evaluation functions)
-    void setEvalErrorString( const QString& str );
+%Docstring
+Returns evaluation error
+ :rtype: str
+%End
+    void setEvalErrorString( const QString &str );
+%Docstring
+Set evaluation error (used internally by evaluation functions)
+%End
 
-    /** Checks whether an expression consists only of a single field reference
-     * @note added in 2.9
-     */
     bool isField() const;
+%Docstring
+ Checks whether an expression consists only of a single field reference
+.. versionadded:: 2.9
+ :rtype: bool
+%End
 
-    /** Tests whether a string is a valid expression.
-     * @param text string to test
-     * @param context optional expression context
-     * @param errorMessage will be filled with any error message from the validation
-     * @returns true if string is a valid expression
-     * @note added in QGIS 3.0
-     */
-    static bool checkExpression( const QString& text, const QgsExpressionContext* context, QString &errorMessage /Out/ );
+    static bool checkExpression( const QString &text, const QgsExpressionContext *context, QString &errorMessage /Out/ );
+%Docstring
+ Tests whether a string is a valid expression.
+ \param text string to test
+ \param context optional expression context
+ \param errorMessage will be filled with any error message from the validation
+ :return: true if string is a valid expression
+.. versionadded:: 2.12
+ :rtype: bool
+%End
 
-    /**
-     * Set the expression string, will reset the whole internal structure.
-     *
-     * @note Added in QGIS 3.0
-     */
-    void setExpression( const QString& expression );
+    void setExpression( const QString &expression );
+%Docstring
+ Set the expression string, will reset the whole internal structure.
 
-    //! Return the original, unmodified expression string.
-    //! If there was none supplied because it was constructed by sole
-    //! API calls, dump() will be used to create one instead.
+.. versionadded:: 3.0
+%End
+
     QString expression() const;
+%Docstring
+API calls, dump() will be used to create one instead.
+ :rtype: str
+%End
 
-    //! Return an expression string, constructed from the internal
-    //! abstract syntax tree. This does not contain any nice whitespace
-    //! formatting or comments. In general it is preferable to use
-    //! expression() instead.
     QString dump() const;
+%Docstring
+expression() instead.
+ :rtype: str
+%End
 
-    /** Return calculator used for distance and area calculations
-     * (used by $length, $area and $perimeter functions only)
-     * @see setGeomCalculator()
-     * @see distanceUnits()
-     */
     QgsDistanceArea *geomCalculator();
+%Docstring
+ Return calculator used for distance and area calculations
+ (used by $length, $area and $perimeter functions only)
+ \see setGeomCalculator()
+ \see distanceUnits()
+ \see areaUnits()
+ :rtype: QgsDistanceArea
+%End
 
-    /** Sets the geometry calculator used for distance and area calculations in expressions.
-     * (used by $length, $area and $perimeter functions only). By default, no geometry
-     * calculator is set and all distance and area calculations are performed using simple
-     * cartesian methods (ie no ellipsoidal calculations).
-     * @param calc geometry calculator. Ownership is not transferred. Set to a nullptr to force
-     * cartesian calculations.
-     * @see geomCalculator()
-     */
-    void setGeomCalculator( const QgsDistanceArea* calc );
+    void setGeomCalculator( const QgsDistanceArea *calc );
+%Docstring
+ Sets the geometry calculator used for distance and area calculations in expressions.
+ (used by $length, $area and $perimeter functions only). By default, no geometry
+ calculator is set and all distance and area calculations are performed using simple
+ cartesian methods (ie no ellipsoidal calculations).
+ \param calc geometry calculator. Ownership is not transferred. Set to a None to force
+ cartesian calculations.
+ \see geomCalculator()
+%End
 
-    /** Returns the desired distance units for calculations involving geomCalculator(), e.g., "$length" and "$perimeter".
-     * @note distances are only converted when a geomCalculator() has been set
-     * @note added in QGIS 2.14
-     * @see setDistanceUnits()
-     */
     QgsUnitTypes::DistanceUnit distanceUnits() const;
+%Docstring
+ Returns the desired distance units for calculations involving geomCalculator(), e.g., "$length" and "$perimeter".
+.. note::
 
-    /** Sets the desired distance units for calculations involving geomCalculator(), e.g., "$length" and "$perimeter".
-     * @note distances are only converted when a geomCalculator() has been set
-     * @note added in QGIS 2.14
-     * @see distanceUnits()
-     */
+   distances are only converted when a geomCalculator() has been set
+.. versionadded:: 2.14
+ \see setDistanceUnits()
+ \see areaUnits()
+ :rtype: QgsUnitTypes.DistanceUnit
+%End
+
     void setDistanceUnits( QgsUnitTypes::DistanceUnit unit );
+%Docstring
+ Sets the desired distance units for calculations involving geomCalculator(), e.g., "$length" and "$perimeter".
+.. note::
 
-    /** Returns the desired areal units for calculations involving geomCalculator(), e.g., "$area".
-     * @note areas are only converted when a geomCalculator() has been set
-     * @note added in QGIS 2.14
-     * @see setAreaUnits()
-     * @see distanceUnits()
-     */
+   distances are only converted when a geomCalculator() has been set
+.. versionadded:: 2.14
+ \see distanceUnits()
+ \see setAreaUnits()
+%End
+
     QgsUnitTypes::AreaUnit areaUnits() const;
+%Docstring
+ Returns the desired areal units for calculations involving geomCalculator(), e.g., "$area".
+.. note::
 
-    /** Sets the desired areal units for calculations involving geomCalculator(), e.g., "$area".
-     * @note areas are only converted when a geomCalculator() has been set
-     * @note added in QGIS 2.14
-     * @see areaUnits()
-     * @see setDistanceUnits()
-     */
+   areas are only converted when a geomCalculator() has been set
+.. versionadded:: 2.14
+ \see setAreaUnits()
+ \see distanceUnits()
+ :rtype: QgsUnitTypes.AreaUnit
+%End
+
     void setAreaUnits( QgsUnitTypes::AreaUnit unit );
+%Docstring
+ Sets the desired areal units for calculations involving geomCalculator(), e.g., "$area".
+.. note::
 
-    /** This function replaces each expression between [% and %]
-     * in the string with the result of its evaluation with the specified context
-     *
-     * Additional substitutions can be passed through the substitutionMap parameter
-     * @param action
-     * @param context expression context
-     * @param distanceArea optional QgsDistanceArea. If specified, the QgsDistanceArea is used for distance
-     * and area conversion
-     * @note added in QGIS 2.12
-     */
-    static QString replaceExpressionText( const QString &action, const QgsExpressionContext* context,
-                                          const QgsDistanceArea* distanceArea = 0 );
+   areas are only converted when a geomCalculator() has been set
+.. versionadded:: 2.14
+ \see areaUnits()
+ \see setDistanceUnits()
+%End
 
-    /** Attempts to evaluate a text string as an expression to a resultant double
-     * value.
-     * @param text text to evaluate as expression
-     * @param fallbackValue value to return if text can not be evaluated as a double
-     * @returns evaluated double value, or fallback value
-     * @note added in QGIS 2.7
-     * @note this method is inefficient for bulk evaluation of expressions, it is intended
-     * for one-off evaluations only.
-     */
-    static double evaluateToDouble( const QString& text, const double fallbackValue );
+    static QString replaceExpressionText( const QString &action, const QgsExpressionContext *context,
+                                          const QgsDistanceArea *distanceArea = 0 );
+%Docstring
+ This function replaces each expression between [% and %]
+ in the string with the result of its evaluation with the specified context
 
-    /**
-     * @brief list of unary operators
-     * @note if any change is made here, the definition of QgsExpression::UnaryOperatorText[] must be adapted.
-     */
+ Additional substitutions can be passed through the substitutionMap parameter
+ \param action The source string in which placeholders should be replaced.
+ \param context Expression context
+ \param distanceArea Optional QgsDistanceArea. If specified, the QgsDistanceArea is used for distance
+ and area conversion
+.. versionadded:: 2.12
+ :rtype: str
+%End
+
+    static double evaluateToDouble( const QString &text, const double fallbackValue );
+%Docstring
+ Attempts to evaluate a text string as an expression to a resultant double
+ value.
+ \param text text to evaluate as expression
+ \param fallbackValue value to return if text can not be evaluated as a double
+ :return: evaluated double value, or fallback value
+.. versionadded:: 2.7
+.. note::
+
+   this method is inefficient for bulk evaluation of expressions, it is intended
+ for one-off evaluations only.
+ :rtype: float
+%End
+
     enum UnaryOperator
     {
       uoNot,
       uoMinus,
     };
 
-    /**
-     * @brief list of binary operators
-     * @note if any change is made here, the definition of QgsExpression::BinaryOperatorText[] must be adapted.
-     */
     enum BinaryOperator
     {
       // logical
@@ -215,12 +373,12 @@ class QgsExpression
       boAnd,
 
       // comparison
-      boEQ,  // =
-      boNE,  // <>
-      boLE,  // <=
-      boGE,  // >=
-      boLT,  // <
-      boGT,  // >
+      boEQ,
+      boNE,
+      boLE,
+      boGE,
+      boLT,
+      boGT,
       boRegexp,
       boLike,
       boNotLike,
@@ -255,236 +413,332 @@ class QgsExpression
       soWithin,
     };
 
-    //! @note not available in Python bindings
-    // static const char* BinaryOperatorText[];
 
-    //! @note not available in Python bindings
-    // static const char* UnaryOperatorText[];
 
-    /**
-      * Represents a single parameter passed to a function.
-      * \note added in QGIS 2.16
-      */
     class Parameter
-    {
+{
+%Docstring
+ Represents a single parameter passed to a function.
+.. versionadded:: 2.16
+%End
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
 
-        /** Constructor for Parameter.
-         * @param name parameter name, used when named parameter are specified in an expression
-         * @param optional set to true if parameter should be optional
-         * @param defaultValue default value to use for optional parameters
-         */
-        Parameter( const QString& name,
+        Parameter( const QString &name,
                    bool optional = false,
-                   const QVariant& defaultValue = QVariant() );
+                   const QVariant &defaultValue = QVariant() );
+%Docstring
+ Constructor for Parameter.
+ \param name parameter name, used when named parameter are specified in an expression
+ \param optional set to true if parameter should be optional
+ \param defaultValue default value to use for optional parameters
+%End
 
-        //! Returns the name of the parameter.
         QString name() const;
+%Docstring
+Returns the name of the parameter.
+ :rtype: str
+%End
 
-        //! Returns true if the parameter is optional.
         bool optional() const;
+%Docstring
+Returns true if the parameter is optional.
+ :rtype: bool
+%End
 
-        //! Returns the default value for the parameter.
         QVariant defaultValue() const;
+%Docstring
+Returns the default value for the parameter.
+ :rtype: QVariant
+%End
 
-        bool operator==( const QgsExpression::Parameter& other ) const;
+        bool operator==( const QgsExpression::Parameter &other ) const;
+%Docstring
+ :rtype: bool
+%End
 
     };
 
-    //! List of parameters, used for function definition
     typedef QList< QgsExpression::Parameter > ParameterList;
 
-    /**
-     * A abstract base class for defining QgsExpression functions.
-     */
+
+
     class Function
-    {
+{
+%Docstring
+ A abstract base class for defining QgsExpression functions.
+%End
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
 
-        //! Constructor for function which uses unnamed parameters
-        Function( const QString& fnname,
+        Function( const QString &fnname,
                   int params,
-                  const QString& group,
-                  const QString& helpText = QString(),
+                  const QString &group,
+                  const QString &helpText = QString(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false );
+%Docstring
+Constructor for function which uses unnamed parameters
+%End
 
-        /** Constructor for function which uses unnamed parameters and group list
-         * @note added in QGIS 3.0
-         */
-        Function( const QString& fnname,
+        Function( const QString &fnname,
                   int params,
-                  const QStringList& groups,
-                  const QString& helpText = QString(),
+                  const QStringList &groups,
+                  const QString &helpText = QString(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false );
+%Docstring
+ Constructor for function which uses unnamed parameters and group list
+.. versionadded:: 3.0
+%End
 
-        /** Constructor for function which uses named parameter list.
-         * @note added in QGIS 2.16
-         */
-        Function( const QString& fnname,
-                  const QgsExpression::ParameterList& params,
-                  const QString& group,
-                  const QString& helpText = QString(),
+        Function( const QString &fnname,
+                  const QgsExpression::ParameterList &params,
+                  const QString &group,
+                  const QString &helpText = QString(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false );
+%Docstring
+ Constructor for function which uses named parameter list.
+.. versionadded:: 2.16
+%End
 
-        /** Constructor for function which uses named parameter list and group list.
-         * @note added in QGIS 3.0
-         */
-        Function( const QString& fnname,
-                  const QgsExpression::ParameterList& params,
-                  const QStringList& groups,
-                  const QString& helpText = QString(),
+        Function( const QString &fnname,
+                  const QgsExpression::ParameterList &params,
+                  const QStringList &groups,
+                  const QString &helpText = QString(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false );
+%Docstring
+ Constructor for function which uses named parameter list and group list.
+.. versionadded:: 3.0
+%End
 
         virtual ~Function();
 
-        /** The name of the function. */
         QString name() const;
-        /** The number of parameters this function takes. */
+%Docstring
+The name of the function.
+ :rtype: str
+%End
+
         int params() const;
+%Docstring
+The number of parameters this function takes.
+ :rtype: int
+%End
 
-        /** The minimum number of parameters this function takes. */
         int minParams() const;
+%Docstring
+The minimum number of parameters this function takes.
+ :rtype: int
+%End
 
-        /** Returns the list of named parameters for the function, if set.
-         * @note added in QGIS 2.16
-        */
-        const QgsExpression::ParameterList& parameters() const;
+        const QgsExpression::ParameterList &parameters() const;
+%Docstring
+ Returns the list of named parameters for the function, if set.
+.. versionadded:: 2.16
+ :rtype: QgsExpression.ParameterList
+%End
 
-        //! Does this function use a geometry object.
-        virtual bool usesGeometry( const QgsExpression::NodeFunction* node ) const;
+        virtual bool usesGeometry( const QgsExpression::NodeFunction *node ) const;
+%Docstring
+Does this function use a geometry object.
+ :rtype: bool
+%End
 
-        /** Returns a list of possible aliases for the function. These include
-         * other permissible names for the function, e.g., deprecated names.
-         * @return list of known aliases
-         * @note added in QGIS 2.9
-         */
         virtual QStringList aliases() const;
+%Docstring
+ Returns a list of possible aliases for the function. These include
+ other permissible names for the function, e.g., deprecated names.
+ :return: list of known aliases
+.. versionadded:: 2.9
+ :rtype: list of str
+%End
 
-        /** True if this function should use lazy evaluation.  Lazy evaluation functions take QgsExpression::Node objects
-         * rather than the node results when called.  You can use node->eval(parent, feature) to evaluate the node and return the result
-         * Functions are non lazy default and will be given the node return value when called
-         */
         bool lazyEval() const;
+%Docstring
+ True if this function should use lazy evaluation.  Lazy evaluation functions take QgsExpression.Node objects
+ rather than the node results when called.  You can use node->eval(parent, feature) to evaluate the node and return the result
+ Functions are non lazy default and will be given the node return value when called **
+ :rtype: bool
+%End
 
-        /**
-         * Returns a set of field names which are required for this function.
-         * May contain QgsFeatureRequest::AllAttributes to signal that all
-         * attributes are required.
-         * If in doubt this will return more fields than strictly required.
-         *
-         * @note Added in QGIS 3.0
-         */
-        virtual QSet<QString> referencedColumns( const QgsExpression::NodeFunction* node ) const;
+        virtual QSet<QString> referencedColumns( const QgsExpression::NodeFunction *node ) const;
+%Docstring
+ Returns a set of field names which are required for this function.
+ May contain QgsFeatureRequest.AllAttributes to signal that all
+ attributes are required.
+ If in doubt this will return more fields than strictly required.
 
-        /** Returns whether the function is only available if provided by a QgsExpressionContext object.
-         * @note added in QGIS 2.12
-         */
+.. versionadded:: 3.0
+ :rtype: set of str
+%End
+
         bool isContextual() const;
+%Docstring
+ Returns whether the function is only available if provided by a QgsExpressionContext object.
+.. versionadded:: 2.12
+ :rtype: bool
+%End
 
-        /** Returns true if the function is deprecated and should not be presented as a valid option
-         * to users in expression builders.
-         * @note added in QGIS 3.0
-         */
         virtual bool isDeprecated() const;
+%Docstring
+ Returns true if the function is deprecated and should not be presented as a valid option
+ to users in expression builders.
+.. versionadded:: 3.0
+ :rtype: bool
+%End
 
-        /** Returns the first group which the function belongs to.
-         * @note consider using groups() instead, as some functions naturally belong in multiple groups
-        */
         QString group() const;
+%Docstring
+ Returns the first group which the function belongs to.
+.. note::
 
-        /** Returns a list of the groups the function belongs to.
-         * @note added in QGIS 3.0
-         * @see group()
-        */
+   consider using groups() instead, as some functions naturally belong in multiple groups
+ :rtype: str
+%End
+
         QStringList groups() const;
+%Docstring
+ Returns a list of the groups the function belongs to.
+.. versionadded:: 3.0
+ \see group()
+ :rtype: list of str
+%End
 
-        /** The help text for the function. */
         const QString helpText() const;
+%Docstring
+The help text for the function.
+ :rtype: str
+%End
 
-        /** Returns result of evaluating the function.
-         * @param values list of values passed to the function
-         * @param context context expression is being evaluated against
-         * @param parent parent expression
-         * @returns result of function
-         */
-        virtual QVariant func( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent ) = 0;
+        virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) = 0;
+%Docstring
+ Returns result of evaluating the function.
+ \param values list of values passed to the function
+ \param context context expression is being evaluated against
+ \param parent parent expression
+ :return: result of function
+ :rtype: QVariant
+%End
+
+        bool operator==( const QgsExpression::Function &other ) const;
+%Docstring
+ :rtype: bool
+%End
 
         virtual bool handlesNull() const;
+%Docstring
+ :rtype: bool
+%End
+
     };
 
-    static const QList<QgsExpression::Function *>& Functions();
-    static const QStringList& BuiltinFunctions();
 
-    /** Registers a function to the expression engine. This is required to allow expressions to utilize the function.
-     * @param function function to register
-     * @param transferOwnership set to true to transfer ownership of function to expression engine
-     * @returns true on successful registration
-     * @see unregisterFunction
-     */
-    static bool registerFunction( Function* function );
+    static const QList<QgsExpression::Function *> &Functions();
+%Docstring
+ :rtype: list of QgsExpression.Function
+%End
 
-    /** Unregisters a function from the expression engine. The function will no longer be usable in expressions.
-     * @param name function name
-     * @see registerFunction
-     */
-    static bool unregisterFunction( const QString& name );
+    static const QStringList &BuiltinFunctions();
+%Docstring
+ :rtype: list of str
+%End
 
-    /** Deletes all registered functions whose ownership have been transferred to the expression engine.
-     * @note added in QGIS 2.12
-     */
+    static bool registerFunction( QgsExpression::Function *function, bool transferOwnership = false );
+%Docstring
+ Registers a function to the expression engine. This is required to allow expressions to utilize the function.
+ \param function function to register
+ \param transferOwnership set to true to transfer ownership of function to expression engine
+ :return: true on successful registration
+ \see unregisterFunction
+ :rtype: bool
+%End
+
+    static bool unregisterFunction( const QString &name );
+%Docstring
+ Unregisters a function from the expression engine. The function will no longer be usable in expressions.
+ \param name function name
+ \see registerFunction
+ :rtype: bool
+%End
+
+
     static void cleanRegisteredFunctions();
+%Docstring
+ Deletes all registered functions whose ownership have been transferred to the expression engine.
+.. versionadded:: 2.12
+%End
 
-    //! tells whether the identifier is a name of existing function
-    static bool isFunctionName( const QString& name );
+    static bool isFunctionName( const QString &name );
+%Docstring
+tells whether the identifier is a name of existing function
+ :rtype: bool
+%End
 
-    //! return index of the function in Functions array
-    static int functionIndex( const QString& name );
+    static int functionIndex( const QString &name );
+%Docstring
+return index of the function in Functions array
+ :rtype: int
+%End
 
-    /** Returns the number of functions defined in the parser
-     *  @return The number of function defined in the parser.
-     */
     static int functionCount();
+%Docstring
+ Returns the number of functions defined in the parser
+  :return: The number of function defined in the parser.
+ :rtype: int
+%End
 
-    /** Returns a quoted column reference (in double quotes)
-     * @see quotedString()
-     * @see quotedValue()
-     */
     static QString quotedColumnRef( QString name );
+%Docstring
+ Returns a quoted column reference (in double quotes)
+ \see quotedString()
+ \see quotedValue()
+ :rtype: str
+%End
 
-    /** Returns a quoted version of a string (in single quotes)
-     * @see quotedValue()
-     * @see quotedColumnRef()
-     */
     static QString quotedString( QString text );
+%Docstring
+ Returns a quoted version of a string (in single quotes)
+ \see quotedValue()
+ \see quotedColumnRef()
+ :rtype: str
+%End
 
-    /** Returns a string representation of a literal value, including appropriate
-     * quotations where required.
-     * @param value value to convert to a string representation
-     * @note added in QGIS 2.14
-     * @see quotedString()
-     * @see quotedColumnRef()
-     */
-    static QString quotedValue( const QVariant& value );
+    static QString quotedValue( const QVariant &value );
+%Docstring
+ Returns a string representation of a literal value, including appropriate
+ quotations where required.
+ \param value value to convert to a string representation
+.. versionadded:: 2.14
+ \see quotedString()
+ \see quotedColumnRef()
+ :rtype: str
+%End
 
-    /** Returns a string representation of a literal value, including appropriate
-     * quotations where required.
-     * @param value value to convert to a string representation
-     * @param type value type
-     * @note added in QGIS 2.14
-     * @see quotedString()
-     * @see quotedColumnRef()
-     */
-    static QString quotedValue( const QVariant& value, QVariant::Type type );
+    static QString quotedValue( const QVariant &value, QVariant::Type type );
+%Docstring
+ Returns a string representation of a literal value, including appropriate
+ quotations where required.
+ \param value value to convert to a string representation
+ \param type value type
+.. versionadded:: 2.14
+ \see quotedString()
+ \see quotedColumnRef()
+ :rtype: str
+%End
 
-    //////
 
     enum NodeType
     {
@@ -498,9 +752,14 @@ class QgsExpression
     };
 
     class Node
-    {
-      %ConvertToSubClassCode
-        switch (sipCpp->nodeType())
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
+
+%ConvertToSubClassCode
+        switch ( sipCpp->nodeType() )
         {
           case QgsExpression::ntUnaryOperator:   sipType = sipType_QgsExpression_NodeUnaryOperator; break;
           case QgsExpression::ntBinaryOperator:  sipType = sipType_QgsExpression_NodeBinaryOperator; break;
@@ -511,326 +770,484 @@ class QgsExpression
           case QgsExpression::ntCondition:       sipType = sipType_QgsExpression_NodeCondition; break;
           default:                               sipType = 0; break;
         }
-      %End
-
+%End
       public:
         virtual ~Node();
 
-        /**
-         * Abstract virtual that returns the type of this node.
-         *
-         * @return The type of this node
-         */
         virtual QgsExpression::NodeType nodeType() const = 0;
+%Docstring
+ Abstract virtual that returns the type of this node.
 
-        /**
-         * Abstract virtual eval method
-         * Errors are reported to the parent
-         * @note added in QGIS 2.12
-         */
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) = 0;
+ :return: The type of this node
+ :rtype: QgsExpression.NodeType
+%End
 
-        /**
-         * Abstract virtual preparation method
-         * Errors are reported to the parent
-         * @note added in QGIS 2.12
-         */
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) = 0;
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
+%Docstring
+ Abstract virtual eval method
+ Errors are reported to the parent
+.. versionadded:: 2.12
+ :rtype: QVariant
+%End
 
-        /**
-         * Abstract virtual dump method
-         *
-         * @return An expression which represents this node as string
-         */
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
+%Docstring
+ Abstract virtual preparation method
+ Errors are reported to the parent
+.. versionadded:: 2.12
+ :rtype: bool
+%End
+
         virtual QString dump() const = 0;
+%Docstring
+ Abstract virtual dump method
 
-        /**
-         * Generate a clone of this node.
-         * Make sure that the clone does not contain any information which is
-         * generated in prepare and context related.
-         * Ownership is transferred to the caller.
-         *
-         * @return a deep copy of this node.
-         */
-        virtual QgsExpression::Node* clone() const = 0;
+ :return: An expression which represents this node as string
+ :rtype: str
+%End
 
-        /**
-         * Abstract virtual method which returns a list of columns required to
-         * evaluate this node.
-         *
-         * When reimplementing this, you need to return any column that is required to
-         * evaluate this node and in addition recursively collect all the columns required
-         * to evaluate child nodes.
-         *
-         * @return A list of columns required to evaluate this expression
-         */
+        virtual QgsExpression::Node *clone() const = 0;
+%Docstring
+ Generate a clone of this node.
+ Make sure that the clone does not contain any information which is
+ generated in prepare and context related.
+ Ownership is transferred to the caller.
+
+ :return: a deep copy of this node.
+ :rtype: QgsExpression.Node
+%End
+
         virtual QSet<QString> referencedColumns() const = 0;
+%Docstring
+ Abstract virtual method which returns a list of columns required to
+ evaluate this node.
 
-        /**
-         * Return a list of all variables which are used in this expression.
-         */
+ When reimplementing this, you need to return any column that is required to
+ evaluate this node and in addition recursively collect all the columns required
+ to evaluate child nodes.
+
+ :return: A list of columns required to evaluate this expression
+ :rtype: set of str
+%End
+
         virtual QSet<QString> referencedVariables() const = 0;
+%Docstring
+ Return a list of all variables which are used in this expression.
+ :rtype: set of str
+%End
 
-        /**
-         * Abstract virtual method which returns if the geometry is required to evaluate
-         * this expression.
-         *
-         * This needs to call `needsGeometry()` recursively on any child nodes.
-         *
-         * @return true if a geometry is required to evaluate this expression
-         */
         virtual bool needsGeometry() const = 0;
+%Docstring
+ Abstract virtual method which returns if the geometry is required to evaluate
+ this expression.
+
+ This needs to call `needsGeometry()` recursively on any child nodes.
+
+ :return: true if a geometry is required to evaluate this expression
+ :rtype: bool
+%End
     };
 
-    //! Named node
-    //! @note added in QGIS 2.16
     class NamedNode
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
 
-        /** Constructor for NamedNode
-         * @param name node name
-         * @param node node
-         */
-        NamedNode( const QString& name, QgsExpression::Node* node );
+        NamedNode( const QString &name, QgsExpression::Node *node );
+%Docstring
+ Constructor for NamedNode
+ \param name node name
+ \param node node
+%End
 
-        //! Node name
         QString name;
+%Docstring
+Node name
+%End
 
-        //! Node
-        QgsExpression::Node* node;
+        QgsExpression::Node *node;
+%Docstring
+Node
+%End
     };
 
     class NodeList
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
         NodeList();
-        ~NodeList();
-        /** Takes ownership of the provided node */
-        void append( QgsExpression::Node* node /Transfer/ );
+        virtual ~NodeList();
+        void append( QgsExpression::Node *node /Transfer/ );
+%Docstring
+Takes ownership of the provided node
+%End
 
-        /** Adds a named node. Takes ownership of the provided node.
-         * @note added in QGIS 2.16
-        */
-        void append( QgsExpression::NamedNode* node /Transfer/ );
+        void append( QgsExpression::NamedNode *node /Transfer/ );
+%Docstring
+ Adds a named node. Takes ownership of the provided node.
+.. versionadded:: 2.16
+%End
 
-        /** Returns the number of nodes in the list.
-         */
         int count() const;
+%Docstring
+ Returns the number of nodes in the list.
+ :rtype: int
+%End
 
-        //! Returns true if list contains any named nodes
-        //! @note added in QGIS 2.16
         bool hasNamedNodes() const;
+%Docstring
+.. versionadded:: 2.16
+ :rtype: bool
+%End
 
-        /**
-         * Get a list of all the nodes.
-         */
-        QList<QgsExpression::Node*> list();
+        QList<QgsExpression::Node *> list();
+%Docstring
+ Get a list of all the nodes.
+ :rtype: list of QgsExpression.Node
+%End
 
-        /**
-         * Get the node at position i in the list.
-         *
-         * @note Added in QGIS 3.0
-         */
-        QgsExpression::Node* at( int i );
+        QgsExpression::Node *at( int i );
+%Docstring
+ Get the node at position i in the list.
 
-        //! Returns a list of names for nodes. Unnamed nodes will be indicated by an empty string in the list.
-        //! @note added in QGIS 2.16
+.. versionadded:: 3.0
+ :rtype: QgsExpression.Node
+%End
+
         QStringList names() const;
+%Docstring
+.. versionadded:: 2.16
+ :rtype: list of str
+%End
 
-        /** Creates a deep copy of this list. Ownership is transferred to the caller */
-        QgsExpression::NodeList* clone() const;
+        QgsExpression::NodeList *clone() const;
+%Docstring
+Creates a deep copy of this list. Ownership is transferred to the caller
+ :rtype: QgsExpression.NodeList
+%End
 
         virtual QString dump() const;
+%Docstring
+ :rtype: str
+%End
+
+      protected:
+
     };
 
     class NodeUnaryOperator : QgsExpression::Node
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
-        NodeUnaryOperator( QgsExpression::UnaryOperator op, QgsExpression::Node* operand /Transfer/ );
+        NodeUnaryOperator( QgsExpression::UnaryOperator op, QgsExpression::Node *operand /Transfer/ );
         ~NodeUnaryOperator();
 
         QgsExpression::UnaryOperator op() const;
-        QgsExpression::Node* operand() const;
+%Docstring
+ :rtype: QgsExpression.UnaryOperator
+%End
+        QgsExpression::Node *operand() const;
+%Docstring
+ :rtype: QgsExpression.Node
+%End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
-        virtual QgsExpression::Node* clone() const;
+        virtual QgsExpression::Node *clone() const;
+
+      protected:
     };
 
     class NodeBinaryOperator : QgsExpression::Node
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
-        NodeBinaryOperator( QgsExpression::BinaryOperator op, QgsExpression::Node* opLeft /Transfer/, QgsExpression::Node* opRight /Transfer/ );
+        NodeBinaryOperator( QgsExpression::BinaryOperator op, QgsExpression::Node *opLeft /Transfer/, QgsExpression::Node *opRight /Transfer/ );
         ~NodeBinaryOperator();
 
         QgsExpression::BinaryOperator op() const;
-        QgsExpression::Node* opLeft() const;
-        QgsExpression::Node* opRight() const;
+%Docstring
+ :rtype: QgsExpression.BinaryOperator
+%End
+        QgsExpression::Node *opLeft() const;
+%Docstring
+ :rtype: QgsExpression.Node
+%End
+        QgsExpression::Node *opRight() const;
+%Docstring
+ :rtype: QgsExpression.Node
+%End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
-        virtual QgsExpression::Node* clone() const;
+        virtual QgsExpression::Node *clone() const;
 
         int precedence() const;
+%Docstring
+ :rtype: int
+%End
         bool leftAssociative() const;
+%Docstring
+ :rtype: bool
+%End
+
     };
 
     class NodeInOperator : QgsExpression::Node
-    {
-      public:
-        NodeInOperator( QgsExpression::Node* node /Transfer/, QgsExpression::NodeList* list /Transfer/, bool notin = false );
-        ~NodeInOperator();
+{
 
-        QgsExpression::Node* node() const;
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
+      public:
+        NodeInOperator( QgsExpression::Node *node /Transfer/, QgsExpression::NodeList *list /Transfer/, bool notin = false );
+        virtual ~NodeInOperator();
+
+        QgsExpression::Node *node() const;
+%Docstring
+ :rtype: QgsExpression.Node
+%End
         bool isNotIn() const;
-        QgsExpression::NodeList* list() const;
+%Docstring
+ :rtype: bool
+%End
+        QgsExpression::NodeList *list() const;
+%Docstring
+ :rtype: QgsExpression.NodeList
+%End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
-        virtual QgsExpression::Node* clone() const;
+        virtual QgsExpression::Node *clone() const;
+
+      protected:
     };
 
     class NodeFunction : QgsExpression::Node
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
-        NodeFunction( int fnIndex, QgsExpression::NodeList* args /Transfer/ );
-        //NodeFunction( QString name, QgsExpression::NodeList* args );
-        ~NodeFunction();
+        NodeFunction( int fnIndex, QgsExpression::NodeList *args /Transfer/ );
+
+        virtual ~NodeFunction();
 
         int fnIndex() const;
-        QgsExpression::NodeList* args() const;
+%Docstring
+ :rtype: int
+%End
+        QgsExpression::NodeList *args() const;
+%Docstring
+ :rtype: QgsExpression.NodeList
+%End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
-        virtual QgsExpression::Node* clone() const;
+        virtual QgsExpression::Node *clone() const;
 
-        //! Tests whether the provided argument list is valid for the matching function
-        static bool validateParams( int fnIndex, QgsExpression::NodeList* args, QString& error );
+        static bool validateParams( int fnIndex, QgsExpression::NodeList *args, QString &error );
+%Docstring
+Tests whether the provided argument list is valid for the matching function
+ :rtype: bool
+%End
+
     };
 
     class NodeLiteral : QgsExpression::Node
-    {
-      public:
-        NodeLiteral( const QVariant& value );
+{
 
-        /** The value of the literal. */
-        const QVariant& value() const;
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
+      public:
+        NodeLiteral( const QVariant &value );
+
+        QVariant value() const;
+%Docstring
+The value of the literal.
+ :rtype: QVariant
+%End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
-        virtual QgsExpression::Node* clone() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
+        virtual QgsExpression::Node *clone() const;
+
+      protected:
     };
 
     class NodeColumnRef : QgsExpression::Node
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
-        NodeColumnRef( const QString& name );
+        NodeColumnRef( const QString &name );
 
-        /** The name of the column. */
         QString name() const;
+%Docstring
+The name of the column.
+ :rtype: str
+%End
 
-        virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual NodeType nodeType() const;
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
 
-        virtual QgsExpression::Node* clone() const;
+        virtual QgsExpression::Node *clone() const;
+
+      protected:
     };
 
     class WhenThen
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
-        WhenThen( QgsExpression::Node* whenExp /Transfer/, QgsExpression::Node* thenExp /Transfer/ );
+        WhenThen( QgsExpression::Node *whenExp /Transfer/, QgsExpression::Node *thenExp /Transfer/ );
         ~WhenThen();
 
-        //protected:
-        QgsExpression::Node* mWhenExp;
-        QgsExpression::Node* mThenExp;
+
+        QgsExpression::Node *mWhenExp;
+        QgsExpression::Node *mThenExp;
 
       private:
-        WhenThen( const QgsExpression::WhenThen& rh );
-
+        WhenThen( const QgsExpression::WhenThen &rh );
     };
+    typedef QList<QgsExpression::WhenThen *> WhenThenList;
 
     class NodeCondition : QgsExpression::Node
-    {
+{
+
+%TypeHeaderCode
+#include "qgsexpression.h"
+%End
       public:
-        NodeCondition( QList<QgsExpression::WhenThen*> *conditions, QgsExpression::Node* elseExp = 0 );
+        NodeCondition( QgsExpression::WhenThenList *conditions, QgsExpression::Node *elseExp = 0 );
+
+
         ~NodeCondition();
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
-        virtual QgsExpression::Node* clone() const;
+        virtual QgsExpression::Node *clone() const;
+
+      protected:
     };
-    /** Returns the help text for a specified function.
-     * @param name function name
-     * @see variableHelpText()
-     */
+
     static QString helpText( QString name );
+%Docstring
+ Returns the help text for a specified function.
+ \param name function name
+ \see variableHelpText()
+ :rtype: str
+%End
 
-    /** Returns the help text for a specified variable.
-     * @param variableName name of variable
-     * @param showValue set to true to include current value of variable in help text
-     * @param value current value of variable to show in help text
-     * @see helpText()
-     * @note added in QGIS 2.12
-     */
-    static QString variableHelpText( const QString& variableName, bool showValue = true, const QVariant& value = QVariant() );
+    static QString variableHelpText( const QString &variableName, bool showValue = true, const QVariant &value = QVariant() );
+%Docstring
+ Returns the help text for a specified variable.
+ \param variableName name of variable
+ \param showValue set to true to include current value of variable in help text
+ \param value current value of variable to show in help text
+ \see helpText()
+.. versionadded:: 2.12
+ :rtype: str
+%End
 
-    /** Returns the translated name for a function group.
-     * @param group untranslated group name
-     */
-    static QString group( const QString& group );
+    static QString group( const QString &group );
+%Docstring
+ Returns the translated name for a function group.
+ \param group untranslated group name
+ :rtype: str
+%End
 
-    /** Formats an expression result for friendly display to the user. Truncates the result to a sensible
-     * length, and presents text representations of non numeric/text types (e.g., geometries and features).
-     * @param value expression result to format
-     * @returns formatted string, may contain HTML formatting characters
-     * @note added in QGIS 2.14
-     */
-    static QString formatPreviewString( const QVariant& value );
+    static QString formatPreviewString( const QVariant &value );
+%Docstring
+ Formats an expression result for friendly display to the user. Truncates the result to a sensible
+ length, and presents text representations of non numeric/text types (e.g., geometries and features).
+ \param value expression result to format
+ :return: formatted string, may contain HTML formatting characters
+.. versionadded:: 2.14
+ :rtype: str
+%End
 
   protected:
     void initGeomCalculator();
+
+
+
+
+
+
+
+
+
 };
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsexpression.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -161,7 +161,7 @@ Returns root node of the expression. Root node is null is parsing has failed
  all attributes from the layer are required for evaluation of the expression.
  QgsFeatureRequest.setSubsetOfAttributes automatically handles this case.
 
- \see referencedAttributeIndexes()
+.. seealso:: referencedAttributeIndexes()
  :rtype: set of str
 %End
 
@@ -267,9 +267,9 @@ expression() instead.
 %Docstring
  Return calculator used for distance and area calculations
  (used by $length, $area and $perimeter functions only)
- \see setGeomCalculator()
- \see distanceUnits()
- \see areaUnits()
+.. seealso:: setGeomCalculator()
+.. seealso:: distanceUnits()
+.. seealso:: areaUnits()
  :rtype: QgsDistanceArea
 %End
 
@@ -281,7 +281,7 @@ expression() instead.
  cartesian methods (ie no ellipsoidal calculations).
  \param calc geometry calculator. Ownership is not transferred. Set to a None to force
  cartesian calculations.
- \see geomCalculator()
+.. seealso:: geomCalculator()
 %End
 
     QgsUnitTypes::DistanceUnit distanceUnits() const;
@@ -291,8 +291,8 @@ expression() instead.
 
    distances are only converted when a geomCalculator() has been set
 .. versionadded:: 2.14
- \see setDistanceUnits()
- \see areaUnits()
+.. seealso:: setDistanceUnits()
+.. seealso:: areaUnits()
  :rtype: QgsUnitTypes.DistanceUnit
 %End
 
@@ -303,8 +303,8 @@ expression() instead.
 
    distances are only converted when a geomCalculator() has been set
 .. versionadded:: 2.14
- \see distanceUnits()
- \see setAreaUnits()
+.. seealso:: distanceUnits()
+.. seealso:: setAreaUnits()
 %End
 
     QgsUnitTypes::AreaUnit areaUnits() const;
@@ -314,8 +314,8 @@ expression() instead.
 
    areas are only converted when a geomCalculator() has been set
 .. versionadded:: 2.14
- \see setAreaUnits()
- \see distanceUnits()
+.. seealso:: setAreaUnits()
+.. seealso:: distanceUnits()
  :rtype: QgsUnitTypes.AreaUnit
 %End
 
@@ -326,8 +326,8 @@ expression() instead.
 
    areas are only converted when a geomCalculator() has been set
 .. versionadded:: 2.14
- \see areaUnits()
- \see setDistanceUnits()
+.. seealso:: areaUnits()
+.. seealso:: setDistanceUnits()
 %End
 
     static QString replaceExpressionText( const QString &action, const QgsExpressionContext *context,
@@ -613,7 +613,7 @@ Does this function use a geometry object.
 %Docstring
  Returns a list of the groups the function belongs to.
 .. versionadded:: 3.0
- \see group()
+.. seealso:: group()
  :rtype: list of str
 %End
 
@@ -662,7 +662,7 @@ The help text for the function.
  \param function function to register
  \param transferOwnership set to true to transfer ownership of function to expression engine
  :return: true on successful registration
- \see unregisterFunction
+.. seealso:: unregisterFunction
  :rtype: bool
 %End
 
@@ -670,7 +670,7 @@ The help text for the function.
 %Docstring
  Unregisters a function from the expression engine. The function will no longer be usable in expressions.
  \param name function name
- \see registerFunction
+.. seealso:: registerFunction
  :rtype: bool
 %End
 
@@ -703,16 +703,16 @@ return index of the function in Functions array
     static QString quotedColumnRef( QString name );
 %Docstring
  Returns a quoted column reference (in double quotes)
- \see quotedString()
- \see quotedValue()
+.. seealso:: quotedString()
+.. seealso:: quotedValue()
  :rtype: str
 %End
 
     static QString quotedString( QString text );
 %Docstring
  Returns a quoted version of a string (in single quotes)
- \see quotedValue()
- \see quotedColumnRef()
+.. seealso:: quotedValue()
+.. seealso:: quotedColumnRef()
  :rtype: str
 %End
 
@@ -722,8 +722,8 @@ return index of the function in Functions array
  quotations where required.
  \param value value to convert to a string representation
 .. versionadded:: 2.14
- \see quotedString()
- \see quotedColumnRef()
+.. seealso:: quotedString()
+.. seealso:: quotedColumnRef()
  :rtype: str
 %End
 
@@ -734,8 +734,8 @@ return index of the function in Functions array
  \param value value to convert to a string representation
  \param type value type
 .. versionadded:: 2.14
- \see quotedString()
- \see quotedColumnRef()
+.. seealso:: quotedString()
+.. seealso:: quotedColumnRef()
  :rtype: str
 %End
 
@@ -753,6 +753,10 @@ return index of the function in Functions array
 
     class Node
 {
+%Docstring
+
+ Abstract base class for all nodes that can appear in an expression.
+%End
 
 %TypeHeaderCode
 #include "qgsexpression.h"
@@ -761,14 +765,30 @@ return index of the function in Functions array
 %ConvertToSubClassCode
         switch ( sipCpp->nodeType() )
         {
-          case QgsExpression::ntUnaryOperator:   sipType = sipType_QgsExpression_NodeUnaryOperator; break;
-          case QgsExpression::ntBinaryOperator:  sipType = sipType_QgsExpression_NodeBinaryOperator; break;
-          case QgsExpression::ntInOperator:      sipType = sipType_QgsExpression_NodeInOperator; break;
-          case QgsExpression::ntFunction:        sipType = sipType_QgsExpression_NodeFunction; break;
-          case QgsExpression::ntLiteral:         sipType = sipType_QgsExpression_NodeLiteral; break;
-          case QgsExpression::ntColumnRef:       sipType = sipType_QgsExpression_NodeColumnRef; break;
-          case QgsExpression::ntCondition:       sipType = sipType_QgsExpression_NodeCondition; break;
-          default:                               sipType = 0; break;
+          case QgsExpression::ntUnaryOperator:
+            sipType = sipType_QgsExpression_NodeUnaryOperator;
+            break;
+          case QgsExpression::ntBinaryOperator:
+            sipType = sipType_QgsExpression_NodeBinaryOperator;
+            break;
+          case QgsExpression::ntInOperator:
+            sipType = sipType_QgsExpression_NodeInOperator;
+            break;
+          case QgsExpression::ntFunction:
+            sipType = sipType_QgsExpression_NodeFunction;
+            break;
+          case QgsExpression::ntLiteral:
+            sipType = sipType_QgsExpression_NodeLiteral;
+            break;
+          case QgsExpression::ntColumnRef:
+            sipType = sipType_QgsExpression_NodeColumnRef;
+            break;
+          case QgsExpression::ntCondition:
+            sipType = sipType_QgsExpression_NodeCondition;
+            break;
+          default:
+            sipType = 0;
+            break;
         }
 %End
       public:
@@ -776,34 +796,28 @@ return index of the function in Functions array
 
         virtual QgsExpression::NodeType nodeType() const = 0;
 %Docstring
- Abstract virtual that returns the type of this node.
+ Get the type of this node.
 
  :return: The type of this node
  :rtype: QgsExpression.NodeType
 %End
 
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
-%Docstring
- Abstract virtual eval method
- Errors are reported to the parent
-.. versionadded:: 2.12
- :rtype: QVariant
-%End
-
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
-%Docstring
- Abstract virtual preparation method
- Errors are reported to the parent
-.. versionadded:: 2.12
- :rtype: bool
-%End
-
         virtual QString dump() const = 0;
 %Docstring
- Abstract virtual dump method
-
- :return: An expression which represents this node as string
+ Dump this node into a serialized (part) of an expression.
+ The returned expression does not necessarily literally match
+ the original expression, it's just guaranteed to behave the same way.
  :rtype: str
+%End
+
+        QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+%Docstring
+ Evaluate this node with the given context and parent.
+ This will return a cached value if it has been determined to be static
+ during the prepare() execution.
+
+.. versionadded:: 2.12
+ :rtype: QVariant
 %End
 
         virtual QgsExpression::Node *clone() const = 0;
@@ -832,7 +846,7 @@ return index of the function in Functions array
 
         virtual QSet<QString> referencedVariables() const = 0;
 %Docstring
- Return a list of all variables which are used in this expression.
+ Return a set of all variables which are used in this expression.
  :rtype: set of str
 %End
 
@@ -845,6 +859,45 @@ return index of the function in Functions array
 
  :return: true if a geometry is required to evaluate this expression
  :rtype: bool
+%End
+
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const = 0;
+%Docstring
+ Returns true if this node can be evaluated for a static value. This is used during
+ the prepare() step and in case it returns true, the value of this node will already
+ be evaluated and the result cached (and therefore not re-evaluated in subsequent calls
+ to eval()). In case this returns true, prepareNode() will never be called.
+
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
+        bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+%Docstring
+ Prepare this node for evaluation.
+ This will check if the node content is static and in this case cache the value.
+ If it's not static it will call prepareNode() to allow the node to do initialization
+ work like for example resolving a column name to an attribute index.
+
+.. versionadded:: 2.12
+ :rtype: bool
+%End
+
+      private:
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0 ;
+%Docstring
+ Abstract virtual preparation method
+ Errors are reported to the parent
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+      private:
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0 ;
+%Docstring
+ Abstract virtual eval method
+ Errors are reported to the parent
+.. versionadded:: 3.0
+ :rtype: QVariant
 %End
     };
 
@@ -937,12 +990,13 @@ Creates a deep copy of this list. Ownership is transferred to the caller
  :rtype: str
 %End
 
-      protected:
-
     };
 
     class NodeUnaryOperator : QgsExpression::Node
 {
+%Docstring
+ A unary node is either negative as in boolean (not) or as in numbers (minus).
+%End
 
 %TypeHeaderCode
 #include "qgsexpression.h"
@@ -961,8 +1015,8 @@ Creates a deep copy of this list. Ownership is transferred to the caller
 %End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
@@ -970,7 +1024,8 @@ Creates a deep copy of this list. Ownership is transferred to the caller
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node *clone() const;
 
-      protected:
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
+
     };
 
     class NodeBinaryOperator : QgsExpression::Node
@@ -980,7 +1035,11 @@ Creates a deep copy of this list. Ownership is transferred to the caller
 #include "qgsexpression.h"
 %End
       public:
+
         NodeBinaryOperator( QgsExpression::BinaryOperator op, QgsExpression::Node *opLeft /Transfer/, QgsExpression::Node *opRight /Transfer/ );
+%Docstring
+ Binary combination of the left and the right with op.
+%End
         ~NodeBinaryOperator();
 
         QgsExpression::BinaryOperator op() const;
@@ -997,14 +1056,15 @@ Creates a deep copy of this list. Ownership is transferred to the caller
 %End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node *clone() const;
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
 
         int precedence() const;
 %Docstring
@@ -1024,7 +1084,11 @@ Creates a deep copy of this list. Ownership is transferred to the caller
 #include "qgsexpression.h"
 %End
       public:
+
         NodeInOperator( QgsExpression::Node *node /Transfer/, QgsExpression::NodeList *list /Transfer/, bool notin = false );
+%Docstring
+ This node tests if the result of \node is in the result of ``list``. Optionally it can be inverted with ``notin`` which by default is false.
+%End
         virtual ~NodeInOperator();
 
         QgsExpression::Node *node() const;
@@ -1041,16 +1105,16 @@ Creates a deep copy of this list. Ownership is transferred to the caller
 %End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node *clone() const;
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
 
-      protected:
     };
 
     class NodeFunction : QgsExpression::Node
@@ -1060,7 +1124,12 @@ Creates a deep copy of this list. Ownership is transferred to the caller
 #include "qgsexpression.h"
 %End
       public:
+
         NodeFunction( int fnIndex, QgsExpression::NodeList *args /Transfer/ );
+%Docstring
+ A function node consists of an index of the function in the global function array and
+ a list of arguments that will be passed to it.
+%End
 
         virtual ~NodeFunction();
 
@@ -1074,14 +1143,15 @@ Creates a deep copy of this list. Ownership is transferred to the caller
 %End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node *clone() const;
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
 
         static bool validateParams( int fnIndex, QgsExpression::NodeList *args, QString &error );
 %Docstring
@@ -1107,16 +1177,16 @@ The value of the literal.
 %End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node *clone() const;
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
 
-      protected:
     };
 
     class NodeColumnRef : QgsExpression::Node
@@ -1135,8 +1205,8 @@ The name of the column.
 %End
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
@@ -1144,9 +1214,10 @@ The name of the column.
         virtual bool needsGeometry() const;
 
         virtual QgsExpression::Node *clone() const;
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
 
-      protected:
     };
+
 
     class WhenThen
 {
@@ -1155,12 +1226,19 @@ The name of the column.
 #include "qgsexpression.h"
 %End
       public:
-        WhenThen( QgsExpression::Node *whenExp /Transfer/, QgsExpression::Node *thenExp /Transfer/ );
+
+        WhenThen( QgsExpression::Node *whenExp, QgsExpression::Node *thenExp );
+%Docstring
+ A combination of when and then. Simple as that.
+%End
         ~WhenThen();
 
 
-        QgsExpression::Node *mWhenExp;
-        QgsExpression::Node *mThenExp;
+        QgsExpression::WhenThen *clone() const;
+%Docstring
+ Get a deep copy of this WhenThen combination.
+ :rtype: QgsExpression.WhenThen
+%End
 
       private:
         WhenThen( const QgsExpression::WhenThen &rh );
@@ -1174,29 +1252,33 @@ The name of the column.
 #include "qgsexpression.h"
 %End
       public:
+
         NodeCondition( QgsExpression::WhenThenList *conditions, QgsExpression::Node *elseExp = 0 );
+%Docstring
+ Create a new node with the given list of ``conditions`` and an optional ``elseExp`` expression.
+%End
 
 
         ~NodeCondition();
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
-        virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context );
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context );
         virtual QString dump() const;
 
         virtual QSet<QString> referencedColumns() const;
         virtual QSet<QString> referencedVariables() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node *clone() const;
+        virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
 
-      protected:
     };
 
     static QString helpText( QString name );
 %Docstring
  Returns the help text for a specified function.
  \param name function name
- \see variableHelpText()
+.. seealso:: variableHelpText()
  :rtype: str
 %End
 
@@ -1206,7 +1288,7 @@ The name of the column.
  \param variableName name of variable
  \param showValue set to true to include current value of variable in help text
  \param value current value of variable to show in help text
- \see helpText()
+.. seealso:: helpText()
 .. versionadded:: 2.12
  :rtype: str
 %End

--- a/qgsprocessingoutputs.cpp
+++ b/qgsprocessingoutputs.cpp
@@ -1,0 +1,21 @@
+/***************************************************************************
+  qgsprocessingoutputs.cpp - QgsProcessingOutputs
+
+ ---------------------
+ begin                : 30.4.2017
+ copyright            : (C) 2017 by Matthias Kuhn, OPENGIS.ch
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsprocessingoutputs.h"
+
+QgsProcessingOutputs::QgsProcessingOutputs()
+{
+
+}

--- a/qgsprocessingoutputs.h
+++ b/qgsprocessingoutputs.h
@@ -1,0 +1,26 @@
+/***************************************************************************
+  qgsprocessingoutputs.h - QgsProcessingOutputs
+
+ ---------------------
+ begin                : 30.4.2017
+ copyright            : (C) 2017 by Matthias Kuhn, OPENGIS.ch
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSPROCESSINGOUTPUTS_H
+#define QGSPROCESSINGOUTPUTS_H
+
+
+class QgsProcessingOutputs
+{
+  public:
+    QgsProcessingOutputs();
+};
+
+#endif // QGSPROCESSINGOUTPUTS_H

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -4708,7 +4708,7 @@ QString QgsExpression::NodeList::dump() const
 
 //
 
-QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression *parent, const QgsExpressionContext *context )
+QVariant QgsExpression::NodeUnaryOperator::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   QVariant val = mOperand->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
@@ -4735,7 +4735,7 @@ QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression *parent, const Qg
   return QVariant();
 }
 
-bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::NodeUnaryOperator::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   return mOperand->prepare( parent, context );
 }
@@ -4760,9 +4760,14 @@ QgsExpression::Node *QgsExpression::NodeUnaryOperator::clone() const
   return new NodeUnaryOperator( mOp, mOperand->clone() );
 }
 
+bool QgsExpression::NodeUnaryOperator::isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  return mOperand->isStatic( parent, context );
+}
+
 //
 
-QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const QgsExpressionContext *context )
+QVariant QgsExpression::NodeBinaryOperator::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   QVariant vL = mOpLeft->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
@@ -4945,13 +4950,13 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
           QgsExpression::NodeLiteral nL( lL.at( i ) );
           QgsExpression::NodeLiteral nR( lR.at( i ) );
           QgsExpression::NodeBinaryOperator eqNode( boEQ, nL.clone(), nR.clone() );
-          QVariant eq = eqNode.eval( parent, context );
+          QVariant eq = eqNode.evalNode( parent, context );
           ENSURE_NO_EVAL_ERROR;
           if ( eq == TVL_False )
           {
             // return the two items comparison
             QgsExpression::NodeBinaryOperator node( mOp, nL.clone(), nR.clone() );
-            QVariant v = node.eval( parent, context );
+            QVariant v = node.evalNode( parent, context );
             ENSURE_NO_EVAL_ERROR;
             return v;
           }
@@ -5186,7 +5191,7 @@ double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
   }
 }
 
-bool QgsExpression::NodeBinaryOperator::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::NodeBinaryOperator::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   bool resL = mOpLeft->prepare( parent, context );
   bool resR = mOpRight->prepare( parent, context );
@@ -5326,9 +5331,14 @@ QgsExpression::Node *QgsExpression::NodeBinaryOperator::clone() const
   return new NodeBinaryOperator( mOp, mOpLeft->clone(), mOpRight->clone() );
 }
 
+bool QgsExpression::NodeBinaryOperator::isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  return mOpLeft->isStatic( parent, context ) && mOpRight->isStatic( parent, context );
+}
+
 //
 
-QVariant QgsExpression::NodeInOperator::eval( QgsExpression *parent, const QgsExpressionContext *context )
+QVariant QgsExpression::NodeInOperator::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   if ( mList->count() == 0 )
     return mNotIn ? TVL_True : TVL_False;
@@ -5378,7 +5388,7 @@ QVariant QgsExpression::NodeInOperator::eval( QgsExpression *parent, const QgsEx
     return mNotIn ? TVL_True : TVL_False;
 }
 
-bool QgsExpression::NodeInOperator::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::NodeInOperator::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   bool res = mNode->prepare( parent, context );
   Q_FOREACH ( Node *n, mList->list() )
@@ -5398,9 +5408,23 @@ QgsExpression::Node *QgsExpression::NodeInOperator::clone() const
   return new NodeInOperator( mNode->clone(), mList->clone(), mNotIn );
 }
 
+bool QgsExpression::NodeInOperator::isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  if ( !mNode->isStatic( parent, context ) )
+    return false;
+
+  Q_FOREACH ( Node *n, mList->list() )
+  {
+    if ( !n->isStatic( parent, context ) )
+      return false;
+  }
+
+  return true;
+}
+
 //
 
-QVariant QgsExpression::NodeFunction::eval( QgsExpression *parent, const QgsExpressionContext *context )
+QVariant QgsExpression::NodeFunction::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   QString name = Functions()[mFnIndex]->name();
   Function *fd = context && context->hasFunction( name ) ? context->function( name ) : Functions()[mFnIndex];
@@ -5476,7 +5500,7 @@ QgsExpression::NodeFunction::NodeFunction( int fnIndex, QgsExpression::NodeList 
   }
 }
 
-bool QgsExpression::NodeFunction::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::NodeFunction::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   Function *fd = Functions()[mFnIndex];
 
@@ -5564,6 +5588,14 @@ QgsExpression::Node *QgsExpression::NodeFunction::clone() const
   return new NodeFunction( mFnIndex, mArgs ? mArgs->clone() : nullptr );
 }
 
+bool QgsExpression::NodeFunction::isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  Q_UNUSED( parent )
+  Q_UNUSED( context )
+  // TODO some functions are static!
+  return false;
+}
+
 bool QgsExpression::NodeFunction::validateParams( int fnIndex, QgsExpression::NodeList *args, QString &error )
 {
   if ( !args || !args->hasNamedNodes() )
@@ -5639,14 +5671,14 @@ bool QgsExpression::NodeFunction::validateParams( int fnIndex, QgsExpression::No
 
 //
 
-QVariant QgsExpression::NodeLiteral::eval( QgsExpression *parent, const QgsExpressionContext *context )
+QVariant QgsExpression::NodeLiteral::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   Q_UNUSED( context );
   Q_UNUSED( parent );
   return mValue;
 }
 
-bool QgsExpression::NodeLiteral::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::NodeLiteral::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   Q_UNUSED( parent );
   Q_UNUSED( context );
@@ -5689,9 +5721,16 @@ QgsExpression::Node *QgsExpression::NodeLiteral::clone() const
   return new NodeLiteral( mValue );
 }
 
+bool QgsExpression::NodeLiteral::isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  Q_UNUSED( context )
+  Q_UNUSED( parent )
+  return true;
+}
+
 //
 
-QVariant QgsExpression::NodeColumnRef::eval( QgsExpression *parent, const QgsExpressionContext *context )
+QVariant QgsExpression::NodeColumnRef::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   Q_UNUSED( parent );
   int index = mIndex;
@@ -5717,7 +5756,7 @@ QVariant QgsExpression::NodeColumnRef::eval( QgsExpression *parent, const QgsExp
   return QVariant( '[' + mName + ']' );
 }
 
-bool QgsExpression::NodeColumnRef::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::NodeColumnRef::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   if ( !context || !context->hasVariable( QgsExpressionContext::EXPR_FIELDS ) )
     return false;
@@ -5739,7 +5778,7 @@ bool QgsExpression::NodeColumnRef::prepare( QgsExpression *parent, const QgsExpr
 
 QString QgsExpression::NodeColumnRef::dump() const
 {
-  return QRegExp( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ).exactMatch( mName ) ? mName : quotedColumnRef( mName );
+  return quotedColumnRef( mName );
 }
 
 QSet<QString> QgsExpression::NodeColumnRef::referencedColumns() const
@@ -5757,9 +5796,16 @@ QgsExpression::Node *QgsExpression::NodeColumnRef::clone() const
   return new NodeColumnRef( mName );
 }
 
+bool QgsExpression::NodeColumnRef::isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  Q_UNUSED( context )
+  Q_UNUSED( parent )
+  return false;
+}
+
 //
 
-QVariant QgsExpression::NodeCondition::eval( QgsExpression *parent, const QgsExpressionContext *context )
+QVariant QgsExpression::NodeCondition::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   Q_FOREACH ( WhenThen *cond, mConditions )
   {
@@ -5785,7 +5831,7 @@ QVariant QgsExpression::NodeCondition::eval( QgsExpression *parent, const QgsExp
   return QVariant();
 }
 
-bool QgsExpression::NodeCondition::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::NodeCondition::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   bool res;
   Q_FOREACH ( WhenThen *cond, mConditions )
@@ -5863,6 +5909,17 @@ QgsExpression::Node *QgsExpression::NodeCondition::clone() const
   Q_FOREACH ( WhenThen *wt, mConditions )
     conditions.append( new WhenThen( wt->mWhenExp->clone(), wt->mThenExp->clone() ) );
   return new NodeCondition( conditions, mElseExp ? mElseExp->clone() : nullptr );
+}
+
+bool QgsExpression::NodeCondition::isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  Q_FOREACH ( WhenThen *wt, mConditions )
+  {
+    if ( !wt->mWhenExp->isStatic( parent, context ) || !wt->mThenExp->isStatic( parent, context ) )
+      return false;
+  }
+
+  return mElseExp->isStatic( parent, context );
 }
 
 
@@ -6268,4 +6325,30 @@ QSet<QString> QgsExpression::StaticFunction::referencedColumns( const NodeFuncti
     return mReferencedColumnsFunc( node );
   else
     return mReferencedColumns;
+}
+
+QVariant QgsExpression::Node::eval( QgsExpression *parent, const QgsExpressionContext *context )
+{
+  if ( mStaticValue.isValid() )
+  {
+    return mStaticValue;
+  }
+  else
+  {
+    QVariant res =  evalNode( parent, context );
+    return res;
+  }
+}
+
+bool QgsExpression::Node::prepare( QgsExpression *parent, const QgsExpressionContext *context )
+{
+  if ( isStatic( parent, context ) )
+  {
+    mStaticValue = evalNode( parent, context );
+    return true;
+  }
+  else
+  {
+    return prepareNode( parent, context );
+  }
 }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -4950,13 +4950,13 @@ QVariant QgsExpression::NodeBinaryOperator::evalNode( QgsExpression *parent, con
           QgsExpression::NodeLiteral nL( lL.at( i ) );
           QgsExpression::NodeLiteral nR( lR.at( i ) );
           QgsExpression::NodeBinaryOperator eqNode( boEQ, nL.clone(), nR.clone() );
-          QVariant eq = eqNode.evalNode( parent, context );
+          QVariant eq = eqNode.eval( parent, context );
           ENSURE_NO_EVAL_ERROR;
           if ( eq == TVL_False )
           {
             // return the two items comparison
             QgsExpression::NodeBinaryOperator node( mOp, nL.clone(), nR.clone() );
-            QVariant v = node.evalNode( parent, context );
+            QVariant v = node.eval( parent, context );
             ENSURE_NO_EVAL_ERROR;
             return v;
           }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -6330,9 +6330,9 @@ QSet<QString> QgsExpression::StaticFunction::referencedColumns( const NodeFuncti
 
 QVariant QgsExpression::Node::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
-  if ( mStaticValue.isValid() )
+  if ( mHasCachedValue )
   {
-    return mStaticValue;
+    return mCachedStaticValue;
   }
   else
   {
@@ -6345,11 +6345,13 @@ bool QgsExpression::Node::prepare( QgsExpression *parent, const QgsExpressionCon
 {
   if ( isStatic( parent, context ) )
   {
-    mStaticValue = evalNode( parent, context );
+    mCachedStaticValue = evalNode( parent, context );
+    mHasCachedValue = true;
     return true;
   }
   else
   {
+    mHasCachedValue = false;
     return prepareNode( parent, context );
   }
 }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -5778,7 +5778,7 @@ bool QgsExpression::NodeColumnRef::prepareNode( QgsExpression *parent, const Qgs
 
 QString QgsExpression::NodeColumnRef::dump() const
 {
-  return quotedColumnRef( mName );
+  return QRegExp( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ).exactMatch( mName ) ? mName : quotedColumnRef( mName );
 }
 
 QSet<QString> QgsExpression::NodeColumnRef::referencedColumns() const
@@ -5804,6 +5804,11 @@ bool QgsExpression::NodeColumnRef::isStatic( QgsExpression *parent, const QgsExp
 }
 
 //
+
+QgsExpression::NodeCondition::NodeCondition( QgsExpression::WhenThenList *conditions, QgsExpression::Node *elseExp )
+  : mConditions( *conditions )
+  , mElseExp( elseExp )
+{ delete conditions; }
 
 QVariant QgsExpression::NodeCondition::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -5838,7 +5838,8 @@ bool QgsExpression::NodeCondition::prepareNode( QgsExpression *parent, const Qgs
   {
     res = cond->mWhenExp->prepare( parent, context )
           & cond->mThenExp->prepare( parent, context );
-    if ( !res ) return false;
+    if ( !res )
+      return false;
   }
 
   if ( mElseExp )
@@ -5907,7 +5908,7 @@ QgsExpression::Node *QgsExpression::NodeCondition::clone() const
 {
   WhenThenList conditions;
   Q_FOREACH ( WhenThen *wt, mConditions )
-    conditions.append( new WhenThen( wt->mWhenExp->clone(), wt->mThenExp->clone() ) );
+    conditions.append( wt->clone() );
   return new NodeCondition( conditions, mElseExp ? mElseExp->clone() : nullptr );
 }
 
@@ -6351,4 +6352,21 @@ bool QgsExpression::Node::prepare( QgsExpression *parent, const QgsExpressionCon
   {
     return prepareNode( parent, context );
   }
+}
+
+QgsExpression::WhenThen::WhenThen( QgsExpression::Node *whenExp, QgsExpression::Node *thenExp )
+  : mWhenExp( whenExp )
+  , mThenExp( thenExp )
+{
+}
+
+QgsExpression::WhenThen::~WhenThen()
+{
+  delete mWhenExp;
+  delete mThenExp;
+}
+
+QgsExpression::WhenThen *QgsExpression::WhenThen::clone() const
+{
+  return new WhenThen( mWhenExp->clone(), mThenExp->clone() );
 }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -5920,7 +5920,10 @@ bool QgsExpression::NodeCondition::isStatic( QgsExpression *parent, const QgsExp
       return false;
   }
 
-  return mElseExp->isStatic( parent, context );
+  if ( mElseExp )
+    return mElseExp->isStatic( parent, context );
+
+  return true;
 }
 
 

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -167,7 +167,7 @@ class CORE_EXPORT QgsExpression
     class Node;
 
     //! Returns root node of the expression. Root node is null is parsing has failed
-    const Node *rootNode() const;
+    const QgsExpression::Node *rootNode() const;
 
     /** Get the expression ready for evaluation - find out column indexes.
      * \param context context for preparing expression
@@ -239,7 +239,7 @@ class CORE_EXPORT QgsExpression
      * \returns true if string is a valid expression
      * \since QGIS 2.12
      */
-    static bool checkExpression( const QString &text, const QgsExpressionContext *context, QString &errorMessage );
+    static bool checkExpression( const QString &text, const QgsExpressionContext *context, QString &errorMessage SIP_OUT );
 
     /**
      * Set the expression string, will reset the whole internal structure.
@@ -395,10 +395,10 @@ class CORE_EXPORT QgsExpression
     };
 
     //! \note not available in Python bindings
-    static const char *BINARY_OPERATOR_TEXT[];
+    static const char *BINARY_OPERATOR_TEXT[] SIP_SKIP;
 
     //! \note not available in Python bindings
-    static const char *UNARY_OPERATOR_TEXT[];
+    static const char *UNARY_OPERATOR_TEXT[] SIP_SKIP;
 
     /** \ingroup core
       * Represents a single parameter passed to a function.
@@ -430,7 +430,7 @@ class CORE_EXPORT QgsExpression
         //! Returns the default value for the parameter.
         QVariant defaultValue() const { return mDefaultValue; }
 
-        bool operator==( const Parameter &other ) const
+        bool operator==( const QgsExpression::Parameter &other ) const
         {
           return ( QString::compare( mName, other.mName, Qt::CaseInsensitive ) == 0 );
         }
@@ -442,11 +442,11 @@ class CORE_EXPORT QgsExpression
     };
 
     //! List of parameters, used for function definition
-    typedef QList< Parameter > ParameterList;
+    typedef QList< QgsExpression::Parameter > ParameterList;
 
     /** Function definition for evaluation against an expression context, using a list of values as parameters to the function.
      */
-    typedef QVariant( *FcnEval )( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent );
+    typedef QVariant( *FcnEval )( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) SIP_SKIP;
 
     class NodeFunction;
 
@@ -499,7 +499,7 @@ class CORE_EXPORT QgsExpression
          * \since QGIS 2.16
          */
         Function( const QString &fnname,
-                  const ParameterList &params,
+                  const QgsExpression::ParameterList &params,
                   const QString &group,
                   const QString &helpText = QString(),
                   bool lazyEval = false,
@@ -519,7 +519,7 @@ class CORE_EXPORT QgsExpression
          * \since QGIS 3.0
          */
         Function( const QString &fnname,
-                  const ParameterList &params,
+                  const QgsExpression::ParameterList &params,
                   const QStringList &groups,
                   const QString &helpText = QString(),
                   bool lazyEval = false,
@@ -561,10 +561,10 @@ class CORE_EXPORT QgsExpression
         /** Returns the list of named parameters for the function, if set.
          * \since QGIS 2.16
         */
-        const ParameterList &parameters() const { return mParameterList; }
+        const QgsExpression::ParameterList &parameters() const { return mParameterList; }
 
         //! Does this function use a geometry object.
-        virtual bool usesGeometry( const NodeFunction *node ) const;
+        virtual bool usesGeometry( const QgsExpression::NodeFunction *node ) const;
 
         /** Returns a list of possible aliases for the function. These include
          * other permissible names for the function, e.g., deprecated names.
@@ -586,7 +586,7 @@ class CORE_EXPORT QgsExpression
          *
          * \since QGIS 3.0
          */
-        virtual QSet<QString> referencedColumns( const NodeFunction *node ) const;
+        virtual QSet<QString> referencedColumns( const QgsExpression::NodeFunction *node ) const;
 
         /** Returns whether the function is only available if provided by a QgsExpressionContext object.
          * \since QGIS 2.12
@@ -621,14 +621,14 @@ class CORE_EXPORT QgsExpression
          */
         virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) = 0;
 
-        bool operator==( const Function &other ) const;
+        bool operator==( const QgsExpression::Function &other ) const;
 
         virtual bool handlesNull() const { return mHandlesNull; }
 
       private:
         QString mName;
         int mParams;
-        ParameterList mParameterList;
+        QgsExpression::ParameterList mParameterList;
         QStringList mGroups;
         QString mHelpText;
         bool mLazyEval;
@@ -640,7 +640,8 @@ class CORE_EXPORT QgsExpression
       * c++ helper class for defining QgsExpression functions.
       * \note not available in Python bindings
       */
-    class StaticFunction : public Function
+#ifndef SIP_RUN
+    class StaticFunction : public QgsExpression::Function
     {
       public:
 
@@ -666,7 +667,7 @@ class CORE_EXPORT QgsExpression
         /** Static function for evaluation against a QgsExpressionContext, using a named list of parameter values.
          */
         StaticFunction( const QString &fnname,
-                        const ParameterList &params,
+                        const QgsExpression::ParameterList &params,
                         FcnEval fcn,
                         const QString &group,
                         const QString &helpText = QString(),
@@ -694,12 +695,12 @@ class CORE_EXPORT QgsExpression
          * could potentially require a geometry or columns.
          */
         StaticFunction( const QString &fnname,
-                        const ParameterList &params,
+                        const QgsExpression::ParameterList &params,
                         FcnEval fcn,
                         const QString &group,
                         const QString &helpText,
-                        std::function < bool ( const NodeFunction *node ) > usesGeometry,
-                        std::function < QSet<QString>( const NodeFunction *node ) > referencedColumns,
+                        std::function < bool ( const QgsExpression::NodeFunction *node ) > usesGeometry,
+                        std::function < QSet<QString>( const QgsExpression::NodeFunction *node ) > referencedColumns,
                         bool lazyEval = false,
                         const QStringList &aliases = QStringList(),
                         bool handlesNull = false );
@@ -708,7 +709,7 @@ class CORE_EXPORT QgsExpression
          * of groups.
          */
         StaticFunction( const QString &fnname,
-                        const ParameterList &params,
+                        const QgsExpression::ParameterList &params,
                         FcnEval fcn,
                         const QStringList &groups,
                         const QString &helpText = QString(),
@@ -745,17 +746,18 @@ class CORE_EXPORT QgsExpression
         FcnEval mFnc;
         QStringList mAliases;
         bool mUsesGeometry;
-        std::function < bool( const NodeFunction *node ) > mUsesGeometryFunc;
-        std::function < QSet<QString>( const NodeFunction *node ) > mReferencedColumnsFunc;
+        std::function < bool( const QgsExpression::NodeFunction *node ) > mUsesGeometryFunc;
+        std::function < QSet<QString>( const QgsExpression::NodeFunction *node ) > mReferencedColumnsFunc;
         QSet<QString> mReferencedColumns;
     };
+#endif
 
     //! \note not available in Python bindings
-    static QList<Function *> sFunctions;
-    static const QList<Function *> &Functions();
+    static QList<QgsExpression::Function *> sFunctions SIP_SKIP;
+    static const QList<QgsExpression::Function *> &Functions();
 
     //! \note not available in Python bindings
-    static QStringList sBuiltinFunctions;
+    static QStringList sBuiltinFunctions SIP_SKIP;
     static const QStringList &BuiltinFunctions();
 
     /** Registers a function to the expression engine. This is required to allow expressions to utilize the function.
@@ -764,7 +766,7 @@ class CORE_EXPORT QgsExpression
      * \returns true on successful registration
      * \see unregisterFunction
      */
-    static bool registerFunction( Function *function, bool transferOwnership = false );
+    static bool registerFunction( QgsExpression::Function *function, bool transferOwnership = false );
 
     /** Unregisters a function from the expression engine. The function will no longer be usable in expressions.
      * \param name function name
@@ -774,7 +776,7 @@ class CORE_EXPORT QgsExpression
 
     //! List of functions owned by the expression engine
     //! \note not available in Python bindings
-    static QList<Function *> sOwnedFunctions;
+    static QList<QgsExpression::Function *> sOwnedFunctions SIP_SKIP;
 
     /** Deletes all registered functions whose ownership have been transferred to the expression engine.
      * \since QGIS 2.12
@@ -840,6 +842,23 @@ class CORE_EXPORT QgsExpression
      */
     class CORE_EXPORT Node
     {
+
+#ifdef SIP_RUN
+        SIP_CONVERT_TO_SUBCLASS_CODE
+        switch ( sipCpp->nodeType() )
+        {
+          case QgsExpression::ntUnaryOperator:   sipType = sipType_QgsExpression_NodeUnaryOperator; break;
+          case QgsExpression::ntBinaryOperator:  sipType = sipType_QgsExpression_NodeBinaryOperator; break;
+          case QgsExpression::ntInOperator:      sipType = sipType_QgsExpression_NodeInOperator; break;
+          case QgsExpression::ntFunction:        sipType = sipType_QgsExpression_NodeFunction; break;
+          case QgsExpression::ntLiteral:         sipType = sipType_QgsExpression_NodeLiteral; break;
+          case QgsExpression::ntColumnRef:       sipType = sipType_QgsExpression_NodeColumnRef; break;
+          case QgsExpression::ntCondition:       sipType = sipType_QgsExpression_NodeCondition; break;
+          default:                               sipType = 0; break;
+        }
+        SIP_END
+#endif
+
       public:
         virtual ~Node() = default;
 
@@ -848,7 +867,7 @@ class CORE_EXPORT QgsExpression
          *
          * \returns The type of this node
          */
-        virtual NodeType nodeType() const = 0;
+        virtual QgsExpression::NodeType nodeType() const = 0;
 
         /**
          * Abstract virtual eval method
@@ -879,7 +898,7 @@ class CORE_EXPORT QgsExpression
          *
          * \returns a deep copy of this node.
          */
-        virtual Node *clone() const = 0;
+        virtual QgsExpression::Node *clone() const = 0;
 
         /**
          * Abstract virtual method which returns a list of columns required to
@@ -920,7 +939,7 @@ class CORE_EXPORT QgsExpression
          * \param name node name
          * \param node node
          */
-        NamedNode( const QString &name, Node *node )
+        NamedNode( const QString &name, QgsExpression::Node *node )
           : name( name )
           , node( node )
         {}
@@ -929,7 +948,7 @@ class CORE_EXPORT QgsExpression
         QString name;
 
         //! Node
-        Node *node = nullptr;
+        QgsExpression::Node *node = nullptr;
     };
 
     /** \ingroup core
@@ -940,12 +959,12 @@ class CORE_EXPORT QgsExpression
         NodeList() : mHasNamedNodes( false ) {}
         virtual ~NodeList() { qDeleteAll( mList ); }
         //! Takes ownership of the provided node
-        void append( Node *node ) { mList.append( node ); mNameList.append( QString() ); }
+        void append( QgsExpression::Node *node SIP_TRANSFER ) { mList.append( node ); mNameList.append( QString() ); }
 
         /** Adds a named node. Takes ownership of the provided node.
          * \since QGIS 2.16
         */
-        void append( NamedNode *node );
+        void append( QgsExpression::NamedNode *node SIP_TRANSFER );
 
         /** Returns the number of nodes in the list.
          */
@@ -958,26 +977,26 @@ class CORE_EXPORT QgsExpression
         /**
          * Get a list of all the nodes.
          */
-        QList<Node *> list() { return mList; }
+        QList<QgsExpression::Node *> list() { return mList; }
 
         /**
          * Get the node at position i in the list.
          *
          * \since QGIS 3.0
          */
-        Node *at( int i ) { return mList.at( i ); }
+        QgsExpression::Node *at( int i ) { return mList.at( i ); }
 
         //! Returns a list of names for nodes. Unnamed nodes will be indicated by an empty string in the list.
         //! \since QGIS 2.16
         QStringList names() const { return mNameList; }
 
         //! Creates a deep copy of this list. Ownership is transferred to the caller
-        NodeList *clone() const;
+        QgsExpression::NodeList *clone() const;
 
         virtual QString dump() const;
 
       protected:
-        QList<Node *> mList;
+        QList<QgsExpression::Node *> mList;
         QStringList mNameList;
 
       private:
@@ -987,19 +1006,19 @@ class CORE_EXPORT QgsExpression
 
     /** \ingroup core
      */
-    class CORE_EXPORT NodeUnaryOperator : public Node
+    class CORE_EXPORT NodeUnaryOperator : public QgsExpression::Node
     {
       public:
-        NodeUnaryOperator( UnaryOperator op, Node *operand )
+        NodeUnaryOperator( QgsExpression::UnaryOperator op, QgsExpression::Node *operand SIP_TRANSFER )
           : mOp( op )
           , mOperand( operand )
         {}
         ~NodeUnaryOperator() { delete mOperand; }
 
-        UnaryOperator op() const { return mOp; }
-        Node *operand() const { return mOperand; }
+        QgsExpression::UnaryOperator op() const { return mOp; }
+        QgsExpression::Node *operand() const { return mOperand; }
 
-        virtual NodeType nodeType() const override { return ntUnaryOperator; }
+        virtual QgsExpression::NodeType nodeType() const override { return ntUnaryOperator; }
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QString dump() const override;
@@ -1007,30 +1026,30 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedColumns() const override;
         virtual QSet<QString> referencedVariables() const override;
         virtual bool needsGeometry() const override { return mOperand->needsGeometry(); }
-        virtual Node *clone() const override;
+        virtual QgsExpression::Node *clone() const override;
 
       protected:
-        UnaryOperator mOp;
-        Node *mOperand = nullptr;
+        QgsExpression::UnaryOperator mOp;
+        QgsExpression::Node *mOperand = nullptr;
     };
 
     /** \ingroup core
      */
-    class CORE_EXPORT NodeBinaryOperator : public Node
+    class CORE_EXPORT NodeBinaryOperator : public QgsExpression::Node
     {
       public:
-        NodeBinaryOperator( BinaryOperator op, Node *opLeft, Node *opRight )
+        NodeBinaryOperator( QgsExpression::BinaryOperator op, QgsExpression::Node *opLeft SIP_TRANSFER, QgsExpression::Node *opRight SIP_TRANSFER )
           : mOp( op )
           , mOpLeft( opLeft )
           , mOpRight( opRight )
         {}
         ~NodeBinaryOperator() { delete mOpLeft; delete mOpRight; }
 
-        BinaryOperator op() const { return mOp; }
-        Node *opLeft() const { return mOpLeft; }
-        Node *opRight() const { return mOpRight; }
+        QgsExpression::BinaryOperator op() const { return mOp; }
+        QgsExpression::Node *opLeft() const { return mOpLeft; }
+        QgsExpression::Node *opRight() const { return mOpRight; }
 
-        virtual NodeType nodeType() const override { return ntBinaryOperator; }
+        virtual QgsExpression::NodeType nodeType() const override { return ntBinaryOperator; }
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QString dump() const override;
@@ -1038,7 +1057,7 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedColumns() const override;
         virtual QSet<QString> referencedVariables() const override;
         virtual bool needsGeometry() const override;
-        virtual Node *clone() const override;
+        virtual QgsExpression::Node *clone() const override;
 
         int precedence() const;
         bool leftAssociative() const;
@@ -1061,21 +1080,21 @@ class CORE_EXPORT QgsExpression
 
     /** \ingroup core
      */
-    class CORE_EXPORT NodeInOperator : public Node
+    class CORE_EXPORT NodeInOperator : public QgsExpression::Node
     {
       public:
-        NodeInOperator( Node *node, NodeList *list, bool notin = false )
+        NodeInOperator( QgsExpression::Node *node SIP_TRANSFER, QgsExpression::NodeList *list SIP_TRANSFER, bool notin = false )
           : mNode( node )
           , mList( list )
           , mNotIn( notin )
         {}
         virtual ~NodeInOperator() { delete mNode; delete mList; }
 
-        Node *node() const { return mNode; }
+        QgsExpression::Node *node() const { return mNode; }
         bool isNotIn() const { return mNotIn; }
-        NodeList *list() const { return mList; }
+        QgsExpression::NodeList *list() const { return mList; }
 
-        virtual NodeType nodeType() const override { return ntInOperator; }
+        virtual QgsExpression::NodeType nodeType() const override { return ntInOperator; }
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QString dump() const override;
@@ -1083,7 +1102,7 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedColumns() const override;
         virtual QSet<QString> referencedVariables() const override;
         virtual bool needsGeometry() const override;
-        virtual Node *clone() const override;
+        virtual QgsExpression::Node *clone() const override;
 
       protected:
         Node *mNode = nullptr;
@@ -1093,17 +1112,17 @@ class CORE_EXPORT QgsExpression
 
     /** \ingroup core
      */
-    class CORE_EXPORT NodeFunction : public Node
+    class CORE_EXPORT NodeFunction : public QgsExpression::Node
     {
       public:
-        NodeFunction( int fnIndex, NodeList *args );
+        NodeFunction( int fnIndex, QgsExpression::NodeList *args SIP_TRANSFER );
 
         virtual ~NodeFunction() { delete mArgs; }
 
         int fnIndex() const { return mFnIndex; }
-        NodeList *args() const { return mArgs; }
+        QgsExpression::NodeList *args() const { return mArgs; }
 
-        virtual NodeType nodeType() const override { return ntFunction; }
+        virtual QgsExpression::NodeType nodeType() const override { return ntFunction; }
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QString dump() const override;
@@ -1111,10 +1130,10 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedColumns() const override;
         virtual QSet<QString> referencedVariables() const override;
         virtual bool needsGeometry() const override;
-        virtual Node *clone() const override;
+        virtual QgsExpression::Node *clone() const override;
 
         //! Tests whether the provided argument list is valid for the matching function
-        static bool validateParams( int fnIndex, NodeList *args, QString &error );
+        static bool validateParams( int fnIndex, QgsExpression::NodeList *args, QString &error );
 
       private:
         int mFnIndex;
@@ -1124,7 +1143,7 @@ class CORE_EXPORT QgsExpression
 
     /** \ingroup core
      */
-    class CORE_EXPORT NodeLiteral : public Node
+    class CORE_EXPORT NodeLiteral : public QgsExpression::Node
     {
       public:
         NodeLiteral( const QVariant &value )
@@ -1134,7 +1153,7 @@ class CORE_EXPORT QgsExpression
         //! The value of the literal.
         inline QVariant value() const { return mValue; }
 
-        virtual NodeType nodeType() const override { return ntLiteral; }
+        virtual QgsExpression::NodeType nodeType() const override { return ntLiteral; }
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QString dump() const override;
@@ -1142,7 +1161,7 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedColumns() const override;
         virtual QSet<QString> referencedVariables() const override;
         virtual bool needsGeometry() const override { return false; }
-        virtual Node *clone() const override;
+        virtual QgsExpression::Node *clone() const override;
 
       protected:
         QVariant mValue;
@@ -1150,7 +1169,7 @@ class CORE_EXPORT QgsExpression
 
     /** \ingroup core
      */
-    class CORE_EXPORT NodeColumnRef : public Node
+    class CORE_EXPORT NodeColumnRef : public QgsExpression::Node
     {
       public:
         NodeColumnRef( const QString &name )
@@ -1170,7 +1189,7 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedVariables() const override;
         virtual bool needsGeometry() const override { return false; }
 
-        virtual Node *clone() const override;
+        virtual QgsExpression::Node *clone() const override;
 
       protected:
         QString mName;
@@ -1182,7 +1201,7 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT WhenThen
     {
       public:
-        WhenThen( Node *whenExp, Node *thenExp )
+        WhenThen( QgsExpression::Node *whenExp SIP_TRANSFER, QgsExpression::Node *thenExp SIP_TRANSFER )
           : mWhenExp( whenExp )
           , mThenExp( thenExp )
         {}
@@ -1194,28 +1213,35 @@ class CORE_EXPORT QgsExpression
         WhenThen &operator=( const WhenThen &rh ) = delete;
 
         // protected:
-        Node *mWhenExp = nullptr;
-        Node *mThenExp = nullptr;
+        QgsExpression::Node *mWhenExp = nullptr;
+        QgsExpression::Node *mThenExp = nullptr;
+
+      private:
+#ifdef SIP_RUN
+        WhenThen( const QgsExpression::WhenThen &rh );
+#endif
 
     };
-    typedef QList<WhenThen *> WhenThenList;
+    typedef QList<QgsExpression::WhenThen *> WhenThenList;
 
     /** \ingroup core
      */
-    class CORE_EXPORT NodeCondition : public Node
+    class CORE_EXPORT NodeCondition : public QgsExpression::Node
     {
       public:
-        NodeCondition( WhenThenList *conditions, Node *elseExp = nullptr )
+        NodeCondition( QgsExpression::WhenThenList *conditions, QgsExpression::Node *elseExp = nullptr )
           : mConditions( *conditions )
           , mElseExp( elseExp )
         { delete conditions; }
-        NodeCondition( const WhenThenList &conditions, Node *elseExp = nullptr )
-          : mConditions( conditions )
-          , mElseExp( elseExp )
+
+        NodeCondition( const QgsExpression::WhenThenList &conditions, QgsExpression::Node *elseExp = nullptr ) SIP_SKIP
+      : mConditions( conditions )
+        , mElseExp( elseExp )
         {}
+
         ~NodeCondition() { delete mElseExp; qDeleteAll( mConditions ); }
 
-        virtual NodeType nodeType() const override { return ntCondition; }
+        virtual QgsExpression::NodeType nodeType() const override { return ntCondition; }
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QString dump() const override;
@@ -1223,11 +1249,11 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedColumns() const override;
         virtual QSet<QString> referencedVariables() const override;
         virtual bool needsGeometry() const override;
-        virtual Node *clone() const override;
+        virtual QgsExpression::Node *clone() const override;
 
       protected:
-        WhenThenList mConditions;
-        Node *mElseExp = nullptr;
+        QgsExpression::WhenThenList mConditions;
+        QgsExpression::Node *mElseExp = nullptr;
     };
 
     /** Returns the help text for a specified function.
@@ -1261,7 +1287,7 @@ class CORE_EXPORT QgsExpression
   protected:
     void initGeomCalculator();
 
-    struct HelpArg
+    struct HelpArg SIP_SKIP
     {
       HelpArg( const QString &arg, const QString &desc, bool descOnly = false, bool syntaxOnly = false,
                bool optional = false, const QString &defaultVal = QString() )
@@ -1281,7 +1307,7 @@ class CORE_EXPORT QgsExpression
       QString mDefaultVal;
     };
 
-    struct HelpExample
+    struct HelpExample SIP_SKIP
     {
       HelpExample( const QString &expression, const QString &returns, const QString &note = QString::null )
         : mExpression( expression )
@@ -1294,12 +1320,12 @@ class CORE_EXPORT QgsExpression
       QString mNote;
     };
 
-    struct HelpVariant
+    struct HelpVariant SIP_SKIP
     {
       HelpVariant( const QString &name, const QString &description,
-                   const QList<HelpArg> &arguments = QList<HelpArg>(),
+                   const QList<QgsExpression::HelpArg> &arguments = QList<QgsExpression::HelpArg>(),
                    bool variableLenArguments = false,
-                   const QList<HelpExample> &examples = QList<HelpExample>(),
+                   const QList<QgsExpression::HelpExample> &examples = QList<QgsExpression::HelpExample>(),
                    const QString &notes = QString::null )
         : mName( name )
         , mDescription( description )
@@ -1311,17 +1337,17 @@ class CORE_EXPORT QgsExpression
 
       QString mName;
       QString mDescription;
-      QList<HelpArg> mArguments;
+      QList<QgsExpression::HelpArg> mArguments;
       bool mVariableLenArguments;
-      QList<HelpExample> mExamples;
+      QList<QgsExpression::HelpExample> mExamples;
       QString mNotes;
     };
 
-    struct Help
+    struct Help SIP_SKIP
     {
       Help() {}
 
-      Help( const QString &name, const QString &type, const QString &description, const QList<HelpVariant> &variants )
+      Help( const QString &name, const QString &type, const QString &description, const QList<QgsExpression::HelpVariant> &variants )
         : mName( name )
         , mType( type )
         , mDescription( description )
@@ -1331,7 +1357,7 @@ class CORE_EXPORT QgsExpression
       QString mName;
       QString mType;
       QString mDescription;
-      QList<HelpVariant> mVariants;
+      QList<QgsExpression::HelpVariant> mVariants;
     };
 
     /**
@@ -1340,7 +1366,7 @@ class CORE_EXPORT QgsExpression
      *
      * \note not available in Python bindings
      */
-    void detach();
+    void detach() SIP_SKIP;
 
     QgsExpressionPrivate *d = nullptr;
 
@@ -1349,9 +1375,9 @@ class CORE_EXPORT QgsExpression
     static QHash<QString, QString> sGroups;
 
     //! \note not available in Python bindings
-    static void initFunctionHelp();
+    static void initFunctionHelp() SIP_SKIP;
     //! \note not available in Python bindings
-    static void initVariableHelp();
+    static void initVariableHelp() SIP_SKIP;
 
     friend class QgsOgcUtils;
 };

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -829,16 +829,19 @@ class CORE_EXPORT QgsExpression
 
     enum NodeType
     {
-      ntUnaryOperator,
-      ntBinaryOperator,
-      ntInOperator,
-      ntFunction,
-      ntLiteral,
-      ntColumnRef,
-      ntCondition
+      ntUnaryOperator, //!< \see QgsExpression::Node::NodeUnaryOperator
+      ntBinaryOperator, //!< \see QgsExpression::Node::NodeBinaryOperator
+      ntInOperator, //!< \see QgsExpression::Node::NodeInOperator
+      ntFunction,  //!< \see QgsExpression::Node::NodeFunction
+      ntLiteral, //!< \see QgsExpression::Node::NodeLiteral
+      ntColumnRef, //!< \see QgsExpression::Node::NodeColumnRef
+      ntCondition //!< \see QgsExpression::Node::NodeCondition
     };
 
-    /** \ingroup core
+    /**
+     * \ingroup core
+     *
+     * Abstract base class for all nodes that can appear in an expression.
      */
     class CORE_EXPORT Node
     {
@@ -863,16 +866,16 @@ class CORE_EXPORT QgsExpression
         virtual ~Node() = default;
 
         /**
-         * Abstract virtual that returns the type of this node.
+         * Get the type of this node.
          *
          * \returns The type of this node
          */
         virtual QgsExpression::NodeType nodeType() const = 0;
 
         /**
-         * Abstract virtual dump method
-         *
-         * \returns An expression which represents this node as string
+         * Dump this node into a serialized (part) of an expression.
+         * The returned expression does not necessarily literally match
+         * the original expression, it's just guaranteed to behave the same way.
          */
         virtual QString dump() const = 0;
 
@@ -880,6 +883,8 @@ class CORE_EXPORT QgsExpression
          * Evaluate this node with the given context and parent.
          * This will return a cached value if it has been determined to be static
          * during the prepare() execution.
+         *
+         * \since QGIS 2.12
          */
         QVariant eval( QgsExpression *parent, const QgsExpressionContext *context );
 
@@ -906,7 +911,7 @@ class CORE_EXPORT QgsExpression
         virtual QSet<QString> referencedColumns() const = 0;
 
         /**
-         * Return a list of all variables which are used in this expression.
+         * Return a set of all variables which are used in this expression.
          */
         virtual QSet<QString> referencedVariables() const = 0;
 
@@ -920,24 +925,39 @@ class CORE_EXPORT QgsExpression
          */
         virtual bool needsGeometry() const = 0;
 
+        /**
+         * Returns true if this node can be evaluated for a static value. This is used during
+         * the prepare() step and in case it returns true, the value of this node will already
+         * be evaluated and the result cached (and therefore not re-evaluated in subsequent calls
+         * to eval()). In case this returns true, prepareNode() will never be called.
+         *
+         * \since QGIS 3.0
+         */
         virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const = 0;
 
+        /**
+         * Prepare this node for evaluation.
+         * This will check if the node content is static and in this case cache the value.
+         * If it's not static it will call prepareNode() to allow the node to do initialization
+         * work like for example resolving a column name to an attribute index.
+         *
+         * \since QGIS 2.12
+         */
         bool prepare( QgsExpression *parent, const QgsExpressionContext *context );
-
 
       private:
 
         /**
          * Abstract virtual preparation method
          * Errors are reported to the parent
-         * \since QGIS 2.12
+         * \since QGIS 3.0
          */
         virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
 
         /**
          * Abstract virtual eval method
          * Errors are reported to the parent
-         * \since QGIS 2.12
+         * \since QGIS 3.0
          */
         virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
 

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -850,14 +850,30 @@ class CORE_EXPORT QgsExpression
         SIP_CONVERT_TO_SUBCLASS_CODE
         switch ( sipCpp->nodeType() )
         {
-          case QgsExpression::ntUnaryOperator:   sipType = sipType_QgsExpression_NodeUnaryOperator; break;
-          case QgsExpression::ntBinaryOperator:  sipType = sipType_QgsExpression_NodeBinaryOperator; break;
-          case QgsExpression::ntInOperator:      sipType = sipType_QgsExpression_NodeInOperator; break;
-          case QgsExpression::ntFunction:        sipType = sipType_QgsExpression_NodeFunction; break;
-          case QgsExpression::ntLiteral:         sipType = sipType_QgsExpression_NodeLiteral; break;
-          case QgsExpression::ntColumnRef:       sipType = sipType_QgsExpression_NodeColumnRef; break;
-          case QgsExpression::ntCondition:       sipType = sipType_QgsExpression_NodeCondition; break;
-          default:                               sipType = 0; break;
+          case QgsExpression::ntUnaryOperator:
+            sipType = sipType_QgsExpression_NodeUnaryOperator;
+            break;
+          case QgsExpression::ntBinaryOperator:
+            sipType = sipType_QgsExpression_NodeBinaryOperator;
+            break;
+          case QgsExpression::ntInOperator:
+            sipType = sipType_QgsExpression_NodeInOperator;
+            break;
+          case QgsExpression::ntFunction:
+            sipType = sipType_QgsExpression_NodeFunction;
+            break;
+          case QgsExpression::ntLiteral:
+            sipType = sipType_QgsExpression_NodeLiteral;
+            break;
+          case QgsExpression::ntColumnRef:
+            sipType = sipType_QgsExpression_NodeColumnRef;
+            break;
+          case QgsExpression::ntCondition:
+            sipType = sipType_QgsExpression_NodeCondition;
+            break;
+          default:
+            sipType = 0;
+            break;
         }
         SIP_END
 #endif
@@ -952,14 +968,14 @@ class CORE_EXPORT QgsExpression
          * Errors are reported to the parent
          * \since QGIS 3.0
          */
-        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
+        virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0 SIP_FORCE;
 
         /**
          * Abstract virtual eval method
          * Errors are reported to the parent
          * \since QGIS 3.0
          */
-        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
+        virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0 SIP_FORCE;
 
         bool mHasCachedValue = false;
         QVariant mCachedStaticValue;
@@ -1040,6 +1056,7 @@ class CORE_EXPORT QgsExpression
     };
 
     /** \ingroup core
+     * A unary node is either negative as in boolean (not) or as in numbers (minus).
      */
     class CORE_EXPORT NodeUnaryOperator : public QgsExpression::Node
     {
@@ -1075,6 +1092,10 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT NodeBinaryOperator : public QgsExpression::Node
     {
       public:
+
+        /**
+         * Binary combination of the left and the right with op.
+         */
         NodeBinaryOperator( QgsExpression::BinaryOperator op, QgsExpression::Node *opLeft SIP_TRANSFER, QgsExpression::Node *opRight SIP_TRANSFER )
           : mOp( op )
           , mOpLeft( opLeft )
@@ -1082,9 +1103,9 @@ class CORE_EXPORT QgsExpression
         {}
         ~NodeBinaryOperator() { delete mOpLeft; delete mOpRight; }
 
-        BinaryOperator op() const { return mOp; }
-        Node *opLeft() const { return mOpLeft; }
-        Node *opRight() const { return mOpRight; }
+        QgsExpression::BinaryOperator op() const { return mOp; }
+        QgsExpression::Node *opLeft() const { return mOpLeft; }
+        QgsExpression::Node *opRight() const { return mOpRight; }
 
         virtual QgsExpression::NodeType nodeType() const override { return ntBinaryOperator; }
         virtual bool prepareNode( QgsExpression *parent, const QgsExpressionContext *context ) override;
@@ -1121,6 +1142,10 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT NodeInOperator : public QgsExpression::Node
     {
       public:
+
+        /**
+         * This node tests if the result of \node is in the result of \a list. Optionally it can be inverted with \a notin which by default is false.
+         */
         NodeInOperator( QgsExpression::Node *node SIP_TRANSFER, QgsExpression::NodeList *list SIP_TRANSFER, bool notin = false )
           : mNode( node )
           , mList( list )
@@ -1154,6 +1179,11 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT NodeFunction : public QgsExpression::Node
     {
       public:
+
+        /**
+         * A function node consists of an index of the function in the global function array and
+         * a list of arguments that will be passed to it.
+         */
         NodeFunction( int fnIndex, QgsExpression::NodeList *args SIP_TRANSFER );
 
         virtual ~NodeFunction() { delete mArgs; }
@@ -1245,6 +1275,10 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT WhenThen
     {
       public:
+
+        /**
+         * A combination of when and then. Simple as that.
+         */
         WhenThen( QgsExpression::Node *whenExp, QgsExpression::Node *thenExp );
         ~WhenThen();
 
@@ -1253,7 +1287,10 @@ class CORE_EXPORT QgsExpression
         //! WhenThen nodes cannot be copied.
         WhenThen &operator=( const WhenThen &rh ) = delete;
 
-        WhenThen *clone() const;
+        /**
+         * Get a deep copy of this WhenThen combination.
+         */
+        QgsExpression::WhenThen *clone() const;
 
       private:
 #ifdef SIP_RUN
@@ -1272,11 +1309,15 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT NodeCondition : public QgsExpression::Node
     {
       public:
-        NodeCondition( QgsExpression::WhenThenList *conditions, QgsExpression::Node *elseExp = nullptr )
-          : mConditions( *conditions )
-          , mElseExp( elseExp )
-        { delete conditions; }
 
+        /**
+         * Create a new node with the given list of \a conditions and an optional \a elseExp expression.
+         */
+        NodeCondition( QgsExpression::WhenThenList *conditions, QgsExpression::Node *elseExp = nullptr );
+
+        /**
+         * Create a new node with the given list of \a conditions and an optional \a elseExp expression.
+         */
         NodeCondition( const QgsExpression::WhenThenList &conditions, QgsExpression::Node *elseExp = nullptr ) SIP_SKIP
       : mConditions( conditions )
         , mElseExp( elseExp )

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -1180,7 +1180,7 @@ class CORE_EXPORT QgsExpression
         //! The name of the column.
         QString name() const { return mName; }
 
-        virtual NodeType nodeType() const override { return ntColumnRef; }
+        virtual QgsExpression::NodeType nodeType() const override { return ntColumnRef; }
         virtual bool prepare( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QVariant eval( QgsExpression *parent, const QgsExpressionContext *context ) override;
         virtual QString dump() const override;

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -941,7 +941,8 @@ class CORE_EXPORT QgsExpression
          */
         virtual QVariant evalNode( QgsExpression *parent, const QgsExpressionContext *context ) = 0;
 
-        QVariant mStaticValue;
+        bool mHasCachedValue = false;
+        QVariant mCachedStaticValue;
     };
 
     //! Named node

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -1011,11 +1011,9 @@ class CORE_EXPORT QgsExpression
 
         virtual QString dump() const;
 
-      protected:
-        QList<QgsExpression::Node *> mList;
-        QStringList mNameList;
-
       private:
+        QList<Node *> mList;
+        QStringList mNameList;
 
         bool mHasNamedNodes;
     };
@@ -1046,9 +1044,9 @@ class CORE_EXPORT QgsExpression
 
         virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
-      protected:
-        QgsExpression::UnaryOperator mOp;
-        QgsExpression::Node *mOperand = nullptr;
+      private:
+        UnaryOperator mOp;
+        Node *mOperand = nullptr;
     };
 
     /** \ingroup core
@@ -1124,7 +1122,7 @@ class CORE_EXPORT QgsExpression
         virtual QgsExpression::Node *clone() const override;
         virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
-      protected:
+      private:
         Node *mNode = nullptr;
         NodeList *mList = nullptr;
         bool mNotIn;
@@ -1185,7 +1183,7 @@ class CORE_EXPORT QgsExpression
         virtual QgsExpression::Node *clone() const override;
         virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
-      protected:
+      private:
         QVariant mValue;
     };
 
@@ -1214,35 +1212,36 @@ class CORE_EXPORT QgsExpression
         virtual QgsExpression::Node *clone() const override;
         virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
-      protected:
+      private:
         QString mName;
         int mIndex;
     };
+
+    class NodeCondition;
 
     /** \ingroup core
      */
     class CORE_EXPORT WhenThen
     {
       public:
-        WhenThen( QgsExpression::Node *whenExp SIP_TRANSFER, QgsExpression::Node *thenExp SIP_TRANSFER )
-          : mWhenExp( whenExp )
-          , mThenExp( thenExp )
-        {}
-        ~WhenThen() { delete mWhenExp; delete mThenExp; }
+        WhenThen( QgsExpression::Node *whenExp, QgsExpression::Node *thenExp );
+        ~WhenThen();
 
         //! WhenThen nodes cannot be copied.
         WhenThen( const WhenThen &rh ) = delete;
         //! WhenThen nodes cannot be copied.
         WhenThen &operator=( const WhenThen &rh ) = delete;
 
-        // protected:
-        QgsExpression::Node *mWhenExp = nullptr;
-        QgsExpression::Node *mThenExp = nullptr;
+        WhenThen *clone() const;
 
       private:
 #ifdef SIP_RUN
         WhenThen( const QgsExpression::WhenThen &rh );
 #endif
+        Node *mWhenExp = nullptr;
+        Node *mThenExp = nullptr;
+
+        friend class NodeCondition;
 
     };
     typedef QList<QgsExpression::WhenThen *> WhenThenList;
@@ -1275,9 +1274,9 @@ class CORE_EXPORT QgsExpression
         virtual QgsExpression::Node *clone() const override;
         virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
-      protected:
-        QgsExpression::WhenThenList mConditions;
-        QgsExpression::Node *mElseExp = nullptr;
+      private:
+        WhenThenList mConditions;
+        Node *mElseExp = nullptr;
     };
 
     /** Returns the help text for a specified function.


### PR DESCRIPTION
When an expression is `prepare()`d, any node that is static will be collapsed. Other nodes will be left untouched.

Some examples:

* `3 * 5` => `15`
* `3 * "height"` => `3 * "height"`
* `3 * 5 + "abc"` => `15 + "abc"`

What's missing: flag static functions. That will be especially useful for variables.