### PR TITLE
Fix crasher caused by feature count (fixes #16470)

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -841,10 +841,10 @@ Return the provider type for this layer
 .. versionadded:: 2.10
 %End
 
-    bool countSymbolFeatures( bool showProgress = true );
+    bool countSymbolFeatures( QgsFeedback *feedback = 0 );
 %Docstring
  Count features for symbols. Feature counts may be get by featureCount().
- \param showProgress show progress dialog
+ \param feedback optional feedback pointer
  :return: true if calculated, false if failed or was canceled by user
  :rtype: bool
 %End

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -808,10 +808,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Count features for symbols. Feature counts may be get by featureCount().
-     * \param showProgress show progress dialog
+     * \param feedback optional feedback pointer
      * \returns true if calculated, false if failed or was canceled by user
      */
-    bool countSymbolFeatures( bool showProgress = true );
+    bool countSymbolFeatures( QgsFeedback *feedback = nullptr );
 
     /**
      * Set the string (typically sql) used to define a subset of the layer


### PR DESCRIPTION
## Description
This PR disables the progress dialog for feature count in the QgsDefaultVectorLayerLegend::createLayerTreeModelLegendNodes() function to fix at least one identified, reproducible crasher (https://issues.qgis.org/issues/16470). 

The problem with the progress dialog is that it calls QCoreApplication::processEvents() , which in turn causes QGIS-specific signals to be emitted earlier than expected.

It's the second time this year I stumbled on an issue resulting from this progress dialog (the first one being an unwarranted changed of projection upon project load).

@nyalldawson , @wonder-sk , @m-kuhn , IMHO, this PR should be applied. The one downside is that we introduce a UI freeze when a large dataset is being counted, but, `crash > freeze`.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
