### PR TITLE
Add Filename to error message

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -765,8 +765,8 @@ bool QgsProject::read()
                            tr( "%1 at line %2 column %3" ).arg( errorMsg ).arg( line ).arg( column ) );
 #endif
 
-    QString errorString = tr( "Project file read error: %1 at line %2 column %3" )
-                          .arg( errorMsg ).arg( line ).arg( column );
+    QString errorString = tr( "Project file read error in file %1: %2 at line %3 column %4" )
+                          .arg( mFile.fileName() ).arg( errorMsg ).arg( line ).arg( column );
 
     QgsDebugMsg( errorString );
 


### PR DESCRIPTION
Make the error message a bit more readable by actually telling the filename where the error happens

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
