### PR TITLE
Map decoration upgrades

### DIFF
--- a/images/north_arrows/default.svg
+++ b/images/north_arrows/default.svg
@@ -25,9 +25,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="7.919596"
-     inkscape:cx="-13.616663"
-     inkscape:cy="32.048127"
+     inkscape:zoom="11.2"
+     inkscape:cx="4.2981085"
+     inkscape:cy="49.312603"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -49,7 +49,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -59,25 +59,23 @@
      id="layer1"
      transform="translate(-194.92496,-185.30539)">
     <path
-       style="fill:#000000;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-       d="m 200.74579,192.05227 1.71507,2.46156 -1.71507,2.8301 2.68363,-1.83791 2.34346,1.83791 -1.30402,-2.61748 1.30402,-2.67418 -2.29621,1.96547 z"
+       fill="param(fill)" fill-opacity="param(fill-opacity)" stroke="param(outline)" stroke-opacity="param(outline-opacity)" stroke-width="param(outline-width)"
+       style="stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 203.39162,187.7025 -0.66089,5.47404 -2.37575,-1.90604 1.8478,2.60801 -5.67441,0.6873 5.67441,0.68536 -1.8478,2.60801 2.37575,-1.84456 0.66089,5.41433 0.65896,-5.41433 2.37575,1.84456 -1.84781,-2.60801 5.67636,-0.68536 -5.67636,-0.6873 1.84781,-2.60801 -2.37575,1.90604 z"
        id="path4519"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       style="fill:#000000;stroke:#ffffff;stroke-width:0.39687499;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
-       d="m 203.39163,188.74498 -0.92605,5.15937 -5.42395,0.92604 5.42395,0.66146 0.92605,5.42396 0.92604,-5.42396 5.42396,-0.66146 -5.42396,-0.92604 z"
-       id="path4517"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccc" />
+       sodipodi:nodetypes="ccccccccccccccccc" />
     <g
        aria-label="N"
-       style="font-size:10.58333302px;line-height:52.91666412px;font-family:Delicious;-inkscape-font-specification:Delicious;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="text4523">
+       style="font-size:10.58333302px;line-height:52.91666412px;font-family:Delicious;-inkscape-font-specification:Delicious;letter-spacing:0px;word-spacing:0px;fill:none;stroke:#000000;stroke-width:0.13229166;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="text4523"
+       transform="translate(0.00672731)">
       <path
+         fill="param(fill)" fill-opacity="param(fill-opacity)" stroke="param(outline)" stroke-opacity="param(outline-opacity)" stroke-width="param(outline-width)"
          d="m 202.41889,185.88618 h 0.58291 l 0.76068,1.11759 v -1.11759 h 0.58842 v 2.02021 h -0.58842 l -0.75654,-1.10932 v 1.10932 h -0.58705 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222223px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4486" />
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222223px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';stroke-miterlimit:4;stroke-dasharray:none;"
+         id="path4486"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
 </svg>

--- a/src/app/qgsdecorationcopyright.h
+++ b/src/app/qgsdecorationcopyright.h
@@ -54,8 +54,10 @@ class APP_EXPORT QgsDecorationCopyright : public QgsDecorationItem
     QFont mQFont;
     //! This is the string that will be used for the copyright label
     QString mLabelQString;
+
     //! This is the color for the copyright label
-    QColor mLabelQColor;
+    QColor mColor;
+
     //! enable or disable use of position percentage for placement
     int mMarginHorizontal;
     int mMarginVertical;

--- a/src/app/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/qgsdecorationcopyrightdialog.cpp
@@ -50,13 +50,14 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   wgtUnitSelection->setUnit( mDeco.mMarginUnit );
 
   // color
-  pbnColorChooser->setColor( mDeco.mLabelQColor );
+  pbnColorChooser->setAllowAlpha( true );
+  pbnColorChooser->setColor( mDeco.mColor );
   pbnColorChooser->setContext( QStringLiteral( "gui" ) );
   pbnColorChooser->setColorDialogTitle( tr( "Select text color" ) );
 
   QTextCursor cursor = txtCopyrightText->textCursor();
   txtCopyrightText->selectAll();
-  txtCopyrightText->setTextColor( mDeco.mLabelQColor );
+  txtCopyrightText->setTextColor( mDeco.mColor );
   txtCopyrightText->setTextCursor( cursor );
 }
 
@@ -89,7 +90,7 @@ void QgsDecorationCopyrightDialog::apply()
 {
   mDeco.mQFont = txtCopyrightText->currentFont();
   mDeco.mLabelQString = txtCopyrightText->toPlainText();
-  mDeco.mLabelQColor = pbnColorChooser->color();
+  mDeco.mColor = pbnColorChooser->color();
   mDeco.setPlacement( static_cast< QgsDecorationItem::Placement>( cboPlacement->currentData().toInt() ) );
   mDeco.mMarginUnit = wgtUnitSelection->unit();
   mDeco.mMarginHorizontal = spnHorizontal->value();

--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -31,6 +31,7 @@ email                : tim@linfiniti.com
 #include "qgslogger.h"
 #include "qgsmaplayer.h"
 #include "qgsproject.h"
+#include "qgssymbollayerutils.h"
 #include "qgssvgcache.h"
 
 // qt includes
@@ -75,6 +76,8 @@ QgsDecorationNorthArrow::~QgsDecorationNorthArrow()
 void QgsDecorationNorthArrow::projectRead()
 {
   QgsDecorationItem::projectRead();
+  mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
+  mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
   mRotationInt = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/Rotation" ), 0 );
   mAutomatic = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Automatic" ), true );
   mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
@@ -84,6 +87,8 @@ void QgsDecorationNorthArrow::projectRead()
 void QgsDecorationNorthArrow::saveToProject()
 {
   QgsDecorationItem::saveToProject();
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Rotation" ), mRotationInt );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Automatic" ), mAutomatic );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
@@ -106,7 +111,7 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
     QSize size( 64, 64 );
     QSvgRenderer svg;
 
-    const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( QStringLiteral( ":/images/north_arrows/default.svg" ), size.width(), QColor( "#000000" ), QColor( "#FFFFFF" ), 0.2, 1.0 );
+    const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( QStringLiteral( ":/images/north_arrows/default.svg" ), size.width(), mColor, mOutlineColor, 1.0, 1.0 );
     svg.load( svgContent );
 
     if ( svg.isValid() )

--- a/src/app/qgsdecorationnortharrow.h
+++ b/src/app/qgsdecorationnortharrow.h
@@ -54,6 +54,11 @@ class APP_EXPORT QgsDecorationNorthArrow: public QgsDecorationItem
     //  static const double DEG2RAD;
     static const double TOL;
 
+    //! The north arrow fill color
+    QColor mColor;
+    //! The north arrow outline color
+    QColor mOutlineColor;
+
     // The amount of rotation for the north arrow
     int mRotationInt;
 

--- a/src/app/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/qgsdecorationnortharrowdialog.cpp
@@ -35,8 +35,6 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
   QPushButton *applyButton = buttonBox->button( QDialogButtonBox::Apply );
   connect( applyButton, &QAbstractButton::clicked, this, &QgsDecorationNorthArrowDialog::apply );
 
-  // rotation
-  rotatePixmap( mDeco.mRotationInt );
   // signal/slot connection defined in 'designer' causes the slider to
   // be moved to reflect the change in the spinbox.
   spinAngle->setValue( mDeco.mRotationInt );
@@ -57,6 +55,21 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
 
   // automatic
   cboxAutomatic->setChecked( mDeco.mAutomatic );
+
+  pbnChangeColor->setAllowAlpha( true );
+  pbnChangeColor->setColor( mDeco.mColor );
+  pbnChangeColor->setContext( QStringLiteral( "gui" ) );
+  pbnChangeColor->setColorDialogTitle( tr( "Select north arrow fill color" ) );
+
+  pbnChangeOutlineColor->setAllowAlpha( true );
+  pbnChangeOutlineColor->setColor( mDeco.mOutlineColor );
+  pbnChangeOutlineColor->setContext( QStringLiteral( "gui" ) );
+  pbnChangeOutlineColor->setColorDialogTitle( tr( "Select north arrow outline color" ) );
+
+  connect( pbnChangeColor, &QgsColorButton::colorChanged, this, [ = ]( QColor ) { drawNorthArrow(); } );
+  connect( pbnChangeOutlineColor, &QgsColorButton::colorChanged, this, [ = ]( QColor ) { drawNorthArrow(); } );
+
+  drawNorthArrow();
 }
 
 QgsDecorationNorthArrowDialog::~QgsDecorationNorthArrowDialog()
@@ -89,11 +102,15 @@ void QgsDecorationNorthArrowDialog::on_spinAngle_valueChanged( int spinAngle )
 
 void QgsDecorationNorthArrowDialog::on_sliderRotation_valueChanged( int rotationValue )
 {
-  rotatePixmap( rotationValue );
+  Q_UNUSED( rotationValue );
+
+  drawNorthArrow();
 }
 
 void QgsDecorationNorthArrowDialog::apply()
 {
+  mDeco.mColor = pbnChangeColor->color();
+  mDeco.mOutlineColor = pbnChangeOutlineColor->color();
   mDeco.mRotationInt = sliderRotation->value();
   mDeco.setPlacement( static_cast< QgsDecorationItem::Placement>( cboPlacement->currentData().toInt() ) );
   mDeco.mMarginUnit = wgtUnitSelection->unit();
@@ -104,12 +121,14 @@ void QgsDecorationNorthArrowDialog::apply()
   mDeco.update();
 }
 
-void QgsDecorationNorthArrowDialog::rotatePixmap( int rotationInt )
+void QgsDecorationNorthArrowDialog::drawNorthArrow()
 {
+  int rotation = spinAngle->value();
+
   QSize size( 64, 64 );
   QSvgRenderer svg;
 
-  const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( QStringLiteral( ":/images/north_arrows/default.svg" ), size.width(), QColor( "#000000" ), QColor( "#FFFFFF" ), 0.2, 1.0 );
+  const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( QStringLiteral( ":/images/north_arrows/default.svg" ), size.width(), pbnChangeColor->color(), pbnChangeOutlineColor->color(), 1.0, 1.0 );
   svg.load( svgContent );
 
   if ( svg.isValid() )
@@ -129,11 +148,11 @@ void QgsDecorationNorthArrowDialog::rotatePixmap( int rotationInt )
     //myQPainter.translate( (int)centerXDouble, (int)centerYDouble );
 
     //rotate the canvas
-    myQPainter.rotate( rotationInt );
+    myQPainter.rotate( rotation );
     //work out how to shift the image so that it appears in the center of the canvas
     //(x cos a + y sin a - x, -x sin a + y cos a - y)
     const double PI = 3.14159265358979323846;
-    double myRadiansDouble = ( PI / 180 ) * rotationInt;
+    double myRadiansDouble = ( PI / 180 ) * rotation;
     int xShift = static_cast<int>( (
                                      ( centerXDouble * cos( myRadiansDouble ) ) +
                                      ( centerYDouble * sin( myRadiansDouble ) )
@@ -175,5 +194,5 @@ void QgsDecorationNorthArrowDialog::rotatePixmap( int rotationInt )
 void QgsDecorationNorthArrowDialog::resizeEvent( QResizeEvent *resizeEvent )
 {
   Q_UNUSED( resizeEvent );
-  rotatePixmap( sliderRotation->value() );
+  drawNorthArrow();
 }

--- a/src/app/qgsdecorationnortharrowdialog.h
+++ b/src/app/qgsdecorationnortharrowdialog.h
@@ -26,7 +26,7 @@ class APP_EXPORT QgsDecorationNorthArrowDialog : public QDialog, private Ui::Qgs
     ~QgsDecorationNorthArrowDialog();
 
   private:
-    void rotatePixmap( int rotationInt );
+    void drawNorthArrow();
     void resizeEvent( QResizeEvent * ) override; //overloads qwidget
 
   private slots:

--- a/src/app/qgsdecorationscalebar.cpp
+++ b/src/app/qgsdecorationscalebar.cpp
@@ -33,6 +33,7 @@ email                : sbr00pwb@users.sourceforge.net
 #include "qgsproject.h"
 #include "qgsunittypes.h"
 #include "qgssettings.h"
+#include "qgssymbollayerutils.h"
 
 #include <QPainter>
 #include <QAction>
@@ -75,10 +76,8 @@ void QgsDecorationScaleBar::projectRead()
   mPreferredSize = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/PreferredSize" ), 30 );
   mStyleIndex = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/Style" ), 0 );
   mSnapping = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Snapping" ), true );
-  int myRedInt = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/ColorRedPart" ), 0 );
-  int myGreenInt = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/ColorGreenPart" ), 0 );
-  int myBlueInt = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/ColorBluePart" ), 0 );
-  mColor = QColor( myRedInt, myGreenInt, myBlueInt );
+  mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
+  mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
   mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
   mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
 }
@@ -89,9 +88,8 @@ void QgsDecorationScaleBar::saveToProject()
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/PreferredSize" ), mPreferredSize );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Snapping" ), mSnapping );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Style" ), mStyleIndex );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/ColorRedPart" ), mColor.red() );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/ColorGreenPart" ), mColor.green() );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/ColorBluePart" ), mColor.blue() );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
 }
@@ -311,7 +309,7 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
 
     //Set pen to draw with
     QPen myForegroundPen( mColor, 2 );
-    QPen myBackgroundPen( Qt::white, 4 );
+    QPen myBackgroundPen( mOutlineColor, 4 );
 
     //Cast myScaleBarWidth to int for drawing
     int myScaleBarWidthInt = static_cast< int >( myScaleBarWidth );
@@ -434,8 +432,8 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
     //Do drawing of scale bar text
     //
 
-    QColor myBackColor = Qt::white;
-    QColor myForeColor = Qt::black;
+    QColor myBackColor = mOutlineColor;
+    QColor myForeColor = mColor;
 
     //Draw the minimum label buffer
     context.painter()->setPen( myBackColor );

--- a/src/app/qgsdecorationscalebar.h
+++ b/src/app/qgsdecorationscalebar.h
@@ -58,8 +58,12 @@ class APP_EXPORT QgsDecorationScaleBar: public QgsDecorationItem
     //! Style of scale bar. An index and the translated text
     int mStyleIndex;
     QStringList mStyleLabels;
+
     //! The scale bar color
     QColor mColor;
+    //! The scale bar otuline color
+    QColor mOutlineColor;
+
     //! Margin percentage values
     int mMarginHorizontal;
     int mMarginVertical;

--- a/src/app/qgsdecorationscalebardialog.cpp
+++ b/src/app/qgsdecorationscalebardialog.cpp
@@ -71,9 +71,15 @@ QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar 
 
   cboStyle->setCurrentIndex( mDeco.mStyleIndex );
 
+  pbnChangeColor->setAllowAlpha( true );
   pbnChangeColor->setColor( mDeco.mColor );
   pbnChangeColor->setContext( QStringLiteral( "gui" ) );
-  pbnChangeColor->setColorDialogTitle( tr( "Select scalebar color" ) );
+  pbnChangeColor->setColorDialogTitle( tr( "Select scale bar fill color" ) );
+
+  pbnChangeOutlineColor->setAllowAlpha( true );
+  pbnChangeOutlineColor->setColor( mDeco.mOutlineColor );
+  pbnChangeOutlineColor->setContext( QStringLiteral( "gui" ) );
+  pbnChangeOutlineColor->setColorDialogTitle( tr( "Select scale bar outline color" ) );
 }
 
 QgsDecorationScaleBarDialog::~QgsDecorationScaleBarDialog()
@@ -98,6 +104,7 @@ void QgsDecorationScaleBarDialog::apply()
   mDeco.setEnabled( grpEnable->isChecked() );
   mDeco.mStyleIndex = cboStyle->currentIndex();
   mDeco.mColor = pbnChangeColor->color();
+  mDeco.mOutlineColor = pbnChangeOutlineColor->color();
   mDeco.update();
 }
 

--- a/src/ui/qgsdecorationnortharrowdialog.ui
+++ b/src/ui/qgsdecorationnortharrowdialog.ui
@@ -30,7 +30,76 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="2" colspan="3">
+      <item row="0" column="1">
+       <widget class="QLabel" name="textLabel1_3_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2" colspan="3">
+       <layout class="QHBoxLayout" name="colorLayout">
+        <item>
+         <widget class="QLabel" name="fillLabel">
+          <property name="text">
+           <string>Fill</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsColorButton" name="pbnChangeColor">
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>120</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="outlineLabel">
+          <property name="text">
+           <string>Outline</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsColorButton" name="pbnChangeOutlineColor">
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>120</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="2" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="labelHorizontal">
@@ -99,7 +168,7 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QLabel" name="textLabel6">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -121,7 +190,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="4">
+      <item row="1" column="4">
        <widget class="QSpinBox" name="spinAngle">
         <property name="maximum">
          <number>360</number>
@@ -134,7 +203,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QLabel" name="textLabel8">
         <property name="text">
          <string>Placement</string>
@@ -144,7 +213,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QLabel" name="lblMargin">
         <property name="minimumSize">
          <size>
@@ -157,14 +226,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2" colspan="3">
+      <item row="2" column="2" colspan="3">
        <widget class="QComboBox" name="cboPlacement">
         <property name="toolTip">
          <string>Placement on screen</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="2">
+      <item row="4" column="1" colspan="2">
        <widget class="QCheckBox" name="cboxAutomatic">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -192,7 +261,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -205,7 +274,7 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="2" colspan="2">
+      <item row="1" column="2" colspan="2">
        <widget class="QSlider" name="sliderRotation">
         <property name="toolTip">
          <string/>
@@ -224,7 +293,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" rowspan="4">
+      <item row="1" column="0" rowspan="4">
        <widget class="QLabel" name="pixmapLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -264,6 +333,12 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
@@ -277,6 +352,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>grpEnable</tabstop>
+  <tabstop>pbnChangeColor</tabstop>
   <tabstop>sliderRotation</tabstop>
   <tabstop>spinAngle</tabstop>
   <tabstop>cboPlacement</tabstop>

--- a/src/ui/qgsdecorationscalebardialog.ui
+++ b/src/ui/qgsdecorationscalebardialog.ui
@@ -53,7 +53,14 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="3" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="colorLayout">
+        <item>
+         <widget class="QLabel" name="fillLabel">
+          <property name="text">
+           <string>Fill</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <widget class="QgsColorButton" name="pbnChangeColor">
           <property name="minimumSize">
@@ -74,17 +81,30 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         <widget class="QLabel" name="outlineLabel">
+          <property name="text">
+           <string>Outline</string>
           </property>
-          <property name="sizeHint" stdset="0">
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsColorButton" name="pbnChangeOutlineColor">
+          <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>150</width>
+            <height>0</height>
            </size>
           </property>
-         </spacer>
+          <property name="maximumSize">
+           <size>
+            <width>120</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
## Description
This PR adds the following features to map decorations:
- Fill and outline color (plus opacity) settings for north arrow decoration
- Outline color (as well as fill and outline opacity) settings for the scale bar decoration
- Color opacity setting for the copyright decorator

Screenshot:
![screenshot from 2017-05-09 11-14-33](https://cloud.githubusercontent.com/assets/1728657/25835492/653ef70c-34a9-11e7-8391-fa990cc66dab.png)
_Above screenshot showcases non-black north arrow, semi-transparent scale bar, semi-transparent copyright text_

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
