### PR TITLE
New API for traversal of geometry's vertices using iterator pattern

### DIFF
--- a/python/core/geometry/qgsabstractgeometry.sip
+++ b/python/core/geometry/qgsabstractgeometry.sip
@@ -459,6 +459,38 @@ QgsMultiLineString -> QgsMultiCurve, QgsMultiPolygonV2 -> QgsMultiSurface
  :rtype: bool
 %End
 
+
+    QgsVertexIterator vertices() const;
+%Docstring
+.. versionadded:: 3.0
+ :rtype: QgsVertexIterator
+%End
+
+  protected:
+    virtual bool hasChildGeometries() const;
+%Docstring
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
+    virtual int childCount() const;
+%Docstring
+.. versionadded:: 3.0
+ :rtype: int
+%End
+
+    virtual QgsAbstractGeometry *childGeometry( int index ) const;
+%Docstring
+.. versionadded:: 3.0
+ :rtype: QgsAbstractGeometry
+%End
+
+    virtual QgsPointV2 childPoint( int index ) const;
+%Docstring
+.. versionadded:: 3.0
+ :rtype: QgsPointV2
+%End
+
   protected:
 
     void setZMTypeFromSubGeometry( const QgsAbstractGeometry *subggeom, QgsWkbTypes::Type baseGeomType );
@@ -523,6 +555,52 @@ struct QgsVertexId
   int ring;
   int vertex;
   VertexType type;
+};
+
+
+class QgsVertexIterator
+{
+%Docstring
+ Java-style iterator for traversal of vertices of a geometry
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsabstractgeometry.h"
+%End
+  public:
+    QgsVertexIterator();
+
+    QgsVertexIterator( const QgsAbstractGeometry *geometry );
+
+    bool hasNext() const;
+%Docstring
+Find out whether there are more vertices
+ :rtype: bool
+%End
+
+    QgsPointV2 next();
+%Docstring
+Return next vertex of the geometry (undefined behavior if hasNext() returns false before calling next())
+ :rtype: QgsPointV2
+%End
+
+    QgsVertexIterator *__iter__();
+%Docstring
+ :rtype: QgsVertexIterator
+%End
+%MethodCode
+    sipRes = sipCpp;
+%End
+
+    SIP_PYOBJECT __next__();
+%MethodCode
+    if ( sipCpp->hasNext() )
+      sipRes = sipConvertFromType( new QgsPointV2( sipCpp->next() ), sipType_QgsPointV2, Py_None );
+    else
+      PyErr_SetString( PyExc_StopIteration, "" );
+%End
+
 };
 
 /************************************************************************

--- a/python/core/geometry/qgscurve.sip
+++ b/python/core/geometry/qgscurve.sip
@@ -159,13 +159,7 @@ class QgsCurve: QgsAbstractGeometry
   protected:
 
     virtual int childCount() const;
-%Docstring
- :rtype: int
-%End
     virtual QgsPointV2 childPoint( int index ) const;
-%Docstring
- :rtype: QgsPointV2
-%End
 
     virtual void clearCache() const;
 

--- a/python/core/geometry/qgscurve.sip
+++ b/python/core/geometry/qgscurve.sip
@@ -158,6 +158,15 @@ class QgsCurve: QgsAbstractGeometry
 
   protected:
 
+    virtual int childCount() const;
+%Docstring
+ :rtype: int
+%End
+    virtual QgsPointV2 childPoint( int index ) const;
+%Docstring
+ :rtype: QgsPointV2
+%End
+
     virtual void clearCache() const;
 
 };

--- a/python/core/geometry/qgscurvepolygon.sip
+++ b/python/core/geometry/qgscurvepolygon.sip
@@ -164,13 +164,7 @@ Adds an interior ring to the geometry (takes ownership)
 
   protected:
     virtual int childCount() const;
-%Docstring
- :rtype: int
-%End
     virtual QgsAbstractGeometry *childGeometry( int index ) const;
-%Docstring
- :rtype: QgsAbstractGeometry
-%End
 
   protected:
 

--- a/python/core/geometry/qgscurvepolygon.sip
+++ b/python/core/geometry/qgscurvepolygon.sip
@@ -163,6 +163,16 @@ Adds an interior ring to the geometry (takes ownership)
     virtual bool dropMValue();
 
   protected:
+    virtual int childCount() const;
+%Docstring
+ :rtype: int
+%End
+    virtual QgsAbstractGeometry *childGeometry( int index ) const;
+%Docstring
+ :rtype: QgsAbstractGeometry
+%End
+
+  protected:
 
 
     virtual QgsRectangle calculateBoundingBox() const;

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -224,6 +224,13 @@ Returns true if WKB of the geometry is of WKBMulti* type
  :rtype: float
 %End
 
+
+    QgsVertexIterator vertices() const;
+%Docstring
+.. versionadded:: 3.0
+ :rtype: QgsVertexIterator
+%End
+
     QgsPoint closestVertex( const QgsPoint &point, int &atVertex /Out/, int &beforeVertex /Out/, int &afterVertex /Out/, double &sqrDist /Out/ ) const;
 %Docstring
  :rtype: QgsPoint

--- a/python/core/geometry/qgsgeometrycollection.sip
+++ b/python/core/geometry/qgsgeometrycollection.sip
@@ -142,6 +142,16 @@ Adds a geometry and takes ownership. Returns true in case of success.
     virtual bool dropMValue();
 
   protected:
+    virtual int childCount() const;
+%Docstring
+ :rtype: int
+%End
+    virtual QgsAbstractGeometry *childGeometry( int index ) const;
+%Docstring
+ :rtype: QgsAbstractGeometry
+%End
+
+  protected:
 
     virtual bool wktOmitChildType() const;
 %Docstring

--- a/python/core/geometry/qgsgeometrycollection.sip
+++ b/python/core/geometry/qgsgeometrycollection.sip
@@ -143,13 +143,7 @@ Adds a geometry and takes ownership. Returns true in case of success.
 
   protected:
     virtual int childCount() const;
-%Docstring
- :rtype: int
-%End
     virtual QgsAbstractGeometry *childGeometry( int index ) const;
-%Docstring
- :rtype: QgsAbstractGeometry
-%End
 
   protected:
 

--- a/python/core/geometry/qgspointv2.sip
+++ b/python/core/geometry/qgspointv2.sip
@@ -366,13 +366,7 @@ class QgsPointV2: QgsAbstractGeometry
 
   protected:
     virtual int childCount() const;
-%Docstring
- :rtype: int
-%End
     virtual QgsPointV2 childPoint( int index ) const;
-%Docstring
- :rtype: QgsPointV2
-%End
 
 };
 

--- a/python/core/geometry/qgspointv2.sip
+++ b/python/core/geometry/qgspointv2.sip
@@ -364,6 +364,16 @@ class QgsPointV2: QgsAbstractGeometry
     virtual bool convertTo( QgsWkbTypes::Type type );
 
 
+  protected:
+    virtual int childCount() const;
+%Docstring
+ :rtype: int
+%End
+    virtual QgsPointV2 childPoint( int index ) const;
+%Docstring
+ :rtype: QgsPointV2
+%End
+
 };
 
 /************************************************************************

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -151,3 +151,16 @@ void QgsCurve::clearCache() const
   QgsAbstractGeometry::clearCache();
 }
 
+int QgsCurve::childCount() const
+{
+  return numPoints();
+}
+
+QgsPointV2 QgsCurve::childPoint( int index ) const
+{
+  QgsPointV2 point;
+  QgsVertexId::VertexType type;
+  bool res = pointAt( index, point, type );
+  Q_ASSERT( res );
+  return point;
+}

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -139,8 +139,8 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry
 
     virtual void clearCache() const override;
 
-    virtual int childCount() const;
-    virtual QgsPointV2 childPoint( int index ) const;
+    virtual int childCount() const override;
+    virtual QgsPointV2 childPoint( int index ) const override;
 
   private:
 

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -139,6 +139,9 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry
 
     virtual void clearCache() const override;
 
+    virtual int childCount() const;
+    virtual QgsPointV2 childPoint( int index ) const;
+
   private:
 
     mutable QgsRectangle mBoundingBox;

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -925,3 +925,16 @@ bool QgsCurvePolygon::dropMValue()
   clearCache();
   return true;
 }
+
+int QgsCurvePolygon::childCount() const
+{
+  return 1 + mInteriorRings.count();
+}
+
+QgsAbstractGeometry *QgsCurvePolygon::childGeometry( int index ) const
+{
+  if ( index == 0 )
+    return mExteriorRing;
+  else
+    return mInteriorRings.at( index - 1 );
+}

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -141,6 +141,10 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     virtual bool dropMValue() override;
 
   protected:
+    virtual int childCount() const;
+    virtual QgsAbstractGeometry *childGeometry( int index ) const;
+
+  protected:
 
     QgsCurve *mExteriorRing = nullptr;
     QList<QgsCurve *> mInteriorRings;

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -141,8 +141,8 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     virtual bool dropMValue() override;
 
   protected:
-    virtual int childCount() const;
-    virtual QgsAbstractGeometry *childGeometry( int index ) const;
+    virtual int childCount() const override;
+    virtual QgsAbstractGeometry *childGeometry( int index ) const override;
 
   protected:
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1399,6 +1399,27 @@ double QgsGeometry::distance( const QgsGeometry &geom ) const
   return g.distance( *( geom.d->geometry ) );
 }
 
+QgsAbstractGeometry::vertex_iterator QgsGeometry::vertices_begin() const
+{
+  if ( !d->geometry )
+    return QgsAbstractGeometry::vertex_iterator();
+  return d->geometry->vertices_begin();
+}
+
+QgsAbstractGeometry::vertex_iterator QgsGeometry::vertices_end() const
+{
+  if ( !d->geometry )
+    return QgsAbstractGeometry::vertex_iterator();
+  return d->geometry->vertices_end();
+}
+
+QgsVertexIterator QgsGeometry::vertices() const
+{
+  if ( !d->geometry )
+    return QgsVertexIterator();
+  return QgsVertexIterator( d->geometry );
+}
+
 QgsGeometry QgsGeometry::buffer( double distance, int segments ) const
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -240,6 +240,20 @@ class CORE_EXPORT QgsGeometry
      */
     double distance( const QgsGeometry &geom ) const;
 
+#ifndef SIP_RUN
+    //! Returns STL-style iterator pointing to the first vertex of the geometry
+    //! \since QGIS 3.0
+    QgsAbstractGeometry::vertex_iterator vertices_begin() const;
+
+    //! Returns STL-style iterator pointing to the imaginary vertex after the last vertex of the geometry
+    //! \since QGIS 3.0
+    QgsAbstractGeometry::vertex_iterator vertices_end() const;
+#endif
+
+    //! Returns Java-style iterator for traversal of vertices of the geometry
+    //! \since QGIS 3.0
+    QgsVertexIterator vertices() const;
+
     /**
      * Returns the vertex closest to the given point, the corresponding vertex index, squared distance snap point / target point
      * and the indices of the vertices before and after the closest vertex.

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -702,3 +702,13 @@ bool QgsGeometryCollection::wktOmitChildType() const
 {
   return false;
 }
+
+int QgsGeometryCollection::childCount() const
+{
+  return mGeometries.count();
+}
+
+QgsAbstractGeometry *QgsGeometryCollection::childGeometry( int index ) const
+{
+  return mGeometries.at( index );
+}

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -136,8 +136,8 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     virtual bool dropMValue() override;
 
   protected:
-    virtual int childCount() const;
-    virtual QgsAbstractGeometry *childGeometry( int index ) const;
+    virtual int childCount() const override;
+    virtual QgsAbstractGeometry *childGeometry( int index ) const override;
 
   protected:
     QVector< QgsAbstractGeometry * > mGeometries;

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -136,6 +136,10 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     virtual bool dropMValue() override;
 
   protected:
+    virtual int childCount() const;
+    virtual QgsAbstractGeometry *childGeometry( int index ) const;
+
+  protected:
     QVector< QgsAbstractGeometry * > mGeometries;
 
     /** Returns whether child type names are omitted from Wkt representations of the collection

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -527,3 +527,14 @@ QgsPointV2 QgsPointV2::project( double distance, double azimuth, double inclinat
 
   return QgsPointV2( pType, mX + dx, mY + dy, mZ + dz, mM );
 }
+
+int QgsPointV2::childCount() const
+{
+  return 1;
+}
+
+QgsPointV2 QgsPointV2::childPoint( int index ) const
+{
+  Q_ASSERT( index == 0 );
+  return *this;
+}

--- a/src/core/geometry/qgspointv2.h
+++ b/src/core/geometry/qgspointv2.h
@@ -357,6 +357,10 @@ class CORE_EXPORT QgsPointV2: public QgsAbstractGeometry
     virtual bool dropMValue() override;
     bool convertTo( QgsWkbTypes::Type type ) override;
 
+  protected:
+    virtual int childCount() const;
+    virtual QgsPointV2 childPoint( int index ) const;
+
   private:
     double mX;
     double mY;

--- a/src/core/geometry/qgspointv2.h
+++ b/src/core/geometry/qgspointv2.h
@@ -358,8 +358,8 @@ class CORE_EXPORT QgsPointV2: public QgsAbstractGeometry
     bool convertTo( QgsWkbTypes::Type type ) override;
 
   protected:
-    virtual int childCount() const;
-    virtual QgsPointV2 childPoint( int index ) const;
+    virtual int childCount() const override;
+    virtual QgsPointV2 childPoint( int index ) const override;
 
   private:
     double mX;

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -2202,7 +2202,7 @@ void TestQgsGeometry::lineString()
   QgsAbstractGeometry::vertex_iterator it1 = l32.vertices_begin();
   QCOMPARE( it1, l32.vertices_end() );
 
-  // Java-style iterator on emtpy linetring
+  // Java-style iterator on empty linetring
   QgsVertexIterator it1x( &l32 );
   QVERIFY( !it1x.hasNext() );
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -69,6 +69,7 @@ class TestQgsGeometry : public QObject
     void asVariant(); //test conversion to and from a QVariant
     void isEmpty();
     void operatorBool();
+    void vertexIterator();
 
     // geometry types
     void point(); //test QgsPointV2
@@ -406,6 +407,23 @@ void TestQgsGeometry::operatorBool()
   QVERIFY( !geom );
 }
 
+void TestQgsGeometry::vertexIterator()
+{
+  QgsGeometry geom;
+  QgsVertexIterator it = geom.vertices();
+  QVERIFY( !it.hasNext() );
+
+  QgsPolyline polyline;
+  polyline << QgsPoint( 1, 2 ) << QgsPoint( 3, 4 );
+  QgsGeometry geom2 = QgsGeometry::fromPolyline( polyline );
+  QgsVertexIterator it2 = geom2.vertices();
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 1, 2 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 3, 4 ) );
+  QVERIFY( !it2.hasNext() );
+}
+
 void TestQgsGeometry::point()
 {
   //test QgsPointV2
@@ -720,6 +738,20 @@ void TestQgsGeometry::point()
   QVERIFY( p21.nextVertex( v, p22 ) );
   QCOMPARE( p22, p21 );
   QCOMPARE( v, QgsVertexId( 1, 0, 0 ) );
+
+  // vertex iterator
+  QgsAbstractGeometry::vertex_iterator it1 = p21.vertices_begin();
+  QgsAbstractGeometry::vertex_iterator it1end = p21.vertices_end();
+  QCOMPARE( *it1, p21 );
+  QCOMPARE( it1.vertexId(), QgsVertexId( 0, 0, 0 ) );
+  ++it1;
+  QCOMPARE( it1, it1end );
+
+  // Java-style iterator
+  QgsVertexIterator it2( &p21 );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), p21 );
+  QVERIFY( !it2.hasNext() );
 
   //vertexAt - will always be same as point
   QCOMPARE( p21.vertexAt( QgsVertexId() ), p21 );
@@ -2165,6 +2197,15 @@ void TestQgsGeometry::lineString()
   QVERIFY( !l32.nextVertex( v, p ) );
   v = QgsVertexId( 0, 0, 10 );
   QVERIFY( !l32.nextVertex( v, p ) );
+
+  // vertex iterator on empty linestring
+  QgsAbstractGeometry::vertex_iterator it1 = l32.vertices_begin();
+  QCOMPARE( it1, l32.vertices_end() );
+
+  // Java-style iterator on emtpy linetring
+  QgsVertexIterator it1x( &l32 );
+  QVERIFY( !it1x.hasNext() );
+
   //LineString
   l32.setPoints( QgsPointSequence() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   v = QgsVertexId( 0, 0, 2 ); //out of range
@@ -2187,6 +2228,24 @@ void TestQgsGeometry::lineString()
   QVERIFY( l32.nextVertex( v, p ) );
   QCOMPARE( v, QgsVertexId( 1, 0, 1 ) ); //test that part number is maintained
   QCOMPARE( p, QgsPointV2( 11, 12 ) );
+
+  // vertex iterator
+  QgsAbstractGeometry::vertex_iterator it2 = l32.vertices_begin();
+  QCOMPARE( *it2, QgsPointV2( 1, 2 ) );
+  QCOMPARE( it2.vertexId(), QgsVertexId( 0, 0, 0 ) );
+  ++it2;
+  QCOMPARE( *it2, QgsPointV2( 11, 12 ) );
+  QCOMPARE( it2.vertexId(), QgsVertexId( 0, 0, 1 ) );
+  ++it2;
+  QCOMPARE( it2, l32.vertices_end() );
+
+  // Java-style iterator
+  QgsVertexIterator it2x( &l32 );
+  QVERIFY( it2x.hasNext() );
+  QCOMPARE( it2x.next(), QgsPointV2( 1, 2 ) );
+  QVERIFY( it2x.hasNext() );
+  QCOMPARE( it2x.next(), QgsPointV2( 11, 12 ) );
+  QVERIFY( !it2x.hasNext() );
 
   //LineStringZ
   l32.setPoints( QgsPointSequence() << QgsPointV2( QgsWkbTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWkbTypes::PointZ, 11, 12, 13 ) );
@@ -4433,6 +4492,25 @@ void TestQgsGeometry::multiPoint()
   QgsVertexId after;
   // return error - points have no segments
   QVERIFY( boundaryMP.closestSegment( QgsPointV2( 0.5, 0.5 ), closest, after, 0, 0 ) < 0 );
+
+  // vertex iterator
+  QgsAbstractGeometry::vertex_iterator it = boundaryMP.vertices_begin();
+  QgsAbstractGeometry::vertex_iterator itEnd = boundaryMP.vertices_end();
+  QCOMPARE( *it, QgsPointV2( 0, 0 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 0 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 1, 1 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 0 ) );
+  ++it;
+  QCOMPARE( it, itEnd );
+
+  // Java-style iterator
+  QgsVertexIterator it2( &boundaryMP );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 0, 0 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 1, 1 ) );
+  QVERIFY( !it2.hasNext() );
 }
 
 void TestQgsGeometry::multiLineString()
@@ -4469,6 +4547,45 @@ void TestQgsGeometry::multiLineString()
   QCOMPARE( static_cast< QgsPointV2 *>( mpBoundary->geometryN( 3 ) )->x(), 11.0 );
   QCOMPARE( static_cast< QgsPointV2 *>( mpBoundary->geometryN( 3 ) )->y(), 11.0 );
   delete boundary;
+
+  // vertex iterator: 2 linestrings with 3 points each
+  QgsAbstractGeometry::vertex_iterator it = multiLine1.vertices_begin();
+  QgsAbstractGeometry::vertex_iterator itEnd = multiLine1.vertices_end();
+  QCOMPARE( *it, QgsPointV2( 0, 0 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 0 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 1, 0 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 1 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 1, 1 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 2 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10, 10 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 0 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 11, 10 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 1 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 11, 11 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 2 ) );
+  ++it;
+  QCOMPARE( it, itEnd );
+
+  // Java-style iterator
+  QgsVertexIterator it2( &multiLine1 );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 0, 0 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 1, 0 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 1, 1 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10, 10 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 11, 10 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 11, 11 ) );
+  QVERIFY( !it2.hasNext() );
 
   // add a closed string = no boundary
   QgsLineString boundaryLine3;
@@ -4558,6 +4675,102 @@ void TestQgsGeometry::multiPolygon()
   boundaryRing2.setPoints( QList<QgsPointV2>() << QgsPointV2( 10.8, 10.8 ) << QgsPointV2( 10.9, 10.8 ) << QgsPointV2( 10.9, 10.9 )  << QgsPointV2( 10.8, 10.8 ) );
   polygon2.setInteriorRings( QList< QgsCurve * >() << boundaryRing1.clone() << boundaryRing2.clone() );
   multiPolygon1.addGeometry( polygon2.clone() );
+
+  // vertex iterator: 2 polygons (one with just exterior ring, other with two interior rings)
+  QgsAbstractGeometry::vertex_iterator it = multiPolygon1.vertices_begin();
+  QgsAbstractGeometry::vertex_iterator itEnd = multiPolygon1.vertices_end();
+  QCOMPARE( *it, QgsPointV2( 0, 0 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 0 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 1, 0 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 1 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 1, 1 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 2 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 0, 0 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 0, 0, 3 ) );
+  ++it;
+  // 2nd polygon - exterior ring
+  QCOMPARE( *it, QgsPointV2( 10, 10 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 0 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 11, 10 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 1 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 11, 11 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 2 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10, 10 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 0, 3 ) );
+  ++it;
+  // 2nd polygon - 1st interior ring
+  QCOMPARE( *it, QgsPointV2( 10.1, 10.1 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 1, 0 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10.2, 10.1 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 1, 1 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10.2, 10.2 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 1, 2 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10.1, 10.1 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 1, 3 ) );
+  ++it;
+  // 2nd polygon - 2nd interior ring
+  QCOMPARE( *it, QgsPointV2( 10.8, 10.8 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 2, 0 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10.9, 10.8 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 2, 1 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10.9, 10.9 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 2, 2 ) );
+  ++it;
+  QCOMPARE( *it, QgsPointV2( 10.8, 10.8 ) );
+  QCOMPARE( it.vertexId(), QgsVertexId( 1, 2, 3 ) );
+  ++it;
+  // done!
+  QCOMPARE( it, itEnd );
+
+  // Java-style iterator
+  QgsVertexIterator it2( &multiPolygon1 );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 0, 0 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 1, 0 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 1, 1 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 0, 0 ) );
+  QVERIFY( it2.hasNext() );
+  // 2nd polygon - exterior ring
+  QCOMPARE( it2.next(), QgsPointV2( 10, 10 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 11, 10 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 11, 11 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10, 10 ) );
+  QVERIFY( it2.hasNext() );
+  // 2nd polygon - 1st interior ring
+  QCOMPARE( it2.next(), QgsPointV2( 10.1, 10.1 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10.2, 10.1 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10.2, 10.2 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10.1, 10.1 ) );
+  QVERIFY( it2.hasNext() );
+  // 2nd polygon - 2nd interior ring
+  QCOMPARE( it2.next(), QgsPointV2( 10.8, 10.8 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10.9, 10.8 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10.9, 10.9 ) );
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next(), QgsPointV2( 10.8, 10.8 ) );
+  QVERIFY( !it2.hasNext() );
 
   boundary = multiPolygon1.boundary();
   QgsMultiLineString *multiLineBoundary = dynamic_cast< QgsMultiLineString * >( boundary );

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -79,6 +79,14 @@ class TestQgsGeometry(unittest.TestCase):
         g = QgsGeometry.fromWkt('MultiPoint ()')
         self.assertTrue(g.isEmpty())
 
+    def testVertexIterator(self):
+        g = QgsGeometry.fromWkt('Linestring(11 12, 13 14)')
+        it = g.vertices()
+        self.assertEqual(next(it), QgsPointV2(11, 12))
+        self.assertEqual(next(it), QgsPointV2(13, 14))
+        with self.assertRaises(StopIteration):
+            next(it)
+
     def testWktPointLoading(self):
         myWKT = 'Point (10 10)'
         myGeometry = QgsGeometry.fromWkt(myWKT)


### PR DESCRIPTION
Introducing:
1. STL-style iterator: QgsAbstractGeometry::vertex_iterator
2. Java-style iterator: QgsVertexIterator (built on top of STL-style)

The iterators are modeled after Qt's STL-style and Java-style iterators, the idea is to replace nextVertex() method and later introduce iterators for other bits (e.g. part_iterator, ring_iterator).
