### PR TITLE
When holding ctrl while mouse wheeling on spin box, increase in smaller amounts

### DIFF
--- a/python/gui/editorwidgets/qgsdoublespinbox.sip
+++ b/python/gui/editorwidgets/qgsdoublespinbox.sip
@@ -117,6 +117,8 @@ Set the current value to the value defined by the clear value.
 
   protected:
     virtual void changeEvent( QEvent *event );
+    virtual void wheelEvent( QWheelEvent *event );
+
 
 };
 

--- a/python/gui/editorwidgets/qgsspinbox.sip
+++ b/python/gui/editorwidgets/qgsspinbox.sip
@@ -117,6 +117,8 @@ Set the current value to the value defined by the clear value.
 
     virtual void changeEvent( QEvent *event );
     virtual void paintEvent( QPaintEvent *event );
+    virtual void wheelEvent( QWheelEvent *event );
+
 
 };
 

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -62,6 +62,28 @@ void QgsDoubleSpinBox::changeEvent( QEvent *event )
   mLineEdit->setShowClearButton( shouldShowClearForValue( value() ) );
 }
 
+void QgsDoubleSpinBox::wheelEvent( QWheelEvent *event )
+{
+  double step = singleStep();
+  if ( event->modifiers() & Qt::ControlModifier )
+  {
+    // ctrl modifier results in finer increments - 10% of usual step
+    double newStep = step / 10;
+    // but don't ever use an increment smaller than would be visible in the widget
+    // i.e. if showing 2 decimals, smallest increment will be 0.01
+    newStep = qMax( newStep, pow( 10.0, 0.0 - decimals() ) );
+
+    setSingleStep( newStep );
+
+    // clear control modifier before handing off event - Qt uses it for unwanted purposes
+    // (*increasing* step size, whereas QGIS UX convention is that control modifier
+    // results in finer changes!)
+    event->setModifiers( event->modifiers() & ~Qt::ControlModifier );
+  }
+  QDoubleSpinBox::wheelEvent( event );
+  setSingleStep( step );
+}
+
 void QgsDoubleSpinBox::paintEvent( QPaintEvent *event )
 {
   mLineEdit->setShowClearButton( shouldShowClearForValue( value() ) );

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -125,6 +125,7 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
 
   protected:
     virtual void changeEvent( QEvent *event ) override;
+    void wheelEvent( QWheelEvent *event ) override;
 
   private slots:
     void changed( double value );

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -68,6 +68,27 @@ void QgsSpinBox::paintEvent( QPaintEvent *event )
   QSpinBox::paintEvent( event );
 }
 
+void QgsSpinBox::wheelEvent( QWheelEvent *event )
+{
+  int step = singleStep();
+  if ( event->modifiers() & Qt::ControlModifier )
+  {
+    // ctrl modifier results in finer increments - 10% of usual step
+    int newStep = step / 10;
+    // step should be at least 1
+    newStep = qMax( newStep, 1 );
+
+    setSingleStep( newStep );
+
+    // clear control modifier before handing off event - Qt uses it for unwanted purposes
+    // (*increasing* step size, whereas QGIS UX convention is that control modifier
+    // results in finer changes!)
+    event->setModifiers( event->modifiers() & ~Qt::ControlModifier );
+  }
+  QSpinBox::wheelEvent( event );
+  setSingleStep( step );
+}
+
 void QgsSpinBox::changed( int value )
 {
   mLineEdit->setShowClearButton( shouldShowClearForValue( value ) );

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -126,6 +126,7 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
 
     virtual void changeEvent( QEvent *event ) override;
     virtual void paintEvent( QPaintEvent *event ) override;
+    void wheelEvent( QWheelEvent *event ) override;
 
   private slots:
     void changed( int value );


### PR DESCRIPTION
Default Qt behavior is to increase step size 10x when ctrl is held while mouse wheel - but everywhere else in QGIS UI we use the ctrl modifier as a "finer" increment with the mouse wheel (e.g. ctrl+wheel = fine zoom into map/composer). 

So override Qt's behavior and instead make ctrl modifier result in 1/10th usual increment for spin boxes.