### PR TITLE
[FEATURE] New decoration type for showing composer map extents

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -24,6 +24,8 @@ SET(QGIS_APP_SRCS
   qgsdecorationitem.cpp
   qgsdecorationcopyright.cpp
   qgsdecorationcopyrightdialog.cpp
+  qgsdecorationlayoutextent.cpp
+  qgsdecorationlayoutextentdialog.cpp
   qgsdecorationnortharrow.cpp
   qgsdecorationnortharrowdialog.cpp
   qgsdecorationscalebar.cpp
@@ -209,6 +211,8 @@ SET (QGIS_APP_MOC_HDRS
   qgsdecorationitem.h
   qgsdecorationcopyright.h
   qgsdecorationcopyrightdialog.h
+  qgsdecorationlayoutextent.h
+  qgsdecorationlayoutextentdialog.h
   qgsdecorationnortharrow.h
   qgsdecorationnortharrowdialog.h
   qgsdecorationscalebar.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -161,6 +161,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsdecorationnortharrow.h"
 #include "qgsdecorationscalebar.h"
 #include "qgsdecorationgrid.h"
+#include "qgsdecorationlayoutextent.h"
 #include "qgsencodingfiledialog.h"
 #include "qgserror.h"
 #include "qgserrordialog.h"
@@ -3527,11 +3528,15 @@ void QgisApp::createDecorations()
   QgsDecorationGrid *mDecorationGrid = new QgsDecorationGrid( this );
   connect( mActionDecorationGrid, &QAction::triggered, mDecorationGrid, &QgsDecorationGrid::run );
 
+  QgsDecorationLayoutExtent *decorationLayoutExtent = new QgsDecorationLayoutExtent( this );
+  connect( mActionDecorationLayoutExtent, &QAction::triggered, decorationLayoutExtent, &QgsDecorationLayoutExtent::run );
+
   // add the decorations in a particular order so they are rendered in that order
   addDecorationItem( mDecorationGrid );
   addDecorationItem( mDecorationCopyright );
   addDecorationItem( mDecorationNorthArrow );
   addDecorationItem( mDecorationScaleBar );
+  addDecorationItem( decorationLayoutExtent );
   connect( mMapCanvas, &QgsMapCanvas::renderComplete, this, &QgisApp::renderDecorationItems );
   connect( this, &QgisApp::newProject, this, &QgisApp::projectReadDecorationItems );
   connect( this, &QgisApp::projectRead, this, &QgisApp::projectReadDecorationItems );

--- a/src/app/qgsdecorationitem.h
+++ b/src/app/qgsdecorationitem.h
@@ -61,6 +61,8 @@ class APP_EXPORT QgsDecorationItem : public QObject, public QgsMapDecoration
      */
     void setPlacement( Placement placement ) { mPlacement = placement; }
 
+    QString name() const { return mName; }
+
   signals:
     void toggled( bool t );
 
@@ -73,13 +75,12 @@ class APP_EXPORT QgsDecorationItem : public QObject, public QgsMapDecoration
     //! Show the dialog box
     virtual void run() {}
 
-    virtual void setName( const char *name );
-    virtual QString name() { return mName; }
-
     //! Redraws the decoration
     void update();
 
   protected:
+
+    void setName( const char *name );
 
     //! True if decoration item has to be displayed
     bool mEnabled;

--- a/src/app/qgsdecorationlayoutextent.cpp
+++ b/src/app/qgsdecorationlayoutextent.cpp
@@ -1,0 +1,153 @@
+/***************************************************************************
+                          qgsdecorationlayoutextent.cpp
+                              ----------------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationlayoutextent.h"
+#include "qgsdecorationlayoutextentdialog.h"
+
+#include "qgslayoutmanager.h"
+#include "qgscomposition.h"
+#include "qgscomposermap.h"
+#include "qgsgeometry.h"
+#include "qgscsexception.h"
+#include "qgslinesymbollayer.h"
+
+#include "qgisapp.h"
+#include "qgsapplication.h"
+#include "qgslogger.h"
+#include "qgsmapcanvas.h"
+#include "qgsproject.h"
+#include "qgssymbollayerutils.h"
+#include "qgsreadwritecontext.h"
+
+#include <QPainter>
+
+QgsDecorationLayoutExtent::QgsDecorationLayoutExtent( QObject *parent )
+  : QgsDecorationItem( parent )
+{
+  mPlacement = BottomRight;
+  mMarginUnit = QgsUnitTypes::RenderMillimeters;
+
+  setName( "Layout Extent" );
+  projectRead();
+}
+
+void QgsDecorationLayoutExtent::projectRead()
+{
+  QgsDecorationItem::projectRead();
+
+  QDomDocument doc;
+  QDomElement elem;
+  QgsReadWriteContext rwContext;
+  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  QString xml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Symbol" ) );
+  mSymbol.reset( nullptr );
+  if ( !xml.isEmpty() )
+  {
+    doc.setContent( xml );
+    elem = doc.documentElement();
+    mSymbol.reset( QgsSymbolLayerUtils::loadSymbol<QgsFillSymbol>( elem, rwContext ) );
+  }
+  if ( ! mSymbol )
+  {
+    mSymbol.reset( new QgsFillSymbol() );
+    QgsSimpleLineSymbolLayer *layer = new QgsSimpleLineSymbolLayer( QColor( 0, 0, 0, 100 ), 0, Qt::DashLine );
+    mSymbol->changeSymbolLayer( 0, layer );
+  }
+}
+
+void QgsDecorationLayoutExtent::saveToProject()
+{
+  QgsDecorationItem::saveToProject();
+  // write symbol info to xml
+  QDomDocument doc;
+  QDomElement elem;
+  QgsReadWriteContext rwContext;
+  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  if ( mSymbol )
+  {
+    elem = QgsSymbolLayerUtils::saveSymbol( QStringLiteral( "Symbol" ), mSymbol.get(), doc, rwContext );
+    doc.appendChild( elem );
+    // FIXME this works, but XML will not be valid as < is replaced by &lt;
+    QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Symbol" ), doc.toString() );
+  }
+}
+
+void QgsDecorationLayoutExtent::run()
+{
+  QgsDecorationLayoutExtentDialog dlg( *this, QgisApp::instance() );
+  dlg.exec();
+}
+
+
+void QgsDecorationLayoutExtent::render( const QgsMapSettings &mapSettings, QgsRenderContext &context )
+{
+  if ( !enabled() )
+    return;
+
+  if ( !mSymbol )
+    return;
+
+  context.painter()->save();
+  context.painter()->setRenderHint( QPainter::Antialiasing, true );
+  mSymbol->startRender( context );
+
+  const QgsMapToPixel &m2p = mapSettings.mapToPixel();
+  QTransform transform = m2p.transform();
+
+  Q_FOREACH ( QgsComposition *composition, QgsProject::instance()->layoutManager()->compositions() )
+  {
+    Q_FOREACH ( const QgsComposerMap *map, composition->composerMapItems() )
+    {
+      QPolygonF extent = map->visibleExtentPolygon();
+      QgsGeometry g = QgsGeometry::fromQPolygonF( extent );
+
+      if ( map->crs() !=
+           mapSettings.destinationCrs() )
+      {
+        // reproject extent
+        QgsCoordinateTransform ct( map->crs(),
+                                   mapSettings.destinationCrs() );
+        g = g.densifyByCount( 20 );
+        try
+        {
+          g.transform( ct );
+        }
+        catch ( QgsCsException & )
+        {
+        }
+      }
+
+      g.transform( transform );
+      extent = g.asQPolygonF();
+      mSymbol->renderPolygon( extent, nullptr, nullptr, context );
+    }
+  }
+  mSymbol->stopRender( context );
+  context.painter()->restore();
+}
+
+QgsFillSymbol *QgsDecorationLayoutExtent::symbol() const
+{
+  return mSymbol.get();
+}
+
+void QgsDecorationLayoutExtent::setSymbol( QgsFillSymbol *symbol )
+{
+  mSymbol.reset( symbol );
+}
+

--- a/src/app/qgsdecorationlayoutextent.cpp
+++ b/src/app/qgsdecorationlayoutextent.cpp
@@ -25,7 +25,7 @@
 #include "qgsgeometry.h"
 #include "qgscsexception.h"
 #include "qgslinesymbollayer.h"
-
+#include "qgscomposer.h"
 #include "qgisapp.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
@@ -109,8 +109,10 @@ void QgsDecorationLayoutExtent::render( const QgsMapSettings &mapSettings, QgsRe
   const QgsMapToPixel &m2p = mapSettings.mapToPixel();
   QTransform transform = m2p.transform();
 
-  Q_FOREACH ( QgsComposition *composition, QgsProject::instance()->layoutManager()->compositions() )
+  // only loop through open composers
+  Q_FOREACH ( QgsComposer *composer, QgisApp::instance()->printComposers() )
   {
+    QgsComposition *composition = composer->composition();
     Q_FOREACH ( const QgsComposerMap *map, composition->composerMapItems() )
     {
       QPolygonF extent = map->visibleExtentPolygon();

--- a/src/app/qgsdecorationlayoutextent.h
+++ b/src/app/qgsdecorationlayoutextent.h
@@ -25,6 +25,7 @@
 #include <QObject>
 #include "qgis_app.h"
 #include "qgssymbol.h"
+#include "qgstextrenderer.h"
 #include <memory>
 
 class QgsDecorationLayoutExtentDialog;
@@ -52,6 +53,34 @@ class APP_EXPORT QgsDecorationLayoutExtent : public QgsDecorationItem
      */
     void setSymbol( QgsFillSymbol *symbol SIP_TRANSFER );
 
+    /**
+     * Returns the text format for extent labels.
+     * \see setTextFormat()
+     * \see labelExtents()
+     */
+    QgsTextFormat textFormat() const { return mTextFormat; }
+
+    /**
+     * Sets the text \a format for extent labels.
+     * \see textFormat()
+     * \see setLabelExtents()
+     */
+    void setTextFormat( const QgsTextFormat &format ) { mTextFormat = format; }
+
+    /**
+     * Returns true if layout extents should be labeled with the name of the associated layout & map.
+     * \see setLabelExtents()
+     * \see textFormat()
+     */
+    bool labelExtents() const;
+
+    /**
+     * Sets whether layout extents should be labeled with the name of the associated layout & map.
+     * \see labelExtents()
+     * \see setTextFormat()
+     */
+    void setLabelExtents( bool labelExtents );
+
   public slots:
     void projectRead() override;
     void saveToProject() override;
@@ -60,6 +89,8 @@ class APP_EXPORT QgsDecorationLayoutExtent : public QgsDecorationItem
 
   private:
     std::unique_ptr< QgsFillSymbol > mSymbol;
+    QgsTextFormat mTextFormat;
+    bool mLabelExtents = true;
 
     friend class QgsDecorationLayoutExtentDialog;
 };

--- a/src/app/qgsdecorationlayoutextent.h
+++ b/src/app/qgsdecorationlayoutextent.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+                          qgsdecorationlayoutextent.h
+                              -------------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDECORATIONLAYOUTEXTENT_H
+#define QGSDECORATIONLAYOUTEXTENT_H
+
+#include "qgsdecorationitem.h"
+
+#include <QColor>
+#include <QFont>
+#include <QObject>
+#include "qgis_app.h"
+#include "qgssymbol.h"
+#include <memory>
+
+class QgsDecorationLayoutExtentDialog;
+
+class APP_EXPORT QgsDecorationLayoutExtent : public QgsDecorationItem
+{
+    Q_OBJECT
+  public:
+
+    //! Constructor
+    QgsDecorationLayoutExtent( QObject *parent = nullptr );
+
+    QgsFillSymbol *symbol() const;
+    void setSymbol( QgsFillSymbol *symbol SIP_TRANSFER );
+
+  public slots:
+    //! set values on the gui when a project is read or the gui first loaded
+    void projectRead() override;
+    //! save values to the project
+    void saveToProject() override;
+
+    //! Show the dialog box
+    void run() override;
+    //! render the copyright label
+    void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
+
+  private:
+    std::unique_ptr< QgsFillSymbol > mSymbol;
+
+    friend class QgsDecorationLayoutExtentDialog;
+};
+
+#endif //QGSDECORATIONLAYOUTEXTENT_H

--- a/src/app/qgsdecorationlayoutextent.h
+++ b/src/app/qgsdecorationlayoutextent.h
@@ -34,21 +34,28 @@ class APP_EXPORT QgsDecorationLayoutExtent : public QgsDecorationItem
     Q_OBJECT
   public:
 
-    //! Constructor
+    /**
+     * Constructor for QgsDecorationLayoutExtent.
+    */
     QgsDecorationLayoutExtent( QObject *parent = nullptr );
 
+    /**
+     * Returns the fill symbol used for shading layout extents.
+     * \see setSymbol()
+     */
     QgsFillSymbol *symbol() const;
+
+    /**
+     * Sets the fill \a symbol used for shading layout extents. Ownership of
+     * \a symbol is transferred.
+     * \see symbol()
+     */
     void setSymbol( QgsFillSymbol *symbol SIP_TRANSFER );
 
   public slots:
-    //! set values on the gui when a project is read or the gui first loaded
     void projectRead() override;
-    //! save values to the project
     void saveToProject() override;
-
-    //! Show the dialog box
     void run() override;
-    //! render the copyright label
     void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
 
   private:

--- a/src/app/qgsdecorationlayoutextentdialog.cpp
+++ b/src/app/qgsdecorationlayoutextentdialog.cpp
@@ -1,0 +1,110 @@
+/***************************************************************************
+                          qgsdecorationlayoutextentdialog.cpp
+                              ----------------------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationlayoutextentdialog.h"
+
+#include "qgsdecorationlayoutextent.h"
+
+#include "qgslogger.h"
+#include "qgshelp.h"
+#include "qgsstyle.h"
+#include "qgssymbol.h"
+#include "qgssymbolselectordialog.h"
+#include "qgisapp.h"
+#include "qgsguiutils.h"
+#include "qgssettings.h"
+
+QgsDecorationLayoutExtentDialog::QgsDecorationLayoutExtentDialog( QgsDecorationLayoutExtent &deco, QWidget *parent )
+  : QDialog( parent )
+  , mDeco( deco )
+{
+  setupUi( this );
+
+  QgsSettings settings;
+  restoreGeometry( settings.value( "/Windows/DecorationLayoutExtent/geometry" ).toByteArray() );
+
+  updateGuiElements();
+  connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsDecorationLayoutExtentDialog::apply );
+  connect( mSymbolButton, &QPushButton::clicked, this, &QgsDecorationLayoutExtentDialog::changeSymbol );
+}
+
+void QgsDecorationLayoutExtentDialog::updateGuiElements()
+{
+  grpEnable->setChecked( mDeco.enabled() );
+
+  if ( mDeco.symbol() )
+  {
+    mSymbol.reset( static_cast<QgsFillSymbol *>( mDeco.symbol()->clone() ) );
+    QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( mSymbol.get(), mSymbolButton->iconSize() );
+    mSymbolButton->setIcon( icon );
+  }
+}
+
+void QgsDecorationLayoutExtentDialog::updateDecoFromGui()
+{
+  mDeco.setEnabled( grpEnable->isChecked() );
+
+  if ( mSymbol )
+  {
+    mDeco.setSymbol( mSymbol->clone() );
+  }
+}
+
+QgsDecorationLayoutExtentDialog::~QgsDecorationLayoutExtentDialog()
+{
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "/Windows/DecorationLayoutExtent/geometry" ), saveGeometry() );
+}
+
+void QgsDecorationLayoutExtentDialog::on_buttonBox_accepted()
+{
+  apply();
+  accept();
+}
+
+void QgsDecorationLayoutExtentDialog::apply()
+{
+  updateDecoFromGui();
+  mDeco.update();
+}
+
+void QgsDecorationLayoutExtentDialog::on_buttonBox_rejected()
+{
+  reject();
+}
+
+void QgsDecorationLayoutExtentDialog::changeSymbol()
+{
+  if ( !mSymbol )
+    return;
+
+  QgsFillSymbol *symbol = mSymbol->clone();
+  QgsSymbolSelectorDialog dlg( symbol, QgsStyle::defaultStyle(), nullptr, this );
+  if ( dlg.exec() == QDialog::Rejected )
+  {
+    delete symbol;
+  }
+  else
+  {
+    mSymbol.reset( symbol );
+    if ( mSymbol )
+    {
+      QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( mSymbol.get(), mSymbolButton->iconSize() );
+      mSymbolButton->setIcon( icon );
+    }
+  }
+}

--- a/src/app/qgsdecorationlayoutextentdialog.cpp
+++ b/src/app/qgsdecorationlayoutextentdialog.cpp
@@ -27,6 +27,7 @@
 #include "qgisapp.h"
 #include "qgsguiutils.h"
 #include "qgssettings.h"
+#include "qgstextformatwidget.h"
 
 QgsDecorationLayoutExtentDialog::QgsDecorationLayoutExtentDialog( QgsDecorationLayoutExtent &deco, QWidget *parent )
   : QDialog( parent )
@@ -37,9 +38,15 @@ QgsDecorationLayoutExtentDialog::QgsDecorationLayoutExtentDialog( QgsDecorationL
   QgsSettings settings;
   restoreGeometry( settings.value( "/Windows/DecorationLayoutExtent/geometry" ).toByteArray() );
 
+  connect( mCheckBoxLabelExtents, &QCheckBox::toggled, mButtonFontStyle, &QPushButton::setEnabled );
+  mCheckBoxLabelExtents->setChecked( false );
+  mButtonFontStyle->setEnabled( false );
+
   updateGuiElements();
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsDecorationLayoutExtentDialog::apply );
   connect( mSymbolButton, &QPushButton::clicked, this, &QgsDecorationLayoutExtentDialog::changeSymbol );
+  connect( mButtonFontStyle, &QPushButton::clicked, this, &QgsDecorationLayoutExtentDialog::changeFont );
+
 }
 
 void QgsDecorationLayoutExtentDialog::updateGuiElements()
@@ -52,6 +59,8 @@ void QgsDecorationLayoutExtentDialog::updateGuiElements()
     QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( mSymbol.get(), mSymbolButton->iconSize() );
     mSymbolButton->setIcon( icon );
   }
+  mTextFormat = mDeco.textFormat();
+  mCheckBoxLabelExtents->setChecked( mDeco.labelExtents() );
 }
 
 void QgsDecorationLayoutExtentDialog::updateDecoFromGui()
@@ -62,6 +71,8 @@ void QgsDecorationLayoutExtentDialog::updateDecoFromGui()
   {
     mDeco.setSymbol( mSymbol->clone() );
   }
+  mDeco.setTextFormat( mTextFormat );
+  mDeco.setLabelExtents( mCheckBoxLabelExtents->isChecked() );
 }
 
 QgsDecorationLayoutExtentDialog::~QgsDecorationLayoutExtentDialog()
@@ -107,4 +118,11 @@ void QgsDecorationLayoutExtentDialog::changeSymbol()
       mSymbolButton->setIcon( icon );
     }
   }
+}
+
+void QgsDecorationLayoutExtentDialog::changeFont()
+{
+  QgsTextFormatDialog dlg( mTextFormat, QgisApp::instance()->mapCanvas(), this );
+  if ( dlg.exec() )
+    mTextFormat = dlg.format();
 }

--- a/src/app/qgsdecorationlayoutextentdialog.h
+++ b/src/app/qgsdecorationlayoutextentdialog.h
@@ -20,6 +20,7 @@
 #include "ui_qgsdecorationlayoutextentdialog.h"
 #include <QDialog>
 #include "qgis_app.h"
+#include "qgstextrenderer.h"
 #include <memory>
 
 class QgsDecorationLayoutExtent;
@@ -39,10 +40,12 @@ class APP_EXPORT QgsDecorationLayoutExtentDialog : public QDialog, private Ui::Q
     void on_buttonBox_rejected();
 
     void changeSymbol();
+    void changeFont();
 
   private:
     QgsDecorationLayoutExtent &mDeco;
     std::unique_ptr< QgsFillSymbol > mSymbol;
+    QgsTextFormat mTextFormat;
 
     void updateGuiElements();
     void updateDecoFromGui();

--- a/src/app/qgsdecorationlayoutextentdialog.h
+++ b/src/app/qgsdecorationlayoutextentdialog.h
@@ -1,0 +1,52 @@
+/***************************************************************************
+                          qgsdecorationlayoutextentdialog.h
+                              -------------------
+    begin                : May 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDECORATIONLAYOUTEXTENTDIALOG_H
+#define QGSDECORATIONLAYOUTEXTENTDIALOG_H
+
+#include "ui_qgsdecorationlayoutextentdialog.h"
+#include <QDialog>
+#include "qgis_app.h"
+#include <memory>
+
+class QgsDecorationLayoutExtent;
+class QgsFillSymbol;
+
+class APP_EXPORT QgsDecorationLayoutExtentDialog : public QDialog, private Ui::QgsDecorationLayoutExtentDialog
+{
+    Q_OBJECT
+
+  public:
+    QgsDecorationLayoutExtentDialog( QgsDecorationLayoutExtent &decoration, QWidget *parent = nullptr );
+    ~QgsDecorationLayoutExtentDialog();
+
+  private slots:
+    void apply();
+    void on_buttonBox_accepted();
+    void on_buttonBox_rejected();
+
+    void changeSymbol();
+
+  private:
+    QgsDecorationLayoutExtent &mDeco;
+    std::unique_ptr< QgsFillSymbol > mSymbol;
+
+    void updateGuiElements();
+    void updateDecoFromGui();
+
+};
+
+#endif // QGSDECORATIONLAYOUTEXTENTDIALOG_H

--- a/src/core/qgstextrenderer.cpp
+++ b/src/core/qgstextrenderer.cpp
@@ -1423,7 +1423,11 @@ void QgsTextFormat::readFromLayer( QgsVectorLayer *layer )
 
 void QgsTextFormat::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
 {
-  QDomElement textStyleElem = elem.firstChildElement( QStringLiteral( "text-style" ) );
+  QDomElement textStyleElem;
+  if ( elem.nodeName() == QStringLiteral( "text-style" ) )
+    textStyleElem = elem;
+  else
+    textStyleElem = elem.firstChildElement( QStringLiteral( "text-style" ) );
   QFont appFont = QApplication::font();
   mTextFontFamily = textStyleElem.attribute( QStringLiteral( "fontFamily" ), appFont.family() );
   QString fontFamily = mTextFontFamily;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -17,7 +17,7 @@
      <x>0</x>
      <y>0</y>
      <width>1018</width>
-     <height>18</height>
+     <height>21</height>
     </rect>
    </property>
    <property name="toolTip">
@@ -82,6 +82,7 @@
      <addaction name="mActionDecorationScaleBar"/>
      <addaction name="mActionDecorationNorthArrow"/>
      <addaction name="mActionDecorationCopyright"/>
+     <addaction name="mActionDecorationLayoutExtent"/>
     </widget>
     <widget class="QMenu" name="mMenuPreviewMode">
      <property name="title">
@@ -2611,6 +2612,15 @@ Acts on currently active editable layer</string>
    </property>
    <property name="text">
     <string>Install plugin from ZIP...</string>
+   </property>
+  </action>
+  <action name="mActionDecorationLayoutExtent">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionAddMap.svg</normaloff>:/images/themes/default/mActionAddMap.svg</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Layout Extents...</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsdecorationlayoutextentdialog.ui
+++ b/src/ui/qgsdecorationlayoutextentdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>293</width>
-    <height>124</height>
+    <height>143</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,6 +30,20 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="1">
+       <widget class="QPushButton" name="mButtonFontStyle">
+        <property name="text">
+         <string>Font...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="mCheckBoxLabelExtents">
+        <property name="text">
+         <string>Label extents</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/src/ui/qgsdecorationlayoutextentdialog.ui
+++ b/src/ui/qgsdecorationlayoutextentdialog.ui
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDecorationLayoutExtentDialog</class>
+ <widget class="QDialog" name="QgsDecorationLayoutExtentDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>293</width>
+    <height>124</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Grid properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="grpEnable">
+     <property name="title">
+      <string>Show layout extents</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mLineSymbolLabel">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Symbol</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="mSymbolButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>grpEnable</tabstop>
+  <tabstop>mSymbolButton</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>grpEnable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mSymbolButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>146</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>108</x>
+     <y>43</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>grpEnable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mLineSymbolLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>146</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>35</x>
+     <y>43</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Adds a new (disabled by default) decoration item for showing the extents of composer maps in the main canvas. When enabled, the extents of all maps within all composers will be shown using a lightly dotted border. The border symbol is configurable for improved legibility against different map backgrounds.

I was missing this a lot last week, while working on a labeling heavy map. I needed a way to see the actual visible page extents so that I could ensure that labels were nicely placed with respect to the map edges. This seems like an elegant approach as it avoids UI clutter and is totally opt-in.

