### PR TITLE
[sipify] use a distinct header to simplify includes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -684,6 +684,7 @@ SET(QGIS_CORE_HDRS
   ../plugins/qgisplugin.h
 
   qgis.h
+  qgis_sip.h
   qgsaction.h
   qgsactionscope.h
   qgsactionmanager.h

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -27,7 +27,7 @@
 #include <QDateTime>
 #include "qgsconfig.h"
 #include "qgslogger.h"
-#include "geometry/qgswkbtypes.h"
+#include "qgswkbtypes.h"
 
 #include <ogr_api.h>
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -34,6 +34,8 @@
 
 #include "qgswkbtypes.h"
 #include "qgis_core.h"
+#include "qgis_sip.h"
+
 
 /** \ingroup core
  * The Qgis class provides global constants for use throughout the application.
@@ -127,6 +129,7 @@ class CORE_EXPORT Qgis
 // QLibrary
 #define cast_to_fptr(f) f
 
+
 /** \ingroup core
  * RAII signal blocking class. Used for temporarily blocking signals from a QObject
  * for the lifetime of QgsSignalBlocker object.
@@ -135,7 +138,7 @@ class CORE_EXPORT Qgis
  * \note not available in Python bindings
  */
 // based on Boojum's code from http://stackoverflow.com/questions/3556687/prevent-firing-signals-in-qt
-template<class Object> class QgsSignalBlocker // clazy:exclude=rule-of-three
+template<class Object> class QgsSignalBlocker SIP_SKIP // clazy:exclude=rule-of-three
 {
   public:
 
@@ -175,7 +178,7 @@ template<class Object> class QgsSignalBlocker // clazy:exclude=rule-of-three
  * \note not available in Python bindings
  */
 // based on Boojum's code from http://stackoverflow.com/questions/3556687/prevent-firing-signals-in-qt
-template<class Object> inline QgsSignalBlocker<Object> whileBlocking( Object *object )
+template<class Object> inline QgsSignalBlocker<Object> whileBlocking( Object *object ) SIP_SKIP
 {
   return QgsSignalBlocker<Object>( object );
 }
@@ -391,118 +394,4 @@ typedef unsigned long long qgssize;
 #define FALLTHROUGH
 #endif
 
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-Transfer
- *
- * Example QgsVectorLayer::setDiagramRenderer
- */
-#define SIP_TRANSFER
 
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-TransferBack
- */
-#define SIP_TRANSFERBACK
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-TransferThis
- */
-#define SIP_TRANSFERTHIS
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-Out
- */
-#define SIP_OUT
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-In
- */
-#define SIP_IN
-
-/*
- * Combination of
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-In
- * and
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-Out
- */
-#define SIP_INOUT
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-Factory
- */
-#define SIP_FACTORY
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-PyName
- */
-#define SIP_PYNAME(name)
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-KeepReference
- */
-#define SIP_KEEPREFERENCE
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html#argument-annotation-Array
- */
-#define SIP_ARRAY
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html#argument-annotation-ArraySize
- */
-#define SIP_ARRAYSIZE
-
-/*
-  * discard line
-  */
-#define SIP_SKIP
-
-/*
-  * force a private line to be written
-  */
-#define SIP_FORCE
-
-/*
-  * specify an alternative type for SIP argument or return value
-  */
-#define SIP_PYTYPE(type)
-
-/*
-  * specify an alternative default value for SIP argument
-  */
-#define SIP_PYARGDEFAULT(value)
-
-/*
-  * remove argument in SIP method
-  */
-#define SIP_PYARGREMOVE
-
-
-/*
- * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-ReleaseGIL
- */
-#define SIP_RELEASEGIL
-
-/*
- * Will insert a `%Feature feature` directive in sip files
- */
-#define SIP_FEATURE(feature)
-
-/*
- * Will insert a `%If feature` directive in sip files
- */
-#define SIP_IF_FEATURE(feature)
-
-/*
- * Convert to subclass code
- */
-#define SIP_CONVERT_TO_SUBCLASS_CODE(code)
-
-/*
- * Will insert a `%End` directive in sip files
- */
-#define SIP_END
-
-/*
- * Class level annotation for abstract classes
- */
-#define SIP_ABSTRACT

--- a/src/core/qgis_sip.h
+++ b/src/core/qgis_sip.h
@@ -1,0 +1,136 @@
+/***************************************************************************
+  qgis_sip - QGIS SIP Macros
+
+ ---------------------
+ begin                : 4.5.2017
+ copyright            : (C) 2017 by Denis Rouzaud
+ email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGIS_SIP_H
+#define QGIS_SIP_H
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-Transfer
+ *
+ * Example QgsVectorLayer::setDiagramRenderer
+ */
+#define SIP_TRANSFER
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-TransferBack
+ */
+#define SIP_TRANSFERBACK
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-TransferThis
+ */
+#define SIP_TRANSFERTHIS
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-Out
+ */
+#define SIP_OUT
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-In
+ */
+#define SIP_IN
+
+/*
+ * Combination of
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-In
+ * and
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-Out
+ */
+#define SIP_INOUT
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-Factory
+ */
+#define SIP_FACTORY
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-PyName
+ */
+#define SIP_PYNAME(name)
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#argument-annotation-KeepReference
+ */
+#define SIP_KEEPREFERENCE
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html#argument-annotation-Array
+ */
+#define SIP_ARRAY
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html#argument-annotation-ArraySize
+ */
+#define SIP_ARRAYSIZE
+
+/*
+  * discard line
+  */
+#define SIP_SKIP
+
+/*
+  * force a private line to be written
+  */
+#define SIP_FORCE
+
+/*
+  * specify an alternative type for SIP argument or return value
+  */
+#define SIP_PYTYPE(type)
+
+/*
+  * specify an alternative default value for SIP argument
+  */
+#define SIP_PYARGDEFAULT(value)
+
+/*
+  * remove argument in SIP method
+  */
+#define SIP_PYARGREMOVE
+
+
+/*
+ * http://pyqt.sourceforge.net/Docs/sip4/annotations.html?highlight=keepreference#function-annotation-ReleaseGIL
+ */
+#define SIP_RELEASEGIL
+
+/*
+ * Will insert a `%Feature feature` directive in sip files
+ */
+#define SIP_FEATURE(feature)
+
+/*
+ * Will insert a `%If feature` directive in sip files
+ */
+#define SIP_IF_FEATURE(feature)
+
+/*
+ * Convert to subclass code
+ */
+#define SIP_CONVERT_TO_SUBCLASS_CODE(code)
+
+/*
+ * Will insert a `%End` directive in sip files
+ */
+#define SIP_END
+
+/*
+ * Class level annotation for abstract classes
+ */
+#define SIP_ABSTRACT
+
+
+#endif // QGIS_SIP_H

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -17,8 +17,10 @@
 #ifndef QGSCOORDINATETRANSFORM_H
 #define QGSCOORDINATETRANSFORM_H
 
-#include "qgis_core.h"
 #include <QExplicitlySharedDataPointer>
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
 #include "qgscoordinatereferencesystem.h"
 
 class QgsCoordinateTransformPrivate;

--- a/src/core/qgslogger.h
+++ b/src/core/qgslogger.h
@@ -19,6 +19,7 @@
 #define QGSLOGGER_H
 
 #include <iostream>
+#include "qgis_sip.h"
 #include <sstream>
 #include <QString>
 #include <QTime>
@@ -70,12 +71,12 @@ class CORE_EXPORT QgsLogger
 
     //! Similar to the previous method, but prints a variable double-value pair
     //! \note not available in Python bindings
-    static void debug( const QString &var, double val, int debuglevel = 1, const char *file = nullptr, const char *function = nullptr, int line = -1 );
+    static void debug( const QString &var, double val, int debuglevel = 1, const char *file = nullptr, const char *function = nullptr, int line = -1 ) SIP_SKIP;
 
     //! Prints out a variable/value pair for types with overloaded operator<<
     //! \note not available in Python bindings
     template <typename T> static void debug( const QString &var, T val, const char *file = nullptr, const char *function = nullptr,
-        int line = -1, int debuglevel = 1 )
+        int line = -1, int debuglevel = 1 ) SIP_SKIP
     {
       std::ostringstream os;
       os << var.toLocal8Bit().data() << " = " << val;


### PR DESCRIPTION
there was an issue in libdxf which includes qgslogger in debug mode
and qgsdebug.h includes qgis.h include qgswkbtypes.h (which geometry directory was not listed in libdxrw included paths)

