### PR TITLE
Added a little more padding for recent projects title

### DIFF
--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -45,8 +45,8 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
   recentProjectsContainer->layout()->setMargin( 0 );
 
   int titleSize = QApplication::fontMetrics().height() * 1.4;
-  QLabel *recentProjectsTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold;'>%2</div>" ).arg( titleSize ).arg( tr( "Recent Projects" ) ) );
-  recentProjectsTitle->setContentsMargins( 0, 3, 0, 0 );
+  QLabel *recentProjectsTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold'>%2</div>" ).arg( titleSize ).arg( tr( "Recent Projects" ) ) );
+  recentProjectsTitle->setContentsMargins( 10, 3, 0, 0 );
 
   recentProjectsContainer->layout()->addWidget( recentProjectsTitle );
 


### PR DESCRIPTION
## Description
Improve the padding on the recent projects title

Before:

<img width="1191" alt="screen shot 2017-04-29 at 2 31 04 pm" src="https://cloud.githubusercontent.com/assets/178003/25556824/6b4eaa68-2d04-11e7-9fba-dbe75c905e6d.png">


After:

<img width="811" alt="screen shot 2017-04-29 at 5 44 28 pm" src="https://cloud.githubusercontent.com/assets/178003/25556816/56dbc57a-2d04-11e7-9126-00e9cd3f5cec.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit