### PR TITLE
Display name of layers in need of rasterization when saving as PDF

### DIFF
--- a/python/core/qgsmapsettingsutils.sip
+++ b/python/core/qgsmapsettingsutils.sip
@@ -22,11 +22,11 @@ class QgsMapSettingsUtils
 %End
   public:
 
-    static bool containsAdvancedEffects( const QgsMapSettings &mapSettings );
+    static const QStringList containsAdvancedEffects( const QgsMapSettings &mapSettings );
 %Docstring
  Checks whether any of the layers attached to a map settings object contain advanced effects
  \param mapSettings map settings
- :rtype: bool
+ :rtype: list of str
 %End
 
     static QString worldFileContent( const QgsMapSettings &mapSettings );

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -66,7 +66,23 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
   {
     mSaveWorldFile->setVisible( false );
 
-    mSaveAsRaster->setChecked( QgsMapSettingsUtils::containsAdvancedEffects( mapCanvas->mapSettings() ) );
+    QStringList layers = QgsMapSettingsUtils::containsAdvancedEffects( mapCanvas->mapSettings() );
+    if ( !layers.isEmpty() )
+    {
+      // Limit number of items to avoid extreme dialog height
+      if ( layers.count() >= 10 )
+      {
+        layers = layers.mid( 0, 9 );
+        layers << QChar( 0x2026 );
+      }
+      mInfo->setText( tr( "The following layer(s) use advanced effects:\n%1\nRasterizing map is recommended for proper rendering." ).arg(
+                        QChar( 0x2022 ) + QString( " " ) + layers.join( QString( "\n" ) + QChar( 0x2022 ) + QString( " " ) ) ) );
+      mSaveAsRaster->setChecked( true );
+    }
+    else
+    {
+      mSaveAsRaster->setChecked( false );
+    }
     mSaveAsRaster->setVisible( true );
 
     this->setWindowTitle( tr( "Save map as PDF" ) );

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -1082,7 +1082,7 @@ bool QgsComposerMap::containsAdvancedEffects() const
 
   QgsMapSettings ms;
   ms.setLayers( layersToRender() );
-  return QgsMapSettingsUtils::containsAdvancedEffects( ms );
+  return ( !QgsMapSettingsUtils::containsAdvancedEffects( ms ).isEmpty() );
 }
 
 void QgsComposerMap::connectUpdateSlot()

--- a/src/core/qgsmapsettingsutils.cpp
+++ b/src/core/qgsmapsettingsutils.cpp
@@ -23,8 +23,10 @@
 
 #include <QString>
 
-bool QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSettings &mapSettings )
+const QStringList QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSettings &mapSettings )
 {
+  QSet< QString > layers;
+
   QgsTextFormat layerFormat;
   Q_FOREACH ( QgsMapLayer *layer, mapSettings.layers() )
   {
@@ -32,7 +34,7 @@ bool QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSettings &mapSett
     {
       if ( layer->blendMode() != QPainter::CompositionMode_SourceOver )
       {
-        return true;
+        layers << layer->name();
       }
       // if vector layer, check labels and feature blend mode
       QgsVectorLayer *currentVectorLayer = qobject_cast<QgsVectorLayer *>( layer );
@@ -40,11 +42,11 @@ bool QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSettings &mapSett
       {
         if ( currentVectorLayer->layerTransparency() != 0 )
         {
-          return true;
+          layers << layer->name();
         }
         if ( currentVectorLayer->featureBlendMode() != QPainter::CompositionMode_SourceOver )
         {
-          return true;
+          layers << layer->name();
         }
         // check label blend modes
         if ( QgsPalLabeling::staticWillUseLayer( currentVectorLayer ) )
@@ -52,12 +54,15 @@ bool QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSettings &mapSett
           // Check all label blending properties
           layerFormat.readFromLayer( currentVectorLayer );
           if ( layerFormat.containsAdvancedEffects() )
-            return true;
+          {
+            layers << layer->name();
+          }
         }
       }
     }
   }
-  return false;
+
+  return layers.toList();
 }
 
 QString QgsMapSettingsUtils::worldFileContent( const QgsMapSettings &mapSettings )

--- a/src/core/qgsmapsettingsutils.h
+++ b/src/core/qgsmapsettingsutils.h
@@ -35,7 +35,7 @@ class CORE_EXPORT QgsMapSettingsUtils
     /** Checks whether any of the layers attached to a map settings object contain advanced effects
      * \param mapSettings map settings
      */
-    static bool containsAdvancedEffects( const QgsMapSettings &mapSettings );
+    static const QStringList containsAdvancedEffects( const QgsMapSettings &mapSettings );
 
     /** Creates the content of a world file.
      * \param mapSettings map settings

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -16,6 +16,13 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="9" column="0" colspan="2">
+      <widget class="QLabel" name="mInfo">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
      <item row="8" column="0" colspan="2">
       <widget class="QCheckBox" name="mSaveAsRaster">
        <property name="text">


### PR DESCRIPTION
## Description
In projects with a large number of layers, it can be quite frustrating to try and identify which layer(s) rely on advanced effects requiring rasterization. This PR updates the Save as PDF dialog to display the name of such layers (when present):
![screenshot from 2017-05-12 12-10-37](https://cloud.githubusercontent.com/assets/1728657/25983143/a821f6c2-370c-11e7-83bc-964726266be3.png)

It's a big time saver when you actually don't want to / can't export as raster.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
