### PR TITLE
Add a QgsStatusBar widget/interface for adding messages/widgets to main window statusbar

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -401,6 +401,8 @@ are similar, but only apply to composer windows when they are exist. To access a
 from a project, the new QgsProject.instance().layoutManager() class should be used instead.
 Additionally, the new interface methods work with QgsComposerInterface objects instead
 of QgsComposerView objects.
+- interaction with the main window status bar should no longer use the native Qt statusBar() method.
+Instead iface.statusBarIface() should be used.
 
 CharacterWidget        {#qgis_api_break_3_0_CharacterWidget}
 -------------------

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -159,6 +159,7 @@
 %Include qgsshortcutsmanager.sip
 %Include qgsslider.sip
 %Include qgssourceselectdialog.sip
+%Include qgsstatusbar.sip
 %Include qgssublayersdialog.sip
 %Include qgssubstitutionlistwidget.sip
 %Include qgstablewidgetbase.sip

--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -509,6 +509,8 @@ class QgisInterface : QObject
     /** Get timeout for timed messages: default of 5 seconds */
     virtual int messageTimeout() = 0;
 
+	virtual QgsStatusBar *statusBarIface() = 0;
+
     /**
      * Registers a locator \a filter for the app's locator bar. Ownership of the filter is transferred to the
      * locator.

--- a/python/gui/qgsstatusbar.sip
+++ b/python/gui/qgsstatusbar.sip
@@ -1,0 +1,98 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsstatusbar.h                                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsStatusBar : QWidget
+{
+%Docstring
+ A proxy widget for QStatusBar.
+
+ Unlike QStatusBar, QgsStatusBar allows finer control of widget placement, including
+ the option to locate permanent widgets on the left side of the bar.
+
+ QgsStatusBar is designed to be embedded into an existing
+ window's QStatusBar, as a permanent widget. This allows reuse of the special QStatusBar handling
+ for resize grips and other platform specific status bar tweaks.
+
+ Instead of adding child widgets and showing messages directly in the window's status bar,
+ these widgets (and messages) should instead be added into the embedded QgsStatusBar.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsstatusbar.h"
+%End
+  public:
+
+    enum Anchor
+    {
+      AnchorLeft,
+      AnchorRight,
+    };
+
+    QgsStatusBar( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+ Constructor for QgsStatusBar.
+%End
+
+    void addPermanentWidget( QWidget *widget /Transfer/, int stretch = 0, Anchor anchor = AnchorRight );
+%Docstring
+ Adds the given ``widget`` permanently to this status bar, reparenting the widget if it isn't already a child
+ of this object.
+
+ The ``stretch`` parameter is used to compute a suitable size for the given widget as the status bar
+ grows and shrinks. The default stretch factor is 0, i.e giving the widget a minimum of space.
+
+ The ``anchor`` parameter controls which side of the status bar the widget should be anchored to.
+%End
+
+    void removeWidget( QWidget *widget );
+%Docstring
+ Removes a ``widget`` from the status bar. Ownership of the widget remains unchanged, and the
+ widget itself is not deleted.
+%End
+
+    QString currentMessage() const;
+%Docstring
+ Returns the current message shown in the status bar.
+.. seealso:: showMessage()
+ :rtype: str
+%End
+
+  public slots:
+
+    void showMessage( const QString &message, int timeout = 0 );
+%Docstring
+ Displays the given ``message`` for the specified number of milli-seconds (``timeout``).
+ If ``timeout`` is 0 (default), the message remains displayed until the clearMessage()
+ slot is called or until the showMessage() slot is called again to change the message.
+.. seealso:: clearMessage()
+.. seealso:: currentMessage()
+%End
+
+    void clearMessage();
+%Docstring
+ Removes any temporary message being shown.
+.. seealso:: showMessage()
+%End
+
+};
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsstatusbar.h                                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -36,6 +36,7 @@
 #include "qgsvectorlayer.h"
 #include "qgswkbptr.h"
 #include "qgssettings.h"
+#include "qgsstatusbar.h"
 
 // QWT Charting widget
 
@@ -1122,5 +1123,5 @@ void QgsGPSInformationWidget::setStatusIndicator( const FixStatus statusValue )
 
 void QgsGPSInformationWidget::showStatusBarMessage( const QString &msg )
 {
-  QgisApp::instance()->statusBar()->showMessage( msg );
+  QgisApp::instance()->statusBarIface()->showMessage( msg );
 }

--- a/src/app/nodetool/qgsnodetool.cpp
+++ b/src/app/nodetool/qgsnodetool.cpp
@@ -31,7 +31,7 @@
 #include "qgssnappingutils.h"
 #include "qgsvectorlayer.h"
 #include "qgsvertexmarker.h"
-
+#include "qgsstatusbar.h"
 #include "qgisapp.h"
 #include "qgsselectedfeature.h"
 #include "qgsnodeeditor.h"
@@ -1797,7 +1797,7 @@ void QgsNodeTool::validationFinished()
     GeometryValidation &validation = *it;
     if ( validation.validator == validator )
     {
-      QStatusBar *sb = QgisApp::instance()->statusBar();
+      QgsStatusBar *sb = QgisApp::instance()->statusBarIface();
       sb->showMessage( tr( "Validation finished (%n error(s) found).", "number of geometry errors", validation.errorMarkers.size() ) );
       if ( validation.errorMarkers.isEmpty() )
       {
@@ -1838,7 +1838,7 @@ void QgsNodeTool::GeometryValidation::addError( QgsGeometry::Error e )
     errorMarkers << marker;
   }
 
-  QStatusBar *sb = QgisApp::instance()->statusBar();
+  QgsStatusBar *sb = QgisApp::instance()->statusBarIface();
   sb->showMessage( e.what() );
   sb->setToolTip( errors );
 }

--- a/src/app/nodetool/qgsselectedfeature.cpp
+++ b/src/app/nodetool/qgsselectedfeature.cpp
@@ -27,6 +27,7 @@
 #include "qgisapp.h"
 #include "qgslayertreeview.h"
 #include "qgsproject.h"
+#include "qgsstatusbar.h"
 
 QgsSelectedFeature::QgsSelectedFeature( QgsFeatureId featureId,
                                         QgsVectorLayer *vlayer,
@@ -189,7 +190,7 @@ void QgsSelectedFeature::validateGeometry( QgsGeometry *g )
   connect( mValidator, &QThread::finished, this, &QgsSelectedFeature::validationFinished );
   mValidator->start();
 
-  QStatusBar *sb = QgisApp::instance()->statusBar();
+  QgsStatusBar *sb = QgisApp::instance()->statusBarIface();
   sb->showMessage( tr( "Validation started." ) );
 }
 
@@ -212,14 +213,14 @@ void QgsSelectedFeature::addError( QgsGeometry::Error e )
     mGeomErrorMarkers << marker;
   }
 
-  QStatusBar *sb = QgisApp::instance()->statusBar();
+  QgsStatusBar *sb = QgisApp::instance()->statusBarIface();
   sb->showMessage( e.what() );
   sb->setToolTip( mTip );
 }
 
 void QgsSelectedFeature::validationFinished()
 {
-  QStatusBar *sb = QgisApp::instance()->statusBar();
+  QgsStatusBar *sb = QgisApp::instance()->statusBarIface();
   sb->showMessage( tr( "Validation finished (%n error(s) found).", "number of geometry errors", mGeomErrorMarkers.size() ) );
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -92,6 +92,7 @@ class QgsVectorLayer;
 class QgsVectorLayerTools;
 class QgsWelcomePage;
 class QgsOptionsWidgetFactory;
+class QgsStatusBar;
 
 class QDomDocument;
 class QNetworkReply;
@@ -556,6 +557,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QToolBar *vectorToolBar() { return mVectorToolBar; }
     QToolBar *databaseToolBar() { return mDatabaseToolBar; }
     QToolBar *webToolBar() { return mWebToolBar; }
+
+    QgsStatusBar *statusBarIface() { return mStatusBar; }
 
     //! return CAD dock widget
     QgsAdvancedDigitizingDockWidget *cadDockWidget() { return mAdvancedDigitizingDockWidget; }
@@ -1978,6 +1981,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QSystemTrayIcon *mTray = nullptr;
 
     QgsLocatorWidget *mLocatorWidget = nullptr;
+
+    QgsStatusBar *mStatusBar = nullptr;
 
     friend class TestQgisAppPython;
 };

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -736,6 +736,11 @@ int QgisAppInterface::messageTimeout()
   return qgis->messageTimeout();
 }
 
+QgsStatusBar *QgisAppInterface::statusBarIface()
+{
+  return qgis->statusBarIface();
+}
+
 void QgisAppInterface::registerLocatorFilter( QgsLocatorFilter *filter )
 {
   qgis->mLocatorWidget->locator()->registerFilter( filter );

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -494,6 +494,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     //! Get timeout for timed messages: default of 5 seconds
     virtual int messageTimeout() override;
 
+    QgsStatusBar *statusBarIface() override;
+
     void registerLocatorFilter( QgsLocatorFilter *filter ) override;
     void deregisterLocatorFilter( QgsLocatorFilter *filter ) override;
 

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -18,6 +18,7 @@
 #include "qgisapp.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
+#include "qgsstatusbar.h"
 
 #include <QAction>
 #include <QDir>
@@ -599,7 +600,7 @@ void QgsCustomization::createTreeItemStatus()
   topItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsSelectable );
   topItem->setCheckState( 0, Qt::Checked );
 
-  QStatusBar *sb = QgisApp::instance()->statusBar();
+  QgsStatusBar *sb = QgisApp::instance()->statusBarIface();
   Q_FOREACH ( QObject *obj, sb->children() )
   {
     if ( obj->inherits( "QWidget" ) && !obj->objectName().isEmpty() )
@@ -653,7 +654,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
   if ( !mEnabled )
     return;
 
-  QMainWindow *mw = QgisApp::instance();
+  QgisApp *mw = QgisApp::instance();
   QMenuBar *menubar = mw->menuBar();
 
   mSettings->beginGroup( QStringLiteral( "Customization/Menus" ) );
@@ -738,7 +739,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
   {
     mSettings->beginGroup( QStringLiteral( "Customization/StatusBar" ) );
 
-    QStatusBar *sb = mw->statusBar();
+    QgsStatusBar *sb = mw->statusBarIface();
     Q_FOREACH ( QObject *obj, sb->children() )
     {
       if ( obj->inherits( "QWidget" ) )

--- a/src/app/qgsmaptoolcircularstringradius.cpp
+++ b/src/app/qgsmaptoolcircularstringradius.cpp
@@ -21,6 +21,7 @@
 #include "qgsgeometryrubberband.h"
 #include "qgsmapcanvas.h"
 #include "qgspointv2.h"
+#include "qgsstatusbar.h"
 #include <QDoubleSpinBox>
 #include <QMouseEvent>
 #include <cmath>
@@ -167,7 +168,7 @@ void QgsMapToolCircularStringRadius::deleteRadiusSpinBox()
 {
   if ( mRadiusSpinBox )
   {
-    QgisApp::instance()->statusBar()->removeWidget( mRadiusSpinBox );
+    QgisApp::instance()->statusBarIface()->removeWidget( mRadiusSpinBox );
     delete mRadiusSpinBox;
     mRadiusSpinBox = nullptr;
   }

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -32,6 +32,7 @@
 #include "qgsmaplayeractionregistry.h"
 #include "qgisapp.h"
 #include "qgsgui.h"
+#include "qgsstatusbar.h"
 
 #include <QSettings>
 #include <QMouseEvent>
@@ -80,7 +81,7 @@ void QgsMapToolFeatureAction::canvasReleaseEvent( QgsMapMouseEvent *e )
   }
 
   if ( !doAction( vlayer, e->x(), e->y() ) )
-    QgisApp::instance()->statusBar()->showMessage( tr( "No features at this position found." ) );
+    QgisApp::instance()->statusBarIface()->showMessage( tr( "No features at this position found." ) );
 }
 
 void QgsMapToolFeatureAction::activate()

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -36,6 +36,7 @@
 #include "qgsproject.h"
 #include "qgsrenderer.h"
 #include "qgsunittypes.h"
+#include "qgsstatusbar.h"
 
 #include "qgssettings.h"
 #include <QMouseEvent>
@@ -135,7 +136,7 @@ void QgsMapToolIdentifyAction::canvasReleaseEvent( QgsMapMouseEvent *e )
   if ( results.isEmpty() )
   {
     resultsDialog()->clear();
-    QgisApp::instance()->statusBar()->showMessage( tr( "No features at this position found." ) );
+    QgisApp::instance()->statusBarIface()->showMessage( tr( "No features at this position found." ) );
   }
   else
   {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -306,6 +306,7 @@ SET(QGIS_GUI_SRCS
   qgssublayersdialog.cpp
   qgssubstitutionlistwidget.cpp
   qgssqlcomposerdialog.cpp
+  qgsstatusbar.cpp
   qgstablewidgetbase.cpp
   qgstabwidget.cpp
   qgstablewidgetitem.cpp
@@ -451,6 +452,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsshortcutsmanager.h
   qgsslider.h
   qgssqlcomposerdialog.h
+  qgsstatusbar.h
   qgssublayersdialog.h
   qgssubstitutionlistwidget.h
   qgstablewidgetbase.h

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -54,8 +54,8 @@ QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
   // setup floating container widget
   mResultsContainer = new QgsFloatingWidget( parent ? parent->window() : nullptr );
   mResultsContainer->setAnchorWidget( mLineEdit );
-  mResultsContainer->setAnchorPoint( QgsFloatingWidget::BottomRight );
-  mResultsContainer->setAnchorWidgetPoint( QgsFloatingWidget::TopRight );
+  mResultsContainer->setAnchorPoint( QgsFloatingWidget::BottomLeft );
+  mResultsContainer->setAnchorWidgetPoint( QgsFloatingWidget::TopLeft );
 
   QHBoxLayout *containerLayout = new QHBoxLayout( this );
   containerLayout->setMargin( 0 );

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -43,6 +43,7 @@ class QgsVectorLayer;
 class QgsVectorLayerTools;
 class QgsOptionsWidgetFactory;
 class QgsLocatorFilter;
+class QgsStatusBar;
 
 #include <QObject>
 #include <QFont>
@@ -651,6 +652,14 @@ class GUI_EXPORT QgisInterface : public QObject
 
     //! Get timeout for timed messages: default of 5 seconds
     virtual int messageTimeout() = 0;
+
+    /**
+     * Returns a pointer to the app's status bar interface. This should be
+     * used for interacting and adding widgets and messages to the app's
+     * status bar (do not use the native Qt statusBar() method).
+     * \since QGIS 3.0
+     */
+    virtual QgsStatusBar *statusBarIface() = 0;
 
     /**
      * Registers a locator \a filter for the app's locator bar. Ownership of the filter is transferred to the

--- a/src/gui/qgsstatusbar.cpp
+++ b/src/gui/qgsstatusbar.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+                         qgsstatusbar.cpp
+                         ----------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsstatusbar.h"
+#include <QLayout>
+#include <QLabel>
+#include <QTimer>
+
+QgsStatusBar::QgsStatusBar( QWidget *parent )
+  : QWidget( parent )
+{
+  mLayout = new QHBoxLayout();
+  mLayout->setMargin( 0 );
+  mLayout->setContentsMargins( 2, 0, 2, 0 );
+  mLayout->setSpacing( 6 );
+
+  mLabel = new QLabel( QString() );
+  mLayout->addWidget( mLabel, 1 );
+  setLayout( mLayout );
+}
+
+void QgsStatusBar::addPermanentWidget( QWidget *widget, int stretch, Anchor anchor )
+{
+  switch ( anchor )
+  {
+    case AnchorLeft:
+      mLayout->insertWidget( 0, widget, stretch, Qt::AlignLeft );
+      break;
+
+    case AnchorRight:
+      mLayout->addWidget( widget, stretch, Qt::AlignLeft );
+      break;
+  }
+}
+
+void QgsStatusBar::removeWidget( QWidget *widget )
+{
+  mLayout->removeWidget( widget );
+}
+
+QString QgsStatusBar::currentMessage() const
+{
+  return mLabel->text();
+}
+
+void QgsStatusBar::showMessage( const QString &text, int timeout )
+{
+  mLabel->setText( text );
+  if ( timeout > 0 )
+  {
+    if ( !mTempMessageTimer )
+    {
+      mTempMessageTimer = new QTimer( this );
+      connect( mTempMessageTimer, &QTimer::timeout, this, &QgsStatusBar::clearMessage );
+    }
+    mTempMessageTimer->start( timeout );
+  }
+  else if ( mTempMessageTimer )
+  {
+    delete mTempMessageTimer;
+    mTempMessageTimer = nullptr;
+  }
+}
+
+void QgsStatusBar::clearMessage()
+{
+  mLabel->setText( QString() );
+}

--- a/src/gui/qgsstatusbar.h
+++ b/src/gui/qgsstatusbar.h
@@ -1,0 +1,113 @@
+/***************************************************************************
+                         qgsstatusbar.h
+                         --------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSTATUSBAR_H
+#define QGSSTATUSBAR_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include <QWidget>
+
+class QHBoxLayout;
+class QLabel;
+
+/**
+ * \class QgsStatusBar
+ * \ingroup gui
+ * A proxy widget for QStatusBar.
+ *
+ * Unlike QStatusBar, QgsStatusBar allows finer control of widget placement, including
+ * the option to locate permanent widgets on the left side of the bar.
+ *
+ * QgsStatusBar is designed to be embedded into an existing
+ * window's QStatusBar, as a permanent widget. This allows reuse of the special QStatusBar handling
+ * for resize grips and other platform specific status bar tweaks.
+ *
+ * Instead of adding child widgets and showing messages directly in the window's status bar,
+ * these widgets (and messages) should instead be added into the embedded QgsStatusBar.
+ *
+ * \since QGIS 3.0
+ */
+class GUI_EXPORT QgsStatusBar : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    //! Placement anchor for widgets
+    enum Anchor
+    {
+      AnchorLeft = 0, //!< Anchor widget to left of status bar
+      AnchorRight, //!< Anchor widget to right of status bar
+    };
+
+    /**
+     * Constructor for QgsStatusBar.
+     */
+    QgsStatusBar( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Adds the given \a widget permanently to this status bar, reparenting the widget if it isn't already a child
+     * of this object.
+     *
+     * The \a stretch parameter is used to compute a suitable size for the given widget as the status bar
+     * grows and shrinks. The default stretch factor is 0, i.e giving the widget a minimum of space.
+     *
+     * The \a anchor parameter controls which side of the status bar the widget should be anchored to.
+     */
+    void addPermanentWidget( QWidget *widget SIP_TRANSFER, int stretch = 0, Anchor anchor = AnchorRight );
+
+    /**
+     * Removes a \a widget from the status bar. Ownership of the widget remains unchanged, and the
+     * widget itself is not deleted.
+     */
+    void removeWidget( QWidget *widget );
+
+    /**
+     * Returns the current message shown in the status bar.
+     * \see showMessage()
+     */
+    QString currentMessage() const;
+
+  public slots:
+
+    /**
+     * Displays the given \a message for the specified number of milli-seconds (\a timeout).
+     * If \a timeout is 0 (default), the message remains displayed until the clearMessage()
+     * slot is called or until the showMessage() slot is called again to change the message.
+     * \see clearMessage()
+     * \see currentMessage()
+     */
+    void showMessage( const QString &message, int timeout = 0 );
+
+    /**
+     * Removes any temporary message being shown.
+     * \see showMessage()
+     */
+    void clearMessage();
+
+  private:
+
+    QHBoxLayout *mLayout = nullptr;
+    QLabel *mLabel = nullptr;
+    QTimer *mTempMessageTimer = nullptr;
+
+};
+
+#endif // QGSSTATUSBAR_H
+
+


### PR DESCRIPTION
QStatusBar gives almost no control over display and placement of child widgets. It's not possible to subclass and reimplement either, due to how QMainWindow works internally, and also due to the special handling for the size grip and other platform specific handling in QStatusBar.

Instead, we embed a single QgsStatusBar covering the whole real status bar. All child widgets and temporary messages instead are pushed to the QgsStatusBar instead - giving us as much control as we 
desire over how these widgets are placed and their behavior.

As a result the locator widget has been moved to its logical placement on the left of the status bar:

![image](https://cloud.githubusercontent.com/assets/1829991/26181833/9eca0048-3bb6-11e7-97e7-34118cbb3f2a.png)


All plugins must ensure that they use the status bar interface available via iface.statusBarIface() instead of directly interacting with the status bar (e.g. iface.mainWindow().statusBar()...)
