### PR TITLE
[FEATURE] customizable output width and height in save as image dialog

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -100,6 +100,7 @@
 %Include qgsmaprenderersequentialjob.sip
 %Include qgsmaprenderertask.sip
 %Include qgsmapsettings.sip
+%Include qgsmapsettingsutils.sip
 %Include qgsmaptopixel.sip
 %Include qgsmapunitscale.sip
 %Include qgsmargins.sip

--- a/python/core/qgsmaprenderertask.sip
+++ b/python/core/qgsmaprenderertask.sip
@@ -52,6 +52,11 @@ class QgsMapRendererTask : QgsTask
  Adds ``decorations`` to be rendered on the map.
 %End
 
+    void setSaveWorldFile( bool save );
+%Docstring
+ Sets whether a world file will be created alongside an image file.
+%End
+
     virtual void cancel();
 
 

--- a/python/core/qgsmapsettingsutils.sip
+++ b/python/core/qgsmapsettingsutils.sip
@@ -1,0 +1,43 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsmapsettingsutils.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsMapSettingsUtils
+{
+%Docstring
+ Utilities for map settings.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsmapsettingsutils.h"
+%End
+  public:
+
+    static QString worldFileContent( const QgsMapSettings &mapSettings );
+%Docstring
+ Creates the content of a world file.
+ \param mapSettings map settings
+.. note::
+
+   Uses 17 places of precision for all numbers output
+ :rtype: str
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsmapsettingsutils.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5835,7 +5835,7 @@ void QgisApp::saveMapAsImage()
 
     connect( mapRendererTask, &QgsMapRendererTask::renderingComplete, this, [ = ]
     {
-      messageBar()->pushSuccess( tr( "Save as image" ), tr( "Successfully saved canvas to image" ) );
+      messageBar()->pushSuccess( tr( "Save as image" ), tr( "Successfully saved map to image" ) );
     } );
     connect( mapRendererTask, &QgsMapRendererTask::errorOccurred, this, [ = ]( int error )
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5833,6 +5833,8 @@ void QgisApp::saveMapAsImage()
       mapRendererTask->addDecorations( decorations );
     }
 
+    mapRendererTask->setSaveWorldFile( dlg.saveWorldFile() );
+
     connect( mapRendererTask, &QgsMapRendererTask::renderingComplete, this, [ = ]
     {
       messageBar()->pushSuccess( tr( "Save as image" ), tr( "Successfully saved map to image" ) );

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -50,6 +50,8 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
   mDrawDecorations->setText( tr( "Draw active decorations: %1" ).arg( !activeDecorations.isEmpty() ? activeDecorations : tr( "none" ) ) );
 
   connect( mResolutionSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsMapSaveDialog::updateDpi );
+  connect( mOutputWidthSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsMapSaveDialog::updateOutputWidth );
+  connect( mOutputHeightSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsMapSaveDialog::updateOutputHeight );
   connect( mExtentGroupBox, &QgsExtentGroupBox::extentChanged, this, &QgsMapSaveDialog::updateExtent );
   connect( mScaleWidget, &QgsScaleWidget::scaleChanged, this, &QgsMapSaveDialog::updateScale );
 
@@ -62,6 +64,32 @@ void QgsMapSaveDialog::updateDpi( int dpi )
   mDpi = dpi;
 
   updateOutputSize();
+}
+
+void QgsMapSaveDialog::updateOutputWidth( int width )
+{
+  double scale = ( double )width / mSize.width();
+  double adjustment = ( ( mExtent.width() * scale ) - mExtent.width() ) / 2;
+
+  mExtent.setXMinimum( mExtent.xMinimum() - adjustment );
+  mExtent.setXMaximum( mExtent.xMaximum() + adjustment );
+
+  whileBlocking( mExtentGroupBox )->setOutputExtentFromUser( mExtent, mExtentGroupBox->currentCrs() );
+
+  mSize.setWidth( width );
+}
+
+void QgsMapSaveDialog::updateOutputHeight( int height )
+{
+  double scale = ( double )height / mSize.height();
+  double adjustment = ( ( mExtent.height() * scale ) - mExtent.height() ) / 2;
+
+  mExtent.setYMinimum( mExtent.yMinimum() - adjustment );
+  mExtent.setYMaximum( mExtent.yMaximum() + adjustment );
+
+  whileBlocking( mExtentGroupBox )->setOutputExtentFromUser( mExtent, mExtentGroupBox->currentCrs() );
+
+  mSize.setHeight( height );
 }
 
 void QgsMapSaveDialog::updateExtent( const QgsRectangle &extent )
@@ -87,7 +115,8 @@ void QgsMapSaveDialog::updateScale( double scale )
 
 void QgsMapSaveDialog::updateOutputSize()
 {
-  mOutputSize->setText( tr( "Output size: %1 x %2 pixels" ).arg( mSize.width() ).arg( mSize.height() ) );
+  whileBlocking( mOutputWidthSpinBox )->setValue( mSize.width() );
+  whileBlocking( mOutputHeightSpinBox )->setValue( mSize.height() );
 }
 
 QgsRectangle QgsMapSaveDialog::extent() const

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -143,3 +143,8 @@ bool QgsMapSaveDialog::drawDecorations() const
 {
   return mDrawDecorations->isChecked();
 }
+
+bool QgsMapSaveDialog::saveWorldFile() const
+{
+  return mSaveWorldFile->isChecked();
+}

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -59,6 +59,8 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
   private:
 
     void updateDpi( int dpi );
+    void updateOutputWidth( int width );
+    void updateOutputHeight( int height );
     void updateExtent( const QgsRectangle &extent );
     void updateScale( double scale );
     void updateOutputSize();

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -56,6 +56,9 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
     //! returns whether the draw decorations element is checked
     bool drawDecorations() const;
 
+    //! returns whether a world file will be created
+    bool saveWorldFile() const;
+
   private:
 
     void updateDpi( int dpi );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -184,6 +184,7 @@ SET(QGIS_CORE_SRCS
   qgsmaprenderersequentialjob.cpp
   qgsmaprenderertask.cpp
   qgsmapsettings.cpp
+  qgsmapsettingsutils.cpp
   qgsmaptopixel.cpp
   qgsmaptopixelgeometrysimplifier.cpp
   qgsmapunitscale.cpp
@@ -751,6 +752,7 @@ SET(QGIS_CORE_HDRS
   qgsmaplayerrenderer.h
   qgsmaplayerstylemanager.h
   qgsmapsettings.h
+  qgsmapsettingsutils.h
   qgsmaptopixel.h
   qgsmaptopixelgeometrysimplifier.h
   qgsmapunitscale.h

--- a/src/core/qgsmaprenderertask.cpp
+++ b/src/core/qgsmaprenderertask.cpp
@@ -18,6 +18,7 @@
 #include "qgsannotation.h"
 #include "qgsannotationmanager.h"
 #include "qgsmaprenderertask.h"
+#include "qgsmapsettingsutils.h"
 
 #include <QFile>
 #include <QTextStream>
@@ -159,23 +160,8 @@ bool QgsMapRendererTask::run()
 
     if ( mSaveWorldFile )
     {
-      QString content;
-      // note: use 17 places of precision for all numbers output
-      //Pixel XDim
-      content += qgsDoubleToString( mMapSettings.mapUnitsPerPixel() ) + "\r\n";
-      //Rotation on y axis - hard coded
-      content += QLatin1String( "0 \r\n" );
-      //Rotation on x axis - hard coded
-      content += QLatin1String( "0 \r\n" );
-      //Pixel YDim - almost always negative - see
-      //http://en.wikipedia.org/wiki/World_file#cite_note-2
-      content += '-' + qgsDoubleToString( mMapSettings.mapUnitsPerPixel() ) + "\r\n";
-      //Origin X (center of top left cell)
-      content += qgsDoubleToString( mMapSettings.visibleExtent().xMinimum() + ( mMapSettings.mapUnitsPerPixel() / 2 ) ) + "\r\n";
-      //Origin Y (center of top left cell)
-      content += qgsDoubleToString( mMapSettings.visibleExtent().yMaximum() - ( mMapSettings.mapUnitsPerPixel() / 2 ) ) + "\r\n";
-
       QFileInfo info  = QFileInfo( mFileName );
+
       // build the world file name
       QString outputSuffix = info.suffix();
       QString worldFileName = info.absolutePath() + '/' + info.baseName() + '.'
@@ -185,7 +171,7 @@ bool QgsMapRendererTask::run()
       if ( worldFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) //don't use QIODevice::Text
       {
         QTextStream stream( &worldFile );
-        stream << content;
+        stream << QgsMapSettingsUtils::worldFileContent( mMapSettings );
       }
     }
   }

--- a/src/core/qgsmaprenderertask.h
+++ b/src/core/qgsmaprenderertask.h
@@ -73,6 +73,11 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
      */
     void addDecorations( QList< QgsMapDecoration * > decorations );
 
+    /**
+     * Sets whether a world file will be created alongside an image file.
+     */
+    void setSaveWorldFile( bool save ) { mSaveWorldFile = save; }
+
     void cancel() override;
 
   signals:
@@ -103,6 +108,7 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
 
     QString mFileName;
     QString mFileFormat;
+    bool mSaveWorldFile = false;
 
     QList< QgsAnnotation * > mAnnotations;
     QList< QgsMapDecoration * > mDecorations;

--- a/src/core/qgsmapsettingsutils.cpp
+++ b/src/core/qgsmapsettingsutils.cpp
@@ -1,0 +1,44 @@
+/***************************************************************************
+                         qgsmapsettingsutils.cpp
+                             -------------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmapsettings.h"
+#include "qgsmapsettingsutils.h"
+
+#include <QString>
+
+QString QgsMapSettingsUtils::worldFileContent( const QgsMapSettings &mapSettings )
+{
+  double xOrigin = mapSettings.visiblePolygon().at( 0 ).x() + ( mapSettings.mapUnitsPerPixel() / 2 );
+  double yOrigin = mapSettings.visiblePolygon().at( 0 ).y() - ( mapSettings.mapUnitsPerPixel() / 2 );
+
+  QString content;
+  // Pixel XDim
+  content += qgsDoubleToString( mapSettings.mapUnitsPerPixel() ) + "\r\n";
+  // Rotation on y axis
+  content += QString( "%1\r\n" ).arg( mapSettings.rotation() );
+  // Rotation on x axis
+  content += QString( "%1\r\n" ).arg( mapSettings.rotation() );
+  // Pixel YDim - almost always negative
+  // See https://en.wikipedia.org/wiki/World_file#cite_ref-3
+  content += '-' + qgsDoubleToString( mapSettings.mapUnitsPerPixel() ) + "\r\n";
+  // Origin X (center of top left cell)
+  content += qgsDoubleToString( xOrigin ) + "\r\n";
+  // Origin Y (center of top left cell)
+  content += qgsDoubleToString( yOrigin ) + "\r\n";
+
+  return content;
+}

--- a/src/core/qgsmapsettingsutils.h
+++ b/src/core/qgsmapsettingsutils.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+                         qgsmapsettingsutils.h
+                             -------------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPSETTINGSUTILS_H
+#define QGSMAPSETTINGSUTILS_H
+
+#include "qgis_core.h"
+#include "qgsmapsettings.h"
+
+#include <QString>
+
+/** \ingroup core
+ * Utilities for map settings.
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsMapSettingsUtils
+{
+
+  public:
+
+    /** Creates the content of a world file.
+     * \param mapSettings map settings
+     * \note Uses 17 places of precision for all numbers output
+     */
+    static QString worldFileContent( const QgsMapSettings &mapSettings );
+
+};
+
+#endif

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -56,6 +56,7 @@ email                : sherman at mrcc.com
 #include "qgsmaprenderercustompainterjob.h"
 #include "qgsmaprendererparalleljob.h"
 #include "qgsmaprenderersequentialjob.h"
+#include "qgsmapsettingsutils.h"
 #include "qgsmessagelog.h"
 #include "qgsmessageviewer.h"
 #include "qgspallabeling.h"
@@ -723,24 +724,8 @@ void QgsMapCanvas::saveAsImage( const QString &fileName, QPixmap *theQPixmap, co
   painter.end();
   image.save( fileName, format.toLocal8Bit().data() );
 
-  //create a world file to go with the image...
-  QgsRectangle myRect = mapSettings().visibleExtent();
-  QString myHeader;
-  // note: use 17 places of precision for all numbers output
-  //Pixel XDim
-  myHeader += qgsDoubleToString( mapUnitsPerPixel() ) + "\r\n";
-  //Rotation on y axis - hard coded
-  myHeader += QLatin1String( "0 \r\n" );
-  //Rotation on x axis - hard coded
-  myHeader += QLatin1String( "0 \r\n" );
-  //Pixel YDim - almost always negative - see
-  //http://en.wikipedia.org/wiki/World_file#cite_note-2
-  myHeader += '-' + qgsDoubleToString( mapUnitsPerPixel() ) + "\r\n";
-  //Origin X (center of top left cell)
-  myHeader += qgsDoubleToString( myRect.xMinimum() + ( mapUnitsPerPixel() / 2 ) ) + "\r\n";
-  //Origin Y (center of top left cell)
-  myHeader += qgsDoubleToString( myRect.yMaximum() - ( mapUnitsPerPixel() / 2 ) ) + "\r\n";
   QFileInfo myInfo  = QFileInfo( fileName );
+
   // build the world file name
   QString outputSuffix = myInfo.suffix();
   QString myWorldFileName = myInfo.absolutePath() + '/' + myInfo.baseName() + '.'
@@ -751,7 +736,7 @@ void QgsMapCanvas::saveAsImage( const QString &fileName, QPixmap *theQPixmap, co
     return;
   }
   QTextStream myStream( &myWorldFile );
-  myStream << myHeader;
+  myStream << QgsMapSettingsUtils::worldFileContent( mapSettings() );
 } // saveAsImage
 
 

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -16,6 +16,16 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="7" column="0" colspan="2">
+      <widget class="QCheckBox" name="mSaveWorldFile">
+       <property name="text">
+        <string>Save world file</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="6" column="0" colspan="2">>
       <widget class="QCheckBox" name="mDrawAnnotations">
        <property name="text">

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -16,7 +16,7 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="5" column="0" colspan="2">>
+     <item row="6" column="0" colspan="2">>
       <widget class="QCheckBox" name="mDrawAnnotations">
        <property name="text">
         <string>Draw annotations</string>
@@ -26,7 +26,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0" colspan="2">
+     <item row="5" column="0" colspan="2">
       <widget class="QCheckBox" name="mDrawDecorations">
        <property name="text">
         <string>Draw active decorations</string>
@@ -36,13 +36,55 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0" colspan="2">
-      <widget class="QLabel" name="mOutputSize">
-       <property name="enabled">
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Output height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QgsSpinBox" name="mOutputHeightSpinBox">
+       <property name="suffix">
+        <string> px</string>
+       </property>
+       <property name="prefix">
+        <string/>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>99999</number>
+       </property>
+       <property name="showClearButton" stdset="0">
         <bool>false</bool>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Output width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QgsSpinBox" name="mOutputWidthSpinBox">
+       <property name="suffix">
+        <string> px</string>
+       </property>
+       <property name="prefix">
+        <string/>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>99999</number>
+       </property>
+       <property name="showClearButton" stdset="0">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -60,6 +102,9 @@
        </property>
        <property name="prefix">
         <string/>
+       </property>
+       <property name="minimum">
+        <number>1</number>
        </property>
        <property name="maximum">
         <number>3000</number>

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -128,6 +128,7 @@ SET(TESTS
  testqgsmaprendererjob.cpp
  testqgsmaprotation.cpp
  testqgsmapsettings.cpp
+ testqgsmapsettingsutils.cpp
  testqgsmaptopixelgeometrysimplifier.cpp
  testqgsmaptopixel.cpp
  testqgsmarkerlinesymbol.cpp

--- a/tests/src/core/testqgsmapsettingsutils.cpp
+++ b/tests/src/core/testqgsmapsettingsutils.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+                         testqgsmapsettingsutils.cpp
+                         -----------------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgsmapsettings.h"
+#include "qgsmapsettingsutils.h"
+
+#include <QString>
+
+class TestQgsMapSettingsUtils : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase() {} // will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after each testfunction was executed.
+
+    void createWorldFileContent(); //test world file content function
+
+  private:
+
+    QgsMapSettings mMapSettings;
+
+};
+
+void TestQgsMapSettingsUtils::initTestCase()
+{
+  mMapSettings.setExtent( QgsRectangle( 0, 0, 1, 1 ) );
+}
+
+void TestQgsMapSettingsUtils::createWorldFileContent()
+{
+  QCOMPARE( QgsMapSettingsUtils::worldFileContent( mMapSettings ), QString( "1\r\n0\r\n0\r\n-1\r\n0.5\r\n0.5\r\n" ) );
+}
+
+QGSTEST_MAIN( TestQgsMapSettingsUtils )
+#include "testqgsmapsettingsutils.moc"


### PR DESCRIPTION
## Description
This adds output width and height spin boxes to the recently improved save as image feature:
![screenshot from 2017-05-01 11-40-26](https://cloud.githubusercontent.com/assets/1728657/25572275/b66e3fe4-2e63-11e7-8a45-2cab00aef20d.png)

Wallpaper time!

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
