### PR TITLE
Use invalid CRS as default in map settings

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1598,6 +1598,7 @@ be returned instead of a null pointer if no transformation is required.
 - destinationCrs() now returns a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
 plugins calling this method will need to be updated.
 - setCrsTransformEnabled() and hasCrsTransformEnabled() were removed. CRS transformation is now always enabled.
+- the default destination CRS has changed from WGS 84 to invalid CRS (i.e. undefined, no reprojection will be done).
 - setMapUnits() was removed. The map units are dictated by the units for the destination CRS.
 
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -37,7 +37,7 @@ QgsMapSettings::QgsMapSettings()
   , mExtent()
   , mRotation( 0.0 )
   , mMagnificationFactor( 1.0 )
-  , mDestCRS( QgsCoordinateReferenceSystem::fromSrsId( GEOCRS_ID ) )  // WGS 84
+  , mDestCRS()
   , mDatumTransformStore( mDestCRS )
   , mBackgroundColor( Qt::white )
   , mSelectionColor( Qt::yellow )

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -34,6 +34,7 @@ class TestQgsMapSettings: public QObject
   private slots:
     void initTestCase();
     void cleanupTestCase();
+    void testDefaults();
     void visibleExtent();
     void mapUnitsPerPixel();
     void visiblePolygon();
@@ -71,6 +72,12 @@ QString TestQgsMapSettings::toString( const QPolygonF &p, int dec ) const
   }
 
   return s;
+}
+
+void TestQgsMapSettings::testDefaults()
+{
+  QgsMapSettings ms;
+  QCOMPARE( ms.destinationCrs(), QgsCoordinateReferenceSystem() );
 }
 
 void TestQgsMapSettings::visibleExtent()


### PR DESCRIPTION
I have got caught by the default set to WGS 84 when I loaded a layer
in projected CRS, set extent to layer's extent and... nothing got rendered
because map renderer was reprojecting to WGS 84.

This default is closer to the default in 2.x where reprojection is turned off.