### PR TITLE
Add an explicit argument to set QgsGeometryValidator method

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -1077,9 +1077,16 @@ Ring 0 is outer ring and can't be deleted.
 %End
     };
 
-    void validateGeometry( QList<QgsGeometry::Error> &errors /Out/ );
+    enum ValidationMethod
+    {
+      ValidatorQgisInternal,
+      ValidatorGeos,
+    };
+
+    void validateGeometry( QList<QgsGeometry::Error> &errors /Out/, ValidationMethod method = ValidatorQgisInternal );
 %Docstring
- Validate geometry and produce a list of geometry errors
+ Validate geometry and produce a list of geometry errors.
+ The ``method`` argument dictates which validator to utilize.
 .. versionadded:: 1.5
 .. note::
 

--- a/python/core/qgsgeometryvalidator.sip
+++ b/python/core/qgsgeometryvalidator.sip
@@ -15,9 +15,10 @@ class QgsGeometryValidator : QThread
 #include "qgsgeometryvalidator.h"
 %End
   public:
-    QgsGeometryValidator( const QgsGeometry *g, QList<QgsGeometry::Error> *errors = 0 );
+
+    QgsGeometryValidator( const QgsGeometry *g, QList<QgsGeometry::Error> *errors = 0, QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal );
 %Docstring
-Constructor
+ Constructor for QgsGeometryValidator.
 %End
     ~QgsGeometryValidator();
 
@@ -25,7 +26,7 @@ Constructor
 
     void stop();
 
-    static void validateGeometry( const QgsGeometry *g, QList<QgsGeometry::Error> &errors /Out/ );
+    static void validateGeometry( const QgsGeometry *g, QList<QgsGeometry::Error> &errors /Out/, QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal );
 %Docstring
 Validate geometry and produce a list of geometry errors
 %End
@@ -36,7 +37,7 @@ Validate geometry and produce a list of geometry errors
   public slots:
     void addError( const QgsGeometry::Error & );
 
-}; // class QgsGeometryValidator
+};
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/nodetool/qgsnodetool.cpp
+++ b/src/app/nodetool/qgsnodetool.cpp
@@ -1814,7 +1814,12 @@ void QgsNodeTool::GeometryValidation::start( QgsGeometry &geom, QgsNodeTool *t, 
 {
   tool = t;
   layer = l;
-  validator = new QgsGeometryValidator( &geom );
+  QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal;
+  QgsSettings settings;
+  if ( settings.value( QStringLiteral( "qgis/digitizing/validate_geometries" ), 1 ).toInt() == 2 )
+    method = QgsGeometry::ValidatorGeos;
+
+  validator = new QgsGeometryValidator( &geom, nullptr, method );
   connect( validator, &QgsGeometryValidator::errorFound, tool, &QgsNodeTool::validationErrorFound );
   connect( validator, &QThread::finished, tool, &QgsNodeTool::validationFinished );
   validator->start();

--- a/src/app/nodetool/qgsselectedfeature.cpp
+++ b/src/app/nodetool/qgsselectedfeature.cpp
@@ -185,7 +185,10 @@ void QgsSelectedFeature::validateGeometry( QgsGeometry *g )
     delete vm;
   }
 
-  mValidator = new QgsGeometryValidator( g );
+  QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal;
+  if ( settings.value( QStringLiteral( "qgis/digitizing/validate_geometries" ), 1 ).toInt() == 2 )
+    method = QgsGeometry::ValidatorGeos;
+  mValidator = new QgsGeometryValidator( g, nullptr, method );
   connect( mValidator, &QgsGeometryValidator::errorFound, this, &QgsSelectedFeature::addError );
   connect( mValidator, &QThread::finished, this, &QgsSelectedFeature::validationFinished );
   mValidator->start();

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1964,9 +1964,9 @@ QgsGeometry QgsGeometry::makeValid()
 }
 
 
-void QgsGeometry::validateGeometry( QList<QgsGeometry::Error> &errors )
+void QgsGeometry::validateGeometry( QList<QgsGeometry::Error> &errors, ValidationMethod method )
 {
-  QgsGeometryValidator::validateGeometry( this, errors );
+  QgsGeometryValidator::validateGeometry( this, errors, method );
 }
 
 bool QgsGeometry::isGeosValid() const

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -946,11 +946,22 @@ class CORE_EXPORT QgsGeometry
         bool hasWhere() { return hasLocation; }
     };
 
-    /** Validate geometry and produce a list of geometry errors
+    /**
+     * Available methods for validating geometries.
+     * \since QGIS 3.0
+     */
+    enum ValidationMethod
+    {
+      ValidatorQgisInternal, //!< Use internal QgsGeometryValidator method
+      ValidatorGeos, //!< Use GEOS validation methods
+    };
+
+    /** Validate geometry and produce a list of geometry errors.
+     * The \a method argument dictates which validator to utilize.
      * \since QGIS 1.5
      * \note Available in Python bindings since QGIS 1.6
      **/
-    void validateGeometry( QList<QgsGeometry::Error> &errors SIP_OUT );
+    void validateGeometry( QList<QgsGeometry::Error> &errors SIP_OUT, ValidationMethod method = ValidatorQgisInternal );
 
     /** Compute the unary union on a list of \a geometries. May be faster than an iterative union on a set of geometries.
      * The returned geometry will be fully noded, i.e. a node will be created at every common intersection of the

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -29,15 +29,18 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
     Q_OBJECT
 
   public:
-    //! Constructor
-    QgsGeometryValidator( const QgsGeometry *g, QList<QgsGeometry::Error> *errors = nullptr );
+
+    /**
+     * Constructor for QgsGeometryValidator.
+     */
+    QgsGeometryValidator( const QgsGeometry *g, QList<QgsGeometry::Error> *errors = nullptr, QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal );
     ~QgsGeometryValidator();
 
     void run() override;
     void stop();
 
     //! Validate geometry and produce a list of geometry errors
-    static void validateGeometry( const QgsGeometry *g, QList<QgsGeometry::Error> &errors SIP_OUT );
+    static void validateGeometry( const QgsGeometry *g, QList<QgsGeometry::Error> &errors SIP_OUT, QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal );
 
   signals:
     void errorFound( const QgsGeometry::Error & );
@@ -58,6 +61,7 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
     QList<QgsGeometry::Error> *mErrors;
     bool mStop;
     int mErrorCount;
-}; // class QgsGeometryValidator
+    QgsGeometry::ValidationMethod mMethod = QgsGeometry::ValidatorQgisInternal;
+};
 
 #endif

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -663,7 +663,10 @@ void QgsMapToolCapture::validateGeometry()
   if ( !g )
     return;
 
-  mValidator = new QgsGeometryValidator( g.get() );
+  QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal;
+  if ( settings.value( QStringLiteral( "qgis/digitizing/validate_geometries" ), 1 ).toInt() == 2 )
+    method = QgsGeometry::ValidatorGeos;
+  mValidator = new QgsGeometryValidator( g.get(), nullptr, method );
   connect( mValidator, &QgsGeometryValidator::errorFound, this, &QgsMapToolCapture::addError );
   connect( mValidator, &QThread::finished, this, &QgsMapToolCapture::validationFinished );
   mValidator->start();


### PR DESCRIPTION
Previously this was always read from QgsSettings when using QgsGeometryValidator. It's now an explicit argumentwhen constructing QgsGeometryValidator or calling the static validation methods, allowing choice of internal/GEOS validation methods.

Helps remove more QgsSettings use from core, and makes this class safer to use in non-main threads.