### PR TITLE
When setting scale range, make sure to set min before max scale

### DIFF
--- a/src/gui/qgsscalerangewidget.cpp
+++ b/src/gui/qgsscalerangewidget.cpp
@@ -132,8 +132,8 @@ double QgsScaleRangeWidget::maximumScaleDenom()
 
 void QgsScaleRangeWidget::setScaleRange( double min, double max )
 {
-  setMaximumScale( max );
   setMinimumScale( min );
+  setMaximumScale( max );
 }
 
 void QgsScaleRangeWidget::emitRangeChanged()


### PR DESCRIPTION
This ensures the limit on max scale imposed by previously set min
scale does not trim the new value.

Fixes https://issues.qgis.org/issues/15463
Superceeds https://github.com/qgis/QGIS/pull/4612