### PR TITLE
[raster] fix raster blending (fixes #16546)

### DIFF
--- a/src/core/raster/qgsrasterdrawer.cpp
+++ b/src/core/raster/qgsrasterdrawer.cpp
@@ -102,7 +102,11 @@ void QgsRasterDrawer::draw( QPainter *p, QgsRasterViewPort *viewPort, const QgsM
 
     delete block;
 
-    p->setCompositionMode( QPainter::CompositionMode_SourceOver );  // go back to the default composition mode
+    if ( feedback && feedback->renderPartialOutput() )
+    {
+      // go back to the default composition mode
+      p->setCompositionMode( QPainter::CompositionMode_SourceOver );
+    }
 
     // ok this does not matter much anyway as the tile size quite big so most of the time
     // there would be just one tile for the whole display area, but it won't hurt...


### PR DESCRIPTION
## Description
@wonder-sk , 9 months ago, a change of yours (commit e2bcba54d) let to a regression when rendering non-normal blended rasters. Long story short here, a specific painter composition mode would be wrongly reset to default while iterating through the parts of a raster layer's.

The PR fixes the regression (discussed with screenshots here https://issues.qgis.org/issues/16546). Does this look right to you? 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
