### PR TITLE
Sipify qgsfieldconstraints QgsFieldFormatter and QgsFieldFormatterRegistry

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -13,7 +13,6 @@ core/qgsexpressioncontextgenerator.sip
 core/qgsfeaturefilterprovider.sip
 core/qgsfeatureiterator.sip
 core/qgsfeaturerequest.sip
-core/qgsfieldformatterregistry.sip
 core/qgsgeometrysimplifier.sip
 core/qgsgeometryvalidator.sip
 core/qgsgml.sip

--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -13,7 +13,6 @@ core/qgsexpressioncontextgenerator.sip
 core/qgsfeaturefilterprovider.sip
 core/qgsfeatureiterator.sip
 core/qgsfeaturerequest.sip
-core/qgsfieldconstraints.sip
 core/qgsfieldformatterregistry.sip
 core/qgsfieldformatter.sip
 core/qgsgeometrysimplifier.sip

--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -14,7 +14,6 @@ core/qgsfeaturefilterprovider.sip
 core/qgsfeatureiterator.sip
 core/qgsfeaturerequest.sip
 core/qgsfieldformatterregistry.sip
-core/qgsfieldformatter.sip
 core/qgsgeometrysimplifier.sip
 core/qgsgeometryvalidator.sip
 core/qgsgml.sip

--- a/python/core/qgsfieldconstraints.sip
+++ b/python/core/qgsfieldconstraints.sip
@@ -1,127 +1,143 @@
-/**
- * \class QgsFieldConstraints
- * \ingroup core
- * Stores information about constraints which may be present on a field.
- * \note added in QGIS 3.0
- */
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfieldconstraints.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
 
 
 class QgsFieldConstraints
 {
-
-%TypeHeaderCode
-#include <qgsfieldconstraints.h>
+%Docstring
+ Stores information about constraints which may be present on a field.
+.. versionadded:: 3.0
 %End
 
+%TypeHeaderCode
+#include "qgsfieldconstraints.h"
+%End
   public:
 
-    /**
-     * Constraints which may be present on a field.
-     */
     enum Constraint
     {
-      ConstraintNotNull, //!< Field may not be null
-      ConstraintUnique, //!< Field must have a unique value
-      ConstraintExpression, //!< Field has an expression constraint set. See constraintExpression().
+      ConstraintNotNull,
+      ConstraintUnique,
+      ConstraintExpression,
     };
     typedef QFlags<QgsFieldConstraints::Constraint> Constraints;
 
-    /**
-     * Origin of constraints.
-     */
+
     enum ConstraintOrigin
     {
-      ConstraintOriginNotSet, //!< Constraint is not set
-      ConstraintOriginProvider, //!< Constraint was set at data provider
-      ConstraintOriginLayer, //!< Constraint was set by layer
+      ConstraintOriginNotSet,
+      ConstraintOriginProvider,
+      ConstraintOriginLayer,
     };
 
-    /**
-     * Strength of constraints.
-     */
     enum ConstraintStrength
     {
-      ConstraintStrengthNotSet, //!< Constraint is not set
-      ConstraintStrengthHard, //!< Constraint must be honored before feature can be accepted
-      ConstraintStrengthSoft, //!< User is warned if constraint is violated but feature can still be accepted
+      ConstraintStrengthNotSet,
+      ConstraintStrengthHard,
+      ConstraintStrengthSoft,
     };
 
-    /**
-     * Constructor for QgsFieldConstraints.
-     */
     QgsFieldConstraints();
+%Docstring
+ Constructor for QgsFieldConstraints.
+%End
 
-    /**
-     * Returns any constraints which are present for the field.
-     * @see setConstraints()
-     * @see constraintOrigin()
-     */
     Constraints constraints() const;
+%Docstring
+ Returns any constraints which are present for the field.
+.. seealso:: setConstraints()
+.. seealso:: constraintOrigin()
+ :rtype: Constraints
+%End
 
-    /**
-     * Returns the origin of a field constraint, or ConstraintOriginNotSet if the constraint
-     * is not present on this field.
-     * @see constraints()
-     */
     ConstraintOrigin constraintOrigin( Constraint constraint ) const;
+%Docstring
+ Returns the origin of a field constraint, or ConstraintOriginNotSet if the constraint
+ is not present on this field.
+.. seealso:: constraints()
+ :rtype: ConstraintOrigin
+%End
 
-    /**
-     * Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
-     * is not present on this field.
-     * @see constraints()
-     * @see setConstraintStrength()
-     */
     ConstraintStrength constraintStrength( Constraint constraint ) const;
+%Docstring
+ Returns the strength of a field constraint, or ConstraintStrengthNotSet if the constraint
+ is not present on this field.
+.. seealso:: constraints()
+.. seealso:: setConstraintStrength()
+ :rtype: ConstraintStrength
+%End
 
-    /**
-     * Sets the strength of a constraint. Note that the strength of constraints which originate
-     * from a provider cannot be changed. Constraints default to ConstraintStrengthHard unless
-     * explicitly changed.
-     * @see constraintStrength()
-     */
     void setConstraintStrength( Constraint constraint, ConstraintStrength strength );
+%Docstring
+ Sets the strength of a constraint. Note that the strength of constraints which originate
+ from a provider cannot be changed. Constraints default to ConstraintStrengthHard unless
+ explicitly changed.
+.. seealso:: constraintStrength()
+%End
 
-    /**
-     * Sets a constraint on the field.
-     * @see constraints()
-     * @see removeConstraint()
-     */
     void setConstraint( Constraint constraint, ConstraintOrigin origin = ConstraintOriginLayer );
+%Docstring
+ Sets a constraint on the field.
+.. seealso:: constraints()
+.. seealso:: removeConstraint()
+%End
 
-    /**
-     * Removes a constraint from the field.
-     * @see setConstraint()
-     * @see constraints()
-     */
     void removeConstraint( Constraint constraint );
+%Docstring
+ Removes a constraint from the field.
+.. seealso:: setConstraint()
+.. seealso:: constraints()
+%End
 
-    /**
-     * Returns the constraint expression for the field, if set.
-     * @see constraints()
-     * @see constraintDescription()
-     * @see setConstraintExpression()
-     */
     QString constraintExpression() const;
+%Docstring
+ Returns the constraint expression for the field, if set.
+.. seealso:: constraints()
+.. seealso:: constraintDescription()
+.. seealso:: setConstraintExpression()
+ :rtype: str
+%End
 
-    /**
-     * Returns the descriptive name for the constraint expression.
-     * @see constraints()
-     * @see constraintExpression()
-     * @see setConstraintExpression()
-     */
     QString constraintDescription() const;
+%Docstring
+ Returns the descriptive name for the constraint expression.
+.. seealso:: constraints()
+.. seealso:: constraintExpression()
+.. seealso:: setConstraintExpression()
+ :rtype: str
+%End
 
-    /**
-     * Set the constraint expression for the field. An optional descriptive name for the constraint
-     * can also be set. Setting an empty expression will clear any existing expression constraint.
-     * @see constraintExpression()
-     * @see constraintDescription()
-     * @see constraints()
-     */
-    void setConstraintExpression( const QString& expression, const QString& description = QString() );
+    void setConstraintExpression( const QString &expression, const QString &description = QString() );
+%Docstring
+ Set the constraint expression for the field. An optional descriptive name for the constraint
+ can also be set. Setting an empty expression will clear any existing expression constraint.
+.. seealso:: constraintExpression()
+.. seealso:: constraintDescription()
+.. seealso:: constraints()
+%End
 
-    bool operator==( const QgsFieldConstraints& other ) const;
+    bool operator==( const QgsFieldConstraints &other ) const;
+%Docstring
+ :rtype: bool
+%End
 
 };
 
 QFlags<QgsFieldConstraints::Constraint> operator|(QgsFieldConstraints::Constraint f1, QFlags<QgsFieldConstraints::Constraint> f2);
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfieldconstraints.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/qgsfieldformatter.sip
+++ b/python/core/qgsfieldformatter.sip
@@ -1,20 +1,30 @@
-/***************************************************************************
-  qgsfieldformatter.sip - QgsFieldFormatter
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfieldformatter.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
 
- ---------------------
- begin                : 2.12.2016
- copyright            : (C) 2016 by Matthias Kuhn
- email                : matthias@opengis.ch
- ***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+
+
+
 class QgsFieldFormatter
 {
+%Docstring
+ A field formatter helps to handle and display values for a field.
+
+ It allows for using a shared configuration with the editor widgets
+ for representation of attribute values.
+ Field kits normally have one single instance which is managed by the
+ QgsFieldFormatterRegistry. Custom field formatters should be registered there and
+ field formatters for use within code should normally be obtained from there.
+
+ This is an abstract base class and will always need to be subclassed.
+
+.. versionadded:: 3.0
+%End
+
 %TypeHeaderCode
 #include "qgsfieldformatter.h"
 %End
@@ -24,12 +34,64 @@ class QgsFieldFormatter
     virtual ~QgsFieldFormatter();
 
     virtual QString id() const = 0;
+%Docstring
+ Return a unique id for this field formatter.
+ This id will later be used to identify this field formatter in the registry with QgsFieldFormatterRegistry.fieldFormatter().
 
-    virtual QString representValue( QgsVectorLayer* layer, int fieldIdx, const QVariantMap& config, const QVariant& cache, const QVariant& value ) const;
+ This id matches the id of a QgsEditorWidgetFactory.
+ :rtype: str
+%End
 
-    virtual QVariant sortValue( QgsVectorLayer* vl, int fieldIdx, const QVariantMap& config, const QVariant& cache, const QVariant& value ) const;
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
+%Docstring
+ Create a pretty String representation of the value.
 
-    virtual Qt::AlignmentFlag alignmentFlag( QgsVectorLayer* vl, int fieldIdx, const QVariantMap& config ) const;
+ :return: By default the string representation of the provided value as implied by the field definition is returned.
 
-    virtual QVariant createCache( QgsVectorLayer* vl, int fieldIdx, const QVariantMap& config ) const;
+.. versionadded:: 3.0
+ :rtype: str
+%End
+
+    virtual QVariant sortValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
+%Docstring
+ If the default sort order should be overwritten for this widget, you can transform the value in here.
+
+ :return: an unmodified value by default.
+
+.. versionadded:: 3.0
+ :rtype: QVariant
+%End
+
+    virtual Qt::AlignmentFlag alignmentFlag( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const;
+%Docstring
+ Return the alignment for a particular field. By default this will consider the field type but can be overwritten if mapped
+ values are represented.
+
+.. versionadded:: 3.0
+ :rtype: Qt.AlignmentFlag
+%End
+
+    virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const;
+%Docstring
+ Create a cache for a given field.
+
+ This will be used in situations where a field is being represented various times in a loop. And will be passed
+ to other methods on QgsFieldKit and QgsEditorWidgetWrapper.
+
+ For example, the attribute table will create a cache once for each field and then use this
+ cache for representation. The QgsValueRelationFieldFormatter and QgsValueRelationEditorWidget
+ implement this functionality to create a lookuptable once (a QVariantMap / dict) and are
+ make use of a cache if present.
+
+.. versionadded:: 3.0
+ :rtype: QVariant
+%End
 };
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfieldformatter.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/qgsfieldformatterregistry.sip
+++ b/python/core/qgsfieldformatterregistry.sip
@@ -1,35 +1,88 @@
-/***************************************************************************
-  qgsfieldformatterregistry.sip - QgsFieldFormatterRegistry
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfieldformatterregistry.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
 
- ---------------------
- begin                : 2.12.2016
- copyright            : (C) 2016 by Matthias Kuhn
- email                : matthias@opengis.ch
- ***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+
+
+
 class QgsFieldFormatterRegistry : QObject
 {
+%Docstring
+ The QgsFieldFormatterRegistry manages registered classes of QgsFieldFormatter.
+ A reference to the QgsFieldFormatterRegistry can be obtained from
+ QgsApplication.fieldFormatterRegistry().
+
+.. versionadded:: 3.0
+%End
+
 %TypeHeaderCode
 #include "qgsfieldformatterregistry.h"
 %End
   public:
 
-    QgsFieldFormatterRegistry( QObject* parent /TransferThis/ );
+    explicit QgsFieldFormatterRegistry( QObject *parent /TransferThis/ = 0 );
+%Docstring
+ You should not normally need to create your own field formatter registry.
+
+ Use the one provided by `QgsApplication.fieldFormatterRegistry()` instead.
+%End
     ~QgsFieldFormatterRegistry();
 
-    void addFieldFormatter( QgsFieldFormatter* formatter /Transfer/ );
+    void addFieldFormatter( QgsFieldFormatter *formatter /Transfer/ );
+%Docstring
+ They will take precedence in order of adding them.
+ The later they are added, the more weight they have.
 
-    void removeFieldFormatter( QgsFieldFormatter* formatter );
-    void removeFieldFormatter( const QString& id );
-    QgsFieldFormatter* fieldFormatter( const QString& id ) const;
-    QgsFieldFormatter* fallbackFieldFormatter() const;
+ Ownership is transferred to the registry.
+%End
+
+    void removeFieldFormatter( QgsFieldFormatter *formatter );
+%Docstring
+ Remove a field formatter from the registry.
+ The field formatter will be deleted.
+%End
+
+    void removeFieldFormatter( const QString &id );
+%Docstring
+ Remove the field formatter with the specified id.
+%End
+
+    QgsFieldFormatter *fieldFormatter( const QString &id ) const;
+%Docstring
+ Get a field formatter by its id. If there is no such id registered,
+ a default QgsFallbackFieldFormatter with a null id will be returned instead.
+ :rtype: QgsFieldFormatter
+%End
+
+    QgsFieldFormatter *fallbackFieldFormatter() const;
+%Docstring
+ Returns a basic fallback field formatter which can be used
+ to represent any field in an unspectacular manner.
+ :rtype: QgsFieldFormatter
+%End
+
   signals:
-    void fieldFormatterAdded( QgsFieldFormatter* formatter );
-    void fieldFormatterRemoved( QgsFieldFormatter* formatter );
+
+    void fieldFormatterAdded( QgsFieldFormatter *formatter );
+%Docstring
+ Will be emitted after a new field formatter has been added.
+%End
+
+    void fieldFormatterRemoved( QgsFieldFormatter *formatter );
+%Docstring
+ Will be emitted just before a field formatter is removed and deleted.
+%End
+
 };
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfieldformatterregistry.h                                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/core/qgsfieldformatterregistry.h
+++ b/src/core/qgsfieldformatterregistry.h
@@ -20,6 +20,7 @@
 #include <QString>
 #include <QObject>
 
+#include "qgis.h"
 #include "qgis_core.h"
 
 class QgsFieldFormatter;
@@ -43,7 +44,7 @@ class CORE_EXPORT QgsFieldFormatterRegistry : public QObject
      *
      * Use the one provided by `QgsApplication::fieldFormatterRegistry()` instead.
      */
-    explicit QgsFieldFormatterRegistry( QObject *parent = nullptr );
+    explicit QgsFieldFormatterRegistry( QObject *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsFieldFormatterRegistry();
 
     /**
@@ -52,7 +53,7 @@ class CORE_EXPORT QgsFieldFormatterRegistry : public QObject
      *
      * Ownership is transferred to the registry.
      */
-    void addFieldFormatter( QgsFieldFormatter *formatter );
+    void addFieldFormatter( QgsFieldFormatter *formatter SIP_TRANSFER );
 
     /**
      * Remove a field formatter from the registry.


### PR DESCRIPTION
## Description

Note that some function parameter names have changed in QgsFieldFormatter.
* vl => layer
* fieldIdx =>  fieldIndex

But this seems good for consistency and it seems to be the right time now to do that.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
