### PR TITLE
[feature] Expression performance improvements

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -574,6 +574,11 @@ Does this function use a geometry object.
  :rtype: bool
 %End
 
+        virtual bool isStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const;
+%Docstring
+ :rtype: bool
+%End
+
         virtual QSet<QString> referencedColumns( const QgsExpression::NodeFunction *node ) const;
 %Docstring
  Returns a set of field names which are required for this function.

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -928,6 +928,9 @@ return index of the function in Functions array
 %Docstring
  Needs to be called by all subclasses as part of their clone() implementation.
 
+.. note::
+
+   Not available in python bindings
 .. versionadded:: 3.0
 %End
 

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -667,6 +667,22 @@ The help text for the function.
  :rtype: bool
 %End
 
+      protected:
+
+        static bool allParamsStatic( const NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context );
+%Docstring
+ This will return true if all the params for the provided function ``node`` are static within the
+ constraints imposed by the ``context`` within the given ``parent``.
+
+ This can be used as callback for custom implementations of subclasses. It is the default for implementation
+ for StaticFunction.isStatic.
+
+.. note::
+
+   Added in QGIS 3.0
+ :rtype: bool
+%End
+
     };
 
 

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -570,12 +570,31 @@ Does this function use a geometry object.
 %Docstring
  True if this function should use lazy evaluation.  Lazy evaluation functions take QgsExpression.Node objects
  rather than the node results when called.  You can use node->eval(parent, feature) to evaluate the node and return the result
- Functions are non lazy default and will be given the node return value when called **
+ Functions are non lazy default and will be given the node return value when called.
  :rtype: bool
 %End
 
         virtual bool isStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const;
 %Docstring
+ Will be called during prepare to determine if the function is static.
+ A function is static if it will return the same value for every feature with different
+ attributes and/or geometry.
+
+ By default this will return true, if all arguments that have been passed to the function
+ are also static.
+
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
+        virtual bool prepare( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const;
+%Docstring
+ This will be called during the prepare step() of an expression if it is not static.
+
+ This can be used by functions to do any preparation steps that might help to speedup the upcoming
+ evaluation.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
 
@@ -828,8 +847,6 @@ return index of the function in Functions array
         virtual QgsExpression::Node *clone() const = 0;
 %Docstring
  Generate a clone of this node.
- Make sure that the clone does not contain any information which is
- generated in prepare and context related.
  Ownership is transferred to the caller.
 
  :return: a deep copy of this node.
@@ -886,6 +903,16 @@ return index of the function in Functions array
 
 .. versionadded:: 2.12
  :rtype: bool
+%End
+
+
+      protected:
+
+        void cloneTo( QgsExpression::Node *target ) const;
+%Docstring
+ Needs to be called by all subclasses as part of their clone() implementation.
+
+.. versionadded:: 3.0
 %End
 
       private:

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -669,7 +669,7 @@ The help text for the function.
 
       protected:
 
-        static bool allParamsStatic( const NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context );
+        static bool allParamsStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context );
 %Docstring
  This will return true if all the params for the provided function ``node`` are static within the
  constraints imposed by the ``context`` within the given ``parent``.

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -76,7 +76,7 @@ class QgsExpressionContextScope
        * @param value initial variable value
        * @param readOnly true if variable should not be editable by users
        */
-      StaticVariable( const QString &name = QString(), const QVariant &value = QVariant(), bool readOnly = false );
+      StaticVariable( const QString &name = QString(), const QVariant &value = QVariant(), bool readOnly = false, bool isStatic = false  );
 
       /** Variable name */
       QString name;
@@ -86,6 +86,9 @@ class QgsExpressionContextScope
 
       /** True if variable should not be editable by users */
       bool readOnly;
+
+      //! A static variable can be cached for the lifetime of a context
+      bool isStatic;
     };
 
     /** Constructor for QgsExpressionContextScope
@@ -109,7 +112,7 @@ class QgsExpressionContextScope
      * @param value variable value
      * @see addVariable()
      */
-    void setVariable( const QString &name, const QVariant &value );
+    void setVariable( const QString &name, const QVariant &value, bool isStatic = false );
 
     /** Adds a variable into the context scope. If a variable with the same name is already set then its
      * value is overwritten, otherwise a new variable is added to the scope.
@@ -161,6 +164,14 @@ class QgsExpressionContextScope
      * @returns true if variable is read only
      */
     bool isReadOnly( const QString &name ) const;
+
+    /**
+     * Tests whether the variable with the specified \a name is static and can
+     * be cached.
+     *
+     * \note Added in QGIS 3.0
+     */
+    bool isStatic( const QString &name ) const;
 
     /** Returns the count of variables contained within the scope.
      */

--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -84,6 +84,15 @@ class QgsFeatureRequest
         QgsExpression expression() const;
 
         /**
+         * Prepare the expression with the given context.
+         *
+         * \see QgsExpression::prepare
+         *
+         * \since QGIS 3.0
+         */
+        bool prepare( QgsExpressionContext *context );
+
+        /**
          * Order ascending
          * @return If ascending order is requested
          */

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2907,7 +2907,9 @@ static QVariant fcnOrderParts( const QVariantList &values, const QgsExpressionCo
     return values.at( 0 );
 
   QString expString = getStringValue( values.at( 1 ), parent );
-  QVariant cachedExpression = ctx->cachedValue( expString );
+  QVariant cachedExpression;
+  if ( ctx )
+    cachedExpression = ctx->cachedValue( expString );
   QgsExpression expression;
 
   if ( cachedExpression.isValid() )

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -6552,7 +6552,7 @@ void QgsExpression::StaticFunction::setPrepareFunction( std::function<bool ( con
   mPrepareFunc = prepareFunc;
 }
 
-bool QgsExpression::StaticFunction::allParamsStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context )
+bool QgsExpression::Function::allParamsStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context )
 {
   if ( node && node->args() )
   {

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -1038,6 +1038,7 @@ class CORE_EXPORT QgsExpression
         /**
          * Needs to be called by all subclasses as part of their clone() implementation.
          *
+         * \note Not available in python bindings
          * \since QGIS 3.0
          */
         void cloneTo( QgsExpression::Node *target ) const;

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -661,7 +661,7 @@ class CORE_EXPORT QgsExpression
          *
          * \note Added in QGIS 3.0
          */
-        static bool allParamsStatic( const NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context );
+        static bool allParamsStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context );
 
       private:
         QString mName;
@@ -782,9 +782,9 @@ class CORE_EXPORT QgsExpression
 
         virtual QSet<QString> referencedColumns( const QgsExpression::NodeFunction *node ) const override;
 
-        virtual bool isStatic( const NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
+        virtual bool isStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
-        virtual bool prepare( const NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
+        virtual bool prepare( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
         /**
          * Set a function that will be called in the prepare step to determine if the function is

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -650,6 +650,19 @@ class CORE_EXPORT QgsExpression
 
         virtual bool handlesNull() const { return mHandlesNull; }
 
+      protected:
+
+        /**
+         * This will return true if all the params for the provided function \a node are static within the
+         * constraints imposed by the \a context within the given \a parent.
+         *
+         * This can be used as callback for custom implementations of subclasses. It is the default for implementation
+         * for StaticFunction::isStatic.
+         *
+         * \note Added in QGIS 3.0
+         */
+        static bool allParamsStatic( const NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context );
+
       private:
         QString mName;
         int mParams;
@@ -800,8 +813,6 @@ class CORE_EXPORT QgsExpression
 
 
       private:
-        static bool allParamsStatic( const NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context );
-
         FcnEval mFnc;
         QStringList mAliases;
         bool mUsesGeometry;

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -1086,3 +1086,8 @@ QSet<QString> QgsScopedExpressionFunction::referencedColumns( const QgsExpressio
   Q_UNUSED( node )
   return mReferencedColumns;
 }
+
+bool QgsScopedExpressionFunction::isStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const
+{
+  return allParamsStatic( node, parent, context );
+}

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -90,17 +90,18 @@ QgsExpressionContextScope::~QgsExpressionContextScope()
   qDeleteAll( mFunctions );
 }
 
-void QgsExpressionContextScope::setVariable( const QString &name, const QVariant &value )
+void QgsExpressionContextScope::setVariable( const QString &name, const QVariant &value, bool isStatic )
 {
   if ( mVariables.contains( name ) )
   {
     StaticVariable existing = mVariables.value( name );
     existing.value = value;
+    existing.isStatic = isStatic;
     addVariable( existing );
   }
   else
   {
-    addVariable( QgsExpressionContextScope::StaticVariable( name, value ) );
+    addVariable( QgsExpressionContextScope::StaticVariable( name, value, false, isStatic ) );
   }
 }
 
@@ -177,6 +178,11 @@ QStringList QgsExpressionContextScope::filteredVariableNames() const
 bool QgsExpressionContextScope::isReadOnly( const QString &name ) const
 {
   return hasVariable( name ) ? mVariables.value( name ).readOnly : false;
+}
+
+bool QgsExpressionContextScope::isStatic( const QString &name ) const
+{
+  return hasVariable( name ) ? mVariables.value( name ).isStatic : false;
 }
 
 bool QgsExpressionContextScope::hasFunction( const QString &name ) const
@@ -545,19 +551,19 @@ QgsExpressionContextScope *QgsExpressionContextUtils::globalScope()
 
   for ( QVariantMap::const_iterator it = customVariables.constBegin(); it != customVariables.constEnd(); ++it )
   {
-    scope->setVariable( it.key(), it.value() );
+    scope->setVariable( it.key(), it.value(), true );
   }
 
   //add some extra global variables
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_version" ), Qgis::QGIS_VERSION, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_version_no" ), Qgis::QGIS_VERSION_INT, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_short_version" ), QStringLiteral( "%1.%2" ).arg( Qgis::QGIS_VERSION_INT / 10000 ).arg( Qgis::QGIS_VERSION_INT / 100 % 100 ), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_release_name" ), Qgis::QGIS_RELEASE_NAME, true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_platform" ), QgsApplication::platform(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_os_name" ), QgsApplication::osName(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_locale" ), QgsApplication::locale(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "user_account_name" ), QgsApplication::userLoginName(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "user_full_name" ), QgsApplication::userFullName(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_version" ), Qgis::QGIS_VERSION, true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_version_no" ), Qgis::QGIS_VERSION_INT, true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_short_version" ), QStringLiteral( "%1.%2" ).arg( Qgis::QGIS_VERSION_INT / 10000 ).arg( Qgis::QGIS_VERSION_INT / 100 % 100 ), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_release_name" ), Qgis::QGIS_RELEASE_NAME, true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_platform" ), QgsApplication::platform(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_os_name" ), QgsApplication::osName(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "qgis_locale" ), QgsApplication::locale(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "user_account_name" ), QgsApplication::userLoginName(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "user_full_name" ), QgsApplication::userFullName(), true, true ) );
 
   return scope;
 }
@@ -715,17 +721,17 @@ QgsExpressionContextScope *QgsExpressionContextUtils::projectScope( const QgsPro
 
   for ( ; it != vars.constEnd(); ++it )
   {
-    scope->setVariable( it.key(), it.value() );
+    scope->setVariable( it.key(), it.value(), true );
   }
 
   //add other known project variables
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_title" ), project->title(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_path" ), project->fileInfo().filePath(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_folder" ), project->fileInfo().dir().path(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_filename" ), project->fileInfo().fileName(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_title" ), project->title(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_path" ), project->fileInfo().filePath(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_folder" ), project->fileInfo().dir().path(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_filename" ), project->fileInfo().fileName(), true, true ) );
   QgsCoordinateReferenceSystem projectCrs = project->crs();
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs" ), projectCrs.authid(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_definition" ), projectCrs.toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs" ), projectCrs.authid(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_definition" ), projectCrs.toProj4(), true, true ) );
 
   scope->addFunction( QStringLiteral( "project_color" ), new GetNamedProjectColor( project ) );
   return scope;
@@ -772,14 +778,14 @@ QgsExpressionContextScope *QgsExpressionContextUtils::layerScope( const QgsMapLa
 
     QVariant varValue = variableValues.at( varIndex );
     varIndex++;
-    scope->setVariable( variableName, varValue );
+    scope->setVariable( variableName, varValue, true );
   }
 
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_name" ), layer->name(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_id" ), layer->id(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer" ), QVariant::fromValue<QgsWeakMapLayerPointer >( QgsWeakMapLayerPointer( const_cast<QgsMapLayer *>( layer ) ) ), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_name" ), layer->name(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer_id" ), layer->id(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layer" ), QVariant::fromValue<QgsWeakMapLayerPointer >( QgsWeakMapLayerPointer( const_cast<QgsMapLayer *>( layer ) ) ), true, true ) );
 
-  const QgsVectorLayer *vLayer = dynamic_cast< const QgsVectorLayer * >( layer );
+  const QgsVectorLayer *vLayer = qobject_cast< const QgsVectorLayer * >( layer );
   if ( vLayer )
   {
     scope->setFields( vLayer->fields() );

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -127,10 +127,11 @@ class CORE_EXPORT QgsExpressionContextScope
        * \param value initial variable value
        * \param readOnly true if variable should not be editable by users
        */
-      StaticVariable( const QString &name = QString(), const QVariant &value = QVariant(), bool readOnly = false )
+      StaticVariable( const QString &name = QString(), const QVariant &value = QVariant(), bool readOnly = false, bool isStatic = false )
         : name( name )
         , value( value )
         , readOnly( readOnly )
+        , isStatic( isStatic )
       {}
 
       //! Variable name
@@ -141,6 +142,9 @@ class CORE_EXPORT QgsExpressionContextScope
 
       //! True if variable should not be editable by users
       bool readOnly;
+
+      //! A static variable can be cached for the lifetime of a context
+      bool isStatic;
     };
 
     /** Constructor for QgsExpressionContextScope
@@ -166,7 +170,7 @@ class CORE_EXPORT QgsExpressionContextScope
      * \param value variable value
      * \see addVariable()
      */
-    void setVariable( const QString &name, const QVariant &value );
+    void setVariable( const QString &name, const QVariant &value, bool isStatic = false );
 
     /** Adds a variable into the context scope. If a variable with the same name is already set then its
      * value is overwritten, otherwise a new variable is added to the scope.
@@ -218,6 +222,14 @@ class CORE_EXPORT QgsExpressionContextScope
      * \returns true if variable is read only
      */
     bool isReadOnly( const QString &name ) const;
+
+    /**
+     * Tests whether the variable with the specified \a name is static and can
+     * be cached.
+     *
+     * \note Added in QGIS 3.0
+     */
+    bool isStatic( const QString &name ) const;
 
     /** Returns the count of variables contained within the scope.
      */

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -126,6 +126,7 @@ class CORE_EXPORT QgsExpressionContextScope
        * \param name variable name (should be unique within the QgsExpressionContextScope)
        * \param value initial variable value
        * \param readOnly true if variable should not be editable by users
+       * \param isStatic true if the variable will not change during the lifteime of an iterator.
        */
       StaticVariable( const QString &name = QString(), const QVariant &value = QVariant(), bool readOnly = false, bool isStatic = false )
         : name( name )
@@ -164,10 +165,10 @@ class CORE_EXPORT QgsExpressionContextScope
      */
     QString name() const { return mName; }
 
-    /** Convenience method for setting a variable in the context scope by name and value. If a variable
+    /** Convenience method for setting a variable in the context scope by \a name name and \a value. If a variable
      * with the same name is already set then its value is overwritten, otherwise a new variable is added to the scope.
-     * \param name variable name
-     * \param value variable value
+     * If the \a isStatic parameter is set to true, this variable can be cached during the execution
+     * of QgsExpression::prepare().
      * \see addVariable()
      */
     void setVariable( const QString &name, const QVariant &value, bool isStatic = false );

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -93,6 +93,8 @@ class CORE_EXPORT QgsScopedExpressionFunction : public QgsExpression::Function
 
     virtual QSet<QString> referencedColumns( const QgsExpression::NodeFunction *node ) const override;
 
+    virtual bool isStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
+
   private:
     bool mUsesGeometry;
     QSet<QString> mReferencedColumns;

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -142,7 +142,7 @@ void QgsAbstractFeatureIterator::setupOrderBy( const QList<QgsFeatureRequest::Or
     QgsExpressionContext *expressionContext( mRequest.expressionContext() );
     do
     {
-      orderByIt->expression().prepare( expressionContext );
+      orderByIt->prepare( expressionContext );
     }
     while ( ++orderByIt != preparedOrderBys.end() );
 

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -302,6 +302,22 @@ QgsFeatureRequest::OrderByClause::OrderByClause( const QString &expression, bool
 {
 }
 
+QgsFeatureRequest::OrderByClause::OrderByClause( const QgsExpression &expression, bool ascending )
+  : mExpression( expression )
+  , mAscending( ascending )
+{
+  // postgres behavior: default for ASC: NULLS LAST, default for DESC: NULLS FIRST
+  mNullsFirst = !ascending;
+}
+
+QgsFeatureRequest::OrderByClause::OrderByClause( const QgsExpression &expression, bool ascending, bool nullsfirst )
+  : mExpression( expression )
+  , mAscending( ascending )
+  , mNullsFirst( nullsfirst )
+{
+
+}
+
 bool QgsFeatureRequest::OrderByClause::ascending() const
 {
   return mAscending;
@@ -333,6 +349,11 @@ QString QgsFeatureRequest::OrderByClause::dump() const
 QgsExpression QgsFeatureRequest::OrderByClause::expression() const
 {
   return mExpression;
+}
+
+bool QgsFeatureRequest::OrderByClause::prepare( QgsExpressionContext *context )
+{
+  return mExpression.prepare( context );
 }
 
 QgsFeatureRequest::OrderBy::OrderBy( const QList<QgsFeatureRequest::OrderByClause> &other )

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -139,10 +139,38 @@ class CORE_EXPORT QgsFeatureRequest
         OrderByClause( const QString &expression, bool ascending, bool nullsfirst );
 
         /**
+         * Creates a new OrderByClause for a QgsFeatureRequest
+         *
+         * \param expression The expression to use for ordering
+         * \param ascending  If the order should be ascending (1,2,3) or descending (3,2,1)
+         *                   If the order is ascending, by default nulls are last
+         *                   If the order is descending, by default nulls are first
+         */
+        OrderByClause( const QgsExpression &expression, bool ascending = true );
+
+        /**
+         * Creates a new OrderByClause for a QgsFeatureRequest
+         *
+         * \param expression The expression to use for ordering
+         * \param ascending  If the order should be ascending (1,2,3) or descending (3,2,1)
+         * \param nullsfirst If true, NULLS are at the beginning, if false, NULLS are at the end
+         */
+        OrderByClause( const QgsExpression &expression, bool ascending, bool nullsfirst );
+
+        /**
          * The expression
          * \returns the expression
          */
         QgsExpression expression() const;
+
+        /**
+         * Prepare the expression with the given context.
+         *
+         * \see QgsExpression::prepare
+         *
+         * \since QGIS 3.0
+         */
+        bool prepare( QgsExpressionContext *context );
 
         /**
          * Order ascending

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -111,6 +111,11 @@ class TestQgsExpressionContext : public QObject
           return new ModifiableFunction( mVal );
         }
 
+        virtual bool isStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override
+        {
+          return false;
+        }
+
       private:
 
         int *mVal = nullptr;

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -111,8 +111,14 @@ class TestQgsExpressionContext : public QObject
           return new ModifiableFunction( mVal );
         }
 
+        /**
+         * This function is not static, it's value changes with every invocation.
+         */
         virtual bool isStatic( const QgsExpression::NodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override
         {
+          Q_UNUSED( node )
+          Q_UNUSED( parent )
+          Q_UNUSED( context )
           return false;
         }
 

--- a/tests/src/python/test_qgsatlascomposition.py
+++ b/tests/src/python/test_qgsatlascomposition.py
@@ -122,7 +122,7 @@ class TestQgsAtlasComposition(unittest.TestCase):
         for i in range(0, self.mAtlas.numFeatures()):
             self.mAtlas.prepareForFeature(i)
             expected = "output_%d" % (i + 1)
-            assert self.mAtlas.currentFilename() == expected
+            self.assertEqual(self.mAtlas.currentFilename(), expected)
         self.mAtlas.endRender()
 
     def autoscale_render_test(self):


### PR DESCRIPTION
This is the second part of improving expression performance. This allows to also precalculate and cache function results in `prepare()`.

## Performance measurements

This results in a 50% speed increase for a sample expression from the 2.5D renderer with fixed height and angle.

    translate( $geometry,  cos( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height ),  sin( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height ))

When used in the wild (i.e. in rendering), there is a 30% performance benefit in rendering with the 2.5D renderer.

## How it works

By default, functions will be considered static if all their parameters are static.

Exceptions:

* `rand` and `randf`, because they can't be static
* `$geometry` etc, because they are feature related
* `var` only if the variable is already present in the context when preparing (and the variable name is static)
* `eval` and `order_parts` only if thir parameters are static and if the provided expression string also is static with the preparation context.

This also makes sure that a couple of expressions that previously not have been prepared are now been prepared.

## TODO

 * Find more expressions that are used without preparing them first
 * Make use of pre-calculated values in the expression compiler. This will help to send variables to the server and might reduce the load with complex queries produced from the rulebased renderer.
