### PR TITLE
Attributetable fixes  crash #16492

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1844,7 +1844,7 @@ Is emitted, before changes are rolled back
 %Docstring
  Emitted when a feature has been deleted.
 
- If you do expensive operations in a slot connected to this, you should prever to use
+ If you do expensive operations in a slot connected to this, you should prefer to use
  featuresDeleted( const QgsFeatureIds& ).
 
  \param fid The id of the feature which has been deleted

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1710,7 +1710,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Emitted when a feature has been deleted.
      *
-     * If you do expensive operations in a slot connected to this, you should prever to use
+     * If you do expensive operations in a slot connected to this, you should prefer to use
      * featuresDeleted( const QgsFeatureIds& ).
      *
      * \param fid The id of the feature which has been deleted

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -93,25 +93,22 @@ void QgsAttributeTableDelegate::setModelData( QWidget *editor, QAbstractItemMode
   if ( !eww )
     return;
 
-  // This fixes https://issues.qgis.org/issues/16492
-  QgsFeatureRequest request( fid );
-  request.setFlags( QgsFeatureRequest::NoGeometry );
-  request.setSubsetOfAttributes( QgsAttributeList( ) );
-  QgsFeature feature;
-  vl->getFeatures( request ).nextFeature( feature );
-  if ( ! feature.isValid( ) )
-  {
-    // Model is out of sync (again!).
-    return;
-  }
-
   newValue = eww->value();
 
   if ( ( oldValue != newValue && newValue.isValid() ) || oldValue.isNull() != newValue.isNull() )
   {
-    vl->beginEditCommand( tr( "Attribute changed" ) );
-    vl->changeAttributeValue( fid, fieldIdx, newValue, oldValue );
-    vl->endEditCommand();
+    // This fixes https://issues.qgis.org/issues/16492
+    QgsFeatureRequest request( fid );
+    request.setFlags( QgsFeatureRequest::NoGeometry );
+    request.setSubsetOfAttributes( QgsAttributeList( ) );
+    QgsFeature feature;
+    vl->getFeatures( request ).nextFeature( feature );
+    if ( feature.isValid( ) )
+    {
+      vl->beginEditCommand( tr( "Attribute changed" ) );
+      vl->changeAttributeValue( fid, fieldIdx, newValue, oldValue );
+      vl->endEditCommand();
+    }
   }
 }
 

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -94,7 +94,12 @@ void QgsAttributeTableDelegate::setModelData( QWidget *editor, QAbstractItemMode
     return;
 
   // This fixes https://issues.qgis.org/issues/16492
-  if ( ! vl->getFeature( fid ).isValid( ) )
+  QgsFeatureRequest request( fid );
+  request.setFlags( QgsFeatureRequest::NoGeometry );
+  request.setSubsetOfAttributes( QgsAttributeList( ) );
+  QgsFeature feature;
+  vl->getFeatures( request ).nextFeature( feature );
+  if ( ! feature.isValid( ) )
   {
     // Model is out of sync (again!).
     return;

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -93,6 +93,13 @@ void QgsAttributeTableDelegate::setModelData( QWidget *editor, QAbstractItemMode
   if ( !eww )
     return;
 
+  // This fixes https://issues.qgis.org/issues/16492
+  if ( ! vl->getFeature( fid ).isValid( ) )
+  {
+    // Model is out of sync (again!).
+    return;
+  }
+
   newValue = eww->value();
 
   if ( ( oldValue != newValue && newValue.isValid() ) || oldValue.isNull() != newValue.isNull() )

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -251,6 +251,7 @@ void TestQgsAttributeTable::testSelected()
 
 void TestQgsAttributeTable::testRegression15974()
 {
+  // Test duplicated rows in attribute table + two crashes.
   QString path = QDir::tempPath() + "/testshp15974.shp";
   std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "polygon?crs=epsg:4326&field=id:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
   QVERIFY( tempLayer->isValid() );
@@ -280,6 +281,7 @@ void TestQgsAttributeTable::testRegression15974()
   // dlg->mMainView->mFilterModel->invalidate();
   QCOMPARE( dlg->mMainView->filteredFeatureCount( ), 3 );
 }
+
 
 QGSTEST_MAIN( TestQgsAttributeTable )
 #include "testqgsattributetable.moc"


### PR DESCRIPTION
Fixes https://issues.qgis.org/issues/16492

The proposed solution is to check for feature validity before editing the attributes.
The problem arises when in the attr-table selected features are deleted while one attribute editor is active.

Needs-backporting

The three other commits are just minor typos and one added comment.
