### PR TITLE
New classes QgsMenuHeader, QgsMenuHeaderWidgetAction

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -119,6 +119,7 @@
 %Include qgsmaptoolpan.sip
 %Include qgsmaptoolzoom.sip
 %Include qgsmaplayerstylemanagerwidget.sip
+%Include qgsmenuheader.sip
 %Include qgsmessagebar.sip
 %Include qgsmessagebaritem.sip
 %Include qgsmessagelogviewer.sip

--- a/python/gui/qgsmenuheader.sip
+++ b/python/gui/qgsmenuheader.sip
@@ -1,0 +1,65 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsmenuheader.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsMenuHeader : QWidget
+{
+%Docstring
+ Custom widget for displaying subheaders within a QMenu in a standard style.
+.. versionadded:: 3.0
+.. seealso:: QgsMenuHeaderWidgetAction()
+%End
+
+%TypeHeaderCode
+#include "qgsmenuheader.h"
+%End
+  public:
+
+    explicit QgsMenuHeader( const QString &text, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+ Constructor for QgsMenuHeader, showing the specified ``text``.
+%End
+
+    virtual QSize minimumSizeHint() const;
+    virtual QSize sizeHint() const;
+
+  protected:
+
+    virtual void paintEvent( QPaintEvent *event );
+
+
+};
+
+class QgsMenuHeaderWidgetAction: QWidgetAction
+{
+%Docstring
+ Custom QWidgetAction for displaying subheaders within a QMenu in a standard style.
+.. versionadded:: 3.0
+.. seealso:: QgsMenuHeader()
+%End
+
+%TypeHeaderCode
+#include "qgsmenuheader.h"
+%End
+  public:
+
+    QgsMenuHeaderWidgetAction( const QString &text, QObject *parent = 0 );
+%Docstring
+ Constructor for QgsMenuHeaderWidgetAction, showing the specified ``text``.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsmenuheader.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -264,6 +264,7 @@ SET(QGIS_GUI_SRCS
   qgsmaptoolpan.cpp
   qgsmaptoolzoom.cpp
   qgsmaplayerconfigwidget.cpp
+  qgsmenuheader.cpp
   qgsmessagebar.cpp
   qgsmessagebaritem.cpp
   qgsmessagelogviewer.cpp
@@ -413,6 +414,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsmaptoolpan.h
   qgsmaptoolzoom.h
   qgsmaplayerconfigwidget.h
+  qgsmenuheader.h
   qgsmessagebar.h
   qgsmessagebaritem.h
   qgsmessagelogviewer.h

--- a/src/gui/qgsmenuheader.cpp
+++ b/src/gui/qgsmenuheader.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+                             qgsmenuheader.cpp
+                             -----------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmenuheader.h"
+#include <QPainter>
+#include <QApplication>
+
+#define LABEL_SIZE 20 //label rect height
+#define LABEL_MARGIN 4 //spacing between label box and text
+
+QgsMenuHeader::QgsMenuHeader( const QString &text, QWidget *parent )
+  : QWidget( parent )
+  , mText( text )
+{
+  int textMinWidth = fontMetrics().width( mText );
+  mMinWidth = 2 * LABEL_MARGIN + textMinWidth;
+  setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Fixed );
+  updateGeometry();
+}
+
+QSize QgsMenuHeader::minimumSizeHint() const
+{
+  return QSize( mMinWidth, LABEL_SIZE );
+}
+
+QSize QgsMenuHeader::sizeHint() const
+{
+  return QSize( mMinWidth, LABEL_SIZE );
+}
+
+void QgsMenuHeader::paintEvent( QPaintEvent * )
+{
+  QPainter painter( this );
+  QPalette pal = QPalette( qApp->palette() );
+  QColor headerBgColor = pal.color( QPalette::Mid );
+  QColor headerTextColor = pal.color( QPalette::BrightText );
+
+  //draw header background
+  painter.setBrush( headerBgColor );
+  painter.setPen( Qt::NoPen );
+  painter.drawRect( QRect( 0, 0, width(), LABEL_SIZE ) );
+
+  //draw header text
+  painter.setPen( headerTextColor );
+  painter.drawText( QRect( LABEL_MARGIN, 0, width() - 2 * LABEL_MARGIN, LABEL_SIZE ),
+                    Qt::AlignLeft | Qt::AlignVCenter, mText );
+  painter.end();
+}
+
+QgsMenuHeaderWidgetAction::QgsMenuHeaderWidgetAction( const QString &text, QObject *parent )
+  : QWidgetAction( parent )
+{
+  QgsMenuHeader *w = new QgsMenuHeader( text, nullptr );
+  setDefaultWidget( w ); //transfers ownership
+}

--- a/src/gui/qgsmenuheader.h
+++ b/src/gui/qgsmenuheader.h
@@ -1,0 +1,74 @@
+/***************************************************************************
+                             qgsmenuheader.h
+                             ---------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSMENUHEADER_H
+#define QGSMENUHEADER_H
+
+#include <QWidget>
+#include <QWidgetAction>
+#include "qgis_gui.h"
+#include "qgis.h"
+
+/** \ingroup gui
+ * \class QgsMenuHeader
+ * Custom widget for displaying subheaders within a QMenu in a standard style.
+ * \since QGIS 3.0
+ * \see QgsMenuHeaderWidgetAction()
+ */
+class GUI_EXPORT QgsMenuHeader : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsMenuHeader, showing the specified \a text.
+     */
+    explicit QgsMenuHeader( const QString &text, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    virtual QSize minimumSizeHint() const override;
+    virtual QSize sizeHint() const override;
+
+  protected:
+
+    void paintEvent( QPaintEvent *event ) override;
+
+  private:
+    int mMinWidth = 0;
+    QString mText;
+
+};
+
+/** \ingroup gui
+ * \class QgsMenuHeader
+ * Custom QWidgetAction for displaying subheaders within a QMenu in a standard style.
+ * \since QGIS 3.0
+ * \see QgsMenuHeader()
+ */
+class GUI_EXPORT QgsMenuHeaderWidgetAction: public QWidgetAction
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsMenuHeaderWidgetAction, showing the specified \a text.
+     */
+    QgsMenuHeaderWidgetAction( const QString &text, QObject *parent = nullptr );
+
+};
+
+#endif //QGSMENUHEADER_H


### PR DESCRIPTION
Some convenient custom widgets designed for displaying subheaders within a QMenu in a standard style (i.e. matching the subheaders shown within the color button drop down menus):

![image](https://cloud.githubusercontent.com/assets/1829991/26706131/4ef573c6-477e-11e7-93a8-ae7ca2b95121.png)
