### PR TITLE
[Server] WMS Fix the mandatory OnlineResource

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -195,7 +195,7 @@ namespace QgsWms
     doc.appendChild( wmsCapabilitiesElement );
 
     //INSERT Service
-    wmsCapabilitiesElement.appendChild( getServiceElement( doc, project, version ) );
+    wmsCapabilitiesElement.appendChild( getServiceElement( doc, project, version, request ) );
 
     //wms:Capability element
     QDomElement capabilityElement = getCapabilityElement( doc, project, version, request, projectSettings );
@@ -222,7 +222,8 @@ namespace QgsWms
     return doc;
   }
 
-  QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project, const QString &version )
+  QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project, const QString &version,
+                                 const QgsServerRequest &request )
   {
     bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
 
@@ -283,14 +284,15 @@ namespace QgsWms
     }
 
     QString onlineResource = QgsServerProjectUtils::owsServiceOnlineResource( *project );
-    if ( !onlineResource.isEmpty() )
+    if ( onlineResource.isEmpty() )
     {
-      QDomElement onlineResourceElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
-      onlineResourceElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
-      onlineResourceElem.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
-      onlineResourceElem.setAttribute( QStringLiteral( "xlink:href" ), onlineResource );
-      serviceElem.appendChild( onlineResourceElem );
+      onlineResource = serviceUrl( request, project ).toString();
     }
+    QDomElement onlineResourceElem = doc.createElement( QStringLiteral( "OnlineResource" ) );
+    onlineResourceElem.setAttribute( QStringLiteral( "xmlns:xlink" ), QStringLiteral( "http://www.w3.org/1999/xlink" ) );
+    onlineResourceElem.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
+    onlineResourceElem.setAttribute( QStringLiteral( "xlink:href" ), onlineResource );
+    serviceElem.appendChild( onlineResourceElem );
 
     QString contactPerson = QgsServerProjectUtils::owsServiceContactPerson( *project );
     QString contactOrganization = QgsServerProjectUtils::owsServiceContactOrganization( *project );

--- a/src/server/services/wms/qgswmsgetcapabilities.h
+++ b/src/server/services/wms/qgswmsgetcapabilities.h
@@ -61,7 +61,8 @@ namespace QgsWms
   /**
    * Create Service element for get capabilities document
    */
-  QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project, const QString &version );
+  QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project, const QString &version,
+                                 const QgsServerRequest &request );
 
   /** Output GetCapabilities response
    */

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -66,7 +66,7 @@ class QgsServerTestBase(unittest.TestCase):
         response_lines = response.splitlines()
         expected_lines = expected.splitlines()
         line_no = 1
-        self.assertEqual(len(expected_lines), len(response_lines), "Expected and response have different number of lines!")
+        self.assertEqual(len(expected_lines), len(response_lines), "Expected and response have different number of lines!\n{}".format(msg))
         for expected_line in expected_lines:
             expected_line = expected_line.strip()
             response_line = response_lines[line_no - 1].strip()

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -62,7 +62,7 @@ class TestQgsServerWMS(QgsServerTestBase):
         response = re.sub(RE_STRIP_UNCHECKABLE, b'*****', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'*****', expected)
 
-        self.assertXMLEqual(response, expected, msg="request %s failed.\n Query: %s\n Expected:\n%s\n\n Response:\n%s" % (query_string, request, expected.decode('utf-8'), response.decode('utf-8')))
+        self.assertXMLEqual(response, expected, msg="request %s failed.\nQuery: %s\nExpected file: %s\nResponse:\n%s" % (query_string, request, reference_path, response.decode('utf-8')))
 
     def test_project_wms(self):
         """Test some WMS request"""
@@ -151,7 +151,7 @@ class TestQgsServerWMS(QgsServerTestBase):
         f.close()
         response = re.sub(RE_STRIP_UNCHECKABLE, b'', response)
         expected = re.sub(RE_STRIP_UNCHECKABLE, b'', expected)
-        self.assertXMLEqual(response, expected, msg="request %s failed.\n Query: %s\n Expected:\n%s\n\n Response:\n%s" % (query_string, request, expected.decode('utf-8'), response.decode('utf-8')))
+        self.assertXMLEqual(response, expected, msg="request %s failed.\nQuery: %s\nExpected file: %s\nResponse:\n%s" % (query_string, request, reference_path, response.decode('utf-8')))
 
     def test_project_wms_inspire(self):
         """Test some WMS request"""

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -572,8 +572,7 @@ class TestQgsServerWMS(QgsServerTestBase):
 
         item_found = False
         for item in str(r).split("\\n"):
-            if "OnlineResource" in item:
-                self.assertEqual("xlink:href=\"my_wms_advertised_url?" in item, True)
+            if "OnlineResource" in item and "xlink:href=\"my_wms_advertised_url?" in item:
                 item_found = True
         self.assertTrue(item_found)
 

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -10,6 +10,7 @@ Content-Type: text/xml; charset=utf-8
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
+  <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?MAP=tests/testdata/qgis_server/test_project.qgs&amp;" xmlns:xlink="http://www.w3.org/1999/xlink"/>
   <ContactInformation>
    <ContactPersonPrimary>
     <ContactPerson>Alessandro Pasotti</ContactPerson>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -10,6 +10,7 @@ Content-Type: text/xml; charset=utf-8
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
+  <OnlineResource xlink:type="simple" xlink:href="?MAP=tests/testdata/qgis_server/test_project_inspire.qgs&amp;" xmlns:xlink="http://www.w3.org/1999/xlink"/>
   <ContactInformation>
    <ContactPersonPrimary>
     <ContactPerson>Alessandro Pasotti</ContactPerson>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -10,6 +10,7 @@ Content-Type: text/xml; charset=utf-8
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
+  <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?MAP=tests/testdata/qgis_server/test_project.qgs&amp;" xmlns:xlink="http://www.w3.org/1999/xlink"/>
   <ContactInformation>
    <ContactPersonPrimary>
     <ContactPerson>Alessandro Pasotti</ContactPerson>


### PR DESCRIPTION
I not sure that well understand the expected result, I see that:

* in the WMS specification the OnlineResource is required in the Service tag.
* in the Service tag we get the OnlineResource from the project configuration.
* in the other tag we automatically generate the OnlineResource from the request.

What should we finally do?