### PR TITLE
Move classify related wigdets in dialogs

### DIFF
--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -11,13 +11,6 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="1">
-    <widget class="QPushButton" name="btnAddCategories">
-     <property name="text">
-      <string>Classify</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="1">
     <widget class="QPushButton" name="btnChangeCategorizedSymbol">
      <property name="sizePolicy">
@@ -67,6 +60,13 @@
    </item>
    <item row="6" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QPushButton" name="btnAddCategories">
+       <property name="text">
+        <string>Classify</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QPushButton" name="btnAddCategory">
        <property name="toolTip">
@@ -145,7 +145,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
      <property name="maximumSize">
       <size>
        <width>500</width>
@@ -190,9 +190,6 @@
        <height>16777215</height>
       </size>
      </property>
-     <zorder>btnAddCategories</zorder>
-     <zorder>btnAddCategories</zorder>
-     <zorder>btnAddCategories</zorder>
     </widget>
    </item>
   </layout>
@@ -202,7 +199,6 @@
   <zorder>label_10</zorder>
   <zorder>mExpressionWidget</zorder>
   <zorder>label_3</zorder>
-  <zorder>btnAddCategories</zorder>
   <zorder>btnColorRamp</zorder>
  </widget>
  <customwidgets>
@@ -222,11 +218,13 @@
  <tabstops>
   <tabstop>mExpressionWidget</tabstop>
   <tabstop>btnChangeCategorizedSymbol</tabstop>
+  <tabstop>btnColorRamp</tabstop>
+  <tabstop>viewCategories</tabstop>
+  <tabstop>btnAddCategories</tabstop>
   <tabstop>btnAddCategory</tabstop>
   <tabstop>btnDeleteCategories</tabstop>
   <tabstop>btnDeleteAllCategories</tabstop>
   <tabstop>btnAdvanced</tabstop>
-  <tabstop>viewCategories</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -61,16 +61,6 @@
    <item row="6" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <widget class="QPushButton" name="btnAddCategories">
-       <property name="toolTip">
-        <string>Add all missing categories from column or expression unique values</string>
-       </property>
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="btnAddCategory">
        <property name="toolTip">
         <string>Add categories manually</string>
@@ -117,6 +107,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnAdvanced">
+       <property name="toolTip">
+        <string>Advanced options</string>
+       </property>
        <property name="text">
         <string>Advanced</string>
        </property>
@@ -151,7 +144,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
      <property name="maximumSize">
       <size>
        <width>500</width>
@@ -198,6 +191,16 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="btnAddCategories">
+     <property name="toolTip">
+      <string>Add all missing categories from column or expression unique values</string>
+     </property>
+     <property name="text">
+      <string>Classify</string>
+     </property>
+    </widget>
+   </item>
   </layout>
   <zorder>viewCategories</zorder>
   <zorder>btnChangeCategorizedSymbol</zorder>
@@ -206,6 +209,7 @@
   <zorder>mExpressionWidget</zorder>
   <zorder>label_3</zorder>
   <zorder>btnColorRamp</zorder>
+  <zorder>btnAddCategories</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -226,7 +230,6 @@
   <tabstop>btnChangeCategorizedSymbol</tabstop>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>viewCategories</tabstop>
-  <tabstop>btnAddCategories</tabstop>
   <tabstop>btnAddCategory</tabstop>
   <tabstop>btnDeleteCategories</tabstop>
   <tabstop>btnDeleteAllCategories</tabstop>

--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -6,47 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>378</width>
-    <height>368</height>
+    <width>339</width>
+    <height>566</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="btnAddCategories">
      <property name="text">
-      <string>Column</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
-     <property name="maximumSize">
-      <size>
-       <width>500</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Symbol</string>
+      <string>Classify</string>
      </property>
     </widget>
    </item>
@@ -63,46 +31,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Color ramp</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QgsColorRampButton" name="btnColorRamp">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QTreeView" name="viewCategories">
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
@@ -136,15 +65,8 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QPushButton" name="btnAddCategories">
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QPushButton" name="btnAddCategory">
        <property name="toolTip">
@@ -196,6 +118,83 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Column</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Color ramp</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
+     <property name="maximumSize">
+      <size>
+       <width>500</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Symbol</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QgsColorRampButton" name="btnColorRamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <zorder>btnAddCategories</zorder>
+     <zorder>btnAddCategories</zorder>
+     <zorder>btnAddCategories</zorder>
+    </widget>
+   </item>
   </layout>
   <zorder>viewCategories</zorder>
   <zorder>btnChangeCategorizedSymbol</zorder>
@@ -203,12 +202,14 @@
   <zorder>label_10</zorder>
   <zorder>mExpressionWidget</zorder>
   <zorder>label_3</zorder>
+  <zorder>btnAddCategories</zorder>
+  <zorder>btnColorRamp</zorder>
  </widget>
  <customwidgets>
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
-   <header location="global">qgsfieldexpressionwidget.h</header>
+   <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -221,8 +222,6 @@
  <tabstops>
   <tabstop>mExpressionWidget</tabstop>
   <tabstop>btnChangeCategorizedSymbol</tabstop>
-  <tabstop>btnColorRamp</tabstop>
-  <tabstop>btnAddCategories</tabstop>
   <tabstop>btnAddCategory</tabstop>
   <tabstop>btnDeleteCategories</tabstop>
   <tabstop>btnDeleteAllCategories</tabstop>

--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>339</width>
+    <width>381</width>
     <height>566</height>
    </rect>
   </property>
@@ -62,6 +62,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="btnAddCategories">
+       <property name="toolTip">
+        <string>Add all missing categories from column or expression unique values</string>
+       </property>
        <property name="text">
         <string>Classify</string>
        </property>
@@ -70,7 +73,7 @@
      <item>
       <widget class="QPushButton" name="btnAddCategory">
        <property name="toolTip">
-        <string>Add</string>
+        <string>Add categories manually</string>
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">
@@ -81,7 +84,7 @@
      <item>
       <widget class="QPushButton" name="btnDeleteCategories">
        <property name="toolTip">
-        <string>Delete</string>
+        <string>Remove selected categories</string>
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">
@@ -91,6 +94,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnDeleteAllCategories">
+       <property name="toolTip">
+        <string>Remove all categories</string>
+       </property>
        <property name="text">
         <string>Delete all</string>
        </property>
@@ -145,7 +151,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
      <property name="maximumSize">
       <size>
        <width>500</width>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -6,11 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>434</width>
+    <width>442</width>
     <height>554</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="15" column="1">
+    <widget class="QPushButton" name="btnGraduatedClassify">
+     <property name="text">
+      <string>Classify</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -84,13 +91,6 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <widget class="QPushButton" name="btnGraduatedClassify">
-           <property name="text">
-            <string>Classify</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QPushButton" name="btnGraduatedAdd">
            <property name="toolTip">
             <string>Add class manually</string>
@@ -137,6 +137,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="btnAdvanced">
+           <property name="toolTip">
+            <string>Advanced options</string>
+           </property>
            <property name="text">
             <string>Advanced</string>
            </property>
@@ -195,7 +198,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -235,7 +238,7 @@
        <property name="value">
         <double>1.000000000000000</double>
        </property>
-       <property name="showClearButton">
+       <property name="showClearButton" stdset="0">
         <bool>false</bool>
        </property>
       </widget>
@@ -267,7 +270,7 @@
        <property name="value">
         <double>10.000000000000000</double>
        </property>
-       <property name="showClearButton">
+       <property name="showClearButton" stdset="0">
         <bool>false</bool>
        </property>
       </widget>
@@ -302,19 +305,6 @@
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Column</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1">
-    <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>14</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
      </property>
     </widget>
    </item>
@@ -492,12 +482,6 @@ Negative rounds to powers of 10</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsGraduatedHistogramWidget</class>
    <extends>QWidget</extends>
    <header>qgsgraduatedhistogramwidget.h</header>
@@ -514,12 +498,10 @@ Negative rounds to powers of 10</string>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>minSizeSpinBox</tabstop>
   <tabstop>maxSizeSpinBox</tabstop>
-  <tabstop>mSizeUnitWidget</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
   <tabstop>spinGraduatedClasses</tabstop>
   <tabstop>tabWidget</tabstop>
   <tabstop>viewGraduated</tabstop>
-  <tabstop>btnGraduatedClassify</tabstop>
   <tabstop>btnGraduatedAdd</tabstop>
   <tabstop>btnGraduatedDelete</tabstop>
   <tabstop>btnDeleteAllClasses</tabstop>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -93,7 +93,7 @@
          <item>
           <widget class="QPushButton" name="btnGraduatedAdd">
            <property name="toolTip">
-            <string>Add class</string>
+            <string>Add class manually</string>
            </property>
            <property name="icon">
             <iconset resource="../../images/images.qrc">
@@ -104,7 +104,7 @@
          <item>
           <widget class="QPushButton" name="btnGraduatedDelete">
            <property name="toolTip">
-            <string>Delete</string>
+            <string>Remove selected class(es)</string>
            </property>
            <property name="icon">
             <iconset resource="../../images/images.qrc">
@@ -114,6 +114,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="btnDeleteAllClasses">
+           <property name="toolTip">
+            <string>Remove all classes</string>
+           </property>
            <property name="text">
             <string>Delete all</string>
            </property>
@@ -192,7 +195,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -232,7 +235,7 @@
        <property name="value">
         <double>1.000000000000000</double>
        </property>
-       <property name="showClearButton" stdset="0">
+       <property name="showClearButton">
         <bool>false</bool>
        </property>
       </widget>
@@ -264,7 +267,7 @@
        <property name="value">
         <double>10.000000000000000</double>
        </property>
-       <property name="showClearButton" stdset="0">
+       <property name="showClearButton">
         <bool>false</bool>
        </property>
       </widget>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -11,249 +11,6 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btnChangeGraduatedSymbol">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>1</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Change...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Symbol</string>
-     </property>
-     <property name="buddy">
-      <cstring>btnChangeGraduatedSymbol</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>10</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>500</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Classes</string>
-       </property>
-       <property name="buddy">
-        <cstring>spinGraduatedClasses</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="spinGraduatedClasses">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>999</number>
-       </property>
-       <property name="value">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnGraduatedClassify">
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="1">
-    <widget class="QgsColorRampButton" name="btnColorRamp">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="lblColorRamp">
-     <property name="text">
-      <string>Color ramp</string>
-     </property>
-     <property name="buddy">
-      <cstring>btnColorRamp</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1">
-    <layout class="QHBoxLayout" name="layoutSize">
-     <item>
-      <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>999999999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="showClearButton">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="lblSizeTo">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>to</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QgsDoubleSpinBox" name="maxSizeSpinBox">
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>999999999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-       <property name="showClearButton">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLineEdit" name="txtLegendFormat">
-       <property name="toolTip">
-        <string>Template for the legend text associated with each classification.
-Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot; for the upper bound.</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="spinPrecision">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Precision of upper and lower values in label text.
-Positive is number of decimal places
-Negative rounds to powers of 10</string>
-       </property>
-       <property name="prefix">
-        <string>Precision </string>
-       </property>
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>10</number>
-       </property>
-       <property name="value">
-        <number>4</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="cbxTrimTrailingZeroes">
-       <property name="toolTip">
-        <string>Check to remove trailing zeroes after the decimal point from the upper and lower values in the legend.</string>
-       </property>
-       <property name="text">
-        <string>Trim</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -267,7 +24,20 @@ Negative rounds to powers of 10</string>
      </property>
     </widget>
    </item>
-   <item row="17" column="0" colspan="2">
+   <item row="1" column="1">
+    <widget class="QPushButton" name="btnChangeGraduatedSymbol">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Change...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0" colspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -313,6 +83,13 @@ Negative rounds to powers of 10</string>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QPushButton" name="btnGraduatedClassify">
+           <property name="text">
+            <string>Classify</string>
+           </property>
+          </widget>
+         </item>
          <item>
           <widget class="QPushButton" name="btnGraduatedAdd">
            <property name="toolTip">
@@ -392,10 +169,122 @@ Negative rounds to powers of 10</string>
      </widget>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="4" column="1">
+    <widget class="QgsColorRampButton" name="btnColorRamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>10</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>500</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
+    <layout class="QHBoxLayout" name="layoutSize">
+     <item>
+      <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>999999999.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="showClearButton" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblSizeTo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>to</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsDoubleSpinBox" name="maxSizeSpinBox">
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>999999999.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+       <property name="showClearButton" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Column</string>
+      <string>Method</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="lblColorRamp">
+     <property name="text">
+      <string>Color ramp</string>
+     </property>
+     <property name="buddy">
+      <cstring>btnColorRamp</cstring>
      </property>
     </widget>
    </item>
@@ -406,25 +295,113 @@ Negative rounds to powers of 10</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>Method</string>
+      <string>Column</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>14</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="lblSize">
+     <property name="text">
+      <string>Size from </string>
+     </property>
+     <property name="buddy">
+      <cstring>minSizeSpinBox</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLineEdit" name="txtLegendFormat">
+       <property name="toolTip">
+        <string>Template for the legend text associated with each classification.
+Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot; for the upper bound.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinPrecision">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Precision of upper and lower values in label text.
+Positive is number of decimal places
+Negative rounds to powers of 10</string>
+       </property>
+       <property name="prefix">
+        <string>Precision </string>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbxTrimTrailingZeroes">
+       <property name="toolTip">
+        <string>Check to remove trailing zeroes after the decimal point from the upper and lower values in the legend.</string>
+       </property>
+       <property name="text">
+        <string>Trim</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Symbol</string>
+     </property>
+     <property name="buddy">
+      <cstring>btnChangeGraduatedSymbol</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Mode</string>
+     </property>
+     <property name="buddy">
+      <cstring>cboGraduatedMode</cstring>
      </property>
     </widget>
    </item>
    <item row="14" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Mode</string>
-       </property>
-       <property name="buddy">
-        <cstring>cboGraduatedMode</cstring>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QComboBox" name="cboGraduatedMode">
        <property name="sizePolicy">
@@ -460,30 +437,36 @@ Negative rounds to powers of 10</string>
        </item>
       </widget>
      </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Classes</string>
+       </property>
+       <property name="buddy">
+        <cstring>spinGraduatedClasses</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinGraduatedClasses">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>999</number>
+       </property>
+       <property name="value">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="lblSize">
-     <property name="text">
-      <string>Size from </string>
-     </property>
-     <property name="buddy">
-      <cstring>minSizeSpinBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1">
-    <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>14</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>
@@ -528,9 +511,12 @@ Negative rounds to powers of 10</string>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>minSizeSpinBox</tabstop>
   <tabstop>maxSizeSpinBox</tabstop>
+  <tabstop>mSizeUnitWidget</tabstop>
+  <tabstop>cboGraduatedMode</tabstop>
+  <tabstop>spinGraduatedClasses</tabstop>
   <tabstop>tabWidget</tabstop>
   <tabstop>viewGraduated</tabstop>
-  <tabstop>cboGraduatedMode</tabstop>
+  <tabstop>btnGraduatedClassify</tabstop>
   <tabstop>btnGraduatedAdd</tabstop>
   <tabstop>btnGraduatedDelete</tabstop>
   <tabstop>btnDeleteAllClasses</tabstop>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -6,20 +6,36 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>442</width>
+    <width>434</width>
     <height>554</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="1" column="1">
+    <widget class="QPushButton" name="btnChangeGraduatedSymbol">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string>Column</string>
+      <string>Change...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Symbol</string>
+     </property>
+     <property name="buddy">
+      <cstring>btnChangeGraduatedSymbol</cstring>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true">
+    <widget class="QgsFieldExpressionWidget" name="mExpressionWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -43,120 +59,58 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Symbol</string>
-     </property>
-     <property name="buddy">
-      <cstring>btnChangeGraduatedSymbol</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btnChangeGraduatedSymbol">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>1</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Change...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Legend Format</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>txtLegendFormat</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
+   <item row="15" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLineEdit" name="txtLegendFormat">
-       <property name="toolTip">
-        <string>Template for the legend text associated with each classification.  
-Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot; for the upper bound.</string>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Classes</string>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       <property name="buddy">
+        <cstring>spinGraduatedClasses</cstring>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="spinPrecision">
+      <widget class="QSpinBox" name="spinGraduatedClasses">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="toolTip">
-        <string>Precision of upper and lower values in label text.
-Positive is number of decimal places
-Negative rounds to powers of 10</string>
-       </property>
-       <property name="prefix">
-        <string>Precision </string>
-       </property>
        <property name="minimum">
-        <number>0</number>
+        <number>1</number>
        </property>
        <property name="maximum">
-        <number>10</number>
+        <number>999</number>
        </property>
        <property name="value">
-        <number>4</number>
+        <number>5</number>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="cbxTrimTrailingZeroes">
-       <property name="toolTip">
-        <string>Check to remove trailing zeroes after the decimal point from the upper and lower values in the legend.</string>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnGraduatedClassify">
        <property name="text">
-        <string>Trim</string>
+        <string>Classify</string>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Method</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="methodComboBox">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose between color and size graduation. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If you want to combine both, use a data-defined size for the symbol and graduate by color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="lblColorRamp">
-     <property name="text">
-      <string>Color ramp</string>
-     </property>
-     <property name="buddy">
-      <cstring>btnColorRamp</cstring>
-     </property>
-    </widget>
    </item>
    <item row="4" column="1">
     <widget class="QgsColorRampButton" name="btnColorRamp">
@@ -180,17 +134,17 @@ Negative rounds to powers of 10</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lblSize">
+   <item row="4" column="0">
+    <widget class="QLabel" name="lblColorRamp">
      <property name="text">
-      <string>Size from </string>
+      <string>Color ramp</string>
      </property>
      <property name="buddy">
-      <cstring>minSizeSpinBox</cstring>
+      <cstring>btnColorRamp</cstring>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="12" column="1">
     <layout class="QHBoxLayout" name="layoutSize">
      <item>
       <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
@@ -245,20 +199,75 @@ Negative rounds to powers of 10</string>
      </item>
     </layout>
    </item>
-   <item row="6" column="1">
-    <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>14</width>
-       <height>0</height>
-      </size>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <property name="topMargin">
+      <number>0</number>
      </property>
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
+     <item>
+      <widget class="QLineEdit" name="txtLegendFormat">
+       <property name="toolTip">
+        <string>Template for the legend text associated with each classification.
+Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot; for the upper bound.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinPrecision">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Precision of upper and lower values in label text.
+Positive is number of decimal places
+Negative rounds to powers of 10</string>
+       </property>
+       <property name="prefix">
+        <string>Precision </string>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbxTrimTrailingZeroes">
+       <property name="toolTip">
+        <string>Check to remove trailing zeroes after the decimal point from the upper and lower values in the legend.</string>
+       </property>
+       <property name="text">
+        <string>Trim</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Legend Format</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>txtLegendFormat</cstring>
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="17" column="0" colspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -303,99 +312,7 @@ Negative rounds to powers of 10</string>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <item>
-          <widget class="QLabel" name="label_8">
-           <property name="text">
-            <string>Mode</string>
-           </property>
-           <property name="buddy">
-            <cstring>cboGraduatedMode</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cboGraduatedMode">
-           <item>
-            <property name="text">
-             <string>Equal Interval</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Quantile (Equal Count)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Natural Breaks (Jenks)</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Standard Deviation</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Pretty Breaks</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Classes</string>
-           </property>
-           <property name="buddy">
-            <cstring>spinGraduatedClasses</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="spinGraduatedClasses">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>999</number>
-           </property>
-           <property name="value">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QPushButton" name="btnGraduatedClassify">
-           <property name="text">
-            <string>Classify</string>
-           </property>
-          </widget>
-         </item>
          <item>
           <widget class="QPushButton" name="btnGraduatedAdd">
            <property name="toolTip">
@@ -475,6 +392,99 @@ Negative rounds to powers of 10</string>
      </widget>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Column</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="methodComboBox">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose between color and size graduation. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If you want to combine both, use a data-defined size for the symbol and graduate by color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Method</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Mode</string>
+       </property>
+       <property name="buddy">
+        <cstring>cboGraduatedMode</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cboGraduatedMode">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Equal Interval</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Quantile (Equal Count)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Natural Breaks (Jenks)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Standard Deviation</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Pretty Breaks</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="lblSize">
+     <property name="text">
+      <string>Size from </string>
+     </property>
+     <property name="buddy">
+      <cstring>minSizeSpinBox</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>14</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -490,15 +500,15 @@ Negative rounds to powers of 10</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -518,12 +528,9 @@ Negative rounds to powers of 10</string>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>minSizeSpinBox</tabstop>
   <tabstop>maxSizeSpinBox</tabstop>
-  <tabstop>mSizeUnitWidget</tabstop>
   <tabstop>tabWidget</tabstop>
   <tabstop>viewGraduated</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
-  <tabstop>spinGraduatedClasses</tabstop>
-  <tabstop>btnGraduatedClassify</tabstop>
   <tabstop>btnGraduatedAdd</tabstop>
   <tabstop>btnGraduatedDelete</tabstop>
   <tabstop>btnDeleteAllClasses</tabstop>

--- a/src/ui/qgspalettedrendererwidgetbase.ui
+++ b/src/ui/qgspalettedrendererwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>277</width>
+    <width>373</width>
     <height>459</height>
    </rect>
   </property>
@@ -80,12 +80,25 @@
       </widget>
      </item>
      <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QToolButton" name="mButtonAdvanced">
        <property name="toolTip">
         <string>Advanced options</string>
        </property>
        <property name="text">
-        <string>…</string>
+        <string>Advanced</string>
        </property>
        <property name="popupMode">
         <enum>QToolButton::InstantPopup</enum>

--- a/src/ui/qgspalettedrendererwidgetbase.ui
+++ b/src/ui/qgspalettedrendererwidgetbase.ui
@@ -27,17 +27,7 @@
     <number>3</number>
    </property>
    <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0,0,1,0">
-     <item>
-      <widget class="QPushButton" name="mClassifyButton">
-       <property name="toolTip">
-        <string>Adds all missing unique values from the raster</string>
-       </property>
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0,1,0,0">
      <item>
       <widget class="QPushButton" name="mAddEntryButton">
        <property name="sizePolicy">
@@ -143,22 +133,6 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="mBandLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Band</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
-     </item>
      <item row="1" column="1">
       <widget class="QgsColorRampButton" name="btnColorRamp">
        <property name="sizePolicy">
@@ -194,28 +168,53 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="mBandLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Band</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QPushButton" name="mClassifyButton">
+       <property name="toolTip">
+        <string>Adds all missing unique values from the raster</string>
+       </property>
+       <property name="text">
+        <string>Classify</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsRasterBandComboBox</class>
-   <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsRasterBandComboBox</class>
+   <extends>QComboBox</extends>
+   <header>raster/qgsrasterbandcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mBandComboBox</tabstop>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>mTreeView</tabstop>
-  <tabstop>mClassifyButton</tabstop>
   <tabstop>mAddEntryButton</tabstop>
   <tabstop>mDeleteEntryButton</tabstop>
   <tabstop>mButtonDeleteAll</tabstop>

--- a/src/ui/qgsrulebasedrendererv2widget.ui
+++ b/src/ui/qgsrulebasedrendererv2widget.ui
@@ -11,16 +11,7 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -73,7 +64,7 @@
      <item>
       <widget class="QPushButton" name="btnRemoveRule">
        <property name="toolTip">
-        <string>Remove selected rules</string>
+        <string>Remove selected rule(s)</string>
        </property>
        <property name="text">
         <string/>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -14,16 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>3</number>
-   </property>
-   <property name="topMargin">
-    <number>3</number>
-   </property>
-   <property name="rightMargin">
-    <number>3</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>3</number>
    </property>
    <item row="5" column="1" colspan="4">
@@ -173,6 +164,9 @@ suffix</string>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="mClassifyButton">
+       <property name="toolTip">
+        <string>Calculate all classes</string>
+       </property>
        <property name="text">
         <string>Classify</string>
        </property>
@@ -192,7 +186,7 @@ suffix</string>
      <item>
       <widget class="QPushButton" name="mDeleteEntryButton">
        <property name="toolTip">
-        <string>Remove selected row(s)</string>
+        <string>Remove selected value(s)</string>
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -14,47 +14,20 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
     <number>3</number>
    </property>
-   <item row="4" column="1" colspan="5">
-    <widget class="QgsColorRampButton" name="btnColorRamp">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mColorInterpolationLabel">
-     <property name="text">
-      <string>Interpolation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" rowspan="2" colspan="5">
+   <property name="topMargin">
+    <number>3</number>
+   </property>
+   <property name="rightMargin">
+    <number>3</number>
+   </property>
+   <property name="bottomMargin">
+    <number>3</number>
+   </property>
+   <item row="5" column="1" colspan="4">
     <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="mClassificationModeLabel">
-       <property name="text">
-        <string>Mode</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QComboBox" name="mClassificationModeComboBox">
        <property name="sizePolicy">
@@ -65,10 +38,6 @@
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item row="7" column="1" rowspan="2" colspan="5">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="mNumberOfEntriesLabel">
        <property name="text">
@@ -95,50 +64,9 @@
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mClassifyButton">
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
-   <item row="3" column="1" colspan="5">
-    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
-   </item>
-   <item row="1" column="5">
-    <widget class="QLineEdit" name="mMaxLineEdit"/>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="mUnitLabel">
-     <property name="text">
-      <string>Label unit
-suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1" colspan="5">
-    <widget class="QLineEdit" name="mUnitLineEdit">
-     <property name="toolTip">
-      <string>Unit suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="6">
+   <item row="9" column="0" colspan="5">
     <widget class="QTreeWidget" name="mColormapTreeWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -178,8 +106,78 @@ suffix</string>
      </column>
     </widget>
    </item>
-   <item row="13" column="0" colspan="6">
+   <item row="4" column="1" colspan="4">
+    <widget class="QgsColorRampButton" name="btnColorRamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mColorInterpolationLabel">
+     <property name="text">
+      <string>Interpolation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="4">
+    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
+   </item>
+   <item row="1" column="4">
+    <widget class="QLineEdit" name="mMaxLineEdit"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="mUnitLabel">
+     <property name="text">
+      <string>Label unit
+suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="mMinLineEdit"/>
+   </item>
+   <item row="8" column="1" colspan="4">
+    <widget class="QLineEdit" name="mUnitLineEdit">
+     <property name="toolTip">
+      <string>Unit suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="5">
+    <widget class="QCheckBox" name="mClipCheckBox">
+     <property name="toolTip">
+      <string>If checked, any pixels with a value out of range will not be rendered</string>
+     </property>
+     <property name="text">
+      <string>Hide out of range values</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QPushButton" name="mClassifyButton">
+       <property name="text">
+        <string>Classify</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QPushButton" name="mAddEntryButton">
        <property name="toolTip">
@@ -250,17 +248,7 @@ suffix</string>
      </item>
     </layout>
    </item>
-   <item row="14" column="0" colspan="6">
-    <widget class="QCheckBox" name="mClipCheckBox">
-     <property name="toolTip">
-      <string>If checked, any pixels with a value out of range will not be rendered</string>
-     </property>
-     <property name="text">
-      <string>Hide out of range values</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="4">
+   <item row="1" column="3">
     <widget class="QLabel" name="mMaxLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -293,10 +281,10 @@ suffix</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="5">
+   <item row="0" column="1" colspan="4">
     <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
    </item>
-   <item row="2" column="0" colspan="6">
+   <item row="2" column="0" colspan="5">
     <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
    </item>
    <item row="0" column="0">
@@ -306,22 +294,26 @@ suffix</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="mMinLineEdit"/>
+   <item row="5" column="0">
+    <widget class="QLabel" name="mClassificationModeLabel">
+     <property name="text">
+      <string>Mode</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsRasterBandComboBox</class>
-   <extends>QComboBox</extends>
-   <header>raster/qgsrasterbandcombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsColorRampButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsRasterBandComboBox</class>
+   <extends>QComboBox</extends>
+   <header>raster/qgsrasterbandcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -330,8 +322,11 @@ suffix</string>
   <tabstop>mMaxLineEdit</tabstop>
   <tabstop>mColorInterpolationComboBox</tabstop>
   <tabstop>btnColorRamp</tabstop>
+  <tabstop>mClassificationModeComboBox</tabstop>
+  <tabstop>mNumberOfEntriesSpinBox</tabstop>
   <tabstop>mUnitLineEdit</tabstop>
   <tabstop>mColormapTreeWidget</tabstop>
+  <tabstop>mClassifyButton</tabstop>
   <tabstop>mAddEntryButton</tabstop>
   <tabstop>mDeleteEntryButton</tabstop>
   <tabstop>mLoadFromBandButton</tabstop>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -6,27 +6,59 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>396</width>
-    <height>605</height>
+    <width>688</width>
+    <height>525</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
+   <property name="margin">
     <number>3</number>
    </property>
-   <property name="topMargin">
-    <number>3</number>
-   </property>
-   <property name="rightMargin">
-    <number>3</number>
-   </property>
-   <property name="bottomMargin">
-    <number>3</number>
-   </property>
-   <item row="6" column="0" colspan="5">
+   <item row="4" column="1" colspan="4">
+    <widget class="QgsColorRampButton" name="btnColorRamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="4">
+    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="mMinLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Min</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QLineEdit" name="mMaxLineEdit"/>
+   </item>
+   <item row="7" column="0" colspan="5">
     <widget class="QTreeWidget" name="mColormapTreeWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -66,64 +98,6 @@
      </column>
     </widget>
    </item>
-   <item row="4" column="1" colspan="4">
-    <widget class="QgsColorRampButton" name="btnColorRamp">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="mColorInterpolationLabel_2">
-     <property name="text">
-      <string>Color ramp</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="4">
-    <widget class="QLineEdit" name="mMaxLineEdit"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="mMinLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="4">
-    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
-   </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mBandLabel">
-     <property name="text">
-      <string>Band</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="3">
     <widget class="QLabel" name="mMaxLabel">
      <property name="sizePolicy">
@@ -137,22 +111,18 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mColorInterpolationLabel">
-     <property name="text">
-      <string>Interpolation</string>
+   <item row="6" column="1" colspan="4">
+    <widget class="QLineEdit" name="mUnitLineEdit">
+     <property name="toolTip">
+      <string>Unit suffix</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="5">
+   <item row="2" column="0" colspan="5">
+    <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
+   </item>
+   <item row="9" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QPushButton" name="mClassifyButton">
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QPushButton" name="mAddEntryButton">
        <property name="toolTip">
@@ -223,20 +193,52 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mBandLabel">
+     <property name="text">
+      <string>Band</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="mUnitLabel">
+     <property name="text">
+      <string>Label unit
+suffix</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="2">
     <widget class="QLineEdit" name="mMinLineEdit"/>
    </item>
-   <item row="9" column="0" colspan="5">
+   <item row="10" column="0" colspan="5">
     <widget class="QCheckBox" name="mClipCheckBox">
      <property name="toolTip">
       <string>If checked, any pixels with a value out of range will not be rendered</string>
      </property>
      <property name="text">
-      <string>Clip out of range values</string>
+      <string>Hide out of range values</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="5">
+   <item row="3" column="0">
+    <widget class="QLabel" name="mColorInterpolationLabel">
+     <property name="text">
+      <string>Interpolation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="mColorInterpolationLabel_2">
+     <property name="text">
+      <string>Color ramp</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QLabel" name="mClassificationModeLabel">
@@ -287,25 +289,27 @@
        </property>
       </widget>
      </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="mClassifyButton">
+       <property name="text">
+        <string>Classify</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item row="5" column="1" colspan="4">
-    <widget class="QLineEdit" name="mUnitLineEdit">
-     <property name="toolTip">
-      <string>Unit suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="5">
-    <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="mUnitLabel">
-     <property name="text">
-      <string>Label unit
-suffix</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>
@@ -332,7 +336,6 @@ suffix</string>
   <tabstop>mColormapTreeWidget</tabstop>
   <tabstop>mClassificationModeComboBox</tabstop>
   <tabstop>mNumberOfEntriesSpinBox</tabstop>
-  <tabstop>mClassifyButton</tabstop>
   <tabstop>mAddEntryButton</tabstop>
   <tabstop>mDeleteEntryButton</tabstop>
   <tabstop>mLoadFromBandButton</tabstop>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>688</width>
-    <height>525</height>
+    <width>355</width>
+    <height>557</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="margin">
     <number>3</number>
    </property>
-   <item row="4" column="1" colspan="4">
+   <item row="4" column="1" colspan="5">
     <widget class="QgsColorRampButton" name="btnColorRamp">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -39,26 +39,106 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="4">
-    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="mMinLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mColorInterpolationLabel">
      <property name="text">
-      <string>Min</string>
+      <string>Interpolation</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
+   <item row="5" column="1" rowspan="2" colspan="5">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="mClassificationModeLabel">
+       <property name="text">
+        <string>Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="mClassificationModeComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="1" rowspan="2" colspan="5">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="mNumberOfEntriesLabel">
+       <property name="text">
+        <string>Classes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="mNumberOfEntriesSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimum">
+        <number>2</number>
+       </property>
+       <property name="maximum">
+        <number>255</number>
+       </property>
+       <property name="value">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="mClassifyButton">
+       <property name="text">
+        <string>Classify</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="1" colspan="5">
+    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
+   </item>
+   <item row="1" column="5">
     <widget class="QLineEdit" name="mMaxLineEdit"/>
    </item>
-   <item row="7" column="0" colspan="5">
+   <item row="10" column="0">
+    <widget class="QLabel" name="mUnitLabel">
+     <property name="text">
+      <string>Label unit
+suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1" colspan="5">
+    <widget class="QLineEdit" name="mUnitLineEdit">
+     <property name="toolTip">
+      <string>Unit suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="6">
     <widget class="QTreeWidget" name="mColormapTreeWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -98,30 +178,7 @@
      </column>
     </widget>
    </item>
-   <item row="1" column="3">
-    <widget class="QLabel" name="mMaxLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Max</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="4">
-    <widget class="QLineEdit" name="mUnitLineEdit">
-     <property name="toolTip">
-      <string>Unit suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="5">
-    <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
-   </item>
-   <item row="9" column="0" colspan="5">
+   <item row="13" column="0" colspan="6">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="mAddEntryButton">
@@ -193,25 +250,7 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mBandLabel">
-     <property name="text">
-      <string>Band</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="mUnitLabel">
-     <property name="text">
-      <string>Label unit
-suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="mMinLineEdit"/>
-   </item>
-   <item row="10" column="0" colspan="5">
+   <item row="14" column="0" colspan="6">
     <widget class="QCheckBox" name="mClipCheckBox">
      <property name="toolTip">
       <string>If checked, any pixels with a value out of range will not be rendered</string>
@@ -221,15 +260,18 @@ suffix</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mColorInterpolationLabel">
+   <item row="1" column="4">
+    <widget class="QLabel" name="mMaxLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string>Interpolation</string>
+      <string>Max</string>
      </property>
     </widget>
-   </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
    </item>
    <item row="4" column="0">
     <widget class="QLabel" name="mColorInterpolationLabel_2">
@@ -238,78 +280,34 @@ suffix</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="5">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QLabel" name="mClassificationModeLabel">
-       <property name="text">
-        <string>Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="mClassificationModeComboBox"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="mNumberOfEntriesLabel">
-       <property name="text">
-        <string>Classes</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="mNumberOfEntriesSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimum">
-        <number>2</number>
-       </property>
-       <property name="maximum">
-        <number>255</number>
-       </property>
-       <property name="value">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mClassifyButton">
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="1">
+    <widget class="QLabel" name="mMinLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Min</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="5">
+    <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
+   </item>
+   <item row="2" column="0" colspan="6">
+    <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mBandLabel">
+     <property name="text">
+      <string>Band</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="mMinLineEdit"/>
    </item>
   </layout>
  </widget>
@@ -334,8 +332,6 @@ suffix</string>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>mUnitLineEdit</tabstop>
   <tabstop>mColormapTreeWidget</tabstop>
-  <tabstop>mClassificationModeComboBox</tabstop>
-  <tabstop>mNumberOfEntriesSpinBox</tabstop>
   <tabstop>mAddEntryButton</tabstop>
   <tabstop>mDeleteEntryButton</tabstop>
   <tabstop>mLoadFromBandButton</tabstop>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -14,9 +14,58 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
     <number>3</number>
    </property>
+   <property name="topMargin">
+    <number>3</number>
+   </property>
+   <property name="rightMargin">
+    <number>3</number>
+   </property>
+   <property name="bottomMargin">
+    <number>3</number>
+   </property>
+   <item row="11" column="0" colspan="2">
+    <widget class="QTreeWidget" name="mColormapTreeWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+     <attribute name="headerDefaultSectionSize">
+      <number>70</number>
+     </attribute>
+     <attribute name="headerMinimumSectionSize">
+      <number>10</number>
+     </attribute>
+     <attribute name="headerStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Value</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Color</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Label</string>
+      </property>
+     </column>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="mBandLabel">
      <property name="text">
@@ -56,6 +105,9 @@ suffix</string>
    <item row="0" column="1">
     <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
    </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
+   </item>
    <item row="1" column="1">
     <layout class="QHBoxLayout" name="minMaxHorizontalLayout">
      <item>
@@ -91,9 +143,6 @@ suffix</string>
       <widget class="QLineEdit" name="mMaxLineEdit"/>
      </item>
     </layout>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
    </item>
    <item row="5" column="1">
     <widget class="QgsColorRampButton" name="btnColorRamp">
@@ -164,58 +213,8 @@ suffix</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QTreeWidget" name="mColormapTreeWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>250</height>
-      </size>
-     </property>
-     <attribute name="headerDefaultSectionSize">
-      <number>70</number>
-     </attribute>
-     <attribute name="headerMinimumSectionSize">
-      <number>10</number>
-     </attribute>
-     <attribute name="headerStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Value</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Color</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Label</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="2">
+   <item row="13" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QPushButton" name="mClassifyButton">
-       <property name="toolTip">
-        <string>Calculate all classes</string>
-       </property>
-       <property name="text">
-        <string>Classify</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QPushButton" name="mAddEntryButton">
        <property name="toolTip">
@@ -286,7 +285,7 @@ suffix</string>
      </item>
     </layout>
    </item>
-   <item row="13" column="0" colspan="2">
+   <item row="14" column="0" colspan="2">
     <widget class="QCheckBox" name="mClipCheckBox">
      <property name="toolTip">
       <string>If checked, any pixels with a value out of range will not be rendered</string>
@@ -298,6 +297,16 @@ suffix</string>
    </item>
    <item row="2" column="0" colspan="2">
     <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
+   </item>
+   <item row="10" column="1">
+    <widget class="QPushButton" name="mClassifyButton">
+     <property name="toolTip">
+      <string>Calculate all classes</string>
+     </property>
+     <property name="text">
+      <string>Classify</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -322,7 +331,6 @@ suffix</string>
   <tabstop>mNumberOfEntriesSpinBox</tabstop>
   <tabstop>mUnitLineEdit</tabstop>
   <tabstop>mColormapTreeWidget</tabstop>
-  <tabstop>mClassifyButton</tabstop>
   <tabstop>mAddEntryButton</tabstop>
   <tabstop>mDeleteEntryButton</tabstop>
   <tabstop>mLoadFromBandButton</tabstop>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>355</width>
-    <height>557</height>
+    <width>337</width>
+    <height>559</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,107 @@
    <property name="margin">
     <number>3</number>
    </property>
-   <item row="5" column="1" colspan="4">
+   <item row="0" column="0">
+    <widget class="QLabel" name="mBandLabel">
+     <property name="text">
+      <string>Band</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="mColorInterpolationLabel">
+     <property name="text">
+      <string>Interpolation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="mClassificationModeLabel">
+     <property name="text">
+      <string>Mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="mUnitLabel">
+     <property name="text">
+      <string>Label unit
+suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="mColorInterpolationLabel_2">
+     <property name="text">
+      <string>Color ramp</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
+   </item>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="minMaxHorizontalLayout">
+     <item>
+      <widget class="QLabel" name="mMinLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="mMinLineEdit"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="mMaxLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="mMaxLineEdit"/>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
+   </item>
+   <item row="5" column="1">
+    <widget class="QgsColorRampButton" name="btnColorRamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QComboBox" name="mClassificationModeComboBox">
@@ -57,7 +157,14 @@
      </item>
     </layout>
    </item>
-   <item row="9" column="0" colspan="5">
+   <item row="9" column="1">
+    <widget class="QLineEdit" name="mUnitLineEdit">
+     <property name="toolTip">
+      <string>Unit suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
     <widget class="QTreeWidget" name="mColormapTreeWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -97,70 +204,7 @@
      </column>
     </widget>
    </item>
-   <item row="4" column="1" colspan="4">
-    <widget class="QgsColorRampButton" name="btnColorRamp">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mColorInterpolationLabel">
-     <property name="text">
-      <string>Interpolation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="4">
-    <widget class="QComboBox" name="mColorInterpolationComboBox"/>
-   </item>
-   <item row="1" column="4">
-    <widget class="QLineEdit" name="mMaxLineEdit"/>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="mUnitLabel">
-     <property name="text">
-      <string>Label unit
-suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="mMinLineEdit"/>
-   </item>
-   <item row="8" column="1" colspan="4">
-    <widget class="QLineEdit" name="mUnitLineEdit">
-     <property name="toolTip">
-      <string>Unit suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="5">
-    <widget class="QCheckBox" name="mClipCheckBox">
-     <property name="toolTip">
-      <string>If checked, any pixels with a value out of range will not be rendered</string>
-     </property>
-     <property name="text">
-      <string>Hide out of range values</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="5">
+   <item row="12" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="mClassifyButton">
@@ -242,58 +286,18 @@ suffix</string>
      </item>
     </layout>
    </item>
-   <item row="1" column="3">
-    <widget class="QLabel" name="mMaxLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="13" column="0" colspan="2">
+    <widget class="QCheckBox" name="mClipCheckBox">
+     <property name="toolTip">
+      <string>If checked, any pixels with a value out of range will not be rendered</string>
      </property>
      <property name="text">
-      <string>Max</string>
+      <string>Hide out of range values</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="mColorInterpolationLabel_2">
-     <property name="text">
-      <string>Color ramp</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="mMinLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QgsRasterBandComboBox" name="mBandComboBox"/>
-   </item>
-   <item row="2" column="0" colspan="5">
+   <item row="2" column="0" colspan="2">
     <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mBandLabel">
-     <property name="text">
-      <string>Band</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="mClassificationModeLabel">
-     <property name="text">
-      <string>Mode</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>
@@ -312,8 +316,6 @@ suffix</string>
  </customwidgets>
  <tabstops>
   <tabstop>mBandComboBox</tabstop>
-  <tabstop>mMinLineEdit</tabstop>
-  <tabstop>mMaxLineEdit</tabstop>
   <tabstop>mColorInterpolationComboBox</tabstop>
   <tabstop>btnColorRamp</tabstop>
   <tabstop>mClassificationModeComboBox</tabstop>


### PR DESCRIPTION
## Description

### Moves Classify related widgets next to the Color Ramp.

IMHO, classify has nothing to do with the Add, Remove, load... buttons. and it's totally related to the Mode and classes widgets, so it should be in the same line. Assuming that the user's workflow steps will be: set the mode; choose the number of classes; and hit Classify; I decided for the right side.

Besides, these three widgets are also related to the color ramp, so I move them next to it. I would have preferred to keep the three widgets below the color ramp selector (excluding the label) but in Docker mode, it would be too large.

I also prefer that the Add, Remove, etc... buttons are as close as possible to the tree widget they are related to. and this way they are.

### Changes Clip out of range values text

The text "Clip out of range values" sounded unclear to me, as for me clipping is associated to cut off a part. I propose change it to *"Hide out of range values"*. Alternatively it could be *"Don't show out of range values"*

### Screenshots

**Current state**

![image](https://cloud.githubusercontent.com/assets/3607161/26658400/baaea812-4661-11e7-9aa3-52d6e673163d.png)

![image](https://cloud.githubusercontent.com/assets/3607161/26658456/2526fa82-4662-11e7-8234-1ce097acc3ce.png)

**Proposal**

![screenshot from 2017-06-01 00-06-47](https://cloud.githubusercontent.com/assets/3607161/26658317/2d5d35aa-4661-11e7-9661-c1ec69f2c526.png)

![screenshot from 2017-06-01 00-07-21](https://cloud.githubusercontent.com/assets/3607161/26658320/3142254a-4661-11e7-9611-a21b2a457602.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
