### PR TITLE
[DB Manager] Avoid remove layer if displayed + reduce exceptions due to object delete: for 2.18 fixes #16476

### DIFF
--- a/python/plugins/db_manager/db_plugins/vlayers/connector.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/connector.py
@@ -96,6 +96,10 @@ class VLayerRegistry:
         lid = self.layers.get(l)
         if lid is None:
             return lid
+        # the instance can refer to a layer in map previe and not in qgis general canvas
+        if lid not in QgsMapLayerRegistry.instance().mapLayers().keys():
+            self.layers.pop(l)
+            return None
         return QgsMapLayerRegistry.instance().mapLayer(lid)
 
 
@@ -246,12 +250,16 @@ class VLayerConnector(DBConnector):
     def getTableRowCount(self, table):
         t = table[1]
         l = VLayerRegistry.instance().getLayer(t)
+        if not l or not l.isValid():
+            return None
         return l.featureCount()
 
     def getTableFields(self, table):
         """ return list of columns in table """
         t = table[1]
         l = VLayerRegistry.instance().getLayer(t)
+        if not l or not l.isValid():
+            return []
         # id, name, type, nonnull, default, pk
         n = l.dataProvider().fields().size()
         f = [(i, f.name(), f.typeName(), False, None, False)
@@ -277,6 +285,8 @@ class VLayerConnector(DBConnector):
             l = QgsMapLayerRegistry.instance().mapLayer(t)
         else:
             l = VLayerRegistry.instance().getLayer(t)
+        if not l or not l.isValid():
+            return None
         e = l.extent()
         r = (e.xMinimum(), e.yMinimum(), e.xMaximum(), e.yMaximum())
         return r


### PR DESCRIPTION
## Description
Fix the problem that  db_manager base class layer_preview remove from registry any previously added layer (currentLayer) with it's id, with assumption that it's id is a temporary layer because added only for the preview.
Virtual layer "qgis layers" is populated of all registry layers => also that are in the QgsLayerRoot list, when you click on that it become current layer => it is removed when switching to another layer in db_manager. This patch fix this effect.
This patch include also small fixes to reduce (but can't avoid) exceptions due to C++/SIP object removes.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
