### PR TITLE
[db_manager] catch exception when item has lost reference. for 2.18 regression fixes #15868

### DIFF
--- a/python/plugins/db_manager/db_tree.py
+++ b/python/plugins/db_manager/db_tree.py
@@ -164,7 +164,7 @@ class DBTree(QTreeView):
             layers = QgsMapLayerRegistry.instance().addMapLayers([layer])
             if len(layers) != 1:
                 QgsMessageLog.logMessage(
-                    self.tr("%1 is an invalid layer - not loaded").replace("%1", layer.publicSource()))
+                    self.tr("%1 is an invalid layer - not loaded").replace("%1", layer.publicSource()), "DBManagerPlugin")
                 msgLabel = QLabel(self.tr(
                     "%1 is an invalid layer and cannot be loaded. Please check the <a href=\"#messageLog\">message log</a> for further info.").replace(
                     "%1", layer.publicSource()), self.mainWindow.infoBar)

--- a/python/plugins/db_manager/layer_preview.py
+++ b/python/plugins/db_manager/layer_preview.py
@@ -25,7 +25,7 @@ from qgis.PyQt.QtGui import QColor, QCursor
 from qgis.PyQt.QtWidgets import QApplication
 
 from qgis.gui import QgsMapCanvas, QgsMapCanvasLayer, QgsMessageBar
-from qgis.core import QgsVectorLayer, QgsMapLayerRegistry, QgsProject
+from qgis.core import QgsVectorLayer, QgsMapLayerRegistry, QgsProject, QgsMessageLog
 
 from .db_plugins.plugin import Table
 
@@ -78,11 +78,13 @@ class LayerPreview(QgsMapCanvas):
     def _clear(self):
         """ remove any layers from preview canvas """
         if self.item is not None:
-            ## skip exception on RuntimeError fixes #6892
             try:
                 self.item.aboutToChange.disconnect(self.setDirty)
-            except RuntimeError:
-                pass
+            ## skip exception on RuntimeError fixes #6892
+            ## skip TypeError and generic Exceptions fixes #15868
+            ## generally due the remove of self.item object or C++ referenced object
+            except Exception as ex:
+                QgsMessageLog.logMessage(unicode(ex))
 
         self.item = None
         self.dirty = False

--- a/python/plugins/db_manager/layer_preview.py
+++ b/python/plugins/db_manager/layer_preview.py
@@ -84,7 +84,7 @@ class LayerPreview(QgsMapCanvas):
             ## skip TypeError and generic Exceptions fixes #15868
             ## generally due the remove of self.item object or C++ referenced object
             except Exception as ex:
-                QgsMessageLog.logMessage(unicode(ex))
+                QgsMessageLog.logMessage(unicode(ex), "DBManagerPlugin")
 
         self.item = None
         self.dirty = False


### PR DESCRIPTION
## Description
This patch is a usability patch. doe not solve the origin of the problem related with the ownership of objects. BTW it catch some exception, log them but does not block or alarm the user experience because this exceptions does not influence the db_manager functioning.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
