### PR TITLE
Fix rotated canvas scale issue in save as image

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5804,14 +5804,6 @@ void QgisApp::saveMapAsImage()
   QPair< QString, QString> myFileNameAndFilter = QgisGui::getSaveAsImageName( this, tr( "Choose a file name to save the map image as" ) );
   if ( myFileNameAndFilter.first != QLatin1String( "" ) )
   {
-    QSize size = mMapCanvas->size();
-    if ( dlg.extent() != mMapCanvas->extent() )
-    {
-      size.setWidth( mMapCanvas->size().width() * dlg.extent().width() / mMapCanvas->extent().width() );
-      size.setHeight( mMapCanvas->size().height() * dlg.extent().height() / mMapCanvas->extent().height() );
-    }
-    size *=  dlg.dpi() / qt_defaultDpiX();
-
     QgsMapSettings ms = QgsMapSettings();
     ms.setDestinationCrs( QgsProject::instance()->crs() );
     ms.setExtent( dlg.extent() );

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -31,19 +31,23 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 
 QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, const QString &activeDecorations )
   : QDialog( parent )
-  , mExtent( mapCanvas->mapSettings().visibleExtent() )
-  , mDpi( mapCanvas->mapSettings().outputDpi() )
-  , mSize( mapCanvas->mapSettings().outputSize() )
 {
   setupUi( this );
 
+  // Use unrotated visible extent to insure output size and scale matches canvas
+  QgsMapSettings ms = mapCanvas->mapSettings();
+  ms.setRotation( 0 );
+  mExtent = ms.visibleExtent();
+  mDpi = ms.outputDpi();
+  mSize = ms.outputSize();
+
   mResolutionSpinBox->setValue( qt_defaultDpiX() );
 
-  mExtentGroupBox->setOutputCrs( mapCanvas->mapSettings().destinationCrs() );
-  mExtentGroupBox->setCurrentExtent( mExtent, mapCanvas->mapSettings().destinationCrs() );
+  mExtentGroupBox->setOutputCrs( ms.destinationCrs() );
+  mExtentGroupBox->setCurrentExtent( mExtent, ms.destinationCrs() );
   mExtentGroupBox->setOutputExtentFromCurrent();
 
-  mScaleWidget->setScale( 1 / mapCanvas->mapSettings().scale() );
+  mScaleWidget->setScale( 1 / ms.scale() );
   mScaleWidget->setMapCanvas( mapCanvas );
   mScaleWidget->setShowCurrentScaleButton( true );
 

--- a/tests/src/core/testqgsmapsettingsutils.cpp
+++ b/tests/src/core/testqgsmapsettingsutils.cpp
@@ -43,11 +43,15 @@ class TestQgsMapSettingsUtils : public QObject
 void TestQgsMapSettingsUtils::initTestCase()
 {
   mMapSettings.setExtent( QgsRectangle( 0, 0, 1, 1 ) );
+  mMapSettings.setOutputSize( QSize( 1, 1 ) );
 }
 
 void TestQgsMapSettingsUtils::createWorldFileContent()
 {
   QCOMPARE( QgsMapSettingsUtils::worldFileContent( mMapSettings ), QString( "1\r\n0\r\n0\r\n-1\r\n0.5\r\n0.5\r\n" ) );
+
+  mMapSettings.setRotation( 45 );
+  QCOMPARE( QgsMapSettingsUtils::worldFileContent( mMapSettings ), QString( "0.70710678118654757\r\n0.70710678118654746\r\n0.70710678118654746\r\n-0.70710678118654757\r\n0.5\r\n0.49999999999999994\r\n" ) );
 }
 
 QGSTEST_MAIN( TestQgsMapSettingsUtils )


### PR DESCRIPTION
## Description
Use unrotated visibleExtent() in the revamped save as image feature to match canvas <-> save as image scale. 

@nyalldawson , this fixes an issue whereas a rotated canvas wouldn't save as is when doing a quick "save as image..." -> [ save ] action.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
