### PR TITLE
Statistics panel: show only relevant statistics depending on the field type

### DIFF
--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -97,6 +97,7 @@ QgsStatisticalSummaryDockWidget::QgsStatisticalSummaryDockWidget( QWidget *paren
   mOptionsToolButton->setMenu( mStatisticsMenu );
 
   mFieldType = DataType::Numeric;
+  mPreviousFieldType = DataType::Numeric;
   refreshStatisticsMenu();
 }
 
@@ -120,7 +121,11 @@ void QgsStatisticalSummaryDockWidget::refreshStatistics()
     mFieldType = fieldType( mFieldExpressionWidget->currentField() );
   }
 
-  refreshStatisticsMenu();
+  if ( mFieldType != mPreviousFieldType )
+  {
+    refreshStatisticsMenu();
+    mPreviousFieldType = mFieldType;
+  }
 
   bool selectedOnly = mSelectedOnlyCheckBox->isChecked();
 

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -62,6 +62,14 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
 
   private:
 
+    //! Enumeration of supported statistics types
+    enum DataType
+    {
+      Numeric,  //!< Numeric fields: int, double, etc
+      String,  //!< String fields
+      DateTime  //!< Date and DateTime fields
+    };
+
     QgsVectorLayer *mLayer = nullptr;
 
     QMap< int, QAction * > mStatsActions;
@@ -77,9 +85,10 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
     QgsExpressionContext createExpressionContext() const override;
 
     void refreshStatisticsMenu();
+    DataType fieldType( const QString &fieldName );
 
     QMenu *mStatisticsMenu = nullptr;
-    QVariant::Type mFieldType;
+    DataType mFieldType;
 };
 
 #endif // QGSSTATISTICALSUMMARYDOCKWIDGET_H

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -89,6 +89,7 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
 
     QMenu *mStatisticsMenu = nullptr;
     DataType mFieldType;
+    DataType mPreviousFieldType;
 };
 
 #endif // QGSSTATISTICALSUMMARYDOCKWIDGET_H

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -24,6 +24,7 @@
 #include "qgsdockwidget.h"
 #include "qgis_app.h"
 
+class QMenu;
 class QgsBrowserModel;
 class QModelIndex;
 class QgsDockBrowserTreeView;
@@ -74,6 +75,10 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
     void addRow( int row, const QString &name, const QString &value, bool showValue );
 
     QgsExpressionContext createExpressionContext() const override;
+
+    void refreshStatisticsMenu( QVariant::Type fieldType );
+
+    QMenu *mStatisticsMenu = nullptr;
 };
 
 #endif // QGSSTATISTICALSUMMARYDOCKWIDGET_H

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -76,9 +76,10 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
 
     QgsExpressionContext createExpressionContext() const override;
 
-    void refreshStatisticsMenu( QVariant::Type fieldType );
+    void refreshStatisticsMenu();
 
     QMenu *mStatisticsMenu = nullptr;
+    QVariant::Type mFieldType;
 };
 
 #endif // QGSSTATISTICALSUMMARYDOCKWIDGET_H


### PR DESCRIPTION
## Description
RIght now drop-down button at the bottom of the Statistics Panel show statistics for an integer field even if string or datetime field selected. This is very confusing and it is not possible to hide unnecessary values when statistics for other field types calculated.

Proposed PR fixes this by refreshing statistics list in the drop-down button depending on the field type. Fixes:

- https://issues.qgis.org/issues/16117
- https://issues.qgis.org/issues/16118
- https://issues.qgis.org/issues/16119

This is GUI thing so no unittests.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit