### PR TITLE
fix bugs related to statistical dock (fix #16117, #16118, #16119)

### DIFF
--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -23,12 +23,7 @@
 #include "qgsdatetimestatisticalsummary.h"
 #include "qgsdockwidget.h"
 
-class QgsBrowserModel;
-class QModelIndex;
-class QgsDockBrowserTreeView;
-class QgsLayerItem;
-class QgsDataItem;
-class QgsBrowserTreeFilterProxyModel;
+class QMenu;
 
 /** A dock widget which displays a statistical summary of the values in a field or expression
  */
@@ -60,7 +55,18 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
 
   private:
 
+    //! Enumeration of supported statistics types
+    enum DataType
+    {
+      Numeric,  //!< Numeric fields: int, double, etc
+      String,  //!< String fields
+      DateTime  //!< Date and DateTime fields
+    };
+
     QgsVectorLayer* mLayer;
+    QMenu *mStatisticsMenu;
+    DataType mFieldType;
+    DataType mPreviousFieldType;
 
     QMap< int, QAction* > mStatsActions;
     static QList< QgsStatisticalSummary::Statistic > mDisplayStats;
@@ -71,6 +77,9 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
     void updateStringStatistics( bool selectedOnly );
     void updateDateTimeStatistics( bool selectedOnly );
     void addRow( int row, const QString& name, const QString& value, bool showValue );
+    void refreshStatisticsMenu();
+    DataType fieldType( const QString &fieldName );
+
 };
 
 #endif // QGSSTATISTICALSUMMARYDOCKWIDGET_H


### PR DESCRIPTION
Fix issues with enabling/disabling statistics and refresing list of available statistics depending on the field type.

Backported from master branch

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
