### PR TITLE
[Server] WMS DXF writer refactoring

### DIFF
--- a/src/server/services/wms/qgsdxfwriter.h
+++ b/src/server/services/wms/qgsdxfwriter.h
@@ -20,7 +20,8 @@ namespace QgsWms
 
   /** Output GetMap response in Dfx format
    */
-  void writeAsDxf( QgsServerInterface *serverIface, const QString &version,  const QgsServerRequest &request,
+  void writeAsDxf( QgsServerInterface *serverIface, const QgsProject *project,
+                   const QString &version,  const QgsServerRequest &request,
                    QgsServerResponse &response );
 
 } // samespace QgsWms

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -96,7 +96,7 @@ namespace QgsWms
           QString format = params.value( QStringLiteral( "FORMAT" ) );
           if QSTR_COMPARE( format, "application/dxf" )
           {
-            writeAsDxf( mServerIface, versionString, request, response );
+            writeAsDxf( mServerIface, project, versionString, request, response );
           }
           else
           {

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -46,6 +46,7 @@ class QgsVectorLayer;
 class QgsSymbol;
 class QgsSymbol;
 class QgsAccessControl;
+class QgsDxfExport;
 
 class QColor;
 class QFile;
@@ -101,6 +102,11 @@ namespace QgsWms
       QImage *getMap( QgsMapSettings &mapSettings, HitTest *hitTest = nullptr );
       QImage *getMapOld( QgsMapSettings &mapSettings, HitTest *hitTest = nullptr );
 
+      /** Returns the map as DXF data
+       \param options: extracted from the FORMAT_OPTIONS parameter
+       \returns the map as DXF data
+       \since QGIS 3.0*/
+      QgsDxfExport getDxf( const QMap<QString, QString> &options );
 
       /** Returns printed page as binary
         \param formatString out: format of the print output (e.g. pdf, svg, png, ...)


### PR DESCRIPTION
Removing QgsWMSProjectParser from DXF writer used in GetMap with dxf format
https://github.com/qgis/qgis3.0_api/issues/57

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
