### PR TITLE
No more QgsGeometry pointers in the public API

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -123,7 +123,7 @@
 %Include qgspathresolver.sip
 %Include qgspluginlayer.sip
 %Include qgspluginlayerregistry.sip
-%Include qgspoint.sip
+%Include qgspointxy.sip
 %Include qgspointlocator.sip
 %Include qgsproject.sip
 %Include qgsprojectbadlayerhandler.sip
@@ -398,7 +398,7 @@
 %Include geometry/qgsmultipoint.sip
 %Include geometry/qgsmultipolygon.sip
 %Include geometry/qgsmultisurface.sip
-%Include geometry/qgspointv2.sip
+%Include geometry/qgspoint.sip
 %Include geometry/qgspolygon.sip
 %Include geometry/qgsrectangle.sip
 %Include geometry/qgsregularpolygon.sip

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -22,12 +22,31 @@ class QgsPoint: QgsAbstractGeometry
 %End
   public:
 
-    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown )];
 %Docstring
  Construct a point with the provided initial coordinate values.
 
- If only z and m are not specified, the type will be a 2D point.
- If any or both of the others are specified, the Z and M values will be added accordingly.
+ If ``wkbType`` is set to `QgsWkbTypes.Point`, `QgsWkbTypes.PointZ`, `QgsWkbTypes.PointM` or `QgsWkbTypes.PointZM`
+ the type will be set accordingly. If it is left to the default `QgsWkbTypes.Unknown`, the type will be set
+ based on the following rules:
+ - If only x and y are specified, the type will be a 2D point.
+ - If any or both of the Z and M are specified, the appropriate type will be created.
+
+ \code{.py}
+   pt = QgsPoint(43.4, 5.3)
+   pt.exportToWkt() # Point(43.4 5.3)
+
+   pt_z = QgsPoint(120, 343, 77)
+   pt.exportToWkt() # PointZ(120 343 77)
+
+   pt_m = QgsPoint(33, 88, m=5)
+   pt_m.m() # 5
+   pt_m.wkbType() # QgsWkbTypes.PointM
+
+   pt = QgsPoint(30, 40, wkbType=QgsWkbTypes.PointZ)
+   pt.z() # nan
+   pt.wkbType() # QgsWkbTypes.PointZ
+ \endcode
 %End
 %MethodCode
     double z;
@@ -51,7 +70,7 @@ class QgsPoint: QgsAbstractGeometry
       m = PyFloat_AsDouble( a3 );
     }
 
-    sipCpp = new sipQgsPoint( a0, a1, z, m );
+    sipCpp = new sipQgsPoint( a0, a1, z, m, a4 );
 %End
 
     explicit QgsPoint( const QgsPointXY &p );
@@ -64,27 +83,6 @@ class QgsPoint: QgsAbstractGeometry
  Construct a QgsPoint from a QPointF
 %End
 
-    QgsPoint( QgsWkbTypes::Type type, double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
-%Docstring
- Construct a point with a specified type (e.g., PointZ, PointM) and initial x, y, z, and m values.
- \param type point type
- \param x x-coordinate of point
- \param y y-coordinate of point
- \param z z-coordinate of point, for PointZ or PointZM types
- \param m m-value of point, for PointM or PointZM types
-%End
-%MethodCode
-    if ( QgsWkbTypes::flatType( a0 ) != QgsWkbTypes::Point )
-    {
-      PyErr_SetString( PyExc_ValueError,
-                       QString( "%1 is not a valid WKB type for point geometries" ).arg( QgsWkbTypes::displayString( a0 ) ).toUtf8().constData() );
-      sipIsErr = 1;
-    }
-    else
-    {
-      sipCpp = new sipQgsPoint( a0, a1, a2, a3, a4 );
-    }
-%End
 
     bool operator==( const QgsPoint &pt ) const;
     bool operator!=( const QgsPoint &pt ) const;

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -22,9 +22,36 @@ class QgsPoint: QgsAbstractGeometry
 %End
   public:
 
-    QgsPoint( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
-%Docstring
- Construct a point with the provided initial coordinate values.
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    % Docstring
+    Construct a point with the provided initial coordinate values.
+
+    If only z and m are not specified, the type will be a 2D point.
+    If any or both of the others are specified, the Z and M values will be added accordingly.
+%End
+%MethodCode
+    double z;
+    double m;
+
+    if ( a2 == Py_None )
+    {
+      z = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      z = PyFloat_AsDouble( a2 );
+    }
+
+    if ( a3 == Py_None )
+    {
+      m = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      m = PyFloat_AsDouble( a3 );
+    }
+
+    sipCpp = new sipQgsPoint( a0, a1, z, m );
 %End
 
     explicit QgsPoint( const QgsPointXY &p );

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -1,7 +1,7 @@
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/geometry/qgspointv2.h                                       *
+ * src/core/geometry/qgspoint.h                                         *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/
@@ -22,11 +22,9 @@ class QgsPoint: QgsAbstractGeometry
 %End
   public:
 
-    QgsPoint( double x = 0.0, double y = 0.0 );
+    QgsPoint( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
 %Docstring
- Construct a 2 dimensional point with an initial x and y coordinate.
- \param x x-coordinate of point
- \param y y-coordinate of point
+ Construct a point with the provided initial coordinate values.
 %End
 
     explicit QgsPoint( const QgsPointXY &p );
@@ -369,7 +367,7 @@ class QgsPoint: QgsAbstractGeometry
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/geometry/qgspointv2.h                                       *
+ * src/core/geometry/qgspoint.h                                         *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -23,11 +23,11 @@ class QgsPoint: QgsAbstractGeometry
   public:
 
     QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
-    % Docstring
-    Construct a point with the provided initial coordinate values.
+%Docstring
+ Construct a point with the provided initial coordinate values.
 
-    If only z and m are not specified, the type will be a 2D point.
-    If any or both of the others are specified, the Z and M values will be added accordingly.
+ If only z and m are not specified, the type will be a 2D point.
+ If any or both of the others are specified, the Z and M values will be added accordingly.
 %End
 %MethodCode
     double z;

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -269,7 +269,7 @@ class QgsPoint: QgsAbstractGeometry
  M value is preserved.
  \param distance distance to project
  \param azimuth angle to project in X Y, clockwise in degrees starting from north
- \param inclination angle to project in Z (3D)
+ \param inclination angle to project in Z (3D). If the point is 2D, the Z value is assumed to be 0.
  :return: The point projected. If a 2D point is projected a 3D point will be returned except if
   inclination is 90. A 3D point is always returned if a 3D point is projected.
  Example:

--- a/python/core/qgspointxy.sip
+++ b/python/core/qgspointxy.sip
@@ -1,7 +1,7 @@
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/qgspoint.h                                                  *
+ * src/core/qgspointxy.h                                                *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/
@@ -15,8 +15,13 @@
 class QgsPointXY
 {
 %Docstring
- A class to represent a point.
- For Z and M support prefer QgsPointV2.
+ A class to represent a 2D point.
+
+ A QgsPointXY represents a position with X and Y coordinates.
+ In most scenarios it is preferable to use a QgsPoint instead which also
+ supports Z and M values.
+
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode
@@ -331,7 +336,7 @@ Divides the coordinates in this point by a scalar quantity in place
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/qgspoint.h                                                  *
+ * src/core/qgspointxy.h                                                *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -768,7 +768,7 @@ while ($LINE_IDX < $LINE_COUNT){
     $LINE = fix_annotations($LINE);
 
     # fix astyle placing space after % character
-    $LINE =~ s/\s*% (MappedType|Type(Header)?Code|Module(Header)?Code|Convert(From|To)TypeCode|MethodCode|End)/%$1/;
+    $LINE =~ s/\s*% (MappedType|Type(Header)?Code|Module(Header)?Code|Convert(From|To)TypeCode|MethodCode|End|Docstring)/%$1/;
     $LINE =~ s/\/\s+GetWrapper\s+\//\/GetWrapper\//;
 
     write_output("NOR", "$LINE\n");

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -31,14 +31,19 @@
  * See details in QEP #17
  ****************************************************************************/
 
-QgsPoint::QgsPoint( double x, double y, double z, double m )
+QgsPoint::QgsPoint( double x, double y, double z, double m, QgsWkbTypes::Type wkbType )
   : QgsAbstractGeometry()
   , mX( x )
   , mY( y )
   , mZ( z )
   , mM( m )
 {
-  if ( qIsNaN( z ) )
+  if ( wkbType != QgsWkbTypes::Unknown )
+  {
+    Q_ASSERT( QgsWkbTypes::flatType( wkbType ) == QgsWkbTypes::Point );
+    mWkbType = wkbType;
+  }
+  else if ( qIsNaN( z ) )
   {
     if ( qIsNaN( m ) )
       mWkbType = QgsWkbTypes::Point;
@@ -71,15 +76,15 @@ QgsPoint::QgsPoint( QPointF p )
   mWkbType = QgsWkbTypes::Point;
 }
 
-QgsPoint::QgsPoint( QgsWkbTypes::Type type, double x, double y, double z, double m )
-  : mX( x )
+QgsPoint::QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z, double m )
+  : QgsAbstractGeometry()
+  , mX( x )
   , mY( y )
   , mZ( z )
   , mM( m )
 {
-  //protect against non-point WKB types
-  Q_ASSERT( QgsWkbTypes::flatType( type ) == QgsWkbTypes::Point );
-  mWkbType = type;
+  Q_ASSERT( QgsWkbTypes::flatType( wkbType ) == QgsWkbTypes::Point );
+  mWkbType = wkbType;
 }
 
 /***************************************************************************
@@ -535,5 +540,5 @@ QgsPoint QgsPoint::project( double distance, double azimuth, double inclination 
     pType = QgsWkbTypes::addM( pType );
   }
 
-  return QgsPoint( pType, mX + dx, mY + dy, mZ + dz, mM );
+  return QgsPoint( mX + dx, mY + dy, mZ + dz, mM, pType );
 }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -546,5 +546,6 @@ QgsPoint QgsPoint::project( double distance, double azimuth, double inclination 
     pType = QgsWkbTypes::addM( pType );
   }
 
-  return QgsPoint( mX + dx, mY + dy, mZ + dz, mM, pType );
+  double z = qIsNaN( mZ ) ? 0 : mZ;
+  return QgsPoint( mX + dx, mY + dy, z + dz, mM, pType );
 }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -38,7 +38,17 @@ QgsPoint::QgsPoint( double x, double y, double z, double m )
   , mZ( z )
   , mM( m )
 {
-  mWkbType = QgsWkbTypes::Point;
+  if ( qIsNaN( z ) )
+  {
+    if ( qIsNaN( m ) )
+      mWkbType = QgsWkbTypes::Point;
+    else
+      mWkbType = QgsWkbTypes::PointM;
+  }
+  else if ( qIsNaN( m ) )
+    mWkbType = QgsWkbTypes::PointZ;
+  else
+    mWkbType = QgsWkbTypes::PointZM;
 }
 
 QgsPoint::QgsPoint( const QgsPointXY &p )

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -95,11 +95,17 @@ QgsPoint::QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z, dou
 
 bool QgsPoint::operator==( const QgsPoint &pt ) const
 {
-  return ( pt.wkbType() == wkbType() &&
-           qgsDoubleNear( pt.x(), mX, 1E-8 ) &&
-           qgsDoubleNear( pt.y(), mY, 1E-8 ) &&
-           qgsDoubleNear( pt.z(), mZ, 1E-8 ) &&
-           qgsDoubleNear( pt.m(), mM, 1E-8 ) );
+  const QgsWkbTypes::Type type = wkbType();
+
+  bool equal = pt.wkbType() == type;
+  equal &= qgsDoubleNear( pt.x(), mX, 1E-8 );
+  equal &= qgsDoubleNear( pt.y(), mY, 1E-8 );
+  if ( QgsWkbTypes::hasZ( type ) )
+    equal &= qgsDoubleNear( pt.z(), mZ, 1E-8 );
+  if ( QgsWkbTypes::hasM( type ) )
+    equal &= qgsDoubleNear( pt.m(), mM, 1E-8 );
+
+  return equal;
 }
 
 bool QgsPoint::operator!=( const QgsPoint &pt ) const

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -47,13 +47,32 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     /**
      * Construct a point with the provided initial coordinate values.
      *
-     * If only z and m are not specified, the type will be a 2D point.
-     * If any or both of the others are specified, the Z and M values will be added accordingly.
+     * If \a wkbType is set to `QgsWkbTypes::Point`, `QgsWkbTypes::PointZ`, `QgsWkbTypes::PointM` or `QgsWkbTypes::PointZM`
+     * the type will be set accordingly. If it is left to the default `QgsWkbTypes::Unknown`, the type will be set
+     * based on the following rules:
+     * - If only x and y are specified, the type will be a 2D point.
+     * - If any or both of the Z and M are specified, the appropriate type will be created.
+     *
+     * \code{.py}
+     *   pt = QgsPoint(43.4, 5.3)
+     *   pt.exportToWkt() # Point(43.4 5.3)
+     *
+     *   pt_z = QgsPoint(120, 343, 77)
+     *   pt.exportToWkt() # PointZ(120 343 77)
+     *
+     *   pt_m = QgsPoint(33, 88, m=5)
+     *   pt_m.m() # 5
+     *   pt_m.wkbType() # QgsWkbTypes.PointM
+     *
+     *   pt = QgsPoint(30, 40, wkbType=QgsWkbTypes.PointZ)
+     *   pt.z() # nan
+     *   pt.wkbType() # QgsWkbTypes.PointZ
+     * \endcode
      */
 #ifndef SIP_RUN
-    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
+    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN(), QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) SIP_SKIP;
 #else
-    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown )];
     % MethodCode
     double z;
     double m;
@@ -76,7 +95,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
       m = PyFloat_AsDouble( a3 );
     }
 
-    sipCpp = new sipQgsPoint( a0, a1, z, m );
+    sipCpp = new sipQgsPoint( a0, a1, z, m, a4 );
     % End
 #endif
 
@@ -88,28 +107,12 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      */
     explicit QgsPoint( QPointF p );
 
-    /** Construct a point with a specified type (e.g., PointZ, PointM) and initial x, y, z, and m values.
-     * \param type point type
-     * \param x x-coordinate of point
-     * \param y y-coordinate of point
-     * \param z z-coordinate of point, for PointZ or PointZM types
-     * \param m m-value of point, for PointM or PointZM types
+    /**
+     * Create a new point with the given wkbtype and values.
+     *
+     * \note Not available in Python bindings
      */
-    QgsPoint( QgsWkbTypes::Type type, double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
-#ifdef SIP_RUN
-    % MethodCode
-    if ( QgsWkbTypes::flatType( a0 ) != QgsWkbTypes::Point )
-    {
-      PyErr_SetString( PyExc_ValueError,
-                       QString( "%1 is not a valid WKB type for point geometries" ).arg( QgsWkbTypes::displayString( a0 ) ).toUtf8().constData() );
-      sipIsErr = 1;
-    }
-    else
-    {
-      sipCpp = new sipQgsPoint( a0, a1, a2, a3, a4 );
-    }
-    % End
-#endif
+    explicit QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
 
     bool operator==( const QgsPoint &pt ) const;
     bool operator!=( const QgsPoint &pt ) const;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -50,15 +50,10 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * If only z and m are not specified, the type will be a 2D point.
      * If any or both of the others are specified, the Z and M values will be added accordingly.
      */
+#ifndef SIP_RUN
     QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
-#ifdef SIP_RUN
+#else
     QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
-    % Docstring
-    Construct a point with the provided initial coordinate values.
-
-    If only z and m are not specified, the type will be a 2D point.
-    If any or both of the others are specified, the Z and M values will be added accordingly.
-    % End
     % MethodCode
     double z;
     double m;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -294,7 +294,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * M value is preserved.
      * \param distance distance to project
      * \param azimuth angle to project in X Y, clockwise in degrees starting from north
-     * \param inclination angle to project in Z (3D)
+     * \param inclination angle to project in Z (3D). If the point is 2D, the Z value is assumed to be 0.
      * \returns The point projected. If a 2D point is projected a 3D point will be returned except if
      *  inclination is 90. A 3D point is always returned if a 3D point is projected.
      * Example:

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -46,8 +46,44 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
 
     /**
      * Construct a point with the provided initial coordinate values.
+     *
+     * If only z and m are not specified, the type will be a 2D point.
+     * If any or both of the others are specified, the Z and M values will be added accordingly.
      */
-    QgsPoint( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
+    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
+#ifdef SIP_RUN
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    % Docstring
+    Construct a point with the provided initial coordinate values.
+
+    If only z and m are not specified, the type will be a 2D point.
+    If any or both of the others are specified, the Z and M values will be added accordingly.
+    % End
+    % MethodCode
+    double z;
+    double m;
+
+    if ( a2 == Py_None )
+    {
+      z = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      z = PyFloat_AsDouble( a2 );
+    }
+
+    if ( a3 == Py_None )
+    {
+      m = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      m = PyFloat_AsDouble( a3 );
+    }
+
+    sipCpp = new sipQgsPoint( a0, a1, z, m );
+    % End
+#endif
 
     /** Construct a QgsPoint from a QgsPointXY object
      */

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -218,7 +218,7 @@ void QgsGeometryValidator::run()
     case QgsGeometry::ValidatorGeos:
     {
       char *r = nullptr;
-      GEOSGeometry *g0 = mG.exportToGeos();
+      GEOSGeometry *g0 = mGeometry.exportToGeos();
       GEOSContextHandle_t handle = QgsGeometry::getGEOSHandler();
       if ( !g0 )
       {
@@ -264,26 +264,26 @@ void QgsGeometryValidator::run()
     {
       QgsDebugMsg( "validation thread started." );
 
-      QgsWkbTypes::Type flatType = QgsWkbTypes::flatType( mG.wkbType() );
+      QgsWkbTypes::Type flatType = QgsWkbTypes::flatType( mGeometry.wkbType() );
       //if ( flatType == QgsWkbTypes::Point || flatType == QgsWkbTypes::MultiPoint )
       //    break;
       if ( flatType == QgsWkbTypes::LineString )
       {
-        validatePolyline( 0, mG.asPolyline() );
+        validatePolyline( 0, mGeometry.asPolyline() );
       }
       else if ( flatType == QgsWkbTypes::MultiLineString )
       {
-        QgsMultiPolyline mp = mG.asMultiPolyline();
+        QgsMultiPolyline mp = mGeometry.asMultiPolyline();
         for ( int i = 0; !mStop && i < mp.size(); i++ )
           validatePolyline( i, mp[i] );
       }
       else if ( flatType == QgsWkbTypes::Polygon )
       {
-        validatePolygon( 0, mG.asPolygon() );
+        validatePolygon( 0, mGeometry.asPolygon() );
       }
       else if ( flatType == QgsWkbTypes::MultiPolygon )
       {
-        QgsMultiPolygon mp = mG.asMultiPolygon();
+        QgsMultiPolygon mp = mGeometry.asMultiPolygon();
         for ( int i = 0; !mStop && i < mp.size(); i++ )
         {
           validatePolygon( i, mp[i] );
@@ -324,7 +324,7 @@ void QgsGeometryValidator::run()
       else if ( flatType == QgsWkbTypes::Unknown )
       {
         QgsDebugMsg( QObject::tr( "Unknown geometry type" ) );
-        emit errorFound( QgsGeometry::Error( QObject::tr( "Unknown geometry type %1" ).arg( mG.wkbType() ) ) );
+        emit errorFound( QgsGeometry::Error( QObject::tr( "Unknown geometry type %1" ).arg( mGeometry.wkbType() ) ) );
         mErrorCount++;
       }
 

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -35,7 +35,7 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(box.yMaximum(), 11.0)
         self.assertEqual(box.zMaximum(), 12.0)
 
-        box = QgsBox3d(QgsPoint(QgsWkbTypes.PointZ, 5, 6, 7), QgsPoint(QgsWkbTypes.PointZ, 10, 11, 12))
+        box = QgsBox3d(QgsPoint(5, 6, 7), QgsPoint(10, 11, 12))
         self.assertEqual(box.xMinimum(), 5.0)
         self.assertEqual(box.yMinimum(), 6.0)
         self.assertEqual(box.zMinimum(), 7.0)
@@ -44,7 +44,7 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(box.zMaximum(), 12.0)
 
         # point constructor should normalize
-        box = QgsBox3d(QgsPoint(QgsWkbTypes.PointZ, 10, 11, 12), QgsPoint(QgsWkbTypes.PointZ, 5, 6, 7))
+        box = QgsBox3d(QgsPoint(10, 11, 12), QgsPoint(5, 6, 7))
         self.assertEqual(box.xMinimum(), 5.0)
         self.assertEqual(box.yMinimum(), 6.0)
         self.assertEqual(box.zMinimum(), 7.0)
@@ -137,14 +137,14 @@ class TestQgsBox3d(unittest.TestCase):
 
     def testContainsPoint(self):
         box = QgsBox3d(5.0, 6.0, 7.0, 11.0, 13.0, 15.0)
-        self.assertTrue(box.contains(QgsPoint(QgsWkbTypes.PointZ, 6, 7, 8)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.PointZ, 16, 7, 8)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.PointZ, 6, 17, 8)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.PointZ, 6, 7, 18)))
+        self.assertTrue(box.contains(QgsPoint(6, 7, 8)))
+        self.assertFalse(box.contains(QgsPoint(16, 7, 8)))
+        self.assertFalse(box.contains(QgsPoint(6, 17, 8)))
+        self.assertFalse(box.contains(QgsPoint(6, 7, 18)))
         # 2d containment
-        self.assertTrue(box.contains(QgsPoint(QgsWkbTypes.Point, 6, 7)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.Point, 16, 7)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.Point, 6, 17)))
+        self.assertTrue(box.contains(QgsPoint(6, 7)))
+        self.assertFalse(box.contains(QgsPoint(16, 7)))
+        self.assertFalse(box.contains(QgsPoint(6, 17)))
 
     def testVolume(self):
         box = QgsBox3d(5.0, 6.0, 7.0, 11.0, 13.0, 15.0)

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4129,6 +4129,12 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertFalse(QgsGeometry.compare(lp, lp2))
         self.assertTrue(QgsGeometry.compare(lp, lp2, 1e-6))
 
+    def testPoint(self):
+        self.assertEqual(QgsPoint(1, 2).wkbType(), QgsWkbTypes.Point)
+        self.assertEqual(QgsPoint(1, 2, 3).wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(QgsPoint(1, 2, m=3).wkbType(), QgsWkbTypes.PointM)
+        self.assertEqual(QgsPoint(1, 2, 3, 4).wkbType(), QgsWkbTypes.PointZM)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1409,7 +1409,7 @@ class TestQgsGeometry(unittest.TestCase):
         # test adding a part with Z values
         point = QgsGeometry.fromPoint(points[0])
         point.geometry().addZValue(4.0)
-        self.assertEqual(point.addPointsV2([QgsPoint(QgsWkbTypes.PointZ, points[1][0], points[1][1], 3.0)]), 0)
+        self.assertEqual(point.addPointsV2([QgsPoint(points[1][0], points[1][1], 3.0, wkbType=QgsWkbTypes.PointZ)]), 0)
         expwkt = "MultiPointZ ((0 0 4), (1 0 3))"
         wkt = point.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
@@ -1438,7 +1438,7 @@ class TestQgsGeometry(unittest.TestCase):
         # test adding a part with Z values
         polyline = QgsGeometry.fromPolyline(points[0])
         polyline.geometry().addZValue(4.0)
-        points2 = [QgsPoint(QgsWkbTypes.PointZ, p[0], p[1], 3.0) for p in points[1]]
+        points2 = [QgsPoint(p[0], p[1], 3.0, wkbType=QgsWkbTypes.PointZ) for p in points[1]]
         self.assertEqual(polyline.addPointsV2(points2), 0)
         expwkt = "MultiLineStringZ ((0 0 4, 1 0 4, 1 1 4, 2 1 4, 2 0 4),(3 0 3, 3 1 3, 5 1 3, 5 0 3, 6 0 3))"
         wkt = polyline.exportToWkt()
@@ -1482,7 +1482,7 @@ class TestQgsGeometry(unittest.TestCase):
         # test adding a part with Z values
         polygon = QgsGeometry.fromPolygon(points[0])
         polygon.geometry().addZValue(4.0)
-        points2 = [QgsPoint(QgsWkbTypes.PointZ, pi[0], pi[1], 3.0) for pi in points[1][0]]
+        points2 = [QgsPoint(pi[0], pi[1], 3.0, wkbType=QgsWkbTypes.PointZ) for pi in points[1][0]]
         self.assertEqual(polygon.addPointsV2(points2), 0)
         expwkt = "MultiPolygonZ (((0 0 4, 1 0 4, 1 1 4, 2 1 4, 2 2 4, 0 2 4, 0 0 4)),((4 0 3, 5 0 3, 5 2 3, 3 2 3, 3 1 3, 4 1 3, 4 0 3)))"
         wkt = polygon.exportToWkt()
@@ -4130,10 +4130,40 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertTrue(QgsGeometry.compare(lp, lp2, 1e-6))
 
     def testPoint(self):
-        self.assertEqual(QgsPoint(1, 2).wkbType(), QgsWkbTypes.Point)
-        self.assertEqual(QgsPoint(1, 2, 3).wkbType(), QgsWkbTypes.PointZ)
-        self.assertEqual(QgsPoint(1, 2, m=3).wkbType(), QgsWkbTypes.PointM)
-        self.assertEqual(QgsPoint(1, 2, 3, 4).wkbType(), QgsWkbTypes.PointZM)
+        point = QgsPoint(1, 2)
+        self.assertEqual(point.wkbType(), QgsWkbTypes.Point)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+
+        point = QgsPoint(1, 2, wkbType=QgsWkbTypes.Point)
+        self.assertEqual(point.wkbType(), QgsWkbTypes.Point)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+
+        point_z = QgsPoint(1, 2, 3)
+        self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.z(), 3)
+
+        point_z = QgsPoint(1, 2, 3, 4, wkbType=QgsWkbTypes.PointZ)
+        self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.z(), 3)
+
+        point_m = QgsPoint(1, 2, m=3)
+        self.assertEqual(point_m.wkbType(), QgsWkbTypes.PointM)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.m(), 3)
+
+        point_zm = QgsPoint(1, 2, 3, 4)
+        self.assertEqual(point_zm.wkbType(), QgsWkbTypes.PointZM)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.z(), 3)
+        self.assertEqual(point.m(), 4)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4142,28 +4142,28 @@ class TestQgsGeometry(unittest.TestCase):
 
         point_z = QgsPoint(1, 2, 3)
         self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.z(), 3)
+        self.assertEqual(point_z.x(), 1)
+        self.assertEqual(point_z.y(), 2)
+        self.assertEqual(point_z.z(), 3)
 
         point_z = QgsPoint(1, 2, 3, 4, wkbType=QgsWkbTypes.PointZ)
         self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.z(), 3)
+        self.assertEqual(point_z.x(), 1)
+        self.assertEqual(point_z.y(), 2)
+        self.assertEqual(point_z.z(), 3)
 
         point_m = QgsPoint(1, 2, m=3)
         self.assertEqual(point_m.wkbType(), QgsWkbTypes.PointM)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.m(), 3)
+        self.assertEqual(point_m.x(), 1)
+        self.assertEqual(point_m.y(), 2)
+        self.assertEqual(point_m.m(), 3)
 
         point_zm = QgsPoint(1, 2, 3, 4)
         self.assertEqual(point_zm.wkbType(), QgsWkbTypes.PointZM)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.z(), 3)
-        self.assertEqual(point.m(), 4)
+        self.assertEqual(point_zm.x(), 1)
+        self.assertEqual(point_zm.y(), 2)
+        self.assertEqual(point_zm.z(), 3)
+        self.assertEqual(point_zm.m(), 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Geometries are passed as const reference and returned by value.
This make using the API easier and reduces the risk of ownership
problems.

The overhead is minimal due to implicit sharing.

Fix https://github.com/qgis/qgis3.0_api/issues/68

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
