### PR TITLE
Typo fix in Algorithms help

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -44,10 +44,10 @@ qgis:buildvirtualvector: >
 
   The output virtual layer will not be open in the current project.
 
-qgis:checkvalidity:
+qgis:checkvalidity: >
   This algorithm performs a validity check on the geometries of a vector layer.
 
-  The geometries are classified in three groups (valid, invalid and error), and a vector layer is generated with the features in each on of this categories.
+  The geometries are classified in three groups (valid, invalid and error), and a vector layer is generated with the features in each of these categories.
 
 qgis:clip: >
   This algorithm clips a vector layer using the polygons of an additional polygons layer. Only the parts of the features in the input layer that falls within the polygons of the clipping layer will be added to the resulting layer.
@@ -89,12 +89,12 @@ qgis:countuniquepointsinpolygon: >
   A new polygons layer is generated, with the exact same content as the input polygons layer, but containing an additional field with the points count corresponding to each polygon.
 
 qgis:createconstantrasterlayer: >
-  Given an input raster layer an a value, this algorithm generates a new layer with the same extent and cellsize as the input one, and all cells with the specified value.
+  Given an input raster layer and a value, this algorithm generates a new layer with the same extent and cell size as the input one, and all cells with the specified value.
 
 qgis:creategrid:
-  This algorithm creates a vector layer with a grid convering a given extent. Features can be lines or polygons, and the shape used in the grid can be rectangles, diamond or hexagons.
+  This algorithm creates a vector layer with a grid covering a given extent. Features can be lines or polygons, and the shape used in the grid can be rectangles, diamond or hexagons.
 
-  The size of each element in the grid is defined using a horizontal and vertical spaciong.
+  The size of each element in the grid is defined using a horizontal and vertical spacing.
 
   The CRS of the output layer must be defined. The grid extent and the spacing values are supposed to be expressed in the coordinates and units of this CRS.
 
@@ -110,18 +110,18 @@ qgis:deletecolumn: >
   This algorithm takes a vector layer and generates a new one that has the exact same content but without one of its columns.
 
 qgis:deleteduplicategeometries: >
-  This algorithm finds duplicated geometries and removes them.  Attributes are not checked, so in case two feature have identical geometries but different attributes, only one of them will be added to the result layer.
+  This algorithm finds duplicated geometries and removes them. Attributes are not checked, so in case two features have identical geometries but different attributes, only one of them will be added to the result layer.
 
 qgis:deleteholes: >
   This algorithm takes a polygon layer and removes holes in polygons. It creates a new vector layer in which polygons with holes have been replaced by polygons with only their external ring. Attributes are not modified.
 
 qgis:densifygeometries:
-  This algorithm takes a polygon or line layer and generaates a new one in which the geometries have a larger number of vertices than the original one.
+  This algorithm takes a polygon or line layer and generates a new one in which the geometries have a larger number of vertices than the original one.
 
   The number of new vertices to add to each feature geometry is specified as an input parameter.
 
 qgis:densifygeometriesgivenaninterval:
-  This algorithm takes a polygon or line layer and generaates a new one in which the geometries have a larger number of vertices than the original one.
+  This algorithm takes a polygon or line layer and generates a new one in which the geometries have a larger number of vertices than the original one.
 
   The number of new vertices depends on the length of the geometry, and is specified as a distance between them. The distance is expressed in the same units used by the layer CRS.
 
@@ -131,21 +131,21 @@ qgis:difference: >
   Attributes are not modified
 
 qgis:dissolve: >
-  This algorithm takes a polygon vector layer and dissolve adjacent polygons into  single geometries. An attribute can be specified to dissolve only polygons belonging to the same class (having the same value for the specified attribute), or all polygons can be dissolved, considering only their geometries.
+  This algorithm takes a polygon vector layer and dissolve adjacent polygons into single geometries. An attribute can be specified to dissolve only polygons belonging to the same class (having the same value for the specified attribute), or all polygons can be dissolved, considering only their geometries.
 
 qgis:distancematrix: >
   This algorithm creates a table containing a distance matrix, with distances between all the points in a points layer.
 
 
 qgis:distancetonearesthub: >
-  Given a layer with source point and another one representing destination points, this algorithm computes the distance between each source point and the closest detination one.
+  Given a layer with source point and another one representing destination points, this algorithm computes the distance between each source point and the closest destination one.
 
   The resulting layer can contain only source points with an additional field indicating the distance to the nearest point and the name of the destination point, or lines linking each source point with its nearest destination point.
 
 qgis:eliminatesliverpolygons:
 
 qgis:explodelines: >
-  This algorithm takes a lines layer and creates a new one in which each line is replaced is replaced by a set of lines representing the segments in the original line. Each line in the resulting layer contains only a start and an end point, with no intermediate nodes between them.
+  This algorithm takes a lines layer and creates a new one in which each line is replaced by a set of lines representing the segments in the original line. Each line in the resulting layer contains only a start and an end point, with no intermediate nodes between them.
 
 qgis:exportaddgeometrycolumns: >
   This algorithm computes geometric properties of the features in a vector layer. It generates a new vector layer with the same content as the input one, but with additional attributes in its attributes table, containing geometric measurements.
@@ -153,10 +153,10 @@ qgis:exportaddgeometrycolumns: >
   Depending on the geometry type of the vector layer, the attributes added to the table will be different.
 
 qgis:extractbyattribute: >
-  This algorithm creates new vector layer that only contain certain features from an input layer. The criteria for adding features to the resulting layer is defined based on the values of an attribute from the input layer.
+  This algorithm creates new vector layer that only contains certain features from an input layer. The criteria for adding features to the resulting layer is defined based on the values of an attribute from the input layer.
 
 qgis:extractbylocation: >
-  This algorithm creates new vector layer that only contain certain features from an input layer. The criteria for adding features to the resulting layer is defined based on the spatial relationship between each feature and the features in an additional layer.
+  This algorithm creates new vector layer that only contains certain features from an input layer. The criteria for adding features to the resulting layer is defined based on the spatial relationship between each feature and the features in an additional layer.
 
 qgis:extractnodes: >
   This algorithm takes a line or polygon layer and generates a point layer with points representing the nodes in the input lines or polygons. The attributes associated to each point are the same ones associated to the line or polygon that the point belongs to.
@@ -180,7 +180,7 @@ qgis:hublines:
 
 
 qgis:hypsometriccurves: >
-  This algorithm computes hypsometric curves  for an input Digital Elevation Model. Curves are produced as table files in an output folder specified by the user.
+  This algorithm computes hypsometric curves for an input Digital Elevation Model. Curves are produced as table files in an output folder specified by the user.
 
 qgis:importintopostgis: >
   This algorithm imports a vector layer into a PostGIS database, creating a new table.
@@ -190,21 +190,21 @@ qgis:importintopostgis: >
 qgis:intersection: >
   This algorithm extracts the overlapping portions of features in the Input and Intersect layers. Features in the Intersection layer are assigned the attributes of the overlapping features from both the Input and Intersect layers.
 
-  Attributes are not modified
+  Attributes are not modified.
 
 qgis:joinattributesbylocation: >
   This algorithm takes an input vector layer and creates a new vector layer that is an extended version of the input one, with additional attributes in its attribute table.
 
-  The additional attributes and their values are taken from a second vector layer.  A spatial critera is applied to select the values from the second layer that are added to each feature from the first layer in the resulting one.
+  The additional attributes and their values are taken from a second vector layer. A spatial critera is applied to select the values from the second layer that are added to each feature from the first layer in the resulting one.
 
 
 qgis:joinattributestable: >
   This algorithm takes an input vector layer and creates a new vector layer that is an extended version of the input one, with additional attributes in its attribute table.
 
-  The additional attributes and their values are taken from a second vector layer.  An attribute is selected in each of them to define the join criteria.
+  The additional attributes and their values are taken from a second vector layer. An attribute is selected in each of them to define the join criteria.
 
 qgis:keepnbiggestparts: >
-  This algorithm takes a polygon layer and creates a new polygon layer in which multipart goemetries have been removed, leaving only the n largest (in terms of area) parts
+  This algorithm takes a polygon layer and creates a new polygon layer in which multipart geometries have been removed, leaving only the n largest (in terms of area) parts.
 
 qgis:lineintersections:
   This algorithm creates point features where the lines in the Intersect layer intersect the lines in the Input layer.
@@ -216,7 +216,7 @@ qgis:lineintersections:
 qgis:linestopolygons:
   This algorithm generates a polygon layer using as polygon rings the lines from an input line layer.
 
-  The attribute table of the output layer is the same as the one from of the input line layer.
+  The attribute table of the output layer is the same as the one of the input line layer.
 
 qgis:listuniquevalues: >
   This algorithm generates a report with information about the categories found in a given attribute of a vector layer.
@@ -229,7 +229,7 @@ qgis:meancoordinates: >
 
   An attribute can be specified as containing weights to be applied to each feature when computing the center of mass.
 
-  If an attribute is selected in the  <Unique ID  field> parameters, features will be grouped according to values in this field. Instead of a single point with the center of mass of the whole layer, the  output layer will contain a center of mass for the features in each category.
+  If an attribute is selected in the <Unique ID field> parameters, features will be grouped according to values in this field. Instead of a single point with the center of mass of the whole layer, the  output layer will contain a center of mass for the features in each category.
 
 qgis:mergelines: >
   This algorithm joins all connected parts of MultiLineString geometries into single LineString geometries.
@@ -239,28 +239,28 @@ qgis:mergelines: >
 qgis:mergevectorlayers: >
   This algorithm combines multiple vector layers of the same geometry type into a single one.
 
-  If attributes tables are different, the attribute table of the resulting layer will contain the attributes from both input layers
+  If attributes tables are different, the attribute table of the resulting layer will contain the attributes from both input layers.
 
 qgis:multiparttosingleparts: >
   This algorithm takes a vector layer with multipart geometries and generates a new one in which all geometries contain a single part. Features with multipart geometries are divided in as many different features as parts the geometry contain, and the same attributes are used for each of them.
 
 qgis:nearestneighbouranalysis: >
-  This algorithm performs nearest neighbout analysis for a point layer.
+  This algorithm performs nearest neighbor analysis for a point layer.
 
   Output is generated as an html file with the computed statistical values.
 
 
 qgis:numberofuniquevaluesinclasses: >
-  This algorithm  counts the different values that appear in a specified attributes for features of the same class.
+  This algorithm counts the different values that appear in a specified attributes for features of the same class.
 
   Classes are defined according to a given attribute. For all layers that share the same value of this attributes, the values of a second attributes are analyzed.
 
   The resulting layer contains the same features as the input layer, but with an additional attribute containing the count of unique values for that class.
 
 qgis:orientedminimumboundingbox: >
-  This algorithm takes a vector layer and generate a new one with the minimum rectangle that covers all the input features.
+  This algorithm takes a vector layer and generates a new one with the minimum rectangle that covers all the input features.
 
-  As an alternative, the output layer can contain not just a single  rectangle, but one for each input feature, representing the minimum rectangle that covers each of them.
+  As an alternative, the output layer can contain not just a single rectangle, but one for each input feature, representing the minimum rectangle that covers each of them.
 
 qgis:pointsdisplacement:
 
@@ -291,7 +291,7 @@ qgis:polygoncentroids: >
 
 
 qgis:polygonfromlayerextent: >
-  This algorithm takes a vector layer and generate a new one with the minimum bounding box (rectangle with N-S orientation) that covers all the input features.
+  This algorithm takes a vector layer and generates a new one with the minimum bounding box (rectangle with N-S orientation) that covers all the input features.
 
   As an alternative, the output layer can contain not just a single bounding box, but one for each input feature, representing the bounding box of each of them.
 
@@ -307,12 +307,12 @@ qgis:postgisexecutesql: >
 qgis:randomextract: >
   This algorithm takes a vector layer and generates a new one that contains only a subset of the features in the input layer.
 
-  The subset is defined randomly,  using a percentage or count value to define the total number of features in the subset.
+  The subset is defined randomly, using a percentage or count value to define the total number of features in the subset.
 
 qgis:randomextractwithinsubsets: >
   This algorithm takes a vector layer and generates a new one that contains only a subset of the features in the input layer.
 
-  The subset is defined randomly,  using a percentage or count value to define the total number of features in the subset.
+  The subset is defined randomly, using a percentage or count value to define the total number of features in the subset.
 
   The percentage/count value is not applied to the whole layer, but instead to each category. Categories are defined according to a given attribute, which is also specified as an input parameter for the algorithm.
 
@@ -328,19 +328,19 @@ qgis:randompointsinlayerbounds: >
   This algorithm creates a new point layer with a given number of random points, all of them within the extent of a given layer. A distance factor can be specified, to avoid points being too close to each other.
 
 qgis:randompointsinsidepolygonsfixed: >
-  This algorithm creates a new point layer with random points insides the ppolygons of a given layer. The number of points in each polygon can be defined as a fixed count or as a density value, and it will be the same for all polygons.
+  This algorithm creates a new point layer with random points inside the polygons of a given layer. The number of points in each polygon can be defined as a fixed count or as a density value, and it will be the same for all polygons.
 
 qgis:randompointsinsidepolygonsvariable: >
-  This algorithm creates a new point layer with random points insides the ppolygons of a given layer. The number of points in each polygon can be defined as a fixed count or as a density value. The count/density valu is taken from an attribute, so it can be different for each polygons in the input layer.
+  This algorithm creates a new point layer with random points inside the polygons of a given layer. The number of points in each polygon can be defined as a fixed count or as a density value. The count/density value is taken from an attribute, so it can be different for each polygon in the input layer.
 
 qgis:randomselection: >
   This algorithm takes a vector layer and selects a subset of its features. No new layer is generated by this algorithm.
-  The subset is defined randomly,  using a percentage or count value to define the total number of features in the subset.
+  The subset is defined randomly, using a percentage or count value to define the total number of features in the subset.
 
 qgis:randomselectionwithinsubsets: >
   This algorithm takes a vector layer and selects a subset of its features. No new layer is generated by this algorithm.
 
-  The subset is defined randomly,  using a percentage or count value to define the total number of features in the subset.
+  The subset is defined randomly, using a percentage or count value to define the total number of features in the subset.
 
   The percentage/count value is not applied to the whole layer, but instead to each category. Categories are defined according to a given attribute, which is also specified as an input parameter for the algorithm.
 
@@ -355,9 +355,9 @@ qgis:rasterlayerstatistics: >
   The raster layer must have a single band.
 
 qgis:refactorfields: >
-  This algorithm allows editing the structure of the attributes table of a vector layer. Fields can be modified in their type and name, using a fields mapping
+  This algorithm allows editing the structure of the attributes table of a vector layer. Fields can be modified in their type and name, using a fields mapping.
 
-  The original layer is not modified. A new layer is generated, which contains a modified attributes table, accordint to the provided fields mapping
+  The original layer is not modified. A new layer is generated, which contains a modified attributes table, according to the provided fields mapping.
 
 qgis:regularpoints:
 


### PR DESCRIPTION
Fix typo in algorithms description (kind of port of #4500). Would be nice to have them merged (also because 2.18 will become ltr)...

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
