### PR TITLE
add missing ConvertToClassCode 

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -113,6 +113,8 @@ INCLUDE_DIRECTORIES(
   ../src/core/scalebar
   ../src/core/symbology-ng
 
+  ../src/gui
+  ../src/gui/symbology-ng
   ../src/gui/raster
   ../src/gui/attributetable
   ../src/gui/auth
@@ -121,8 +123,12 @@ INCLUDE_DIRECTORIES(
   ../src/gui/effects
   ../src/gui/layertree
 
+  ../src/plugins
+
   ${CMAKE_BINARY_DIR}  # qgsconfig.h, qgsversion.h
   ${CMAKE_BINARY_DIR}/src/core
+  ${CMAKE_BINARY_DIR}/src/gui
+  ${CMAKE_BINARY_DIR}/src/ui
   ${CMAKE_BINARY_DIR}/src/analysis
 )
 
@@ -146,15 +152,6 @@ SET(SIP_EXTRA_OPTIONS ${PYQT_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/qgis.co
 GENERATE_SIP_PYTHON_MODULE_CODE(qgis._core core/core.sip cpp_files)
 BUILD_SIP_PYTHON_MODULE(qgis._core core/core.sip ${cpp_files} "" qgis_core)
 SET(SIP_CORE_CPP_FILES ${cpp_files})
-
-# additional gui includes
-INCLUDE_DIRECTORIES(
-  ../src/gui
-  ../src/gui/symbology-ng
-  ../src/plugins
-  ${CMAKE_BINARY_DIR}/src/gui
-  ${CMAKE_BINARY_DIR}/src/ui
-)
 
 # gui module
 FILE(GLOB_RECURSE sip_files_gui gui/*.sip)

--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -282,7 +282,6 @@ gui/qgsfeatureselectiondlg.sip
 gui/qgsfieldvalidator.sip
 gui/qgsfieldvalueslineedit.sip
 gui/qgsfiledropedit.sip
-gui/qgsfilterlineedit.sip
 gui/qgsfloatingwidget.sip
 gui/qgsfocuswatcher.sip
 gui/qgsformannotation.sip
@@ -346,7 +345,6 @@ gui/qgsquerybuilder.sip
 gui/qgsrasterformatsaveoptionswidget.sip
 gui/qgsrasterlayersaveasdialog.sip
 gui/qgsrasterpyramidsoptionswidget.sip
-gui/qgsrelationeditorwidget.sip
 gui/qgsrubberband.sip
 gui/qgsscalerangewidget.sip
 gui/qgsscalevisibilitydialog.sip

--- a/python/gui/editorwidgets/qgsdoublespinbox.sip
+++ b/python/gui/editorwidgets/qgsdoublespinbox.sip
@@ -9,6 +9,15 @@
 
 
 
+
+%ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsdoublespinbox.h>
+%End
+
+
 class QgsDoubleSpinBox : QDoubleSpinBox
 {
 %Docstring
@@ -19,6 +28,13 @@ class QgsDoubleSpinBox : QDoubleSpinBox
 
 %TypeHeaderCode
 #include "qgsdoublespinbox.h"
+%End
+
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsDoubleSpinBox *>( sipCpp ) )
+      sipType = sipType_QgsDoubleSpinBox;
+    else
+      sipType = NULL;
 %End
   public:
 

--- a/python/gui/editorwidgets/qgsrelationreferencewidget.sip
+++ b/python/gui/editorwidgets/qgsrelationreferencewidget.sip
@@ -10,11 +10,25 @@
 
 
 
+%ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsrelationreferencewidget.h>
+%End
+
 class QgsRelationReferenceWidget : QWidget
 {
 
 %TypeHeaderCode
 #include "qgsrelationreferencewidget.h"
+%End
+
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsRelationReferenceWidget *>( sipCpp ) )
+      sipType = sipType_QgsRelationReferenceWidget;
+    else
+      sipType = NULL;
 %End
   public:
 

--- a/python/gui/editorwidgets/qgsspinbox.sip
+++ b/python/gui/editorwidgets/qgsspinbox.sip
@@ -9,6 +9,15 @@
 
 
 
+
+%ModuleHeaderCode
+// fix to allow compilation with sip 4.7 that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsspinbox.h>
+%End
+
+
 class QgsSpinBox : QSpinBox
 {
 %Docstring
@@ -19,6 +28,13 @@ class QgsSpinBox : QSpinBox
 
 %TypeHeaderCode
 #include "qgsspinbox.h"
+%End
+
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsSpinBox *>( sipCpp ) )
+      sipType = sipType_QgsSpinBox;
+    else
+      sipType = NULL;
 %End
   public:
 

--- a/python/gui/qgscolorbutton.sip
+++ b/python/gui/qgscolorbutton.sip
@@ -20,6 +20,13 @@ class QgsColorButton : QToolButton
 %TypeHeaderCode
 #include "qgscolorbutton.h"
 %End
+
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsColorButton *>( sipCpp ) )
+      sipType = sipType_QgsColorButton;
+    else
+      sipType = NULL;
+%End
   public:
 
     enum Behavior

--- a/python/gui/qgsexternalresourcewidget.sip
+++ b/python/gui/qgsexternalresourcewidget.sip
@@ -11,6 +11,14 @@
 
 
 
+%ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsexternalresourcewidget.h>
+%End
+
+
 class QgsExternalResourceWidget : QWidget
 {
 %Docstring
@@ -21,6 +29,13 @@ class QgsExternalResourceWidget : QWidget
 
 %TypeHeaderCode
 #include "qgsexternalresourcewidget.h"
+%End
+
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsExternalResourceWidget *>( sipCpp ) )
+      sipType = sipType_QgsExternalResourceWidget;
+    else
+      sipType = NULL;
 %End
   public:
     enum DocumentViewerContent

--- a/python/gui/qgsfilewidget.sip
+++ b/python/gui/qgsfilewidget.sip
@@ -20,6 +20,13 @@ class QgsFileWidget : QWidget
 %TypeHeaderCode
 #include "qgsfilewidget.h"
 %End
+
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsFileWidget *>( sipCpp ) )
+      sipType = sipType_QgsFileWidget;
+    else
+      sipType = NULL;
+%End
   public:
 
     enum StorageMode

--- a/python/gui/qgsfilterlineedit.sip
+++ b/python/gui/qgsfilterlineedit.sip
@@ -1,158 +1,214 @@
-/** \class QgsFilterLineEdit
- * \ingroup gui
- * QLineEdit subclass with built in support for clearing the widget's value and
- * handling custom null value representations.
- *
- * When using QgsFilterLineEdit the value(), setValue() and clearValue() methods should be used
- * instead of QLineEdit's text(), setText() and clear() methods, and the valueChanged()
- * signal should be used instead of textChanged().
- **/
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsfilterlineedit.h                                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
 class QgsFilterLineEdit : QLineEdit
 {
+%Docstring
+ QLineEdit subclass with built in support for clearing the widget's value and
+ handling custom null value representations.
+
+ When using QgsFilterLineEdit the value(), setValue() and clearValue() methods should be used
+ instead of QLineEdit's text(), setText() and clear() methods, and the valueChanged()
+ signal should be used instead of textChanged().
+*
+%End
+
 %TypeHeaderCode
-#include <qgsfilterlineedit.h>
+#include "qgsfilterlineedit.h"
+%End
+
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsFilterLineEdit *>( sipCpp ) )
+      sipType = sipType_QgsFilterLineEdit;
+    else
+      sipType = NULL;
 %End
   public:
 
-    //! Behavior when clearing value of widget
     enum ClearMode
     {
-      ClearToNull, //!< Reset value to null
-      ClearToDefault, //!< Reset value to default value (see defaultValue() )
+      ClearToNull,
+      ClearToDefault,
     };
 
-    /** Constructor for QgsFilterLineEdit.
-     * @param parent parent widget
-     * @param nullValue string for representing null values
-     */
     QgsFilterLineEdit( QWidget *parent /TransferThis/ = 0, const QString &nullValue = QString::null );
+%Docstring
+ Constructor for QgsFilterLineEdit.
+ \param parent parent widget
+ \param nullValue string for representing null values
+%End
 
-    /** Returns true if the widget's clear button is visible.
-     * @see setShowClearButton()
-     * @note added in QGIS 3.0
-     */
     bool showClearButton() const;
+%Docstring
+ Returns true if the widget's clear button is visible.
+.. seealso:: setShowClearButton()
+.. versionadded:: 3.0
+ :rtype: bool
+%End
 
-    /** Sets whether the widget's clear button is visible.
-     * @param visible set to false to hide the clear button
-     * @see showClearButton()
-     * @note added in QGIS 3.0
-     */
     void setShowClearButton( bool visible );
+%Docstring
+ Sets whether the widget's clear button is visible.
+ \param visible set to false to hide the clear button
+.. seealso:: showClearButton()
+.. versionadded:: 3.0
+%End
 
-    /** Returns the clear mode for the widget. The clear mode defines the behavior of the
-     * widget when its value is cleared. This defaults to ClearToNull.
-     * @see setClearMode()
-     * @note added in QGIS 3.0
-     */
     ClearMode clearMode() const;
+%Docstring
+ Returns the clear mode for the widget. The clear mode defines the behavior of the
+ widget when its value is cleared. This defaults to ClearToNull.
+.. seealso:: setClearMode()
+.. versionadded:: 3.0
+ :rtype: ClearMode
+%End
 
-    /** Sets the clear mode for the widget. The clear mode defines the behavior of the
-     * widget when its value is cleared. This defaults to ClearToNull.
-     * @see clearMode()
-     * @note added in QGIS 3.0
-     */
     void setClearMode( ClearMode mode );
+%Docstring
+ Sets the clear mode for the widget. The clear mode defines the behavior of the
+ widget when its value is cleared. This defaults to ClearToNull.
+.. seealso:: clearMode()
+.. versionadded:: 3.0
+%End
 
-    /** Sets the string representation for null values in the widget. This does not
-     * affect the values returned for null values by value(), rather it only affects
-     * the text that is shown to users when the widget's value is null.
-     * @param nullValue string to show when widget's value is null
-     * @see nullValue()
-     */
     void setNullValue( const QString &nullValue );
+%Docstring
+ Sets the string representation for null values in the widget. This does not
+ affect the values returned for null values by value(), rather it only affects
+ the text that is shown to users when the widget's value is null.
+ \param nullValue string to show when widget's value is null
+.. seealso:: nullValue()
+%End
 
-    /** Returns the string used for representating null values in the widget.
-     * @see setNullValue()
-     * @see isNull()
-     */
     QString nullValue() const;
+%Docstring
+ Returns the string used for representating null values in the widget.
+.. seealso:: setNullValue()
+.. seealso:: isNull()
+ :rtype: str
+%End
 
-    /** Define if a search icon shall be shown on the left of the image
-     * when no text is entered
-     * @param visible set to false to hide the search icon
-     * @note added in QGIS 3.0
-     */
     void setShowSearchIcon( bool visible );
+%Docstring
+ Define if a search icon shall be shown on the left of the image
+ when no text is entered
+ \param visible set to false to hide the search icon
+.. versionadded:: 3.0
+%End
 
-    /** Returns if a search icon shall be shown on the left of the image
-     * when no text is entered
-     * @note added in QGIS 3.0
-     */
     bool showSearchIcon() const;
+%Docstring
+ Returns if a search icon shall be shown on the left of the image
+ when no text is entered
+.. versionadded:: 3.0
+ :rtype: bool
+%End
 
-    /** Sets the default value for the widget. The default value is a value
-     * which the widget will be reset to if it is cleared and the clearMode()
-     * is equal to ClearToDefault.
-     * @param defaultValue default value
-     * @see defaultValue()
-     * @see clearMode()
-     * @note added in QGIS 3.0
-     */
     void setDefaultValue( const QString &defaultValue );
+%Docstring
+ Sets the default value for the widget. The default value is a value
+ which the widget will be reset to if it is cleared and the clearMode()
+ is equal to ClearToDefault.
+ \param defaultValue default value
+.. seealso:: defaultValue()
+.. seealso:: clearMode()
+.. versionadded:: 3.0
+%End
 
-    /** Returns the default value for the widget. The default value is a value
-     * which the widget will be reset to if it is cleared and the clearMode()
-     * is equal to ClearToDefault.
-     * @see setDefaultValue()
-     * @see clearMode()
-     * @note added in QGIS 3.0
-     */
     QString defaultValue() const;
+%Docstring
+ Returns the default value for the widget. The default value is a value
+ which the widget will be reset to if it is cleared and the clearMode()
+ is equal to ClearToDefault.
+.. seealso:: setDefaultValue()
+.. seealso:: clearMode()
+.. versionadded:: 3.0
+ :rtype: str
+%End
 
-    /**
-     * Sets the current text for the widget with support for handling null values.
-     *
-     * @param value The text to set. If a null string is provided, the text shown in the
-     * widget will be set to the current nullValue().
-     * @see value()
-     */
     void setValue( const QString &value );
+%Docstring
+ Sets the current text for the widget with support for handling null values.
 
-    /**
-     * Returns the text of this edit with support for handling null values. If the text
-     * in the widget matches the current nullValue() then the returned value will be
-     * a null string.
-     *
-     * @return Current text (or null string if it matches the nullValue() property )
-     * @see setValue()
-     */
+ \param value The text to set. If a null string is provided, the text shown in the
+ widget will be set to the current nullValue().
+.. seealso:: value()
+%End
+
     QString value() const;
+%Docstring
+ Returns the text of this edit with support for handling null values. If the text
+ in the widget matches the current nullValue() then the returned value will be
+ a null string.
 
-    /**
-     * Determine if the current text represents null.
-     *
-     * @return True if the widget's value is null.
-     * @see nullValue()
-     */
+ :return: Current text (or null string if it matches the nullValue() property )
+.. seealso:: setValue()
+ :rtype: str
+%End
+
     bool isNull() const;
+%Docstring
+ Determine if the current text represents null.
+
+ :return: True if the widget's value is null.
+.. seealso:: nullValue()
+ :rtype: bool
+%End
 
   public slots:
 
-    /** Clears the widget and resets it to the null value.
-     * @see nullValue()
-     * @note added in QGIS 3.0
-     */
     virtual void clearValue();
+%Docstring
+ Clears the widget and resets it to the null value.
+.. seealso:: nullValue()
+.. versionadded:: 3.0
+%End
 
   signals:
 
-    /** Emitted when the widget is cleared
-     * @see clearValue()
-     */
     void cleared();
+%Docstring
+ Emitted when the widget is cleared
+.. seealso:: clearValue()
+%End
 
-    /**
-     * Same as textChanged() but with support for null values.
-     *
-     * @param value The current text or null string if it matches the nullValue() property.
-     */
     void valueChanged( const QString &value );
+%Docstring
+ Same as textChanged() but with support for null values.
+
+ \param value The current text or null string if it matches the nullValue() property.
+%End
 
   protected:
-    void mousePressEvent( QMouseEvent *e );
-    void mouseMoveEvent( QMouseEvent *e );
-    void focusInEvent( QFocusEvent *e );
-    void paintEvent( QPaintEvent *e );
-    void leaveEvent( QEvent *e );
+    virtual void mousePressEvent( QMouseEvent *e );
+
+    virtual void mouseMoveEvent( QMouseEvent *e );
+
+    virtual void focusInEvent( QFocusEvent *e );
+
+    virtual void paintEvent( QPaintEvent *e );
+
+    virtual void leaveEvent( QEvent *e );
+
+
 };
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsfilterlineedit.h                                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgsrelationeditorwidget.sip
+++ b/python/gui/qgsrelationeditorwidget.sip
@@ -1,108 +1,128 @@
-/***************************************************************************
-    qgsrelationeditorwidget.sip
-     --------------------------------------
-    Date                 : 28.11.2015
-    Copyright            : (C) 2015 Matthias Kuhn
-    Email                : matthias at opengis dot ch
- ***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsrelationeditorwidget.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
 
-%ModuleCode
-#include "qgsrelationeditorwidget.h"
+
+
+
+
+%ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsrelationeditorwidget.h>
 %End
 
 class QgsRelationEditorWidget : QgsCollapsibleGroupBox
 {
-%TypeHeaderCode
-#include <qgsrelationeditorwidget.h>
-%End
 
+%TypeHeaderCode
+#include "qgsrelationeditorwidget.h"
+%End
 
 %ConvertToSubClassCode
-  if ( qobject_cast<QgsRelationEditorWidget*>( sipCpp ) )
-    sipType = sipType_QgsRelationEditorWidget;
-  else
-    sipType = 0;
+    if ( qobject_cast<QgsRelationEditorWidget *>( sipCpp ) )
+      sipType = sipType_QgsRelationEditorWidget;
+    else
+      sipType = NULL;
+%End
+  public:
+
+    QgsRelationEditorWidget( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+ \param parent parent widget
 %End
 
-  public:
-    /**
-     * @param parent parent widget
-     */
-    QgsRelationEditorWidget( QWidget *parent /TransferThis/= 0 );
-
-    //! Define the view mode for the dual view
     void setViewMode( QgsDualView::ViewMode mode );
+%Docstring
+Define the view mode for the dual view
+%End
 
-    //! Get the view mode for the dual view
     QgsDualView::ViewMode viewMode();
+%Docstring
+Get the view mode for the dual view
+ :rtype: QgsDualView.ViewMode
+%End
 
     void setRelationFeature( const QgsRelation &relation, const QgsFeature &feature );
 
-    /**
-     * Set the relation(s) for this widget
-     * If only one relation is set, it will act as a simple 1:N relation widget
-     * If both relations are set, it will act as an N:M relation widget
-     * inserting and deleting entries on the intermediate table as required.
-     *
-     * @param relation    Relation referencing the edited table
-     * @param nmrelation  Optional reference from the referencing table to a 3rd N:M table
-     */
     void setRelations( const QgsRelation &relation, const QgsRelation &nmrelation );
+%Docstring
+ Set the relation(s) for this widget
+ If only one relation is set, it will act as a simple 1:N relation widget
+ If both relations are set, it will act as an N:M relation widget
+ inserting and deleting entries on the intermediate table as required.
+
+ \param relation    Relation referencing the edited table
+ \param nmrelation  Optional reference from the referencing table to a 3rd N:M table
+%End
 
     void setFeature( const QgsFeature &feature );
 
     void setEditorContext( const QgsAttributeEditorContext &context );
 
-    /**
-     * The feature selection manager is responsible for the selected features
-     * which are currently being edited.
-     */
     QgsIFeatureSelectionManager *featureSelectionManager();
+%Docstring
+ The feature selection manager is responsible for the selected features
+ which are currently being edited.
+ :rtype: QgsIFeatureSelectionManager
+%End
 
-    /**
-     * Defines if a title label should be shown for this widget.
-     *
-     * @note Added in QGIS 2.18
-     */
     bool showLabel() const;
+%Docstring
+ Defines if a title label should be shown for this widget.
 
-    /**
-     * Defines if a title label should be shown for this widget.
-     *
-     * @note Added in QGIS 2.18
-     */
+.. versionadded:: 2.18
+ :rtype: bool
+%End
+
     void setShowLabel( bool showLabel );
+%Docstring
+ Defines if a title label should be shown for this widget.
 
-    /**
-     * Determines if the "link feature" button should be shown
-     *
-     * @note Added in QGIS 2.18
-     */
+.. versionadded:: 2.18
+%End
+
     bool showLinkButton() const;
-    /**
-     * Determines if the "link feature" button should be shown
-     *
-     * @note Added in QGIS 2.18
-     */
-    void setShowLinkButton( bool showLinkButton );
+%Docstring
+ Determines if the "link feature" button should be shown
 
-    /**
-     * Determines if the "unlink feature" button should be shown
-     *
-     * @note Added in QGIS 2.18
-     */
+.. versionadded:: 2.18
+ :rtype: bool
+%End
+
+    void setShowLinkButton( bool showLinkButton );
+%Docstring
+ Determines if the "link feature" button should be shown
+
+.. versionadded:: 2.18
+%End
+
     bool showUnlinkButton() const;
-    /**
-     * Determines if the "unlink feature" button should be shown
-     *
-     * @note Added in QGIS 2.18
-     */
+%Docstring
+ Determines if the "unlink feature" button should be shown
+
+.. versionadded:: 2.18
+ :rtype: bool
+%End
+
     void setShowUnlinkButton( bool showUnlinkButton );
+%Docstring
+ Determines if the "unlink feature" button should be shown
+
+.. versionadded:: 2.18
+%End
+
 };
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsrelationeditorwidget.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -96,7 +96,8 @@ sub remove_constructor_or_body {
     # https://regex101.com/r/ZaP3tC/3
     do {no warnings 'uninitialized';
         if ( $line =~  m/^(\s*)?(explicit )?(virtual )?(static |const )*(([\w:]+(<.*?>)?\s+(\*|&)?)?(~?\w+|operator.{1,2})\(([\w=()\/ ,&*<>."-]|::)*\)( (?:const|SIP_[A-Z_]*?))*)\s*((\s*[:,]\s+\w+\(.*\))*\s*\{.*\};?|(?!;))(\s*\/\/.*)?$/
-             || $line =~ m/SIP_SKIP\s*(?!;)\s*(\/\/.*)?$/ ){
+             || $line =~ m/SIP_SKIP\s*(?!;)\s*(\/\/.*)?$/
+             || $line =~ m/^\s*class.*SIP_SKIP/ ){
             dbg_info("remove constructor definition, function bodies, member initializing list");
             my $newline = "$1$2$3$4$5;";
             if ($line !~ m/{.*}(\s*SIP_\w+)*\s*(\/\/.*)?$/){

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -22,6 +22,17 @@
 
 class QgsSpinBoxLineEdit;
 
+
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsdoublespinbox.h>
+% End
+#endif
+
+
 /** \ingroup gui
  * \brief The QgsSpinBox is a spin box with a clear button that will set the value to the defined clear value.
  * The clear value can be either the minimum or the maiximum value of the spin box or a custom value.
@@ -29,6 +40,16 @@ class QgsSpinBoxLineEdit;
  */
 class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsDoubleSpinBox *>( sipCpp ) )
+      sipType = sipType_QgsDoubleSpinBox;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
     Q_OBJECT
     Q_PROPERTY( bool showClearButton READ showClearButton WRITE setShowClearButton )
     Q_PROPERTY( bool clearValue READ clearValue WRITE setClearValue )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -40,11 +40,30 @@ class QgsFeatureListModel;
 class QgsCollapsibleGroupBox;
 class QLabel;
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsrelationreferencewidget.h>
+% End
+#endif
+
 /** \ingroup gui
  * \class QgsRelationReferenceWidget
  */
 class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsRelationReferenceWidget *>( sipCpp ) )
+      sipType = sipType_QgsRelationReferenceWidget;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
     Q_OBJECT
     Q_PROPERTY( bool openFormButtonVisible READ openFormButtonVisible WRITE setOpenFormButtonVisible )
 

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -22,6 +22,17 @@
 
 class QgsSpinBoxLineEdit;
 
+
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// fix to allow compilation with sip 4.7 that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsspinbox.h>
+% End
+#endif
+
+
 /** \ingroup gui
  * \brief The QgsSpinBox is a spin box with a clear button that will set the value to the defined clear value.
  * The clear value can be either the minimum or the maiximum value of the spin box or a custom value.
@@ -29,6 +40,16 @@ class QgsSpinBoxLineEdit;
  */
 class GUI_EXPORT QgsSpinBox : public QSpinBox
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsSpinBox *>( sipCpp ) )
+      sipType = sipType_QgsSpinBox;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
     Q_OBJECT
     Q_PROPERTY( bool showClearButton READ showClearButton WRITE setShowClearButton )
     Q_PROPERTY( bool clearValue READ clearValue WRITE setClearValue )

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -34,6 +34,17 @@ class QgsPanelWidget;
  */
 class GUI_EXPORT QgsColorButton : public QToolButton
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsColorButton *>( sipCpp ) )
+      sipType = sipType_QgsColorButton;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
+
     Q_OBJECT
     Q_ENUMS( Behavior )
     Q_PROPERTY( QString colorDialogTitle READ colorDialogTitle WRITE setColorDialogTitle )

--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -59,6 +59,7 @@ QgsExternalResourceWidget::QgsExternalResourceWidget( QWidget *parent )
   setLayout( layout );
 
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsExternalResourceWidget::loadDocument );
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsExternalResourceWidget::valueChanged );
 }
 
 QVariant QgsExternalResourceWidget::documentPath( QVariant::Type type ) const

--- a/src/gui/qgsexternalresourcewidget.h
+++ b/src/gui/qgsexternalresourcewidget.h
@@ -28,12 +28,31 @@ class QgsPixmapLabel;
 #include "qgis.h"
 
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsexternalresourcewidget.h>
+% End
+#endif
+
+
 /** \ingroup gui
  * Widget to display file path with a push button for an "open file" dialog
  * It can also be used to display a picture or a web page.
  **/
 class GUI_EXPORT QgsExternalResourceWidget : public QWidget
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsExternalResourceWidget *>( sipCpp ) )
+      sipType = sipType_QgsExternalResourceWidget;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
 
     Q_OBJECT
     Q_PROPERTY( bool fileWidgetVisible READ fileWidgetVisible WRITE setFileWidgetVisible )

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -33,6 +33,17 @@ class QgsFilterLineEdit;
  */
 class GUI_EXPORT QgsFileWidget : public QWidget
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsFileWidget *>( sipCpp ) )
+      sipType = sipType_QgsFileWidget;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
+
     Q_OBJECT
     Q_PROPERTY( bool fileWidgetButtonVisible READ fileWidgetButtonVisible WRITE setFileWidgetButtonVisible )
     Q_PROPERTY( bool useLink READ useLink WRITE setUseLink )

--- a/src/gui/qgsfilterlineedit.h
+++ b/src/gui/qgsfilterlineedit.h
@@ -24,6 +24,7 @@
 
 class QToolButton;
 
+
 /** \class QgsFilterLineEdit
  * \ingroup gui
  * QLineEdit subclass with built in support for clearing the widget's value and
@@ -35,6 +36,16 @@ class QToolButton;
  **/
 class GUI_EXPORT QgsFilterLineEdit : public QLineEdit
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsFilterLineEdit *>( sipCpp ) )
+      sipType = sipType_QgsFilterLineEdit;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
     Q_OBJECT
     Q_ENUMS( ClearMode )
     Q_PROPERTY( ClearMode clearMode READ clearMode WRITE setClearMode )
@@ -225,7 +236,7 @@ class GUI_EXPORT QgsFilterLineEdit : public QLineEdit
  * of clicks, but override clearValue() and let Qgs(Double)SpinBox handle the clearing
  * themselves.
  */
-class QgsSpinBoxLineEdit : public QgsFilterLineEdit
+class SIP_SKIP QgsSpinBoxLineEdit : public QgsFilterLineEdit
 {
     Q_OBJECT
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -32,11 +32,32 @@ class QgsGenericFeatureSelectionManager;
 class QgsVectorLayer;
 class QgsVectorLayerTools;
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// fix to allow compilation with sip that for some reason
+// doesn't add this include to the file where the code from
+// ConvertToSubClassCode goes.
+#include <qgsrelationeditorwidget.h>
+% End
+#endif
+
 /** \ingroup gui
  * \class QgsRelationEditorWidget
  */
 class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsRelationEditorWidget *>( sipCpp ) )
+      sipType = sipType_QgsRelationEditorWidget;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
+
+
     Q_OBJECT
     Q_PROPERTY( QgsDualView::ViewMode viewMode READ viewMode WRITE setViewMode )
     Q_PROPERTY( bool showLabel READ showLabel WRITE setShowLabel )
@@ -46,7 +67,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     /**
      * \param parent parent widget
      */
-    QgsRelationEditorWidget( QWidget *parent = nullptr );
+    QgsRelationEditorWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     //! Define the view mode for the dual view
     void setViewMode( QgsDualView::ViewMode mode );


### PR DESCRIPTION
This was causing an issue if you tried to access widgets in a form using findChildren
widgets could not be casted to QGIs native types

also sipify QgsFilterLineEdit and QgsRelationEditorWidget

also fix valueChanged signal not emitted in QgsExternalResourceWidget