### PR TITLE
Unify UX behavior, pt 2: rotation

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1732,6 +1732,7 @@ members were removed. Use the QgsProperty framework through dataDefinedPropertie
 and setDataDefinedProperties() instead.
 - readXml() and writeXml() now expect a reference to QgsReadWriteContext.
 - fromLayer() has been reoved. Labeling is read/written in QgsAbstractVectorLayerLabeling and its subclasses.
+- angleOffset is now in degrees clockwise. QGIS 2.x used degrees counterclockwise.
 
 
 QgsPanelWidgetStack        {#qgis_api_break_3_0_QgsPanelWidgetStack}

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1024,6 +1024,7 @@ QgsDiagramSettings        {#qgis_api_break_3_0_QgsDiagramSettings}
 - The SizeType enum was removed. Use QgsUnitTypes.RenderUnit instead.
 - readXml() and writeXml() do not take QgsVectorLayer as an argument anymore.
 - transparency was removed. Use opacity instead.
+- angleOffset was removed. Use rotationOffset instead.
 
 
 QgsDial        {#qgis_api_break_3_0_QgsDial}

--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -373,20 +373,21 @@ In case of annotations, the bounding rectangle can be larger than the map item r
  reimplement setFrameStrokeWidth, so that updateBoundingRect() is called after setting the frame width */
 %End
 
-    void setMapRotation( double r );
+    void setMapRotation( double rotation );
 %Docstring
- Sets rotation for the map - this does not affect the composer item shape, only the
- way the map is drawn within the item
+ Sets the ``rotation`` for the map - this does not affect the composer item shape, only the
+ way the map is drawn within the item. Rotation is in degrees, clockwise.
 .. versionadded:: 2.1
+.. seealso:: mapRotation()
 %End
 
     double mapRotation( QgsComposerObject::PropertyValueType valueType = QgsComposerObject::EvaluatedValue ) const;
 %Docstring
- Returns the rotation used for drawing the map within the composer item
- :return: rotation for map
+ Returns the rotation used for drawing the map within the composer item, in degrees clockwise.
  \param valueType controls whether the returned value is the user specified rotation,
  or the current evaluated rotation (which may be affected by data driven rotation
  settings).
+.. seealso:: setMapRotation()
  :rtype: float
 %End
 

--- a/python/core/effects/qgstransformeffect.sip
+++ b/python/core/effects/qgstransformeffect.sip
@@ -157,16 +157,14 @@ class QgsTransformEffect : QgsPaintEffect
 
     void setRotation( const double rotation );
 %Docstring
- Sets the transform rotation.
- \param rotation degrees to rotate, clockwise
-.. seealso:: rotation
+ Sets the transform ``rotation``, in degrees clockwise.
+.. seealso:: rotation()
 %End
 
     double rotation() const;
 %Docstring
- Returns the transform rotation.
- :return: rotation in degrees clockwise
-.. seealso:: setRotation
+ Returns the transform rotation, in degrees clockwise.
+.. seealso:: setRotation()
  :rtype: float
 %End
 

--- a/python/core/qgsdiagramrenderer.sip
+++ b/python/core/qgsdiagramrenderer.sip
@@ -365,7 +365,12 @@ Opacity, from 0 (transparent) to 1.0 (opaque)
 %End
 
     bool scaleByArea;
-    int angleOffset;
+
+    double rotationOffset;
+%Docstring
+ Rotation offset, in degrees clockwise from horizontal.
+.. versionadded:: 3.0
+%End
 
     bool scaleBasedVisibility;
     double minScaleDenominator;

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -67,7 +67,6 @@ Set the size of the resulting map image
 %Docstring
  Sets the ``rotation`` of the resulting map image, in degrees clockwise.
 .. versionadded:: 2.8
-
 .. seealso:: rotation()
 %End
 

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -57,12 +57,18 @@ Set the size of the resulting map image
 
     double rotation() const;
 %Docstring
+ Returns the rotation of the resulting map image, in degrees clockwise.
 .. versionadded:: 2.8
+.. seealso:: setRotation()
  :rtype: float
 %End
-    void setRotation( double degrees );
+
+    void setRotation( double rotation );
 %Docstring
+ Sets the ``rotation`` of the resulting map image, in degrees clockwise.
 .. versionadded:: 2.8
+
+.. seealso:: rotation()
 %End
 
     double outputDpi() const;

--- a/python/core/qgspallabeling.sip
+++ b/python/core/qgspallabeling.sip
@@ -239,6 +239,7 @@ class QgsPalLayerSettings
       Hali,
       Vali,
       Rotation,
+      LabelRotation,
       RepeatDistance,
       RepeatDistanceUnit,
       Priority,
@@ -346,7 +347,12 @@ Offset type for layer (only applies in certain placement modes)
     double yOffset; // offset from point in mm or map units
     bool labelOffsetInMapUnits; //true if label offset is in map units (otherwise in mm)
     QgsMapUnitScale labelOffsetMapUnitScale;
-    double angleOffset; // rotation applied to offset labels
+
+    double angleOffset;
+%Docstring
+Label rotation, in degrees clockwise
+%End
+
     bool preserveRotation; // preserve predefined rotation data during label pin/unpin operations
 
     double maxCurvedCharAngleIn; // maximum angle between inside curved label characters (defaults to 20.0, range 20.0 to 60.0)

--- a/python/core/qgstextrenderer.sip
+++ b/python/core/qgstextrenderer.sip
@@ -405,7 +405,7 @@ class QgsTextBackgroundSettings
 
     double rotation() const;
 %Docstring
- Returns the rotation for the background shape.
+ Returns the rotation for the background shape, in degrees clockwise.
 .. seealso:: rotationType()
 .. seealso:: setRotation()
  :rtype: float
@@ -413,8 +413,7 @@ class QgsTextBackgroundSettings
 
     void setRotation( double rotation );
 %Docstring
- Sets the rotation for the background shape.
- \param rotation angle in degrees to rotate
+ Sets the ``rotation`` for the background shape, in degrees clockwise.
 .. seealso:: rotation()
 .. seealso:: setRotationType()
 %End

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -150,6 +150,8 @@ QgsComposerItemWidget::QgsComposerItemWidget( QWidget *parent, QgsComposerItem *
 
   setupUi( this );
 
+  mItemRotationSpinBox->setClearValue( 0 );
+
   //make button exclusive
   QButtonGroup *buttonGroup = new QButtonGroup( this );
   buttonGroup->addButton( mUpperLeftCheckBox );

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -47,6 +47,7 @@ QgsComposerMapWidget::QgsComposerMapWidget( QgsComposerMap *composerMap )
 {
   setupUi( this );
   setPanelTitle( tr( "Map properties" ) );
+  mMapRotationSpinBox->setClearValue( 0 );
 
   //add widget for general composer item properties
   QgsComposerItemWidget *itemPropertiesWidget = new QgsComposerItemWidget( this, composerMap );
@@ -116,7 +117,7 @@ QgsComposerMapWidget::QgsComposerMapWidget( QgsComposerMap *composerMap )
   loadGridEntries();
   loadOverviewEntries();
 
-  connect( mMapRotationSpinBox, &QgsDoubleSpinBox::editingFinished, this, &QgsComposerMapWidget::rotationChanged );
+  connect( mMapRotationSpinBox, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsComposerMapWidget::rotationChanged );
 
   blockAllSignals( false );
 }
@@ -451,7 +452,7 @@ void QgsComposerMapWidget::on_mScaleLineEdit_editingFinished()
   mComposerMap->endCommand();
 }
 
-void QgsComposerMapWidget::rotationChanged()
+void QgsComposerMapWidget::rotationChanged( double value )
 {
   if ( !mComposerMap )
   {
@@ -459,7 +460,7 @@ void QgsComposerMapWidget::rotationChanged()
   }
 
   mComposerMap->beginCommand( tr( "Map rotation changed" ), QgsComposerMergeCommand::ComposerMapRotation );
-  mComposerMap->setMapRotation( mMapRotationSpinBox->value() );
+  mComposerMap->setMapRotation( value );
   mComposerMap->endCommand();
   mComposerMap->invalidateCache();
 }

--- a/src/app/composer/qgscomposermapwidget.h
+++ b/src/app/composer/qgscomposermapwidget.h
@@ -130,7 +130,7 @@ class QgsComposerMapWidget: public QgsComposerItemBaseWidget, private Ui::QgsCom
     //! Blocks / unblocks the signals of all GUI elements
     void blockAllSignals( bool b );
 
-    void rotationChanged();
+    void rotationChanged( double value );
 
     void handleChangedFrameDisplay( QgsComposerMapGrid::BorderSide border, const QgsComposerMapGrid::DisplayMode mode );
     void handleChangedAnnotationDisplay( QgsComposerMapGrid::BorderSide border, const QString &text );

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -396,7 +396,7 @@ void QgsDwgImportDialog::createGroup( QgsLayerTreeGroup *group, QString name, QS
         " WHEN alignv=3 THEN 'Top'"
         " END"
         " END" ).arg( DRW::MTEXT ) ) );
-    pls.dataDefinedProperties().setProperty( QgsPalLayerSettings::Rotation, QgsProperty::fromExpression( QStringLiteral( "angle*180.0/pi()" ) ) );
+    pls.dataDefinedProperties().setProperty( QgsPalLayerSettings::LabelRotation, QgsProperty::fromExpression( QStringLiteral( "360-angle*180.0/pi()" ) ) );
 
     pls.placement = QgsPalLayerSettings::OrderedPositionsAroundPoint;
     l->setLabeling( new QgsVectorLayerSimpleLabeling( pls ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2588,7 +2588,7 @@ void QgisApp::createStatusBar()
   mRotationEdit->setKeyboardTracking( false );
   mRotationEdit->setMaximumWidth( 120 );
   mRotationEdit->setDecimals( 1 );
-  mRotationEdit->setRange( -180.0, 180.0 );
+  mRotationEdit->setRange( -360.0, 360.0 );
   mRotationEdit->setWrapping( true );
   mRotationEdit->setSingleStep( 5.0 );
   mRotationEdit->setFont( myFont );

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -147,10 +147,10 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
   mScaleDependencyComboBox->addItem( tr( "Area" ), true );
   mScaleDependencyComboBox->addItem( tr( "Diameter" ), false );
 
-  mAngleOffsetComboBox->addItem( tr( "Top" ), 90 * 16 );
+  mAngleOffsetComboBox->addItem( tr( "Top" ), 270 );
   mAngleOffsetComboBox->addItem( tr( "Right" ), 0 );
-  mAngleOffsetComboBox->addItem( tr( "Bottom" ), 270 * 16 );
-  mAngleOffsetComboBox->addItem( tr( "Left" ), 180 * 16 );
+  mAngleOffsetComboBox->addItem( tr( "Bottom" ), 90 );
+  mAngleOffsetComboBox->addItem( tr( "Left" ), 180 );
 
   QgsSettings settings;
 
@@ -283,7 +283,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
         mLabelPlacementComboBox->setCurrentIndex( 1 );
       }
 
-      mAngleOffsetComboBox->setCurrentIndex( mAngleOffsetComboBox->findData( settingList.at( 0 ).angleOffset ) );
+      mAngleOffsetComboBox->setCurrentIndex( mAngleOffsetComboBox->findData( settingList.at( 0 ).rotationOffset ) );
 
       mOrientationLeftButton->setProperty( "direction", QgsDiagramSettings::Left );
       mOrientationRightButton->setProperty( "direction", QgsDiagramSettings::Right );
@@ -779,7 +779,7 @@ void QgsDiagramProperties::apply()
   ds.scaleBasedVisibility = mScaleVisibilityGroupBox->isChecked();
 
   // Diagram angle offset (pie)
-  ds.angleOffset = mAngleOffsetComboBox->currentData().toInt();
+  ds.rotationOffset = mAngleOffsetComboBox->currentData().toInt();
 
   // Diagram orientation (histogram)
   ds.diagramOrientation = static_cast<QgsDiagramSettings::DiagramOrientation>( mOrientationButtonGroup->checkedButton()->property( "direction" ).toInt() );

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -545,7 +545,7 @@ void QgsLabelingGui::populateDataDefinedButtons()
   mCoordAlignmentHDDBtn->setUsageInfo( ddPlaceInfo );
   registerDataDefinedButton( mCoordAlignmentVDDBtn, QgsPalLayerSettings::Vali );
   mCoordAlignmentVDDBtn->setUsageInfo( ddPlaceInfo );
-  registerDataDefinedButton( mCoordRotationDDBtn, QgsPalLayerSettings::Rotation );
+  registerDataDefinedButton( mCoordRotationDDBtn, QgsPalLayerSettings::LabelRotation );
   mCoordRotationDDBtn->setUsageInfo( ddPlaceInfo );
 
   // rendering

--- a/src/app/qgslabelpropertydialog.cpp
+++ b/src/app/qgslabelpropertydialog.cpp
@@ -36,6 +36,7 @@ QgsLabelPropertyDialog::QgsLabelPropertyDialog( const QString &layerId, const QS
   QDialog( parent, f ), mLabelFont( labelFont ), mCurLabelField( -1 )
 {
   setupUi( this );
+  mRotationSpinBox->setClearValue( 0 );
   fillHaliComboBox();
   fillValiComboBox();
 
@@ -314,7 +315,7 @@ void QgsLabelPropertyDialog::setDataDefinedValues( QgsVectorLayer *vlayer )
       case QgsPalLayerSettings::Color:
         mFontColorButton->setColor( QColor( result.toString() ) );
         break;
-      case QgsPalLayerSettings::Rotation:
+      case QgsPalLayerSettings::LabelRotation:
       {
         double rot = result.toDouble( &ok );
         if ( ok )
@@ -407,7 +408,7 @@ void QgsLabelPropertyDialog::enableDataDefinedWidgets( QgsVectorLayer *vlayer )
       case QgsPalLayerSettings::Color:
         mFontColorButton->setEnabled( true );
         break;
-      case QgsPalLayerSettings::Rotation:
+      case QgsPalLayerSettings::LabelRotation:
         mRotationSpinBox->setEnabled( true );
         break;
       //font related properties
@@ -618,7 +619,7 @@ void QgsLabelPropertyDialog::on_mRotationSpinBox_valueChanged( double d )
     //null value so that size is reset to default
     rotation.clear();
   }
-  insertChangedValue( QgsPalLayerSettings::Rotation, rotation );
+  insertChangedValue( QgsPalLayerSettings::LabelRotation, rotation );
 }
 
 void QgsLabelPropertyDialog::on_mFontColorButton_colorChanged( const QColor &color )

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -485,7 +485,7 @@ bool QgsMapToolLabel::layerIsRotatable( QgsVectorLayer *vlayer, int &rotationCol
 
 bool QgsMapToolLabel::labelIsRotatable( QgsVectorLayer *layer, const QgsPalLayerSettings &settings, int &rotationCol ) const
 {
-  QString rColName = dataDefinedColumnName( QgsPalLayerSettings::Rotation, settings );
+  QString rColName = dataDefinedColumnName( QgsPalLayerSettings::LabelRotation, settings );
   rotationCol = layer->fields().lookupField( rColName );
   return rotationCol != -1;
 }

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -1009,13 +1009,10 @@ double QgsComposerItem::rectHandlerBorderTolerance() const
 
 void QgsComposerItem::setItemRotation( const double r, const bool adjustPosition )
 {
-  if ( r >= 360 )
+  mItemRotation = r;
+  if ( mItemRotation >= 360.0 || mItemRotation <= -360.0 )
   {
-    mItemRotation = ( static_cast< int >( r ) ) % 360;
-  }
-  else
-  {
-    mItemRotation = r;
+    mItemRotation = fmod( mItemRotation, 360.0 );
   }
 
   QgsExpressionContext context = createExpressionContext();

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -427,13 +427,13 @@ class CORE_EXPORT QgsComposerItem: public QgsComposerObject, public QGraphicsRec
      */
     bool positionLock() const { return mItemPositionLocked; }
 
-    /** Returns the current rotation for the composer item.
-     * \returns rotation for composer item
+    /**
+     * Returns the current rotation for the composer item, in degrees clockwise.
      * \param valueType controls whether the returned value is the user specified rotation,
      * or the current evaluated rotation (which may be affected by data driven rotation
      * settings).
      * \since QGIS 2.1
-     * \see setItemRotation
+     * \see setItemRotation()
      */
     double itemRotation( const QgsComposerObject::PropertyValueType valueType = QgsComposerObject::EvaluatedValue ) const;
 
@@ -555,14 +555,15 @@ class CORE_EXPORT QgsComposerItem: public QgsComposerObject, public QGraphicsRec
 
   public slots:
 
-    /** Sets the item rotation
-     * \param r item rotation in degrees
+    /**
+     * Sets the item \a rotation, in degrees clockwise.
+     * \param rotation item rotation in degrees
      * \param adjustPosition set to true if item should be shifted so that rotation occurs
      * around item center. If false, rotation occurs around item origin
      * \since QGIS 2.1
      * \see itemRotation
      */
-    virtual void setItemRotation( const double r, const bool adjustPosition = false );
+    virtual void setItemRotation( const double rotation, const bool adjustPosition = false );
 
     void repaint() override;
 

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -901,12 +901,12 @@ void QgsComposerMap::setOffset( double xOffset, double yOffset )
   mYOffset = yOffset;
 }
 
-void QgsComposerMap::setMapRotation( double r )
+void QgsComposerMap::setMapRotation( double rotation )
 {
-  mMapRotation = r;
+  mMapRotation = rotation;
   mEvaluatedMapRotation = mMapRotation;
   invalidateCache();
-  emit mapRotationChanged( r );
+  emit mapRotationChanged( rotation );
   emit itemChanged();
 }
 

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -329,17 +329,20 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /* reimplement setFrameStrokeWidth, so that updateBoundingRect() is called after setting the frame width */
     virtual void setFrameStrokeWidth( const double strokeWidth ) override;
 
-    /** Sets rotation for the map - this does not affect the composer item shape, only the
-     * way the map is drawn within the item
+    /**
+     * Sets the \a rotation for the map - this does not affect the composer item shape, only the
+     * way the map is drawn within the item. Rotation is in degrees, clockwise.
      * \since QGIS 2.1
+     * \see mapRotation()
      */
-    void setMapRotation( double r );
+    void setMapRotation( double rotation );
 
-    /** Returns the rotation used for drawing the map within the composer item
-     * \returns rotation for map
+    /**
+     * Returns the rotation used for drawing the map within the composer item, in degrees clockwise.
      * \param valueType controls whether the returned value is the user specified rotation,
      * or the current evaluated rotation (which may be affected by data driven rotation
      * settings).
+     * \see setMapRotation()
      */
     double mapRotation( QgsComposerObject::PropertyValueType valueType = QgsComposerObject::EvaluatedValue ) const;
 

--- a/src/core/composer/qgscomposerpicture.cpp
+++ b/src/core/composer/qgscomposerpicture.cpp
@@ -622,10 +622,10 @@ void QgsComposerPicture::setSceneRect( const QRectF &rectangle )
   }
 }
 
-void QgsComposerPicture::setPictureRotation( double r )
+void QgsComposerPicture::setPictureRotation( double rotation )
 {
   double oldRotation = mPictureRotation;
-  mPictureRotation = r;
+  mPictureRotation = rotation;
 
   if ( mResizeMode == Zoom )
   {

--- a/src/core/composer/qgscomposerpicture.h
+++ b/src/core/composer/qgscomposerpicture.h
@@ -105,11 +105,12 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
      */
     bool readXml( const QDomElement &itemElem, const QDomDocument &doc ) override;
 
-    /** Returns the rotation used for drawing the picture within the item's frame
-     * \returns picture rotation in degrees
+    /**
+     * Returns the rotation used for drawing the picture within the item's frame,
+     * in degrees clockwise.
      * \since QGIS 2.2
-     * \see setPictureRotation
-     * \see rotationMap
+     * \see setPictureRotation()
+     * \see rotationMap()
      */
     double pictureRotation() const { return mPictureRotation; }
 
@@ -254,13 +255,13 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
 
   public slots:
 
-    /** Sets the picture rotation within the item bounds. This does not affect
+    /**
+     * Sets the picture \a rotation within the item bounds, in degrees clockwise. This does not affect
      * the item's frame, only the way the picture is drawn within the item.
-     * \param r rotation in degrees clockwise
-     * \see pictureRotation
+     * \see pictureRotation()
      * \since QGIS 2.2
      */
-    virtual void setPictureRotation( double r );
+    virtual void setPictureRotation( double rotation );
 
     /** Sets the resize mode used for drawing the picture within the item bounds.
      * \param mode ResizeMode to use for image file

--- a/src/core/diagram/qgspiediagram.cpp
+++ b/src/core/diagram/qgspiediagram.cpp
@@ -138,7 +138,7 @@ void QgsPieDiagram::renderDiagram( const QgsFeature &feature, QgsRenderContext &
         }
         else
         {
-          p->drawPie( baseX, baseY, w, h, totalAngle + s.angleOffset, currentAngle );
+          p->drawPie( baseX, baseY, w, h, totalAngle - s.rotationOffset * 16.0, currentAngle );
         }
         totalAngle += currentAngle;
       }

--- a/src/core/effects/qgstransformeffect.h
+++ b/src/core/effects/qgstransformeffect.h
@@ -149,15 +149,15 @@ class CORE_EXPORT QgsTransformEffect : public QgsPaintEffect
      */
     double scaleY() const { return mScaleY; }
 
-    /** Sets the transform rotation.
-     * \param rotation degrees to rotate, clockwise
-     * \see rotation
+    /**
+     * Sets the transform \a rotation, in degrees clockwise.
+     * \see rotation()
      */
     void setRotation( const double rotation ) { mRotation = rotation; }
 
-    /** Returns the transform rotation.
-     * \returns rotation in degrees clockwise
-     * \see setRotation
+    /**
+     * Returns the transform rotation, in degrees clockwise.
+     * \see setRotation()
      */
     double rotation() const { return mRotation; }
 

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -255,7 +255,10 @@ void QgsDiagramSettings::readXml( const QDomElement &elem )
 
   barWidth = elem.attribute( QStringLiteral( "barWidth" ) ).toDouble();
 
-  angleOffset = elem.attribute( QStringLiteral( "angleOffset" ) ).toInt();
+  if ( elem.hasAttribute( QStringLiteral( "angleOffset" ) ) )
+    rotationOffset = fmod( 360.0 - elem.attribute( QStringLiteral( "angleOffset" ) ).toInt() / 16.0, 360.0 );
+  else
+    rotationOffset = elem.attribute( QStringLiteral( "rotationOffset" ) ).toDouble();
 
   minimumSize = elem.attribute( QStringLiteral( "minimumSize" ) ).toDouble();
 
@@ -374,7 +377,7 @@ void QgsDiagramSettings::writeXml( QDomElement &rendererElem, QDomDocument &doc 
 
   categoryElem.setAttribute( QStringLiteral( "barWidth" ), QString::number( barWidth ) );
   categoryElem.setAttribute( QStringLiteral( "minimumSize" ), QString::number( minimumSize ) );
-  categoryElem.setAttribute( QStringLiteral( "angleOffset" ), QString::number( angleOffset ) );
+  categoryElem.setAttribute( QStringLiteral( "rotationOffset" ), QString::number( rotationOffset ) );
 
   int nCats = qMin( categoryColors.size(), categoryAttributes.size() );
   for ( int i = 0; i < nCats; ++i )
@@ -447,8 +450,8 @@ void QgsDiagramRenderer::renderDiagram( const QgsFeature &feature, QgsRenderCont
     s.penColor = properties.valueAsColor( QgsDiagramLayerSettings::StrokeColor, c.expressionContext(), s.penColor );
     c.expressionContext().setOriginalValueVariable( s.penWidth );
     s.penWidth = properties.valueAsDouble( QgsDiagramLayerSettings::StrokeWidth, c.expressionContext(), s.penWidth );
-    c.expressionContext().setOriginalValueVariable( s.angleOffset / 16.0 );
-    s.angleOffset = 16.0 * properties.valueAsDouble( QgsDiagramLayerSettings::StartAngle, c.expressionContext(), s.angleOffset / 16.0 );
+    c.expressionContext().setOriginalValueVariable( s.rotationOffset );
+    s.rotationOffset = properties.valueAsDouble( QgsDiagramLayerSettings::StartAngle, c.expressionContext(), s.rotationOffset );
   }
 
   mDiagram->renderDiagram( feature, c, s, pos );

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -374,7 +374,7 @@ class CORE_EXPORT QgsDiagramSettings
       , barWidth( 5.0 )
       , opacity( 1.0 )
       , scaleByArea( true )
-      , angleOffset( 90 * 16 ) //top
+      , rotationOffset( 270 ) //top
       , scaleBasedVisibility( false )
       , minScaleDenominator( -1 )
       , maxScaleDenominator( -1 )
@@ -418,7 +418,12 @@ class CORE_EXPORT QgsDiagramSettings
     double opacity;
 
     bool scaleByArea;
-    int angleOffset;
+
+    /**
+     * Rotation offset, in degrees clockwise from horizontal.
+     * \since QGIS 3.0
+     */
+    double rotationOffset;
 
     bool scaleBasedVisibility;
     //scale range (-1 if no lower / upper bound )

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -106,7 +106,8 @@ double QgsMapSettings::rotation() const
 
 void QgsMapSettings::setRotation( double degrees )
 {
-  if ( qgsDoubleNear( mRotation, degrees ) ) return;
+  if ( qgsDoubleNear( mRotation, degrees ) )
+    return;
 
   mRotation = degrees;
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -76,14 +76,19 @@ class CORE_EXPORT QgsMapSettings
     //! Set the size of the resulting map image
     void setOutputSize( QSize size );
 
-    //! Return the rotation of the resulting map image
-    //! Units are clockwise degrees
-    //! \since QGIS 2.8
+    /**
+     * Returns the rotation of the resulting map image, in degrees clockwise.
+     * \since QGIS 2.8
+     * \see setRotation()
+     */
     double rotation() const;
-    //! Set the rotation of the resulting map image
-    //! Units are clockwise degrees
-    //! \since QGIS 2.8
-    void setRotation( double degrees );
+
+    /**
+     * Sets the \a rotation of the resulting map image, in degrees clockwise.
+     * \since QGIS 2.8
+     * \see rotation()
+     */
+    void setRotation( double rotation );
 
     //! Return DPI used for conversion between real world units (e.g. mm) and pixels
     //! Default value is 96

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -353,7 +353,8 @@ class CORE_EXPORT QgsPalLayerSettings
       PositionY = 10, //!< Y-coordinate data defined label position
       Hali = 11, //!< Horizontal alignment for data defined label position (Left, Center, Right)
       Vali = 12, //!< Vertical alignment for data defined label position (Bottom, Base, Half, Cap, Top)
-      Rotation = 14, //!< Label rotation
+      Rotation = 14, //!< Label rotation (deprecated, for old project compatibility only)
+      LabelRotation = 96, //!< Label rotation (deprecated, for old project compatibility only)
       RepeatDistance = 84,
       RepeatDistanceUnit = 86,
       Priority = 87,
@@ -463,7 +464,10 @@ class CORE_EXPORT QgsPalLayerSettings
     double yOffset; // offset from point in mm or map units
     bool labelOffsetInMapUnits; //true if label offset is in map units (otherwise in mm)
     QgsMapUnitScale labelOffsetMapUnitScale;
-    double angleOffset; // rotation applied to offset labels
+
+    //! Label rotation, in degrees clockwise
+    double angleOffset;
+
     bool preserveRotation; // preserve predefined rotation data during label pin/unpin operations
 
     double maxCurvedCharAngleIn; // maximum angle between inside curved label characters (defaults to 20.0, range 20.0 to 60.0)

--- a/src/core/qgstextrenderer.h
+++ b/src/core/qgstextrenderer.h
@@ -369,14 +369,15 @@ class CORE_EXPORT QgsTextBackgroundSettings
      */
     void setRotationType( RotationType type );
 
-    /** Returns the rotation for the background shape.
+    /**
+     * Returns the rotation for the background shape, in degrees clockwise.
      * \see rotationType()
      * \see setRotation()
      */
     double rotation() const;
 
-    /** Sets the rotation for the background shape.
-     * \param rotation angle in degrees to rotate
+    /**
+     * Sets the \a rotation for the background shape, in degrees clockwise.
      * \see rotation()
      * \see setRotationType()
      */

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3768,7 +3768,7 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
         double rotation = rotationElem.text().toDouble( &ok );
         if ( ok )
         {
-          settings.angleOffset = rotation;
+          settings.angleOffset = 360 - rotation;
         }
       }
     }

--- a/src/gui/effects/qgspainteffectwidget.cpp
+++ b/src/gui/effects/qgspainteffectwidget.cpp
@@ -577,6 +577,7 @@ QgsTransformWidget::QgsTransformWidget( QWidget *parent )
                                   << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
   mSpinTranslateX->setClearValue( 0 );
   mSpinTranslateY->setClearValue( 0 );
+  mRotationSpinBox->setClearValue( 0 );
   mSpinShearX->setClearValue( 0 );
   mSpinShearY->setClearValue( 0 );
   mSpinScaleX->setClearValue( 100.0 );

--- a/src/gui/effects/qgspainteffectwidget.cpp
+++ b/src/gui/effects/qgspainteffectwidget.cpp
@@ -235,6 +235,7 @@ QgsShadowEffectWidget::QgsShadowEffectWidget( QWidget *parent )
   mShadowColorBtn->setAllowOpacity( false );
   mShadowColorBtn->setColorDialogTitle( tr( "Select shadow color" ) );
   mShadowColorBtn->setContext( QStringLiteral( "symbology" ) );
+  mShadowOffsetAngleSpnBx->setClearValue( 0 );
 
   mOffsetUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPixels << QgsUnitTypes::RenderMapUnits
                                << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -214,9 +214,6 @@ void QgsTextFormatWidget::initWidget()
   mPlacePolygonBtnGrp->setExclusive( true );
   connect( mPlacePolygonBtnGrp, static_cast<void ( QButtonGroup::* )( int )>( &QButtonGroup::buttonClicked ), this, &QgsTextFormatWidget::updatePlacementWidgets );
 
-  // TODO: is this necessary? maybe just use the data defined-only rotation?
-  mPointAngleDDBtn->setVisible( false );
-
   // Global settings group for groupboxes' saved/restored collapsed state
   // maintains state across different dialogs
   Q_FOREACH ( QgsCollapsibleGroupBox *grpbox, findChildren<QgsCollapsibleGroupBox *>() )
@@ -359,7 +356,6 @@ void QgsTextFormatWidget::initWidget()
           << mObstacleTypeComboBox
           << mOffsetTypeComboBox
           << mPalShowAllLabelsForLayerChkBx
-          << mPointAngleDDBtn
           << mPointAngleSpinBox
           << mPointOffsetDDBtn
           << mPointOffsetUnitsDDBtn

--- a/src/gui/symbology-ng/qgs25drendererwidget.cpp
+++ b/src/gui/symbology-ng/qgs25drendererwidget.cpp
@@ -40,6 +40,7 @@ Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *sty
   setupUi( this );
   this->layout()->setContentsMargins( 0, 0, 0, 0 );
 
+  mAngleWidget->setClearValue( 0 );
   mWallColorButton->setColorDialogTitle( tr( "Select wall color" ) );
   mWallColorButton->setAllowOpacity( true );
   mWallColorButton->setContext( QStringLiteral( "symbology" ) );

--- a/src/gui/symbology-ng/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerwidget.cpp
@@ -391,6 +391,7 @@ QgsSimpleMarkerSymbolLayerWidget::QgsSimpleMarkerSymbolLayerWidget( const QgsVec
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
+  spinAngle->setClearValue( 0.0 );
 
   //make a temporary symbol for the size assistant preview
   mAssistantPreviewSymbol.reset( new QgsMarkerSymbol() );
@@ -803,6 +804,7 @@ QgsFilledMarkerSymbolLayerWidget::QgsFilledMarkerSymbolLayerWidget( const QgsVec
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
+  spinAngle->setClearValue( 0.0 );
 
   //make a temporary symbol for the size assistant preview
   mAssistantPreviewSymbol.reset( new QgsMarkerSymbol() );
@@ -987,6 +989,7 @@ QgsGradientFillSymbolLayerWidget::QgsGradientFillSymbolLayerWidget( const QgsVec
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
+  mSpinAngle->setClearValue( 0.0 );
 
   connect( btnChangeColor, &QgsColorButton::colorChanged, this, &QgsGradientFillSymbolLayerWidget::setColor );
   connect( btnChangeColor2, &QgsColorButton::colorChanged, this, &QgsGradientFillSymbolLayerWidget::setColor2 );
@@ -1735,6 +1738,7 @@ QgsSvgMarkerSymbolLayerWidget::QgsSvgMarkerSymbolLayerWidget( const QgsVectorLay
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
+  spinAngle->setClearValue( 0.0 );
 
   populateList();
 
@@ -2114,6 +2118,8 @@ QgsSVGFillSymbolLayerWidget::QgsSVGFillSymbolLayerWidget( const QgsVectorLayer *
   mSvgTreeView->setHeaderHidden( true );
   insertIcons();
 
+  mRotationSpinBox->setClearValue( 0.0 );
+
   mChangeColorButton->setColorDialogTitle( tr( "Select fill color" ) );
   mChangeColorButton->setContext( QStringLiteral( "symbology" ) );
   mChangeStrokeColorButton->setColorDialogTitle( tr( "Select stroke color" ) );
@@ -2399,6 +2405,7 @@ QgsLinePatternFillSymbolLayerWidget::QgsLinePatternFillSymbolLayerWidget( const 
   mOffsetUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
                                << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
   mOffsetSpinBox->setClearValue( 0 );
+  mAngleSpinBox->setClearValue( 0 );
 }
 
 void QgsLinePatternFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
@@ -2657,6 +2664,7 @@ QgsFontMarkerSymbolLayerWidget::QgsFontMarkerSymbolLayerWidget( const QgsVectorL
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
+  spinAngle->setClearValue( 0.0 );
 
   //make a temporary symbol for the size assistant preview
   mAssistantPreviewSymbol.reset( new QgsMarkerSymbol() );
@@ -2918,6 +2926,7 @@ QgsRasterFillSymbolLayerWidget::QgsRasterFillSymbolLayerWidget( const QgsVectorL
 
   mSpinOffsetX->setClearValue( 0.0 );
   mSpinOffsetY->setClearValue( 0.0 );
+  mRotationSpinBox->setClearValue( 0.0 );
 
   connect( cboCoordinateMode, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRasterFillSymbolLayerWidget::setCoordinateMode );
   connect( mSpinOffsetX, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsRasterFillSymbolLayerWidget::offsetChanged );

--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -51,6 +51,7 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbol *symbol, QgsStyle *style, 
   , mMapCanvas( nullptr )
 {
   setupUi( this );
+  spinAngle->setClearValue( 0 );
 
   mSymbolUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
                                << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );

--- a/src/ui/composer/qgscomposeritemwidgetbase.ui
+++ b/src/ui/composer/qgscomposeritemwidgetbase.ui
@@ -371,6 +371,9 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="wrapping">
+           <bool>true</bool>
+          </property>
           <property name="suffix">
            <string> °</string>
           </property>

--- a/src/ui/composer/qgscomposeritemwidgetbase.ui
+++ b/src/ui/composer/qgscomposeritemwidgetbase.ui
@@ -374,6 +374,9 @@
           <property name="suffix">
            <string> °</string>
           </property>
+          <property name="minimum">
+           <double>-360.000000000000000</double>
+          </property>
           <property name="maximum">
            <double>360.000000000000000</double>
           </property>

--- a/src/ui/composer/qgscomposermapwidgetbase.ui
+++ b/src/ui/composer/qgscomposermapwidgetbase.ui
@@ -101,6 +101,9 @@
            <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
              <widget class="QgsDoubleSpinBox" name="mMapRotationSpinBox">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
               <property name="suffix">
                <string> °</string>
               </property>

--- a/src/ui/composer/qgscomposermapwidgetbase.ui
+++ b/src/ui/composer/qgscomposermapwidgetbase.ui
@@ -104,6 +104,9 @@
               <property name="suffix">
                <string> °</string>
               </property>
+              <property name="minimum">
+               <double>-360.000000000000000</double>
+              </property>
               <property name="maximum">
                <double>360.000000000000000</double>
               </property>
@@ -775,16 +778,9 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -797,19 +793,26 @@
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsComposerItemComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscomposeritemcombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsComposerItemComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgscomposeritemcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -876,6 +879,30 @@
   <tabstop>mGridPropertiesButton</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/composer/qgscomposerpicturewidgetbase.ui
+++ b/src/ui/composer/qgscomposerpicturewidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>332</width>
+    <width>334</width>
     <height>572</height>
    </rect>
   </property>
@@ -60,9 +60,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-275</y>
-        <width>316</width>
-        <height>827</height>
+        <y>-403</y>
+        <width>318</width>
+        <height>949</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -506,6 +506,9 @@
           </item>
           <item row="0" column="0" colspan="2">
            <widget class="QgsDoubleSpinBox" name="mPictureRotationSpinBox">
+            <property name="wrapping">
+             <bool>true</bool>
+            </property>
             <property name="suffix">
              <string> °</string>
             </property>
@@ -526,6 +529,9 @@
           </item>
           <item row="3" column="1">
            <widget class="QgsDoubleSpinBox" name="mPictureRotationOffsetSpinBox">
+            <property name="wrapping">
+             <bool>true</bool>
+            </property>
             <property name="suffix">
              <string> °</string>
             </property>
@@ -549,22 +555,15 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -572,14 +571,21 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsComposerItemComboBox</class>
    <extends>QComboBox</extends>
    <header>qgscomposeritemcombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/effects/widget_shadoweffect.ui
+++ b/src/ui/effects/widget_shadoweffect.ui
@@ -174,14 +174,17 @@
           </item>
           <item>
            <widget class="QgsSpinBox" name="mShadowOffsetAngleSpnBx">
+            <property name="wrapping">
+             <bool>true</bool>
+            </property>
             <property name="suffix">
              <string>˚</string>
             </property>
             <property name="minimum">
-             <number>-180</number>
+             <number>-360</number>
             </property>
             <property name="maximum">
-             <number>180</number>
+             <number>360</number>
             </property>
             <property name="showClearButton" stdset="0">
              <bool>false</bool>
@@ -250,11 +253,6 @@
    <header>qgsblendmodecombobox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsEffectDrawModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgseffectdrawmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
@@ -265,6 +263,11 @@
    <extends>QWidget</extends>
    <header>qgsopacitywidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsEffectDrawModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgseffectdrawmodecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/effects/widget_transform.ui
+++ b/src/ui/effects/widget_transform.ui
@@ -117,6 +117,9 @@
        <property name="suffix">
         <string> °</string>
        </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
+       </property>
        <property name="maximum">
         <double>360.000000000000000</double>
        </property>

--- a/src/ui/qgslabelpropertydialogbase.ui
+++ b/src/ui/qgslabelpropertydialogbase.ui
@@ -37,9 +37,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>431</width>
-        <height>622</height>
+        <y>-391</y>
+        <width>417</width>
+        <height>689</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mLabelPropertiesLayout">
@@ -576,11 +576,17 @@
           </item>
           <item row="5" column="1">
            <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
+            <property name="wrapping">
+             <bool>true</bool>
+            </property>
             <property name="specialValueText">
              <string>Default</string>
             </property>
+            <property name="suffix">
+             <string>˚</string>
+            </property>
             <property name="minimum">
-             <double>-1.000000000000000</double>
+             <double>-360.000000000000000</double>
             </property>
             <property name="maximum">
              <double>360.000000000000000</double>
@@ -624,21 +630,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -650,6 +644,18 @@
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -6572,7 +6572,6 @@ font-style: italic;</string>
   <tabstop>mPointOffsetUnitWidget</tabstop>
   <tabstop>mPointOffsetUnitsDDBtn</tabstop>
   <tabstop>mPointAngleSpinBox</tabstop>
-  <tabstop>mPointAngleDDBtn</tabstop>
   <tabstop>mRepeatDistanceSpinBox</tabstop>
   <tabstop>mRepeatDistanceDDBtn</tabstop>
   <tabstop>mRepeatDistanceUnitWidget</tabstop>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -3409,14 +3409,17 @@ font-style: italic;</string>
                              </item>
                              <item>
                               <widget class="QgsSpinBox" name="mShadowOffsetAngleSpnBx">
+                               <property name="wrapping">
+                                <bool>true</bool>
+                               </property>
                                <property name="suffix">
                                 <string>˚</string>
                                </property>
                                <property name="minimum">
-                                <number>-180</number>
+                                <number>-360</number>
                                </property>
                                <property name="maximum">
-                                <number>180</number>
+                                <number>360</number>
                                </property>
                                <property name="showClearButton" stdset="0">
                                 <bool>false</bool>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -2647,14 +2647,17 @@ font-style: italic;</string>
                              <property name="enabled">
                               <bool>false</bool>
                              </property>
+                             <property name="wrapping">
+                              <bool>true</bool>
+                             </property>
                              <property name="suffix">
                               <string notr="true">˚</string>
                              </property>
                              <property name="minimum">
-                              <double>-180.000000000000000</double>
+                              <double>-360.000000000000000</double>
                              </property>
                              <property name="maximum">
-                              <double>180.000000000000000</double>
+                              <double>360.000000000000000</double>
                              </property>
                             </widget>
                            </item>
@@ -4781,6 +4784,9 @@ font-style: italic;</string>
                              <verstretch>0</verstretch>
                             </sizepolicy>
                            </property>
+                           <property name="wrapping">
+                            <bool>true</bool>
+                           </property>
                            <property name="suffix">
                             <string>˚</string>
                            </property>
@@ -4789,13 +4795,6 @@ font-style: italic;</string>
                            </property>
                            <property name="maximum">
                             <double>360.000000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="2">
-                          <widget class="QgsPropertyOverrideButton" name="mPointAngleDDBtn">
-                           <property name="text">
-                            <string>...</string>
                            </property>
                           </widget>
                          </item>

--- a/src/ui/raster/qgshillshaderendererwidget.ui
+++ b/src/ui/raster/qgshillshaderendererwidget.ui
@@ -58,6 +58,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="suffix">
+        <string>˚</string>
+       </property>
       </widget>
      </item>
     </layout>
@@ -65,14 +68,14 @@
    <item row="1" column="0" colspan="2">
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Altitude (degrees)</string>
+      <string>Altitude</string>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Azimuth (degrees)</string>
+      <string>Azimuth</string>
      </property>
     </widget>
    </item>
@@ -90,6 +93,9 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="suffix">
+      <string>˚</string>
      </property>
      <property name="singleStep">
       <double>5.000000000000000</double>

--- a/src/ui/symbollayer/qgs25drendererwidgetbase.ui
+++ b/src/ui/symbollayer/qgs25drendererwidgetbase.ui
@@ -115,9 +115,15 @@
     <widget class="QgsFieldExpressionWidget" name="mHeightWidget" native="true"/>
    </item>
    <item row="1" column="1">
-    <widget class="QSpinBox" name="mAngleWidget">
+    <widget class="QgsSpinBox" name="mAngleWidget">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
      <property name="suffix">
       <string>°</string>
+     </property>
+     <property name="minimum">
+      <number>-360</number>
      </property>
      <property name="maximum">
       <number>359</number>
@@ -138,15 +144,20 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsFieldExpressionWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">qgsfieldexpressionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/symbollayer/widget_ellipse.ui
+++ b/src/ui/symbollayer/widget_ellipse.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>305</width>
+    <width>334</width>
     <height>680</height>
    </rect>
   </property>
@@ -228,6 +228,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout_10">
      <item>
       <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
        </property>
@@ -600,15 +603,15 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsPenJoinStyleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspenstylecombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPenJoinStyleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspenstylecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPenStyleComboBox</class>

--- a/src/ui/symbollayer/widget_filledmarker.ui
+++ b/src/ui/symbollayer/widget_filledmarker.ui
@@ -79,11 +79,17 @@
    </item>
    <item row="1" column="1">
     <widget class="QgsDoubleSpinBox" name="spinAngle">
+     <property name="wrapping">
+      <bool>true</bool>
+     </property>
      <property name="suffix">
       <string> °</string>
      </property>
      <property name="decimals">
       <number>2</number>
+     </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
      </property>
      <property name="maximum">
       <double>360.000000000000000</double>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -399,11 +399,17 @@
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinAngle">
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
        </property>
        <property name="decimals">
         <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>
@@ -454,21 +460,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPropertyOverrideButton</class>
@@ -476,9 +471,20 @@
    <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsPenJoinStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>

--- a/src/ui/symbollayer/widget_gradientfill.ui
+++ b/src/ui/symbollayer/widget_gradientfill.ui
@@ -404,8 +404,14 @@
     <layout class="QHBoxLayout" name="horizontalLayout_9">
      <item>
       <widget class="QgsDoubleSpinBox" name="mSpinAngle">
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>
@@ -517,6 +523,11 @@
     </spacer>
    </item>
   </layout>
+  <zorder>btnChangeColor2</zorder>
+  <zorder>btnColorRamp</zorder>
+  <zorder>btnChangeColor</zorder>
+  <zorder>checkRefPoint1Centroid</zorder>
+  <zorder>checkRefPoint2Centroid</zorder>
   <zorder>label_6</zorder>
   <zorder>label_3</zorder>
   <zorder>radioColorRamp</zorder>
@@ -547,12 +558,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorRampButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorrampbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
@@ -566,6 +571,12 @@
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorRampButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorrampbutton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/symbollayer/widget_linepatternfill.ui
+++ b/src/ui/symbollayer/widget_linepatternfill.ui
@@ -121,8 +121,14 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QgsDoubleSpinBox" name="mAngleSpinBox">
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>

--- a/src/ui/symbollayer/widget_rasterfill.ui
+++ b/src/ui/symbollayer/widget_rasterfill.ui
@@ -77,8 +77,14 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>

--- a/src/ui/symbollayer/widget_simplemarker.ui
+++ b/src/ui/symbollayer/widget_simplemarker.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>305</width>
+    <width>318</width>
     <height>637</height>
    </rect>
   </property>
@@ -121,11 +121,17 @@
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinAngle">
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
        </property>
        <property name="decimals">
         <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>
@@ -536,15 +542,15 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsPenJoinStyleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspenstylecombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPenJoinStyleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspenstylecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPenStyleComboBox</class>

--- a/src/ui/symbollayer/widget_svgfill.ui
+++ b/src/ui/symbollayer/widget_svgfill.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>459</height>
+    <width>322</width>
+    <height>509</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,8 +18,14 @@
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QgsDoubleSpinBox" name="mRotationSpinBox">
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>
@@ -274,17 +280,17 @@
      </item>
      <item row="1" column="1">
       <widget class="QListView" name="mSvgListView">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>250</height>
-        </size>
-       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>5</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>250</height>
+        </size>
        </property>
        <property name="iconSize">
         <size>
@@ -328,6 +334,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
@@ -341,12 +353,6 @@
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/symbollayer/widget_svgmarker.ui
+++ b/src/ui/symbollayer/widget_svgmarker.ui
@@ -91,11 +91,17 @@
     <layout class="QHBoxLayout" name="horizontalLayout_7">
      <item>
       <widget class="QgsDoubleSpinBox" name="spinAngle">
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
        <property name="suffix">
         <string> °</string>
        </property>
        <property name="decimals">
         <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>
@@ -526,6 +532,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
@@ -539,12 +551,6 @@
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -320,17 +320,23 @@
            </property>
            <item>
             <widget class="QgsDoubleSpinBox" name="spinAngle">
+             <property name="wrapping">
+              <bool>true</bool>
+             </property>
              <property name="suffix">
               <string> °</string>
              </property>
              <property name="decimals">
               <number>2</number>
              </property>
+             <property name="minimum">
+              <double>-360.000000000000000</double>
+             </property>
              <property name="maximum">
               <double>360.000000000000000</double>
              </property>
              <property name="singleStep">
-              <double>0.500000000000000</double>
+              <double>1.000000000000000</double>
              </property>
             </widget>
            </item>

--- a/tests/src/core/testqgsdiagram.cpp
+++ b/tests/src/core/testqgsdiagram.cpp
@@ -153,7 +153,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 5, 5 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsLinearlyInterpolatedDiagramRenderer *dr = new QgsLinearlyInterpolatedDiagramRenderer();
       dr->setLowerValue( 0.0 );
@@ -190,7 +190,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 5, 5 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsLinearlyInterpolatedDiagramRenderer *dr = new QgsLinearlyInterpolatedDiagramRenderer();
       dr->setLowerValue( 0.0 );
@@ -232,7 +232,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -269,7 +269,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -306,7 +306,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -342,7 +342,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -378,7 +378,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -414,7 +414,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 50, 50 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -448,7 +448,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 50, 50 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -484,7 +484,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 50, 50 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -525,7 +525,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.angleOffset = 0;
+      ds.rotationOffset = 270;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsTextDiagram() );

--- a/tests/src/core/testqgsdiagram.cpp
+++ b/tests/src/core/testqgsdiagram.cpp
@@ -153,7 +153,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 5, 5 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsLinearlyInterpolatedDiagramRenderer *dr = new QgsLinearlyInterpolatedDiagramRenderer();
       dr->setLowerValue( 0.0 );
@@ -190,7 +190,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 5, 5 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsLinearlyInterpolatedDiagramRenderer *dr = new QgsLinearlyInterpolatedDiagramRenderer();
       dr->setLowerValue( 0.0 );
@@ -232,7 +232,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -269,7 +269,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -306,7 +306,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -318,7 +318,7 @@ class TestQgsDiagram : public QObject
       dls.setShowAllDiagrams( true );
 
       //setup data defined start angle
-      dls.dataDefinedProperties().setProperty( QgsDiagramLayerSettings::StartAngle, QgsProperty::fromExpression( "\"Importance\"/20.0 * 360.0", true ) );
+      dls.dataDefinedProperties().setProperty( QgsDiagramLayerSettings::StartAngle, QgsProperty::fromExpression( "360.0-\"Importance\"/20.0 * 360.0", true ) );
 
       mPointsLayer->setDiagramLayerSettings( dls );
 
@@ -342,7 +342,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -378,7 +378,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -414,7 +414,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 50, 50 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -448,7 +448,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 50, 50 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -484,7 +484,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 50, 50 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsPieDiagram() );
@@ -525,7 +525,7 @@ class TestQgsDiagram : public QObject
       ds.scaleByArea = true;
       ds.sizeType = QgsUnitTypes::RenderMillimeters;
       ds.size = QSizeF( 15, 15 );
-      ds.rotationOffset = 270;
+      ds.rotationOffset = 0;
 
       QgsSingleCategoryDiagramRenderer *dr = new QgsSingleCategoryDiagramRenderer();
       dr->setDiagram( new QgsTextDiagram() );


### PR DESCRIPTION
This PR unifies the behavior of controls for specifying rotation, so that all rotation is set in degrees clockwise, and accepts values from -360->360.

It also implements an important fix where label rotation is changed to operate in the same direction (clockwise), so that it matches symbology, map rotation, etc.