### PR TITLE
Use millimeters when declaring QPrinter page size

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5882,8 +5882,10 @@ void QgisApp::saveMapAsPdf()
     printer->setOutputFileName( fileName );
     printer->setOutputFormat( QPrinter::PdfFormat );
     printer->setOrientation( QPrinter::Portrait );
-    printer->setPaperSize( dlg.size(), QPrinter::DevicePixel );
-    printer->setPageMargins( 0, 0, 0, 0, QPrinter::DevicePixel );
+    // paper size needs to be given in millimeters in order to be able to set a resolution to pass onto the map renderer
+    printer->setPaperSize( dlg.size()  * 25.4 / dlg.dpi(), QPrinter::Millimeter );
+    printer->setPageMargins( 0, 0, 0, 0, QPrinter::Millimeter );
+    printer->setResolution( dlg.dpi() );
 
     QPainter *p = new QPainter();
     QImage *image = nullptr;
@@ -5906,7 +5908,6 @@ void QgisApp::saveMapAsPdf()
     }
     else
     {
-      printer->setResolution( dlg.dpi() );
       p->begin( printer );
     }
 


### PR DESCRIPTION
## Description
TIL: To be able to call setResolution on a QPrinter (which is needed for the map renderer), setting the paper size (setPaperSize()) can't be in QPrinter::DevicePixel. Doing so messes up with the map rendering scaling, etc.

@nyalldawson , that's a good lesson learned to keep in mind when you'll add pixel support to the composer/layout engine :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
