### PR TITLE
Update north arrow decorator to use a vector graphic

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -45,6 +45,7 @@
         <file>icons/qgis-icon-60x60.png</file>
         <file>icons/qbrowser_icon.svg</file>
         <file>north_arrows/default.png</file>
+        <file>north_arrows/default.svg</file>
         <file>north_arrows/gpsarrow.svg</file>
         <file>north_arrows/gpsarrow2.svg</file>
         <file>splash/splash.png</file>

--- a/images/north_arrows/default.svg
+++ b/images/north_arrows/default.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933333"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="default.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.919596"
+     inkscape:cx="-13.616663"
+     inkscape:cy="32.048127"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-194.92496,-185.30539)">
+    <path
+       style="fill:#000000;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
+       d="m 200.74579,192.05227 1.71507,2.46156 -1.71507,2.8301 2.68363,-1.83791 2.34346,1.83791 -1.30402,-2.61748 1.30402,-2.67418 -2.29621,1.96547 z"
+       id="path4519"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:#000000;stroke:#ffffff;stroke-width:0.39687499;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 203.39163,188.74498 -0.92605,5.15937 -5.42395,0.92604 5.42395,0.66146 0.92605,5.42396 0.92604,-5.42396 5.42396,-0.66146 -5.42396,-0.92604 z"
+       id="path4517"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <g
+       aria-label="N"
+       style="font-size:10.58333302px;line-height:52.91666412px;font-family:Delicious;-inkscape-font-specification:Delicious;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="text4523">
+      <path
+         d="m 202.41889,185.88618 h 0.58291 l 0.76068,1.11759 v -1.11759 h 0.58842 v 2.02021 h -0.58842 l -0.75654,-1.10932 v 1.10932 h -0.58705 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222223px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4486" />
+    </g>
+  </g>
+</svg>

--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -27,16 +27,18 @@ email                : tim@linfiniti.com
 #include "qgisapp.h"
 #include "qgsbearingutils.h"
 #include "qgscoordinatetransform.h"
+#include "qgscsexception.h"
+#include "qgslogger.h"
 #include "qgsmaplayer.h"
 #include "qgsproject.h"
-#include "qgslogger.h"
-#include "qgscsexception.h"
+#include "qgssvgcache.h"
 
 // qt includes
 #include <QPainter>
 #include <QMenu>
 #include <QDir>
 #include <QFile>
+#include <QSvgRenderer>
 
 //non qt includes
 #include <cmath>
@@ -101,14 +103,17 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
   //Large IF statement controlled by enable check box
   if ( enabled() )
   {
-    QPixmap myQPixmap; //to store the north arrow image in
+    QSize size( 64, 64 );
+    QSvgRenderer svg;
 
-    QString myFileNameQString = QStringLiteral( ":/images/north_arrows/default.png" );
+    const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( QStringLiteral( ":/images/north_arrows/default.svg" ), size.width(), QColor( "#000000" ), QColor( "#FFFFFF" ), 0.2, 1.0 );
+    svg.load( svgContent );
 
-    if ( myQPixmap.load( myFileNameQString ) )
+    if ( svg.isValid() )
     {
-      double centerXDouble = myQPixmap.width() / 2.0;
-      double centerYDouble = myQPixmap.height() / 2.0;
+      double centerXDouble = size.width() / 2.0;
+      double centerYDouble = size.width() / 2.0;
+
       //save the current canvas rotation
       context.painter()->save();
       //
@@ -161,8 +166,8 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
           break;
 
         case QgsUnitTypes::RenderPercentage:
-          myXOffset = ( ( myWidth - myQPixmap.width() ) / 100. ) * mMarginHorizontal;
-          myYOffset = ( ( myHeight - myQPixmap.height() ) / 100. ) * mMarginVertical;
+          myXOffset = ( ( myWidth - size.width() ) / 100. ) * mMarginHorizontal;
+          myYOffset = ( ( myHeight - size.width() ) / 100. ) * mMarginVertical;
           break;
 
         default:  // Use default of top left
@@ -172,17 +177,17 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
       switch ( mPlacement )
       {
         case BottomLeft:
-          context.painter()->translate( myXOffset, myHeight - myYOffset - myQPixmap.height() );
+          context.painter()->translate( myXOffset, myHeight - myYOffset - size.width() );
           break;
         case TopLeft:
           context.painter()->translate( myXOffset, myYOffset );
           break;
         case TopRight:
-          context.painter()->translate( myWidth - myXOffset - myQPixmap.width(), myYOffset );
+          context.painter()->translate( myWidth - myXOffset - size.width(), myYOffset );
           break;
         case BottomRight:
-          context.painter()->translate( myWidth - myXOffset - myQPixmap.width(),
-                                        myHeight - myYOffset - myQPixmap.height() );
+          context.painter()->translate( myWidth - myXOffset - size.width(),
+                                        myHeight - myYOffset - size.width() );
           break;
         default:
         {
@@ -193,8 +198,9 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
       //rotate the canvas by the north arrow rotation amount
       context.painter()->rotate( mRotationInt );
       //Now we can actually do the drawing, and draw a smooth north arrow even when rotated
-      context.painter()->setRenderHint( QPainter::SmoothPixmapTransform );
-      context.painter()->drawPixmap( xShift, yShift, myQPixmap );
+
+      context.painter()->translate( xShift, yShift );
+      svg.render( context.painter(), QRectF( 0, 0, size.width(), size.height() ) );
 
       //unrotate the canvas again
       context.painter()->restore();


### PR DESCRIPTION
## Description
This PR upgrades the north arrow decorator to rely on a vector graphic instead of a bitmap. This is needed to have nice vector north arrows when saving the canvas to PDF.

@nyalldawson , gentle ping.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
