### PR TITLE
Allow specifying a destination CRS in QgsFeatureRequest

### DIFF
--- a/python/core/qgsfeatureiterator.sip
+++ b/python/core/qgsfeatureiterator.sip
@@ -102,7 +102,7 @@ end of iterating: free the resources / lock
  :rtype: bool
 %End
 
-    void transformFeatureGeometry( QgsFeature &feature, const QgsCoordinateTransform &transform ) const;
+    void geometryToDestinationCrs( QgsFeature &feature, const QgsCoordinateTransform &transform ) const;
 %Docstring
  Transforms ``feature``'s geometry according to the specified coordinate ``transform``.
  If ``feature`` has no geometry or ``transform`` is invalid then calling this method
@@ -113,7 +113,7 @@ end of iterating: free the resources / lock
 %End
 
 
-    QgsRectangle transformedFilterRect( const QgsCoordinateTransform &transform ) const;
+    QgsRectangle filterRectToSourceCrs( const QgsCoordinateTransform &transform ) const;
 %Docstring
  Returns a rectangle representing the original request's QgsFeatureRequest.filterRect().
  If ``transform`` is a valid coordinate transform, the return rectangle will represent

--- a/python/core/qgsfeatureiterator.sip
+++ b/python/core/qgsfeatureiterator.sip
@@ -120,6 +120,7 @@ end of iterating: free the resources / lock
  the requested filterRect() transformed to the source's coordinate reference system.
  Iterators should call this method and use the returned rectangle for filtering
  features to ensure that any QgsFeatureRequest.destinationCrs() set on the request is respected.
+ Will throw a QgsCsException if the rect cannot be transformed from the destination CRS.
 .. versionadded:: 3.0
  :rtype: QgsRectangle
 %End

--- a/python/core/qgsfeatureiterator.sip
+++ b/python/core/qgsfeatureiterator.sip
@@ -102,6 +102,28 @@ end of iterating: free the resources / lock
  :rtype: bool
 %End
 
+    void transformFeatureGeometry( QgsFeature &feature, const QgsCoordinateTransform &transform ) const;
+%Docstring
+ Transforms ``feature``'s geometry according to the specified coordinate ``transform``.
+ If ``feature`` has no geometry or ``transform`` is invalid then calling this method
+ has no effect and will be shortcut.
+ Iterators should call this method before returning features to ensure that any
+ QgsFeatureRequest.destinationCrs() set on the request is respected.
+.. versionadded:: 3.0
+%End
+
+
+    QgsRectangle transformedFilterRect( const QgsCoordinateTransform &transform ) const;
+%Docstring
+ Returns a rectangle representing the original request's QgsFeatureRequest.filterRect().
+ If ``transform`` is a valid coordinate transform, the return rectangle will represent
+ the requested filterRect() transformed to the source's coordinate reference system.
+ Iterators should call this method and use the returned rectangle for filtering
+ features to ensure that any QgsFeatureRequest.destinationCrs() set on the request is respected.
+.. versionadded:: 3.0
+ :rtype: QgsRectangle
+%End
+
 
 
 

--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -568,6 +568,15 @@ Set a subset of attributes by names that will be fetched
  set on the request is expected to be in the same CRS as the destination
  CRS.
 
+ The feature geometry transformation to the destination CRS is performed
+ after all filter expressions are tested and any virtual fields are
+ calculated. Accordingly, any geometric expressions used in
+ filterExpression() will be performed in the original
+ source CRS. This ensures consistent results are returned regardless of the
+ destination CRS. Similarly, virtual field values will be calculated using the
+ original geometry in the source CRS, so these values are not affected by
+ any destination CRS transform present in the feature request.
+
 .. seealso:: destinationCrs()
 .. versionadded:: 3.0
  :rtype: QgsFeatureRequest

--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -267,10 +267,16 @@ construct a request with feature ID filter
 %Docstring
 construct a request with feature ID filter
 %End
-    explicit QgsFeatureRequest( const QgsRectangle &rect );
+
+    explicit QgsFeatureRequest( const QgsRectangle &rectangle );
 %Docstring
-construct a request with rectangle filter
+ Construct a request with ``rectangle`` bounding box filter.
+
+ When a destination CRS is set using setDestinationCrs(), ``rectangle``
+ is expected to be in the same CRS as the destinationCrs(). Otherwise, ``rectangle``
+ should use the same CRS as the source layer/provider.
 %End
+
     explicit QgsFeatureRequest( const QgsExpression &expr, const QgsExpressionContext &context = QgsExpressionContext() );
 %Docstring
 construct a request with a filter expression
@@ -288,16 +294,28 @@ copy constructor
  :rtype: FilterType
 %End
 
-    QgsFeatureRequest &setFilterRect( const QgsRectangle &rect );
+    QgsFeatureRequest &setFilterRect( const QgsRectangle &rectangle );
 %Docstring
- Set rectangle from which features will be taken. Empty rectangle removes the filter.
+ Sets the ``rectangle`` from which features will be taken. An empty rectangle removes the filter.
+
+ When a destination CRS is set using setDestinationCrs(), ``rectangle``
+ is expected to be in the same CRS as the destinationCrs(). Otherwise, ``rectangle``
+ should use the same CRS as the source layer/provider.
+
+.. seealso:: filterRect()
  :rtype: QgsFeatureRequest
 %End
 
     const QgsRectangle &filterRect() const;
 %Docstring
- Get the rectangle from which features will be taken. If the returned
+ Returns the rectangle from which features will be taken. If the returned
  rectangle is null, then no filter rectangle is set.
+
+ When a destination CRS is set using setDestinationCrs(), the rectangle
+ will be in the same CRS as the destinationCrs(). Otherwise, the rectangle
+ will use the same CRS as the source layer/provider.
+
+.. seealso:: setFilterRect()
  :rtype: QgsRectangle
 %End
 
@@ -527,6 +545,60 @@ Set a subset of attributes by names that will be fetched
 .. versionadded:: 2.2
  :rtype: QgsSimplifyMethod
 %End
+
+    QgsCoordinateReferenceSystem destinationCrs() const;
+%Docstring
+ Returns the destination coordinate reference system for feature's geometries,
+ or an invalid QgsCoordinateReferenceSystem if no reprojection will be done
+ and all features will be left with their original geometry.
+.. seealso:: setDestinationCrs()
+.. versionadded:: 3.0
+ :rtype: QgsCoordinateReferenceSystem
+%End
+
+    QgsFeatureRequest &setDestinationCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+ Sets the destination ``crs`` for feature's geometries. If set, all
+ geometries will be reprojected from their original coordinate reference
+ system to this desired reference system. If ``crs`` is an invalid
+ QgsCoordinateReferenceSystem then no reprojection will be done
+ and all features will be left with their original geometry.
+
+ When a ``crs`` is set using setDestinationCrs(), then any filterRect()
+ set on the request is expected to be in the same CRS as the destination
+ CRS.
+
+.. seealso:: destinationCrs()
+.. versionadded:: 3.0
+ :rtype: QgsFeatureRequest
+%End
+
+    QgsFeatureRequest &setTransformErrorCallback( SIP_PYCALLABLE / AllowNone / );
+%Docstring
+ Sets a callback function to use when encountering a transform error when iterating
+ features and a destinationCrs() is set. This function will be
+ called using the feature which encountered the transform error as a parameter.
+.. versionadded:: 3.0
+.. seealso:: transformErrorCallback()
+.. seealso:: setDestinationCrs()
+ :rtype: QgsFeatureRequest
+%End
+%MethodCode
+    Py_BEGIN_ALLOW_THREADS
+
+    sipCpp->setTransformErrorCallback( [a0]( const QgsFeature &arg )
+    {
+      SIP_BLOCK_THREADS
+      Py_XDECREF( sipCallMethod( NULL, a0, "D", &arg, sipType_QgsFeature, NULL ) );
+      SIP_UNBLOCK_THREADS
+    } );
+
+    sipRes = sipCpp;
+
+    Py_END_ALLOW_THREADS
+%End
+
+
 
     bool acceptFeature( const QgsFeature &feature );
 %Docstring

--- a/python/core/qgsvectorlayerfeatureiterator.sip
+++ b/python/core/qgsvectorlayerfeatureiterator.sip
@@ -141,6 +141,7 @@ Setup the simplification of geometries to fetch using the specified simplify met
 
 
 
+
   private:
     QgsVectorLayerFeatureIterator( const QgsVectorLayerFeatureIterator &rhs );
 };

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -21,6 +21,7 @@
 #include "qgsspatialindex.h"
 #include "qgsmessagelog.h"
 #include "qgsproject.h"
+#include "qgscsexception.h"
 
 ///@cond PRIVATE
 
@@ -31,7 +32,16 @@ QgsMemoryFeatureIterator::QgsMemoryFeatureIterator( QgsMemoryFeatureSource *sour
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   if ( !mSource->mSubsetString.isEmpty() )
   {

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -27,25 +27,31 @@
 QgsMemoryFeatureIterator::QgsMemoryFeatureIterator( QgsMemoryFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsMemoryFeatureSource>( source, ownSource, request )
 {
+  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
+  {
+    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
+  }
+  mFilterRect = transformedFilterRect( mTransform );
+
   if ( !mSource->mSubsetString.isEmpty() )
   {
     mSubsetExpression = new QgsExpression( mSource->mSubsetString );
     mSubsetExpression->prepare( &mSource->mExpressionContext );
   }
 
-  if ( !mRequest.filterRect().isNull() && mRequest.flags() & QgsFeatureRequest::ExactIntersect )
+  if ( !mFilterRect.isNull() && mRequest.flags() & QgsFeatureRequest::ExactIntersect )
   {
-    mSelectRectGeom = QgsGeometry::fromRect( request.filterRect() );
+    mSelectRectGeom = QgsGeometry::fromRect( mFilterRect );
     mSelectRectEngine.reset( QgsGeometry::createGeometryEngine( mSelectRectGeom.geometry() ) );
     mSelectRectEngine->prepareGeometry();
   }
 
   // if there's spatial index, use it!
   // (but don't use it when selection rect is not specified)
-  if ( !mRequest.filterRect().isNull() && mSource->mSpatialIndex )
+  if ( !mFilterRect.isNull() && mSource->mSpatialIndex )
   {
     mUsingFeatureIdList = true;
-    mFeatureIdList = mSource->mSpatialIndex->intersects( mRequest.filterRect() );
+    mFeatureIdList = mSource->mSpatialIndex->intersects( mFilterRect );
     QgsDebugMsg( "Features returned by spatial index: " + QString::number( mFeatureIdList.count() ) );
   }
   else if ( mRequest.filterType() == QgsFeatureRequest::FilterFid )
@@ -92,7 +98,7 @@ bool QgsMemoryFeatureIterator::nextFeatureUsingList( QgsFeature &feature )
   // option 1: we have a list of features to traverse
   while ( mFeatureIdListIterator != mFeatureIdList.constEnd() )
   {
-    if ( !mRequest.filterRect().isNull() && mRequest.flags() & QgsFeatureRequest::ExactIntersect )
+    if ( !mFilterRect.isNull() && mRequest.flags() & QgsFeatureRequest::ExactIntersect )
     {
       // do exact check in case we're doing intersection
       if ( mSource->mFeatures.value( *mFeatureIdListIterator ).hasGeometry() && mSelectRectEngine->intersects( *mSource->mFeatures.value( *mFeatureIdListIterator ).geometry().geometry() ) )
@@ -124,7 +130,10 @@ bool QgsMemoryFeatureIterator::nextFeatureUsingList( QgsFeature &feature )
     close();
 
   if ( hasFeature )
+  {
     feature.setFields( mSource->mFields ); // allow name-based attribute lookups
+    transformFeatureGeometry( feature, mTransform );
+  }
 
   return hasFeature;
 }
@@ -137,7 +146,7 @@ bool QgsMemoryFeatureIterator::nextFeatureTraverseAll( QgsFeature &feature )
   // option 2: traversing the whole layer
   while ( mSelectIterator != mSource->mFeatures.constEnd() )
   {
-    if ( mRequest.filterRect().isNull() )
+    if ( mFilterRect.isNull() )
     {
       // selection rect empty => using all features
       hasFeature = true;
@@ -153,7 +162,7 @@ bool QgsMemoryFeatureIterator::nextFeatureTraverseAll( QgsFeature &feature )
       else
       {
         // check just bounding box against rect when not using intersection
-        if ( mSelectIterator->hasGeometry() && mSelectIterator->geometry().boundingBox().intersects( mRequest.filterRect() ) )
+        if ( mSelectIterator->hasGeometry() && mSelectIterator->geometry().boundingBox().intersects( mFilterRect ) )
           hasFeature = true;
       }
     }
@@ -178,6 +187,7 @@ bool QgsMemoryFeatureIterator::nextFeatureTraverseAll( QgsFeature &feature )
     ++mSelectIterator;
     feature.setValid( true );
     feature.setFields( mSource->mFields ); // allow name-based attribute lookups
+    transformFeatureGeometry( feature, mTransform );
   }
   else
     close();
@@ -216,6 +226,7 @@ QgsMemoryFeatureSource::QgsMemoryFeatureSource( const QgsMemoryProvider *p )
   , mFeatures( p->mFeatures )
   , mSpatialIndex( p->mSpatialIndex ? new QgsSpatialIndex( *p->mSpatialIndex ) : nullptr )  // just shallow copy
   , mSubsetString( p->mSubsetString )
+  , mCrs( p->mCrs )
 {
   mExpressionContext << QgsExpressionContextUtils::globalScope()
                      << QgsExpressionContextUtils::projectScope( QgsProject::instance() );

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -31,7 +31,7 @@ QgsMemoryFeatureIterator::QgsMemoryFeatureIterator( QgsMemoryFeatureSource *sour
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   if ( !mSource->mSubsetString.isEmpty() )
   {
@@ -132,7 +132,7 @@ bool QgsMemoryFeatureIterator::nextFeatureUsingList( QgsFeature &feature )
   if ( hasFeature )
   {
     feature.setFields( mSource->mFields ); // allow name-based attribute lookups
-    transformFeatureGeometry( feature, mTransform );
+    geometryToDestinationCrs( feature, mTransform );
   }
 
   return hasFeature;
@@ -187,7 +187,7 @@ bool QgsMemoryFeatureIterator::nextFeatureTraverseAll( QgsFeature &feature )
     ++mSelectIterator;
     feature.setValid( true );
     feature.setFields( mSource->mFields ); // allow name-based attribute lookups
-    transformFeatureGeometry( feature, mTransform );
+    geometryToDestinationCrs( feature, mTransform );
   }
   else
     close();

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.h
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.h
@@ -42,6 +42,7 @@ class QgsMemoryFeatureSource : public QgsAbstractFeatureSource
     std::unique_ptr< QgsSpatialIndex > mSpatialIndex;
     QString mSubsetString;
     QgsExpressionContext mExpressionContext;
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsMemoryFeatureIterator;
 };
@@ -67,11 +68,13 @@ class QgsMemoryFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Qgs
 
     QgsGeometry mSelectRectGeom;
     std::unique_ptr< QgsGeometryEngine > mSelectRectEngine;
+    QgsRectangle mFilterRect;
     QgsFeatureMap::const_iterator mSelectIterator;
     bool mUsingFeatureIdList = false;
     QList<QgsFeatureId> mFeatureIdList;
     QList<QgsFeatureId>::const_iterator mFeatureIdListIterator;
     QgsExpression *mSubsetExpression = nullptr;
+    QgsCoordinateTransform mTransform;
 
 };
 

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -24,7 +24,7 @@ QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache
   {
     mTransform = QgsCoordinateTransform( mVectorLayerCache->sourceCrs(), mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
   if ( !mFilterRect.isNull() )
   {
     // update request to be the unprojected filter rect
@@ -72,7 +72,7 @@ bool QgsCachedFeatureIterator::fetchFeature( QgsFeature &f )
     if ( mRequest.acceptFeature( f ) )
     {
       f.setValid( true );
-      transformFeatureGeometry( f, mTransform );
+      geometryToDestinationCrs( f, mTransform );
       return true;
     }
   }
@@ -101,7 +101,7 @@ QgsCachedFeatureWriterIterator::QgsCachedFeatureWriterIterator( QgsVectorLayerCa
   {
     mTransform = QgsCoordinateTransform( mVectorLayerCache->sourceCrs(), mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
   if ( !mFilterRect.isNull() )
   {
     // update request to be the unprojected filter rect
@@ -123,7 +123,7 @@ bool QgsCachedFeatureWriterIterator::fetchFeature( QgsFeature &f )
     // As long as features can be fetched from the provider: Write them to cache
     mVectorLayerCache->cacheFeature( f );
     mFids.insert( f.id() );
-    transformFeatureGeometry( f, mTransform );
+    geometryToDestinationCrs( f, mTransform );
     return true;
   }
   else

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -15,6 +15,7 @@
 
 #include "qgscachedfeatureiterator.h"
 #include "qgsvectorlayercache.h"
+#include "qgscsexception.h"
 
 QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache, const QgsFeatureRequest &featureRequest )
   : QgsAbstractFeatureIterator( featureRequest )
@@ -24,7 +25,16 @@ QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache
   {
     mTransform = QgsCoordinateTransform( mVectorLayerCache->sourceCrs(), mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
   if ( !mFilterRect.isNull() )
   {
     // update request to be the unprojected filter rect
@@ -101,7 +111,16 @@ QgsCachedFeatureWriterIterator::QgsCachedFeatureWriterIterator( QgsVectorLayerCa
   {
     mTransform = QgsCoordinateTransform( mVectorLayerCache->sourceCrs(), mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
   if ( !mFilterRect.isNull() )
   {
     // update request to be the unprojected filter rect

--- a/src/core/qgscachedfeatureiterator.h
+++ b/src/core/qgscachedfeatureiterator.h
@@ -78,6 +78,8 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
     QgsFeatureIds mFeatureIds;
     QgsVectorLayerCache *mVectorLayerCache = nullptr;
     QgsFeatureIds::ConstIterator mFeatureIdIterator;
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 /** \ingroup core
@@ -127,5 +129,7 @@ class CORE_EXPORT QgsCachedFeatureWriterIterator : public QgsAbstractFeatureIter
     QgsFeatureIterator mFeatIt;
     QgsVectorLayerCache *mVectorLayerCache = nullptr;
     QgsFeatureIds mFids;
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 #endif // QGSCACHEDFEATUREITERATOR_H

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -98,7 +98,7 @@ bool QgsAbstractFeatureIterator::nextFeatureFilterFids( QgsFeature &f )
   return false;
 }
 
-void QgsAbstractFeatureIterator::transformFeatureGeometry( QgsFeature &feature, const QgsCoordinateTransform &transform ) const
+void QgsAbstractFeatureIterator::geometryToDestinationCrs( QgsFeature &feature, const QgsCoordinateTransform &transform ) const
 {
   if ( transform.isValid() && feature.hasGeometry() )
   {
@@ -119,7 +119,7 @@ void QgsAbstractFeatureIterator::transformFeatureGeometry( QgsFeature &feature, 
   }
 }
 
-QgsRectangle QgsAbstractFeatureIterator::transformedFilterRect( const QgsCoordinateTransform &transform ) const
+QgsRectangle QgsAbstractFeatureIterator::filterRectToSourceCrs( const QgsCoordinateTransform &transform ) const
 {
   if ( mRequest.filterRect().isNull() )
     return QgsRectangle();

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -124,15 +124,7 @@ QgsRectangle QgsAbstractFeatureIterator::filterRectToSourceCrs( const QgsCoordin
   if ( mRequest.filterRect().isNull() )
     return QgsRectangle();
 
-  try
-  {
-    return transform.transformBoundingBox( mRequest.filterRect(), QgsCoordinateTransform::ReverseTransform );
-  }
-  catch ( QgsCsException & )
-  {
-    // can't reproject mFilterRect
-    return mRequest.filterRect();
-  }
+  return transform.transformBoundingBox( mRequest.filterRect(), QgsCoordinateTransform::ReverseTransform );
 }
 
 void QgsAbstractFeatureIterator::ref()

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -131,6 +131,7 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      * the requested filterRect() transformed to the source's coordinate reference system.
      * Iterators should call this method and use the returned rectangle for filtering
      * features to ensure that any QgsFeatureRequest::destinationCrs() set on the request is respected.
+     * Will throw a QgsCsException if the rect cannot be transformed from the destination CRS.
      * \since QGIS 3.0
      */
     QgsRectangle filterRectToSourceCrs( const QgsCoordinateTransform &transform ) const;

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -114,6 +114,27 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      */
     virtual bool nextFeatureFilterFids( QgsFeature &f );
 
+    /**
+     * Transforms \a feature's geometry according to the specified coordinate \a transform.
+     * If \a feature has no geometry or \a transform is invalid then calling this method
+     * has no effect and will be shortcut.
+     * Iterators should call this method before returning features to ensure that any
+     * QgsFeatureRequest::destinationCrs() set on the request is respected.
+     * \since QGIS 3.0
+     */
+    void transformFeatureGeometry( QgsFeature &feature, const QgsCoordinateTransform &transform ) const;
+
+
+    /**
+     * Returns a rectangle representing the original request's QgsFeatureRequest::filterRect().
+     * If \a transform is a valid coordinate transform, the return rectangle will represent
+     * the requested filterRect() transformed to the source's coordinate reference system.
+     * Iterators should call this method and use the returned rectangle for filtering
+     * features to ensure that any QgsFeatureRequest::destinationCrs() set on the request is respected.
+     * \since QGIS 3.0
+     */
+    QgsRectangle transformedFilterRect( const QgsCoordinateTransform &transform ) const;
+
     //! A copy of the feature request.
     QgsFeatureRequest mRequest;
 

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -122,7 +122,7 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      * QgsFeatureRequest::destinationCrs() set on the request is respected.
      * \since QGIS 3.0
      */
-    void transformFeatureGeometry( QgsFeature &feature, const QgsCoordinateTransform &transform ) const;
+    void geometryToDestinationCrs( QgsFeature &feature, const QgsCoordinateTransform &transform ) const;
 
 
     /**
@@ -133,7 +133,7 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      * features to ensure that any QgsFeatureRequest::destinationCrs() set on the request is respected.
      * \since QGIS 3.0
      */
-    QgsRectangle transformedFilterRect( const QgsCoordinateTransform &transform ) const;
+    QgsRectangle filterRectToSourceCrs( const QgsCoordinateTransform &transform ) const;
 
     //! A copy of the feature request.
     QgsFeatureRequest mRequest;

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -83,6 +83,8 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mSimplifyMethod = rh.mSimplifyMethod;
   mLimit = rh.mLimit;
   mOrderBy = rh.mOrderBy;
+  mCrs = rh.mCrs;
+  mTransformErrorCallback = rh.mTransformErrorCallback;
   return *this;
 }
 
@@ -231,6 +233,24 @@ QgsFeatureRequest &QgsFeatureRequest::setSubsetOfAttributes( const QSet<QString>
 QgsFeatureRequest &QgsFeatureRequest::setSimplifyMethod( const QgsSimplifyMethod &simplifyMethod )
 {
   mSimplifyMethod = simplifyMethod;
+  return *this;
+}
+
+
+QgsCoordinateReferenceSystem QgsFeatureRequest::destinationCrs() const
+{
+  return mCrs;
+}
+
+QgsFeatureRequest &QgsFeatureRequest::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  mCrs = crs;
+  return *this;
+}
+
+QgsFeatureRequest &QgsFeatureRequest::setTransformErrorCallback( std::function<void ( const QgsFeature & )> callback )
+{
+  mTransformErrorCallback = callback;
   return *this;
 }
 

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -522,6 +522,15 @@ class CORE_EXPORT QgsFeatureRequest
      * set on the request is expected to be in the same CRS as the destination
      * CRS.
      *
+     * The feature geometry transformation to the destination CRS is performed
+     * after all filter expressions are tested and any virtual fields are
+     * calculated. Accordingly, any geometric expressions used in
+     * filterExpression() will be performed in the original
+     * source CRS. This ensures consistent results are returned regardless of the
+     * destination CRS. Similarly, virtual field values will be calculated using the
+     * original geometry in the source CRS, so these values are not affected by
+     * any destination CRS transform present in the feature request.
+     *
      * \see destinationCrs()
      * \since QGIS 3.0
      */

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -25,6 +25,7 @@
 #include "qgsdistancearea.h"
 #include "qgsproject.h"
 #include "qgsmessagelog.h"
+#include "qgscsexception.h"
 
 QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( const QgsVectorLayer *layer )
 {
@@ -113,7 +114,16 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
   if ( !mFilterRect.isNull() )
   {
     // update request to be the unprojected filter rect

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -113,7 +113,7 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
   if ( !mFilterRect.isNull() )
   {
     // update request to be the unprojected filter rect
@@ -717,7 +717,7 @@ bool QgsVectorLayerFeatureIterator::postProcessFeature( QgsFeature &feature )
 {
   bool result = checkGeometryValidity( feature );
   if ( result )
-    transformFeatureGeometry( feature, mTransform );
+    geometryToDestinationCrs( feature, mTransform );
   return result;
 }
 

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -208,6 +208,9 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     QgsFeatureRequest mChangedFeaturesRequest;
     QgsFeatureIterator mChangedFeaturesIterator;
 
+    QgsRectangle mFilterRect;
+    QgsCoordinateTransform mTransform;
+
     // only related to editing
     QSet<QgsFeatureId> mFetchConsidered;
     QgsGeometryMap::ConstIterator mFetchChangedGeomIt;
@@ -250,9 +253,9 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     void createOrderedJoinList();
 
     /**
-     * Performs any feature based validity checking, e.g. checking for geometry validity.
+     * Performs any post-processing (such as transformation) and feature based validity checking, e.g. checking for geometry validity.
      */
-    bool testFeature( const QgsFeature &feature );
+    bool postProcessFeature( QgsFeature &feature );
 
     /**
      * Checks a feature's geometry for validity, if requested in feature request.

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -45,7 +45,7 @@ QgsAfsFeatureIterator::QgsAfsFeatureIterator( QgsAfsFeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 }
 
 QgsAfsFeatureIterator::~QgsAfsFeatureIterator()
@@ -74,7 +74,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
   if ( mRequest.filterType() == QgsFeatureRequest::FilterFid )
   {
     bool result = mSource->provider()->getFeature( mRequest.filterFid(), f, fetchGeometries, fetchAttribures );
-    transformFeatureGeometry( f, mTransform );
+    geometryToDestinationCrs( f, mTransform );
     return result;
   }
   else
@@ -88,7 +88,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
       ++mFeatureIterator;
       if ( !success )
         continue;
-      transformFeatureGeometry( f, mTransform );
+      geometryToDestinationCrs( f, mTransform );
       return true;
     }
   }

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -17,7 +17,7 @@
 #include "qgsafsprovider.h"
 #include "qgsmessagelog.h"
 #include "geometry/qgsgeometry.h"
-
+#include "qgscsexception.h"
 
 QgsAfsFeatureSource::QgsAfsFeatureSource( const QgsAfsProvider *provider )
 // FIXME: ugly const_cast...
@@ -45,7 +45,16 @@ QgsAfsFeatureIterator::QgsAfsFeatureIterator( QgsAfsFeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 }
 
 QgsAfsFeatureIterator::~QgsAfsFeatureIterator()

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.h
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.h
@@ -31,6 +31,7 @@ class QgsAfsFeatureSource : public QgsAbstractFeatureSource
 
   protected:
     QgsAfsProvider *mProvider = nullptr;
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsAfsFeatureIterator;
 };
@@ -48,6 +49,8 @@ class QgsAfsFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsAfs
 
   private:
     QgsFeatureId mFeatureIterator = 0;
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 #endif // QGSAFSFEATUREITERATOR_H

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -22,6 +22,7 @@
 #include "qgssettings.h"
 #include "qgslogger.h"
 #include "qgsgeometry.h"
+#include "qgscsexception.h"
 
 #include <QObject>
 #include <QTextStream>
@@ -37,7 +38,16 @@ QgsDb2FeatureIterator::QgsDb2FeatureIterator( QgsDb2FeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   BuildStatement( request );
 

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -37,7 +37,7 @@ QgsDb2FeatureIterator::QgsDb2FeatureIterator( QgsDb2FeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   BuildStatement( request );
 
@@ -378,7 +378,7 @@ bool QgsDb2FeatureIterator::fetchFeature( QgsFeature &feature )
     }
     feature.setValid( true );
     mFetchCount++;
-    transformFeatureGeometry( feature, mTransform );
+    geometryToDestinationCrs( feature, mTransform );
     if ( mFetchCount % 100 == 0 )
     {
       QgsDebugMsg( QString( "Fetch count: %1" ).arg( mFetchCount ) );

--- a/src/providers/db2/qgsdb2featureiterator.h
+++ b/src/providers/db2/qgsdb2featureiterator.h
@@ -52,6 +52,8 @@ class QgsDb2FeatureSource : public QgsAbstractFeatureSource
     // SQL statement used to limit the features retrieved
     QString mSqlWhereClause;
 
+    QgsCoordinateReferenceSystem mCrs;
+
     // Return True if this feature source has spatial attributes.
     bool isSpatial() { return !mGeometryColName.isEmpty() || !mGeometryColType.isEmpty(); }
 
@@ -100,6 +102,9 @@ class QgsDb2FeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsDb2
     bool mOrderByCompiled;
 
     int mFetchCount = 0;
+
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 #endif // QGSDB2FEATUREITERATOR_H

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -43,7 +43,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   if ( !mFilterRect.isNull() && hasGeometry )
   {
@@ -216,7 +216,7 @@ bool QgsDelimitedTextFeatureIterator::fetchFeature( QgsFeature &feature )
 
   if ( ! gotFeature ) close();
 
-  transformFeatureGeometry( feature, mTransform );
+  geometryToDestinationCrs( feature, mTransform );
 
   return gotFeature;
 }

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -43,7 +43,16 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   if ( !mFilterRect.isNull() && hasGeometry )
   {

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -22,6 +22,7 @@
 #include "qgsmessagelog.h"
 #include "qgsproject.h"
 #include "qgsspatialindex.h"
+#include "qgscsexception.h"
 
 #include <QtAlgorithms>
 #include <QTextStream>
@@ -38,7 +39,13 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   // load it.
   bool hasGeometry = mSource->mGeomRep != QgsDelimitedTextProvider::GeomNone;
 
-  if ( !request.filterRect().isNull() && hasGeometry )
+  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
+  {
+    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
+  }
+  mFilterRect = transformedFilterRect( mTransform );
+
+  if ( !mFilterRect.isNull() && hasGeometry )
   {
     QgsDebugMsg( "Configuring for rectangle select" );
     mTestGeometry = true;
@@ -46,10 +53,8 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
     mTestGeometryExact = mRequest.flags() & QgsFeatureRequest::ExactIntersect
                          && mSource->mGeomRep == QgsDelimitedTextProvider::GeomAsWkt;
 
-    QgsRectangle rect = request.filterRect();
-
     // If request doesn't overlap extents, then nothing to return
-    if ( ! rect.intersects( mSource->mExtent ) && !mTestSubset )
+    if ( ! mFilterRect.intersects( mSource->mExtent ) && !mTestSubset )
     {
       QgsDebugMsg( "Rectangle outside layer extents - no features to return" );
       mMode = FeatureIds;
@@ -57,7 +62,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
     // If the request extents include the entire layer, then revert to
     // a file scan
 
-    else if ( rect.contains( mSource->mExtent ) && !mTestSubset )
+    else if ( mFilterRect.contains( mSource->mExtent ) && !mTestSubset )
     {
       QgsDebugMsg( "Rectangle contains layer extents - bypass spatial filter" );
       mTestGeometry = false;
@@ -69,7 +74,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
 
     else if ( mSource->mUseSpatialIndex )
     {
-      mFeatureIds = mSource->mSpatialIndex->intersects( rect );
+      mFeatureIds = mSource->mSpatialIndex->intersects( mFilterRect );
       // Sort for efficient sequential retrieval
       std::sort( mFeatureIds.begin(), mFeatureIds.end() );
       QgsDebugMsg( QString( "Layer has spatial index - selected %1 features from index" ).arg( mFeatureIds.size() ) );
@@ -82,7 +87,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   if ( request.filterType() == QgsFeatureRequest::FilterFid )
   {
     QgsDebugMsg( "Configuring for returning single id" );
-    if ( request.filterRect().isNull() || mFeatureIds.contains( request.filterFid() ) )
+    if ( mFilterRect.isNull() || mFeatureIds.contains( request.filterFid() ) )
     {
       mFeatureIds = QList<QgsFeatureId>() << request.filterFid();
     }
@@ -211,6 +216,8 @@ bool QgsDelimitedTextFeatureIterator::fetchFeature( QgsFeature &feature )
 
   if ( ! gotFeature ) close();
 
+  transformFeatureGeometry( feature, mTransform );
+
   return gotFeature;
 }
 
@@ -249,7 +256,7 @@ bool QgsDelimitedTextFeatureIterator::close()
 bool QgsDelimitedTextFeatureIterator::wantGeometry( const QgsPointXY &pt ) const
 {
   if ( ! mTestGeometry ) return true;
-  return mRequest.filterRect().contains( pt );
+  return mFilterRect.contains( pt );
 }
 
 /**
@@ -260,9 +267,9 @@ bool QgsDelimitedTextFeatureIterator::wantGeometry( const QgsGeometry &geom ) co
   if ( ! mTestGeometry ) return true;
 
   if ( mTestGeometryExact )
-    return geom.intersects( mRequest.filterRect() );
+    return geom.intersects( mFilterRect );
   else
-    return geom.boundingBox().intersects( mRequest.filterRect() );
+    return geom.boundingBox().intersects( mFilterRect );
 }
 
 
@@ -500,6 +507,7 @@ QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimited
   , mDecimalPoint( p->mDecimalPoint )
   , mXyDms( p->mXyDms )
   , attributeColumns( p->attributeColumns )
+  , mCrs( p->mCrs )
 {
   QUrl url = p->mFile->url();
 

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -50,6 +50,7 @@ class QgsDelimitedTextFeatureSource : public QgsAbstractFeatureSource
     QString mDecimalPoint;
     bool mXyDms;
     QList<int> attributeColumns;
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsDelimitedTextFeatureIterator;
 };
@@ -94,6 +95,8 @@ class QgsDelimitedTextFeatureIterator : public QgsAbstractFeatureIteratorFromSou
     bool mTestGeometry = false;
     bool mTestGeometryExact = false;
     bool mLoadGeometry = false;
+    QgsRectangle mFilterRect;
+    QgsCoordinateTransform mTransform;
 };
 
 

--- a/src/providers/gpx/qgsgpxfeatureiterator.cpp
+++ b/src/providers/gpx/qgsgpxfeatureiterator.cpp
@@ -20,6 +20,7 @@
 #include "qgsgeometry.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
+#include "qgscsexception.h"
 
 #include <limits>
 #include <cstring>
@@ -32,7 +33,16 @@ QgsGPXFeatureIterator::QgsGPXFeatureIterator( QgsGPXFeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   rewind();
 }

--- a/src/providers/gpx/qgsgpxfeatureiterator.cpp
+++ b/src/providers/gpx/qgsgpxfeatureiterator.cpp
@@ -32,7 +32,7 @@ QgsGPXFeatureIterator::QgsGPXFeatureIterator( QgsGPXFeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   rewind();
 }
@@ -87,7 +87,7 @@ bool QgsGPXFeatureIterator::fetchFeature( QgsFeature &feature )
     bool res = readFid( feature );
     close();
     if ( res )
-      transformFeatureGeometry( feature, mTransform );
+      geometryToDestinationCrs( feature, mTransform );
     return res;
   }
 
@@ -100,7 +100,7 @@ bool QgsGPXFeatureIterator::fetchFeature( QgsFeature &feature )
       if ( readWaypoint( *mWptIter, feature ) )
       {
         ++mWptIter;
-        transformFeatureGeometry( feature, mTransform );
+        geometryToDestinationCrs( feature, mTransform );
         return true;
       }
     }
@@ -114,7 +114,7 @@ bool QgsGPXFeatureIterator::fetchFeature( QgsFeature &feature )
       if ( readRoute( *mRteIter, feature ) )
       {
         ++mRteIter;
-        transformFeatureGeometry( feature, mTransform );
+        geometryToDestinationCrs( feature, mTransform );
         return true;
       }
     }
@@ -128,7 +128,7 @@ bool QgsGPXFeatureIterator::fetchFeature( QgsFeature &feature )
       if ( readTrack( *mTrkIter, feature ) )
       {
         ++mTrkIter;
-        transformFeatureGeometry( feature, mTransform );
+        geometryToDestinationCrs( feature, mTransform );
         return true;
       }
     }

--- a/src/providers/gpx/qgsgpxfeatureiterator.h
+++ b/src/providers/gpx/qgsgpxfeatureiterator.h
@@ -37,6 +37,7 @@ class QgsGPXFeatureSource : public QgsAbstractFeatureSource
     QgsGPSData *data = nullptr;
     QVector<int> indexToAttr;
     QgsFields mFields;
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsGPXFeatureIterator;
 };
@@ -80,6 +81,9 @@ class QgsGPXFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsGPX
     QgsGPSData::TrackIterator mTrkIter;
 
     bool mFetchedFid = false;
+
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 #endif // QGSGPXFEATUREITERATOR_H

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -37,7 +37,7 @@ QgsMssqlFeatureIterator::QgsMssqlFeatureIterator( QgsMssqlFeatureSource *source,
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   BuildStatement( request );
 
@@ -330,7 +330,7 @@ bool QgsMssqlFeatureIterator::fetchFeature( QgsFeature &feature )
     }
 
     feature.setValid( true );
-    transformFeatureGeometry( feature, mTransform );
+    geometryToDestinationCrs( feature, mTransform );
     return true;
   }
   return false;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -20,6 +20,7 @@
 #include "qgsmssqlprovider.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgscsexception.h"
 
 #include <QObject>
 #include <QTextStream>
@@ -37,7 +38,16 @@ QgsMssqlFeatureIterator::QgsMssqlFeatureIterator( QgsMssqlFeatureSource *source,
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   BuildStatement( request );
 

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -61,6 +61,8 @@ class QgsMssqlFeatureSource : public QgsAbstractFeatureSource
     // SQL statement used to limit the features retrieved
     QString mSqlWhereClause;
 
+    QgsCoordinateReferenceSystem mCrs;
+
     // Return True if this feature source has spatial attributes.
     bool isSpatial() { return !mGeometryColName.isEmpty() || !mGeometryColType.isEmpty(); }
 
@@ -114,6 +116,9 @@ class QgsMssqlFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsM
 
     bool mExpressionCompiled = false;
     bool mOrderByCompiled = false;
+
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 #endif // QGSMSSQLFEATUREITERATOR_H

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -80,7 +80,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   mFetchGeometry = ( !mFilterRect.isNull() ) || !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   QgsAttributeList attrs = ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes ) ? mRequest.subsetOfAttributes() : mSource->mFields.allAttributesList();
@@ -197,7 +197,7 @@ bool QgsOgrFeatureIterator::fetchFeatureWithId( QgsFeatureId id, QgsFeature &fea
     OGR_F_Destroy( fet );
 
   feature.setValid( true );
-  transformFeatureGeometry( feature, mTransform );
+  geometryToDestinationCrs( feature, mTransform );
   return true;
 }
 
@@ -242,7 +242,7 @@ bool QgsOgrFeatureIterator::fetchFeature( QgsFeature &feature )
 
     // we have a feature, end this cycle
     feature.setValid( true );
-    transformFeatureGeometry( feature, mTransform );
+    geometryToDestinationCrs( feature, mTransform );
     return true;
 
   } // while

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -80,7 +80,16 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   mFetchGeometry = ( !mFilterRect.isNull() ) || !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   QgsAttributeList attrs = ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes ) ? mRequest.subsetOfAttributes() : mSource->mFields.allAttributesList();

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -24,6 +24,7 @@
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
 #include "qgssettings.h"
+#include "qgscsexception.h"
 
 #include <QTextCodec>
 #include <QFile>
@@ -75,7 +76,13 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
     mSubsetStringSet = true;
   }
 
-  mFetchGeometry = ( !mRequest.filterRect().isNull() ) || !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
+  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
+  {
+    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
+  }
+  mFilterRect = transformedFilterRect( mTransform );
+
+  mFetchGeometry = ( !mFilterRect.isNull() ) || !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   QgsAttributeList attrs = ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes ) ? mRequest.subsetOfAttributes() : mSource->mFields.allAttributesList();
 
   // ensure that all attributes required for expression filter are being fetched
@@ -109,17 +116,15 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   // unless it's a VRT data source filtered by geometry as we don't know which
   // attributes make up the geometry and OGR won't fetch them to evaluate the
   // filter if we choose to ignore them (fixes #11223)
-  if ( ( mSource->mDriverName != QLatin1String( "VRT" ) && mSource->mDriverName != QLatin1String( "OGR_VRT" ) ) || mRequest.filterRect().isNull() )
+  if ( ( mSource->mDriverName != QLatin1String( "VRT" ) && mSource->mDriverName != QLatin1String( "OGR_VRT" ) ) || mFilterRect.isNull() )
   {
     QgsOgrProviderUtils::setRelevantFields( ogrLayer, mSource->mFields.count(), mFetchGeometry, attrs, mSource->mFirstFieldIsFid );
   }
 
   // spatial query to select features
-  if ( !mRequest.filterRect().isNull() )
+  if ( !mFilterRect.isNull() )
   {
-    const QgsRectangle &rect = mRequest.filterRect();
-
-    OGR_L_SetSpatialFilterRect( ogrLayer, rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() );
+    OGR_L_SetSpatialFilterRect( ogrLayer, mFilterRect.xMinimum(), mFilterRect.yMinimum(), mFilterRect.xMaximum(), mFilterRect.yMaximum() );
   }
   else
   {
@@ -192,6 +197,7 @@ bool QgsOgrFeatureIterator::fetchFeatureWithId( QgsFeatureId id, QgsFeature &fea
     OGR_F_Destroy( fet );
 
   feature.setValid( true );
+  transformFeatureGeometry( feature, mTransform );
   return true;
 }
 
@@ -231,11 +237,12 @@ bool QgsOgrFeatureIterator::fetchFeature( QgsFeature &feature )
     else
       OGR_F_Destroy( fet );
 
-    if ( !mRequest.filterRect().isNull() && !feature.hasGeometry() )
+    if ( !mFilterRect.isNull() && !feature.hasGeometry() )
       continue;
 
     // we have a feature, end this cycle
     feature.setValid( true );
+    transformFeatureGeometry( feature, mTransform );
     return true;
 
   } // while
@@ -304,7 +311,6 @@ void QgsOgrFeatureIterator::getFeatureAttribute( OGRFeatureH ogrFet, QgsFeature 
   f.setAttribute( attindex, value );
 }
 
-
 bool QgsOgrFeatureIterator::readFeature( OGRFeatureH fet, QgsFeature &feature ) const
 {
   feature.setId( OGR_F_GetFID( fet ) );
@@ -329,7 +335,7 @@ bool QgsOgrFeatureIterator::readFeature( OGRFeatureH fet, QgsFeature &feature ) 
     {
       // OK
     }
-    else if ( ( useIntersect && ( !feature.hasGeometry() || !feature.geometry().intersects( mRequest.filterRect() ) ) )
+    else if ( ( useIntersect && ( !feature.hasGeometry() || !feature.geometry().intersects( mFilterRect ) ) )
               || ( geometryTypeFilter && ( !feature.hasGeometry() || QgsOgrProvider::ogrWkbSingleFlatten( ( OGRwkbGeometryType )feature.geometry().wkbType() ) != mSource->mOgrGeometryTypeFilter ) ) )
     {
       OGR_F_Destroy( fet );
@@ -374,6 +380,7 @@ QgsOgrFeatureSource::QgsOgrFeatureSource( const QgsOgrProvider *p )
   , mFirstFieldIsFid( p->mFirstFieldIsFid )
   , mOgrGeometryTypeFilter( QgsOgrProvider::ogrWkbSingleFlatten( p->mOgrGeometryTypeFilter ) )
   , mDriverName( p->ogrDriverName )
+  , mCrs( p->crs() )
 {
   for ( int i = ( p->mFirstFieldIsFid ) ? 1 : 0; i < mFields.size(); i++ )
     mFieldsWithoutFid.append( mFields.at( i ) );

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -43,6 +43,7 @@ class QgsOgrFeatureSource : public QgsAbstractFeatureSource
     QgsFields mFieldsWithoutFid;
     OGRwkbGeometryType mOgrGeometryTypeFilter;
     QString mDriverName;
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsOgrFeatureIterator;
     friend class QgsOgrExpressionCompiler;
@@ -80,6 +81,9 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
     bool mExpressionCompiled;
     QgsFeatureIds mFilterFids;
     QgsFeatureIds::const_iterator mFilterFidsIt;
+
+    QgsRectangle mFilterRect;
+    QgsCoordinateTransform mTransform;
 
     bool fetchFeatureWithId( QgsFeatureId id, QgsFeature &feature ) const;
 };

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -38,6 +38,12 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
     return;
   }
 
+  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
+  {
+    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
+  }
+  mFilterRect = transformedFilterRect( mTransform );
+
   QVariantList args;
   mQry = QSqlQuery( *mConnection );
 
@@ -74,12 +80,11 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
       mFetchGeometry = true;
     }
 
-    if ( !mRequest.filterRect().isNull() )
+    if ( !mFilterRect.isNull() )
     {
       // sdo_filter requires spatial index
       if ( mSource->mHasSpatialIndex )
       {
-        QgsRectangle rect( mRequest.filterRect() );
         QString bbox = QStringLiteral( "mdsys.sdo_geometry(2003,?,NULL,"
                                        "mdsys.sdo_elem_info_array(1,1003,3),"
                                        "mdsys.sdo_ordinate_array(?,?,?,?)"
@@ -88,7 +93,7 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
         whereClause = QStringLiteral( "sdo_filter(%1,%2)='TRUE'" )
                       .arg( QgsOracleProvider::quotedIdentifier( mSource->mGeometryColumn ) ).arg( bbox );
 
-        args << ( mSource->mSrid < 1 ? QVariant( QVariant::Int ) : mSource->mSrid ) << rect.xMinimum() << rect.yMinimum() << rect.xMaximum() << rect.yMaximum();
+        args << ( mSource->mSrid < 1 ? QVariant( QVariant::Int ) : mSource->mSrid ) << mFilterRect.xMinimum() << mFilterRect.yMinimum() << mFilterRect.xMaximum() << mFilterRect.yMaximum();
 
         if ( ( mRequest.flags() & QgsFeatureRequest::ExactIntersect ) != 0 )
         {
@@ -98,7 +103,7 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
             whereClause += QString( " AND sdo_relate(%1,%2,'mask=ANYINTERACT')='TRUE'" )
                            .arg( QgsOracleProvider::quotedIdentifier( mSource->mGeometryColumn ) )
                            .arg( bbox );
-            args << ( mSource->mSrid < 1 ? QVariant( QVariant::Int ) : mSource->mSrid ) << rect.xMinimum() << rect.yMinimum() << rect.xMaximum() << rect.yMaximum();
+            args << ( mSource->mSrid < 1 ? QVariant( QVariant::Int ) : mSource->mSrid ) << mFilterRect.xMinimum() << mFilterRect.yMinimum() << mFilterRect.xMaximum() << mFilterRect.yMaximum();
           }
           else
           {
@@ -114,7 +119,7 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
       }
     }
   }
-  else if ( !mRequest.filterRect().isNull() )
+  else if ( !mFilterRect.isNull() )
   {
     QgsDebugMsg( "filterRect without geometry ignored" );
   }
@@ -277,7 +282,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
         feature.clearGeometry();
       }
 
-      if ( !mRequest.filterRect().isNull() )
+      if ( !mFilterRect.isNull() )
       {
         if ( !feature.hasGeometry() )
         {
@@ -291,7 +296,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
           if ( !mSource->mHasSpatialIndex )
           {
             // only intersect with bbox
-            if ( !feature.geometry().boundingBox().intersects( mRequest.filterRect() ) )
+            if ( !feature.geometry().boundingBox().intersects( mFilterRect ) )
             {
               // skip feature that don't intersect with our rectangle
               QgsDebugMsg( "no bbox intersect" );
@@ -302,7 +307,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
         else if ( !mConnection->hasSpatial() || !mSource->mHasSpatialIndex )
         {
           // couldn't use sdo_relate earlier
-          if ( !feature.geometry().intersects( mRequest.filterRect() ) )
+          if ( !feature.geometry().intersects( mFilterRect ) )
           {
             // skip feature that don't intersect with our rectangle
             QgsDebugMsg( "no exact intersect" );
@@ -394,6 +399,8 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
 
     feature.setValid( true );
     feature.setFields( mSource->mFields ); // allow name-based attribute lookups
+
+    transformFeatureGeometry( feature, mTransform );
 
     return true;
   }
@@ -511,6 +518,7 @@ QgsOracleFeatureSource::QgsOracleFeatureSource( const QgsOracleProvider *p )
   , mPrimaryKeyType( p->mPrimaryKeyType )
   , mPrimaryKeyAttrs( p->mPrimaryKeyAttrs )
   , mQuery( p->mQuery )
+  , mCrs( p->crs() )
   , mShared( p->mShared )
 {
 }

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -42,7 +42,7 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   QVariantList args;
   mQry = QSqlQuery( *mConnection );
@@ -400,7 +400,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
     feature.setValid( true );
     feature.setFields( mSource->mFields ); // allow name-based attribute lookups
 
-    transformFeatureGeometry( feature, mTransform );
+    geometryToDestinationCrs( feature, mTransform );
 
     return true;
   }

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -22,6 +22,7 @@
 #include "qgsmessagelog.h"
 #include "qgsgeometry.h"
 #include "qgssettings.h"
+#include "qgscsexception.h"
 
 #include <QObject>
 
@@ -42,7 +43,16 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   QVariantList args;
   mQry = QSqlQuery( *mConnection );

--- a/src/providers/oracle/qgsoraclefeatureiterator.h
+++ b/src/providers/oracle/qgsoraclefeatureiterator.h
@@ -48,6 +48,7 @@ class QgsOracleFeatureSource : public QgsAbstractFeatureSource
     QgsOraclePrimaryKeyType mPrimaryKeyType;
     QList<int> mPrimaryKeyAttrs;
     QString mQuery;
+    QgsCoordinateReferenceSystem mCrs;
 
     QSharedPointer<QgsOracleSharedData> mShared;
 
@@ -80,6 +81,9 @@ class QgsOracleFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Qgs
     QgsAttributeList mAttributeList;
     QString mSql;
     QVariantList mArgs;
+
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 #endif // QGSORACLEFEATUREITERATOR_H

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -21,6 +21,7 @@
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
 #include "qgssettings.h"
+#include "qgscsexception.h"
 
 #include <QElapsedTimer>
 #include <QObject>
@@ -57,7 +58,16 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   mCursorName = mConn->uniqueCursorName();
   QString whereClause;

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -57,7 +57,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   mCursorName = mConn->uniqueCursorName();
   QString whereClause;
@@ -303,7 +303,7 @@ bool QgsPostgresFeatureIterator::fetchFeature( QgsFeature &feature )
 
   feature.setValid( true );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups
-  transformFeatureGeometry( feature, mTransform );
+  geometryToDestinationCrs( feature, mTransform );
 
   return true;
 }

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -51,6 +51,7 @@ class QgsPostgresFeatureSource : public QgsAbstractFeatureSource
     QList<int> mPrimaryKeyAttrs;
     QString mQuery;
     // TODO: loadFields()
+    QgsCoordinateReferenceSystem mCrs;
 
     std::shared_ptr<QgsPostgresSharedData> mShared;
 
@@ -123,6 +124,9 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
     bool mOrderByCompiled;
     bool mLastFetch;
     bool mFilterRequiresGeometry;
+
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 #endif // QGSPOSTGRESFEATUREITERATOR_H

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -47,7 +47,16 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   //beware - limitAtProvider needs to be set to false if the request cannot be completely handled
   //by the provider (e.g., utilising QGIS expression filters)

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -24,6 +24,7 @@
 #include "qgsmessagelog.h"
 #include "qgsjsonutils.h"
 #include "qgssettings.h"
+#include "qgscsexception.h"
 
 QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsSpatiaLiteFeatureSource>( source, ownSource, request )
@@ -42,11 +43,17 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
   QString fallbackWhereClause;
   QString whereClause;
 
+  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
+  {
+    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
+  }
+  mFilterRect = transformedFilterRect( mTransform );
+
   //beware - limitAtProvider needs to be set to false if the request cannot be completely handled
   //by the provider (e.g., utilising QGIS expression filters)
   bool limitAtProvider = ( mRequest.limit() >= 0 );
 
-  if ( !request.filterRect().isNull() && !mSource->mGeometryColumn.isNull() )
+  if ( !mFilterRect.isNull() && !mSource->mGeometryColumn.isNull() )
   {
     // some kind of MBR spatial filtering is required
     whereClause = whereClauseRect();
@@ -232,6 +239,7 @@ bool QgsSpatiaLiteFeatureIterator::fetchFeature( QgsFeature &feature )
   }
 
   feature.setValid( true );
+  transformFeatureGeometry( feature, mTransform );
   return true;
 }
 
@@ -377,28 +385,27 @@ QString QgsSpatiaLiteFeatureIterator::whereClauseFids()
 
 QString QgsSpatiaLiteFeatureIterator::whereClauseRect()
 {
-  QgsRectangle rect = mRequest.filterRect();
   QString whereClause;
 
   if ( mRequest.flags() & QgsFeatureRequest::ExactIntersect )
   {
     // we are requested to evaluate a true INTERSECT relationship
-    whereClause += QStringLiteral( "Intersects(%1, BuildMbr(%2)) AND " ).arg( QgsSpatiaLiteProvider::quotedIdentifier( mSource->mGeometryColumn ), mbr( rect ) );
+    whereClause += QStringLiteral( "Intersects(%1, BuildMbr(%2)) AND " ).arg( QgsSpatiaLiteProvider::quotedIdentifier( mSource->mGeometryColumn ), mbr( mFilterRect ) );
   }
   if ( mSource->mVShapeBased )
   {
     // handling a VirtualShape layer
-    whereClause += QStringLiteral( "MbrIntersects(%1, BuildMbr(%2))" ).arg( QgsSpatiaLiteProvider::quotedIdentifier( mSource->mGeometryColumn ), mbr( rect ) );
+    whereClause += QStringLiteral( "MbrIntersects(%1, BuildMbr(%2))" ).arg( QgsSpatiaLiteProvider::quotedIdentifier( mSource->mGeometryColumn ), mbr( mFilterRect ) );
   }
-  else if ( rect.isFinite() )
+  else if ( mFilterRect.isFinite() )
   {
     if ( mSource->mSpatialIndexRTree )
     {
       // using the RTree spatial index
-      QString mbrFilter = QStringLiteral( "xmin <= %1 AND " ).arg( qgsDoubleToString( rect.xMaximum() ) );
-      mbrFilter += QStringLiteral( "xmax >= %1 AND " ).arg( qgsDoubleToString( rect.xMinimum() ) );
-      mbrFilter += QStringLiteral( "ymin <= %1 AND " ).arg( qgsDoubleToString( rect.yMaximum() ) );
-      mbrFilter += QStringLiteral( "ymax >= %1" ).arg( qgsDoubleToString( rect.yMinimum() ) );
+      QString mbrFilter = QStringLiteral( "xmin <= %1 AND " ).arg( qgsDoubleToString( mFilterRect.xMaximum() ) );
+      mbrFilter += QStringLiteral( "xmax >= %1 AND " ).arg( qgsDoubleToString( mFilterRect.xMinimum() ) );
+      mbrFilter += QStringLiteral( "ymin <= %1 AND " ).arg( qgsDoubleToString( mFilterRect.yMaximum() ) );
+      mbrFilter += QStringLiteral( "ymax >= %1" ).arg( qgsDoubleToString( mFilterRect.yMinimum() ) );
       QString idxName = QStringLiteral( "idx_%1_%2" ).arg( mSource->mIndexTable, mSource->mIndexGeometry );
       whereClause += QStringLiteral( "%1 IN (SELECT pkid FROM %2 WHERE %3)" )
                      .arg( quotedPrimaryKey(),
@@ -412,12 +419,12 @@ QString QgsSpatiaLiteFeatureIterator::whereClauseRect()
       whereClause += QStringLiteral( "%1 IN (SELECT rowid FROM %2 WHERE mbr = FilterMbrIntersects(%3))" )
                      .arg( quotedPrimaryKey(),
                            QgsSpatiaLiteProvider::quotedIdentifier( idxName ),
-                           mbr( rect ) );
+                           mbr( mFilterRect ) );
     }
     else
     {
       // using simple MBR filtering
-      whereClause += QStringLiteral( "MbrIntersects(%1, BuildMbr(%2))" ).arg( QgsSpatiaLiteProvider::quotedIdentifier( mSource->mGeometryColumn ), mbr( rect ) );
+      whereClause += QStringLiteral( "MbrIntersects(%1, BuildMbr(%2))" ).arg( QgsSpatiaLiteProvider::quotedIdentifier( mSource->mGeometryColumn ), mbr( mFilterRect ) );
     }
   }
   else
@@ -612,6 +619,7 @@ QgsSpatiaLiteFeatureSource::QgsSpatiaLiteFeatureSource( const QgsSpatiaLiteProvi
   , mSpatialIndexRTree( p->mSpatialIndexRTree )
   , mSpatialIndexMbrCache( p->mSpatialIndexMbrCache )
   , mSqlitePath( p->mSqlitePath )
+  , mCrs( p->crs() )
 {
 }
 

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -47,7 +47,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   //beware - limitAtProvider needs to be set to false if the request cannot be completely handled
   //by the provider (e.g., utilising QGIS expression filters)
@@ -239,7 +239,7 @@ bool QgsSpatiaLiteFeatureIterator::fetchFeature( QgsFeature &feature )
   }
 
   feature.setValid( true );
-  transformFeatureGeometry( feature, mTransform );
+  geometryToDestinationCrs( feature, mTransform );
   return true;
 }
 

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -48,6 +48,7 @@ class QgsSpatiaLiteFeatureSource : public QgsAbstractFeatureSource
     bool mSpatialIndexRTree;
     bool mSpatialIndexMbrCache;
     QString mSqlitePath;
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsSpatiaLiteFeatureIterator;
     friend class QgsSpatiaLiteExpressionCompiler;
@@ -101,6 +102,9 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIteratorFromSource
 
     bool mOrderByCompiled;
     bool mExpressionCompiled;
+
+    QgsRectangle mFilterRect;
+    QgsCoordinateTransform mTransform;
 };
 
 #endif // QGSSPATIALITEFEATUREITERATOR_H

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -46,7 +46,7 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   try
   {
@@ -266,7 +266,7 @@ bool QgsVirtualLayerFeatureIterator::fetchFeature( QgsFeature &feature )
   }
 
   feature.setValid( true );
-  transformFeatureGeometry( feature, mTransform );
+  geometryToDestinationCrs( feature, mTransform );
   return true;
 }
 

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -19,6 +19,7 @@ email                : hugo dot mercier at oslandia dot com
 #include "qgsmessagelog.h"
 #include "qgsgeometry.h"
 #include "qgsvirtuallayerblob.h"
+#include "qgscsexception.h"
 
 #include <stdexcept>
 
@@ -46,7 +47,16 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   try
   {

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -42,6 +42,12 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
     return;
   }
 
+  if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
+  {
+    mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
+  }
+  mFilterRect = transformedFilterRect( mTransform );
+
   try
   {
     QString tableName = mSource->mTableName;
@@ -56,11 +62,10 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
     if ( !mSource->mDefinition.uid().isNull() )
     {
       // filters are only available when a column with unique id exists
-      if ( mSource->mDefinition.hasDefinedGeometry() && !request.filterRect().isNull() )
+      if ( mSource->mDefinition.hasDefinedGeometry() && !mFilterRect.isNull() )
       {
         bool do_exact = request.flags() & QgsFeatureRequest::ExactIntersect;
-        QgsRectangle rect( request.filterRect() );
-        QString mbr = QStringLiteral( "%1,%2,%3,%4" ).arg( rect.xMinimum() ).arg( rect.yMinimum() ).arg( rect.xMaximum() ).arg( rect.yMaximum() );
+        QString mbr = QStringLiteral( "%1,%2,%3,%4" ).arg( mFilterRect.xMinimum() ).arg( mFilterRect.yMinimum() ).arg( mFilterRect.xMaximum() ).arg( mFilterRect.yMaximum() );
         wheres << quotedColumn( mSource->mDefinition.geometryField() ) + " is not null";
         wheres <<  QStringLiteral( "%1Intersects(%2,BuildMbr(%3))" )
                .arg( do_exact ? "" : "Mbr",
@@ -261,6 +266,7 @@ bool QgsVirtualLayerFeatureIterator::fetchFeature( QgsFeature &feature )
   }
 
   feature.setValid( true );
+  transformFeatureGeometry( feature, mTransform );
   return true;
 }
 
@@ -271,6 +277,7 @@ QgsVirtualLayerFeatureSource::QgsVirtualLayerFeatureSource( const QgsVirtualLaye
   , mSqlite( p->mSqlite.get() )
   , mTableName( p->mTableName )
   , mSubset( p->mSubset )
+  , mCrs( p->crs() )
 {
 }
 

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
@@ -46,6 +46,7 @@ class QgsVirtualLayerFeatureSource : public QgsAbstractFeatureSource
     sqlite3 *mSqlite = nullptr;
     QString mTableName;
     QString mSubset;
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsVirtualLayerFeatureIterator;
 };
@@ -70,6 +71,8 @@ class QgsVirtualLayerFeatureIterator : public QgsAbstractFeatureIteratorFromSour
     QgsAttributeList mAttributes;
     QString mSqlQuery;
     QgsFeatureId mFid = 0;
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 
 };
 

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -793,7 +793,7 @@ QgsWFSFeatureIterator::QgsWFSFeatureIterator( QgsWFSFeatureSource *source,
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = transformedFilterRect( mTransform );
+  mFilterRect = filterRectToSourceCrs( mTransform );
 
   // Configurable for the purpose of unit tests
   QString threshold( getenv( "QGIS_WFS_ITERATOR_TRANSFER_THRESHOLD" ) );
@@ -1051,7 +1051,7 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
     }
 
     copyFeature( cachedFeature, f );
-    transformFeatureGeometry( f, mTransform );
+    geometryToDestinationCrs( f, mTransform );
     return true;
   }
 

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -26,6 +26,7 @@
 #include "qgswfsutils.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgscsexception.h"
 
 #include <QDir>
 #include <QProgressDialog>
@@ -793,7 +794,16 @@ QgsWFSFeatureIterator::QgsWFSFeatureIterator( QgsWFSFeatureSource *source,
   {
     mTransform = QgsCoordinateTransform( mSource->mCrs, mRequest.destinationCrs() );
   }
-  mFilterRect = filterRectToSourceCrs( mTransform );
+  try
+  {
+    mFilterRect = filterRectToSourceCrs( mTransform );
+  }
+  catch ( QgsCsException & )
+  {
+    // can't reproject mFilterRect
+    mClosed = true;
+    return;
+  }
 
   // Configurable for the purpose of unit tests
   QString threshold( getenv( "QGIS_WFS_ITERATOR_TRANSFER_THRESHOLD" ) );

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -244,6 +244,9 @@ class QgsWFSFeatureIterator : public QObject,
     QFile *mReaderFile = nullptr;
     QDataStream *mReaderStream = nullptr;
     bool mFetchGeometry;
+
+    QgsCoordinateTransform mTransform;
+    QgsRectangle mFilterRect;
 };
 
 //! Feature source
@@ -258,6 +261,7 @@ class QgsWFSFeatureSource : public QgsAbstractFeatureSource
   private:
 
     std::shared_ptr<QgsWFSSharedData> mShared;  //!< Mutable data shared between provider and feature sources
+    QgsCoordinateReferenceSystem mCrs;
 
     friend class QgsWFSFeatureIterator;
 };

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -533,6 +533,12 @@ class FeatureSourceTestCase(object):
         self.assertAlmostEqual(features[4].geometry().geometry().x(), -7271389, -5)
         self.assertAlmostEqual(features[4].geometry().geometry().y(), 14531322, -5)
 
+        # bad rect for transform
+        rect = QgsRectangle(-99999999999, 99999999999, -99999999998, 99999999998)
+        request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('epsg:28356')).setFilterRect(rect)
+        features = [f for f in self.source.getFeatures(request)]
+        self.assertFalse(features)
+
     def testGetFeaturesLimit(self):
         it = self.source.getFeatures(QgsFeatureRequest().setLimit(2))
         features = [f['pk'] for f in it]

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -25,6 +25,7 @@ from qgis.core import (
     QgsExpressionContextScope,
     QgsExpressionContext,
     QgsVectorLayerFeatureSource,
+    QgsCoordinateReferenceSystem,
     NULL
 )
 
@@ -506,6 +507,31 @@ class FeatureSourceTestCase(object):
         # test that results match QgsFeatureRequest.acceptFeature
         for f in self.source.getFeatures():
             self.assertEqual(request.acceptFeature(f), f['pk'] in expected)
+
+    def testGetFeaturesDestinationCrs(self):
+        request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('epsg:3785'))
+        features = {f['pk']:f for f in self.source.getFeatures(request)}
+        # test that features have been reprojected
+        self.assertAlmostEqual(features[1].geometry().geometry().x(), -7829322, -5)
+        self.assertAlmostEqual(features[1].geometry().geometry().y(), 9967753, -5)
+        self.assertAlmostEqual(features[2].geometry().geometry().x(), -7591989, -5)
+        self.assertAlmostEqual(features[2].geometry().geometry().y(), 11334232, -5)
+        self.assertFalse(features[3].hasGeometry())
+        self.assertAlmostEqual(features[4].geometry().geometry().x(), -7271389, -5)
+        self.assertAlmostEqual(features[4].geometry().geometry().y(), 14531322, -5)
+        self.assertAlmostEqual(features[5].geometry().geometry().x(), -7917376, -5)
+        self.assertAlmostEqual(features[5].geometry().geometry().y(), 14493008, -5)
+
+        # when destination crs is set, filter rect should be in destination crs
+        rect = QgsRectangle(-7650000,10500000,-7200000,15000000)
+        request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('epsg:3785')).setFilterRect(rect)
+        features = {f['pk']:f for f in self.source.getFeatures(request)}
+        self.assertEqual(set(features.keys()),{2,4})
+        # test that features have been reprojected
+        self.assertAlmostEqual(features[2].geometry().geometry().x(), -7591989, -5)
+        self.assertAlmostEqual(features[2].geometry().geometry().y(), 11334232, -5)
+        self.assertAlmostEqual(features[4].geometry().geometry().x(), -7271389, -5)
+        self.assertAlmostEqual(features[4].geometry().geometry().y(), 14531322, -5)
 
     def testGetFeaturesLimit(self):
         it = self.source.getFeatures(QgsFeatureRequest().setLimit(2))

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -510,7 +510,7 @@ class FeatureSourceTestCase(object):
 
     def testGetFeaturesDestinationCrs(self):
         request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('epsg:3785'))
-        features = {f['pk']:f for f in self.source.getFeatures(request)}
+        features = {f['pk']: f for f in self.source.getFeatures(request)}
         # test that features have been reprojected
         self.assertAlmostEqual(features[1].geometry().geometry().x(), -7829322, -5)
         self.assertAlmostEqual(features[1].geometry().geometry().y(), 9967753, -5)
@@ -523,10 +523,10 @@ class FeatureSourceTestCase(object):
         self.assertAlmostEqual(features[5].geometry().geometry().y(), 14493008, -5)
 
         # when destination crs is set, filter rect should be in destination crs
-        rect = QgsRectangle(-7650000,10500000,-7200000,15000000)
+        rect = QgsRectangle(-7650000, 10500000, -7200000, 15000000)
         request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('epsg:3785')).setFilterRect(rect)
-        features = {f['pk']:f for f in self.source.getFeatures(request)}
-        self.assertEqual(set(features.keys()),{2,4})
+        features = {f['pk']: f for f in self.source.getFeatures(request)}
+        self.assertEqual(set(features.keys()), {2, 4})
         # test that features have been reprojected
         self.assertAlmostEqual(features[2].geometry().geometry().x(), -7591989, -5)
         self.assertAlmostEqual(features[2].geometry().geometry().y(), 11334232, -5)

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -2364,6 +2364,32 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         ids = set([f.id() for f in source.getFeatures()])
         self.assertEqual(ids, {f1.id(), f3.id(), f5.id()})
 
+    def testFeatureRequestWithReprojectionAndVirtualFields(self):
+        layer = self.getSource()
+        field = QgsField('virtual', QVariant.Double)
+        layer.addExpressionField('$x', field)
+        virtual_values = [f['virtual'] for f in layer.getFeatures()]
+        self.assertAlmostEqual(virtual_values[0], -71.123, 2)
+        self.assertEqual(virtual_values[1], NULL)
+        self.assertAlmostEqual(virtual_values[2], -70.332, 2)
+        self.assertAlmostEqual(virtual_values[3], -68.2, 2)
+        self.assertAlmostEqual(virtual_values[4], -65.32, 2)
+
+        # repeat, with reprojection on request
+        request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('epsg:3785'))
+        features = [f for f in layer.getFeatures(request)]
+        # virtual field value should not change, even though geometry has
+        self.assertAlmostEqual(features[0]['virtual'], -71.123, 2)
+        self.assertAlmostEqual(features[0].geometry().geometry().x(), -7917376, -5)
+        self.assertEqual(features[1]['virtual'], NULL)
+        self.assertFalse(features[1].hasGeometry())
+        self.assertAlmostEqual(features[2]['virtual'], -70.332, 2)
+        self.assertAlmostEqual(features[2].geometry().geometry().x(), -7829322, -5)
+        self.assertAlmostEqual(features[3]['virtual'], -68.2, 2)
+        self.assertAlmostEqual(features[3].geometry().geometry().x(), -7591989, -5)
+        self.assertAlmostEqual(features[4]['virtual'], -65.32, 2)
+        self.assertAlmostEqual(features[4].geometry().geometry().x(), -7271389, -5)
+
 
 class TestQgsVectorLayerSourceAddedFeaturesInBuffer(unittest.TestCase, FeatureSourceTestCase):
 


### PR DESCRIPTION
If set, all geometries will be reprojected from their original coordinate reference system to the destination CRS while iterating over features.

If a CRS has been set as the destination CRS, then the filterRect parameter should be specified in the same CRS as this destination CRS.

Additionally, a callback function can be specified on the request to be called if a transform exception is encountered while iterating over features.

This is designed to make it easier for scripts and plugins to correctly reproject layers in an efficient and robust way, instead of having to implement lots of repeated code themselves and potentially missing some of the important considerations which come with reprojecting geometries & bounding boxes.

Now, if a script wants the features from a layer in a specific CRS, they can call:

    crs = QgsCoordinateReferenceSystem('epsg:4326')
    request = QgsFeatureRequest().setDestinationCrs(crs)
    for f in layer.getFeatures(reqeuest):
        print('geometry in 4326 is {}.format(f.geometry().exportToWkt()))

This is a early WIP for review and comment. If it's desirable, I need to add unit tests to the provider test suite & implement for other iterators (only memory provider iterator is changed here so far)