### PR TITLE
[FEATURE] create_ramp() expression function

### DIFF
--- a/python/core/qgscolorramp.sip
+++ b/python/core/qgscolorramp.sip
@@ -259,6 +259,7 @@ Creates a new QgsColorRamp from a map of properties
 };
 
 
+
 class QgsLimitedRandomColorRamp : QgsColorRamp
 {
 %Docstring

--- a/resources/function_help/json/create_ramp
+++ b/resources/function_help/json/create_ramp
@@ -1,0 +1,8 @@
+{
+  "name": "create_ramp",
+  "type": "function",
+  "description": "Returns a gradient ramp from a map of color strings and steps.",
+  "arguments": [ {"arg":"map","description":"a map of color strings and steps"},
+                 {"arg":"discrete","optional":true,"description":"declare whether the color ramp is discrete"}],
+  "examples": [ { "expression":"ramp_color(create_array(map(0,'0,0,0',1,'255,0,0')),1)", "returns":"'255,0,0,255'"} ]
+}

--- a/resources/function_help/json/ramp_color
+++ b/resources/function_help/json/ramp_color
@@ -2,8 +2,18 @@
   "name": "ramp_color",
   "type": "function",
   "description": "Returns a string representing a color from a color ramp.",
-  "arguments": [ {"arg":"ramp_name","description":"the name of the color ramp as a string, for example 'Spectral'"},
+  "variants": [
+  { "variant": "Saved ramp variant",
+    "variant_description": "Returns a string representing a color from a saved ramp",
+    "arguments": [ {"arg":"ramp_name","description":"the name of the color ramp as a string, for example 'Spectral'"},
                  {"arg":"value","description":"the position on the ramp to select the color from as a real number between 0 and 1"}],
-  "examples": [ { "expression":"ramp_color('Spectral',0.3)", "returns":"'253,190,115,255'"} ],
-  "notes": "The color ramps available vary between QGIS installations. This function may not give the expected results if you move your QGIS project between installations."
+    "examples": [ { "expression":"ramp_color('Spectral',0.3)", "returns":"'253,190,115,255'"} ],
+    "notes": "The color ramps available vary between QGIS installations. This function may not give the expected results if you move your QGIS project between installations."
+  },
+  { "variant": "Expression-created ramp variant",
+    "variant_description": "Returns a string representing a color from an expression-created ramp",
+    "arguments": [ {"arg":"ramp","description":"the color ramp"},
+                 {"arg":"value","description":"the position on the ramp to select the color from as a real number between 0 and 1"}],
+    "examples": [ { "expression":"ramp_color(create_array(map(0,'0,0,0',1,'255,0,0')),1)", "returns":"'255,0,0,255'"} ]
+  }]
 }

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -18,6 +18,7 @@
 #include "qgsexpressionprivate.h"
 #include "qgsexpressionnodeimpl.h"
 #include "qgsfeaturerequest.h"
+#include "qgscolorramp.h"
 #include "qgslogger.h"
 #include "qgsexpressioncontext.h"
 #include "qgsgeometry.h"
@@ -762,6 +763,10 @@ QString QgsExpression::formatPreviewString( const QVariant &value )
     //result is a feature
     QgsInterval interval = value.value<QgsInterval>();
     return tr( "<i>&lt;interval: %1 days&gt;</i>" ).arg( interval.days() );
+  }
+  else if ( value.canConvert< QgsGradientColorRamp >() )
+  {
+    return tr( "<i>&lt;gradient ramp&gt;</i>" );
   }
   else if ( value.type() == QVariant::Date )
   {

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -287,7 +287,7 @@ class QgsExpressionUtils
       }
       // If we get here then we can't convert so we just error and return invalid.
       if ( report_error )
-        parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to Interval" ).arg( value.toString() ) );
+        parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to interval" ).arg( value.toString() ) );
 
       return QgsInterval();
     }
@@ -299,7 +299,7 @@ class QgsExpressionUtils
 
       // If we get here then we can't convert so we just error and return invalid.
       if ( report_error )
-        parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to QgsGradientColorRamp" ).arg( value.toString() ) );
+        parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to gradient ramp" ).arg( value.toString() ) );
 
       return QgsGradientColorRamp();
     }
@@ -309,7 +309,7 @@ class QgsExpressionUtils
       if ( value.canConvert<QgsGeometry>() )
         return value.value<QgsGeometry>();
 
-      parent->setEvalErrorString( QStringLiteral( "Cannot convert to QgsGeometry" ) );
+      parent->setEvalErrorString( QStringLiteral( "Cannot convert to geometry" ) );
       return QgsGeometry();
     }
 
@@ -318,7 +318,7 @@ class QgsExpressionUtils
       if ( value.canConvert<QgsFeature>() )
         return value.value<QgsFeature>();
 
-      parent->setEvalErrorString( QStringLiteral( "Cannot convert to QgsFeature" ) );
+      parent->setEvalErrorString( QStringLiteral( "Cannot convert to feature" ) );
       return 0;
     }
 
@@ -327,7 +327,7 @@ class QgsExpressionUtils
       if ( value.canConvert<QgsExpressionNode *>() )
         return value.value<QgsExpressionNode *>();
 
-      parent->setEvalErrorString( QStringLiteral( "Cannot convert to Node" ) );
+      parent->setEvalErrorString( QStringLiteral( "Cannot convert to node" ) );
       return nullptr;
     }
 

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -19,6 +19,7 @@
 
 #include "qgsfeature.h"
 #include "qgsexpression.h"
+#include "qgscolorramp.h"
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
 #include "qgsrelationmanager.h"
@@ -289,6 +290,18 @@ class QgsExpressionUtils
         parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to Interval" ).arg( value.toString() ) );
 
       return QgsInterval();
+    }
+
+    static QgsGradientColorRamp getRamp( const QVariant &value, QgsExpression *parent, bool report_error = false )
+    {
+      if ( value.canConvert<QgsGradientColorRamp>() )
+        return value.value<QgsGradientColorRamp>();
+
+      // If we get here then we can't convert so we just error and return invalid.
+      if ( report_error )
+        parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to QgsGradientColorRamp" ).arg( value.toString() ) );
+
+      return QgsGradientColorRamp();
     }
 
     static QgsGeometry getGeometry( const QVariant &value, QgsExpression *parent )

--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -240,6 +240,8 @@ class CORE_EXPORT QgsGradientColorRamp : public QgsColorRamp
     QgsStringMap mInfo;
 };
 
+Q_DECLARE_METATYPE( QgsGradientColorRamp )
+
 #define DEFAULT_RANDOM_COUNT   10
 #define DEFAULT_RANDOM_HUE_MIN 0
 #define DEFAULT_RANDOM_HUE_MAX 359

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1010,6 +1010,12 @@ class TestQgsExpression: public QObject
 
       // Color functions
       QTest::newRow( "ramp color" ) << "ramp_color('Spectral',0.3)" << false << QVariant( "254,190,116,255" );
+      QTest::newRow( "create ramp color, wrong parameter" ) << "create_ramp(1)" << true << QVariant();
+      QTest::newRow( "create ramp color, no color" ) << "create_ramp(map())" << true << QVariant();
+      QTest::newRow( "create ramp color, one color" ) << "ramp_color(create_ramp(map(0,'0,0,0')),0.5)" << false << QVariant( "0,0,0,255" );
+      QTest::newRow( "create ramp color, two colors" ) << "ramp_color(create_ramp(map(0,'0,0,0',1,'255,0,0')),0.33)" << false << QVariant( "84,0,0,255" );
+      QTest::newRow( "create ramp color, four colors" ) << "ramp_color(create_ramp(map(0,'0,0,0',0.33,'0,255,0',0.66,'0,0,255',1,'255,0,0')),0.5)" << false << QVariant( "0,124,131,255" );
+      QTest::newRow( "create ramp color, discrete" ) << "ramp_color(create_ramp(map(0,'0,0,0',0.33,'0,255,0',0.66,'0,0,255',1,'255,0,0'),true),0.6)" << false << QVariant( "0,255,0,255" );
       QTest::newRow( "color rgb" ) << "color_rgb(255,127,0)" << false << QVariant( "255,127,0" );
       QTest::newRow( "color rgba" ) << "color_rgba(255,127,0,200)" << false << QVariant( "255,127,0,200" );
       QTest::newRow( "color hsl" ) << "color_hsl(100,50,70)" << false << QVariant( "166,217,140" );


### PR DESCRIPTION
## Description
This PR adds a useful expression function to create color ramps from scratch. It can be quite useful when a project in shared among many users as it does not rely on the presence of a saved ramp (let alone having that ramp having the same colors).

It's also simply useful to be able to quickly create ramps within expressions :smile:

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
