### PR TITLE
Use QgsMessageBar instead of QMessageBoxes to show result of testing connection

### DIFF
--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -145,7 +145,6 @@ void QgsDb2NewConnection::on_cb_trustedConnection_clicked()
 
 QgsDb2NewConnection::~QgsDb2NewConnection()
 {
-  delete bar;
 }
 
 bool QgsDb2NewConnection::testConnection()

--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -167,7 +167,8 @@ bool QgsDb2NewConnection::testConnection()
 
   if ( !rc )
   {
-    db2ConnectStatus -> setText( errMsg );
+    bar->pushMessage( tr( "Error: %1." ).arg( errMsg ),
+                      QgsMessageBar::WARNING );
     QgsDebugMsg( "errMsg: " + errMsg );
     return false;
   }

--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -50,7 +50,6 @@ QgsDb2NewConnection::QgsDb2NewConnection( QWidget *parent, const QString &connNa
     txtDriver->setText( settings.value( key + "/driver" ).toString() );
     txtDatabase->setText( settings.value( key + "/database" ).toString() );
 
-
     if ( settings.value( key + "/saveUsername" ).toString() == QLatin1String( "true" ) )
     {
       txtUsername->setText( settings.value( key + "/username" ).toString() );
@@ -129,7 +128,6 @@ void QgsDb2NewConnection::accept()
 
 void QgsDb2NewConnection::on_btnConnect_clicked()
 {
-  QgsDebugMsg( "DB2: TestDatabase; button clicked" );
   testConnection();
 }
 
@@ -147,7 +145,7 @@ void QgsDb2NewConnection::on_cb_trustedConnection_clicked()
 
 QgsDb2NewConnection::~QgsDb2NewConnection()
 {
-
+  delete bar;
 }
 
 bool QgsDb2NewConnection::testConnection()
@@ -179,18 +177,19 @@ bool QgsDb2NewConnection::testConnection()
   if ( errMsg.isEmpty() )
   {
     QgsDebugMsg( "connection open succeeded " + connInfo );
-    db2ConnectStatus -> setText( QStringLiteral( "DB2 connection open succeeded" ) );
+    bar->pushMessage( tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ),
+                      QgsMessageBar::INFO );
     return true;
   }
   else
   {
     QgsDebugMsg( "connection open failed: " + errMsg );
-    db2ConnectStatus -> setText( "DB2 connection failed : " + errMsg );
+    bar->pushMessage( tr( "Connection failed: %1." ).arg( errMsg ),
+                      QgsMessageBar::WARNING );
     return false;
   }
 }
 
 void QgsDb2NewConnection::listDatabases()
 {
-  QgsDebugMsg( "DB2 New Connection Dialogue : list database" );
 }

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -143,7 +143,6 @@ void QgsMssqlNewConnection::on_cb_trustedConnection_clicked()
 
 QgsMssqlNewConnection::~QgsMssqlNewConnection()
 {
-  delete bar;
 }
 
 bool QgsMssqlNewConnection::testConnection( const QString &testDatabase )

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -166,5 +166,4 @@ void QgsOracleNewConnection::on_btnConnect_clicked()
 
 QgsOracleNewConnection::~QgsOracleNewConnection()
 {
-  delete bar;
 }

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -150,18 +150,15 @@ void QgsOracleNewConnection::on_btnConnect_clicked()
   if ( conn )
   {
     // Database successfully opened; we can now issue SQL commands.
-    QMessageBox::information( this,
-                              tr( "Test connection" ),
-                              tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ) );
-
+    bar->pushMessage( tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ),
+                      QgsMessageBar::INFO );
     // free connection resources
     QgsOracleConnPool::instance()->releaseConnection( conn );
   }
   else
   {
-    QMessageBox::information( this,
-                              tr( "Test connection" ),
-                              tr( "Connection failed - consult message log for details.\n\n" ) );
+    bar->pushMessage( tr( "Connection failed - consult message log for details." ),
+                      QgsMessageBar::WARNING );
   }
 }
 
@@ -169,4 +166,5 @@ void QgsOracleNewConnection::on_btnConnect_clicked()
 
 QgsOracleNewConnection::~QgsOracleNewConnection()
 {
+  delete bar;
 }

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -107,7 +107,7 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
 
 QgsPgNewConnection::~QgsPgNewConnection()
 {
-  delete bar;
+
 }
 
 //! Autoconnected SLOTS *

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -104,6 +104,12 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
     txtName->setText( connName );
   }
 }
+
+QgsPgNewConnection::~QgsPgNewConnection()
+{
+  delete bar;
+}
+
 //! Autoconnected SLOTS *
 void QgsPgNewConnection::accept()
 {
@@ -201,17 +207,15 @@ void QgsPgNewConnection::testConnection()
   if ( conn )
   {
     // Database successfully opened; we can now issue SQL commands.
-    QMessageBox::information( this,
-                              tr( "Test connection" ),
-                              tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ) );
+    bar->pushMessage( tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ),
+                      QgsMessageBar::INFO );
 
     // free pg connection resources
     conn->unref();
   }
   else
   {
-    QMessageBox::information( this,
-                              tr( "Test connection" ),
-                              tr( "Connection failed - consult message log for details.\n\n" ) );
+    bar->pushMessage( tr( "Connection failed - consult message log for details." ),
+                      QgsMessageBar::WARNING );
   }
 }

--- a/src/providers/postgres/qgspgnewconnection.h
+++ b/src/providers/postgres/qgspgnewconnection.h
@@ -32,6 +32,8 @@ class QgsPgNewConnection : public QDialog, private Ui::QgsPgNewConnectionBase
     //! Constructor
     QgsPgNewConnection( QWidget *parent = nullptr, const QString &connName = QString::null, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
+    ~QgsPgNewConnection();
+
     //! Tests the connection using the parameters supplied
     void testConnection();
   public slots:

--- a/src/ui/qgsdb2newconnectionbase.ui
+++ b/src/ui/qgsdb2newconnectionbase.ui
@@ -15,23 +15,6 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="1" column="0">
-    <widget class="QLabel" name="db2ConnectStatus">
-     <property name="text">
-      <string>DB2 Connect Status: </string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Connection Information</string>
@@ -196,6 +179,19 @@
      </property>
     </spacer>
    </item>
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QgsMessageBar" name="bar" native="true"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -203,6 +199,12 @@
    <class>QgsPasswordLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgspasswordlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>513</height>
+    <height>529</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -41,14 +41,14 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="1" column="0">
     <widget class="QGroupBox" name="GroupBox1">
      <property name="title">
       <string>Connection Information</string>
@@ -277,6 +277,9 @@
      </layout>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QgsMessageBar" name="bar" native="true"/>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
@@ -285,6 +288,12 @@
    <class>QgsPasswordLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgspasswordlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -26,32 +26,110 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout3">
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="1" column="0">
     <widget class="QGroupBox" name="GroupBox1">
      <property name="title">
       <string>Connection Information</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout2">
-      <property name="leftMargin">
-       <number>5</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <property name="horizontalSpacing">
-       <number>5</number>
-      </property>
-      <item row="1" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="TextLabel1_2">
+          <property name="text">
+           <string>Name</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtName</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="txtName">
+          <property name="toolTip">
+           <string>Name of the new connection</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Service</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtService</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="txtService"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="TextLabel1">
+          <property name="text">
+           <string>Host</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtHost</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="txtHost"/>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="TextLabel2_2">
+          <property name="text">
+           <string>Port</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtPort</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLineEdit" name="txtPort">
+          <property name="text">
+           <string>5432</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="TextLabel2">
+          <property name="text">
+           <string>Database</string>
+          </property>
+          <property name="buddy">
+           <cstring>txtDatabase</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLineEdit" name="txtDatabase"/>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="TextLabel3_3">
+          <property name="text">
+           <string>SSL mode</string>
+          </property>
+          <property name="buddy">
+           <cstring>cbxSSLmode</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QComboBox" name="cbxSSLmode"/>
+        </item>
+       </layout>
+      </item>
+      <item>
        <widget class="QTabWidget" name="tabAuthentication">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
@@ -127,7 +205,14 @@
         </widget>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item>
+       <widget class="QPushButton" name="btnConnect">
+        <property name="text">
+         <string>&amp;Test Connection</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="cb_geometryColumnsOnly">
         <property name="toolTip">
          <string>Restrict the displayed tables to those that are in the layer registries.</string>
@@ -140,112 +225,27 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <layout class="QHBoxLayout">
-        <item>
-         <layout class="QVBoxLayout">
-          <item>
-           <widget class="QLabel" name="TextLabel1_2">
-            <property name="text">
-             <string>Name</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtName</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Service</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtService</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="TextLabel1">
-            <property name="text">
-             <string>Host</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtHost</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="TextLabel2_2">
-            <property name="text">
-             <string>Port</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtPort</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="TextLabel2">
-            <property name="text">
-             <string>Database</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtDatabase</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="TextLabel3_3">
-            <property name="text">
-             <string>SSL mode</string>
-            </property>
-            <property name="buddy">
-             <cstring>cbxSSLmode</cstring>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout">
-          <item>
-           <widget class="QLineEdit" name="txtName">
-            <property name="toolTip">
-             <string>Name of the new connection</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="txtService"/>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="txtHost"/>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="txtPort">
-            <property name="text">
-             <string>5432</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="txtDatabase"/>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cbxSSLmode"/>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </item>
-      <item row="4" column="0">
+      <item>
        <widget class="QCheckBox" name="cb_dontResolveType">
         <property name="text">
          <string>Don't resolve type of unrestricted columns (GEOMETRY)</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item>
+       <widget class="QCheckBox" name="cb_publicSchemaOnly">
+        <property name="toolTip">
+         <string>Restrict the search to the public schema for spatial tables not in the geometry_columns table</string>
+        </property>
+        <property name="whatsThis">
+         <string>When searching for spatial tables that are not in the geometry_columns tables, restrict the search to tables that are in the public schema (for some databases this can save lots of time)</string>
+        </property>
+        <property name="text">
+         <string>Only look in the 'public' schema</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="cb_allowGeometrylessTables">
         <property name="text">
          <string>Also list tables with no geometry</string>
@@ -255,7 +255,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
+      <item>
        <widget class="QCheckBox" name="cb_useEstimatedMetadata">
         <property name="toolTip">
          <string>Use estimated table statistics for the layer metadata.</string>
@@ -276,27 +276,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QPushButton" name="btnConnect">
-        <property name="text">
-         <string>&amp;Test Connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QCheckBox" name="cb_publicSchemaOnly">
-        <property name="toolTip">
-         <string>Restrict the search to the public schema for spatial tables not in the geometry_columns table</string>
-        </property>
-        <property name="whatsThis">
-         <string>When searching for spatial tables that are not in the geometry_columns tables, restrict the search to tables that are in the public schema (for some databases this can save lots of time)</string>
-        </property>
-        <property name="text">
-         <string>Only look in the 'public' schema</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -312,6 +292,9 @@
      </layout>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QgsMessageBar" name="bar" native="true"/>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
@@ -320,6 +303,12 @@
    <class>QgsPasswordLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgspasswordlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
## Description
All dialogs for adding new database connection, except MSSQL, use `QMessageBox` to report results of the connection test (success/failure). This PR replaces them with internal `QgsMessageBar`.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
