### PR TITLE
API Cleanups (and rename) for QgsVectorLayerImport, background export of layers when dropping to browser

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2190,7 +2190,8 @@ pointers makes for more robust, safer code. Use an invalid (default constructed)
 in code which previously passed a null pointer to QgsVectorLayerImport.
 - importLayer was renamed to exportLayer
 - The unused skipAttributeCreation in exportLayer() was removed
-- The unused QProgressBar argument in the QgsVectorLayerImport was removed
+- The QProgressDialog argument in exportLayer() was changed to a QgsFeedback object.
+- The unused QProgressDialog argument in the QgsVectorLayerImport was removed
 - ImportError was renamed to ExportError
 - The unused enum value ErrDriverNotFound was removed
 - hasError() was renamed to errorCode()

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2189,6 +2189,7 @@ QgsCoordinateReferenceSystem is now implicitly shared, using references to QgsCo
 pointers makes for more robust, safer code. Use an invalid (default constructed) QgsCoordinateReferenceSystem
 in code which previously passed a null pointer to QgsVectorLayerImport.
 - importLayer was renamed to exportLayer
+- The unused skipAttributeCreation in exportLayer() was removed
 - The unused QProgressBar argument in the QgsVectorLayerImport was removed
 - ImportError was renamed to ExportError
 - The unused enum value ErrDriverNotFound was removed

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -186,6 +186,7 @@ Renamed Classes        {#qgis_api_break_3_0_renamed_classes}
 <tr><td>QgsVectorGradientColorRampV2DialogBase<td>QgsGradientColorRampDialogBase
 <tr><td>QgsVectorGradientRampV2<td>QgsVectorGradientRamp
 <tr><td>QgsVectorJoinInfo<td>QgsVectorLayerJoinInfo
+<tr><td>QgsVectorLayerImport<td>QgsVectorLayerExporter
 <tr><td>QgsVectorLayersetRendererV2<td>QgsVectorLayersetRenderer
 <tr><td>QgsVectorRandomColorRampV2<td>QgsLimitedRandomColorRamp
 <tr><td>QgsVectorRandomColorRampV2Dialog<td>QgsLimitedRandomColorRampDialog
@@ -2180,15 +2181,19 @@ QgsVectorLayerEditUtils        {#qgis_api_break_3_0_QgsVectorLayerEditUtils}
 - cache() has been removed.
 
 
-QgsVectorLayerImport        {#qgis_api_break_3_0_QgsVectorLayerImport}
+QgsVectorLayerExporter (renamed from QgsVectorLayerImport) {#qgis_api_break_3_0_QgsVectorLayerExporter}
 --------------------
 
-- QgsVectorLayerImport now takes references instead of pointers to QgsCoordinateReferenceSystem objects. Since
+- QgsVectorLayerExporter now takes references instead of pointers to QgsCoordinateReferenceSystem objects. Since
 QgsCoordinateReferenceSystem is now implicitly shared, using references to QgsCoordinateReferenceSystem rather than
 pointers makes for more robust, safer code. Use an invalid (default constructed) QgsCoordinateReferenceSystem
 in code which previously passed a null pointer to QgsVectorLayerImport.
+- importLayer was renamed to exportLayer
 - The unused QProgressBar argument in the QgsVectorLayerImport was removed
-- ErrUserCancelled (ImportError enum value) has been renamed to ErrUserCanceled  <!--#spellok-->
+- ImportError was renamed to ExportError
+- The unused enum value ErrDriverNotFound was removed
+- hasError() was renamed to errorCode()
+- ErrUserCancelled (ExportError enum value) has been renamed to ErrUserCanceled  <!--#spellok-->
 
 
 QgsVectorLayerJoinBuffer        {#qgis_api_break_3_0_QgsVectorLayerJoinBuffer}

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -165,8 +165,8 @@
 %Include qgsvectorlayercache.sip
 %Include qgsvectorlayereditbuffer.sip
 %Include qgsvectorlayereditpassthrough.sip
+%Include qgsvectorlayerexporter.sip
 %Include qgsvectorlayerfeaturecounter.sip
-%Include qgsvectorlayerimport.sip
 %Include qgsvectorlayerjoinbuffer.sip
 %Include qgsvectorlayerjoininfo.sip
 %Include qgsvectorlayertools.sip

--- a/python/core/qgsvectorlayerexporter.sip
+++ b/python/core/qgsvectorlayerexporter.sip
@@ -52,7 +52,6 @@ class QgsVectorLayerExporter : QgsFeatureSink
                                     const QgsCoordinateReferenceSystem &destCRS,
                                     bool onlySelected = false,
                                     QString *errorMessage /Out/ = 0,
-                                    bool skipAttributeCreation = false,
                                     QMap<QString, QVariant> *options = 0,
                                     QProgressDialog *progress = 0
                                   );
@@ -65,7 +64,6 @@ class QgsVectorLayerExporter : QgsFeatureSink
  not available
  \param onlySelected set to true to export only selected features
  \param errorMessage if non-null, will be set to any error messages
- \param skipAttributeCreation set to true to skip exporting feature attributes
  \param options optional provider dataset options
  \param progress optional progress dialog to show progress of export
  :return: NoError for a successful export, or encountered error

--- a/python/core/qgsvectorlayerexporter.sip
+++ b/python/core/qgsvectorlayerexporter.sip
@@ -130,6 +130,69 @@ class QgsVectorLayerExporter : QgsFeatureSink
     QgsVectorLayerExporter( const QgsVectorLayerExporter &rh );
 };
 
+
+class QgsVectorLayerExporterTask : QgsTask
+{
+%Docstring
+ QgsTask task which performs a QgsVectorLayerExporter layer export operation as a background
+ task. This can be used to export a vector layer out to a provider without blocking the
+ QGIS interface.
+.. versionadded:: 3.0
+.. seealso:: QgsVectorFileWriterTask
+.. seealso:: QgsRasterFileWriterTask
+%End
+
+%TypeHeaderCode
+#include "qgsvectorlayerexporter.h"
+%End
+  public:
+
+    QgsVectorLayerExporterTask( QgsVectorLayer *layer,
+                                const QString &uri,
+                                const QString &providerKey,
+                                const QgsCoordinateReferenceSystem &destinationCrs,
+                                QMap<QString, QVariant> *options = 0 );
+%Docstring
+ Constructor for QgsVectorLayerExporterTask. Takes a source ``layer``, destination ``uri``
+ and ``providerKey``, and various export related parameters such as destination CRS
+ and export ``options``.
+%End
+
+    static QgsVectorLayerExporterTask *withLayerOwnership( QgsVectorLayer *layer /Transfer/,
+        const QString &uri,
+        const QString &providerKey,
+        const QgsCoordinateReferenceSystem &destinationCrs,
+        QMap<QString, QVariant> *options = 0 ) /Factory/;
+%Docstring
+ Creates a new QgsVectorLayerExporterTask which has ownership over a source ``layer``.
+ When the export task has completed (successfully or otherwise) ``layer`` will be
+ deleted. The destination ``uri`` and ``providerKey``, and various export related parameters such as destination CRS
+ and export ``options`` must be specified.
+ :rtype: QgsVectorLayerExporterTask
+%End
+
+    virtual void cancel();
+
+  signals:
+
+    void exportComplete();
+%Docstring
+ Emitted when exporting the layer is successfully completed.
+%End
+
+    void errorOccurred( int error, const QString &errorMessage );
+%Docstring
+ Emitted when an error occurs which prevented the layer being exported (or if
+ the task is canceled). The export ``error`` and ``errorMessage`` will be reported.
+%End
+
+  protected:
+
+    virtual bool run();
+    virtual void finished( bool result );
+
+};
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/qgsvectorlayerexporter.sip
+++ b/python/core/qgsvectorlayerexporter.sip
@@ -53,7 +53,7 @@ class QgsVectorLayerExporter : QgsFeatureSink
                                     bool onlySelected = false,
                                     QString *errorMessage /Out/ = 0,
                                     QMap<QString, QVariant> *options = 0,
-                                    QProgressDialog *progress = 0
+                                    QgsFeedback *feedback = 0
                                   );
 %Docstring
  Writes the contents of vector layer to a different datasource.
@@ -65,7 +65,7 @@ class QgsVectorLayerExporter : QgsFeatureSink
  \param onlySelected set to true to export only selected features
  \param errorMessage if non-null, will be set to any error messages
  \param options optional provider dataset options
- \param progress optional progress dialog to show progress of export
+ \param feedback optional feedback object to show progress and cancelation of export
  :return: NoError for a successful export, or encountered error
  :rtype: ExportError
 %End

--- a/python/core/qgsvectorlayerexporter.sip
+++ b/python/core/qgsvectorlayerexporter.sip
@@ -1,7 +1,7 @@
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/qgsvectorlayerimport.h                                      *
+ * src/core/qgsvectorlayerexporter.h                                    *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/
@@ -10,24 +10,29 @@
 
 
 
-class QgsVectorLayerImport : QgsFeatureSink
+class QgsVectorLayerExporter : QgsFeatureSink
 {
 %Docstring
- A convenience class for writing vector files to disk.
-There are two possibilities how to use this class:
-1. static call to QgsVectorFileWriter.writeAsShapefile(...) which saves the whole vector layer
-2. create an instance of the class and issue calls to addFeature(...)
+ A convenience class for exporting vector layers to a destination data provider.
+
+ QgsVectorLayerExporter can be used in two ways:
+
+ 1. Using a static call to QgsVectorLayerExporter.exportLayer(...) which exports the
+ entire layer to the destination provider.
+
+ 2. Create an instance of the class and issue calls to addFeature(...)
+
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 %End
   public:
 
-    enum ImportError
+    enum ExportError
     {
       NoError,
-      ErrDriverNotFound,
       ErrCreateDataSource,
       ErrCreateLayer,
       ErrAttributeTypeUnsupported,
@@ -41,7 +46,7 @@ There are two possibilities how to use this class:
       ErrUserCanceled,
     };
 
-    static ImportError importLayer( QgsVectorLayer *layer,
+    static ExportError exportLayer( QgsVectorLayer *layer,
                                     const QString &uri,
                                     const QString &providerKey,
                                     const QgsCoordinateReferenceSystem &destCRS,
@@ -64,18 +69,18 @@ There are two possibilities how to use this class:
  \param options optional provider dataset options
  \param progress optional progress dialog to show progress of export
  :return: NoError for a successful export, or encountered error
- :rtype: ImportError
+ :rtype: ExportError
 %End
 
-    QgsVectorLayerImport( const QString &uri,
-                          const QString &provider,
-                          const QgsFields &fields,
-                          QgsWkbTypes::Type geometryType,
-                          const QgsCoordinateReferenceSystem &crs,
-                          bool overwrite = false,
-                          const QMap<QString, QVariant> *options = 0 );
+    QgsVectorLayerExporter( const QString &uri,
+                            const QString &provider,
+                            const QgsFields &fields,
+                            QgsWkbTypes::Type geometryType,
+                            const QgsCoordinateReferenceSystem &crs,
+                            bool overwrite = false,
+                            const QMap<QString, QVariant> *options = 0 );
 %Docstring
- Constructor for QgsVectorLayerImport.
+ Constructor for QgsVectorLayerExporter.
  \param uri URI for destination data source
  \param provider string key for destination data provider
  \param fields fields to include in created layer
@@ -87,20 +92,27 @@ There are two possibilities how to use this class:
 %End
 
 
-    ImportError hasError();
+    ExportError errorCode() const;
 %Docstring
-Checks whether there were any errors
- :rtype: ImportError
+ Returns any encountered error code, or false if no error was encountered.
+.. seealso:: errorMessage()
+.. seealso:: errorCount()
+ :rtype: ExportError
 %End
 
-    QString errorMessage();
+    QString errorMessage() const;
 %Docstring
-Retrieves error message
+ Returns any error message encountered during the export.
+.. seealso:: errorCount()
+.. seealso:: errorCode()
  :rtype: str
 %End
 
     int errorCount() const;
 %Docstring
+ Returns the number of error messages encountered during the export.
+.. seealso:: errorMessage()
+.. seealso:: errorCode()
  :rtype: int
 %End
 
@@ -109,19 +121,19 @@ Retrieves error message
     virtual bool addFeature( QgsFeature &feature );
 
 
-    ~QgsVectorLayerImport();
+    ~QgsVectorLayerExporter();
 %Docstring
-Close the new created layer
+ Finalizes the export and closes the new created layer.
 %End
 
   private:
-    QgsVectorLayerImport( const QgsVectorLayerImport &rh );
+    QgsVectorLayerExporter( const QgsVectorLayerExporter &rh );
 };
 
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/qgsvectorlayerimport.h                                      *
+ * src/core/qgsvectorlayerexporter.h                                    *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/

--- a/python/core/raster/qgsrasterfilewritertask.sip
+++ b/python/core/raster/qgsrasterfilewritertask.sip
@@ -16,6 +16,7 @@ class QgsRasterFileWriterTask : QgsTask
  task. This can be used to save a raster layer out to a file without blocking the
  QGIS interface.
 .. seealso:: QgsVectorFileWriterTask
+.. seealso:: QgsVectorFileExporterTask
 .. versionadded:: 3.0
 %End
 

--- a/python/plugins/db_manager/db_model.py
+++ b/python/plugins/db_manager/db_model.py
@@ -36,7 +36,7 @@ from qgis.core import QgsDataSourceUri, QgsVectorLayer, QgsRasterLayer, QgsMimeD
 from . import resources_rc  # NOQA
 
 try:
-    from qgis.core import QgsVectorLayerImport  # NOQA
+    from qgis.core import QgsVectorLayerExporter  # NOQA
     isImportVectorAvail = True
 except:
     isImportVectorAvail = False

--- a/python/plugins/db_manager/db_plugins/oracle/TODO.md
+++ b/python/plugins/db_manager/db_plugins/oracle/TODO.md
@@ -23,11 +23,11 @@
   modify field dialog. #13089
 
 * Import Table does not work because of a problem in
-  QgsVectorLayerImport. After the creation of the table, QGIS tries to
+  QgsVectorLayerExporter. After the creation of the table, QGIS tries to
   open the layer but, as there is no geometries in it, QGIS can't
   determinate the geometry type of the layer and refuses to open
   it. Then, no data importation can occur. Must dig into
-  src/core/qgsvectorlayerimport.cpp and into the provider code.
+  src/core/qgsvectorlayerexporter.cpp and into the provider code.
   See #13096 .
 
 # Future work

--- a/python/plugins/db_manager/dlg_export_vector.py
+++ b/python/plugins/db_manager/dlg_export_vector.py
@@ -179,7 +179,7 @@ class DlgExportVector(QDialog, Ui_Dialog):
                 self.inLayer.setCrs(inCrs)
 
             # do the export!
-            ret, errMsg = QgsVectorLayerExporter.exportLayer(self.inLayer, uri, providerName, outCrs, False,
+            ret, errMsg = QgsVectorLayerExporter.exportLayer(self.inLayer, uri, providerName, outCrs,
                                                              False, options)
         except Exception as e:
             ret = -1

--- a/python/plugins/db_manager/dlg_export_vector.py
+++ b/python/plugins/db_manager/dlg_export_vector.py
@@ -27,7 +27,11 @@ from qgis.PyQt.QtCore import Qt, QFileInfo
 from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QMessageBox, QApplication
 from qgis.PyQt.QtGui import QCursor
 
-from qgis.core import QgsVectorFileWriter, QgsVectorDataProvider, QgsCoordinateReferenceSystem, QgsVectorLayerImport, QgsSettings
+from qgis.core import (QgsVectorFileWriter,
+                       QgsVectorDataProvider,
+                       QgsCoordinateReferenceSystem,
+                       QgsVectorLayerExporter,
+                       QgsSettings)
 
 from .ui.ui_DlgExportVector import Ui_DbManagerDlgExportVector as Ui_Dialog
 
@@ -175,8 +179,8 @@ class DlgExportVector(QDialog, Ui_Dialog):
                 self.inLayer.setCrs(inCrs)
 
             # do the export!
-            ret, errMsg = QgsVectorLayerImport.importLayer(self.inLayer, uri, providerName, outCrs, False,
-                                                           False, options)
+            ret, errMsg = QgsVectorLayerExporter.exportLayer(self.inLayer, uri, providerName, outCrs, False,
+                                                             False, options)
         except Exception as e:
             ret = -1
             errMsg = str(e)

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -28,7 +28,14 @@ from qgis.PyQt.QtCore import Qt, QFileInfo
 from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QMessageBox, QApplication
 from qgis.PyQt.QtGui import QCursor
 
-from qgis.core import QgsDataSourceUri, QgsVectorLayer, QgsMapLayer, QgsProviderRegistry, QgsCoordinateReferenceSystem, QgsVectorLayerImport, QgsProject, QgsSettings
+from qgis.core import (QgsDataSourceUri,
+                       QgsVectorLayer,
+                       QgsMapLayer,
+                       QgsProviderRegistry,
+                       QgsCoordinateReferenceSystem,
+                       QgsVectorLayerExporter,
+                       QgsProject,
+                       QgsSettings)
 from qgis.gui import QgsMessageViewer
 
 from .ui.ui_DlgImportVector import Ui_DbManagerDlgImportVector as Ui_Dialog
@@ -353,7 +360,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
             onlySelected = self.chkSelectedFeatures.isChecked()
 
             # do the import!
-            ret, errMsg = QgsVectorLayerImport.importLayer(self.inLayer, uri, providerName, outCrs, onlySelected, False, options)
+            ret, errMsg = QgsVectorLayerExporter.exportLayer(self.inLayer, uri, providerName, outCrs, onlySelected, False, options)
         except Exception as e:
             ret = -1
             errMsg = str(e)

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -360,7 +360,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
             onlySelected = self.chkSelectedFeatures.isChecked()
 
             # do the import!
-            ret, errMsg = QgsVectorLayerExporter.exportLayer(self.inLayer, uri, providerName, outCrs, onlySelected, False, options)
+            ret, errMsg = QgsVectorLayerExporter.exportLayer(self.inLayer, uri, providerName, outCrs, onlySelected, options)
         except Exception as e:
             ret = -1
             errMsg = str(e)

--- a/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
@@ -25,7 +25,7 @@ __copyright__ = '(C) 2012, Victor Olaya'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsVectorLayerImport,
+from qgis.core import (QgsVectorLayerExporter,
                        QgsSettings,
                        QgsApplication,
                        QgsProcessingUtils)
@@ -164,7 +164,7 @@ class ImportIntoPostGIS(GeoAlgorithm):
         if encoding:
             layer.setProviderEncoding(encoding)
 
-        (ret, errMsg) = QgsVectorLayerImport.importLayer(
+        (ret, errMsg) = QgsVectorLayerExporter.exportLayer(
             layer,
             uri.uri(),
             providerName,

--- a/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
@@ -170,7 +170,6 @@ class ImportIntoPostGIS(GeoAlgorithm):
             providerName,
             self.crs,
             False,
-            False,
             options,
         )
         if ret != 0:

--- a/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
@@ -26,7 +26,7 @@ __copyright__ = '(C) 2012, Mathieu Pellerin'
 __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsDataSourceUri,
-                       QgsVectorLayerImport,
+                       QgsVectorLayerExporter,
                        QgsApplication,
                        QgsProcessingUtils)
 
@@ -134,7 +134,7 @@ class ImportIntoSpatialite(GeoAlgorithm):
         if encoding:
             layer.setProviderEncoding(encoding)
 
-        (ret, errMsg) = QgsVectorLayerImport.importLayer(
+        (ret, errMsg) = QgsVectorLayerExporter.exportLayer(
             layer,
             uri.uri(),
             providerName,

--- a/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
@@ -140,7 +140,6 @@ class ImportIntoSpatialite(GeoAlgorithm):
             providerName,
             self.crs,
             False,
-            False,
             options,
         )
         if ret != 0:

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -570,6 +570,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsvectorlayereditbuffer.h
   qgsvectorlayereditpassthrough.h
   qgsvectorlayer.h
+  qgsvectorlayerexporter.h
   qgsvectorlayerfeaturecounter.h
   qgsvectorlayerjoinbuffer.h
   qgsvectorlayertools.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -270,7 +270,7 @@ SET(QGIS_CORE_SRCS
   qgsvectorlayereditpassthrough.cpp
   qgsvectorlayereditutils.cpp
   qgsvectorlayerfeatureiterator.cpp
-  qgsvectorlayerimport.cpp
+  qgsvectorlayerexporter.cpp
   qgsvectorlayerjoinbuffer.cpp
   qgsvectorlayerlabeling.cpp
   qgsvectorlayerlabelprovider.cpp
@@ -819,7 +819,7 @@ SET(QGIS_CORE_HDRS
   qgsvectorlayerdiagramprovider.h
   qgsvectorlayereditutils.h
   qgsvectorlayerfeatureiterator.h
-  qgsvectorlayerimport.h
+  qgsvectorlayerexporter.h
   qgsvectorlayerjoininfo.h
   qgsvectorlayerlabelprovider.h
   qgsvectorlayerrenderer.h

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -19,7 +19,7 @@
 #include "qgsproject.h"
 #include "qgssettings.h"
 #include "qgsprocessingcontext.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsmemoryproviderutils.h"
 
@@ -367,8 +367,8 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, con
     {
       //create empty layer
       {
-        QgsVectorLayerImport import( uri, providerKey, fields, geometryType, crs, false, &options );
-        if ( import.hasError() )
+        QgsVectorLayerExporter import( uri, providerKey, fields, geometryType, crs, false, &options );
+        if ( import.errorCode() )
           return nullptr;
       }
 

--- a/src/core/qgsvectorfilewritertask.h
+++ b/src/core/qgsvectorfilewritertask.h
@@ -30,6 +30,7 @@
  * task. This can be used to save a vector layer out to a file without blocking the
  * QGIS interface.
  * \since QGIS 3.0
+ * \see QgsVectorLayerExporterTask
  * \see QgsRasterFileWriterTask
  */
 class CORE_EXPORT QgsVectorFileWriterTask : public QgsTask

--- a/src/core/qgsvectorlayerexporter.cpp
+++ b/src/core/qgsvectorlayerexporter.cpp
@@ -326,10 +326,10 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
   QgsFeatureRequest req;
   if ( wkbType == QgsWkbTypes::NoGeometry )
     req.setFlags( QgsFeatureRequest::NoGeometry );
+  if ( onlySelected )
+    req.setFilterFids( layer->selectedFeatureIds() );
 
   QgsFeatureIterator fit = layer->getFeatures( req );
-
-  const QgsFeatureIds &ids = layer->selectedFeatureIds();
 
   // Create our transform
   if ( destCRS.isValid() )
@@ -374,9 +374,6 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
       }
       break;
     }
-
-    if ( onlySelected && !ids.contains( fet.id() ) )
-      continue;
 
     if ( shallTransform )
     {

--- a/src/core/qgsvectorlayerexporter.cpp
+++ b/src/core/qgsvectorlayerexporter.cpp
@@ -231,7 +231,6 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
                                      const QgsCoordinateReferenceSystem &destCRS,
                                      bool onlySelected,
                                      QString *errorMessage,
-                                     bool skipAttributeCreation,
                                      QMap<QString, QVariant> *options,
                                      QProgressDialog *progress )
 {
@@ -263,7 +262,7 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
     forceSinglePartGeom = options->take( QStringLiteral( "forceSinglePartGeometryType" ) ).toBool();
   }
 
-  QgsFields fields = skipAttributeCreation ? QgsFields() : layer->fields();
+  QgsFields fields = layer->fields();
   QgsWkbTypes::Type wkbType = layer->wkbType();
 
   // Special handling for Shapefiles
@@ -327,8 +326,6 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
   QgsFeatureRequest req;
   if ( wkbType == QgsWkbTypes::NoGeometry )
     req.setFlags( QgsFeatureRequest::NoGeometry );
-  if ( skipAttributeCreation )
-    req.setSubsetOfAttributes( QgsAttributeList() );
 
   QgsFeatureIterator fit = layer->getFeatures( req );
 
@@ -404,10 +401,6 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
 
         return ErrProjection;
       }
-    }
-    if ( skipAttributeCreation )
-    {
-      fet.initAttributes( 0 );
     }
     if ( !writer->addFeature( fet ) )
     {
@@ -504,7 +497,7 @@ bool QgsVectorLayerExporterTask::run()
 
 
   mError = QgsVectorLayerExporter::exportLayer(
-             mLayer.data(), mDestUri, mDestProviderKey, mDestCrs, false, &mErrorMessage, false,
+             mLayer.data(), mDestUri, mDestProviderKey, mDestCrs, false, &mErrorMessage,
              &mOptions );
 
   if ( mOwnsLayer )

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -75,7 +75,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
      * \param onlySelected set to true to export only selected features
      * \param errorMessage if non-null, will be set to any error messages
      * \param options optional provider dataset options
-     * \param progress optional progress dialog to show progress of export
+     * \param feedback optional feedback object to show progress and cancelation of export
      * \returns NoError for a successful export, or encountered error
      */
     static ExportError exportLayer( QgsVectorLayer *layer,
@@ -85,7 +85,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
                                     bool onlySelected = false,
                                     QString *errorMessage SIP_OUT = 0,
                                     QMap<QString, QVariant> *options = nullptr,
-                                    QProgressDialog *progress = nullptr
+                                    QgsFeedback *feedback = nullptr
                                   );
 
     /**

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -74,7 +74,6 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
      * not available
      * \param onlySelected set to true to export only selected features
      * \param errorMessage if non-null, will be set to any error messages
-     * \param skipAttributeCreation set to true to skip exporting feature attributes
      * \param options optional provider dataset options
      * \param progress optional progress dialog to show progress of export
      * \returns NoError for a successful export, or encountered error
@@ -85,7 +84,6 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
                                     const QgsCoordinateReferenceSystem &destCRS,
                                     bool onlySelected = false,
                                     QString *errorMessage SIP_OUT = 0,
-                                    bool skipAttributeCreation = false,
                                     QMap<QString, QVariant> *options = nullptr,
                                     QProgressDialog *progress = nullptr
                                   );

--- a/src/core/raster/qgsrasterfilewritertask.h
+++ b/src/core/raster/qgsrasterfilewritertask.h
@@ -31,6 +31,7 @@
  * task. This can be used to save a raster layer out to a file without blocking the
  * QGIS interface.
  * \see QgsVectorFileWriterTask
+ * \see QgsVectorFileExporterTask
  * \since QGIS 3.0
  */
 class CORE_EXPORT QgsRasterFileWriterTask : public QgsTask

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -24,6 +24,7 @@
 #include "qgsvectorlayerexporter.h"
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
+#include "qgsmessageoutput.h"
 
 #include <QMessageBox>
 #include <QProgressDialog>
@@ -316,16 +317,8 @@ bool QgsDb2ConnectionItem::handleDrop( const QMimeData *data, const QString &toS
     return false;
 
   // TODO: probably should show a GUI with settings etc
-  qApp->setOverrideCursor( Qt::WaitCursor );
-
-  QProgressDialog *progress = new QProgressDialog( tr( "Copying features..." ), tr( "Abort" ), 0, 0, nullptr );
-  progress->setWindowTitle( tr( "Import layer" ) );
-  progress->setWindowModality( Qt::WindowModal );
-  progress->show();
-
   QStringList importResults;
   bool hasError = false;
-  bool canceled = false;
 
   QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( data );
   Q_FOREACH ( const QgsMimeDataUtils::Uri &u, lst )
@@ -357,60 +350,51 @@ bool QgsDb2ConnectionItem::handleDrop( const QMimeData *data, const QString &toS
       if ( srcLayer->geometryType() != QgsWkbTypes::NullGeometry )
         uri += QLatin1String( " (geom)" );
 
-      QgsVectorLayerExporter::ExportError err;
-      QString importError;
-      err = QgsVectorLayerExporter::exportLayer( srcLayer, uri, QStringLiteral( "DB2" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerExporter::NoError )
+      std::unique_ptr< QgsVectorLayerExporterTask > exportTask( QgsVectorLayerExporterTask::withLayerOwnership( srcLayer, uri, QStringLiteral( "DB2" ), srcLayer->crs() ) );
+
+      // when export is successful:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, this, [ = ]()
       {
-        importResults.append( tr( "%1: OK!" ).arg( u.name ) );
-        QgsDebugMsg( "import successful" );
-      }
-      else
-      {
-        if ( err == QgsVectorLayerExporter::ErrUserCanceled )
-        {
-          canceled = true;
-          QgsDebugMsg( "import canceled" );
-        }
+        // this is gross - TODO - find a way to get access to messageBar from data items
+        QMessageBox::information( nullptr, tr( "Import to DB2 database" ), tr( "Import was successful." ) );
+        if ( state() == Populated )
+          refresh();
         else
+          populate();
+      } );
+
+      // when an error occurs:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::errorOccurred, this, [ = ]( int error, const QString & errorMessage )
+      {
+        if ( error != QgsVectorLayerExporter::ErrUserCanceled )
         {
-          QString errMsg = QStringLiteral( "%1: %2" ).arg( u.name, importError );
-          QgsDebugMsg( "import failed: " + errMsg );
-          importResults.append( errMsg );
-          hasError = true;
+          QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+          output->setTitle( tr( "Import to DB2 database" ) );
+          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->showMessage();
         }
-      }
+        if ( state() == Populated )
+          refresh();
+        else
+          populate();
+      } );
+
+      QgsApplication::taskManager()->addTask( exportTask.release() );
     }
     else
     {
-      importResults.append( tr( "%1: OK!" ).arg( u.name ) );
+      importResults.append( tr( "%1: Not a valid layer!" ).arg( u.name ) );
       hasError = true;
     }
-
-    delete srcLayer;
   }
 
-  delete progress;
-  qApp->restoreOverrideCursor();
-
-  if ( canceled )
+  if ( hasError )
   {
-    QMessageBox::information( nullptr, tr( "Import to DB2 database" ), tr( "Import canceled." ) );
-    refresh();
+    QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+    output->setTitle( tr( "Import to DB2 database" ) );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QStringLiteral( "\n" ) ), QgsMessageOutput::MessageText );
+    output->showMessage();
   }
-  else if ( hasError )
-  {
-    QMessageBox::warning( nullptr, tr( "Import to DB2 database" ), tr( "Failed to import some layers!\n\n" ) + importResults.join( QStringLiteral( "\n" ) ) );
-  }
-  else
-  {
-    QMessageBox::information( nullptr, tr( "Import to DB2 database" ), tr( "Import was successful." ) );
-  }
-
-  if ( state() == Populated )
-    refresh();
-  else
-    populate();
 
   return true;
 }

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -21,7 +21,7 @@
 #include "qgsdb2geometrycolumns.h"
 #include "qgslogger.h"
 #include "qgsmimedatautils.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
 
@@ -357,17 +357,17 @@ bool QgsDb2ConnectionItem::handleDrop( const QMimeData *data, const QString &toS
       if ( srcLayer->geometryType() != QgsWkbTypes::NullGeometry )
         uri += QLatin1String( " (geom)" );
 
-      QgsVectorLayerImport::ImportError err;
+      QgsVectorLayerExporter::ExportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, uri, QStringLiteral( "DB2" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerImport::NoError )
+      err = QgsVectorLayerExporter::exportLayer( srcLayer, uri, QStringLiteral( "DB2" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
+      if ( err == QgsVectorLayerExporter::NoError )
       {
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
         QgsDebugMsg( "import successful" );
       }
       else
       {
-        if ( err == QgsVectorLayerImport::ErrUserCanceled )
+        if ( err == QgsVectorLayerExporter::ErrUserCanceled )
         {
           canceled = true;
           QgsDebugMsg( "import canceled" );

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -931,7 +931,7 @@ bool QgsDb2Provider::addFeatures( QgsFeatureList &flist )
   bool first = true;
 
 // Get the first geometry and its wkbType as when we are doing drag/drop,
-// the wkbType is not passed to the DB2 provider from QgsVectorLayerImport
+// the wkbType is not passed to the DB2 provider from QgsVectorLayerExporter
 // Can't figure out how to resolved "unreferenced" wkbType compile message
 // Don't really do anything with it at this point
 #if 0
@@ -1244,7 +1244,7 @@ bool QgsDb2Provider::changeGeometryValues( const QgsGeometryMap &geometry_map )
   return true;
 }
 
-QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QString &uri,
+QgsVectorLayerExporter::ExportError QgsDb2Provider::createEmptyLayer( const QString &uri,
     const QgsFields &fields,
     QgsWkbTypes::Type wkbType,
     const QgsCoordinateReferenceSystem &srs,
@@ -1270,7 +1270,7 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
   {
     if ( errorMessage )
       *errorMessage = errMsg;
-    return QgsVectorLayerImport::ErrConnectionFailed;
+    return QgsVectorLayerExporter::ErrConnectionFailed;
   }
 
   // Get the SRS name using srid, needed to register the spatial column
@@ -1323,7 +1323,7 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
   // a multi-type, the insert will fail if the actual data is a single-type
   // due to type mismatch.
   // We could potentially defer adding the spatial column until addFeatures is
-  // called the first time, but QgsVectorLayerImport doesn't pass the CRS/srid
+  // called the first time, but QgsVectorLayerExporter doesn't pass the CRS/srid
   // information to the DB2 provider and we need this information to register
   // the spatial column.
   // This hack is problematic because the drag/drop will fail if the
@@ -1395,7 +1395,7 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
         {
           *errorMessage = lastError;
         }
-        return QgsVectorLayerImport::ErrCreateLayer;
+        return QgsVectorLayerExporter::ErrCreateLayer;
       }
     }
   }
@@ -1435,7 +1435,7 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
         {
           *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( fld.name() );
         }
-        return QgsVectorLayerImport::ErrAttributeTypeUnsupported;
+        return QgsVectorLayerExporter::ErrAttributeTypeUnsupported;
       }
 
       if ( oldToNewAttrIdxMap )
@@ -1475,7 +1475,7 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
       {
         *errorMessage = lastError;
       }
-      return QgsVectorLayerImport::ErrCreateLayer;
+      return QgsVectorLayerExporter::ErrCreateLayer;
     }
 
 
@@ -1553,7 +1553,7 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
 
   }
   QgsDebugMsg( "successfully created empty layer" );
-  return QgsVectorLayerImport::NoError;
+  return QgsVectorLayerExporter::NoError;
 }
 
 QString QgsDb2Provider::qgsFieldToDb2Field( const QgsField &field )
@@ -1724,7 +1724,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
 }
 
 
-QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
+QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
   const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -19,7 +19,7 @@
 #define QGSDB2PROVIDER_H
 
 #include "qgsvectordataprovider.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include <qgscoordinatereferencesystem.h>
 #include "qgsgeometry.h"
 #include "qgsfields.h"
@@ -92,7 +92,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
     virtual bool changeGeometryValues( const QgsGeometryMap &geometry_map ) override;
 
     //! Import a vector layer into the database
-    static QgsVectorLayerImport::ImportError createEmptyLayer(
+    static QgsVectorLayerExporter::ExportError createEmptyLayer(
       const QString &uri,
       const QgsFields &fields,
       QgsWkbTypes::Type wkbType,

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -22,7 +22,7 @@
 #include "qgslogger.h"
 #include "qgsmimedatautils.h"
 #include "qgsvectorlayer.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsdatasourceuri.h"
 #include "qgsmssqlprovider.h"
 #include "qgssettings.h"
@@ -423,12 +423,12 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
       if ( srcLayer->geometryType() != QgsWkbTypes::NullGeometry )
         uri += QLatin1String( " (geom)" );
 
-      QgsVectorLayerImport::ImportError err;
+      QgsVectorLayerExporter::ExportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, uri, QStringLiteral( "mssql" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerImport::NoError )
+      err = QgsVectorLayerExporter::exportLayer( srcLayer, uri, QStringLiteral( "mssql" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
+      if ( err == QgsVectorLayerExporter::NoError )
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
-      else if ( err == QgsVectorLayerImport::ErrUserCanceled )
+      else if ( err == QgsVectorLayerExporter::ErrUserCanceled )
         canceled = true;
       else
       {

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -26,6 +26,7 @@
 #include "qgsdatasourceuri.h"
 #include "qgsmssqlprovider.h"
 #include "qgssettings.h"
+#include "qgsmessageoutput.h"
 
 #include <QMessageBox>
 #include <QSqlDatabase>
@@ -383,16 +384,8 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
     return false;
 
   // TODO: probably should show a GUI with settings etc
-  qApp->setOverrideCursor( Qt::WaitCursor );
-
-  QProgressDialog *progress = new QProgressDialog( tr( "Copying features..." ), tr( "Abort" ), 0, 0, nullptr );
-  progress->setWindowTitle( tr( "Import layer" ) );
-  progress->setWindowModality( Qt::WindowModal );
-  progress->show();
-
   QStringList importResults;
   bool hasError = false;
-  bool canceled = false;
 
   QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( data );
   Q_FOREACH ( const QgsMimeDataUtils::Uri &u, lst )
@@ -423,49 +416,49 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
       if ( srcLayer->geometryType() != QgsWkbTypes::NullGeometry )
         uri += QLatin1String( " (geom)" );
 
-      QgsVectorLayerExporter::ExportError err;
-      QString importError;
-      err = QgsVectorLayerExporter::exportLayer( srcLayer, uri, QStringLiteral( "mssql" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerExporter::NoError )
-        importResults.append( tr( "%1: OK!" ).arg( u.name ) );
-      else if ( err == QgsVectorLayerExporter::ErrUserCanceled )
-        canceled = true;
-      else
+      std::unique_ptr< QgsVectorLayerExporterTask > exportTask( QgsVectorLayerExporterTask::withLayerOwnership( srcLayer, uri, QStringLiteral( "mssql" ), srcLayer->crs() ) );
+
+      // when export is successful:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, this, [ = ]()
       {
-        importResults.append( QStringLiteral( "%1: %2" ).arg( u.name, importError ) );
-        hasError = true;
-      }
+        // this is gross - TODO - find a way to get access to messageBar from data items
+        QMessageBox::information( nullptr, tr( "Import to MSSQL database" ), tr( "Import was successful." ) );
+        if ( state() == Populated )
+          refresh();
+        else
+          populate();
+      } );
+
+      // when an error occurs:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::errorOccurred, this, [ = ]( int error, const QString & errorMessage )
+      {
+        if ( error != QgsVectorLayerExporter::ErrUserCanceled )
+        {
+          QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+          output->setTitle( tr( "Import to MSSQL database" ) );
+          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->showMessage();
+        }
+        if ( state() == Populated )
+          refresh();
+        else
+          populate();
+      } );
     }
     else
     {
-      importResults.append( tr( "%1: OK!" ).arg( u.name ) );
+      importResults.append( tr( "%1: Not a valid layer!" ).arg( u.name ) );
       hasError = true;
     }
-
-    delete srcLayer;
   }
 
-  delete progress;
-  qApp->restoreOverrideCursor();
-
-  if ( canceled )
+  if ( hasError )
   {
-    QMessageBox::information( nullptr, tr( "Import to MSSQL database" ), tr( "Import canceled." ) );
-    refresh();
+    QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+    output->setTitle( tr( "Import to MSSQL database" ) );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QStringLiteral( "\n" ) ), QgsMessageOutput::MessageText );
+    output->showMessage();
   }
-  else if ( hasError )
-  {
-    QMessageBox::warning( nullptr, tr( "Import to MSSQL database" ), tr( "Failed to import some layers!\n\n" ) + importResults.join( QStringLiteral( "\n" ) ) );
-  }
-  else
-  {
-    QMessageBox::information( nullptr, tr( "Import to MSSQL database" ), tr( "Import was successful." ) );
-  }
-
-  if ( state() == Populated )
-    refresh();
-  else
-    populate();
 
   return true;
 }

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1654,7 +1654,7 @@ QgsWkbTypes::Type QgsMssqlProvider::getWkbType( const QString &geometryType, int
 }
 
 
-QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QString &uri,
+QgsVectorLayerExporter::ExportError QgsMssqlProvider::createEmptyLayer( const QString &uri,
     const QgsFields &fields,
     QgsWkbTypes::Type wkbType,
     const QgsCoordinateReferenceSystem &srs,
@@ -1675,7 +1675,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
   {
     if ( errorMessage )
       *errorMessage = db.lastError().text();
-    return QgsVectorLayerImport::ErrConnectionFailed;
+    return QgsVectorLayerExporter::ErrConnectionFailed;
   }
 
   QString dbName = dsUri.database();
@@ -1756,7 +1756,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
   {
     if ( errorMessage )
       *errorMessage = q.lastError().text();
-    return QgsVectorLayerImport::ErrCreateLayer;
+    return QgsVectorLayerExporter::ErrCreateLayer;
   }
 
   // set up spatial reference id
@@ -1782,7 +1782,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
     {
       if ( errorMessage )
         *errorMessage = q.lastError().text();
-      return QgsVectorLayerImport::ErrCreateLayer;
+      return QgsVectorLayerExporter::ErrCreateLayer;
     }
   }
 
@@ -1800,7 +1800,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
     {
       if ( errorMessage )
         *errorMessage = q.lastError().text();
-      return QgsVectorLayerImport::ErrCreateLayer;
+      return QgsVectorLayerExporter::ErrCreateLayer;
     }
   }
 
@@ -1836,7 +1836,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
   {
     if ( errorMessage )
       *errorMessage = q.lastError().text();
-    return QgsVectorLayerImport::ErrCreateLayer;
+    return QgsVectorLayerExporter::ErrCreateLayer;
   }
 
   // clear any resources hold by the query
@@ -1852,7 +1852,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
       *errorMessage = QObject::tr( "Loading of the MSSQL provider failed" );
 
     delete provider;
-    return QgsVectorLayerImport::ErrInvalidLayer;
+    return QgsVectorLayerExporter::ErrInvalidLayer;
   }
 
   // add fields to the layer
@@ -1886,7 +1886,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
           *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( fld.name() );
 
         delete provider;
-        return QgsVectorLayerImport::ErrAttributeTypeUnsupported;
+        return QgsVectorLayerExporter::ErrAttributeTypeUnsupported;
       }
 
       flist.append( fld );
@@ -1900,10 +1900,10 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
         *errorMessage = QObject::tr( "Creation of fields failed" );
 
       delete provider;
-      return QgsVectorLayerImport::ErrAttributeCreationFailed;
+      return QgsVectorLayerExporter::ErrAttributeCreationFailed;
     }
   }
-  return QgsVectorLayerImport::NoError;
+  return QgsVectorLayerExporter::NoError;
 }
 
 
@@ -1957,7 +1957,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   return new QgsMssqlRootItem( parentItem, QStringLiteral( "MSSQL" ), QStringLiteral( "mssql:" ) );
 }
 
-QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
+QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
   const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -20,7 +20,7 @@
 
 #include "qgsvectordataprovider.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsfields.h"
 
 #include <QStringList>
@@ -126,7 +126,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     QString defaultValueClause( int fieldId ) const override;
 
     //! Import a vector layer into the database
-    static QgsVectorLayerImport::ImportError createEmptyLayer(
+    static QgsVectorLayerExporter::ExportError createEmptyLayer(
       const QString &uri,
       const QgsFields &fields,
       QgsWkbTypes::Type wkbType,

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -29,7 +29,7 @@ email                : sherman at mrcc.com
 #include "qgsfields.h"
 #include "qgsgeometry.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 
 #define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <gdal.h>         // to collect version information
@@ -216,7 +216,7 @@ void QgsOgrProvider::repack()
 }
 
 
-QgsVectorLayerImport::ImportError QgsOgrProvider::createEmptyLayer( const QString &uri,
+QgsVectorLayerExporter::ExportError QgsOgrProvider::createEmptyLayer( const QString &uri,
     const QgsFields &fields,
     QgsWkbTypes::Type wkbType,
     const QgsCoordinateReferenceSystem &srs,
@@ -272,7 +272,7 @@ QgsVectorLayerImport::ImportError QgsOgrProvider::createEmptyLayer( const QStrin
             if ( errorMessage )
               *errorMessage += QObject::tr( "Layer %2 of %1 exists and overwrite flag is false." )
                                .arg( uri ).arg( layerName );
-            return QgsVectorLayerImport::ErrCreateDataSource;
+            return QgsVectorLayerExporter::ErrCreateDataSource;
           }
           OGR_DS_Destroy( hDS );
         }
@@ -289,7 +289,7 @@ QgsVectorLayerImport::ImportError QgsOgrProvider::createEmptyLayer( const QStrin
       if ( errorMessage )
         *errorMessage += QObject::tr( "Unable to create the datasource. %1 exists and overwrite flag is false." )
                          .arg( uri );
-      return QgsVectorLayerImport::ErrCreateDataSource;
+      return QgsVectorLayerExporter::ErrCreateDataSource;
     }
   }
 
@@ -306,7 +306,7 @@ QgsVectorLayerImport::ImportError QgsOgrProvider::createEmptyLayer( const QStrin
       *errorMessage += writer->errorMessage();
 
     delete writer;
-    return ( QgsVectorLayerImport::ImportError ) error;
+    return ( QgsVectorLayerExporter::ExportError ) error;
   }
 
   QMap<int, int> attrIdxMap = writer->attrIdxToOgrIdx();
@@ -340,7 +340,7 @@ QgsVectorLayerImport::ImportError QgsOgrProvider::createEmptyLayer( const QStrin
     }
   }
 
-  return QgsVectorLayerImport::NoError;
+  return QgsVectorLayerExporter::NoError;
 }
 
 static QString AnalyzeURI( QString const &uri,
@@ -4233,7 +4233,7 @@ QGISEXTERN QString getStyleById( const QString &uri, QString styleId, QString &e
 
 // ---------------------------------------------------------------------------
 
-QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
+QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
   const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -23,10 +23,10 @@ email                : sherman at mrcc.com
 #include "qgsrectangle.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorfilewriter.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 
 class QgsField;
-class QgsVectorLayerImport;
+class QgsVectorLayerExporter;
 
 class QgsOgrFeatureIterator;
 
@@ -43,7 +43,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
   public:
 
     //! Convert a vector layer to a vector file
-    static QgsVectorLayerImport::ImportError createEmptyLayer(
+    static QgsVectorLayerExporter::ExportError createEmptyLayer(
       const QString &uri,
       const QgsFields &fields,
       QgsWkbTypes::Type wkbType,

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -230,16 +230,8 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
   // TODO: probably should show a GUI with settings etc
   QgsDataSourceUri uri = QgsOracleConn::connUri( mName );
 
-  qApp->setOverrideCursor( Qt::WaitCursor );
-
-  QProgressDialog *progress = new QProgressDialog( tr( "Copying features..." ), tr( "Abort" ), 0, 0, nullptr );
-  progress->setWindowTitle( tr( "Import layer" ) );
-  progress->setWindowModality( Qt::WindowModal );
-  progress->show();
-
   QStringList importResults;
   bool hasError = false;
-  bool canceled = false;
 
   QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( data );
   Q_FOREACH ( const QgsMimeDataUtils::Uri &u, lst )
@@ -264,54 +256,52 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
         uri.setSrid( authid.mid( 5 ) );
       }
       QgsDebugMsgLevel( "URI " + uri.uri(), 3 );
-      QgsVectorLayerExporter::ExportError err;
-      QString importError;
-      err = QgsVectorLayerExporter::exportLayer( srcLayer, uri.uri(), "oracle", srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerExporter::NoError )
-        importResults.append( tr( "%1: OK!" ).arg( u.name ) );
-      else if ( err == QgsVectorLayerExporter::ErrUserCanceled )
-        canceled = true;
-      else
+
+      std::unique_ptr< QgsVectorLayerExporterTask > exportTask( QgsVectorLayerExporterTask::withLayerOwnership( srcLayer, uri.uri(), QStringLiteral( "oracle" ), srcLayer->crs() ) );
+
+      // when export is successful:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, this, [ = ]()
       {
-        importResults.append( QString( "%1: %2" ).arg( u.name ).arg( importError ) );
-        hasError = true;
-      }
+        // this is gross - TODO - find a way to get access to messageBar from data items
+        QMessageBox::information( nullptr, tr( "Import to Oracle database" ), tr( "Import was successful." ) );
+        if ( state() == Populated )
+          refresh();
+        else
+          populate();
+      } );
+
+      // when an error occurs:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::errorOccurred, this, [ = ]( int error, const QString & errorMessage )
+      {
+        if ( error != QgsVectorLayerExporter::ErrUserCanceled )
+        {
+          QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+          output->setTitle( tr( "Import to Oracle database" ) );
+          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->showMessage();
+        }
+        if ( state() == Populated )
+          refresh();
+        else
+          populate();
+      } );
+
+      QgsApplication::taskManager()->addTask( exportTask.release() );
     }
     else
     {
-      importResults.append( tr( "%1: OK!" ).arg( u.name ) );
+      importResults.append( tr( "%1: Not a valid layer!" ).arg( u.name ) );
       hasError = true;
     }
-
-    delete srcLayer;
   }
 
-  delete progress;
-
-  qApp->restoreOverrideCursor();
-
-  if ( canceled )
-  {
-    QMessageBox::information( nullptr, tr( "Import to Oracle database" ), tr( "Import canceled." ) );
-    refresh();
-  }
-  else if ( hasError )
+  if ( hasError )
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to Oracle database" ) );
     output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( "\n" ), QgsMessageOutput::MessageText );
     output->showMessage();
   }
-  else
-  {
-    QMessageBox::information( 0, tr( "Import to Oracle database" ), tr( "Import was successful." ) );
-    refresh();
-  }
-
-  if ( state() == Populated )
-    refresh();
-  else
-    populate();
 
   return true;
 }

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -264,12 +264,12 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
         uri.setSrid( authid.mid( 5 ) );
       }
       QgsDebugMsgLevel( "URI " + uri.uri(), 3 );
-      QgsVectorLayerImport::ImportError err;
+      QgsVectorLayerExporter::ExportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, uri.uri(), "oracle", srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerImport::NoError )
+      err = QgsVectorLayerExporter::exportLayer( srcLayer, uri.uri(), "oracle", srcLayer->crs(), false, &importError, false, nullptr, progress );
+      if ( err == QgsVectorLayerExporter::NoError )
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
-      else if ( err == QgsVectorLayerImport::ErrUserCanceled )
+      else if ( err == QgsVectorLayerExporter::ErrUserCanceled )
         canceled = true;
       else
       {

--- a/src/providers/oracle/qgsoracledataitems.h
+++ b/src/providers/oracle/qgsoracledataitems.h
@@ -23,7 +23,7 @@
 #include "qgsoracletablemodel.h"
 #include "qgsoraclesourceselect.h"
 #include "qgsmimedatautils.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 
 class QSqlDatabase;
 

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -22,7 +22,7 @@
 #include "qgsmessagelog.h"
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgslogger.h"
 
 #include "qgsoracleprovider.h"
@@ -2564,7 +2564,7 @@ bool QgsOracleProvider::convertField( QgsField &field )
   return true;
 }
 
-QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
+QgsVectorLayerExporter::ExportError QgsOracleProvider::createEmptyLayer(
   const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,
@@ -2589,7 +2589,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
   {
     if ( errorMessage )
       *errorMessage = QObject::tr( "Connection to database failed" );
-    return QgsVectorLayerImport::ErrConnectionFailed;
+    return QgsVectorLayerExporter::ErrConnectionFailed;
   }
 
   if ( ownerName.isEmpty() )
@@ -2601,7 +2601,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
   {
     if ( errorMessage )
       *errorMessage = QObject::tr( "No owner name found" );
-    return QgsVectorLayerImport::ErrInvalidLayer;
+    return QgsVectorLayerExporter::ErrInvalidLayer;
   }
 
   QString tableName = dsUri.table();
@@ -2800,7 +2800,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
 
     conn->disconnect();
 
-    return QgsVectorLayerImport::ErrCreateLayer;
+    return QgsVectorLayerExporter::ErrCreateLayer;
   }
 
   conn->disconnect();
@@ -2816,7 +2816,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
       *errorMessage = QObject::tr( "Loading of the layer %1 failed" ).arg( ownerTableName );
 
     delete provider;
-    return QgsVectorLayerImport::ErrInvalidLayer;
+    return QgsVectorLayerExporter::ErrInvalidLayer;
   }
 
   QgsDebugMsg( "layer loaded" );
@@ -2858,7 +2858,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
             *errorMessage = QObject::tr( "Field name clash found (%1 not remappable)" ).arg( fld.name() );
 
           delete provider;
-          return QgsVectorLayerImport::ErrAttributeTypeUnsupported;
+          return QgsVectorLayerExporter::ErrAttributeTypeUnsupported;
         }
       }
 
@@ -2894,7 +2894,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
           *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( fld.name() );
 
         delete provider;
-        return QgsVectorLayerImport::ErrAttributeTypeUnsupported;
+        return QgsVectorLayerExporter::ErrAttributeTypeUnsupported;
       }
 
       QgsDebugMsg( QString( "Field #%1 name %2 type %3 typename %4 width %5 precision %6" )
@@ -2913,7 +2913,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
         *errorMessage = QObject::tr( "Creation of fields failed" );
 
       delete provider;
-      return QgsVectorLayerImport::ErrAttributeCreationFailed;
+      return QgsVectorLayerExporter::ErrAttributeCreationFailed;
     }
 
     QgsDebugMsg( "Done creating fields" );
@@ -2925,7 +2925,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
 
   delete provider;
 
-  return QgsVectorLayerImport::NoError;
+  return QgsVectorLayerExporter::NoError;
 }
 
 QgsCoordinateReferenceSystem QgsOracleProvider::crs() const
@@ -3045,7 +3045,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
 
 // ---------------------------------------------------------------------------
 
-QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
+QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
   const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -20,7 +20,7 @@
 
 #include "qgsvectordataprovider.h"
 #include "qgsrectangle.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsoracletablemodel.h"
 #include "qgsdatasourceuri.h"
 #include "qgsfields.h"
@@ -61,7 +61,7 @@ class QgsOracleProvider : public QgsVectorDataProvider
   public:
 
     //! Import a vector layer into the database
-    static QgsVectorLayerImport::ImportError createEmptyLayer(
+    static QgsVectorLayerExporter::ExportError createEmptyLayer(
       const QString &uri,
       const QgsFields &fields,
       QgsWkbTypes::Type wkbType,

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -228,12 +228,12 @@ bool QgsPGConnectionItem::handleDrop( const QMimeData *data, const QString &toSc
         uri.setSchema( toSchema );
       }
 
-      QgsVectorLayerImport::ImportError err;
+      QgsVectorLayerExporter::ExportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, uri.uri( false ), QStringLiteral( "postgres" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerImport::NoError )
+      err = QgsVectorLayerExporter::exportLayer( srcLayer, uri.uri( false ), QStringLiteral( "postgres" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
+      if ( err == QgsVectorLayerExporter::NoError )
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
-      else if ( err == QgsVectorLayerImport::ErrUserCanceled )
+      else if ( err == QgsVectorLayerExporter::ErrUserCanceled )
         canceled = true;
       else
       {

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -22,7 +22,7 @@
 #include "qgspostgresconn.h"
 #include "qgspgsourceselect.h"
 #include "qgsmimedatautils.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 
 class QgsPGRootItem;
 class QgsPGConnectionItem;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -28,7 +28,7 @@
 
 #include <QMessageBox>
 
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgspostgresprovider.h"
 #include "qgspostgresconn.h"
 #include "qgspostgresconnpool.h"
@@ -3639,7 +3639,7 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
   return true;
 }
 
-QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const QString &uri,
+QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const QString &uri,
     const QgsFields &fields,
     QgsWkbTypes::Type wkbType,
     const QgsCoordinateReferenceSystem &srs,
@@ -3680,7 +3680,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
   {
     if ( errorMessage )
       *errorMessage = QObject::tr( "Connection to database failed" );
-    return QgsVectorLayerImport::ErrConnectionFailed;
+    return QgsVectorLayerExporter::ErrConnectionFailed;
   }
 
   // get the pk's name and type
@@ -3841,7 +3841,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
 
     conn->PQexecNR( QStringLiteral( "ROLLBACK" ) );
     conn->unref();
-    return QgsVectorLayerImport::ErrCreateLayer;
+    return QgsVectorLayerExporter::ErrCreateLayer;
   }
   conn->unref();
 
@@ -3856,7 +3856,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
       *errorMessage = QObject::tr( "Loading of the layer %1 failed" ).arg( schemaTableName );
 
     delete provider;
-    return QgsVectorLayerImport::ErrInvalidLayer;
+    return QgsVectorLayerExporter::ErrInvalidLayer;
   }
 
   QgsDebugMsg( "layer loaded" );
@@ -3917,7 +3917,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
           *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( fld.name() );
 
         delete provider;
-        return QgsVectorLayerImport::ErrAttributeTypeUnsupported;
+        return QgsVectorLayerExporter::ErrAttributeTypeUnsupported;
       }
 
       QgsDebugMsg( QString( "creating field #%1 -> #%2 name %3 type %4 typename %5 width %6 precision %7" )
@@ -3937,12 +3937,12 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
         *errorMessage = QObject::tr( "Creation of fields failed" );
 
       delete provider;
-      return QgsVectorLayerImport::ErrAttributeCreationFailed;
+      return QgsVectorLayerExporter::ErrAttributeCreationFailed;
     }
 
     QgsDebugMsg( "Done creating fields" );
   }
-  return QgsVectorLayerImport::NoError;
+  return QgsVectorLayerExporter::NoError;
 }
 
 QgsCoordinateReferenceSystem QgsPostgresProvider::crs() const
@@ -4285,7 +4285,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
 
 // ---------------------------------------------------------------------------
 
-QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
+QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
   const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -20,7 +20,7 @@
 
 #include "qgsvectordataprovider.h"
 #include "qgsrectangle.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgspostgresconn.h"
 #include "qgsfields.h"
 #include <memory>
@@ -55,7 +55,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      * field names to lowercase), dropStringConstraints (set to true to remove
      * length constraints on character fields).
      */
-    static QgsVectorLayerImport::ImportError createEmptyLayer(
+    static QgsVectorLayerExporter::ExportError createEmptyLayer(
       const QString &uri,
       const QgsFields &fields,
       QgsWkbTypes::Type wkbType,

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -20,7 +20,7 @@
 
 #include "qgslogger.h"
 #include "qgsmimedatautils.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsmessageoutput.h"
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
@@ -227,12 +227,12 @@ bool QgsSLConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction )
     {
       destUri.setDataSource( QString(), u.name, srcLayer->geometryType() != QgsWkbTypes::NullGeometry ? QStringLiteral( "geom" ) : QString() );
       QgsDebugMsg( "URI " + destUri.uri() );
-      QgsVectorLayerImport::ImportError err;
+      QgsVectorLayerExporter::ExportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, destUri.uri(), QStringLiteral( "spatialite" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
-      if ( err == QgsVectorLayerImport::NoError )
+      err = QgsVectorLayerExporter::exportLayer( srcLayer, destUri.uri(), QStringLiteral( "spatialite" ), srcLayer->crs(), false, &importError, false, nullptr, progress );
+      if ( err == QgsVectorLayerExporter::NoError )
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
-      else if ( err == QgsVectorLayerImport::ErrUserCanceled )
+      else if ( err == QgsVectorLayerExporter::ErrUserCanceled )
         canceled = true;
       else
       {

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -24,7 +24,7 @@ email                : a.furieri@lqt.it
 #include "qgscoordinatereferencesystem.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsslconnect.h"
 #include "qgsspatialiteprovider.h"
 #include "qgsspatialiteconnpool.h"
@@ -111,7 +111,7 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
 }
 
 
-QgsVectorLayerImport::ImportError
+QgsVectorLayerExporter::ExportError
 QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
     const QgsFields &fields,
     QgsWkbTypes::Type wkbType,
@@ -151,7 +151,7 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
       QgsDebugMsg( "Connection to database failed. Import of layer aborted." );
       if ( errorMessage )
         *errorMessage = QObject::tr( "Connection to database failed" );
-      return QgsVectorLayerImport::ErrConnectionFailed;
+      return QgsVectorLayerExporter::ErrConnectionFailed;
     }
 
     sqlite3 *sqliteHandle = handle->handle();
@@ -342,7 +342,7 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
       }
 
       QgsSqliteHandle::closeDb( handle );
-      return QgsVectorLayerImport::ErrCreateLayer;
+      return QgsVectorLayerExporter::ErrCreateLayer;
     }
 
     QgsSqliteHandle::closeDb( handle );
@@ -360,7 +360,7 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
                       .arg( tableName );
 
     delete provider;
-    return QgsVectorLayerImport::ErrInvalidLayer;
+    return QgsVectorLayerExporter::ErrInvalidLayer;
   }
 
   QgsDebugMsg( "layer loaded" );
@@ -395,7 +395,7 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
                           .arg( fld.name() );
 
         delete provider;
-        return QgsVectorLayerImport::ErrAttributeTypeUnsupported;
+        return QgsVectorLayerExporter::ErrAttributeTypeUnsupported;
       }
 
       QgsDebugMsg( "creating field #" + QString::number( fldIdx ) +
@@ -420,12 +420,12 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
         *errorMessage = QObject::tr( "creation of fields failed" );
 
       delete provider;
-      return QgsVectorLayerImport::ErrAttributeCreationFailed;
+      return QgsVectorLayerExporter::ErrAttributeCreationFailed;
     }
 
     QgsDebugMsg( "Done creating fields" );
   }
-  return QgsVectorLayerImport::NoError;
+  return QgsVectorLayerExporter::NoError;
 }
 
 
@@ -5268,7 +5268,7 @@ QGISEXTERN bool isProvider()
   return true;
 }
 
-QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
+QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
   const QString &uri,
   const QgsFields &fields,
   QgsWkbTypes::Type wkbType,

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -27,7 +27,7 @@ extern "C"
 
 #include "qgsvectordataprovider.h"
 #include "qgsrectangle.h"
-#include "qgsvectorlayerimport.h"
+#include "qgsvectorlayerexporter.h"
 #include "qgsfields.h"
 #include <list>
 #include <queue>
@@ -56,7 +56,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
 
   public:
     //! Import a vector layer into the database
-    static QgsVectorLayerImport::ImportError createEmptyLayer(
+    static QgsVectorLayerExporter::ExportError createEmptyLayer(
       const QString &uri,
       const QgsFields &fields,
       QgsWkbTypes::Type wkbType,

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -19,7 +19,7 @@ import tempfile
 import shutil
 from osgeo import gdal, ogr
 
-from qgis.core import QgsVectorLayer, QgsVectorLayerImport, QgsFeature, QgsGeometry, QgsRectangle, QgsSettings
+from qgis.core import QgsVectorLayer, QgsVectorLayerExporter, QgsFeature, QgsGeometry, QgsRectangle, QgsSettings
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.testing import start_app, unittest
 
@@ -416,8 +416,8 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         options['update'] = True
         options['driverName'] = 'GPKG'
         options['layerName'] = 'my_out_table'
-        err = QgsVectorLayerImport.importLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
-        self.assertEqual(err[0], QgsVectorLayerImport.NoError,
+        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
+        self.assertEqual(err[0], QgsVectorLayerExporter.NoError,
                          'unexpected import error {0}'.format(err))
         lyr = QgsVectorLayer(tmpfile + "|layername=my_out_table", "y", "ogr")
         self.assertTrue(lyr.isValid())
@@ -431,8 +431,8 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         features = None
 
         # Test overwriting without overwrite option
-        err = QgsVectorLayerImport.importLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
-        self.assertEqual(err[0], QgsVectorLayerImport.ErrCreateDataSource)
+        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
+        self.assertEqual(err[0], QgsVectorLayerExporter.ErrCreateDataSource)
 
         # Test overwriting
         lyr = QgsVectorLayer(uri, "x", "memory")
@@ -441,8 +441,8 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         f['f1'] = 3
         lyr.dataProvider().addFeatures([f])
         options['overwrite'] = True
-        err = QgsVectorLayerImport.importLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
-        self.assertEqual(err[0], QgsVectorLayerImport.NoError,
+        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
+        self.assertEqual(err[0], QgsVectorLayerExporter.NoError,
                          'unexpected import error {0}'.format(err))
         lyr = QgsVectorLayer(tmpfile + "|layername=my_out_table", "y", "ogr")
         self.assertTrue(lyr.isValid())

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -416,7 +416,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         options['update'] = True
         options['driverName'] = 'GPKG'
         options['layerName'] = 'my_out_table'
-        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
+        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, options)
         self.assertEqual(err[0], QgsVectorLayerExporter.NoError,
                          'unexpected import error {0}'.format(err))
         lyr = QgsVectorLayer(tmpfile + "|layername=my_out_table", "y", "ogr")
@@ -431,7 +431,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         features = None
 
         # Test overwriting without overwrite option
-        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
+        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, options)
         self.assertEqual(err[0], QgsVectorLayerExporter.ErrCreateDataSource)
 
         # Test overwriting
@@ -441,7 +441,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         f['f1'] = 3
         lyr.dataProvider().addFeatures([f])
         options['overwrite'] = True
-        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, False, options)
+        err = QgsVectorLayerExporter.exportLayer(lyr, tmpfile, "ogr", lyr.crs(), False, options)
         self.assertEqual(err[0], QgsVectorLayerExporter.NoError,
                          'unexpected import error {0}'.format(err))
         lyr = QgsVectorLayer(tmpfile + "|layername=my_out_table", "y", "ogr")

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -20,7 +20,7 @@ import os
 
 from qgis.core import (
     QgsVectorLayer,
-    QgsVectorLayerImport,
+    QgsVectorLayerExporter,
     QgsFeatureRequest,
     QgsFeature,
     QgsFieldConstraints,
@@ -600,8 +600,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         lyr.dataProvider().addFeatures([f])
         uri = '%s table="qgis_test"."b18155" (g) key=\'f1\'' % (self.dbconn)
         self.execSQLCommand('DROP TABLE IF EXISTS qgis_test.b18155')
-        err = QgsVectorLayerImport.importLayer(lyr, uri, "postgres", lyr.crs())
-        self.assertEqual(err[0], QgsVectorLayerImport.NoError,
+        err = QgsVectorLayerExporter.exportLayer(lyr, uri, "postgres", lyr.crs())
+        self.assertEqual(err[0], QgsVectorLayerExporter.NoError,
                          'unexpected import error {0}'.format(err))
         lyr = QgsVectorLayer(uri, "y", "postgres")
         self.assertTrue(lyr.isValid())
@@ -623,8 +623,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             uri = '%s table="qgis_test"."import_test" (g)' % self.dbconn
             if key is not None:
                 uri += ' key=\'%s\'' % key
-            err = QgsVectorLayerImport.importLayer(lyr, uri, "postgres", lyr.crs())
-            self.assertEqual(err[0], QgsVectorLayerImport.NoError,
+            err = QgsVectorLayerExporter.exportLayer(lyr, uri, "postgres", lyr.crs())
+            self.assertEqual(err[0], QgsVectorLayerExporter.NoError,
                              'unexpected import error {0}'.format(err))
             olyr = QgsVectorLayer(uri, "y", "postgres")
             self.assertTrue(olyr.isValid())


### PR DESCRIPTION
This PR implements both a bunch of cleanups to QgsVectorLayerImport and a new feature.

1. Renames QgsVectorLayerImport to QgsVectorLayerExporter. Since the majority of users of this class will be exporting an existing map layer to a data provider, the QgsVectorLayerImport name is misleading and suggests that this class is designed just to bring layers "into" QGIS. Explicitly naming the class "Exporter" should help API users discover this class.

2. Removed a bunch of unused API calls from QgsVectorLayerExporter, improved docs

3. Flips the drag and drop import of layers to browser data sources to use task manager, allowing these slow imports to occur in the background.