### PR TITLE
Add clone() methods for layers

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1696,6 +1696,7 @@ QgsPluginLayer        {#qgis_api_break_3_0_QgsPluginLayer}
 --------------
 
 - createMapRenderer(): default implementation (which called plugin's draw() method) has been removed. Plugin layers must implement createMapRenderer().
+- clone(): new pure virtual method. Plugin layer must implement clone().
 
 
 QgsPluginLayerRegistry        {#qgis_api_break_3_0_QgsPluginLayerRegistry}

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -67,10 +67,10 @@ class QgsMapLayer : QObject
     virtual ~QgsMapLayer();
 
 
-    virtual QgsMapLayer *clone( bool deep ) const = 0;
+    virtual QgsMapLayer *clone() const = 0;
 %Docstring
- Returns a new instance equivalent to this one.
- \param deep If true, a deep copy is done
+ Returns a new instance equivalent to this one except for the id which
+  is still unique.
  :return: a new layer instance
 .. versionadded:: 3.0
  :rtype: QgsMapLayer
@@ -1045,12 +1045,10 @@ Signal emitted when the blend mode is changed, through QgsMapLayer.setBlendMode(
 
   protected:
 
-    void clone( QgsMapLayer *layer, bool deep = false ) const;
+    void clone( QgsMapLayer *layer ) const;
 %Docstring
- Copies attributes like name, short name, ... into another layer. The
-  unique ID is copied too if deep parameter is true.
+ Copies attributes like name, short name, ... into another layer.
  \param layer The copy recipient
- \param deep To copy the unique ID or not
 .. versionadded:: 3.0
 %End
 

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -67,6 +67,15 @@ class QgsMapLayer : QObject
     virtual ~QgsMapLayer();
 
 
+    virtual QgsMapLayer *clone( bool deep ) const = 0;
+%Docstring
+ Returns a new instance equivalent to this one.
+ \param deep If true, a deep copy is done
+ :return: a new layer instance
+.. versionadded:: 3.0
+ :rtype: QgsMapLayer
+%End
+
     QgsMapLayer::LayerType type() const;
 %Docstring
  Returns the type of the layer.
@@ -468,6 +477,13 @@ Invoked by QgsProject.read().
  Read a custom property from layer. Properties are stored in a map and saved in project file.
 .. seealso:: setCustomProperty()
  :rtype: QVariant
+%End
+
+    void setCustomProperties( const QgsObjectCustomProperties &properties );
+%Docstring
+ Set custom properties for layer.
+ \param properties The custom properties to set.
+.. versionadded:: 3.0
 %End
 
     void removeCustomProperty( const QString &key );
@@ -1028,6 +1044,16 @@ Signal emitted when the blend mode is changed, through QgsMapLayer.setBlendMode(
 %End
 
   protected:
+
+    void clone( QgsMapLayer *layer, bool deep = false ) const;
+%Docstring
+ Copies attributes like name, short name, ... into another layer. The
+  unique ID is copied too if deep parameter is true.
+ \param layer The copy recipient
+ \param deep To copy the unique ID or not
+.. versionadded:: 3.0
+%End
+
     virtual void setExtent( const QgsRectangle &rect );
 %Docstring
 Set the extent

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -481,8 +481,7 @@ Invoked by QgsProject.read().
 
     void setCustomProperties( const QgsObjectCustomProperties &properties );
 %Docstring
- Set custom properties for layer.
- \param properties The custom properties to set.
+ Set custom properties for layer. Current properties are dropped.
 .. versionadded:: 3.0
 %End
 

--- a/python/core/qgsmaplayerstylemanager.sip
+++ b/python/core/qgsmaplayerstylemanager.sip
@@ -133,6 +133,15 @@ Write configuration (for project saving)
 Return list of all defined style names
  :rtype: list of str
 %End
+
+    QMap<QString, QgsMapLayerStyle> mapLayerStyles() const;
+%Docstring
+ Gets available styles for the associated map layer.
+ :return: A map of map layer style by style name
+.. versionadded:: 3.0
+ :rtype: QMap<str, QgsMapLayerStyle>
+%End
+
     QgsMapLayerStyle style( const QString &name ) const;
 %Docstring
 Return data of a stored style - accessed by its unique name

--- a/python/core/qgspluginlayer.sip
+++ b/python/core/qgspluginlayer.sip
@@ -26,7 +26,7 @@ In order to be readable from project files, they should set these attributes in 
     QgsPluginLayer( const QString &layerType, const QString &layerName = QString() );
     ~QgsPluginLayer();
 
-    virtual QgsPluginLayer *clone( bool deep ) const = 0;
+    virtual QgsPluginLayer *clone() const = 0;
 %Docstring
  Returns a new instance equivalent to this one.
  \param deep If true, a deep copy is done

--- a/python/core/qgspluginlayer.sip
+++ b/python/core/qgspluginlayer.sip
@@ -29,7 +29,6 @@ In order to be readable from project files, they should set these attributes in 
     virtual QgsPluginLayer *clone() const = 0;
 %Docstring
  Returns a new instance equivalent to this one.
- \param deep If true, a deep copy is done
  :return: a new layer instance
 .. versionadded:: 3.0
  :rtype: QgsPluginLayer

--- a/python/core/qgspluginlayer.sip
+++ b/python/core/qgspluginlayer.sip
@@ -26,6 +26,15 @@ In order to be readable from project files, they should set these attributes in 
     QgsPluginLayer( const QString &layerType, const QString &layerName = QString() );
     ~QgsPluginLayer();
 
+    virtual QgsPluginLayer *clone( bool deep ) const = 0;
+%Docstring
+ Returns a new instance equivalent to this one.
+ \param deep If true, a deep copy is done
+ :return: a new layer instance
+.. versionadded:: 3.0
+ :rtype: QgsPluginLayer
+%End
+
     QString pluginLayerType();
 %Docstring
 Return plugin layer type (the same as used in QgsPluginLayerRegistry)

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1432,6 +1432,9 @@ Assembles mUpdatedFields considering provider fields, joined fields and added fi
 
     QMap< QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength> fieldConstraintsAndStrength( int fieldIndex ) const;
 %Docstring
+ Returns a map of constraint with their strength for a specific field of the layer.
+ \param fieldIndex field index
+.. versionadded:: 3.0
  :rtype: QMap< QgsFieldConstraints.Constraint, QgsFieldConstraints.ConstraintStrength>
 %End
 

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -507,6 +507,7 @@ Setup the coordinate system transformation for the layer
  :rtype: QgsActionManager
 %End
 
+
     int selectedFeatureCount() const;
 %Docstring
  The number of features that are selected in this layer
@@ -1427,6 +1428,11 @@ Assembles mUpdatedFields considering provider fields, joined fields and added fi
 .. versionadded:: 3.0
 .. seealso:: setFieldConstraint()
  :rtype: QgsFieldConstraints.Constraints
+%End
+
+    QMap< QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength> fieldConstraintsAndStrength( int fieldIndex ) const;
+%Docstring
+ :rtype: QMap< QgsFieldConstraints.Constraint, QgsFieldConstraints.ConstraintStrength>
 %End
 
     void setFieldConstraint( int index, QgsFieldConstraints::Constraint constraint, QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthHard );

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -334,13 +334,12 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator, QgsFeatureSin
     virtual ~QgsVectorLayer();
 
 
-    virtual QgsVectorLayer *clone( bool deep = false ) const /Factory/;
+    virtual QgsVectorLayer *clone() const /Factory/;
 %Docstring
  Returns a new instance equivalent to this one. A new provider is
   created for the same data source and renderers for features and diagrams
   are cloned too. Moreover, each attributes (transparency, extent, selected
   features and so on) are identicals.
- \param deep If true, a deep copy is done (unique ID is copied too)
  :return: a new layer instance
 .. versionadded:: 3.0
  :rtype: QgsVectorLayer

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -334,6 +334,18 @@ class QgsVectorLayer : QgsMapLayer, QgsExpressionContextGenerator, QgsFeatureSin
     virtual ~QgsVectorLayer();
 
 
+    virtual QgsVectorLayer *clone( bool deep = false ) const /Factory/;
+%Docstring
+ Returns a new instance equivalent to this one. A new provider is
+  created for the same data source and renderers for features and diagrams
+  are cloned too. Moreover, each attributes (transparency, extent, selected
+  features and so on) are identicals.
+ \param deep If true, a deep copy is done (unique ID is copied too)
+ :return: a new layer instance
+.. versionadded:: 3.0
+ :rtype: QgsVectorLayer
+%End
+
     QString storageType() const;
 %Docstring
 Returns the permanent storage type for this layer as a friendly name.

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -43,11 +43,10 @@ class QgsRasterLayer : QgsMapLayer
 
     /** Returns a new instance equivalent to this one. A new provider is
      *  created for the same data source and renderer is cloned too.
-     * \param deep If true, a deep copy is done (unique ID is copy too)
      * \returns a new layer instance
      * \since QGIS 3.0
      */
-    virtual QgsRasterLayer *clone( bool deep = true ) const /Factory/;
+    virtual QgsRasterLayer *clone() const /Factory/;
 
     /** \brief This enumerator describes the types of shading that can be used */
     enum ColorShadingAlgorithm

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -41,6 +41,14 @@ class QgsRasterLayer : QgsMapLayer
     /** \brief The destructor */
     ~QgsRasterLayer();
 
+    /** Returns a new instance equivalent to this one. A new provider is
+     *  created for the same data source and renderer is cloned too.
+     * \param deep If true, a deep copy is done (unique ID is copy too)
+     * \returns a new layer instance
+     * \since QGIS 3.0
+     */
+    virtual QgsRasterLayer *clone( bool deep = true ) const /Factory/;
+
     /** \brief This enumerator describes the types of shading that can be used */
     enum ColorShadingAlgorithm
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8985,39 +8985,7 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
       }
       else if ( vlayer )
       {
-        QgsVectorLayer *dupVLayer = new QgsVectorLayer( vlayer->source(), layerDupName, vlayer->providerType() );
-        if ( vlayer->dataProvider() )
-        {
-          dupVLayer->setProviderEncoding( vlayer->dataProvider()->encoding() );
-        }
-
-        //add variables defined in layer properties
-        QStringList variableNames = vlayer->customProperty( QStringLiteral( "variableNames" ) ).toStringList();
-        QStringList variableValues = vlayer->customProperty( QStringLiteral( "variableValues" ) ).toStringList();
-
-        int varIndex = 0;
-        Q_FOREACH ( const QString &variableName, variableNames )
-        {
-          if ( varIndex >= variableValues.length() )
-          {
-            break;
-          }
-
-          QVariant varValue = variableValues.at( varIndex );
-          varIndex++;
-          QgsExpressionContextUtils::setLayerVariable( dupVLayer, variableName, varValue );
-        }
-
-        Q_FOREACH ( const QgsVectorLayerJoinInfo &join, vlayer->vectorJoins() )
-          dupVLayer->addJoin( join );
-
-        for ( int fld = 0; fld < vlayer->fields().count(); fld++ )
-        {
-          if ( vlayer->fields().fieldOrigin( fld ) == QgsFields::OriginExpression )
-            dupVLayer->addExpressionField( vlayer->expressionField( fld ), vlayer->fields().at( fld ) );
-        }
-
-        dupLayer = dupVLayer;
+        dupLayer = vlayer->clone();
       }
     }
 
@@ -9026,7 +8994,7 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
       QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( selectedLyr );
       if ( rlayer )
       {
-        dupLayer = new QgsRasterLayer( rlayer->source(), layerDupName );
+        dupLayer = rlayer->clone();
       }
     }
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -105,6 +105,7 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
 
   layer->setName( name() );
   layer->setShortName( shortName() );
+  layer->setExtent( extent() );
   layer->setMinimumScale( minimumScale() );
   layer->setMaximumScale( maximumScale() );
   layer->setScaleBasedVisibility( hasScaleBasedVisibility() );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -98,10 +98,9 @@ void QgsMapLayer::clone( QgsMapLayer *layer, bool deep ) const
 {
   layer->setBlendMode( blendMode() );
 
-  QMap<QString, QgsMapLayerStyle> styles = styleManager()->mapLayerStyles();
-  for ( QString s : styles.keys() )
+  Q_FOREACH ( QString s, styleManager()->styles() )
   {
-    layer->styleManager()->addStyle( s, styles.value( s ) );
+    layer->styleManager()->addStyle( s, styleManager()->style( s ) );
   }
 
   layer->setName( name() );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -94,6 +94,43 @@ QgsMapLayer::~QgsMapLayer()
   delete mStyleManager;
 }
 
+void QgsMapLayer::clone( QgsMapLayer *layer, bool deep ) const
+{
+  layer->setBlendMode( blendMode() );
+
+  QMap<QString, QgsMapLayerStyle> styles = styleManager()->mapLayerStyles();
+  for ( QString s : styles.keys() )
+  {
+    layer->styleManager()->addStyle( s, styles.value( s ) );
+  }
+
+  layer->setName( name() );
+  layer->setShortName( shortName() );
+  layer->setMinimumScale( minimumScale() );
+  layer->setMaximumScale( maximumScale() );
+  layer->setScaleBasedVisibility( hasScaleBasedVisibility() );
+  layer->setTitle( title() );
+  layer->setAbstract( abstract() );
+  layer->setKeywordList( keywordList() );
+  layer->setDataUrl( dataUrl() );
+  layer->setDataUrlFormat( dataUrlFormat() );
+  layer->setAttribution( attribution() );
+  layer->setAttributionUrl( attributionUrl() );
+  layer->setMetadataUrl( metadataUrl() );
+  layer->setMetadataUrlType( metadataUrlType() );
+  layer->setMetadataUrlFormat( metadataUrlFormat() );
+  layer->setLegendUrl( legendUrl() );
+  layer->setLegendUrlFormat( legendUrlFormat() );
+  layer->setDependencies( dependencies() );
+  layer->setCrs( crs() );
+  layer->setCustomProperties( mCustomProperties );
+
+  if ( deep )
+  {
+    layer->setId( id() );
+  }
+}
+
 QgsMapLayer::LayerType QgsMapLayer::type() const
 {
   return mLayerType;
@@ -102,6 +139,11 @@ QgsMapLayer::LayerType QgsMapLayer::type() const
 QString QgsMapLayer::id() const
 {
   return mID;
+}
+
+void QgsMapLayer::setId( const QString &id )
+{
+  mID = id;
 }
 
 void QgsMapLayer::setName( const QString &name )
@@ -1581,6 +1623,11 @@ QStringList QgsMapLayer::customPropertyKeys() const
 void QgsMapLayer::setCustomProperty( const QString &key, const QVariant &value )
 {
   mCustomProperties.setValue( key, value );
+}
+
+void QgsMapLayer::setCustomProperties( const QgsObjectCustomProperties &properties )
+{
+  mCustomProperties = properties;
 }
 
 QVariant QgsMapLayer::customProperty( const QString &value, const QVariant &defaultValue ) const

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -98,7 +98,7 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
 {
   layer->setBlendMode( blendMode() );
 
-  Q_FOREACH ( QString s, styleManager()->styles() )
+  Q_FOREACH ( const QString &s, styleManager()->styles() )
   {
     layer->styleManager()->addStyle( s, styleManager()->style( s ) );
   }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -94,7 +94,7 @@ QgsMapLayer::~QgsMapLayer()
   delete mStyleManager;
 }
 
-void QgsMapLayer::clone( QgsMapLayer *layer, bool deep ) const
+void QgsMapLayer::clone( QgsMapLayer *layer ) const
 {
   layer->setBlendMode( blendMode() );
 
@@ -123,11 +123,6 @@ void QgsMapLayer::clone( QgsMapLayer *layer, bool deep ) const
   layer->setDependencies( dependencies() );
   layer->setCrs( crs() );
   layer->setCustomProperties( mCustomProperties );
-
-  if ( deep )
-  {
-    layer->setId( id() );
-  }
 }
 
 QgsMapLayer::LayerType QgsMapLayer::type() const
@@ -138,11 +133,6 @@ QgsMapLayer::LayerType QgsMapLayer::type() const
 QString QgsMapLayer::id() const
 {
   return mID;
-}
-
-void QgsMapLayer::setId( const QString &id )
-{
-  mID = id;
 }
 
 void QgsMapLayer::setName( const QString &name )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -110,6 +110,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! QgsMapLayer cannot be copied
     QgsMapLayer &operator=( QgsMapLayer const & ) = delete;
 
+    /** Returns a new instance equivalent to this one.
+     * \param deep If true, a deep copy is done
+     * \returns a new layer instance
+     * \since QGIS 3.0
+     */
+    virtual QgsMapLayer *clone( bool deep ) const = 0;
+
     /** Returns the type of the layer.
      */
     QgsMapLayer::LayerType type() const;
@@ -443,6 +450,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see setCustomProperty()
     */
     QVariant customProperty( const QString &value, const QVariant &defaultValue = QVariant() ) const;
+
+    /** Set custom properties for layer.
+     * \param properties The custom properties to set.
+     * \since QGIS 3.0
+     */
+    void setCustomProperties( const QgsObjectCustomProperties &properties );
 
     /** Remove a custom property from layer. Properties are stored in a map and saved in project file.
      * \see setCustomProperty()
@@ -916,6 +929,15 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void metadataChanged();
 
   protected:
+
+    /** Copies attributes like name, short name, ... into another layer. The
+     *  unique ID is copied too if deep parameter is true.
+     * \param layer The copy recipient
+     * \param deep To copy the unique ID or not
+     * \since QGIS 3.0
+     */
+    void clone( QgsMapLayer *layer, bool deep = false ) const;
+
     //! Set the extent
     virtual void setExtent( const QgsRectangle &rect );
 
@@ -1008,6 +1030,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
     bool hasDependencyCycle( const QSet<QgsMapLayerDependency> &layers ) const;
 
   private:
+
+    /** Set the unique id of the layer.
+     * /param id the new unique id of the layer
+     */
+    void setId( const QString &id );
 
     /**
      * This method returns true by default but can be overwritten to specify

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -451,8 +451,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     */
     QVariant customProperty( const QString &value, const QVariant &defaultValue = QVariant() ) const;
 
-    /** Set custom properties for layer.
-     * \param properties The custom properties to set.
+    /** Set custom properties for layer. Current properties are dropped.
      * \since QGIS 3.0
      */
     void setCustomProperties( const QgsObjectCustomProperties &properties );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -110,12 +110,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! QgsMapLayer cannot be copied
     QgsMapLayer &operator=( QgsMapLayer const & ) = delete;
 
-    /** Returns a new instance equivalent to this one.
-     * \param deep If true, a deep copy is done
+    /** Returns a new instance equivalent to this one except for the id which
+     *  is still unique.
      * \returns a new layer instance
      * \since QGIS 3.0
      */
-    virtual QgsMapLayer *clone( bool deep ) const = 0;
+    virtual QgsMapLayer *clone() const = 0;
 
     /** Returns the type of the layer.
      */
@@ -930,13 +930,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
   protected:
 
-    /** Copies attributes like name, short name, ... into another layer. The
-     *  unique ID is copied too if deep parameter is true.
+    /** Copies attributes like name, short name, ... into another layer.
      * \param layer The copy recipient
-     * \param deep To copy the unique ID or not
      * \since QGIS 3.0
      */
-    void clone( QgsMapLayer *layer, bool deep = false ) const;
+    void clone( QgsMapLayer *layer ) const;
 
     //! Set the extent
     virtual void setExtent( const QgsRectangle &rect );
@@ -1030,11 +1028,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
     bool hasDependencyCycle( const QSet<QgsMapLayerDependency> &layers ) const;
 
   private:
-
-    /** Set the unique id of the layer.
-     * /param id the new unique id of the layer
-     */
-    void setId( const QString &id );
 
     /**
      * This method returns true by default but can be overwritten to specify

--- a/src/core/qgsmaplayerstylemanager.cpp
+++ b/src/core/qgsmaplayerstylemanager.cpp
@@ -70,6 +70,11 @@ QStringList QgsMapLayerStyleManager::styles() const
   return mStyles.keys();
 }
 
+QMap<QString, QgsMapLayerStyle> QgsMapLayerStyleManager::mapLayerStyles() const
+{
+  return mStyles;
+}
+
 QgsMapLayerStyle QgsMapLayerStyleManager::style( const QString &name ) const
 {
   if ( name == mCurrentStyle )

--- a/src/core/qgsmaplayerstylemanager.h
+++ b/src/core/qgsmaplayerstylemanager.h
@@ -110,6 +110,13 @@ class CORE_EXPORT QgsMapLayerStyleManager : public QObject
 
     //! Return list of all defined style names
     QStringList styles() const;
+
+    /** Gets available styles for the associated map layer.
+     * \returns A map of map layer style by style name
+     * \since QGIS 3.0
+     */
+    QMap<QString, QgsMapLayerStyle> mapLayerStyles() const;
+
     //! Return data of a stored style - accessed by its unique name
     QgsMapLayerStyle style( const QString &name ) const;
 

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -36,6 +36,13 @@ class CORE_EXPORT QgsPluginLayer : public QgsMapLayer
     QgsPluginLayer( const QString &layerType, const QString &layerName = QString() );
     ~QgsPluginLayer();
 
+    /** Returns a new instance equivalent to this one.
+     * \param deep If true, a deep copy is done
+     * \returns a new layer instance
+     * \since QGIS 3.0
+     */
+    virtual QgsPluginLayer *clone( bool deep ) const override = 0;
+
     //! Return plugin layer type (the same as used in QgsPluginLayerRegistry)
     QString pluginLayerType();
 

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsPluginLayer : public QgsMapLayer
      * \returns a new layer instance
      * \since QGIS 3.0
      */
-    virtual QgsPluginLayer *clone( bool deep ) const override = 0;
+    virtual QgsPluginLayer *clone() const override = 0;
 
     //! Return plugin layer type (the same as used in QgsPluginLayerRegistry)
     QString pluginLayerType();

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -37,7 +37,6 @@ class CORE_EXPORT QgsPluginLayer : public QgsMapLayer
     ~QgsPluginLayer();
 
     /** Returns a new instance equivalent to this one.
-     * \param deep If true, a deep copy is done
      * \returns a new layer instance
      * \since QGIS 3.0
      */

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -202,10 +202,10 @@ QgsVectorLayer::~QgsVectorLayer()
   delete mConditionalStyles;
 }
 
-QgsVectorLayer *QgsVectorLayer::clone( bool deep ) const
+QgsVectorLayer *QgsVectorLayer::clone() const
 {
   QgsVectorLayer *layer = new QgsVectorLayer( source(), originalName(), mProviderKey );
-  QgsMapLayer::clone( layer, deep );
+  QgsMapLayer::clone( layer );
 
   QList<QgsVectorLayerJoinInfo> joins = vectorJoins();
   Q_FOREACH ( QgsVectorLayerJoinInfo join, joins )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -222,7 +222,6 @@ QgsVectorLayer *QgsVectorLayer::clone() const
   layer->setAttributeTableConfig( attributeTableConfig() );
   layer->setFeatureBlendMode( featureBlendMode() );
   layer->setLayerTransparency( layerTransparency() );
-  layer->setEditFormConfig( editFormConfig() );
 
   Q_FOREACH ( QgsAction action, actions()->actions() )
   {
@@ -269,6 +268,8 @@ QgsVectorLayer *QgsVectorLayer::clone() const
       layer->addExpressionField( expressionField( i ), fields().at( i ) );
     }
   }
+
+  layer->setEditFormConfig( editFormConfig() );
 
   return layer;
 }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -223,7 +223,7 @@ QgsVectorLayer *QgsVectorLayer::clone() const
   layer->setFeatureBlendMode( featureBlendMode() );
   layer->setLayerTransparency( layerTransparency() );
 
-  Q_FOREACH ( QgsAction action, actions()->actions() )
+  Q_FOREACH ( const QgsAction &action, actions()->actions() )
   {
     layer->actions()->addAction( action );
   }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -85,7 +85,6 @@
 #include "qgsxmlutils.h"
 #include "qgsunittypes.h"
 #include "qgstaskmanager.h"
-#include "qgsreadwritecontext.h"
 
 #include "diagram/qgsdiagram.h"
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -207,7 +207,7 @@ QgsVectorLayer *QgsVectorLayer::clone() const
   QgsMapLayer::clone( layer );
 
   QList<QgsVectorLayerJoinInfo> joins = vectorJoins();
-  Q_FOREACH ( QgsVectorLayerJoinInfo join, joins )
+  Q_FOREACH ( const QgsVectorLayerJoinInfo &join, joins )
   {
     layer->addJoin( join );
   }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -219,7 +219,6 @@ QgsVectorLayer *QgsVectorLayer::clone() const
   layer->selectByIds( selectedFeatureIds() );
   layer->setExcludeAttributesWms( excludeAttributesWms() );
   layer->setExcludeAttributesWfs( excludeAttributesWfs() );
-  layer->setExtent( extent() );
   layer->setRenderer( renderer()->clone() );
   layer->setAttributeTableConfig( attributeTableConfig() );
   layer->setFeatureBlendMode( featureBlendMode() );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -219,10 +219,14 @@ QgsVectorLayer *QgsVectorLayer::clone() const
   layer->selectByIds( selectedFeatureIds() );
   layer->setExcludeAttributesWms( excludeAttributesWms() );
   layer->setExcludeAttributesWfs( excludeAttributesWfs() );
-  layer->setRenderer( renderer()->clone() );
   layer->setAttributeTableConfig( attributeTableConfig() );
   layer->setFeatureBlendMode( featureBlendMode() );
   layer->setLayerTransparency( layerTransparency() );
+
+  if ( renderer() )
+  {
+    layer->setRenderer( renderer()->clone() );
+  }
 
   if ( labeling() )
   {

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -404,11 +404,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *  created for the same data source and renderers for features and diagrams
      *  are cloned too. Moreover, each attributes (transparency, extent, selected
      *  features and so on) are identicals.
-     * \param deep If true, a deep copy is done (unique ID is copied too)
      * \returns a new layer instance
      * \since QGIS 3.0
      */
-    virtual QgsVectorLayer *clone( bool deep = false ) const override SIP_FACTORY;
+    virtual QgsVectorLayer *clone() const override SIP_FACTORY;
 
     //! Returns the permanent storage type for this layer as a friendly name.
     QString storageType() const;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -400,6 +400,16 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! QgsVectorLayer cannot be copied.
     QgsVectorLayer &operator=( QgsVectorLayer const &rhs ) = delete;
 
+    /** Returns a new instance equivalent to this one. A new provider is
+     *  created for the same data source and renderers for features and diagrams
+     *  are cloned too. Moreover, each attributes (transparency, extent, selected
+     *  features and so on) are identicals.
+     * \param deep If true, a deep copy is done (unique ID is copied too)
+     * \returns a new layer instance
+     * \since QGIS 3.0
+     */
+    virtual QgsVectorLayer *clone( bool deep = false ) const override SIP_FACTORY;
+
     //! Returns the permanent storage type for this layer as a friendly name.
     QString storageType() const;
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1347,6 +1347,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     QgsFieldConstraints::Constraints fieldConstraints( int fieldIndex ) const;
 
+    /**
+     * Returns a map of constraint with their strength for a specific field of the layer.
+     * \param fieldIndex field index
+     * \since QGIS 3.0
+     */
     QMap< QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength> fieldConstraintsAndStrength( int fieldIndex ) const;
 
     /**

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -539,6 +539,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     QgsActionManager *actions() { return mActions; }
 
     /**
+     * Get all layer actions defined on this layer.
+     *
+     * The pointer which is returned is const.
+     */
+    const QgsActionManager *actions() const SIP_SKIP { return mActions; }
+
+    /**
      * The number of features that are selected in this layer
      *
      * \returns See description
@@ -1339,6 +1346,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see setFieldConstraint()
      */
     QgsFieldConstraints::Constraints fieldConstraints( int fieldIndex ) const;
+
+    QMap< QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength> fieldConstraintsAndStrength( int fieldIndex ) const;
 
     /**
      * Sets a constraint for a specified field index. Any constraints inherited from the layer's

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -148,7 +148,12 @@ QgsRasterLayer *QgsRasterLayer::clone() const
 {
   QgsRasterLayer *layer = new QgsRasterLayer( source(), originalName(), mProviderKey );
   QgsMapLayer::clone( layer );
-  layer->setRenderer( renderer()->clone() );
+
+  for ( int i = 0; i < mPipe.size(); i++ )
+  {
+    layer->pipe()->set( mPipe.at( i )->clone() );
+  }
+
   return layer;
 }
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -149,9 +149,11 @@ QgsRasterLayer *QgsRasterLayer::clone() const
   QgsRasterLayer *layer = new QgsRasterLayer( source(), originalName(), mProviderKey );
   QgsMapLayer::clone( layer );
 
-  for ( int i = 0; i < mPipe.size(); i++ )
+  // do not clone data provider which is the first element in pipe
+  for ( int i = 1; i < mPipe.size(); i++ )
   {
-    layer->pipe()->set( mPipe.at( i )->clone() );
+    if ( mPipe.at( i ) )
+      layer->pipe()->set( mPipe.at( i )->clone() );
   }
 
   return layer;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -144,6 +144,14 @@ QgsRasterLayer::~QgsRasterLayer()
   // Note: provider and other interfaces are owned and deleted by pipe
 }
 
+QgsRasterLayer *QgsRasterLayer::clone( bool deep ) const
+{
+  QgsRasterLayer *layer = new QgsRasterLayer( source(), originalName(), mProviderKey );
+  QgsMapLayer::clone( layer, deep );
+  layer->setRenderer( renderer()->clone() );
+  return layer;
+}
+
 //////////////////////////////////////////////////////////
 //
 // Static Methods and members

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -144,10 +144,10 @@ QgsRasterLayer::~QgsRasterLayer()
   // Note: provider and other interfaces are owned and deleted by pipe
 }
 
-QgsRasterLayer *QgsRasterLayer::clone( bool deep ) const
+QgsRasterLayer *QgsRasterLayer::clone() const
 {
   QgsRasterLayer *layer = new QgsRasterLayer( source(), originalName(), mProviderKey );
-  QgsMapLayer::clone( layer, deep );
+  QgsMapLayer::clone( layer );
   layer->setRenderer( renderer()->clone() );
   return layer;
 }

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -190,11 +190,10 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
     /** Returns a new instance equivalent to this one. A new provider is
      *  created for the same data source and renderer is cloned too.
-     * \param deep If true, a deep copy is done (unique ID is copy too)
      * \returns a new layer instance
      * \since QGIS 3.0
      */
-    virtual QgsRasterLayer *clone( bool deep = false ) const override SIP_FACTORY;
+    virtual QgsRasterLayer *clone() const override SIP_FACTORY;
 
     //! \brief This enumerator describes the types of shading that can be used
     enum ColorShadingAlgorithm

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -188,6 +188,14 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
     ~QgsRasterLayer();
 
+    /** Returns a new instance equivalent to this one. A new provider is
+     *  created for the same data source and renderer is cloned too.
+     * \param deep If true, a deep copy is done (unique ID is copy too)
+     * \returns a new layer instance
+     * \since QGIS 3.0
+     */
+    virtual QgsRasterLayer *clone( bool deep = false ) const override SIP_FACTORY;
+
     //! \brief This enumerator describes the types of shading that can be used
     enum ColorShadingAlgorithm
     {

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -655,6 +655,20 @@ class TestQgsRasterLayer(unittest.TestCase):
         self.assertEqual(renderer.nColors(), 2)
         self.assertEqual(renderer.usesBands(), [1])
 
+    def testClone(self):
+        myPath = os.path.join(unitTestDataPath('raster'),
+                              'band1_float32_noct_epsg4326.tif')
+        myFileInfo = QFileInfo(myPath)
+        myBaseName = myFileInfo.baseName()
+        layer = QgsRasterLayer(myPath, myBaseName)
+
+        renderer = layer.renderer().clone()
+        renderer.setOpacity(33.3)
+        layer.setRenderer(renderer)
+
+        clone = layer.clone()
+        self.assertEqual(clone.renderer().opacity(), 33.3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -2195,15 +2195,8 @@ class TestQgsVectorLayer(unittest.TestCase):
     def testCloneId(self):
         layer = createLayerWithFivePoints()
 
-        # deep clone by default
         clone = layer.clone()
         self.assertFalse(clone.id() == layer.id())
-
-        clone = layer.clone(False)
-        self.assertFalse(clone.id() == layer.id())
-
-        clone = layer.clone(True)
-        self.assertEqual(clone.id(), layer.id())
 
     def testCloneVectorLayerAttributes(self):
         # init layer


### PR DESCRIPTION
## Description

A new method `clone()` is added to map layers (see previous conversation with @m-kuhn on https://github.com/qgis/QGIS/pull/4313). 

These cloning methods are used within the `duplicateLayers()` function.

This PR comes with unit tests.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
