### PR TITLE
[Server] WMS DescribeLayer refactoring

### DIFF
--- a/python/server/qgsserverprojectutils.sip
+++ b/python/server/qgsserverprojectutils.sip
@@ -243,5 +243,5 @@ namespace QgsServerProjectUtils
       * @param project the QGIS project
       * @return the Layer ids list.
       */
-    QStringList wcsLayers( const QgsProject &project );
+    QStringList wcsLayerIds( const QgsProject &project );
 };

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -263,7 +263,7 @@ QString QgsServerProjectUtils::wcsServiceUrl( const QgsProject &project )
   return project.readEntry( QStringLiteral( "WCSUrl" ), QStringLiteral( "/" ), "" );
 }
 
-QStringList QgsServerProjectUtils::wcsLayers( const QgsProject &project )
+QStringList QgsServerProjectUtils::wcsLayerIds( const QgsProject &project )
 {
   return project.readListEntry( QStringLiteral( "WCSLayers" ), QStringLiteral( "/" ) );
 }

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -245,7 +245,7 @@ namespace QgsServerProjectUtils
     * \param project the QGIS project
     * \returns the Layer ids list.
     */
-  SERVER_EXPORT QStringList wcsLayers( const QgsProject &project );
+  SERVER_EXPORT QStringList wcsLayerIds( const QgsProject &project );
 };
 
 #endif

--- a/src/server/services/wcs/qgswcsdescribecoverage.cpp
+++ b/src/server/services/wcs/qgswcsdescribecoverage.cpp
@@ -94,7 +94,7 @@ namespace QgsWcs
       }
     }
 
-    QStringList wcsLayersId = QgsServerProjectUtils::wcsLayers( *project );
+    QStringList wcsLayersId = QgsServerProjectUtils::wcsLayerIds( *project );
     for ( int i = 0; i < wcsLayersId.size(); ++i )
     {
       QgsMapLayer *layer = project->mapLayer( wcsLayersId.at( i ) );

--- a/src/server/services/wcs/qgswcsgetcapabilities.cpp
+++ b/src/server/services/wcs/qgswcsgetcapabilities.cpp
@@ -260,7 +260,7 @@ namespace QgsWcs
      */
     QDomElement contentMetadataElement = doc.createElement( QStringLiteral( "ContentMetadata" )/*wcs:ContentMetadata*/ );
 
-    QStringList wcsLayersId = QgsServerProjectUtils::wcsLayers( *project );
+    QStringList wcsLayersId = QgsServerProjectUtils::wcsLayerIds( *project );
     for ( int i = 0; i < wcsLayersId.size(); ++i )
     {
       QgsMapLayer *layer = project->mapLayer( wcsLayersId.at( i ) );

--- a/src/server/services/wcs/qgswcsgetcoverage.cpp
+++ b/src/server/services/wcs/qgswcsgetcoverage.cpp
@@ -73,7 +73,7 @@ namespace QgsWcs
     }
 
     //get the raster layer
-    QStringList wcsLayersId = QgsServerProjectUtils::wcsLayers( *project );
+    QStringList wcsLayersId = QgsServerProjectUtils::wcsLayerIds( *project );
 
     QgsRasterLayer *rLayer = nullptr;
     for ( int i = 0; i < wcsLayersId.size(); ++i )

--- a/src/server/services/wms/qgswmsdescribelayer.cpp
+++ b/src/server/services/wms/qgswmsdescribelayer.cpp
@@ -40,7 +40,6 @@ namespace QgsWms
     Q_UNUSED( version );
 
     QgsServerRequest::Parameters parameters = request.parameters();
-    QgsWmsConfigParser *configParser = getConfigParser( serverIface );
 
     if ( !parameters.contains( QStringLiteral( "SLD_VERSION" ) ) )
     {
@@ -64,6 +63,24 @@ namespace QgsWms
     {
       throw QgsServiceException( QStringLiteral( "InvalidParameterValue" ), QStringLiteral( "Layers is empty" ), 400 );
     }
+    QDomDocument myDocument = QDomDocument();
+
+    QDomNode header = myDocument.createProcessingInstruction( QStringLiteral( "xml" ), QStringLiteral( "version=\"1.0\" encoding=\"UTF-8\"" ) );
+    myDocument.appendChild( header );
+
+    // Create the root element
+    QDomElement root = myDocument.createElementNS( QStringLiteral( "http://www.opengis.net/sld" ), QStringLiteral( "DescribeLayerResponse" ) );
+    root.setAttribute( QStringLiteral( "xsi:schemaLocation" ), QStringLiteral( "http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/DescribeLayer.xsd" ) );
+    root.setAttribute( QStringLiteral( "xmlns:ows" ), QStringLiteral( "http://www.opengis.net/ows" ) );
+    root.setAttribute( QStringLiteral( "xmlns:se" ), QStringLiteral( "http://www.opengis.net/se" ) );
+    root.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
+    root.setAttribute( QStringLiteral( "xmlns:xsi" ), QStringLiteral( "http://www.w3.org/2001/XMLSchema-instance" ) );
+    myDocument.appendChild( root );
+
+    // store the Version element
+    QDomElement versionNode = myDocument.createElement( QStringLiteral( "Version" ) );
+    versionNode.appendChild( myDocument.createTextNode( QStringLiteral( "1.1.0" ) ) );
+    root.appendChild( versionNode );
 
     // get the wms service url defined in project or keep the one from the
     // request url
@@ -85,7 +102,86 @@ namespace QgsWms
       wcsHrefString = wmsHrefString;
     }
 
-    return configParser->describeLayer( layersList, wfsHrefString, wcsHrefString );
+    // access control
+    QgsAccessControl *accessControl = serverIface->accessControls();
+    // Use layer ids
+    bool useLayerIds = QgsServerProjectUtils::wmsUseLayerIds( *project );
+    // WMS restricted layers
+    QStringList restrictedLayers = QgsServerProjectUtils::wmsRestrictedLayers( *project );
+    // WFS layers
+    QStringList wfsLayerIds = QgsServerProjectUtils::wfsLayerIds( *project );
+    // WCS layers
+    QStringList wcsLayerIds = QgsServerProjectUtils::wcsLayerIds( *project );
+
+    Q_FOREACH ( QgsMapLayer *layer, project->mapLayers() )
+    {
+      QString name = layer->name();
+      if ( useLayerIds )
+        name = layer->id();
+      else if ( !layer->shortName().isEmpty() )
+        name = layer->shortName();
+
+      if ( !layersList.contains( name ) )
+      {
+        continue;
+      }
+
+      //unpublished layer
+      if ( restrictedLayers.contains( layer->name() ) )
+      {
+        throw QgsSecurityException( QStringLiteral( "You are not allowed to access to this layer" ) );
+      }
+
+      if ( accessControl && !accessControl->layerReadPermission( layer ) )
+      {
+        throw QgsSecurityException( QStringLiteral( "You are not allowed to access to this layer" ) );
+      }
+
+      // Create the NamedLayer element
+      QDomElement layerNode = myDocument.createElement( QStringLiteral( "LayerDescription" ) );
+      root.appendChild( layerNode );
+
+      // store the owsType element
+      QDomElement typeNode = myDocument.createElement( QStringLiteral( "owsType" ) );
+      // store the se:OnlineResource element
+      QDomElement oResNode = myDocument.createElement( QStringLiteral( "se:OnlineResource" ) );
+      oResNode.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
+      // store the TypeName element
+      QDomElement nameNode = myDocument.createElement( QStringLiteral( "TypeName" ) );
+      if ( layer->type() == QgsMapLayer::VectorLayer )
+      {
+        typeNode.appendChild( myDocument.createTextNode( QStringLiteral( "wfs" ) ) );
+
+        if ( wfsLayerIds.indexOf( layer->id() ) != -1 )
+        {
+          oResNode.setAttribute( QStringLiteral( "xlink:href" ), wfsHrefString );
+        }
+
+        // store the se:FeatureTypeName element
+        QDomElement typeNameNode = myDocument.createElement( QStringLiteral( "se:FeatureTypeName" ) );
+        typeNameNode.appendChild( myDocument.createTextNode( name ) );
+        nameNode.appendChild( typeNameNode );
+      }
+      else if ( layer->type() == QgsMapLayer::RasterLayer )
+      {
+        typeNode.appendChild( myDocument.createTextNode( QStringLiteral( "wcs" ) ) );
+
+        if ( wcsLayerIds.indexOf( layer->id() ) != -1 )
+        {
+          oResNode.setAttribute( QStringLiteral( "xlink:href" ), wcsHrefString );
+        }
+
+        // store the se:CoverageTypeName element
+        QDomElement typeNameNode = myDocument.createElement( QStringLiteral( "se:CoverageTypeName" ) );
+        typeNameNode.appendChild( myDocument.createTextNode( name ) );
+        nameNode.appendChild( typeNameNode );
+      }
+      layerNode.appendChild( typeNode );
+      layerNode.appendChild( oResNode );
+      layerNode.appendChild( nameNode );
+    }
+
+    return myDocument;
   }
 
 } // samespace QgsWms

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -125,6 +125,12 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'FEATURE_COUNT=10&FILTER=testlayer%20%C3%A8%C3%A9' + urllib.parse.quote(':"NAME" = \'two\' OR "utf8nameè" = \'three èé↓\''),
                                  'wms_getfeatureinfo_filter_or_utf8')
 
+        # Test DescribeLayer
+        self.wms_request_compare('DescribeLayer',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'SLD_VERSION=1.1.0',
+                                 'describelayer')
+
     def wms_inspire_request_compare(self, request):
         """WMS INSPIRE tests"""
         project = self.testdata_path + "test_project_inspire.qgs"

--- a/tests/testdata/qgis_server/describelayer.txt
+++ b/tests/testdata/qgis_server/describelayer.txt
@@ -1,0 +1,14 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<?xml version="1.0" encoding="utf-8"?>
+<DescribeLayerResponse xmlns="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/DescribeLayer.xsd" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <Version>1.1.0</Version>
+ <LayerDescription>
+  <owsType>wfs</owsType>
+  <se:OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****"/>
+  <TypeName>
+   <se:FeatureTypeName>testlayer èé</se:FeatureTypeName>
+  </TypeName>
+ </LayerDescription>
+</DescribeLayerResponse>


### PR DESCRIPTION
Removing QgsWMSProjectParser from DescribeLayer
https://github.com/qgis/qgis3.0_api/issues/57

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
