### PR TITLE
Optimise memory provider

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -272,6 +272,16 @@ QgsFeatureIterator QgsMemoryProvider::getFeatures( const QgsFeatureRequest &requ
 
 QgsRectangle QgsMemoryProvider::extent() const
 {
+  if ( mExtent.isEmpty() && !mFeatures.isEmpty() )
+  {
+    mExtent.setMinimal();
+    Q_FOREACH ( const QgsFeature &feat, mFeatures )
+    {
+      if ( feat.hasGeometry() )
+        mExtent.unionRect( feat.geometry().boundingBox() );
+    }
+  }
+
   return mExtent;
 }
 
@@ -315,6 +325,9 @@ QgsCoordinateReferenceSystem QgsMemoryProvider::crs() const
 
 bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist )
 {
+  // whether or not to update the layer extent on the fly as we add features
+  bool updateExtent = mFeatures.isEmpty() || !mExtent.isEmpty();
+
   // TODO: sanity checks of fields and geometries
   for ( QgsFeatureList::iterator it = flist.begin(); it != flist.end(); ++it )
   {
@@ -323,14 +336,18 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist )
 
     mFeatures.insert( mNextFeatureId, *it );
 
-    // update spatial index
-    if ( mSpatialIndex )
-      mSpatialIndex->insertFeature( *it );
+    if ( it->hasGeometry() )
+    {
+      if ( updateExtent )
+        mExtent.combineExtentWith( it->geometry().boundingBox() );
+
+      // update spatial index
+      if ( mSpatialIndex )
+        mSpatialIndex->insertFeature( *it );
+    }
 
     mNextFeatureId++;
   }
-
-  updateExtent();
 
   return true;
 }
@@ -352,7 +369,7 @@ bool QgsMemoryProvider::deleteFeatures( const QgsFeatureIds &id )
     mFeatures.erase( fit );
   }
 
-  updateExtent();
+  updateExtents();
 
   return true;
 }
@@ -471,7 +488,7 @@ bool QgsMemoryProvider::changeGeometryValues( const QgsGeometryMap &geometry_map
       mSpatialIndex->insertFeature( *fit );
   }
 
-  updateExtent();
+  updateExtents();
 
   return true;
 }
@@ -522,21 +539,9 @@ QgsVectorDataProvider::Capabilities QgsMemoryProvider::capabilities() const
 }
 
 
-void QgsMemoryProvider::updateExtent()
+void QgsMemoryProvider::updateExtents()
 {
-  if ( mFeatures.isEmpty() )
-  {
-    mExtent = QgsRectangle();
-  }
-  else
-  {
-    mExtent.setMinimal();
-    Q_FOREACH ( const QgsFeature &feat, mFeatures )
-    {
-      if ( feat.hasGeometry() )
-        mExtent.unionRect( feat.geometry().boundingBox() );
-    }
-  }
+  mExtent.setMinimal();
 }
 
 QString QgsMemoryProvider::name() const

--- a/src/core/providers/memory/qgsmemoryprovider.h
+++ b/src/core/providers/memory/qgsmemoryprovider.h
@@ -68,13 +68,9 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     QString name() const override;
     QString description() const override;
     virtual QgsRectangle extent() const override;
+    void updateExtents() override;
     bool isValid() const override;
     virtual QgsCoordinateReferenceSystem crs() const override;
-
-  protected:
-
-    // called when added / removed features or geometries has been changed
-    void updateExtent();
 
   private:
     // Coordinate reference system
@@ -83,7 +79,7 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     // fields
     QgsFields mFields;
     QgsWkbTypes::Type mWkbType;
-    QgsRectangle mExtent;
+    mutable QgsRectangle mExtent;
 
     // features
     QgsFeatureMap mFeatures;

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -361,6 +361,24 @@ class ProviderTestCase(FeatureSourceTestCase):
             # expect fail
             self.assertFalse(l.dataProvider().addFeatures([f1, f2]), 'Provider reported no AddFeatures capability, but returned true to addFeatures')
 
+    def testAddFeaturesUpdateExtent(self):
+        if not getattr(self, 'getEditableLayer', None):
+            return
+
+        l = self.getEditableLayer()
+        self.assertTrue(l.isValid())
+
+        self.assertEqual(l.dataProvider().extent().toString(1), '-71.1,66.3 : -65.3,78.3')
+
+        if l.dataProvider().capabilities() & QgsVectorDataProvider.AddFeatures:
+            f1 = QgsFeature()
+            f1.setAttributes([6, -220, NULL, 'String', '15'])
+            f1.setGeometry(QgsGeometry.fromWkt('Point (-50 90)'))
+            l.dataProvider().addFeatures([f1])
+
+            l.dataProvider().updateExtents()
+            self.assertEqual(l.dataProvider().extent().toString(1), '-71.1,66.3 : -50.0,90.0')
+
     def testDeleteFeatures(self):
         if not getattr(self, 'getEditableLayer', None):
             return
@@ -387,6 +405,23 @@ class ProviderTestCase(FeatureSourceTestCase):
             # expect fail
             self.assertFalse(l.dataProvider().deleteFeatures(to_delete),
                              'Provider reported no DeleteFeatures capability, but returned true to deleteFeatures')
+
+    def testDeleteFeaturesUpdateExtent(self):
+        if not getattr(self, 'getEditableLayer', None):
+            return
+
+        l = self.getEditableLayer()
+        self.assertTrue(l.isValid())
+
+        self.assertEqual(l.dataProvider().extent().toString(1), '-71.1,66.3 : -65.3,78.3')
+
+        to_delete = [f.id() for f in l.dataProvider().getFeatures() if f.attributes()[0] in [5, 4]]
+
+        if l.dataProvider().capabilities() & QgsVectorDataProvider.DeleteFeatures:
+            l.dataProvider().deleteFeatures(to_delete)
+
+            l.dataProvider().updateExtents()
+            self.assertEqual(l.dataProvider().extent().toString(1), '-70.3,66.3 : -68.2,70.8')
 
     def testTruncate(self):
         if not getattr(self, 'getEditableLayer', None):


### PR DESCRIPTION
Previously, the memory provider would automatically recalculate the extent of the layer after new features are added by looping through the entire set of existing features and calculating the bounding boxes. This is very wasteful, as many code paths add features one-by-one, so with every new feature added to the provider every existing feature is iterated over. This caused memory layers to slow to a crawl after many features are added.

This commit improves the logic so that IF an existing layer extent is known, then it's updated on the fly as each individual feauture is added. Instead of looping through all features, we just expand the existing known extent with the added features bounds. If the extent isn't known, we just invalidate it when adding/deleting/modifying features, and defer the actual extent calculation until it's next requested.

Makes memory layers many thousands of magnitudes of orders faster when adding lots of features (e.g. when memory providers are used as temporary outputs in processing)

I've also swapped the provider to use a hash for feature storage instead of a map. This gives faster feature lookups, at the cost of unordered features. But no other provider guarantees that features are 
returned in the same order as added, so this is a safe trade off to make.