### PR TITLE
Remove QgsPoint::onSegment() method

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1702,6 +1702,12 @@ QgsPluginLayerRegistry        {#qgis_api_break_3_0_QgsPluginLayerRegistry}
 - This class is no longer a singleton and instance() has been removed. Instead use QgsApplication::pluginLayerRegistry() to access an application-wide registry.
 
 
+QgsPoint   {#qgis_api_break_3_0_QgsPoint}
+--------
+
+- onSegment() has been removed. Use sqrDistToSegment() instead for a more precise test.
+
+
 QgsPointDisplacementRenderer        {#qgis_api_break_3_0_QgsPointDisplacementRenderer}
 ----------------------------
 

--- a/python/core/qgspoint.sip
+++ b/python/core/qgspoint.sip
@@ -229,12 +229,6 @@ Inequality operator
 Multiply x and y by the given value
 %End
 
-    int onSegment( const QgsPoint &a, const QgsPoint &b ) const;
-%Docstring
-3 if point is on open ray b.
- :rtype: int
-%End
-
 
     QgsVector operator-( const QgsPoint &p ) const;
 %Docstring

--- a/src/core/qgspoint.cpp
+++ b/src/core/qgspoint.cpp
@@ -329,36 +329,6 @@ void QgsPoint::multiply( double scalar )
   mY *= scalar;
 }
 
-int QgsPoint::onSegment( const QgsPoint &a, const QgsPoint &b ) const
-{
-  //algorithm from 'graphics GEMS', A. Paeth: 'A Fast 2D Point-on-line test'
-  if (
-    qAbs( ( b.y() - a.y() ) * ( mX - a.x() ) - ( mY - a.y() ) * ( b.x() - a.x() ) )
-    >= qMax( qAbs( b.x() - a.x() ), qAbs( b.y() - a.y() ) )
-  )
-  {
-    return 0;
-  }
-  if ( ( b.x() < a.x() && a.x() < mX ) || ( b.y() < a.y() && a.y() < mY ) )
-  {
-    return 1;
-  }
-  if ( ( mX < a.x() && a.x() < b.x() ) || ( mY < a.y() && a.y() < b.y() ) )
-  {
-    return 1;
-  }
-  if ( ( a.x() < b.x() && b.x() < mX ) || ( a.y() < b.y() && b.y() < mY ) )
-  {
-    return 3;
-  }
-  if ( ( mX < b.x() && b.x() < a.x() ) || ( mY < b.y() && b.y() < a.y() ) )
-  {
-    return 3;
-  }
-
-  return 2;
-}
-
 double QgsPoint::sqrDistToSegment( double x1, double y1, double x2, double y2, QgsPoint &minDistPoint, double epsilon ) const
 {
   double nx, ny; //normal vector

--- a/src/core/qgspoint.h
+++ b/src/core/qgspoint.h
@@ -225,12 +225,6 @@ class CORE_EXPORT QgsPoint
     //! Multiply x and y by the given value
     void multiply( double scalar );
 
-    //! Test if this point is on the segment defined by points a, b
-    //! \returns 0 if this point is not on the open ray through a and b,
-    //! 1 if point is on open ray a, 2 if point is within line segment,
-    //! 3 if point is on open ray b.
-    int onSegment( const QgsPoint &a, const QgsPoint &b ) const;
-
     //! Assignment
     QgsPoint &operator=( const QgsPoint &other );
 


### PR DESCRIPTION
This is a completely wrong use of an algorithm that is meant to be used with *integer* values,
e.g. when dealing with pixels on screen, but not for coordinates that are floating point numbers.
The algorithm has a fixed tolerance of 1 unit.

QgsPoint(5,0.9).onSegment(QgsPoint(0,0), QgsPoint(10,0)) would return 2 (i.e. point is on line segment)

See the original code: https://github.com/erich666/GraphicsGems/blob/master/gems/PntOnLine.c
