### PR TITLE
Typo fix: Add missing spacing

### DIFF
--- a/python/plugins/processing/algs/qgis/Dissolve.py
+++ b/python/plugins/processing/algs/qgis/Dissolve.py
@@ -104,7 +104,7 @@ class Dissolve(GeoAlgorithm):
                 errors = tmpInGeom.validateGeometry()
                 if len(errors) != 0:
                     for error in errors:
-                        QgsMessageLog.logMessage(self.tr('ValidateGeometry()'
+                        QgsMessageLog.logMessage(self.tr('ValidateGeometry() '
                                                          'error: One or more '
                                                          'input features have '
                                                          'invalid geometry: ') +
@@ -147,7 +147,7 @@ class Dissolve(GeoAlgorithm):
                 if len(errors) != 0:
                     for error in errors:
                         QgsMessageLog.logMessage(self.tr('ValidateGeometry() '
-                                                         'error: One or more input'
+                                                         'error: One or more input '
                                                          'features have invalid '
                                                          'geometry: ') +
                                                  error.what(), self.tr('Processing'), QgsMessageLog.CRITICAL)


### PR DESCRIPTION
Fix typo in translatable texts (missing space)

Also I wonder if `ValidateGeometry()` is appropriate in the translatable text. Something like `Error during geometry validation` would be less specialist and easier to translate. Just a thought...