### PR TITLE
Avoid using thread unsafe proj API - approach 2

### DIFF
--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -453,8 +453,8 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
   //
   // We must check the prj def is valid!
   //
-
-  projPJ myProj = pj_init_plus( teParameters->toPlainText().toLocal8Bit().data() );
+  projCtx pContext = pj_ctx_alloc();
+  projPJ myProj = pj_init_plus_ctx( pContext, teParameters->toPlainText().toLocal8Bit().data() );
 
   QgsDebugMsg( QString( "My proj: %1" ).arg( teParameters->toPlainText() ) );
 
@@ -465,6 +465,7 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
     projectedX->setText( QLatin1String( "" ) );
     projectedY->setText( QLatin1String( "" ) );
     pj_free( myProj );
+    pj_ctx_free( pContext );
     return;
 
   }
@@ -480,10 +481,11 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
     projectedX->setText( QLatin1String( "" ) );
     projectedY->setText( QLatin1String( "" ) );
     pj_free( myProj );
+    pj_ctx_free( pContext );
     return;
   }
 
-  projPJ wgs84Proj = pj_init_plus( GEOPROJ4.toLocal8Bit().data() ); //defined in qgis.h
+  projPJ wgs84Proj = pj_init_plus_ctx( pContext, GEOPROJ4.toLocal8Bit().data() ); //defined in qgis.h
 
   if ( !wgs84Proj )
   {
@@ -492,6 +494,7 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
     projectedX->setText( QLatin1String( "" ) );
     projectedY->setText( QLatin1String( "" ) );
     pj_free( wgs84Proj );
+    pj_ctx_free( pContext );
     return;
   }
 
@@ -517,6 +520,7 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
   //
   pj_free( myProj );
   pj_free( wgs84Proj );
+  pj_ctx_free( pContext );
 
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -128,6 +128,7 @@ SET(QGIS_CORE_SRCS
   qgscontexthelp.cpp
   qgscoordinatereferencesystem.cpp
   qgscoordinatetransform.cpp
+  qgscoordinatetransform_p.cpp
   qgscoordinateutils.cpp
   qgscredentials.cpp
   qgscrscache.cpp

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1099,16 +1099,18 @@ void QgsCoordinateReferenceSystem::setProj4String( const QString &proj4String )
   // e.g if they lack a +ellps parameter, it will automatically add +ellps=WGS84, but as
   // we use the original mProj4 with QgsCoordinateTransform, it will fail to initialize
   // so better detect it now.
-  projPJ proj = pj_init_plus( proj4String.trimmed().toLatin1().constData() );
+  projCtx pContext = pj_ctx_alloc();
+  projPJ proj = pj_init_plus_ctx( pContext, proj4String.trimmed().toLatin1().constData() );
   if ( !proj )
   {
-    QgsDebugMsgLevel( "proj.4 string rejected by pj_init_plus()", 4 );
+    QgsDebugMsgLevel( "proj.4 string rejected by pj_init_plus_ctx()", 4 );
     d->mIsValid = false;
   }
   else
   {
     pj_free( proj );
   }
+  pj_ctx_free( pContext );
   d->mWkt.clear();
   setMapUnits();
 }
@@ -2020,6 +2022,8 @@ int QgsCoordinateReferenceSystem::syncDatabase()
                sqlite3_errmsg( database ) );
   }
 
+  projCtx pContext = pj_ctx_alloc();
+
 #if !defined(PJ_VERSION) || PJ_VERSION!=470
   sql = QStringLiteral( "select auth_name,auth_id,parameters from tbl_srs WHERE auth_name<>'EPSG' AND NOT deprecated AND NOT noupdate" );
   if ( sqlite3_prepare( database, sql.toLatin1(), sql.size(), &select, &tail ) == SQLITE_OK )
@@ -2031,11 +2035,11 @@ int QgsCoordinateReferenceSystem::syncDatabase()
       const char *params    = reinterpret_cast< const char * >( sqlite3_column_text( select, 2 ) );
 
       QString input = QStringLiteral( "+init=%1:%2" ).arg( QString( auth_name ).toLower(), auth_id );
-      projPJ pj = pj_init_plus( input.toLatin1() );
+      projPJ pj = pj_init_plus_ctx( pContext, input.toLatin1() );
       if ( !pj )
       {
         input = QStringLiteral( "+init=%1:%2" ).arg( QString( auth_name ).toUpper(), auth_id );
-        pj = pj_init_plus( input.toLatin1() );
+        pj = pj_init_plus_ctx( pContext, input.toLatin1() );
       }
 
       if ( pj )
@@ -2099,6 +2103,7 @@ int QgsCoordinateReferenceSystem::syncDatabase()
   sqlite3_finalize( select );
 #endif
 
+  pj_ctx_free( pContext );
 
   if ( sqlite3_exec( database, "COMMIT", nullptr, nullptr, nullptr ) != SQLITE_OK )
   {

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -474,8 +474,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
   // if the source/destination projection is lat/long, convert the points to radians
   // prior to transforming
-  if ( ( pj_is_latlong( d->mDestinationProjection ) && ( direction == ReverseTransform ) )
-       || ( pj_is_latlong( d->mSourceProjection ) && ( direction == ForwardTransform ) ) )
+  if ( ( pj_is_latlong( d->destProjection() ) && ( direction == ReverseTransform ) )
+       || ( pj_is_latlong( d->sourceProjection() ) && ( direction == ForwardTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {
@@ -487,13 +487,13 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
   int projResult;
   if ( direction == ReverseTransform )
   {
-    projResult = pj_transform( d->mDestinationProjection, d->mSourceProjection, numPoints, 0, x, y, z );
+    projResult = pj_transform( d->destProjection(), d->sourceProjection(), numPoints, 0, x, y, z );
   }
   else
   {
-    Q_ASSERT( d->mSourceProjection );
-    Q_ASSERT( d->mDestinationProjection );
-    projResult = pj_transform( d->mSourceProjection, d->mDestinationProjection, numPoints, 0, x, y, z );
+    Q_ASSERT( d->sourceProjection() );
+    Q_ASSERT( d->destProjection() );
+    projResult = pj_transform( d->sourceProjection(), d->destProjection(), numPoints, 0, x, y, z );
   }
 
   if ( projResult != 0 )
@@ -515,8 +515,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
     QString dir = ( direction == ForwardTransform ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
 
-    char *srcdef = pj_get_def( d->mSourceProjection, 0 );
-    char *dstdef = pj_get_def( d->mDestinationProjection, 0 );
+    char *srcdef = pj_get_def( d->sourceProjection(), 0 );
+    char *dstdef = pj_get_def( d->destProjection(), 0 );
 
     QString msg = QObject::tr( "%1 of\n"
                                "%2"
@@ -538,8 +538,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
   // if the result is lat/long, convert the results from radians back
   // to degrees
-  if ( ( pj_is_latlong( d->mDestinationProjection ) && ( direction == ForwardTransform ) )
-       || ( pj_is_latlong( d->mSourceProjection ) && ( direction == ReverseTransform ) ) )
+  if ( ( pj_is_latlong( d->destProjection() ) && ( direction == ForwardTransform ) )
+       || ( pj_is_latlong( d->sourceProjection() ) && ( direction == ReverseTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -474,8 +474,12 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
   // if the source/destination projection is lat/long, convert the points to radians
   // prior to transforming
-  if ( ( pj_is_latlong( d->destProjection() ) && ( direction == ReverseTransform ) )
-       || ( pj_is_latlong( d->sourceProjection() ) && ( direction == ForwardTransform ) ) )
+  QPair<projPJ, projPJ> projData = d->threadLocalProjData();
+  projPJ sourceProj = projData.first;
+  projPJ destProj = projData.second;
+
+  if ( ( pj_is_latlong( destProj ) && ( direction == ReverseTransform ) )
+       || ( pj_is_latlong( sourceProj ) && ( direction == ForwardTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {
@@ -487,13 +491,13 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
   int projResult;
   if ( direction == ReverseTransform )
   {
-    projResult = pj_transform( d->destProjection(), d->sourceProjection(), numPoints, 0, x, y, z );
+    projResult = pj_transform( destProj, sourceProj, numPoints, 0, x, y, z );
   }
   else
   {
-    Q_ASSERT( d->sourceProjection() );
-    Q_ASSERT( d->destProjection() );
-    projResult = pj_transform( d->sourceProjection(), d->destProjection(), numPoints, 0, x, y, z );
+    Q_ASSERT( sourceProj );
+    Q_ASSERT( destProj );
+    projResult = pj_transform( sourceProj, destProj, numPoints, 0, x, y, z );
   }
 
   if ( projResult != 0 )
@@ -515,8 +519,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
     QString dir = ( direction == ForwardTransform ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
 
-    char *srcdef = pj_get_def( d->sourceProjection(), 0 );
-    char *dstdef = pj_get_def( d->destProjection(), 0 );
+    char *srcdef = pj_get_def( sourceProj, 0 );
+    char *dstdef = pj_get_def( destProj, 0 );
 
     QString msg = QObject::tr( "%1 of\n"
                                "%2"
@@ -538,8 +542,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
   // if the result is lat/long, convert the results from radians back
   // to degrees
-  if ( ( pj_is_latlong( d->destProjection() ) && ( direction == ForwardTransform ) )
-       || ( pj_is_latlong( d->sourceProjection() ) && ( direction == ReverseTransform ) ) )
+  if ( ( pj_is_latlong( destProj ) && ( direction == ForwardTransform ) )
+       || ( pj_is_latlong( sourceProj ) && ( direction == ReverseTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -280,7 +280,7 @@ class CORE_EXPORT QgsCoordinateTransform
 
     static void searchDatumTransform( const QString &sql, QList< int > &transforms );
 
-    QExplicitlySharedDataPointer<QgsCoordinateTransformPrivate> d;
+    mutable QExplicitlySharedDataPointer<QgsCoordinateTransformPrivate> d;
 };
 
 //! Output stream operator

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -1,0 +1,312 @@
+/***************************************************************************
+               qgscoordinatetransform_p.cpp
+               ----------------------------
+    begin                : May 2017
+    copyright            : (C) 2017 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscoordinatetransform_p.h"
+#include "qgslogger.h"
+#include "qgsapplication.h"
+
+extern "C"
+{
+#include <proj_api.h>
+}
+#include <sqlite3.h>
+
+#include <QStringList>
+
+/// @cond PRIVATE
+
+QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate()
+  : mIsValid( false )
+  , mShortCircuit( false )
+  , mSourceProjection( nullptr )
+  , mDestinationProjection( nullptr )
+  , mSourceDatumTransform( -1 )
+  , mDestinationDatumTransform( -1 )
+{
+  setFinder();
+}
+
+QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
+  : mIsValid( false )
+  , mShortCircuit( false )
+  , mSourceCRS( source )
+  , mDestCRS( destination )
+  , mSourceProjection( nullptr )
+  , mDestinationProjection( nullptr )
+  , mSourceDatumTransform( -1 )
+  , mDestinationDatumTransform( -1 )
+{
+  setFinder();
+  initialize();
+}
+
+QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate( const QgsCoordinateTransformPrivate &other )
+  : QSharedData( other )
+  , mIsValid( other.mIsValid )
+  , mShortCircuit( other.mShortCircuit )
+  , mSourceCRS( other.mSourceCRS )
+  , mDestCRS( other.mDestCRS )
+  , mSourceProjection( nullptr )
+  , mDestinationProjection( nullptr )
+  , mSourceDatumTransform( other.mSourceDatumTransform )
+  , mDestinationDatumTransform( other.mDestinationDatumTransform )
+{
+  //must reinitialize to setup mSourceProjection and mDestinationProjection
+  initialize();
+}
+
+QgsCoordinateTransformPrivate::~QgsCoordinateTransformPrivate()
+{
+  // free the proj objects
+  if ( mSourceProjection )
+  {
+    pj_free( mSourceProjection );
+  }
+  if ( mDestinationProjection )
+  {
+    pj_free( mDestinationProjection );
+  }
+}
+
+bool QgsCoordinateTransformPrivate::initialize()
+{
+  mShortCircuit = true;
+  mIsValid = false;
+
+  if ( !mSourceCRS.isValid() )
+  {
+    // Pass through with no projection since we have no idea what the layer
+    // coordinates are and projecting them may not be appropriate
+    QgsDebugMsgLevel( "Source CRS is invalid!", 4 );
+    return false;
+  }
+
+  if ( !mDestCRS.isValid() )
+  {
+    //No destination projection is set so we set the default output projection to
+    //be the same as input proj.
+    mDestCRS = mSourceCRS;
+    QgsDebugMsgLevel( "Destination CRS is invalid!", 4 );
+    return false;
+  }
+
+  mIsValid = true;
+
+  bool useDefaultDatumTransform = ( mSourceDatumTransform == - 1 && mDestinationDatumTransform == -1 );
+
+  // init the projections (destination and source)
+
+  pj_free( mSourceProjection );
+  QString sourceProjString = mSourceCRS.toProj4();
+  if ( !useDefaultDatumTransform )
+  {
+    sourceProjString = stripDatumTransform( sourceProjString );
+  }
+  if ( mSourceDatumTransform != -1 )
+  {
+    sourceProjString += ( ' ' + datumTransformString( mSourceDatumTransform ) );
+  }
+
+  pj_free( mDestinationProjection );
+  QString destProjString = mDestCRS.toProj4();
+  if ( !useDefaultDatumTransform )
+  {
+    destProjString = stripDatumTransform( destProjString );
+  }
+  if ( mDestinationDatumTransform != -1 )
+  {
+    destProjString += ( ' ' +  datumTransformString( mDestinationDatumTransform ) );
+  }
+
+  if ( !useDefaultDatumTransform )
+  {
+    addNullGridShifts( sourceProjString, destProjString );
+  }
+
+  mSourceProjection = pj_init_plus( sourceProjString.toUtf8() );
+  mDestinationProjection = pj_init_plus( destProjString.toUtf8() );
+
+#ifdef COORDINATE_TRANSFORM_VERBOSE
+  QgsDebugMsg( "From proj : " + mSourceCRS.toProj4() );
+  QgsDebugMsg( "To proj   : " + mDestCRS.toProj4() );
+#endif
+
+  if ( !mDestinationProjection || !mSourceProjection )
+  {
+    mIsValid = false;
+  }
+
+#ifdef COORDINATE_TRANSFORM_VERBOSE
+  if ( mIsValid )
+  {
+    QgsDebugMsg( "------------------------------------------------------------" );
+    QgsDebugMsg( "The OGR Coordinate transformation for this layer was set to" );
+    QgsLogger::debug<QgsCoordinateReferenceSystem>( "Input", mSourceCRS, __FILE__, __FUNCTION__, __LINE__ );
+    QgsLogger::debug<QgsCoordinateReferenceSystem>( "Output", mDestCRS, __FILE__, __FUNCTION__, __LINE__ );
+    QgsDebugMsg( "------------------------------------------------------------" );
+  }
+  else
+  {
+    QgsDebugMsg( "------------------------------------------------------------" );
+    QgsDebugMsg( "The OGR Coordinate transformation FAILED TO INITIALIZE!" );
+    QgsDebugMsg( "------------------------------------------------------------" );
+  }
+#else
+  if ( !mIsValid )
+  {
+    QgsDebugMsg( "Coordinate transformation failed to initialize!" );
+  }
+#endif
+
+  //XXX todo overload == operator for QgsCoordinateReferenceSystem
+  //at the moment srs.parameters contains the whole proj def...soon it won't...
+  //if (mSourceCRS->toProj4() == mDestCRS->toProj4())
+  if ( mSourceCRS == mDestCRS )
+  {
+    // If the source and destination projection are the same, set the short
+    // circuit flag (no transform takes place)
+    mShortCircuit = true;
+    QgsDebugMsgLevel( "Source/Dest CRS equal, shortcircuit is set.", 3 );
+  }
+  else
+  {
+    // Transform must take place
+    mShortCircuit = false;
+    QgsDebugMsgLevel( "Source/Dest CRS not equal, shortcircuit is not set.", 3 );
+  }
+  return mIsValid;
+}
+
+QString QgsCoordinateTransformPrivate::stripDatumTransform( const QString &proj4 ) const
+{
+  QStringList parameterSplit = proj4.split( '+', QString::SkipEmptyParts );
+  QString currentParameter;
+  QString newProjString;
+
+  for ( int i = 0; i < parameterSplit.size(); ++i )
+  {
+    currentParameter = parameterSplit.at( i );
+    if ( !currentParameter.startsWith( QLatin1String( "towgs84" ), Qt::CaseInsensitive )
+         && !currentParameter.startsWith( QLatin1String( "nadgrids" ), Qt::CaseInsensitive ) )
+    {
+      newProjString.append( '+' );
+      newProjString.append( currentParameter );
+      newProjString.append( ' ' );
+    }
+  }
+  return newProjString;
+}
+
+QString QgsCoordinateTransformPrivate::datumTransformString( int datumTransform )
+{
+  QString transformString;
+
+  sqlite3 *db = nullptr;
+  int openResult = sqlite3_open_v2( QgsApplication::srsDatabaseFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
+  if ( openResult != SQLITE_OK )
+  {
+    sqlite3_close( db );
+    return transformString;
+  }
+
+  sqlite3_stmt *stmt = nullptr;
+  QString sql = QStringLiteral( "SELECT coord_op_method_code,p1,p2,p3,p4,p5,p6,p7 FROM tbl_datum_transform WHERE coord_op_code=%1" ).arg( datumTransform );
+  int prepareRes = sqlite3_prepare( db, sql.toLatin1(), sql.size(), &stmt, nullptr );
+  if ( prepareRes != SQLITE_OK )
+  {
+    sqlite3_finalize( stmt );
+    sqlite3_close( db );
+    return transformString;
+  }
+
+  if ( sqlite3_step( stmt ) == SQLITE_ROW )
+  {
+    //coord_op_methode_code
+    int methodCode = sqlite3_column_int( stmt, 0 );
+    if ( methodCode == 9615 ) //ntv2
+    {
+      transformString = "+nadgrids=" + QString( reinterpret_cast< const char * >( sqlite3_column_text( stmt, 1 ) ) );
+    }
+    else if ( methodCode == 9603 || methodCode == 9606 || methodCode == 9607 )
+    {
+      transformString += QLatin1String( "+towgs84=" );
+      double p1 = sqlite3_column_double( stmt, 1 );
+      double p2 = sqlite3_column_double( stmt, 2 );
+      double p3 = sqlite3_column_double( stmt, 3 );
+      double p4 = sqlite3_column_double( stmt, 4 );
+      double p5 = sqlite3_column_double( stmt, 5 );
+      double p6 = sqlite3_column_double( stmt, 6 );
+      double p7 = sqlite3_column_double( stmt, 7 );
+      if ( methodCode == 9603 ) //3 parameter transformation
+      {
+        transformString += QStringLiteral( "%1,%2,%3" ).arg( p1 ).arg( p2 ).arg( p3 );
+      }
+      else //7 parameter transformation
+      {
+        transformString += QStringLiteral( "%1,%2,%3,%4,%5,%6,%7" ).arg( p1 ).arg( p2 ).arg( p3 ).arg( p4 ).arg( p5 ).arg( p6 ).arg( p7 );
+      }
+    }
+  }
+
+  sqlite3_finalize( stmt );
+  sqlite3_close( db );
+  return transformString;
+}
+
+void QgsCoordinateTransformPrivate::addNullGridShifts( QString &srcProjString, QString &destProjString ) const
+{
+  //if one transformation uses ntv2, the other one needs to be null grid shift
+  if ( mDestinationDatumTransform == -1 && srcProjString.contains( QLatin1String( "+nadgrids" ) ) ) //add null grid if source transformation is ntv2
+  {
+    destProjString += QLatin1String( " +nadgrids=@null" );
+    return;
+  }
+  if ( mSourceDatumTransform == -1 && destProjString.contains( QLatin1String( "+nadgrids" ) ) )
+  {
+    srcProjString += QLatin1String( " +nadgrids=@null" );
+    return;
+  }
+
+  //add null shift grid for google mercator
+  //(see e.g. http://trac.osgeo.org/proj/wiki/FAQ#ChangingEllipsoidWhycantIconvertfromWGS84toGoogleEarthVirtualGlobeMercator)
+  if ( mSourceCRS.authid().compare( QLatin1String( "EPSG:3857" ), Qt::CaseInsensitive ) == 0 && mSourceDatumTransform == -1 )
+  {
+    srcProjString += QLatin1String( " +nadgrids=@null" );
+  }
+  if ( mDestCRS.authid().compare( QLatin1String( "EPSG:3857" ), Qt::CaseInsensitive ) == 0 && mDestinationDatumTransform == -1 )
+  {
+    destProjString += QLatin1String( " +nadgrids=@null" );
+  }
+}
+
+void QgsCoordinateTransformPrivate::setFinder()
+{
+#if 0
+  // Attention! It should be possible to set PROJ_LIB
+  // but it can happen that it was previously set by installer
+  // (version 0.7) and the old installation was deleted
+
+  // Another problem: PROJ checks if pj_finder was set before
+  // PROJ_LIB environment variable. pj_finder is probably set in
+  // GRASS gproj library when plugin is loaded, consequently
+  // PROJ_LIB is ignored
+
+  pj_set_finder( finder );
+#endif
+}
+
+///@endcond

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -30,289 +30,24 @@
 
 #include <QSharedData>
 #include "qgscoordinatereferencesystem.h"
-#include "qgslogger.h"
-#include "qgsapplication.h"
 
-extern "C"
-{
-#include <proj_api.h>
-}
-#include <sqlite3.h>
-
-#include <QStringList>
+typedef void *projPJ;
 
 class QgsCoordinateTransformPrivate : public QSharedData
 {
 
   public:
 
-    explicit QgsCoordinateTransformPrivate()
-      : mIsValid( false )
-      , mShortCircuit( false )
-      , mSourceProjection( nullptr )
-      , mDestinationProjection( nullptr )
-      , mSourceDatumTransform( -1 )
-      , mDestinationDatumTransform( -1 )
-    {
-      setFinder();
-    }
+    explicit QgsCoordinateTransformPrivate();
 
     QgsCoordinateTransformPrivate( const QgsCoordinateReferenceSystem &source,
-                                   const QgsCoordinateReferenceSystem &destination )
-      : mIsValid( false )
-      , mShortCircuit( false )
-      , mSourceCRS( source )
-      , mDestCRS( destination )
-      , mSourceProjection( nullptr )
-      , mDestinationProjection( nullptr )
-      , mSourceDatumTransform( -1 )
-      , mDestinationDatumTransform( -1 )
-    {
-      setFinder();
-      initialize();
-    }
+                                   const QgsCoordinateReferenceSystem &destination );
 
-    QgsCoordinateTransformPrivate( const QgsCoordinateTransformPrivate &other )
-      : QSharedData( other )
-      , mIsValid( other.mIsValid )
-      , mShortCircuit( other.mShortCircuit )
-      , mSourceCRS( other.mSourceCRS )
-      , mDestCRS( other.mDestCRS )
-      , mSourceProjection( nullptr )
-      , mDestinationProjection( nullptr )
-      , mSourceDatumTransform( other.mSourceDatumTransform )
-      , mDestinationDatumTransform( other.mDestinationDatumTransform )
-    {
-      //must reinitialize to setup mSourceProjection and mDestinationProjection
-      initialize();
-    }
+    QgsCoordinateTransformPrivate( const QgsCoordinateTransformPrivate &other );
 
-    ~QgsCoordinateTransformPrivate()
-    {
-      // free the proj objects
-      if ( mSourceProjection )
-      {
-        pj_free( mSourceProjection );
-      }
-      if ( mDestinationProjection )
-      {
-        pj_free( mDestinationProjection );
-      }
-    }
+    ~QgsCoordinateTransformPrivate();
 
-    bool initialize()
-    {
-      mShortCircuit = true;
-      mIsValid = false;
-
-      if ( !mSourceCRS.isValid() )
-      {
-        // Pass through with no projection since we have no idea what the layer
-        // coordinates are and projecting them may not be appropriate
-        QgsDebugMsgLevel( "Source CRS is invalid!", 4 );
-        return false;
-      }
-
-      if ( !mDestCRS.isValid() )
-      {
-        //No destination projection is set so we set the default output projection to
-        //be the same as input proj.
-        mDestCRS = mSourceCRS;
-        QgsDebugMsgLevel( "Destination CRS is invalid!", 4 );
-        return false;
-      }
-
-      mIsValid = true;
-
-      bool useDefaultDatumTransform = ( mSourceDatumTransform == - 1 && mDestinationDatumTransform == -1 );
-
-      // init the projections (destination and source)
-
-      pj_free( mSourceProjection );
-      QString sourceProjString = mSourceCRS.toProj4();
-      if ( !useDefaultDatumTransform )
-      {
-        sourceProjString = stripDatumTransform( sourceProjString );
-      }
-      if ( mSourceDatumTransform != -1 )
-      {
-        sourceProjString += ( ' ' + datumTransformString( mSourceDatumTransform ) );
-      }
-
-      pj_free( mDestinationProjection );
-      QString destProjString = mDestCRS.toProj4();
-      if ( !useDefaultDatumTransform )
-      {
-        destProjString = stripDatumTransform( destProjString );
-      }
-      if ( mDestinationDatumTransform != -1 )
-      {
-        destProjString += ( ' ' +  datumTransformString( mDestinationDatumTransform ) );
-      }
-
-      if ( !useDefaultDatumTransform )
-      {
-        addNullGridShifts( sourceProjString, destProjString );
-      }
-
-      mSourceProjection = pj_init_plus( sourceProjString.toUtf8() );
-      mDestinationProjection = pj_init_plus( destProjString.toUtf8() );
-
-#ifdef COORDINATE_TRANSFORM_VERBOSE
-      QgsDebugMsg( "From proj : " + mSourceCRS.toProj4() );
-      QgsDebugMsg( "To proj   : " + mDestCRS.toProj4() );
-#endif
-
-      if ( !mDestinationProjection || !mSourceProjection )
-      {
-        mIsValid = false;
-      }
-
-#ifdef COORDINATE_TRANSFORM_VERBOSE
-      if ( mIsValid )
-      {
-        QgsDebugMsg( "------------------------------------------------------------" );
-        QgsDebugMsg( "The OGR Coordinate transformation for this layer was set to" );
-        QgsLogger::debug<QgsCoordinateReferenceSystem>( "Input", mSourceCRS, __FILE__, __FUNCTION__, __LINE__ );
-        QgsLogger::debug<QgsCoordinateReferenceSystem>( "Output", mDestCRS, __FILE__, __FUNCTION__, __LINE__ );
-        QgsDebugMsg( "------------------------------------------------------------" );
-      }
-      else
-      {
-        QgsDebugMsg( "------------------------------------------------------------" );
-        QgsDebugMsg( "The OGR Coordinate transformation FAILED TO INITIALIZE!" );
-        QgsDebugMsg( "------------------------------------------------------------" );
-      }
-#else
-      if ( !mIsValid )
-      {
-        QgsDebugMsg( "Coordinate transformation failed to initialize!" );
-      }
-#endif
-
-      //XXX todo overload == operator for QgsCoordinateReferenceSystem
-      //at the moment srs.parameters contains the whole proj def...soon it won't...
-      //if (mSourceCRS->toProj4() == mDestCRS->toProj4())
-      if ( mSourceCRS == mDestCRS )
-      {
-        // If the source and destination projection are the same, set the short
-        // circuit flag (no transform takes place)
-        mShortCircuit = true;
-        QgsDebugMsgLevel( "Source/Dest CRS equal, shortcircuit is set.", 3 );
-      }
-      else
-      {
-        // Transform must take place
-        mShortCircuit = false;
-        QgsDebugMsgLevel( "Source/Dest CRS not equal, shortcircuit is not set.", 3 );
-      }
-      return mIsValid;
-    }
-
-    //! Removes +nadgrids and +towgs84 from proj4 string
-    QString stripDatumTransform( const QString &proj4 ) const
-    {
-      QStringList parameterSplit = proj4.split( '+', QString::SkipEmptyParts );
-      QString currentParameter;
-      QString newProjString;
-
-      for ( int i = 0; i < parameterSplit.size(); ++i )
-      {
-        currentParameter = parameterSplit.at( i );
-        if ( !currentParameter.startsWith( QLatin1String( "towgs84" ), Qt::CaseInsensitive )
-             && !currentParameter.startsWith( QLatin1String( "nadgrids" ), Qt::CaseInsensitive ) )
-        {
-          newProjString.append( '+' );
-          newProjString.append( currentParameter );
-          newProjString.append( ' ' );
-        }
-      }
-      return newProjString;
-    }
-
-    static QString datumTransformString( int datumTransform )
-    {
-      QString transformString;
-
-      sqlite3 *db = nullptr;
-      int openResult = sqlite3_open_v2( QgsApplication::srsDatabaseFilePath().toUtf8().constData(), &db, SQLITE_OPEN_READONLY, 0 );
-      if ( openResult != SQLITE_OK )
-      {
-        sqlite3_close( db );
-        return transformString;
-      }
-
-      sqlite3_stmt *stmt = nullptr;
-      QString sql = QStringLiteral( "SELECT coord_op_method_code,p1,p2,p3,p4,p5,p6,p7 FROM tbl_datum_transform WHERE coord_op_code=%1" ).arg( datumTransform );
-      int prepareRes = sqlite3_prepare( db, sql.toLatin1(), sql.size(), &stmt, nullptr );
-      if ( prepareRes != SQLITE_OK )
-      {
-        sqlite3_finalize( stmt );
-        sqlite3_close( db );
-        return transformString;
-      }
-
-      if ( sqlite3_step( stmt ) == SQLITE_ROW )
-      {
-        //coord_op_methode_code
-        int methodCode = sqlite3_column_int( stmt, 0 );
-        if ( methodCode == 9615 ) //ntv2
-        {
-          transformString = "+nadgrids=" + QString( reinterpret_cast< const char * >( sqlite3_column_text( stmt, 1 ) ) );
-        }
-        else if ( methodCode == 9603 || methodCode == 9606 || methodCode == 9607 )
-        {
-          transformString += QLatin1String( "+towgs84=" );
-          double p1 = sqlite3_column_double( stmt, 1 );
-          double p2 = sqlite3_column_double( stmt, 2 );
-          double p3 = sqlite3_column_double( stmt, 3 );
-          double p4 = sqlite3_column_double( stmt, 4 );
-          double p5 = sqlite3_column_double( stmt, 5 );
-          double p6 = sqlite3_column_double( stmt, 6 );
-          double p7 = sqlite3_column_double( stmt, 7 );
-          if ( methodCode == 9603 ) //3 parameter transformation
-          {
-            transformString += QStringLiteral( "%1,%2,%3" ).arg( p1 ).arg( p2 ).arg( p3 );
-          }
-          else //7 parameter transformation
-          {
-            transformString += QStringLiteral( "%1,%2,%3,%4,%5,%6,%7" ).arg( p1 ).arg( p2 ).arg( p3 ).arg( p4 ).arg( p5 ).arg( p6 ).arg( p7 );
-          }
-        }
-      }
-
-      sqlite3_finalize( stmt );
-      sqlite3_close( db );
-      return transformString;
-    }
-
-    //! In certain situations, null grid shifts have to be added to src / dst proj string
-    void addNullGridShifts( QString &srcProjString, QString &destProjString ) const
-    {
-      //if one transformation uses ntv2, the other one needs to be null grid shift
-      if ( mDestinationDatumTransform == -1 && srcProjString.contains( QLatin1String( "+nadgrids" ) ) ) //add null grid if source transformation is ntv2
-      {
-        destProjString += QLatin1String( " +nadgrids=@null" );
-        return;
-      }
-      if ( mSourceDatumTransform == -1 && destProjString.contains( QLatin1String( "+nadgrids" ) ) )
-      {
-        srcProjString += QLatin1String( " +nadgrids=@null" );
-        return;
-      }
-
-      //add null shift grid for google mercator
-      //(see e.g. http://trac.osgeo.org/proj/wiki/FAQ#ChangingEllipsoidWhycantIconvertfromWGS84toGoogleEarthVirtualGlobeMercator)
-      if ( mSourceCRS.authid().compare( QLatin1String( "EPSG:3857" ), Qt::CaseInsensitive ) == 0 && mSourceDatumTransform == -1 )
-      {
-        srcProjString += QLatin1String( " +nadgrids=@null" );
-      }
-      if ( mDestCRS.authid().compare( QLatin1String( "EPSG:3857" ), Qt::CaseInsensitive ) == 0 && mDestinationDatumTransform == -1 )
-      {
-        destProjString += QLatin1String( " +nadgrids=@null" );
-      }
-    }
-
+    bool initialize();
 
     //! Flag to indicate whether the transform is valid (ie has a valid
     //! source and destination crs)
@@ -339,21 +74,17 @@ class QgsCoordinateTransformPrivate : public QSharedData
     int mSourceDatumTransform;
     int mDestinationDatumTransform;
 
-    void setFinder()
-    {
-#if 0
-      // Attention! It should be possible to set PROJ_LIB
-      // but it can happen that it was previously set by installer
-      // (version 0.7) and the old installation was deleted
+    static QString datumTransformString( int datumTransform );
 
-      // Another problem: PROJ checks if pj_finder was set before
-      // PROJ_LIB environment variable. pj_finder is probably set in
-      // GRASS gproj library when plugin is loaded, consequently
-      // PROJ_LIB is ignored
+  private:
 
-      pj_set_finder( finder );
-#endif
-    }
+    //! Removes +nadgrids and +towgs84 from proj4 string
+    QString stripDatumTransform( const QString &proj4 ) const;
+
+    //! In certain situations, null grid shifts have to be added to src / dst proj string
+    void addNullGridShifts( QString &srcProjString, QString &destProjString ) const;
+
+    void setFinder();
 };
 
 /// @endcond

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -67,7 +67,8 @@ class QgsCoordinateTransformPrivate : public QSharedData
     ~QgsCoordinateTransformPrivate();
 
     bool initialize();
-    void initializeCurrentContext();
+
+    QPair< projPJ, projPJ > threadLocalProjData();
 
     //! Flag to indicate whether the transform is valid (ie has a valid
     //! source and destination crs)
@@ -87,8 +88,6 @@ class QgsCoordinateTransformPrivate : public QSharedData
 
     QString mSourceProjString;
     QString mDestProjString;
-    projPJ sourceProjection();
-    projPJ destProjection();
 
     int mSourceDatumTransform;
     int mDestinationDatumTransform;


### PR DESCRIPTION
(Alternative approach to https://github.com/qgis/QGIS/pull/4553)

While working on #4515 I noticed some odd behavior were QgsCsExceptions were being unpredictably thrown while rendering multiple map layers in parallel. I believe this is caused by QGIS not using the thread safe proj API.

This PR avoids unpredictable behavior when transforms are being conducted in background threads, such as map renders, and is likely a fix for https://issues.qgis.org/issues/11441

This commit:
1. Uses thread_local storage for projCtx objects, to ensure that every thread correctly has its own projCtx context.

2. Refactors QgsCoordinateTransformPrivate so that the projPJ source and destination objects are instead stored in a map (by projCtx). This allows transforms to be transparently performed using the correct projPJ objects for the particular thread in which the transform is being conducted. This approach avoids expensive detachment of QgsCoordinateTransformPrivate, and allows a single QgsCoordinateTransformPrivate to be safely utilised by QgsCoordinateTransform objects in different threads.

The advantage of this approach over #4553 is that the thread safety is transparent to API users - there's no need to prepare a QgsCoordinateTransform in advance before using in a background thread. The disadvantage is that the code is more complex, and there's also a small performance hit due to the use of the context->projPj map (and the mutex required to accompany this). Still, of the two I'd prefer this approach...