### PR TITLE
[Server] WMS GetContext refactoring

### DIFF
--- a/python/server/qgsserverprojectutils.sip
+++ b/python/server/qgsserverprojectutils.sip
@@ -127,7 +127,7 @@ namespace QgsServerProjectUtils
       * \param project the QGIS project
       * \returns if Inspire is activated.
       */
-    bool wmsInspireActivated( const QgsProject &project );
+    bool wmsInspireActivate( const QgsProject &project );
 
     /** Returns the Inspire language.
       * \param project the QGIS project

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -104,7 +104,7 @@ bool QgsServerProjectUtils::wmsInfoFormatSia2045( const QgsProject &project )
   return false;
 }
 
-bool QgsServerProjectUtils::wmsInspireActivated( const QgsProject &project )
+bool QgsServerProjectUtils::wmsInspireActivate( const QgsProject &project )
 {
   return project.readBoolEntry( QStringLiteral( "WMSInspire" ), QStringLiteral( "/activated" ) );
 }

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -34,7 +34,20 @@ QString QgsServerProjectUtils::owsServiceAbstract( const QgsProject &project )
 
 QStringList QgsServerProjectUtils::owsServiceKeywords( const QgsProject &project )
 {
-  return project.readListEntry( QStringLiteral( "WMSKeywordList" ), QStringLiteral( "/" ) );
+  QStringList keywordList;
+  QStringList list = project.readListEntry( QStringLiteral( "WMSKeywordList" ), QStringLiteral( "/" ), QStringList() );
+  if ( !list.isEmpty() )
+  {
+    for ( int i = 0; i < list.size(); ++i )
+    {
+      QString keyword = list.at( i );
+      if ( !keyword.isEmpty() )
+      {
+        keywordList.append( keyword );
+      }
+    }
+  }
+  return keywordList;
 }
 
 QString QgsServerProjectUtils::owsServiceOnlineResource( const QgsProject &project )
@@ -141,7 +154,19 @@ QStringList QgsServerProjectUtils::wmsRestrictedComposers( const QgsProject &pro
 
 QStringList QgsServerProjectUtils::wmsOutputCrsList( const QgsProject &project )
 {
-  QStringList crsList = project.readListEntry( QStringLiteral( "WMSCrsList" ), QStringLiteral( "/" ), QStringList() );
+  QStringList crsList;
+  QStringList wmsCrsList = project.readListEntry( QStringLiteral( "WMSCrsList" ), QStringLiteral( "/" ), QStringList() );
+  if ( !wmsCrsList.isEmpty() )
+  {
+    for ( int i = 0; i < wmsCrsList.size(); ++i )
+    {
+      QString crs = wmsCrsList.at( i );
+      if ( !crs.isEmpty() )
+      {
+        crsList.append( crs );
+      }
+    }
+  }
   if ( crsList.isEmpty() )
   {
     QStringList valueList = project.readListEntry( QStringLiteral( "WMSEpsgList" ), QStringLiteral( "/" ), QStringList() );

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -129,7 +129,7 @@ namespace QgsServerProjectUtils
     * \param project the QGIS project
     * \returns if Inspire is activated.
     */
-  SERVER_EXPORT bool wmsInspireActivated( const QgsProject &project );
+  SERVER_EXPORT bool wmsInspireActivate( const QgsProject &project );
 
   /** Returns the Inspire language.
     * \param project the QGIS project

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -34,10 +34,10 @@
 #include "qgslayertreelayer.h"
 #include "qgslayertreemodel.h"
 #include "qgslayertree.h"
+#include "qgsmaplayerstylemanager.h"
 
 #include "qgscsexception.h"
 #include "qgsexpressionnodeimpl.h"
-#include "qgsmaplayerstylemanager.h"
 
 
 namespace QgsWms
@@ -180,7 +180,7 @@ namespace QgsWms
       schemaLocation += QLatin1String( " http://www.opengis.net/sld" );
       schemaLocation += QLatin1String( " http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd" );
       schemaLocation += QLatin1String( " http://www.qgis.org/wms" );
-      if ( QgsServerProjectUtils::wmsInspireActivated( *project ) )
+      if ( QgsServerProjectUtils::wmsInspireActivate( *project ) )
       {
         wmsCapabilitiesElement.setAttribute( QStringLiteral( "xmlns:inspire_common" ), QStringLiteral( "http://inspire.ec.europa.eu/schemas/common/1.0" ) );
         wmsCapabilitiesElement.setAttribute( QStringLiteral( "xmlns:inspire_vs" ), QStringLiteral( "http://inspire.ec.europa.eu/schemas/inspire_vs/1.0" ) );
@@ -533,7 +533,7 @@ namespace QgsWms
       elem.setAttribute( QStringLiteral( "RemoteWCS" ), QStringLiteral( "0" ) );
       capabilityElem.appendChild( elem );
 
-      if ( QgsServerProjectUtils::wmsInspireActivated( *project ) )
+      if ( QgsServerProjectUtils::wmsInspireActivate( *project ) )
       {
         capabilityElem.appendChild( getInspireCapabilitiesElement( doc, project ) );
       }
@@ -546,7 +546,7 @@ namespace QgsWms
   {
     QDomElement inspireCapabilitiesElem;
 
-    if ( !QgsServerProjectUtils::wmsInspireActivated( *project ) )
+    if ( !QgsServerProjectUtils::wmsInspireActivate( *project ) )
       return inspireCapabilitiesElem;
 
     inspireCapabilitiesElem = doc.createElement( QStringLiteral( "inspire_vs:ExtendedCapabilities" ) );
@@ -993,7 +993,7 @@ namespace QgsWms
           // add details about supported styles of the layer
           appendLayerStyles( doc, layerElem, l, project, version, request );
 
-          //min/max scale denominatormScaleBasedVisibility
+          //min/max scale denominatorScaleBasedVisibility
           if ( l->hasScaleBasedVisibility() )
           {
             if ( version == QLatin1String( "1.1.1" ) )

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -20,9 +20,36 @@
  ***************************************************************************/
 #include "qgswmsutils.h"
 #include "qgswmsgetcontext.h"
+#include "qgsserverprojectutils.h"
+
+#include "qgslayertreenode.h"
+#include "qgslayertreegroup.h"
+#include "qgslayertreelayer.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertree.h"
+#include "qgsmaplayerstylemanager.h"
+
+#include "qgscsexception.h"
 
 namespace QgsWms
 {
+  namespace
+  {
+    void appendOwsLayerStyles( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer );
+
+    void appendOwsLayersFromTreeGroup( QDomDocument &doc,
+                                       QDomElement &parentLayer,
+                                       QgsServerInterface *serverIface,
+                                       const QgsProject *project,
+                                       const QgsServerRequest &request,
+                                       const QgsLayerTreeGroup *layerTreeGroup,
+                                       QgsRectangle &combinedBBox,
+                                       const QString &strGroup );
+
+    void appendOwsGeneralAndResourceList( QDomDocument &doc, QDomElement &parentElement,
+                                          QgsServerInterface *serverIface, const QgsProject *project,
+                                          const QgsServerRequest &request );
+  }
 
   void writeGetContext( QgsServerInterface *serverIface, const QgsProject *project,
                         const QString &version, const QgsServerRequest &request,
@@ -40,7 +67,7 @@ namespace QgsWms
   {
     Q_UNUSED( version );
 
-    QgsWmsConfigParser  *configParser = getConfigParser( serverIface );
+    //QgsWmsConfigParser  *configParser = getConfigParser( serverIface );
 
     QDomDocument doc;
     QDomProcessingInstruction xmlDeclaration = doc.createProcessingInstruction( QStringLiteral( "xml" ),
@@ -64,10 +91,373 @@ namespace QgsWms
     owsContextElem.setAttribute( QStringLiteral( "version" ), QStringLiteral( "0.3.1" ) );
     doc.appendChild( owsContextElem );
 
-    QString hrefString = serviceUrl( request, project ).toString( QUrl::FullyDecoded );
-    configParser->owsGeneralAndResourceList( owsContextElem, doc, hrefString );
+    appendOwsGeneralAndResourceList( doc, owsContextElem, serverIface, project, request );
 
     return doc;
+  }
+  namespace
+  {
+    void appendOwsGeneralAndResourceList( QDomDocument &doc, QDomElement &parentElement,
+                                          QgsServerInterface *serverIface, const QgsProject *project,
+                                          const QgsServerRequest &request )
+    {
+      parentElement.setAttribute( QStringLiteral( "id" ), "ows-context-" + project->fileInfo().baseName() );
+
+      // OWSContext General element
+      QDomElement generalElem = doc.createElement( QStringLiteral( "General" ) );
+
+      // OWSContext Window element
+      QDomElement windowElem = doc.createElement( QStringLiteral( "Window" ) );
+      windowElem.setAttribute( QStringLiteral( "height" ), QStringLiteral( "600" ) );
+      windowElem.setAttribute( QStringLiteral( "width" ), QStringLiteral( "800" ) );
+      generalElem.appendChild( windowElem );
+
+      //OWS title
+      //why not use project title ?
+      QString title = QgsServerProjectUtils::owsServiceTitle( *project );
+      if ( !title.isEmpty() )
+      {
+        QDomElement titleElem = doc.createElement( QStringLiteral( "ows:Title" ) );
+        QDomText titleText = doc.createTextNode( title );
+        titleElem.appendChild( titleText );
+        generalElem.appendChild( titleElem );
+      }
+
+      //OWS abstract
+      QString abstract = QgsServerProjectUtils::owsServiceAbstract( *project );
+      if ( !abstract.isEmpty() )
+      {
+        QDomElement abstractElem = doc.createElement( QStringLiteral( "ows:Abstract" ) );
+        QDomText abstractText = doc.createCDATASection( abstract );
+        abstractElem.appendChild( abstractText );
+        generalElem.appendChild( abstractElem );
+      }
+
+      //OWS Keywords
+      QStringList keywords = QgsServerProjectUtils::owsServiceKeywords( *project );
+      if ( !keywords.isEmpty() )
+      {
+        bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
+
+        QDomElement keywordsElem = doc.createElement( QStringLiteral( "ows:Keywords" ) );
+
+        for ( int i = 0; i < keywords.size(); ++i )
+        {
+          QString keyword = keywords.at( i );
+          if ( !keyword.isEmpty() )
+          {
+            QDomElement keywordElem = doc.createElement( QStringLiteral( "ows:Keyword" ) );
+            QDomText keywordText = doc.createTextNode( keyword );
+            keywordElem.appendChild( keywordText );
+            if ( sia2045 )
+            {
+              keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
+            }
+            keywordsElem.appendChild( keywordElem );
+          }
+        }
+        generalElem.appendChild( keywordsElem );
+      }
+
+      // OWSContext General element is complete
+      parentElement.appendChild( generalElem );
+
+      // OWSContext ResourceList element
+      QDomElement resourceListElem = doc.createElement( QStringLiteral( "ResourceList" ) );
+      const QgsLayerTree *projectLayerTreeRoot = project->layerTreeRoot();
+      QgsRectangle combinedBBox;
+      appendOwsLayersFromTreeGroup( doc, resourceListElem, serverIface, project, request, projectLayerTreeRoot, combinedBBox, QString() );
+      parentElement.appendChild( resourceListElem );
+
+      // OWSContext BoundingBox
+      QgsCoordinateReferenceSystem projectCrs = project->crs();
+      QgsRectangle mapRect = QgsServerProjectUtils::wmsExtent( *project );
+      if ( mapRect.isEmpty() )
+      {
+        mapRect = combinedBBox;
+      }
+      QDomElement bboxElem = doc.createElement( QStringLiteral( "ows:BoundingBox" ) );
+      bboxElem.setAttribute( QStringLiteral( "crs" ), projectCrs.authid() );
+      if ( projectCrs.hasAxisInverted() )
+      {
+        mapRect.invert();
+      }
+      QDomElement lowerCornerElem = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
+      QDomText lowerCornerText = doc.createTextNode( QString::number( mapRect.xMinimum() ) + " " +  QString::number( mapRect.yMinimum() ) );
+      lowerCornerElem.appendChild( lowerCornerText );
+      bboxElem.appendChild( lowerCornerElem );
+      QDomElement upperCornerElem = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
+      QDomText upperCornerText = doc.createTextNode( QString::number( mapRect.xMaximum() ) + " " +  QString::number( mapRect.yMaximum() ) );
+      upperCornerElem.appendChild( upperCornerText );
+      bboxElem.appendChild( upperCornerElem );
+      generalElem.appendChild( bboxElem );
+    }
+
+    void appendOwsLayersFromTreeGroup( QDomDocument &doc,
+                                       QDomElement &parentLayer,
+                                       QgsServerInterface *serverIface,
+                                       const QgsProject *project,
+                                       const QgsServerRequest &request,
+                                       const QgsLayerTreeGroup *layerTreeGroup,
+                                       QgsRectangle &combinedBBox,
+                                       const QString &strGroup )
+    {
+      QStringList restrictedLayers = QgsServerProjectUtils::wmsRestrictedLayers( *project );
+
+      QList< QgsLayerTreeNode * > layerTreeGroupChildren = layerTreeGroup->children();
+      for ( int i = 0; i < layerTreeGroupChildren.size(); ++i )
+      {
+        QgsLayerTreeNode *treeNode = layerTreeGroupChildren.at( i );
+
+        if ( treeNode->nodeType() == QgsLayerTreeNode::NodeGroup )
+        {
+          QgsLayerTreeGroup *treeGroupChild = static_cast<QgsLayerTreeGroup *>( treeNode );
+
+          QString name = treeGroupChild->name();
+          if ( restrictedLayers.contains( name ) ) //unpublished group
+          {
+            continue;
+          }
+
+          QString group;
+          if ( strGroup.isEmpty() )
+          {
+            group = name;
+          }
+          else
+          {
+            group = strGroup + "/" + name;
+          }
+
+          appendOwsLayersFromTreeGroup( doc, parentLayer, serverIface, project, request, treeGroupChild, combinedBBox, group );
+        }
+        else
+        {
+          QgsLayerTreeLayer *treeLayer = static_cast<QgsLayerTreeLayer *>( treeNode );
+          QgsMapLayer *l = treeLayer->layer();
+          if ( restrictedLayers.contains( l->name() ) ) //unpublished layer
+          {
+            continue;
+          }
+
+          QgsAccessControl *accessControl = serverIface->accessControls();
+          if ( accessControl && !accessControl->layerReadPermission( l ) )
+          {
+            continue;
+          }
+
+          QDomElement layerElem = doc.createElement( QStringLiteral( "Layer" ) );
+
+          // queryable layer
+          if ( project->nonIdentifiableLayers().contains( l->id() ) )
+          {
+            layerElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "false" ) );
+          }
+          else
+          {
+            layerElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "true" ) );
+          }
+
+          // visibility
+          if ( treeLayer->itemVisibilityChecked() )
+          {
+            layerElem.setAttribute( QStringLiteral( "hidden" ), QStringLiteral( "true" ) );
+          }
+          else
+          {
+            layerElem.setAttribute( QStringLiteral( "hidden" ), QStringLiteral( "false" ) );
+          }
+
+          // layer group
+          if ( !strGroup.isEmpty() )
+          {
+            layerElem.setAttribute( QStringLiteral( "group" ), strGroup );
+          }
+
+          // Because Layer transparency is used for the rendering
+          // OWSContext Layer opacity is set to 1
+          layerElem.setAttribute( QStringLiteral( "opacity" ), 1 );
+
+          QString wmsName =  l->name();
+          if ( QgsServerProjectUtils::wmsUseLayerIds( *project ) )
+          {
+            wmsName = l->id();
+          }
+          else if ( !l->shortName().isEmpty() )
+          {
+            wmsName = l->shortName();
+          }
+          // layer wms name
+          layerElem.setAttribute( QStringLiteral( "name" ), wmsName );
+          // define an id based on layer wms name
+          layerElem.setAttribute( QStringLiteral( "id" ), wmsName.replace( QRegExp( "[\\W]" ), QStringLiteral( "_" ) ) );
+
+          // layer title
+          QDomElement titleElem = doc.createElement( QStringLiteral( "ows:Title" ) );
+          QString title = l->title();
+          if ( title.isEmpty() )
+          {
+            title = l->name();
+          }
+          QDomText titleText = doc.createTextNode( title );
+          titleElem.appendChild( titleText );
+          layerElem.appendChild( titleElem );
+
+          // WMS GetMap output format
+          QDomElement formatElem = doc.createElement( QStringLiteral( "ows:OutputFormat" ) );
+          QDomText formatText = doc.createTextNode( QStringLiteral( "image/png" ) );
+          formatElem.appendChild( formatText );
+          layerElem.appendChild( formatElem );
+
+          // Get WMS service URL for Server Element
+          QUrl href = serviceUrl( request, project );
+
+          //href needs to be a prefix
+          QString hrefString = href.toString( QUrl::FullyDecoded );
+          hrefString.append( href.hasQuery() ? "&" : "?" );
+
+          // COntext Server Element with WMS service URL
+          QDomElement serverElem = doc.createElement( QStringLiteral( "Server" ) );
+          serverElem.setAttribute( QStringLiteral( "service" ), QStringLiteral( "urn:ogc:serviceType:WMS" ) );
+          serverElem.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.3.0" ) );
+          serverElem.setAttribute( QStringLiteral( "default" ), QStringLiteral( "true" ) );
+          QDomElement orServerElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
+          orServerElem.setAttribute( QStringLiteral( "xlink:href" ), hrefString );
+          serverElem.appendChild( orServerElem );
+          layerElem.appendChild( serverElem );
+
+          QString abstract = l->abstract();
+          if ( !abstract.isEmpty() )
+          {
+            QDomElement abstractElem = doc.createElement( QStringLiteral( "ows:Abstract" ) );
+            QDomText abstractText = doc.createTextNode( abstract );
+            abstractElem.appendChild( abstractText );
+            layerElem.appendChild( abstractElem );
+          }
+
+          //min/max scale denominatorScaleBasedVisibility
+          if ( l->hasScaleBasedVisibility() )
+          {
+            QString minScaleString = QString::number( l->minimumScale() );
+            QString maxScaleString = QString::number( l->maximumScale() );
+            QDomElement minScaleElem = doc.createElement( QStringLiteral( "sld:MinScaleDenominator" ) );
+            QDomText minScaleText = doc.createTextNode( minScaleString );
+            minScaleElem.appendChild( minScaleText );
+            layerElem.appendChild( minScaleElem );
+            QDomElement maxScaleElem = doc.createElement( QStringLiteral( "sld:MaxScaleDenominator" ) );
+            QDomText maxScaleText = doc.createTextNode( maxScaleString );
+            maxScaleElem.appendChild( maxScaleText );
+            layerElem.appendChild( maxScaleElem );
+          }
+
+          // Style list
+          appendOwsLayerStyles( doc, layerElem, l );
+
+          //keyword list
+          if ( !l->keywordList().isEmpty() )
+          {
+            QStringList keywordStringList = l->keywordList().split( QStringLiteral( "," ) );
+            bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
+
+            QDomElement keywordsElem = doc.createElement( QStringLiteral( "ows:Keywords" ) );
+            for ( int i = 0; i < keywordStringList.size(); ++i )
+            {
+              QDomElement keywordElem = doc.createElement( QStringLiteral( "ows:Keyword" ) );
+              QDomText keywordText = doc.createTextNode( keywordStringList.at( i ).trimmed() );
+              keywordElem.appendChild( keywordText );
+              if ( sia2045 )
+              {
+                keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
+              }
+              keywordsElem.appendChild( keywordElem );
+            }
+            layerElem.appendChild( keywordsElem );
+          }
+
+          // layer data URL
+          QString dataUrl = l->dataUrl();
+          if ( !dataUrl.isEmpty() )
+          {
+            QDomElement dataUrlElem = doc.createElement( QStringLiteral( "DataURL" ) );
+            QString dataUrlFormat = l->dataUrlFormat();
+            dataUrlElem.setAttribute( QStringLiteral( "format" ), dataUrlFormat );
+            QDomElement dataORElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
+            dataORElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
+            dataORElem.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
+            dataORElem.setAttribute( QStringLiteral( "xlink:href" ), dataUrl );
+            dataUrlElem.appendChild( dataORElem );
+            layerElem.appendChild( dataUrlElem );
+          }
+
+          // layer metadata URL
+          QString metadataUrl = l->metadataUrl();
+          if ( !metadataUrl.isEmpty() )
+          {
+            QDomElement metaUrlElem = doc.createElement( QStringLiteral( "MetadataURL" ) );
+            QString metadataUrlFormat = l->metadataUrlFormat();
+            metaUrlElem.setAttribute( QStringLiteral( "format" ), metadataUrlFormat );
+            QDomElement metaUrlORElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
+            metaUrlORElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
+            metaUrlORElem.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
+            metaUrlORElem.setAttribute( QStringLiteral( "xlink:href" ), metadataUrl );
+            metaUrlElem.appendChild( metaUrlORElem );
+            layerElem.appendChild( metaUrlElem );
+          }
+
+          // update combineBBox
+          try
+          {
+            QgsCoordinateTransform t( l->crs(), project->crs() );
+            QgsRectangle BBox = t.transformBoundingBox( l->extent() );
+            if ( combinedBBox.isEmpty() )
+            {
+              combinedBBox = BBox;
+            }
+            else
+            {
+              combinedBBox.combineExtentWith( BBox );
+            }
+          }
+          catch ( const QgsCsException &cse )
+          {
+            Q_UNUSED( cse );
+          }
+
+          if ( parentLayer.hasChildNodes() )
+          {
+            parentLayer.insertBefore( layerElem, parentLayer.firstChild() );
+          }
+          else
+          {
+            parentLayer.appendChild( layerElem );
+          }
+        }// end of treeNode type
+      }// end of for
+    }
+
+    void appendOwsLayerStyles( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer )
+    {
+      Q_FOREACH ( QString styleName, currentLayer->styleManager()->styles() )
+      {
+        if ( styleName.isEmpty() )
+          styleName = EMPTY_STYLE_NAME;
+
+        QDomElement styleListElem = doc.createElement( QStringLiteral( "StyleList" ) );
+        //only one default style in project file mode
+        QDomElement styleElem = doc.createElement( QStringLiteral( "Style" ) );
+        styleElem.setAttribute( QStringLiteral( "current" ), QStringLiteral( "true" ) );
+        QDomElement styleNameElem = doc.createElement( QStringLiteral( "Name" ) );
+        QDomText styleNameText = doc.createTextNode( styleName );
+        styleNameElem.appendChild( styleNameText );
+        QDomElement styleTitleElem = doc.createElement( QStringLiteral( "Title" ) );
+        QDomText styleTitleText = doc.createTextNode( styleName );
+        styleTitleElem.appendChild( styleTitleText );
+        styleElem.appendChild( styleNameElem );
+        styleElem.appendChild( styleTitleElem );
+        styleListElem.appendChild( styleElem );
+        layerElem.appendChild( styleListElem );
+      }
+    }
   }
 
 } // samespace QgsWms

--- a/tests/src/python/test_qgsserver_accesscontrol.py
+++ b/tests/src/python/test_qgsserver_accesscontrol.py
@@ -264,6 +264,34 @@ class TestQgsServerAccessControl(unittest.TestCase):
             str(response).find("<LayerDrawingOrder>Country_Labels,dem,Hello_Filter_SubsetString,Hello_Project_SubsetString,Hello_SubsetString,Hello,db_point</LayerDrawingOrder>") != -1,
             "LayerDrawingOrder in GetProjectSettings\n%s" % response)
 
+    def test_wms_getprojectsettings(self):
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetContext"
+        }.items())])
+
+        response, headers = self._get_fullaccess(query_string)
+        self.assertTrue(
+            str(response).find("name=\"Hello\"") != -1,
+            "No Hello layer in GetContext\n%s" % response)
+        self.assertTrue(
+            str(response).find("name=\"Country\"") != -1,
+            "No Country layer in GetProjectSettings\n%s" % response)
+        self.assertTrue(
+            str(response).find("name=\"Country\"")
+            < str(response).find("name=\"Hello\""),
+            "Hello layer not after Country layer\n%s" % response)
+
+        response, headers = self._get_restricted(query_string)
+        self.assertTrue(
+            str(response).find("name=\"Hello\"") != -1,
+            "No Hello layer in GetContext\n%s" % response)
+        self.assertFalse(
+            str(response).find("name=\"Country\"") != -1,
+            "No Country layer in GetProjectSettings\n%s" % response)
+
     def test_wms_describelayer_hello(self):
         query_string = "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -65,7 +65,7 @@ class TestQgsServerWMS(QgsServerTestBase):
 
     def test_project_wms(self):
         """Test some WMS request"""
-        for request in ('GetCapabilities', 'GetProjectSettings'):
+        for request in ('GetCapabilities', 'GetProjectSettings', 'GetContext'):
             self.wms_request_compare(request)
 
         # Test getfeatureinfo response

--- a/tests/testdata/qgis_server/getcontext.txt
+++ b/tests/testdata/qgis_server/getcontext.txt
@@ -1,0 +1,31 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<?xml version="1.0" encoding="utf-8"?>
+<OWSContext xmlns:ogc="http://www.opengis.net/ogc" version="0.3.1" xmlns:context="http://www.opengis.net/context" xmlns="http://www.opengis.net/ows-context" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ows-context="http://www.opengis.net/ows-context" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" id="ows-context-test_project" xmlns:ows="http://www.opengis.net/ows" xmlns:ns9="http://www.w3.org/2005/Atom" xmlns:ins="http://www.inspire.org">
+ <General>
+  <Window width="800" height="600"/>
+  <ows:Title>QGIS TestProject</ows:Title>
+  <ows:Abstract>Some UTF8 text èòù</ows:Abstract>
+  <ows:BoundingBox crs="EPSG:4326">
+   <ows:LowerCorner>44.9012 8.20315</ows:LowerCorner>
+   <ows:UpperCorner>44.9016 8.20416</ows:UpperCorner>
+  </ows:BoundingBox>
+ </General>
+ <ResourceList>
+  <Layer opacity="1" queryable="true" hidden="false" id="testlayer_èé" name="testlayer èé">
+   <ows:Title>A test vector layer</ows:Title>
+   <ows:OutputFormat>image/png</ows:OutputFormat>
+   <Server version="1.3.0" default="true" service="urn:ogc:serviceType:WMS">
+    <OnlineResource xlink:href="https://www.qgis.org/?*****&amp;"/>
+   </Server>
+   <ows:Abstract>A test vector layer with unicode òà</ows:Abstract>
+   <StyleList>
+    <Style current="true">
+     <Name>default</Name>
+     <Title>default</Title>
+    </Style>
+   </StyleList>
+  </Layer>
+ </ResourceList>
+</OWSContext>

--- a/tests/testdata/qgis_server/wcs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wcs_getcapabilities.txt
@@ -6,9 +6,6 @@ Content-Type: text/xml; charset=utf-8
   <name>WCS</name>
   <label>QGIS Server test</label>
   <description><![CDATA[Simple test app.]]></description>
-  <keywords>
-   <keyword></keyword>
-  </keywords>
   <responsibleParty>
    <individualName>Stéphane Brunner</individualName>
    <organisationName>QGIS</organisationName>


### PR DESCRIPTION
Removing QgsWMSProjectParser from GetContext
https://github.com/qgis/qgis3.0_api/issues/57

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
