### PR TITLE
Fix #16528 mix of Qgis and qgis as root in settins

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -213,13 +213,13 @@ bool QgsManageConnectionsDialog::populateConnections()
     switch ( mConnectionType )
     {
       case WMS:
-        settings.beginGroup( QStringLiteral( "/Qgis/connections-wms" ) );
+        settings.beginGroup( QStringLiteral( "/qgis/connections-wms" ) );
         break;
       case WFS:
-        settings.beginGroup( QStringLiteral( "/Qgis/connections-wfs" ) );
+        settings.beginGroup( QStringLiteral( "/qgis/connections-wfs" ) );
         break;
       case WCS:
-        settings.beginGroup( QStringLiteral( "/Qgis/connections-wcs" ) );
+        settings.beginGroup( QStringLiteral( "/qgis/connections-wcs" ) );
         break;
       case PostGIS:
         settings.beginGroup( QStringLiteral( "/PostgreSQL/connections" ) );
@@ -361,7 +361,7 @@ QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &
   QString path;
   for ( int i = 0; i < connections.count(); ++i )
   {
-    path = "/Qgis/connections-" + service.toLower() + '/';
+    path = "/qgis/connections-" + service.toLower() + '/';
     QDomElement el = doc.createElement( service.toLower() );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
     el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url", "" ).toString() );
@@ -377,7 +377,7 @@ QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &
       el.setAttribute( QStringLiteral( "dpiMode" ), settings.value( path + connections[i] + "/dpiMode", "7" ).toInt() );
     }
 
-    path = "/Qgis/" + service.toUpper() + '/';
+    path = "/qgis/" + service.toUpper() + '/';
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
     el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password", "" ).toString() );
     root.appendChild( el );
@@ -397,14 +397,14 @@ QDomDocument QgsManageConnectionsDialog::saveWfsConnections( const QStringList &
   QString path;
   for ( int i = 0; i < connections.count(); ++i )
   {
-    path = QStringLiteral( "/Qgis/connections-wfs/" );
+    path = QStringLiteral( "/qgis/connections-wfs/" );
     QDomElement el = doc.createElement( QStringLiteral( "wfs" ) );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
     el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url", "" ).toString() );
 
     el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer", "" ).toString() );
 
-    path = QStringLiteral( "/Qgis/WFS/" );
+    path = QStringLiteral( "/qgis/WFS/" );
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
     el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password", "" ).toString() );
     root.appendChild( el );
@@ -592,7 +592,7 @@ void QgsManageConnectionsDialog::loadOWSConnections( const QDomDocument &doc, co
 
   QString connectionName;
   QgsSettings settings;
-  settings.beginGroup( "/Qgis/connections-" + service.toLower() );
+  settings.beginGroup( "/qgis/connections-" + service.toLower() );
   QStringList keys = settings.childGroups();
   settings.endGroup();
   QDomElement child = root.firstChildElement();
@@ -645,7 +645,7 @@ void QgsManageConnectionsDialog::loadOWSConnections( const QDomDocument &doc, co
     }
 
     // no dups detected or overwrite is allowed
-    settings.beginGroup( "/Qgis/connections-" + service.toLower() );
+    settings.beginGroup( "/qgis/connections-" + service.toLower() );
     settings.setValue( QString( '/' + connectionName + "/url" ), child.attribute( QStringLiteral( "url" ) ) );
     settings.setValue( QString( '/' + connectionName + "/ignoreGetMapURI" ), child.attribute( QStringLiteral( "ignoreGetMapURI" ) ) == QLatin1String( "true" ) );
     settings.setValue( QString( '/' + connectionName + "/ignoreGetFeatureInfoURI" ), child.attribute( QStringLiteral( "ignoreGetFeatureInfoURI" ) ) == QLatin1String( "true" ) );
@@ -658,7 +658,7 @@ void QgsManageConnectionsDialog::loadOWSConnections( const QDomDocument &doc, co
 
     if ( !child.attribute( QStringLiteral( "username" ) ).isEmpty() )
     {
-      settings.beginGroup( "/Qgis/" + service.toUpper() + '/' + connectionName );
+      settings.beginGroup( "/qgis/" + service.toUpper() + '/' + connectionName );
       settings.setValue( QStringLiteral( "/username" ), child.attribute( QStringLiteral( "username" ) ) );
       settings.setValue( QStringLiteral( "/password" ), child.attribute( QStringLiteral( "password" ) ) );
       settings.endGroup();
@@ -679,7 +679,7 @@ void QgsManageConnectionsDialog::loadWfsConnections( const QDomDocument &doc, co
 
   QString connectionName;
   QgsSettings settings;
-  settings.beginGroup( QStringLiteral( "/Qgis/connections-wfs" ) );
+  settings.beginGroup( QStringLiteral( "/qgis/connections-wfs" ) );
   QStringList keys = settings.childGroups();
   settings.endGroup();
   QDomElement child = root.firstChildElement();
@@ -732,13 +732,13 @@ void QgsManageConnectionsDialog::loadWfsConnections( const QDomDocument &doc, co
     }
 
     // no dups detected or overwrite is allowed
-    settings.beginGroup( QStringLiteral( "/Qgis/connections-wfs" ) );
+    settings.beginGroup( QStringLiteral( "/qgis/connections-wfs" ) );
     settings.setValue( QString( '/' + connectionName + "/url" ), child.attribute( QStringLiteral( "url" ) ) );
     settings.endGroup();
 
     if ( !child.attribute( QStringLiteral( "username" ) ).isEmpty() )
     {
-      settings.beginGroup( "/Qgis/WFS/" + connectionName );
+      settings.beginGroup( "/qgis/WFS/" + connectionName );
       settings.setValue( QStringLiteral( "/username" ), child.attribute( QStringLiteral( "username" ) ) );
       settings.setValue( QStringLiteral( "/password" ), child.attribute( QStringLiteral( "password" ) ) );
       settings.endGroup();

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -239,7 +239,7 @@ void QgsOWSSourceSelect::populateConnectionList()
 }
 void QgsOWSSourceSelect::on_mNewButton_clicked()
 {
-  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, "/Qgis/connections-" + mService.toLower() + '/' );
+  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, "/qgis/connections-" + mService.toLower() + '/' );
 
   if ( nc->exec() )
   {
@@ -252,7 +252,7 @@ void QgsOWSSourceSelect::on_mNewButton_clicked()
 
 void QgsOWSSourceSelect::on_mEditButton_clicked()
 {
-  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, "/Qgis/connections-" + mService.toLower() + '/', mConnectionsComboBox->currentText() );
+  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, "/qgis/connections-" + mService.toLower() + '/', mConnectionsComboBox->currentText() );
 
   if ( nc->exec() )
   {
@@ -598,7 +598,7 @@ void QgsOWSSourceSelect::addDefaultServers()
   //  exampleServers["Qgis users map"] = "http://qgis.org/wms.cgi";
 
   QgsSettings settings;
-  settings.beginGroup( "/Qgis/connections-" + mService.toLower() );
+  settings.beginGroup( "/qgis/connections-" + mService.toLower() );
   QMap<QString, QString>::const_iterator i = exampleServers.constBegin();
   for ( ; i != exampleServers.constEnd(); ++i )
   {


### PR DESCRIPTION
On Linux the use of Qgis and qgis as root for connection settings
makes it currently impossible to add a new WCS connection

Fixes #16528

## Description

See https://issues.qgis.org/issues/16528

There was a mix of 'Qgis' and 'qgis' as root for ows/cws connections. Without the fix on a clean config, after adding a wcs connection called 'aa' you would end up with (in QGIS3.ini):

```
[Qgis]
connections-wcs\aa\referer=
connections-wcs\aa\url=http://geodata.rivm.nl/geoserver/wcs
connections-wcs\selected=aa
...
[qgis]
WCS\aa\authcfg=
WCS\aa\password=
WCS\aa\username=
connections-wcs\selected=
```
And always an empty dropdown, on Windows it apperently was ok (case-insensetive?)
While NOW you get:

```
[qgis]
WCS\aa\authcfg=
WCS\aa\password=
WCS\aa\username=
connections-wcs\aa\referer=
connections-wcs\aa\url=http://geodata.rivm.nl/geoserver/wcs
connections-wcs\selected=aa
symbolsListGroupsIndex=0
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X ] Commit messages are descriptive and explain the rationale for changes
- [ X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
