### PR TITLE
Add QgsProxyFeatureSink

### DIFF
--- a/python/core/qgsfeaturesink.sip
+++ b/python/core/qgsfeaturesink.sip
@@ -80,6 +80,12 @@ class QgsProxyFeatureSink : QgsFeatureSink
     virtual bool addFeatures( QgsFeatureIterator &iterator );
 
 
+    QgsFeatureSink *destinationSink();
+%Docstring
+ Returns the destination QgsFeatureSink which the proxy will forward features to.
+ :rtype: QgsFeatureSink
+%End
+
 };
 
 

--- a/python/core/qgsfeaturesink.sip
+++ b/python/core/qgsfeaturesink.sip
@@ -49,6 +49,40 @@ class QgsFeatureSink
 
 };
 
+
+class QgsProxyFeatureSink : QgsFeatureSink
+{
+%Docstring
+ A simple feature sink which proxies feature addition on to another feature sink.
+
+ This class is designed to allow factory methods which always return new QgsFeatureSink
+ objects. Since it is not always possible to create an entirely new QgsFeatureSink
+ (e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
+ can instead be returned which forwards features on to the destination sink. The
+ proxy sink can be safely deleted without affecting the destination sink.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsfeaturesink.h"
+%End
+  public:
+
+    QgsProxyFeatureSink( QgsFeatureSink *sink );
+%Docstring
+ Constructs a new QgsProxyFeatureSink which forwards features onto a destination ``sink``.
+%End
+    virtual bool addFeature( QgsFeature &feature );
+
+    virtual bool addFeatures( QgsFeatureList &features );
+
+    virtual bool addFeatures( QgsFeatureIterator &iterator );
+
+
+};
+
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/qgsfeaturesink.sip
+++ b/python/core/qgsfeaturesink.sip
@@ -74,11 +74,8 @@ class QgsProxyFeatureSink : QgsFeatureSink
  Constructs a new QgsProxyFeatureSink which forwards features onto a destination ``sink``.
 %End
     virtual bool addFeature( QgsFeature &feature );
-
     virtual bool addFeatures( QgsFeatureList &features );
-
     virtual bool addFeatures( QgsFeatureIterator &iterator );
-
 
     QgsFeatureSink *destinationSink();
 %Docstring

--- a/python/core/qgsfeaturestore.sip
+++ b/python/core/qgsfeaturestore.sip
@@ -58,6 +58,22 @@ Constructor
     virtual bool addFeatures( QgsFeatureList &features );
 
 
+    int count() const;
+%Docstring
+ Returns the number of features contained in the store.
+ :rtype: int
+%End
+
+
+    int __len__() const;
+%Docstring
+ Returns the number of features contained in the store.
+ :rtype: int
+%End
+%MethodCode
+    sipRes = sipCpp->count();
+%End
+
     QgsFeatureList features() const;
 %Docstring
  Returns the list of features contained in the store.

--- a/src/core/qgsfeaturesink.cpp
+++ b/src/core/qgsfeaturesink.cpp
@@ -43,18 +43,3 @@ bool QgsFeatureSink::addFeatures( QgsFeatureIterator &iterator )
 QgsProxyFeatureSink::QgsProxyFeatureSink( QgsFeatureSink *sink )
   : mSink( sink )
 {}
-
-bool QgsProxyFeatureSink::addFeature( QgsFeature &feature )
-{
-  return mSink->addFeature( feature );
-}
-
-bool QgsProxyFeatureSink::addFeatures( QgsFeatureList &features )
-{
-  return mSink->addFeatures( features );
-}
-
-bool QgsProxyFeatureSink::addFeatures( QgsFeatureIterator &iterator )
-{
-  return mSink->addFeatures( iterator );
-}

--- a/src/core/qgsfeaturesink.cpp
+++ b/src/core/qgsfeaturesink.cpp
@@ -39,3 +39,22 @@ bool QgsFeatureSink::addFeatures( QgsFeatureIterator &iterator )
   return result;
 }
 
+
+QgsProxyFeatureSink::QgsProxyFeatureSink( QgsFeatureSink *sink )
+  : mSink( sink )
+{}
+
+bool QgsProxyFeatureSink::addFeature( QgsFeature &feature )
+{
+  return mSink->addFeature( feature );
+}
+
+bool QgsProxyFeatureSink::addFeatures( QgsFeatureList &features )
+{
+  return mSink->addFeatures( features );
+}
+
+bool QgsProxyFeatureSink::addFeatures( QgsFeatureIterator &iterator )
+{
+  return mSink->addFeatures( iterator );
+}

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -58,4 +58,36 @@ class CORE_EXPORT QgsFeatureSink
 
 };
 
+
+/**
+ * \class QgsProxyFeatureSink
+ * \ingroup core
+ * A simple feature sink which proxies feature addition on to another feature sink.
+ *
+ * This class is designed to allow factory methods which always return new QgsFeatureSink
+ * objects. Since it is not always possible to create an entirely new QgsFeatureSink
+ * (e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
+ * can instead be returned which forwards features on to the destination sink. The
+ * proxy sink can be safely deleted without affecting the destination sink.
+ *
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
+{
+  public:
+
+    /**
+     * Constructs a new QgsProxyFeatureSink which forwards features onto a destination \a sink.
+     */
+    QgsProxyFeatureSink( QgsFeatureSink *sink );
+    bool addFeature( QgsFeature &feature ) override;
+    bool addFeatures( QgsFeatureList &features ) override;
+    bool addFeatures( QgsFeatureIterator &iterator ) override;
+
+  private:
+
+    QgsFeatureSink *mSink;
+};
+
+
 #endif // QGSFEATURESINK_H

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -80,9 +80,9 @@ class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
      * Constructs a new QgsProxyFeatureSink which forwards features onto a destination \a sink.
      */
     QgsProxyFeatureSink( QgsFeatureSink *sink );
-    bool addFeature( QgsFeature &feature ) override;
-    bool addFeatures( QgsFeatureList &features ) override;
-    bool addFeatures( QgsFeatureIterator &iterator ) override;
+    bool addFeature( QgsFeature &feature ) override { return mSink->addFeature( feature ); }
+    bool addFeatures( QgsFeatureList &features ) override { return mSink->addFeatures( features ); }
+    bool addFeatures( QgsFeatureIterator &iterator ) override { return mSink->addFeatures( iterator ); }
 
     /**
      * Returns the destination QgsFeatureSink which the proxy will forward features to.

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -84,6 +84,11 @@ class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
     bool addFeatures( QgsFeatureList &features ) override;
     bool addFeatures( QgsFeatureIterator &iterator ) override;
 
+    /**
+     * Returns the destination QgsFeatureSink which the proxy will forward features to.
+     */
+    QgsFeatureSink *destinationSink() { return mSink; }
+
   private:
 
     QgsFeatureSink *mSink;

--- a/src/core/qgsfeaturestore.h
+++ b/src/core/qgsfeaturestore.h
@@ -65,6 +65,22 @@ class CORE_EXPORT QgsFeatureStore : public QgsFeatureSink
     bool addFeatures( QgsFeatureList &features ) override;
 
     /**
+     * Returns the number of features contained in the store.
+     */
+    int count() const { return mFeatures.size(); }
+
+#ifdef SIP_RUN
+
+    /**
+     * Returns the number of features contained in the store.
+     */
+    int __len__() const;
+    % MethodCode
+    sipRes = sipCpp->count();
+    % End
+#endif
+
+    /**
      * Returns the list of features contained in the store.
      */
     QgsFeatureList features() const { return mFeatures; }

--- a/tests/src/python/test_qgsfeaturesink.py
+++ b/tests/src/python/test_qgsfeaturesink.py
@@ -74,6 +74,7 @@ class TestQgsFeatureSink(unittest.TestCase):
 
         store = QgsFeatureStore(fields, QgsCoordinateReferenceSystem())
         proxy = QgsProxyFeatureSink(store)
+        self.assertEqual(proxy.destinationSink(), store)
 
         self.assertEqual(len(store), 0)
 

--- a/tests/src/python/test_qgsfeaturesink.py
+++ b/tests/src/python/test_qgsfeaturesink.py
@@ -19,7 +19,12 @@ from qgis.core import (QgsFeatureStore,
                        QgsVectorLayer,
                        QgsFeature,
                        QgsGeometry,
-                       QgsPoint)
+                       QgsPoint,
+                       QgsField,
+                       QgsFields,
+                       QgsCoordinateReferenceSystem,
+                       QgsProxyFeatureSink)
+from qgis.PyQt.QtCore import QVariant
 from qgis.testing import start_app, unittest
 start_app()
 
@@ -61,6 +66,34 @@ class TestQgsFeatureSink(unittest.TestCase):
         self.assertTrue(store.addFeatures(layer.getFeatures()))
         vals = [f['fldint'] for f in store.features()]
         self.assertEqual(vals, [123, 457, 888, -1, 0])
+
+    def testProxyFeatureSink(self):
+        fields = QgsFields()
+        fields.append(QgsField('fldtxt', QVariant.String))
+        fields.append(QgsField('fldint', QVariant.Int))
+
+        store = QgsFeatureStore(fields, QgsCoordinateReferenceSystem())
+        proxy = QgsProxyFeatureSink(store)
+
+        self.assertEqual(len(store), 0)
+
+        f = QgsFeature()
+        f.setAttributes(["test", 123])
+        f.setGeometry(QgsGeometry.fromPoint(QgsPoint(100, 200)))
+        proxy.addFeature(f)
+        self.assertEqual(len(store), 1)
+        self.assertEqual(store.features()[0]['fldtxt'], 'test')
+
+        f2 = QgsFeature()
+        f2.setAttributes(["test2", 457])
+        f2.setGeometry(QgsGeometry.fromPoint(QgsPoint(200, 200)))
+        f3 = QgsFeature()
+        f3.setAttributes(["test3", 888])
+        f3.setGeometry(QgsGeometry.fromPoint(QgsPoint(300, 200)))
+        proxy.addFeatures([f2, f3])
+        self.assertEqual(len(store), 3)
+        self.assertEqual(store.features()[1]['fldtxt'], 'test2')
+        self.assertEqual(store.features()[2]['fldtxt'], 'test3')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A simple feature sink which proxies feature addition on to another feature sink.

This class is designed to allow factory methods which always return new QgsFeatureSink objects. Since it is not always possible to create an entirely new QgsFeatureSink (e.g. if the feature sink is a layer or a layer's data provider), a new QgsProxyFeatureSink can instead be returned which forwards features on to
the destination sink. The proxy sink can be safely deleted without affecting the destination sink.
