### PR TITLE
Avoid using thread unsafe proj API

### DIFF
--- a/python/core/qgscoordinatetransform.sip
+++ b/python/core/qgscoordinatetransform.sip
@@ -72,6 +72,14 @@ Default constructor, creates an invalid QgsCoordinateTransform.
  :rtype: bool
 %End
 
+    void detachForThread();
+%Docstring
+ Detaches the coordinate transform, making it safe for use in a new thread.
+ \warning This MUST be called for all QgsCoordinateTransform objects which
+ will be performing transformations in a new thread!
+.. versionadded:: 3.0
+%End
+
     void setSourceCrs( const QgsCoordinateReferenceSystem &crs );
 %Docstring
  Sets the source coordinate reference system.

--- a/python/core/qgscoordinatetransform.sip
+++ b/python/core/qgscoordinatetransform.sip
@@ -24,6 +24,12 @@ class QgsCoordinateTransform
  and destination coordinate systems refer to layer and map canvas respectively. All
  operations are from the perspective of the layer. For example, a forward transformation
  transforms coordinates from the layer's coordinate system to the map canvas.
+
+ \warning QgsCoordinateTransform transformations are not thread safe. If
+ a QgsCoordinateTransform object is to be reused in a background thread,
+ the detachForThread() method MUST be called prior to performing any
+ transformations using the object.
+
 .. note::
 
    Since QGIS 3.0 QgsCoordinateReferenceSystem objects are implicitly shared.

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -479,7 +479,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
   if ( !d->mOwnerThread )
     d->mOwnerThread = QThread::currentThread();
   else
-    Q_ASSERT( QThread::currentThread() == d->mOwnerThread );
+    Q_ASSERT_X( QThread::currentThread() == d->mOwnerThread, "transformCoords", "Using `QgsCoordinateTransform` in background thread without calling `detachForThread()`" );
 #endif
 
   // if the source/destination projection is lat/long, convert the points to radians

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -559,6 +559,11 @@ bool QgsCoordinateTransform::isValid() const
   return d->mIsValid;
 }
 
+void QgsCoordinateTransform::detachForThread()
+{
+  d.detach();
+}
+
 bool QgsCoordinateTransform::isShortCircuited() const
 {
   return !d->mIsValid || d->mShortCircuit;

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -30,6 +30,7 @@
 #include <QPolygonF>
 #include <QStringList>
 #include <QVector>
+#include <QThread>
 
 extern "C"
 {
@@ -449,6 +450,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 {
   if ( !d->mIsValid || d->mShortCircuit )
     return;
+
   // Refuse to transform the points if the srs's are invalid
   if ( !d->mSourceCRS.isValid() )
   {
@@ -471,6 +473,14 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 #endif
 
   // use proj4 to do the transform
+
+#ifdef QGISDEBUG
+  // thread safety check - if this fails, you haven't called detachForThread()!
+  if ( !d->mOwnerThread )
+    d->mOwnerThread = QThread::currentThread();
+  else
+    Q_ASSERT( QThread::currentThread() == d->mOwnerThread );
+#endif
 
   // if the source/destination projection is lat/long, convert the points to radians
   // prior to transforming

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -40,6 +40,12 @@ class QPolygonF;
 * and destination coordinate systems refer to layer and map canvas respectively. All
 * operations are from the perspective of the layer. For example, a forward transformation
 * transforms coordinates from the layer's coordinate system to the map canvas.
+*
+* \warning QgsCoordinateTransform transformations are not thread safe. If
+* a QgsCoordinateTransform object is to be reused in a background thread,
+* the detachForThread() method MUST be called prior to performing any
+* transformations using the object.
+*
 * \note Since QGIS 3.0 QgsCoordinateReferenceSystem objects are implicitly shared.
 */
 class CORE_EXPORT QgsCoordinateTransform

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -84,6 +84,14 @@ class CORE_EXPORT QgsCoordinateTransform
     bool isValid() const;
 
     /**
+     * Detaches the coordinate transform, making it safe for use in a new thread.
+     * \warning This MUST be called for all QgsCoordinateTransform objects which
+     * will be performing transformations in a new thread!
+     * \since QGIS 3.0
+     */
+    void detachForThread();
+
+    /**
      * Sets the source coordinate reference system.
      * \param crs CRS to transform coordinates from
      * \see sourceCrs()

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -49,6 +49,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
     explicit QgsCoordinateTransformPrivate()
       : mIsValid( false )
       , mShortCircuit( false )
+      , mProjContext( nullptr )
       , mSourceProjection( nullptr )
       , mDestinationProjection( nullptr )
       , mSourceDatumTransform( -1 )
@@ -63,6 +64,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
       , mShortCircuit( false )
       , mSourceCRS( source )
       , mDestCRS( destination )
+      , mProjContext( nullptr )
       , mSourceProjection( nullptr )
       , mDestinationProjection( nullptr )
       , mSourceDatumTransform( -1 )
@@ -78,6 +80,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
       , mShortCircuit( other.mShortCircuit )
       , mSourceCRS( other.mSourceCRS )
       , mDestCRS( other.mDestCRS )
+      , mProjContext( nullptr )
       , mSourceProjection( nullptr )
       , mDestinationProjection( nullptr )
       , mSourceDatumTransform( other.mSourceDatumTransform )
@@ -98,6 +101,8 @@ class QgsCoordinateTransformPrivate : public QSharedData
       {
         pj_free( mDestinationProjection );
       }
+      if ( mProjContext )
+        pj_ctx_free( mProjContext );
     }
 
     bool initialize()
@@ -121,6 +126,9 @@ class QgsCoordinateTransformPrivate : public QSharedData
         QgsDebugMsgLevel( "Destination CRS is invalid!", 4 );
         return false;
       }
+
+      if ( !mProjContext )
+        mProjContext = pj_ctx_alloc();
 
       mIsValid = true;
 
@@ -155,8 +163,8 @@ class QgsCoordinateTransformPrivate : public QSharedData
         addNullGridShifts( sourceProjString, destProjString );
       }
 
-      mSourceProjection = pj_init_plus( sourceProjString.toUtf8() );
-      mDestinationProjection = pj_init_plus( destProjString.toUtf8() );
+      mSourceProjection = pj_init_plus_ctx( mProjContext, sourceProjString.toUtf8() );
+      mDestinationProjection = pj_init_plus_ctx( mProjContext, destProjString.toUtf8() );
 
 #ifdef COORDINATE_TRANSFORM_VERBOSE
       QgsDebugMsg( "From proj : " + mSourceCRS.toProj4() );
@@ -329,6 +337,8 @@ class QgsCoordinateTransformPrivate : public QSharedData
 
     //! QgsCoordinateReferenceSystem of the destination (map canvas) coordinate system
     QgsCoordinateReferenceSystem mDestCRS;
+
+    projCtx mProjContext = nullptr;
 
     //! Proj4 data structure of the source projection (layer coordinate system)
     projPJ mSourceProjection;

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -85,6 +85,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
       , mDestinationProjection( nullptr )
       , mSourceDatumTransform( other.mSourceDatumTransform )
       , mDestinationDatumTransform( other.mDestinationDatumTransform )
+        // important - don't copy mOwnerThread!
     {
       //must reinitialize to setup mSourceProjection and mDestinationProjection
       initialize();
@@ -348,6 +349,11 @@ class QgsCoordinateTransformPrivate : public QSharedData
 
     int mSourceDatumTransform;
     int mDestinationDatumTransform;
+
+#ifdef QGISDEBUG
+    //! Owner thread - used during debugging to ensure QgsCoordinateTransform::detachForThread() is called
+    QThread *mOwnerThread = nullptr;
+#endif
 
     void setFinder()
     {

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -107,6 +107,7 @@ void QgsDiagramLayerSettings::setRenderer( QgsDiagramRenderer *diagramRenderer )
 void QgsDiagramLayerSettings::setCoordinateTransform( const QgsCoordinateTransform &transform )
 {
   mCt = transform;
+  mCt.detachForThread();
 }
 
 void QgsDiagramLayerSettings::readXml( const QDomElement &elem )

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -289,6 +289,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     job.context.expressionContext().appendScope( QgsExpressionContextUtils::layerScope( ml ) );
     job.context.setPainter( painter );
     job.context.setLabelingEngine( labelingEngine2 );
+    ct.detachForThread();
     job.context.setCoordinateTransform( ct );
     job.context.setExtent( r1 );
 

--- a/src/core/qgsvectorfilewritertask.cpp
+++ b/src/core/qgsvectorfilewritertask.cpp
@@ -31,6 +31,7 @@ QgsVectorFileWriterTask::QgsVectorFileWriterTask( QgsVectorLayer *layer, const Q
   }
   if ( mLayer )
     setDependentLayers( QList< QgsMapLayer * >() << mLayer );
+  mOptions.ct.detachForThread();
 }
 
 void QgsVectorFileWriterTask::cancel()

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -173,11 +173,17 @@ bool QgsVectorLayerLabelProvider::prepare( const QgsRenderContext &context, QSet
   lyr.xform = &mapSettings.mapToPixel();
   lyr.ct = QgsCoordinateTransform();
   if ( context.coordinateTransform().isValid() )
+  {
     // this is context for layer rendering - use its CT as it includes correct datum transform
     lyr.ct = context.coordinateTransform();
+    lyr.ct.detachForThread();
+  }
   else
+  {
     // otherwise fall back to creating our own CT - this one may not have the correct datum transform!
     lyr.ct = QgsCoordinateTransform( mCrs, mapSettings.destinationCrs() );
+    lyr.ct.detachForThread();
+  }
   lyr.ptZero = lyr.xform->toMapCoordinates( 0, 0 );
   lyr.ptOne = lyr.xform->toMapCoordinates( 1, 0 );
 

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -228,6 +228,7 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
       if ( projector && projector->destinationCrs() != projector->sourceCrs() )
       {
         QgsCoordinateTransform ct( projector->destinationCrs(), projector->sourceCrs() );
+        ct.detachForThread();
         srcExtent = ct.transformBoundingBox( outputExtent );
       }
       if ( !srcProvider->extent().contains( srcExtent ) )

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -760,6 +760,7 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
   }
 
   QgsCoordinateTransform inverseCt = QgsCoordinateTransformCache::instance()->transform( mDestCRS.authid(), mSrcCRS.authid(), mDestDatumTransform, mSrcDatumTransform );
+  inverseCt.detachForThread(); //needed? can we optimise this?
 
   ProjectorData pd( extent, width, height, mInput, inverseCt, mPrecision );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -417,6 +417,7 @@ namespace QgsWms
       }
 
       QgsCoordinateTransform tr = mapSettings.layerTransform( vl );
+      tr.detachForThread();
       context.setCoordinateTransform( tr );
       context.setExtent( tr.transformBoundingBox( mapSettings.extent(), QgsCoordinateTransform::ReverseTransform ) );
 


### PR DESCRIPTION
While working on https://github.com/qgis/QGIS/pull/4515 I noticed some odd behavior were QgsCsExceptions were being unpredictably thrown while rendering multiple map layers in parallel. I believe this is caused by QGIS *not* using the thread safe proj API.

So this PR adds QgsCoordinateTransform::detachForThread(). Calling this modifies an existing QgsCoordinateTransform to make it safe for use in a background thread. This is done by
1. using the proj thread safe API with contexts.
2. taking advantage of the reinitialization which is performed when QgsCoordinateTransformPrivate is copied to create a new projCtx. By detaching the private data member in QgsCoordinateTransform we effectively create a new projCtx which is safe for use in a new thread.

Any code performing transforms in background threads MUST call detachForThread() on any utilised QgsCoordinateTransform objects BEFORE performing transformations in this thread to avoid unpredictable behavior.

I *think* I've caught all the existing occurences of this and ensured detachForThread() is called. After these changes I'm no longer seeing these unpredictable and invalid QgsCsExceptions exceptions.

Likely a fix for https://issues.qgis.org/issues/11441