### PR TITLE
[attributetable] Fix "Move selection to top" for 3.x regression fixes #15803

### DIFF
--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -197,13 +197,8 @@ void QgsAttributeTableConfig::readXml( const QDomNode &node )
   }
 
   mSortExpression = configNode.toElement().attribute( QStringLiteral( "sortExpression" ) );
-  mSortOrder = static_cast<Qt::SortOrder>( configNode.toElement().attribute( QStringLiteral( "sortOrder" ) ).toInt() );
-  // fix https://hub.qgis.org/issues/15803
-  // because static_cast give umpredictable value if value is not in the enum range
-  if ( mSortOrder != Qt::AscendingOrder && mSortOrder != Qt::DescendingOrder )
-  {
-    mSortOrder = Qt::AscendingOrder;
-  }
+  Qt::SortOrder sortOrder = static_cast<Qt::SortOrder>( configNode.toElement().attribute( QStringLiteral( "sortOrder" ) ).toInt() );
+  setSortOrder( sortOrder );
 }
 
 QString QgsAttributeTableConfig::sortExpression() const

--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -198,6 +198,12 @@ void QgsAttributeTableConfig::readXml( const QDomNode &node )
 
   mSortExpression = configNode.toElement().attribute( QStringLiteral( "sortExpression" ) );
   mSortOrder = static_cast<Qt::SortOrder>( configNode.toElement().attribute( QStringLiteral( "sortOrder" ) ).toInt() );
+  // fix https://hub.qgis.org/issues/15803
+  // because static_cast give umpredictable value if value is not in the enum range
+  if ( mSortOrder != Qt::AscendingOrder && mSortOrder != Qt::DescendingOrder )
+  {
+    mSortOrder = Qt::AscendingOrder;
+  }
 }
 
 QString QgsAttributeTableConfig::sortExpression() const
@@ -242,6 +248,12 @@ Qt::SortOrder QgsAttributeTableConfig::sortOrder() const
 
 void QgsAttributeTableConfig::setSortOrder( Qt::SortOrder sortOrder )
 {
+  // fix https://hub.qgis.org/issues/15803
+  if ( sortOrder != Qt::AscendingOrder && sortOrder != Qt::DescendingOrder )
+  {
+    sortOrder = Qt::AscendingOrder;
+  }
+
   mSortOrder = sortOrder;
 }
 

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -64,6 +64,9 @@ bool QgsAttributeTableFilterModel::lessThan( const QModelIndex &left, const QMod
 
 void QgsAttributeTableFilterModel::sort( int column, Qt::SortOrder order )
 {
+  if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
+    order = Qt::AscendingOrder;
+
   int myColumn = mColumnMapping.at( column );
   masterModel()->prefetchColumnData( myColumn );
   QSortFilterProxyModel::sort( myColumn, order );
@@ -211,6 +214,9 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
 
 void QgsAttributeTableFilterModel::sort( const QString &expression, Qt::SortOrder order )
 {
+  if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
+    order = Qt::AscendingOrder;
+
   QSortFilterProxyModel::sort( -1 );
   masterModel()->prefetchSortData( expression );
   QSortFilterProxyModel::sort( 0, order ) ;
@@ -226,11 +232,17 @@ void QgsAttributeTableFilterModel::setSelectedOnTop( bool selectedOnTop )
   if ( mSelectedOnTop != selectedOnTop )
   {
     mSelectedOnTop = selectedOnTop;
+    int column = sortColumn();
+    Qt::SortOrder order = sortOrder();
 
-    if ( sortColumn() == -1 )
-    {
-      sort( 0 );
-    }
+    // set default sort values if they are not correctly set
+    if ( column < 0 )
+      column = 0;
+
+    if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
+      order = Qt::AscendingOrder;
+
+    sort( column, order );
     invalidate();
   }
 }


### PR DESCRIPTION
fix for https://hub.qgis.org/issues/15803
port to 3.0 for PR https://github.com/qgis/QGIS/pull/4306

## Description
Fix "Move selection to top" in attribute table. The origin of the problem is due the fact that sortOrder is undefined enetring in selectionOnTop. I wasn't able to find why it is undefined albeit the base class constructor set it as Ascending. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
