### PR TITLE
Fix double delete of symbol

### DIFF
--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -1011,7 +1011,7 @@ void QgsCategorizedSymbolRendererV2Widget::cleanUpSymbolSelector( QgsPanelWidget
   if ( !dlg )
     return;
 
-  delete dlg->symbol();
+  dlg->releaseSymbol();
 }
 
 void QgsCategorizedSymbolRendererV2Widget::updateSymbolsFromWidget()

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -693,7 +693,7 @@ void QgsGraduatedSymbolRendererV2Widget::cleanUpSymbolSelector( QgsPanelWidget *
   if ( !dlg )
     return;
 
-  delete dlg->symbol();
+  dlg->releaseSymbol();
 }
 
 void QgsGraduatedSymbolRendererV2Widget::updateSymbolsFromWidget()

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -300,6 +300,12 @@ void QgsSymbolV2SelectorWidget::setMapCanvas( QgsMapCanvas *canvas )
     listWidget->setMapCanvas( canvas );
 }
 
+void QgsSymbolV2SelectorWidget::releaseSymbol()
+{
+  delete mSymbol;
+  mSymbol = nullptr;
+}
+
 void QgsSymbolV2SelectorWidget::loadSymbol( QgsSymbolV2* symbol, SymbolLayerItem* parent )
 {
   SymbolLayerItem* symbolItem = new SymbolLayerItem( symbol );

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.h
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.h
@@ -128,6 +128,14 @@ class GUI_EXPORT QgsSymbolV2SelectorWidget: public QgsPanelWidget, private Ui::Q
      */
     QgsSymbolV2* symbol() { return mSymbol; }
 
+    /**
+     * Delete the symbol.
+     *
+     * \note Not available in Python
+     * \note Added in QGIS 2.18.8
+     */
+    void releaseSymbol();
+
   protected:
 
     /**


### PR DESCRIPTION
Fix #15961

The `QgsSymbolV2SelectorWidget::mSymbol` is double deleted under some circumstances (see https://issues.qgis.org/issues/15961), because `QgsGraduatedSymbolRendererV2Widget::cleanUpSymbolSelector` is called twice. This works around the issue by resetting the `mSymbol` to a `nullptr`, so the second call is harmless.

**Note:**

This is more a workaround than a fix. If we find this issue on master as well, we should prefer to delete the symbol in the dialog destructor (clear ownership handling).