### PR TITLE
[processing] reset variables list in field calculator on layer change  (fix #15633)

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsCalculatorDialog.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsCalculatorDialog.py
@@ -105,7 +105,6 @@ class FieldsCalculatorDialog(BASE, WIDGET):
         self.mOutputFieldTypeComboBox.blockSignals(False)
         self.builder.loadRecent('fieldcalc')
 
-        self.initContext()
         self.updateLayer(self.cmbInputLayer.currentLayer())
 
     def initContext(self):
@@ -117,6 +116,8 @@ class FieldsCalculatorDialog(BASE, WIDGET):
 
     def updateLayer(self, layer):
         self.layer = layer
+
+        self.initContext()
         self.builder.setLayer(self.layer)
         self.builder.loadFieldNames()
         self.populateFields()

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -516,8 +516,7 @@ void QgsExpressionBuilderWidget::setExpressionText( const QString &expression )
 void QgsExpressionBuilderWidget::setExpressionContext( const QgsExpressionContext &context )
 {
   mExpressionContext = context;
-
-  loadExpressionContext();
+  updateFunctionTree();
 }
 
 void QgsExpressionBuilderWidget::on_txtExpressionString_textChanged()


### PR DESCRIPTION
## Description
`QgsExpressionBuilderWidget` does not clear/update functions and variables when new expression context is set. This caused duplicating layer variables after changing layer without closing widget like in Processing Field Calculator.

Proposed PR fixes this by updating functions/variables each time when expression context is set. Fixes https://issues.qgis.org/issues/15633.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
