### PR TITLE
store profiles as QStringList to avoid issues with spaces (fix #16327)

### DIFF
--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -493,7 +493,6 @@ void QgsRasterFormatSaveOptionsWidget::on_mOptionsDeleteButton_clicked()
   }
 }
 
-
 QString QgsRasterFormatSaveOptionsWidget::settingsKey( QString profileName ) const
 {
   if ( profileName != QLatin1String( "" ) )
@@ -528,16 +527,16 @@ void QgsRasterFormatSaveOptionsWidget::deleteCreateOptions( const QString &profi
 void QgsRasterFormatSaveOptionsWidget::setCreateOptions()
 {
   QgsSettings mySettings;
-  QString myProfiles;
+  QStringList myProfiles;
   QMap< QString, QString >::const_iterator i = mOptionsMap.constBegin();
   while ( i != mOptionsMap.constEnd() )
   {
     setCreateOptions( i.key(), i.value() );
-    myProfiles += i.key() + QStringLiteral( " " );
+    myProfiles << i.key();
     ++i;
   }
   mySettings.setValue( mProvider + "/driverOptions/" + pseudoFormat().toLower() + "/profiles",
-                       myProfiles.trimmed() );
+                       myProfiles );
   mySettings.setValue( mProvider + "/driverOptions/" + pseudoFormat().toLower() + "/defaultProfile",
                        currentProfileKey().trimmed() );
 }
@@ -556,7 +555,7 @@ void QgsRasterFormatSaveOptionsWidget::setCreateOptions( const QString &profileN
 QStringList QgsRasterFormatSaveOptionsWidget::profiles() const
 {
   QgsSettings mySettings;
-  return mySettings.value( mProvider + "/driverOptions/" + pseudoFormat().toLower() + "/profiles", "" ).toString().trimmed().split( ' ', QString::SkipEmptyParts );
+  return mySettings.value( mProvider + "/driverOptions/" + pseudoFormat().toLower() + "/profiles", "" ).toStringList();
 }
 
 void QgsRasterFormatSaveOptionsWidget::swapOptionsUI( int newIndex )


### PR DESCRIPTION
## Description
When creating new profile in the `Settings → Options → GDAL → Edit Create Options` profile names with spaces splitted and profile created for each word. Proposed PR fixes this by saving list of profiles as QStingList instead of string, separated by spaces.

No tests as this is GUI thing. Issue present also in 2.18 we probably need to backport fix.

Fixes https://issues.qgis.org/issues/16327

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
