### PR TITLE
QgsVectorLayerSelectedFeatureSource

### DIFF
--- a/python/core/qgsvectorlayerfeatureiterator.sip
+++ b/python/core/qgsvectorlayerfeatureiterator.sip
@@ -46,6 +46,13 @@ class QgsVectorLayerFeatureSource : QgsAbstractFeatureSource
  :rtype: QgsFields
 %End
 
+    QgsCoordinateReferenceSystem crs() const;
+%Docstring
+ Returns the coordinate reference system for features retrieved from this source.
+.. versionadded:: 3.0
+ :rtype: QgsCoordinateReferenceSystem
+%End
+
   protected:
 
 
@@ -136,6 +143,35 @@ Setup the simplification of geometries to fetch using the specified simplify met
 
   private:
     QgsVectorLayerFeatureIterator( const QgsVectorLayerFeatureIterator &rhs );
+};
+
+
+
+class QgsVectorLayerSelectedFeatureSource : QgsFeatureSource
+{
+%Docstring
+ QgsFeatureSource subclass for the selected features from a QgsVectorLayer.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsvectorlayerfeatureiterator.h"
+%End
+  public:
+
+    QgsVectorLayerSelectedFeatureSource( QgsVectorLayer *layer );
+%Docstring
+ Constructor for QgsVectorLayerSelectedFeatureSource, for selected features from the specified ``layer``.
+ The currently selected feature IDs are stored, so change to the layer selection after constructing
+ the QgsVectorLayerSelectedFeatureSource will not be reflected.
+%End
+
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const;
+    virtual QgsCoordinateReferenceSystem sourceCrs() const;
+    virtual QgsFields fields() const;
+    virtual QgsWkbTypes::Type wkbType() const;
+    virtual long featureCount() const;
+
 };
 
 /************************************************************************

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -98,6 +98,11 @@ QgsFields QgsVectorLayerFeatureSource::fields() const
   return mFields;
 }
 
+QgsCoordinateReferenceSystem QgsVectorLayerFeatureSource::crs() const
+{
+  return mCrs;
+}
+
 
 QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsVectorLayerFeatureSource>( source, ownSource, request )
@@ -1006,3 +1011,51 @@ bool QgsVectorLayerFeatureIterator::prepareOrderBy( const QList<QgsFeatureReques
   return true;
 }
 
+
+//
+// QgsVectorLayerSelectedFeatureSource
+//
+
+QgsVectorLayerSelectedFeatureSource::QgsVectorLayerSelectedFeatureSource( QgsVectorLayer *layer )
+  : mSource( layer )
+  , mSelectedFeatureIds( layer->selectedFeatureIds() )
+  , mWkbType( layer->wkbType() )
+{}
+
+QgsFeatureIterator QgsVectorLayerSelectedFeatureSource::getFeatures( const QgsFeatureRequest &request ) const
+{
+  QgsFeatureRequest req( request );
+
+  if ( req.filterFids().isEmpty() && req.filterType() != QgsFeatureRequest::FilterFids )
+  {
+    req.setFilterFids( mSelectedFeatureIds );
+  }
+  else if ( !req.filterFids().isEmpty() )
+  {
+    QgsFeatureIds reqIds = mSelectedFeatureIds;
+    reqIds.intersect( req.filterFids() );
+    req.setFilterFids( reqIds );
+  }
+
+  return mSource.getFeatures( req );
+}
+
+QgsCoordinateReferenceSystem QgsVectorLayerSelectedFeatureSource::sourceCrs() const
+{
+  return mSource.crs();
+}
+
+QgsFields QgsVectorLayerSelectedFeatureSource::fields() const
+{
+  return mSource.fields();
+}
+
+QgsWkbTypes::Type QgsVectorLayerSelectedFeatureSource::wkbType() const
+{
+  return mWkbType;
+}
+
+long QgsVectorLayerSelectedFeatureSource::featureCount() const
+{
+  return mSelectedFeatureIds.count();
+}

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -1026,7 +1026,7 @@ QgsFeatureIterator QgsVectorLayerSelectedFeatureSource::getFeatures( const QgsFe
 {
   QgsFeatureRequest req( request );
 
-  if ( req.filterFids().isEmpty() && req.filterType() != QgsFeatureRequest::FilterFids )
+  if ( req.filterFids().isEmpty() && req.filterType() != QgsFeatureRequest::FilterFid )
   {
     req.setFilterFids( mSelectedFeatureIds );
   }

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -20,6 +20,7 @@
 #include "qgsfeatureiterator.h"
 #include "qgsfields.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsfeaturesource.h"
 
 #include <QSet>
 #include <memory>
@@ -66,6 +67,12 @@ class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
      * \since QGIS 3.0
      */
     QgsFields fields() const;
+
+    /**
+     * Returns the coordinate reference system for features retrieved from this source.
+     * \since QGIS 3.0
+     */
+    QgsCoordinateReferenceSystem crs() const;
 
   protected:
 
@@ -251,6 +258,40 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
      * Checks a feature's geometry for validity, if requested in feature request.
      */
     bool checkGeometryValidity( const QgsFeature &feature );
+};
+
+
+
+/**
+ * \class QgsVectorLayerSelectedFeatureSource
+ * \ingroup core
+ * QgsFeatureSource subclass for the selected features from a QgsVectorLayer.
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsVectorLayerSelectedFeatureSource : public QgsFeatureSource
+{
+  public:
+
+    /**
+     * Constructor for QgsVectorLayerSelectedFeatureSource, for selected features from the specified \a layer.
+     * The currently selected feature IDs are stored, so change to the layer selection after constructing
+     * the QgsVectorLayerSelectedFeatureSource will not be reflected.
+     */
+    QgsVectorLayerSelectedFeatureSource( QgsVectorLayer *layer );
+
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const override;
+    virtual QgsCoordinateReferenceSystem sourceCrs() const override;
+    virtual QgsFields fields() const override;
+    virtual QgsWkbTypes::Type wkbType() const override;
+    virtual long featureCount() const override;
+
+  private:
+
+    // ideally this wouldn't be mutable, but QgsVectorLayerFeatureSource has non-const getFeatures()
+    mutable QgsVectorLayerFeatureSource mSource;
+    QgsFeatureIds mSelectedFeatureIds;
+    QgsWkbTypes::Type mWkbType = QgsWkbTypes::Unknown;
+
 };
 
 #endif // QGSVECTORLAYERFEATUREITERATOR_H

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -2343,6 +2343,16 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         ids = set([f.id() for f in source.getFeatures()])
         self.assertEqual(ids, {f1.id(), f3.id(), f5.id()})
 
+        # test that requesting subset of ids intersects this request with the selected ids
+        ids = set([f.id() for f in source.getFeatures(QgsFeatureRequest().setFilterFids([f1.id(), f2.id(), f5.id()]))])
+        self.assertEqual(ids, {f1.id(), f5.id()})
+
+        # test that requesting id works
+        ids = set([f.id() for f in source.getFeatures(QgsFeatureRequest().setFilterFid(f1.id()))])
+        self.assertEqual(ids, {f1.id()})
+        ids = set([f.id() for f in source.getFeatures(QgsFeatureRequest().setFilterFid(f5.id()))])
+        self.assertEqual(ids, {f5.id()})
+
         # test that source has stored snapshot of selected features
         layer.selectByIds([f2.id(), f4.id()])
         self.assertEqual(source.featureCount(), 3)


### PR DESCRIPTION
QgsVectorLayerSelectedFeatureSource is a QgsFeatureSource subclass which only considers selected features from a QgsVectorLayer.

The initial use case is to remove the UseSelectionIfPresent processing context flag and replace it with a per source "use selected features" option. Eventually (when this filters through to the GUI) the processing-wide setting for "use selection" will be removed and replaced with a checkbox next to each input layer in an algorithm.