### PR TITLE
[processing] allow optional feature sink parameters

### DIFF
--- a/python/core/processing/qgsprocessingoutputs.sip
+++ b/python/core/processing/qgsprocessingoutputs.sip
@@ -34,6 +34,8 @@ class QgsProcessingOutputDefinition
       sipType = sipType_QgsProcessingOutputRasterLayer;
     else if ( sipCpp->type() == "outputHtml" )
       sipType = sipType_QgsProcessingOutputHtml;
+    else if ( sipCpp->type() == "outputNumber" )
+      sipType = sipType_QgsProcessingOutputNumber;
 %End
   public:
 
@@ -157,6 +159,26 @@ class QgsProcessingOutputHtml : QgsProcessingOutputDefinition
     QgsProcessingOutputHtml( const QString &name, const QString &description = QString() );
 %Docstring
  Constructor for QgsProcessingOutputHtml.
+%End
+
+    virtual QString type() const;
+};
+
+class QgsProcessingOutputNumber : QgsProcessingOutputDefinition
+{
+%Docstring
+ A numeric output for processing algorithms.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingoutputs.h"
+%End
+  public:
+
+    QgsProcessingOutputNumber( const QString &name, const QString &description = QString() );
+%Docstring
+ Constructor for QgsProcessingOutputNumber.
 %End
 
     virtual QString type() const;

--- a/python/plugins/processing/algs/qgis/BasicStatistics.py
+++ b/python/plugins/processing/algs/qgis/BasicStatistics.py
@@ -158,6 +158,8 @@ class BasicStatisticsForField(QgisAlgorithm):
         total = 100.0 / float(count)
         stat = QgsStatisticalSummary()
         for current, ft in enumerate(features):
+            if feedback.isCanceled():
+                break
             stat.addVariant(ft[field.name()])
             feedback.setProgress(int(current * total))
         stat.finalize()
@@ -205,6 +207,8 @@ class BasicStatisticsForField(QgisAlgorithm):
         total = 100.0 / float(count)
         stat = QgsStringStatisticalSummary()
         for current, ft in enumerate(features):
+            if feedback.isCanceled():
+                break
             stat.addValue(ft[field.name()])
             feedback.setProgress(int(current * total))
         stat.finalize()
@@ -235,6 +239,8 @@ class BasicStatisticsForField(QgisAlgorithm):
         total = 100.0 / float(count)
         stat = QgsDateTimeStatisticalSummary()
         for current, ft in enumerate(features):
+            if feedback.isCanceled():
+                break
             stat.addValue(ft[field.name()])
             feedback.setProgress(int(current * total))
         stat.finalize()

--- a/python/plugins/processing/algs/qgis/CheckValidity.py
+++ b/python/plugins/processing/algs/qgis/CheckValidity.py
@@ -36,11 +36,14 @@ from qgis.core import (QgsSettings,
                        QgsField,
                        QgsWkbTypes,
                        QgsProcessingUtils,
-                       QgsFields)
+                       QgsFields,
+                       QgsProcessingParameterFeatureSource,
+                       QgsProcessingParameterEnum,
+                       QgsProcessingParameterFeatureSink,
+                       QgsProcessingOutputVectorLayer,
+                       QgsProcessingParameterDefinition
+                       )
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
-from processing.core.parameters import ParameterVector
-from processing.core.parameters import ParameterSelection
-from processing.core.outputs import OutputVector
 
 settings_method_key = "/qgis/digitizing/validate_geometries"
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
@@ -66,26 +69,17 @@ class CheckValidity(QgisAlgorithm):
                         'QGIS',
                         'GEOS']
 
-        self.addParameter(ParameterVector(
-            self.INPUT_LAYER,
-            self.tr('Input layer')))
+        self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER,
+                                                              self.tr('Input layer')))
+        self.addParameter(QgsProcessingParameterEnum(self.METHOD,
+                                                     self.tr('Method'), self.methods))
 
-        self.addParameter(ParameterSelection(
-            self.METHOD,
-            self.tr('Method'),
-            self.methods))
-
-        self.addOutput(OutputVector(
-            self.VALID_OUTPUT,
-            self.tr('Valid output')))
-
-        self.addOutput(OutputVector(
-            self.INVALID_OUTPUT,
-            self.tr('Invalid output')))
-
-        self.addOutput(OutputVector(
-            self.ERROR_OUTPUT,
-            self.tr('Error output')))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.VALID_OUTPUT, self.tr('Valid output'), QgsProcessingParameterDefinition.TypeVectorAny, '', True))
+        self.addOutput(QgsProcessingOutputVectorLayer(self.VALID_OUTPUT, self.tr('Valid output')))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.INVALID_OUTPUT, self.tr('Invalid output'), QgsProcessingParameterDefinition.TypeVectorAny, '', True))
+        self.addOutput(QgsProcessingOutputVectorLayer(self.INVALID_OUTPUT, self.tr('Invalid output')))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.ERROR_OUTPUT, self.tr('Error output'), QgsProcessingParameterDefinition.TypeVectorAny, '', True))
+        self.addOutput(QgsProcessingOutputVectorLayer(self.ERROR_OUTPUT, self.tr('Error output')))
 
     def name(self):
         return 'checkvalidity'
@@ -94,51 +88,48 @@ class CheckValidity(QgisAlgorithm):
         return self.tr('Check validity')
 
     def processAlgorithm(self, parameters, context, feedback):
-        settings = QgsSettings()
-        initial_method_setting = settings.value(settings_method_key, 1)
+        method_param = self.parameterAsEnum(parameters, self.METHOD, context)
+        if method_param == 0:
+            settings = QgsSettings()
+            method = int(settings.value(settings_method_key, 0)) - 1
+            if method < 0:
+                method = 0
+        else:
+            method = method_param - 1
 
-        method = self.getParameterValue(self.METHOD)
-        if method != 0:
-            settings.setValue(settings_method_key, method)
-        try:
-            self.doCheck(context, feedback)
-        finally:
-            settings.setValue(settings_method_key, initial_method_setting)
+        results = self.doCheck(method, parameters, context, feedback)
+        return results
 
-    def doCheck(self, context, feedback):
-        layer = QgsProcessingUtils.mapLayerFromString(self.getParameterValue(self.INPUT_LAYER), context)
+    def doCheck(self, method, parameters, context, feedback):
+        source = self.parameterAsSource(parameters, self.INPUT_LAYER, context)
 
-        settings = QgsSettings()
-        method = int(settings.value(settings_method_key, 1))
-
-        valid_output = self.getOutputFromName(self.VALID_OUTPUT)
-        valid_fields = layer.fields()
-        valid_writer = valid_output.getVectorWriter(valid_fields, layer.wkbType(), layer.crs(), context)
+        (valid_output_sink, valid_output_dest_id) = self.parameterAsSink(parameters, self.VALID_OUTPUT, context,
+                                                                         source.fields(), source.wkbType(), source.sourceCrs())
         valid_count = 0
 
-        invalid_output = self.getOutputFromName(self.INVALID_OUTPUT)
-        invalid_fields = layer.fields()
-        invalid_fields.append(QgsField('_errors',
-                                       QVariant.String,
-                                       255))
-        invalid_writer = invalid_output.getVectorWriter(invalid_fields, layer.wkbType(), layer.crs(), context)
+        invalid_fields = source.fields()
+        invalid_fields.append(QgsField('_errors', QVariant.String, 'string', 255))
+        (invalid_output_sink, invalid_output_dest_id) = self.parameterAsSink(parameters, self.INVALID_OUTPUT, context,
+                                                                             invalid_fields, source.wkbType(), source.sourceCrs())
         invalid_count = 0
 
-        error_output = self.getOutputFromName(self.ERROR_OUTPUT)
         error_fields = QgsFields()
-        error_fields.append(QgsField('message', QVariant.String, 255))
-        error_writer = error_output.getVectorWriter(error_fields, QgsWkbTypes.Point, layer.crs(), context)
+        error_fields.append(QgsField('message', QVariant.String, 'string', 255))
+        (error_output_sink, error_output_dest_id) = self.parameterAsSink(parameters, self.ERROR_OUTPUT, context,
+                                                                         error_fields, QgsWkbTypes.Point, source.sourceCrs())
         error_count = 0
 
-        features = QgsProcessingUtils.getFeatures(layer, context)
-        total = 100.0 / QgsProcessingUtils.featureCount(layer, context)
+        features = source.getFeatures()
+        total = 100.0 / source.featureCount()
         for current, inFeat in enumerate(features):
+            if feedback.isCanceled():
+                break
             geom = inFeat.geometry()
             attrs = inFeat.attributes()
 
             valid = True
             if not geom.isNull() and not geom.isEmpty():
-                errors = list(geom.validateGeometry())
+                errors = list(geom.validateGeometry(method))
                 if errors:
                     # QGIS method return a summary at the end
                     if method == 1:
@@ -150,7 +141,8 @@ class CheckValidity(QgisAlgorithm):
                         error_geom = QgsGeometry.fromPoint(error.where())
                         errFeat.setGeometry(error_geom)
                         errFeat.setAttributes([error.what()])
-                        error_writer.addFeature(errFeat)
+                        if error_output_sink:
+                            error_output_sink.addFeature(errFeat)
                         error_count += 1
 
                         reasons.append(error.what())
@@ -165,22 +157,22 @@ class CheckValidity(QgisAlgorithm):
             outFeat.setAttributes(attrs)
 
             if valid:
-                valid_writer.addFeature(outFeat)
+                if valid_output_sink:
+                    valid_output_sink.addFeature(outFeat)
                 valid_count += 1
 
             else:
-                invalid_writer.addFeature(outFeat)
+                if invalid_output_sink:
+                    invalid_output_sink.addFeature(outFeat)
                 invalid_count += 1
 
             feedback.setProgress(int(current * total))
 
-        del valid_writer
-        del invalid_writer
-        del error_writer
-
-        if valid_count != 0:
-            context.addLayerToLoadOnCompletion(valid_output.value)
-        if invalid_count != 0:
-            context.addLayerToLoadOnCompletion(invalid_output.value)
-        if error_count != 0:
-            context.addLayerToLoadOnCompletion(error_output.value)
+        results = {}
+        if valid_output_sink:
+            results[self.VALID_OUTPUT] = valid_output_dest_id
+        if invalid_output_sink:
+            results[self.INVALID_OUTPUT] = invalid_output_dest_id
+        if error_output_sink:
+            results[self.ERROR_OUTPUT] = error_output_dest_id
+        return results

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -136,7 +136,7 @@ from .AutoincrementalField import AutoincrementalField
 # from .SplitLinesWithLines import SplitLinesWithLines
 # from .FieldsMapper import FieldsMapper
 # from .Datasources2Vrt import Datasources2Vrt
-# from .CheckValidity import CheckValidity
+from .CheckValidity import CheckValidity
 # from .OrientedMinimumBoundingBox import OrientedMinimumBoundingBox
 # from .Smooth import Smooth
 # from .ReverseLineDirection import ReverseLineDirection
@@ -237,7 +237,7 @@ class QGISAlgorithmProvider(QgsProcessingProvider):
         #         SelectByExpression(), HypsometricCurves(),
         #         SplitWithLines(), SplitLinesWithLines(), CreateConstantRaster(),
         #         FieldsMapper(), SelectByAttributeSum(), Datasources2Vrt(),
-        #         CheckValidity(), OrientedMinimumBoundingBox(), Smooth(),
+        #         OrientedMinimumBoundingBox(), Smooth(),
         #         ReverseLineDirection(), SpatialIndex(), DefineProjection(),
         #         RectanglesOvalsDiamondsVariable(),
         #         RectanglesOvalsDiamondsFixed(), MergeLines(),
@@ -265,6 +265,7 @@ class QGISAlgorithmProvider(QgsProcessingProvider):
                 BasicStatisticsForField(),
                 Boundary(),
                 BoundingBox(),
+                CheckValidity(),
                 Clip(),
                 DeleteColumn(),
                 ExtentFromLayer()

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -170,7 +170,7 @@ from .Aspect import Aspect
 # from .RasterCalculator import RasterCalculator
 # from .CreateAttributeIndex import CreateAttributeIndex
 # from .DropGeometry import DropGeometry
-# from .BasicStatistics import BasicStatisticsForField
+from .BasicStatistics import BasicStatisticsForField
 # from .Heatmap import Heatmap
 # from .Orthogonalize import Orthogonalize
 # from .ShortestPathPointToPoint import ShortestPathPointToPoint
@@ -251,7 +251,7 @@ class QGISAlgorithmProvider(QgsProcessingProvider):
         #         ExtendLines(), ExtractSpecificNodes(),
         #         GeometryByExpression(), SnapGeometriesToLayer(),
         #         PoleOfInaccessibility(), CreateAttributeIndex(),
-        #         DropGeometry(), BasicStatisticsForField(),
+        #         DropGeometry(),
         #         RasterCalculator(), Heatmap(), Orthogonalize(),
         #         ShortestPathPointToPoint(), ShortestPathPointToLayer(),
         #         ShortestPathLayerToPoint(), ServiceAreaFromPoint(),
@@ -262,6 +262,7 @@ class QGISAlgorithmProvider(QgsProcessingProvider):
         algs = [AddTableField(),
                 Aspect(),
                 AutoincrementalField(),
+                BasicStatisticsForField(),
                 Boundary(),
                 BoundingBox(),
                 Clip(),

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -118,8 +118,9 @@ class AlgorithmDialog(AlgorithmDialogBase):
                         dest_project = QgsProject.instance()
 
                 value = self.mainWidget.outputWidgets[param.name()].getValue()
-                value.destinationProject = dest_project
-                parameters[param.name()] = value
+                if value:
+                    value.destinationProject = dest_project
+                    parameters[param.name()] = value
 
         return parameters
 

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -153,58 +153,56 @@ tests:
 #          fields:
 #            fid: skip
 #
-#  - algorithm: qgis:basicstatisticsforfields
-#    name: Basic statistics for numeric fields
-#    params:
-#    - name: multipolys.gml
-#      type: vector
-#    - 'Bfloatval'
-#    results:
-#      OUTPUT_HTML_FILE:
-#        name: basic_statistics_numeric_float.html
-#        type: regex
-#        rules:
-#          - 'Analyzed layer: multipolys.gml'
-#          - 'Analyzed field: Bfloatval'
-#          - 'Count: 3'
-#          - 'Unique values: 3'
-#          - 'Minimum value: -0.123'
-#          - 'Maximum value: 0.123'
-#          - 'Range: 0.246'
-#          - 'Sum: 0.0'
-#          - 'Mean value: 0.0'
-#          - 'Median value: 0.0'
-#          - 'Standard deviation: 0.100429079454'
-#          - 'Coefficient of Variation: 0'
-#          - 'Minority \(rarest occurring value\): -0.123'
-#          - 'Majority \(most frequently occurring value\): -0.123'
-#          - 'First quartile: -0.0615'
-#          - 'Third quartile: 0.0615'
-#          - 'NULL \(missing\) values: 1'
-#          - 'Interquartile Range \(IQR\): 0.123'
-#
-#  - algorithm: qgis:basicstatisticsforfields
-#    name: Basic statistics for text fields
-#    params:
-#    - name: multipolys.gml
-#      type: vector
-#    - 'Bname'
-#    results:
-#      OUTPUT_HTML_FILE:
-#        name: expected/basic_statistics_string.html
-#        type: regex
-#        rules:
-#          - 'Analyzed layer: multipolys.gml'
-#          - 'Analyzed field: Bname'
-#          - 'Count: 4'
-#          - 'Unique values: 2'
-#          - 'Minimum value: Test'
-#          - 'Maximum value: Test'
-#          - 'Minimum length: 0'
-#          - 'Maximum length: 4'
-#          - 'Mean length: 3.0'
-#          - 'NULL \(missing\) values: 1'
-#
+  - algorithm: qgis:basicstatisticsforfields
+    name: Basic statistics for numeric fields
+    params:
+    - name: multipolys.gml
+      type: vector
+    - 'Bfloatval'
+    results:
+      OUTPUT_HTML_FILE:
+        name: basic_statistics_numeric_float.html
+        type: regex
+        rules:
+          - 'Analyzed field: Bfloatval'
+          - 'Count: 3'
+          - 'Unique values: 3'
+          - 'Minimum value: -0.123'
+          - 'Maximum value: 0.123'
+          - 'Range: 0.246'
+          - 'Sum: 0.0'
+          - 'Mean value: 0.0'
+          - 'Median value: 0.0'
+          - 'Standard deviation: 0.100429079454'
+          - 'Coefficient of Variation: 0'
+          - 'Minority \(rarest occurring value\): -0.123'
+          - 'Majority \(most frequently occurring value\): -0.123'
+          - 'First quartile: -0.0615'
+          - 'Third quartile: 0.0615'
+          - 'NULL \(missing\) values: 1'
+          - 'Interquartile Range \(IQR\): 0.123'
+
+  - algorithm: qgis:basicstatisticsforfields
+    name: Basic statistics for text fields
+    params:
+    - name: multipolys.gml
+      type: vector
+    - 'Bname'
+    results:
+      OUTPUT_HTML_FILE:
+        name: expected/basic_statistics_string.html
+        type: regex
+        rules:
+          - 'Analyzed field: Bname'
+          - 'Count: 4'
+          - 'Unique values: 2'
+          - 'Minimum value: Test'
+          - 'Maximum value: Test'
+          - 'Minimum length: 0'
+          - 'Maximum length: 4'
+          - 'Mean length: 3.0'
+          - 'NULL \(missing\) values: 1'
+
 #  # Split lines with lines considers two cases
 #  # case 1: two different layers
 #  - algorithm: qgis:splitlineswithlines
@@ -1834,66 +1832,63 @@ tests:
 #        name: expected/removed_holes_min_area.gml
 #        type: vector
 #
-#  - algorithm: qgis:basicstatisticsforfields
-#    name: Basic stats datetime
-#    params:
-#      FIELD_NAME: date_time
-#      INPUT_LAYER:
-#        name: custom/datetimes.tab
-#        type: table
-#    results:
-#      OUTPUT_HTML_FILE:
-#        name: expected/basic_statistics_datetime.html
-#        type: regex
-#        rules:
-#          - 'Analyzed layer: custom/datetimes.tab'
-#          - 'Analyzed field: date_time'
-#          - 'Count: 4'
-#          - 'Unique values: 3'
-#          - 'Minimum value: 2014-11-30T14:30:02'
-#          - 'Maximum value: 2016-11-30T14:29:22'
-#          - 'NULL \(missing\) values: 1'
-#
-#  - algorithm: qgis:basicstatisticsforfields
-#    name: Basic stats date
-#    params:
-#      FIELD_NAME: date
-#      INPUT_LAYER:
-#        name: custom/datetimes.tab
-#        type: table
-#    results:
-#      OUTPUT_HTML_FILE:
-#        name: expected/basic_statistics_date.html
-#        type: regex
-#        rules:
-#          - 'Analyzed layer: custom/datetimes.tab'
-#          - 'Analyzed field: date'
-#          - 'Count: 4'
-#          - 'Unique values: 3'
-#          - 'Minimum value: 2014-11-30T00:00:00'
-#          - 'Maximum value: 2016-11-30T00:00:00'
-#          - 'NULL \(missing\) values: 1'
-#
-#  - algorithm: qgis:basicstatisticsforfields
-#    name: Basic stats time
-#    params:
-#      FIELD_NAME: time
-#      INPUT_LAYER:
-#        name: custom/datetimes.tab
-#        type: table
-#    results:
-#      OUTPUT_HTML_FILE:
-#        name: expected/basic_statistics_time.html
-#        type: regex
-#        rules:
-#          - 'Analyzed layer: custom/datetimes.tab'
-#          - 'Analyzed field: time'
-#          - 'Count: 4'
-#          - 'Unique values: 3'
-#          - 'Minimum value: 03:29:40'
-#          - 'Maximum value: 15:29:22'
-#          - 'NULL \(missing\) values: 1'
-#
+  - algorithm: qgis:basicstatisticsforfields
+    name: Basic stats datetime
+    params:
+      FIELD_NAME: date_time
+      INPUT_LAYER:
+        name: custom/datetimes.tab
+        type: table
+    results:
+      OUTPUT_HTML_FILE:
+        name: expected/basic_statistics_datetime.html
+        type: regex
+        rules:
+          - 'Analyzed field: date_time'
+          - 'Count: 4'
+          - 'Unique values: 3'
+          - 'Minimum value: 2014-11-30T14:30:02'
+          - 'Maximum value: 2016-11-30T14:29:22'
+          - 'NULL \(missing\) values: 1'
+
+  - algorithm: qgis:basicstatisticsforfields
+    name: Basic stats date
+    params:
+      FIELD_NAME: date
+      INPUT_LAYER:
+        name: custom/datetimes.tab
+        type: table
+    results:
+      OUTPUT_HTML_FILE:
+        name: expected/basic_statistics_date.html
+        type: regex
+        rules:
+          - 'Analyzed field: date'
+          - 'Count: 4'
+          - 'Unique values: 3'
+          - 'Minimum value: 2014-11-30T00:00:00'
+          - 'Maximum value: 2016-11-30T00:00:00'
+          - 'NULL \(missing\) values: 1'
+
+  - algorithm: qgis:basicstatisticsforfields
+    name: Basic stats time
+    params:
+      FIELD_NAME: time
+      INPUT_LAYER:
+        name: custom/datetimes.tab
+        type: table
+    results:
+      OUTPUT_HTML_FILE:
+        name: expected/basic_statistics_time.html
+        type: regex
+        rules:
+          - 'Analyzed field: time'
+          - 'Count: 4'
+          - 'Unique values: 3'
+          - 'Minimum value: 03:29:40'
+          - 'Maximum value: 15:29:22'
+          - 'NULL \(missing\) values: 1'
+
 #  - algorithm: qgis:rastercalculator
 #    name: Raster Calculator with cellsize
 #    params:

--- a/src/core/processing/qgsprocessingoutputs.cpp
+++ b/src/core/processing/qgsprocessingoutputs.cpp
@@ -45,6 +45,8 @@ QgsProcessingOutputRasterLayer::QgsProcessingOutputRasterLayer( const QString &n
 
 QgsProcessingOutputHtml::QgsProcessingOutputHtml( const QString &name, const QString &description )
   : QgsProcessingOutputDefinition( name, description )
-{
+{}
 
-}
+QgsProcessingOutputNumber::QgsProcessingOutputNumber( const QString &name, const QString &description )
+  : QgsProcessingOutputDefinition( name, description )
+{}

--- a/src/core/processing/qgsprocessingoutputs.h
+++ b/src/core/processing/qgsprocessingoutputs.h
@@ -49,6 +49,8 @@ class CORE_EXPORT QgsProcessingOutputDefinition
       sipType = sipType_QgsProcessingOutputRasterLayer;
     else if ( sipCpp->type() == "outputHtml" )
       sipType = sipType_QgsProcessingOutputHtml;
+    else if ( sipCpp->type() == "outputNumber" )
+      sipType = sipType_QgsProcessingOutputNumber;
     SIP_END
 #endif
 
@@ -175,6 +177,24 @@ class CORE_EXPORT QgsProcessingOutputHtml : public QgsProcessingOutputDefinition
     QgsProcessingOutputHtml( const QString &name, const QString &description = QString() );
 
     QString type() const override { return QStringLiteral( "outputHtml" ); }
+};
+
+/**
+ * \class QgsProcessingOutputNumber
+ * \ingroup core
+ * A numeric output for processing algorithms.
+  * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsProcessingOutputNumber : public QgsProcessingOutputDefinition
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingOutputNumber.
+     */
+    QgsProcessingOutputNumber( const QString &name, const QString &description = QString() );
+
+    QString type() const override { return QStringLiteral( "outputNumber" ); }
 };
 
 #endif // QGSPROCESSINGOUTPUTS_H

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -231,6 +231,11 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   }
   else if ( !val.isValid() || val.toString().isEmpty() )
   {
+    if ( definition && definition->flags() & QgsProcessingParameterDefinition::FlagOptional && !definition->defaultValue().isValid() )
+    {
+      // unset, optional sink, no default => no sink
+      return nullptr;
+    }
     // fall back to default
     dest = definition->defaultValue().toString();
   }


### PR DESCRIPTION
If a feature sink parameter is optional and not set, we don't create the sink.

This adds a lot of flexibility to algorithms, as it makes output sinks truly optional. For instance, the various "Extract by..." algorithms could add a new optional sink for features which 'fail' the extraction criteria. This effectively allows these algorithms to become feature 'routers', directing features onto other parts of a model depending on whether they pass or fail the test.

But in this situation we don't always care about these failing features, and we don't want to force them to always be fetched from the provider. By making the outputs truly optional, the algorithm can tweak its logic to either fetch all features and send them to the correct output, or only fetch matching features from the provider in the first place (a big speed boost).

This has been done so far just for the check validity alg.