### PR TITLE
[API] convenience API call to create empty raster file with given number of bands

### DIFF
--- a/python/core/raster/qgsrasterfilewriter.sip
+++ b/python/core/raster/qgsrasterfilewriter.sip
@@ -53,6 +53,21 @@ class QgsRasterFileWriter
  :rtype: QgsRasterDataProvider
 %End
 
+    QgsRasterDataProvider *createRaster( Qgis::DataType dataType,
+                                         int width, int height, const QgsRectangle &extent,
+                                         int nBands, const QgsCoordinateReferenceSystem &crs ) /Factory/;
+%Docstring
+ Create a raster file with given number of bands without initializing the pixel data.
+ Returned provider may be used to initialize the raster using writeBlock() calls.
+ Ownership of the returned provider is passed to the caller.
+.. note::
+
+   Does not work with tiled mode enabled.
+ :return: Instance of data provider in editing mode (on success) or None on error.
+.. versionadded:: 3.0
+ :rtype: QgsRasterDataProvider
+%End
+
     WriterError writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
                              const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = 0 );
 %Docstring

--- a/python/core/raster/qgsrasterfilewriter.sip
+++ b/python/core/raster/qgsrasterfilewriter.sip
@@ -53,9 +53,11 @@ class QgsRasterFileWriter
  :rtype: QgsRasterDataProvider
 %End
 
-    QgsRasterDataProvider *createRaster( Qgis::DataType dataType,
-                                         int width, int height, const QgsRectangle &extent,
-                                         int nBands, const QgsCoordinateReferenceSystem &crs ) /Factory/;
+    QgsRasterDataProvider *createMultiBandRaster( Qgis::DataType dataType,
+        int width, int height,
+        const QgsRectangle &extent,
+        const QgsCoordinateReferenceSystem &crs,
+        int nBands ) /Factory/;
 %Docstring
  Create a raster file with given number of bands without initializing the pixel data.
  Returned provider may be used to initialize the raster using writeBlock() calls.

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -41,6 +41,18 @@ QgsRasterDataProvider *QgsRasterFileWriter::createOneBandRaster( Qgis::DataType 
   return initOutput( width, height, crs, geoTransform, 1, dataType, QList<bool>(), QList<double>() );
 }
 
+QgsRasterDataProvider *QgsRasterFileWriter::createRaster( Qgis::DataType dataType, int width, int height, const QgsRectangle &extent, int nBands, const QgsCoordinateReferenceSystem &crs )
+{
+  if ( mTiledMode )
+    return nullptr;  // does not make sense with tiled mode
+
+  double pixelSize;
+  double geoTransform[6];
+  globalOutputParameters( extent, width, height, geoTransform, pixelSize );
+
+  return initOutput( width, height, crs, geoTransform, nBands, dataType, QList<bool>(), QList<double>() );
+}
+
 QgsRasterFileWriter::QgsRasterFileWriter( const QString &outputUrl )
   : mMode( Raw )
   , mOutputUrl( outputUrl )

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -41,7 +41,7 @@ QgsRasterDataProvider *QgsRasterFileWriter::createOneBandRaster( Qgis::DataType 
   return initOutput( width, height, crs, geoTransform, 1, dataType, QList<bool>(), QList<double>() );
 }
 
-QgsRasterDataProvider *QgsRasterFileWriter::createRaster( Qgis::DataType dataType, int width, int height, const QgsRectangle &extent, int nBands, const QgsCoordinateReferenceSystem &crs )
+QgsRasterDataProvider *QgsRasterFileWriter::createMultiBandRaster( Qgis::DataType dataType, int width, int height, const QgsRectangle &extent, const QgsCoordinateReferenceSystem &crs, int nBands )
 {
   if ( mTiledMode )
     return nullptr;  // does not make sense with tiled mode

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -67,6 +67,17 @@ class CORE_EXPORT QgsRasterFileWriter
         const QgsRectangle &extent,
         const QgsCoordinateReferenceSystem &crs ) SIP_FACTORY;
 
+    /** Create a raster file with given number of bands without initializing the pixel data.
+     * Returned provider may be used to initialize the raster using writeBlock() calls.
+     * Ownership of the returned provider is passed to the caller.
+     * \note Does not work with tiled mode enabled.
+     * \returns Instance of data provider in editing mode (on success) or nullptr on error.
+     * \since QGIS 3.0
+     */
+    QgsRasterDataProvider *createRaster( Qgis::DataType dataType,
+                                         int width, int height, const QgsRectangle &extent,
+                                         int nBands, const QgsCoordinateReferenceSystem &crs ) SIP_FACTORY;
+
     /** Write raster file
         \param pipe raster pipe
         \param nCols number of output columns

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -74,9 +74,11 @@ class CORE_EXPORT QgsRasterFileWriter
      * \returns Instance of data provider in editing mode (on success) or nullptr on error.
      * \since QGIS 3.0
      */
-    QgsRasterDataProvider *createRaster( Qgis::DataType dataType,
-                                         int width, int height, const QgsRectangle &extent,
-                                         int nBands, const QgsCoordinateReferenceSystem &crs ) SIP_FACTORY;
+    QgsRasterDataProvider *createMultiBandRaster( Qgis::DataType dataType,
+        int width, int height,
+        const QgsRectangle &extent,
+        const QgsCoordinateReferenceSystem &crs,
+        int nBands ) SIP_FACTORY;
 
     /** Write raster file
         \param pipe raster pipe


### PR DESCRIPTION
## Description
We already have an API call to create single-band raster, but sometimes a multiband images required, for example this will be useful for porting raster analysis code to use QgsRasterBlock instead of GDAL calls.

Follow up ff8d91214748e0363010e263401212d0b4e0e491

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
