### PR TITLE
Use uuid instead of timestamp when generating layer ids

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -16,7 +16,6 @@
  ***************************************************************************/
 
 
-#include <QDateTime>
 #include <QDir>
 #include <QDomDocument>
 #include <QDomElement>
@@ -56,7 +55,6 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
   : mValid( false ) // assume the layer is invalid
   , mDataSource( source )
   , mLayerOrigName( lyrname ) // store the original name
-  , mID( QLatin1String( "" ) )
   , mLayerType( type )
   , mBlendMode( QPainter::CompositionMode_SourceOver ) // Default to normal blending
   , mLegend( nullptr )
@@ -65,12 +63,13 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
   // Set the display name = internal name
   mLayerName = capitalizeLayerName( mLayerOrigName );
 
-  mShortName = QLatin1String( "" );
   //mShortName.replace( QRegExp( "[\\W]" ), "_" );
 
   // Generate the unique ID of this layer
-  QDateTime dt = QDateTime::currentDateTime();
-  mID = lyrname + dt.toString( QStringLiteral( "yyyyMMddhhmmsszzz" ) );
+  QString uuid = QUuid::createUuid().toString();
+  // trim { } from uuid
+  mID = lyrname + '_' + uuid.mid( 1, uuid.length() - 2 );
+
   // Tidy the ID up to avoid characters that may cause problems
   // elsewhere (e.g in some parts of XML). Replaces every non-word
   // character (word characters are the alphabet, numbers and

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -25,6 +25,26 @@ start_app()
 
 class TestQgsMapLayer(unittest.TestCase):
 
+    def testUniqueId(self):
+        """
+        Test that layers created quickly with same name get a unique ID
+        """
+
+        # make 1000 layers quickly
+        layers = []
+        for i in range(1000):
+            layer = QgsVectorLayer(
+                'Point?crs=epsg:4326&field=name:string(20)',
+                'test',
+                'memory')
+            layers.append(layer)
+
+        # make sure all ids are unique
+        ids = set()
+        for l in layers:
+            self.assertFalse(l.id() in ids)
+            ids.add(l.id())
+
     def copyLayerViaXmlReadWrite(self, source, dest):
         # write to xml
         doc = QDomDocument("testdoc")


### PR DESCRIPTION
Timestamps can result in duplicate layer ids when layers are created rapidly or in different threads.

This had me totally confused last week when I was trying to diagnose an intermittently failing test!

Fix #14390
