### PR TITLE
[attributetable] Avoid sort rows during editing: for 3.0 regression fixes #15976

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -242,9 +242,8 @@ void QgsAttributeTableModel::updatedFields()
 
 void QgsAttributeTableModel::editCommandEnded()
 {
-  reload( createIndex( mChangedCellBounds.top(), mChangedCellBounds.left() ),
-          createIndex( mChangedCellBounds.bottom(), mChangedCellBounds.right() ) );
-
+  // do not do releoad(...) due would trigger (dataChanged) row sort
+  // giving issue: https://issues.qgis.org/issues/15976
   mChangedCellBounds = QRect();
 }
 


### PR DESCRIPTION
## Description
Port to 3.0 for: https://github.com/qgis/QGIS/pull/4461
Due to attribute table refactoring in 2.18/3.x there is a regression from 2.14 that apply sortFilter model due to model reload. The fix avoid to apply dataModel reload when end editing of a cell.
Sorting has been leaved to clicking on column header.
Redmine issue: https://issues.qgis.org/issues/15976
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
