### PR TITLE
Fix Interlis 2 extension for OGR open and save

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1222,7 +1222,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                          MetaData(
                            QStringLiteral( "INTERLIS 2" ),
                            QObject::tr( "INTERLIS 2" ),
-                           QStringLiteral( "*.itf *.xml *.ili" ),
+                           QStringLiteral( "*.xtf *.xml *.ili" ),
                            QStringLiteral( "ili" ),
                            datasetOptions,
                            layerOptions

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -2280,8 +2280,8 @@ QString createFilters( const QString &type )
       }
       else if ( driverName.startsWith( QLatin1String( "Interlis 2" ) ) )
       {
-        sFileFilters += createFileFilter_( QObject::tr( "INTERLIS 2" ), QStringLiteral( "*.itf *.xml *.ili" ) );
-        sExtensions << QStringLiteral( "itf" ) << QStringLiteral( "xml" ) << QStringLiteral( "ili" );
+        sFileFilters += createFileFilter_( QObject::tr( "INTERLIS 2" ), QStringLiteral( "*.xtf *.xml *.ili" ) );
+        sExtensions << QStringLiteral( "xtf" ) << QStringLiteral( "xml" ) << QStringLiteral( "ili" );
       }
       else if ( driverName.startsWith( QLatin1String( "Ingres" ) ) )
       {


### PR DESCRIPTION
## Description
Simple PR to fix Interlis 2 extension from ITF (which is Interlis 1 extension) to XTF.
See http://www.gdal.org/drv_ili.html
