### PR TITLE
Asyncronously render composer map previews 

### DIFF
--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -292,7 +292,6 @@ void QgsComposerMap::cache()
 
 void QgsComposerMap::painterJobFinished()
 {
-  QgsDebugMsg( "Finished composer painter job" );
   mPainter->end();
   mPainterJob.reset( nullptr );
   mPainter.reset( nullptr );
@@ -1065,10 +1064,8 @@ void QgsComposerMap::updateItem()
 
   if ( mPreviewMode != QgsComposerMap::Rectangle && !mCacheUpdated )
   {
-    QgsDebugMsg( "Requesting new cache image item" );
     cache();
   }
-  QgsDebugMsg( "Updating item" );
   QgsComposerItem::updateItem();
 }
 

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -332,23 +332,36 @@ void QgsComposerMap::paint( QPainter *painter, const QStyleOptionGraphicsItem *,
   {
     if ( !mCacheFinalImage || mCacheFinalImage->isNull() )
     {
+      // No initial render available - so draw some preview text alerting user
+      drawBackground( painter );
+      painter->setBrush( QBrush( QColor( 125, 125, 125, 125 ) ) );
+      painter->drawRect( thisPaintRect );
+      painter->setBrush( Qt::NoBrush );
+      QFont messageFont;
+      messageFont.setPointSize( 12 );
+      painter->setFont( messageFont );
+      painter->setPen( QColor( 255, 255, 255, 255 ) );
+      painter->drawText( thisPaintRect, Qt::AlignCenter | Qt::AlignHCenter, tr( "Rendering map" ) );
+
+
       cache();
-      return;
     }
+    else
+    {
+      //Background color is already included in cached image, so no need to draw
 
-    //Background color is already included in cached image, so no need to draw
+      double imagePixelWidth = mCacheFinalImage->width(); //how many pixels of the image are for the map extent?
+      double scale = rect().width() / imagePixelWidth;
 
-    double imagePixelWidth = mCacheFinalImage->width(); //how many pixels of the image are for the map extent?
-    double scale = rect().width() / imagePixelWidth;
+      painter->save();
 
-    painter->save();
+      painter->translate( mLastRenderedImageOffsetX + mXOffset, mLastRenderedImageOffsetY + mYOffset );
+      painter->scale( scale, scale );
+      painter->drawImage( 0, 0, *mCacheFinalImage );
 
-    painter->translate( mLastRenderedImageOffsetX + mXOffset, mLastRenderedImageOffsetY + mYOffset );
-    painter->scale( scale, scale );
-    painter->drawImage( 0, 0, *mCacheFinalImage );
-
-    //restore rotation
-    painter->restore();
+      //restore rotation
+      painter->restore();
+    }
   }
   else if ( mComposition->plotStyle() == QgsComposition::Print ||
             mComposition->plotStyle() == QgsComposition::Postscript )

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -707,7 +707,7 @@ void QgsComposerMap::setSceneRect( const QRectF &rectangle )
   mCacheUpdated = false;
 
   updateBoundingRect();
-  update();
+  updateItem();
   emit itemChanged();
   emit extentChanged();
 }

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -348,9 +348,11 @@ void QgsComposerMap::paint( QPainter *painter, const QStyleOptionGraphicsItem *,
       painter->setFont( messageFont );
       painter->setPen( QColor( 255, 255, 255, 255 ) );
       painter->drawText( thisPaintRect, Qt::AlignCenter | Qt::AlignHCenter, tr( "Rendering map" ) );
-
-
-      cache();
+      if ( !mPainterJob )
+      {
+        // this is the map's very first paint - trigger a cache update
+        cache();
+      }
     }
     else
     {

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -265,6 +265,9 @@ void QgsComposerMap::cache()
     }
   }
 
+  if ( w <= 0 || h <= 0 )
+    return;
+
   mCacheRenderingImage.reset( new QImage( w, h, QImage::Format_ARGB32 ) );
 
   // set DPI of the image
@@ -306,7 +309,7 @@ void QgsComposerMap::paint( QPainter *painter, const QStyleOptionGraphicsItem *,
 {
   Q_UNUSED( pWidget );
 
-  if ( !mComposition || !painter )
+  if ( !mComposition || !painter || !painter->device() )
   {
     return;
   }
@@ -316,6 +319,9 @@ void QgsComposerMap::paint( QPainter *painter, const QStyleOptionGraphicsItem *,
   }
 
   QRectF thisPaintRect = QRectF( 0, 0, QGraphicsRectItem::rect().width(), QGraphicsRectItem::rect().height() );
+  if ( thisPaintRect.width() == 0 || thisPaintRect.height() == 0 )
+    return;
+
   painter->save();
   painter->setClipRect( thisPaintRect );
 

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -297,6 +297,8 @@ void QgsComposerMap::painterJobFinished()
   mPainter.reset( nullptr );
   mCacheUpdated = true;
   mCacheFinalImage = std::move( mCacheRenderingImage );
+  mLastRenderedImageOffsetX = 0;
+  mLastRenderedImageOffsetY = 0;
   updateItem();
 }
 
@@ -341,7 +343,7 @@ void QgsComposerMap::paint( QPainter *painter, const QStyleOptionGraphicsItem *,
 
     painter->save();
 
-    painter->translate( mXOffset, mYOffset );
+    painter->translate( mLastRenderedImageOffsetX + mXOffset, mLastRenderedImageOffsetY + mYOffset );
     painter->scale( scale, scale );
     painter->drawImage( 0, 0, *mCacheFinalImage );
 
@@ -599,6 +601,8 @@ void QgsComposerMap::resize( double dx, double dy )
 
 void QgsComposerMap::moveContent( double dx, double dy )
 {
+  mLastRenderedImageOffsetX -= dx;
+  mLastRenderedImageOffsetY -= dy;
   if ( !mDrawing )
   {
     transformShift( dx, dy );

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -43,6 +43,7 @@ class QgsFillSymbol;
 class QgsLineSymbol;
 class QgsVectorLayer;
 class QgsAnnotation;
+class QgsMapRendererCustomPainterJob;
 
 /** \ingroup core
  *  \class QgsComposerMap
@@ -491,6 +492,8 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
   private slots:
     void layersAboutToBeRemoved( QList<QgsMapLayer *> layers );
 
+    void painterJobFinished();
+
   private:
 
     //! Unique identifier
@@ -586,6 +589,10 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     AtlasScalingMode mAtlasScalingMode = Auto;
     //! Margin size for atlas driven extents (percentage of feature size) - when in auto scaling mode
     double mAtlasMargin = 0.10;
+
+    QPainter *mPainter = nullptr;
+    QgsMapRendererCustomPainterJob *mPainterJob = nullptr;
+    bool mPainterCancelWait = false;
 
     void init();
 

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -543,6 +543,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     //! Offset in y direction for showing map cache image
     double mYOffset = 0.0;
 
+    double mLastRenderedImageOffsetX = 0.0;
+    double mLastRenderedImageOffsetY = 0.0;
+
     //! Map rotation
     double mMapRotation = 0;
 

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -517,7 +517,7 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     QgsRectangle mAtlasFeatureExtent;
 
     // Cache used in composer preview
-    QImage mCacheImage;
+    std::unique_ptr< QImage > mCacheImage;
 
     // Is cache up to date
     bool mCacheUpdated = false;
@@ -590,8 +590,8 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     //! Margin size for atlas driven extents (percentage of feature size) - when in auto scaling mode
     double mAtlasMargin = 0.10;
 
-    QPainter *mPainter = nullptr;
-    QgsMapRendererCustomPainterJob *mPainterJob = nullptr;
+    std::unique_ptr< QPainter > mPainter;
+    std::unique_ptr< QgsMapRendererCustomPainterJob > mPainterJob;
     bool mPainterCancelWait = false;
 
     void init();

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -516,8 +516,15 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     // to manually tweak each atlas preview page without affecting the actual original map extent.
     QgsRectangle mAtlasFeatureExtent;
 
-    // Cache used in composer preview
-    std::unique_ptr< QImage > mCacheImage;
+    // We have two images used for rendering/storing cached map images.
+    // the first (mCacheFinalImage) is used ONLY for storing the most recent completed map render. It's always
+    // used when drawing map item previews. The second (mCacheRenderingImage) is used temporarily while
+    // rendering a new preview image in the background. If (and only if) the background render completes, then
+    // mCacheRenderingImage is pushed into mCacheFinalImage, and used from then on when drawing the item preview.
+    // This ensures that something is always shown in the map item, even while refreshing the preview image in the
+    // background
+    std::unique_ptr< QImage > mCacheFinalImage;
+    std::unique_ptr< QImage > mCacheRenderingImage;
 
     // Is cache up to date
     bool mCacheUpdated = false;

--- a/tests/src/python/test_qgspallabeling_composer.py
+++ b/tests/src/python/test_qgspallabeling_composer.py
@@ -23,7 +23,7 @@ import sys
 import os
 import subprocess
 
-from qgis.PyQt.QtCore import QRect, QRectF, QSize, QSizeF, qDebug
+from qgis.PyQt.QtCore import QRect, QRectF, QSize, QSizeF, qDebug, QThreadPool
 from qgis.PyQt.QtGui import QImage, QColor, QPainter
 from qgis.PyQt.QtPrintSupport import QPrinter
 from qgis.PyQt.QtSvg import QSvgRenderer, QSvgGenerator
@@ -88,6 +88,8 @@ class TestComposerBase(TestQgsPalLabeling):
         TestQgsPalLabeling.tearDownClass()
         cls.removeMapLayer(cls.layer)
         cls.layer = None
+        # avoid crash on finish, probably related to https://bugreports.qt.io/browse/QTBUG-35760
+        QThreadPool.globalInstance().waitForDone()
 
     def setUp(self):
         """Run before each test."""


### PR DESCRIPTION
Found this interesting commit floating away on Sourcepole's fork, and thought that upstream could benefit from this improvement too.

I'd say this is a risky change, but we've got a lot of time before release to iron out any bugs. I've tested quite extensively and it's a big improvement, and verified with valgrind that there's no leakage involved.

