### PR TITLE
Fix Postgis Merge selected features regression: for 3.0 fixes #15741

### DIFF
--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -56,6 +56,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     Q_OBJECT
 
     friend class QgsTransaction;
+    friend class QgsVectorLayerEditBuffer;
 
   public:
 

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -320,7 +320,8 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList &commitErrors )
     {
       for ( QgsFeature f : mAddedFeatures )
       {
-        if ( f.geometry().wkbType() == provider->wkbType() )
+        if ( ( ! f.hasGeometry() ) ||
+             ( f.geometry().wkbType() == provider->wkbType() ) )
           continue;
 
         std::unique_ptr<QgsGeometry> convertedGeom( provider->convertToProviderType( f.geometry() ) );

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -310,6 +310,34 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList &commitErrors )
   // no                 yes                   => changeAttributeValues
   // yes                yes                   => changeFeatures
 
+  // to fix https://issues.qgis.org/issues/15741
+  // first of all check if feature to add is compatible with provider type
+  // this check have to be done before all checks to avoid to clear internal
+  // buffer if some of next steps success.
+  if ( success && !mAddedFeatures.isEmpty() )
+  {
+    if ( cap & QgsVectorDataProvider::AddFeatures )
+    {
+      for ( QgsFeature f : mAddedFeatures )
+      {
+        if ( f.geometry().wkbType() == provider->wkbType() )
+          continue;
+
+        std::unique_ptr<QgsGeometry> convertedGeom( provider->convertToProviderType( f.geometry() ) );
+        if ( ! convertedGeom )
+        {
+          commitErrors << tr( "ERROR: %n feature(s) not added - geometry type is not compatible with the current layer.", "not added features count", mAddedFeatures.size() );
+          success = false;
+        }
+      }
+    }
+    else
+    {
+      commitErrors << tr( "ERROR: %n feature(s) not added - provider doesn't support adding features.", "not added features count", mAddedFeatures.size() );
+      success = false;
+    }
+  }
+
   //
   // update geometries
   //

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -328,6 +328,7 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList &commitErrors )
         {
           commitErrors << tr( "ERROR: %n feature(s) not added - geometry type is not compatible with the current layer.", "not added features count", mAddedFeatures.size() );
           success = false;
+          break;
         }
       }
     }

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -324,8 +324,7 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList &commitErrors )
              ( f.geometry().wkbType() == provider->wkbType() ) )
           continue;
 
-        std::unique_ptr<QgsGeometry> convertedGeom( provider->convertToProviderType( f.geometry() ) );
-        if ( ! convertedGeom )
+        if ( provider->convertToProviderType( f.geometry() ).isNull() )
         {
           commitErrors << tr( "ERROR: %n feature(s) not added - geometry type is not compatible with the current layer.", "not added features count", mAddedFeatures.size() );
           success = false;

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -97,8 +97,8 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         # add a features with a multi line geometry of not touched lines =>
         # cannot be forced to be linestring
         multiline = [
-            [QgsPoint(1, 1), QgsPointXY(2, 2)],
-            [QgsPoint(3, 3), QgsPointXY(4, 4)],
+            [QgsPointXY(1, 1), QgsPointXY(2, 2)],
+            [QgsPointXY(3, 3), QgsPointXY(4, 4)],
         ]
         f1 = QgsFeature(layer.fields(), 1)
         f1.setGeometry(QgsGeometry.fromMultiPolyline(multiline))

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -94,7 +94,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertFalse(layer.editBuffer().isFeatureAdded(1))
         self.assertFalse(layer.editBuffer().isFeatureAdded(3))
 
-        # add a features with a multi line geometry of not toched lines =>
+        # add a features with a multi line geometry of not touched lines =>
         # cannot be forced to be linestring
         multiline = [
             [QgsPoint(1, 1), QgsPoint(2, 2)],

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -44,6 +44,13 @@ def createLayerWithOnePoint():
     return layer
 
 
+def createEmptyLinestringLayer():
+    layer = QgsVectorLayer("Linestring?field=fldtxt:string&field=fldint:integer",
+                           "addfeat", "memory")
+    assert layer.isValid()
+    return layer
+
+
 class TestQgsVectorLayerEditBuffer(unittest.TestCase):
 
     def testAddFeatures(self):
@@ -77,6 +84,27 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
 
         self.assertTrue(layer.editBuffer().isFeatureAdded(new_feature_ids[0]))
         self.assertTrue(layer.editBuffer().isFeatureAdded(new_feature_ids[1]))
+
+        # check if error in case adding not adaptable geometry
+        # eg. a Multiline in a Line
+        layer = createEmptyLinestringLayer()
+        self.assertTrue(layer.startEditing())
+
+        self.assertEqual(layer.editBuffer().addedFeatures(), {})
+        self.assertFalse(layer.editBuffer().isFeatureAdded(1))
+        self.assertFalse(layer.editBuffer().isFeatureAdded(3))
+
+        # add a features with a multi line geometry of not toched lines =>
+        # cannot be forced to be linestring
+        multiline = [
+            [QgsPoint(1, 1), QgsPoint(2, 2)],
+            [QgsPoint(3, 3), QgsPoint(4, 4)],
+        ]
+        f1 = QgsFeature(layer.fields(), 1)
+        f1.setGeometry(QgsGeometry.fromMultiPolyline(multiline))
+        f1.setAttributes(["test", 123])
+        self.assertTrue(layer.addFeatures([f1]))
+        self.assertFalse(layer.commitChanges())
 
     def testAddMultipleFeatures(self):
         # test adding multiple features to an edit buffer

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -97,8 +97,8 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         # add a features with a multi line geometry of not touched lines =>
         # cannot be forced to be linestring
         multiline = [
-            [QgsPoint(1, 1), QgsPoint(2, 2)],
-            [QgsPoint(3, 3), QgsPoint(4, 4)],
+            [QgsPoint(1, 1), QgsPointXY(2, 2)],
+            [QgsPoint(3, 3), QgsPointXY(4, 4)],
         ]
         f1 = QgsFeature(layer.fields(), 1)
         f1.setGeometry(QgsGeometry.fromMultiPolyline(multiline))


### PR DESCRIPTION
## Description
port to 3.0 of https://github.com/qgis/QGIS/pull/4594

add a geometry compatibility check before apply all stages that compose the commitChange

Commit 8d70a51 allowed to raise a limitation of the:
QgsVectorLayerEditBuffer::commitChanges [2] class (see doc [3])
commitChanges is a multi staged commit task with a limitation, each
stage, if success, clean it's stage buffer => it can't be recovered if
one of the next stages fail.

This is exactly what happen in the issue. Merge Features is done doing:

- deleted features to merge
- add the new merged feature
- stage 2 will fail (due the fact that if postgis layer is linestring, the merged is multi type => incompatible). but failing the rollback
- (done aborting the editing session) rollback only the stage 2, because
- stage 1 was success and cleaned from editBuffer.

Solutions:
There is no a unique solution. These are the options:

1. revert or partially revert the above commit 8d70a51
2. don't clean the stage buffers, and do them only if no error is found (opening to other regressions)
3. refactor editing buffer (would make sense integrating QgsTransaction and QgsTransactionGroups where possible)... but IMHO out of the scope of a bug fix
4. Check geometry compatibility before to apply commit phases

this PR apply the simplest solution 4)

[1] https://issues.qgis.org/issues/15741
[2] https://github.com/qgis/QGIS/blob/release-2_18/src/core/qgsvectorlayereditbuffer.cpp#L292
[3] https://github.com/qgis/QGIS/blob/release-2_18/src/core/qgsvectorlayereditbuffer.h#L93

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
