### PR TITLE
add building with oracle dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -368,7 +368,7 @@ new subdirectory called `build` or `build-qt5` in it.
   clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel
   qt5-qtsvg-devel qt5-qtxmlpatterns-devel spatialindex-devel expat-devel proj-devel
   qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3
-  python3-psycopg2 python3-PyYAML qca-qt5-ossl
+  python3-psycopg2 python3-PyYAML qca-qt5-ossl qtbase5-private-dev
 
 To build QGIS server additional dependencies are required:
 

--- a/doc/linux.t2t
+++ b/doc/linux.t2t
@@ -258,7 +258,7 @@ qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5
 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel
 qt5-qtsvg-devel qt5-qtxmlpatterns-devel spatialindex-devel expat-devel proj-devel
 qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3
-python3-psycopg2 python3-PyYAML qca-qt5-ossl
+python3-psycopg2 python3-PyYAML qca-qt5-ossl qtbase5-private-dev
 ```
 
 To build QGIS server additional dependencies are required:


### PR DESCRIPTION
## Description
Add missing dependency for building with oracle.
Without it, I got:
```
..src/providers/oracle/ocispatial/qsql_ocispatial.cpp:61:46: fatal error: QtSql/private/qsqlcachedresult_p.h: No such file or directory
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
