### PR TITLE
[processing][needs-docs] always use SAGA shipped with QGIS (refs #16422)

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -53,11 +53,6 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
         ProcessingConfig.settingIcons[self.name()] = self.icon()
         ProcessingConfig.addSetting(Setting("SAGA", 'ACTIVATE_SAGA',
                                             self.tr('Activate'), True))
-        if (isWindows() or isMac()):
-            ProcessingConfig.addSetting(Setting("SAGA",
-                                                SagaUtils.SAGA_FOLDER, self.tr('SAGA folder'),
-                                                '',
-                                                valuetype=Setting.FOLDER))
         ProcessingConfig.addSetting(Setting("SAGA",
                                             SagaUtils.SAGA_IMPORT_EXPORT_OPTIMIZATION,
                                             self.tr('Enable SAGA Import/Export optimizations'), False))
@@ -73,9 +68,6 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
 
     def unload(self):
         ProcessingConfig.removeSetting('ACTIVATE_SAGA')
-        if (isWindows() or isMac()):
-            ProcessingConfig.removeSetting(SagaUtils.SAGA_FOLDER)
-
         ProcessingConfig.removeSetting(SagaUtils.SAGA_LOG_CONSOLE)
         ProcessingConfig.removeSetting(SagaUtils.SAGA_LOG_COMMANDS)
 

--- a/python/plugins/processing/algs/saga/SagaUtils.py
+++ b/python/plugins/processing/algs/saga/SagaUtils.py
@@ -39,7 +39,6 @@ from processing.tools.system import isWindows, isMac, userFolder
 
 SAGA_LOG_COMMANDS = 'SAGA_LOG_COMMANDS'
 SAGA_LOG_CONSOLE = 'SAGA_LOG_CONSOLE'
-SAGA_FOLDER = 'SAGA_FOLDER'
 SAGA_IMPORT_EXPORT_OPTIMIZATION = 'SAGA_IMPORT_EXPORT_OPTIMIZATION'
 
 _installedVersion = None
@@ -83,13 +82,10 @@ def findSagaFolder():
 
 
 def sagaPath():
-    folder = ProcessingConfig.getSetting(SAGA_FOLDER)
-    if folder and not os.path.isdir(folder):
-        folder = None
-        QgsMessageLog.logMessage('Specified SAGA folder does not exist. Will try to find built-in binaries.', 'Processing', QgsMessageLog.WARNING)
-    if folder is None or folder == '':
-        folder = findSagaFolder()
+    if not isWindows() and not isMac():
+        return ''
 
+    folder = findSagaFolder()
     return folder or ''
 
 


### PR DESCRIPTION
## Description
As now we support only SAGA LTR and SAGA shipped with OSGeo4W, therre is no sense in having option to choose external SAGA installation. Moreover this option will lead to confusion and complains if user installs non-supported SAGA version.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
