### PR TITLE
Fixes GRASS 7 v.net.alloc - fixes #16672

### DIFF
--- a/python/plugins/processing/algs/grass7/ext/v_net.py
+++ b/python/plugins/processing/algs/grass7/ext/v_net.py
@@ -84,7 +84,7 @@ def variableOutput(alg, params, nocats=True):
             continue
 
         out = alg.getOutputValue(outputName)
-        command = u"v.out.ogr {} type={} layer={} -s -e input={} output=\"{}\" format=ESRI_Shapefile output_layer={}".format(
+        command = u"v.out.ogr {} type={} layer={} -s -e input={} output=\"{}\" format=ESRI_Shapefile output_layer={} --overwrite".format(
             u"" if typeList[0] == u"line" and nocats else u"-c",
             typeList[0],
             typeList[1],


### PR DESCRIPTION
## Description
This PR makes v.net.alloc usable in QGIS Processing, with GRASS 7.
Fixes https://issues.qgis.org/issues/16672 

It needs to be backported to 2.18

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
