### PR TITLE
Utilise thread safe proj API within QgsCoordinateTransform

### DIFF
--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -37,12 +37,12 @@ extern "C"
 // if defined shows all information about transform to stdout
 // #define COORDINATE_TRANSFORM_VERBOSE
 
+QThreadStorage< QgsCoordinateTransform::QgsProjContextStore* > QgsCoordinateTransform::mProjContext;
+
 QgsCoordinateTransform::QgsCoordinateTransform()
     : QObject()
     , mShortCircuit( false )
     , mInitialisedFlag( false )
-    , mSourceProjection( nullptr )
-    , mDestinationProjection( nullptr )
     , mSourceDatumTransform( -1 )
     , mDestinationDatumTransform( -1 )
 {
@@ -53,8 +53,6 @@ QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSyst
     : QObject()
     , mShortCircuit( false )
     , mInitialisedFlag( false )
-    , mSourceProjection( nullptr )
-    , mDestinationProjection( nullptr )
     , mSourceDatumTransform( -1 )
     , mDestinationDatumTransform( -1 )
 {
@@ -69,8 +67,6 @@ QgsCoordinateTransform::QgsCoordinateTransform( long theSourceSrsId, long theDes
     , mInitialisedFlag( false )
     , mSourceCRS( QgsCRSCache::instance()->crsBySrsId( theSourceSrsId ) )
     , mDestCRS( QgsCRSCache::instance()->crsBySrsId( theDestSrsId ) )
-    , mSourceProjection( nullptr )
-    , mDestinationProjection( nullptr )
     , mSourceDatumTransform( -1 )
     , mDestinationDatumTransform( -1 )
 {
@@ -80,8 +76,6 @@ QgsCoordinateTransform::QgsCoordinateTransform( long theSourceSrsId, long theDes
 QgsCoordinateTransform::QgsCoordinateTransform( const QString& theSourceCRS, const QString& theDestCRS )
     : QObject()
     , mInitialisedFlag( false )
-    , mSourceProjection( nullptr )
-    , mDestinationProjection( nullptr )
     , mSourceDatumTransform( -1 )
     , mDestinationDatumTransform( -1 )
 {
@@ -100,8 +94,6 @@ QgsCoordinateTransform::QgsCoordinateTransform( long theSourceSrid,
     QgsCoordinateReferenceSystem::CrsType theSourceCRSType )
     : QObject()
     , mInitialisedFlag( false )
-    , mSourceProjection( nullptr )
-    , mDestinationProjection( nullptr )
     , mSourceDatumTransform( -1 )
     , mDestinationDatumTransform( -1 )
 {
@@ -118,15 +110,7 @@ QgsCoordinateTransform::QgsCoordinateTransform( long theSourceSrid,
 
 QgsCoordinateTransform::~QgsCoordinateTransform()
 {
-  // free the proj objects
-  if ( mSourceProjection )
-  {
-    pj_free( mSourceProjection );
-  }
-  if ( mDestinationProjection )
-  {
-    pj_free( mDestinationProjection );
-  }
+  freeProj();
 }
 
 QgsCoordinateTransform* QgsCoordinateTransform::clone() const
@@ -180,37 +164,35 @@ void QgsCoordinateTransform::initialise()
 
   bool useDefaultDatumTransform = ( mSourceDatumTransform == - 1 && mDestinationDatumTransform == -1 );
 
-  // init the projections (destination and source)
+  freeProj();
 
-  pj_free( mSourceProjection );
-  QString sourceProjString = mSourceCRS.toProj4();
+  mSourceProjString = mSourceCRS.toProj4();
   if ( !useDefaultDatumTransform )
   {
-    sourceProjString = stripDatumTransform( sourceProjString );
+    mSourceProjString = stripDatumTransform( mSourceProjString );
   }
   if ( mSourceDatumTransform != -1 )
   {
-    sourceProjString += ( ' ' + datumTransformString( mSourceDatumTransform ) );
+    mSourceProjString += ( ' ' + datumTransformString( mSourceDatumTransform ) );
   }
 
-  pj_free( mDestinationProjection );
-  QString destProjString = mDestCRS.toProj4();
+  mDestProjString = mDestCRS.toProj4();
   if ( !useDefaultDatumTransform )
   {
-    destProjString = stripDatumTransform( destProjString );
+    mDestProjString = stripDatumTransform( mDestProjString );
   }
   if ( mDestinationDatumTransform != -1 )
   {
-    destProjString += ( ' ' +  datumTransformString( mDestinationDatumTransform ) );
+    mDestProjString += ( ' ' +  datumTransformString( mDestinationDatumTransform ) );
   }
 
   if ( !useDefaultDatumTransform )
   {
-    addNullGridShifts( sourceProjString, destProjString );
+    addNullGridShifts( mSourceProjString, mDestProjString );
   }
 
-  mSourceProjection = pj_init_plus( sourceProjString.toUtf8() );
-  mDestinationProjection = pj_init_plus( destProjString.toUtf8() );
+  // create proj projections for current thread
+  QPair< projPJ, projPJ > res = threadLocalProjData();
 
 #ifdef COORDINATE_TRANSFORM_VERBOSE
   QgsDebugMsg( "From proj : " + mSourceCRS.toProj4() );
@@ -218,11 +200,11 @@ void QgsCoordinateTransform::initialise()
 #endif
 
   mInitialisedFlag = true;
-  if ( !mDestinationProjection )
+  if ( !res.second )
   {
     mInitialisedFlag = false;
   }
-  if ( !mSourceProjection )
+  if ( !res.first )
   {
     mInitialisedFlag = false;
   }
@@ -661,8 +643,12 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
   QString dir;
   // if the source/destination projection is lat/long, convert the points to radians
   // prior to transforming
-  if (( pj_is_latlong( mDestinationProjection ) && ( direction == ReverseTransform ) )
-      || ( pj_is_latlong( mSourceProjection ) && ( direction == ForwardTransform ) ) )
+  QPair< projPJ, projPJ > projData = threadLocalProjData();
+  projPJ sourceProj = projData.first;
+  projPJ destProj = projData.second;
+
+  if (( pj_is_latlong( destProj ) && ( direction == ReverseTransform ) )
+      || ( pj_is_latlong( sourceProj ) && ( direction == ForwardTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {
@@ -674,13 +660,13 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
   int projResult;
   if ( direction == ReverseTransform )
   {
-    projResult = pj_transform( mDestinationProjection, mSourceProjection, numPoints, 0, x, y, z );
+    projResult = pj_transform( destProj, sourceProj, numPoints, 0, x, y, z );
   }
   else
   {
-    Q_ASSERT( mSourceProjection );
-    Q_ASSERT( mDestinationProjection );
-    projResult = pj_transform( mSourceProjection, mDestinationProjection, numPoints, 0, x, y, z );
+    Q_ASSERT( sourceProj );
+    Q_ASSERT( destProj );
+    projResult = pj_transform( sourceProj, destProj, numPoints, 0, x, y, z );
   }
 
   if ( projResult != 0 )
@@ -702,8 +688,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
     dir = ( direction == ForwardTransform ) ? tr( "forward transform" ) : tr( "inverse transform" );
 
-    char *srcdef = pj_get_def( mSourceProjection, 0 );
-    char *dstdef = pj_get_def( mDestinationProjection, 0 );
+    char *srcdef = pj_get_def( sourceProj, 0 );
+    char *dstdef = pj_get_def( destProj, 0 );
 
     QString msg = tr( "%1 of\n"
                       "%2"
@@ -728,8 +714,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
   // if the result is lat/long, convert the results from radians back
   // to degrees
-  if (( pj_is_latlong( mDestinationProjection ) && ( direction == ForwardTransform ) )
-      || ( pj_is_latlong( mSourceProjection ) && ( direction == ReverseTransform ) ) )
+  if (( pj_is_latlong( destProj ) && ( direction == ForwardTransform ) )
+      || ( pj_is_latlong( sourceProj ) && ( direction == ReverseTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {
@@ -1054,4 +1040,57 @@ void QgsCoordinateTransform::addNullGridShifts( QString& srcProjString, QString&
   {
     destProjString += " +nadgrids=@null";
   }
+}
+
+QPair<projPJ, projPJ> QgsCoordinateTransform::threadLocalProjData() const
+{
+  mProjLock.lockForRead();
+  projCtx pContext = nullptr;
+  if ( mProjContext.hasLocalData() )
+    pContext = mProjContext.localData()->get();
+  else
+  {
+    mProjContext.setLocalData( new QgsProjContextStore() );
+    pContext = mProjContext.localData()->get();
+  }
+
+  QMap< uintptr_t, QPair< projPJ, projPJ > >::const_iterator it = mProjProjections.constFind( reinterpret_cast< uintptr_t >( pContext ) );
+  if ( it != mProjProjections.constEnd() )
+  {
+    QPair< projPJ, projPJ > res = it.value();
+    mProjLock.unlock();
+    return res;
+  }
+
+  // proj projections don't exist yet, so we need to create
+  mProjLock.unlock();
+  mProjLock.lockForWrite();
+  QPair< projPJ, projPJ > res = qMakePair( pj_init_plus_ctx( pContext, mSourceProjString.toUtf8() ),
+                                pj_init_plus_ctx( pContext, mDestProjString.toUtf8() ) );
+  mProjProjections.insert( reinterpret_cast< uintptr_t >( pContext ), res );
+  mProjLock.unlock();
+  return res;
+}
+
+void QgsCoordinateTransform::freeProj()
+{
+  mProjLock.lockForWrite();
+  QMap< uintptr_t, QPair< projPJ, projPJ > >::const_iterator it = mProjProjections.constBegin();
+  for ( ; it != mProjProjections.constEnd(); ++it )
+  {
+    pj_free( it.value().first );
+    pj_free( it.value().second );
+  }
+  mProjProjections.clear();
+  mProjLock.unlock();
+}
+
+QgsCoordinateTransform::QgsProjContextStore::QgsProjContextStore()
+{
+  context = pj_ctx_alloc();
+}
+
+QgsCoordinateTransform::QgsProjContextStore::~QgsProjContextStore()
+{
+  pj_ctx_free( context );
 }


### PR DESCRIPTION
Avoids unpredictable behavior when transforms are being conducted in background threads, such as map renders.

Refs #11441

This commit:
1. Uses QThreadStorage for projCtx objects, to ensure that every thread correctly has its own projCtx context

2. Refactors QgsCoordinateTransform so that the projPJ source and destination objects are instead stored in a map (by projCtx). This allows transforms to be transparently performed using the correct projPJ objects for the particular thread in which the transform is being conducted. This approach allows a single  QgsCoordinateTransform to be safely utilised in different threads.

This backports the recent fix which landed in master, but adapts for lack of Qt5/c++11 features. This is a high risk change IMO, but it's also a crucial fix to have. In depth peer review would be appreciated :)