### PR TITLE
Simplified QgsPoint constructors

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -123,7 +123,7 @@
 %Include qgspathresolver.sip
 %Include qgspluginlayer.sip
 %Include qgspluginlayerregistry.sip
-%Include qgspoint.sip
+%Include qgspointxy.sip
 %Include qgspointlocator.sip
 %Include qgsproject.sip
 %Include qgsprojectbadlayerhandler.sip
@@ -398,7 +398,7 @@
 %Include geometry/qgsmultipoint.sip
 %Include geometry/qgsmultipolygon.sip
 %Include geometry/qgsmultisurface.sip
-%Include geometry/qgspointv2.sip
+%Include geometry/qgspoint.sip
 %Include geometry/qgspolygon.sip
 %Include geometry/qgsrectangle.sip
 %Include geometry/qgsregularpolygon.sip

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -126,7 +126,6 @@ class QgsPoint: QgsAbstractGeometry
 
 
 
-
     void setX( double x );
 %Docstring
  Sets the point's x-coordinate.

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -126,6 +126,7 @@ class QgsPoint: QgsAbstractGeometry
 
 
 
+
     void setX( double x );
 %Docstring
  Sets the point's x-coordinate.

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -22,12 +22,31 @@ class QgsPoint: QgsAbstractGeometry
 %End
   public:
 
-    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown )];
 %Docstring
  Construct a point with the provided initial coordinate values.
 
- If only z and m are not specified, the type will be a 2D point.
- If any or both of the others are specified, the Z and M values will be added accordingly.
+ If ``wkbType`` is set to `QgsWkbTypes.Point`, `QgsWkbTypes.PointZ`, `QgsWkbTypes.PointM` or `QgsWkbTypes.PointZM`
+ the type will be set accordingly. If it is left to the default `QgsWkbTypes.Unknown`, the type will be set
+ based on the following rules:
+ - If only x and y are specified, the type will be a 2D point.
+ - If any or both of the Z and M are specified, the appropriate type will be created.
+
+ \code{.py}
+   pt = QgsPoint(43.4, 5.3)
+   pt.exportToWkt() # Point(43.4 5.3)
+
+   pt_z = QgsPoint(120, 343, 77)
+   pt.exportToWkt() # PointZ(120 343 77)
+
+   pt_m = QgsPoint(33, 88, m=5)
+   pt_m.m() # 5
+   pt_m.wkbType() # QgsWkbTypes.PointM
+
+   pt = QgsPoint(30, 40, wkbType=QgsWkbTypes.PointZ)
+   pt.z() # nan
+   pt.wkbType() # QgsWkbTypes.PointZ
+ \endcode
 %End
 %MethodCode
     double z;
@@ -51,7 +70,7 @@ class QgsPoint: QgsAbstractGeometry
       m = PyFloat_AsDouble( a3 );
     }
 
-    sipCpp = new sipQgsPoint( a0, a1, z, m );
+    sipCpp = new sipQgsPoint( a0, a1, z, m, a4 );
 %End
 
     explicit QgsPoint( const QgsPointXY &p );
@@ -64,27 +83,6 @@ class QgsPoint: QgsAbstractGeometry
  Construct a QgsPoint from a QPointF
 %End
 
-    QgsPoint( QgsWkbTypes::Type type, double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
-%Docstring
- Construct a point with a specified type (e.g., PointZ, PointM) and initial x, y, z, and m values.
- \param type point type
- \param x x-coordinate of point
- \param y y-coordinate of point
- \param z z-coordinate of point, for PointZ or PointZM types
- \param m m-value of point, for PointM or PointZM types
-%End
-%MethodCode
-    if ( QgsWkbTypes::flatType( a0 ) != QgsWkbTypes::Point )
-    {
-      PyErr_SetString( PyExc_ValueError,
-                       QString( "%1 is not a valid WKB type for point geometries" ).arg( QgsWkbTypes::displayString( a0 ) ).toUtf8().constData() );
-      sipIsErr = 1;
-    }
-    else
-    {
-      sipCpp = new sipQgsPoint( a0, a1, a2, a3, a4 );
-    }
-%End
 
     bool operator==( const QgsPoint &pt ) const;
     bool operator!=( const QgsPoint &pt ) const;

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -22,9 +22,36 @@ class QgsPoint: QgsAbstractGeometry
 %End
   public:
 
-    QgsPoint( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
-%Docstring
- Construct a point with the provided initial coordinate values.
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    % Docstring
+    Construct a point with the provided initial coordinate values.
+
+    If only z and m are not specified, the type will be a 2D point.
+    If any or both of the others are specified, the Z and M values will be added accordingly.
+%End
+%MethodCode
+    double z;
+    double m;
+
+    if ( a2 == Py_None )
+    {
+      z = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      z = PyFloat_AsDouble( a2 );
+    }
+
+    if ( a3 == Py_None )
+    {
+      m = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      m = PyFloat_AsDouble( a3 );
+    }
+
+    sipCpp = new sipQgsPoint( a0, a1, z, m );
 %End
 
     explicit QgsPoint( const QgsPointXY &p );

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -1,7 +1,7 @@
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/geometry/qgspointv2.h                                       *
+ * src/core/geometry/qgspoint.h                                         *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/
@@ -22,11 +22,9 @@ class QgsPoint: QgsAbstractGeometry
 %End
   public:
 
-    QgsPoint( double x = 0.0, double y = 0.0 );
+    QgsPoint( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
 %Docstring
- Construct a 2 dimensional point with an initial x and y coordinate.
- \param x x-coordinate of point
- \param y y-coordinate of point
+ Construct a point with the provided initial coordinate values.
 %End
 
     explicit QgsPoint( const QgsPointXY &p );
@@ -369,7 +367,7 @@ class QgsPoint: QgsAbstractGeometry
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/geometry/qgspointv2.h                                       *
+ * src/core/geometry/qgspoint.h                                         *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -23,11 +23,11 @@ class QgsPoint: QgsAbstractGeometry
   public:
 
     QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
-    % Docstring
-    Construct a point with the provided initial coordinate values.
+%Docstring
+ Construct a point with the provided initial coordinate values.
 
-    If only z and m are not specified, the type will be a 2D point.
-    If any or both of the others are specified, the Z and M values will be added accordingly.
+ If only z and m are not specified, the type will be a 2D point.
+ If any or both of the others are specified, the Z and M values will be added accordingly.
 %End
 %MethodCode
     double z;

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -269,7 +269,7 @@ class QgsPoint: QgsAbstractGeometry
  M value is preserved.
  \param distance distance to project
  \param azimuth angle to project in X Y, clockwise in degrees starting from north
- \param inclination angle to project in Z (3D)
+ \param inclination angle to project in Z (3D). If the point is 2D, the Z value is assumed to be 0.
  :return: The point projected. If a 2D point is projected a 3D point will be returned except if
   inclination is 90. A 3D point is always returned if a 3D point is projected.
  Example:

--- a/python/core/qgspointxy.sip
+++ b/python/core/qgspointxy.sip
@@ -1,7 +1,7 @@
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/qgspoint.h                                                  *
+ * src/core/qgspointxy.h                                                *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/
@@ -15,8 +15,13 @@
 class QgsPointXY
 {
 %Docstring
- A class to represent a point.
- For Z and M support prefer QgsPointV2.
+ A class to represent a 2D point.
+
+ A QgsPointXY represents a position with X and Y coordinates.
+ In most scenarios it is preferable to use a QgsPoint instead which also
+ supports Z and M values.
+
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode
@@ -331,7 +336,7 @@ Divides the coordinates in this point by a scalar quantity in place
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/core/qgspoint.h                                                  *
+ * src/core/qgspointxy.h                                                *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/

--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -234,7 +234,7 @@ bool QgsAbstractGeometry::convertTo( QgsWkbTypes::Type type )
   }
   else if ( !is3D() )
   {
-    addZValue();
+    addZValue( std::numeric_limits<double>::quiet_NaN() );
   }
 
   if ( !needM )
@@ -243,7 +243,7 @@ bool QgsAbstractGeometry::convertTo( QgsWkbTypes::Type type )
   }
   else if ( !isMeasure() )
   {
-    addMValue();
+    addMValue( std::numeric_limits<double>::quiet_NaN() );
   }
 
   return true;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -957,8 +957,8 @@ QgsPoint QgsGeometryUtils::midpoint( const QgsPoint &pt1, const QgsPoint &pt2 )
 
   double x = ( pt1.x() + pt2.x() ) / 2.0;
   double y = ( pt1.y() + pt2.y() ) / 2.0;
-  double z = 0.0;
-  double m = 0.0;
+  double z = std::numeric_limits<double>::quiet_NaN();
+  double m = std::numeric_limits<double>::quiet_NaN();
 
   if ( pt1.is3D() || pt2.is3D() )
   {

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -592,8 +592,8 @@ void QgsLineString::append( const QgsLineString *line )
     }
     else
     {
-      // if append line does not have z coordinates, fill with 0 to match number of points in final line
-      mZ.insert( mZ.count(), mX.size() - mZ.size(), 0 );
+      // if append line does not have z coordinates, fill with NaN to match number of points in final line
+      mZ.insert( mZ.count(), mX.size() - mZ.size(), std::numeric_limits<double>::quiet_NaN() );
     }
   }
 
@@ -605,8 +605,8 @@ void QgsLineString::append( const QgsLineString *line )
     }
     else
     {
-      // if append line does not have m values, fill with 0 to match number of points in final line
-      mM.insert( mM.count(), mX.size() - mM.size(), 0 );
+      // if append line does not have m values, fill with NaN to match number of points in final line
+      mM.insert( mM.count(), mX.size() - mM.size(), std::numeric_limits<double>::quiet_NaN() );
     }
   }
 
@@ -1128,7 +1128,7 @@ bool QgsLineString::convertTo( QgsWkbTypes::Type type )
   {
     //special handling required for conversion to LineString25D
     dropMValue();
-    addZValue();
+    addZValue( std::numeric_limits<double>::quiet_NaN() );
     mWkbType = QgsWkbTypes::LineString25D;
     return true;
   }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -101,9 +101,9 @@ bool QgsPoint::operator==( const QgsPoint &pt ) const
   equal &= qgsDoubleNear( pt.x(), mX, 1E-8 );
   equal &= qgsDoubleNear( pt.y(), mY, 1E-8 );
   if ( QgsWkbTypes::hasZ( type ) )
-    equal &= qgsDoubleNear( pt.z(), mZ, 1E-8 );
+    equal &= qgsDoubleNear( pt.z(), mZ, 1E-8 ) || ( qIsNaN( pt.z() ) && qIsNaN( mZ ) );
   if ( QgsWkbTypes::hasM( type ) )
-    equal &= qgsDoubleNear( pt.m(), mM, 1E-8 );
+    equal &= qgsDoubleNear( pt.m(), mM, 1E-8 ) || ( qIsNaN( pt.m() ) && qIsNaN( mM ) );
 
   return equal;
 }
@@ -546,10 +546,14 @@ double QgsPoint::inclination( const QgsPoint &other ) const
 
 QgsPoint QgsPoint::project( double distance, double azimuth, double inclination ) const
 {
+  QgsWkbTypes::Type pType = mWkbType;
   double radsXy = azimuth * M_PI / 180.0;
   double dx = 0.0, dy = 0.0, dz = 0.0;
 
   inclination = fmod( inclination, 360.0 );
+
+  if ( !qgsDoubleNear( inclination, 90.0 ) )
+    pType = QgsWkbTypes::addZ( pType );
 
   if ( !is3D() && qgsDoubleNear( inclination, 90.0 ) )
   {
@@ -564,5 +568,5 @@ QgsPoint QgsPoint::project( double distance, double azimuth, double inclination 
     dz = distance * cos( radsZ );
   }
 
-  return QgsPoint( mX + dx, mY + dy, mZ + dz, mM, mWkbType );
+  return QgsPoint( mX + dx, mY + dy, mZ + dz, mM, pType );
 }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -31,14 +31,19 @@
  * See details in QEP #17
  ****************************************************************************/
 
-QgsPoint::QgsPoint( double x, double y, double z, double m )
+QgsPoint::QgsPoint( double x, double y, double z, double m, QgsWkbTypes::Type wkbType )
   : QgsAbstractGeometry()
   , mX( x )
   , mY( y )
   , mZ( z )
   , mM( m )
 {
-  if ( qIsNaN( z ) )
+  if ( wkbType != QgsWkbTypes::Unknown )
+  {
+    Q_ASSERT( QgsWkbTypes::flatType( wkbType ) == QgsWkbTypes::Point );
+    mWkbType = wkbType;
+  }
+  else if ( qIsNaN( z ) )
   {
     if ( qIsNaN( m ) )
       mWkbType = QgsWkbTypes::Point;
@@ -71,15 +76,15 @@ QgsPoint::QgsPoint( QPointF p )
   mWkbType = QgsWkbTypes::Point;
 }
 
-QgsPoint::QgsPoint( QgsWkbTypes::Type type, double x, double y, double z, double m )
-  : mX( x )
+QgsPoint::QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z, double m )
+  : QgsAbstractGeometry()
+  , mX( x )
   , mY( y )
   , mZ( z )
   , mM( m )
 {
-  //protect against non-point WKB types
-  Q_ASSERT( QgsWkbTypes::flatType( type ) == QgsWkbTypes::Point );
-  mWkbType = type;
+  Q_ASSERT( QgsWkbTypes::flatType( wkbType ) == QgsWkbTypes::Point );
+  mWkbType = wkbType;
 }
 
 /***************************************************************************
@@ -535,5 +540,5 @@ QgsPoint QgsPoint::project( double distance, double azimuth, double inclination 
     pType = QgsWkbTypes::addM( pType );
   }
 
-  return QgsPoint( pType, mX + dx, mY + dy, mZ + dz, mM );
+  return QgsPoint( mX + dx, mY + dy, mZ + dz, mM, pType );
 }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -546,5 +546,6 @@ QgsPoint QgsPoint::project( double distance, double azimuth, double inclination 
     pType = QgsWkbTypes::addM( pType );
   }
 
-  return QgsPoint( mX + dx, mY + dy, mZ + dz, mM, pType );
+  double z = qIsNaN( mZ ) ? 0 : mZ;
+  return QgsPoint( mX + dx, mY + dy, z + dz, mM, pType );
 }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -38,7 +38,17 @@ QgsPoint::QgsPoint( double x, double y, double z, double m )
   , mZ( z )
   , mM( m )
 {
-  mWkbType = QgsWkbTypes::Point;
+  if ( qIsNaN( z ) )
+  {
+    if ( qIsNaN( m ) )
+      mWkbType = QgsWkbTypes::Point;
+    else
+      mWkbType = QgsWkbTypes::PointM;
+  }
+  else if ( qIsNaN( m ) )
+    mWkbType = QgsWkbTypes::PointZ;
+  else
+    mWkbType = QgsWkbTypes::PointZM;
 }
 
 QgsPoint::QgsPoint( const QgsPointXY &p )

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -95,11 +95,17 @@ QgsPoint::QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z, dou
 
 bool QgsPoint::operator==( const QgsPoint &pt ) const
 {
-  return ( pt.wkbType() == wkbType() &&
-           qgsDoubleNear( pt.x(), mX, 1E-8 ) &&
-           qgsDoubleNear( pt.y(), mY, 1E-8 ) &&
-           qgsDoubleNear( pt.z(), mZ, 1E-8 ) &&
-           qgsDoubleNear( pt.m(), mM, 1E-8 ) );
+  const QgsWkbTypes::Type type = wkbType();
+
+  bool equal = pt.wkbType() == type;
+  equal &= qgsDoubleNear( pt.x(), mX, 1E-8 );
+  equal &= qgsDoubleNear( pt.y(), mY, 1E-8 );
+  if ( QgsWkbTypes::hasZ( type ) )
+    equal &= qgsDoubleNear( pt.z(), mZ, 1E-8 );
+  if ( QgsWkbTypes::hasM( type ) )
+    equal &= qgsDoubleNear( pt.m(), mM, 1E-8 );
+
+  return equal;
 }
 
 bool QgsPoint::operator!=( const QgsPoint &pt ) const

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      *
      * \note Not available in Python bindings
      */
-    explicit QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
+    explicit QgsPoint( QgsWkbTypes::Type wkbType, double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
 
     bool operator==( const QgsPoint &pt ) const;
     bool operator!=( const QgsPoint &pt ) const;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -177,13 +177,21 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \see x()
      * \see rx()
      */
-    void setX( double x ) { clearCache(); mX = x; }
+    void setX( double x )
+    {
+      clearCache();
+      mX = x;
+    }
 
     /** Sets the point's y-coordinate.
      * \see y()
      * \see ry()
      */
-    void setY( double y ) { clearCache(); mY = y; }
+    void setY( double y )
+    {
+      clearCache();
+      mY = y;
+    }
 
     /** Sets the point's z-coordinate.
      * \note calling this will have no effect if the point does not contain a z-dimension. Use addZValue() to
@@ -191,7 +199,13 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \see z()
      * \see rz()
      */
-    void setZ( double z ) { clearCache(); mZ = z; }
+    void setZ( double z )
+    {
+      if ( !is3D() )
+        return;
+      clearCache();
+      mZ = z;
+    }
 
     /** Sets the point's m-value.
      * \note calling this will have no effect if the point does not contain a m-dimension. Use addMValue() to
@@ -199,7 +213,13 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \see m()
      * \see rm()
      */
-    void setM( double m ) { clearCache(); mM = m; }
+    void setM( double m )
+    {
+      if ( !isMeasure() )
+        return;
+      clearCache();
+      mM = m;
+    }
 
     /** Returns the point as a QPointF.
      * \since QGIS 2.14

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * \endcode
      */
 #ifndef SIP_RUN
-    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN(), QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) SIP_SKIP;
+    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN(), QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown );
 #else
     QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown )];
     % MethodCode

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -47,13 +47,32 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     /**
      * Construct a point with the provided initial coordinate values.
      *
-     * If only z and m are not specified, the type will be a 2D point.
-     * If any or both of the others are specified, the Z and M values will be added accordingly.
+     * If \a wkbType is set to `QgsWkbTypes::Point`, `QgsWkbTypes::PointZ`, `QgsWkbTypes::PointM` or `QgsWkbTypes::PointZM`
+     * the type will be set accordingly. If it is left to the default `QgsWkbTypes::Unknown`, the type will be set
+     * based on the following rules:
+     * - If only x and y are specified, the type will be a 2D point.
+     * - If any or both of the Z and M are specified, the appropriate type will be created.
+     *
+     * \code{.py}
+     *   pt = QgsPoint(43.4, 5.3)
+     *   pt.exportToWkt() # Point(43.4 5.3)
+     *
+     *   pt_z = QgsPoint(120, 343, 77)
+     *   pt.exportToWkt() # PointZ(120 343 77)
+     *
+     *   pt_m = QgsPoint(33, 88, m=5)
+     *   pt_m.m() # 5
+     *   pt_m.wkbType() # QgsWkbTypes.PointM
+     *
+     *   pt = QgsPoint(30, 40, wkbType=QgsWkbTypes.PointZ)
+     *   pt.z() # nan
+     *   pt.wkbType() # QgsWkbTypes.PointZ
+     * \endcode
      */
 #ifndef SIP_RUN
-    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
+    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN(), QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) SIP_SKIP;
 #else
-    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0, QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown )];
     % MethodCode
     double z;
     double m;
@@ -76,7 +95,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
       m = PyFloat_AsDouble( a3 );
     }
 
-    sipCpp = new sipQgsPoint( a0, a1, z, m );
+    sipCpp = new sipQgsPoint( a0, a1, z, m, a4 );
     % End
 #endif
 
@@ -88,28 +107,12 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      */
     explicit QgsPoint( QPointF p );
 
-    /** Construct a point with a specified type (e.g., PointZ, PointM) and initial x, y, z, and m values.
-     * \param type point type
-     * \param x x-coordinate of point
-     * \param y y-coordinate of point
-     * \param z z-coordinate of point, for PointZ or PointZM types
-     * \param m m-value of point, for PointM or PointZM types
+    /**
+     * Create a new point with the given wkbtype and values.
+     *
+     * \note Not available in Python bindings
      */
-    QgsPoint( QgsWkbTypes::Type type, double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
-#ifdef SIP_RUN
-    % MethodCode
-    if ( QgsWkbTypes::flatType( a0 ) != QgsWkbTypes::Point )
-    {
-      PyErr_SetString( PyExc_ValueError,
-                       QString( "%1 is not a valid WKB type for point geometries" ).arg( QgsWkbTypes::displayString( a0 ) ).toUtf8().constData() );
-      sipIsErr = 1;
-    }
-    else
-    {
-      sipCpp = new sipQgsPoint( a0, a1, a2, a3, a4 );
-    }
-    % End
-#endif
+    explicit QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
 
     bool operator==( const QgsPoint &pt ) const;
     bool operator!=( const QgsPoint &pt ) const;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -50,15 +50,10 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * If only z and m are not specified, the type will be a 2D point.
      * If any or both of the others are specified, the Z and M values will be added accordingly.
      */
+#ifndef SIP_RUN
     QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
-#ifdef SIP_RUN
+#else
     QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
-    % Docstring
-    Construct a point with the provided initial coordinate values.
-
-    If only z and m are not specified, the type will be a 2D point.
-    If any or both of the others are specified, the Z and M values will be added accordingly.
-    % End
     % MethodCode
     double z;
     double m;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -294,7 +294,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      * M value is preserved.
      * \param distance distance to project
      * \param azimuth angle to project in X Y, clockwise in degrees starting from north
-     * \param inclination angle to project in Z (3D)
+     * \param inclination angle to project in Z (3D). If the point is 2D, the Z value is assumed to be 0.
      * \returns The point projected. If a 2D point is projected a 3D point will be returned except if
      *  inclination is 90. A 3D point is always returned if a 3D point is projected.
      * Example:

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -46,8 +46,44 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
 
     /**
      * Construct a point with the provided initial coordinate values.
+     *
+     * If only z and m are not specified, the type will be a 2D point.
+     * If any or both of the others are specified, the Z and M values will be added accordingly.
      */
-    QgsPoint( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 );
+    QgsPoint( double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
+#ifdef SIP_RUN
+    QgsPoint( double x = 0.0, double y = 0.0, SIP_PYOBJECT z = Py_None, SIP_PYOBJECT m = Py_None ) [( double x = 0.0, double y = 0.0, double z = 0.0, double m = 0.0 )];
+    % Docstring
+    Construct a point with the provided initial coordinate values.
+
+    If only z and m are not specified, the type will be a 2D point.
+    If any or both of the others are specified, the Z and M values will be added accordingly.
+    % End
+    % MethodCode
+    double z;
+    double m;
+
+    if ( a2 == Py_None )
+    {
+      z = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      z = PyFloat_AsDouble( a2 );
+    }
+
+    if ( a3 == Py_None )
+    {
+      m = std::numeric_limits<double>::quiet_NaN();
+    }
+    else
+    {
+      m = PyFloat_AsDouble( a3 );
+    }
+
+    sipCpp = new sipQgsPoint( a0, a1, z, m );
+    % End
+#endif
 
     /** Construct a QgsPoint from a QgsPointXY object
      */

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -816,7 +816,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "project x" ) << "toint(x(project( make_point( 1, 2 ), 3, radians(270)))*1000000)" << false << QVariant( -2 * 1000000 );
       QTest::newRow( "project y" ) << "toint(y(project( point:=make_point( 1, 2 ), distance:=3, azimuth:=radians(270)))*1000000)" << false << QVariant( 2 * 1000000 );
       QTest::newRow( "project m value preserved" ) << "geom_to_wkt(project( make_point( 1, 2, 2, 5), 1, 0.0, 0.0 ) )" << false << QVariant( "PointZM (1 2 3 5)" );
-      QTest::newRow( "project 2D Point" ) << "geom_to_wkt(project( point:=make_point( 1, 2), distance:=1, azimuth:=radians(0), elevation:=0 ) )" << false << QVariant( "PointZ (1 2 1)" );
+      QTest::newRow( "project 2D Point" ) << "geom_to_wkt(project( point:=make_point( 1, 2), distance:=1, azimuth:=radians(0), elevation:=0 ) )" << false << QVariant( "PointZ (1 2 nan)" );
       QTest::newRow( "project 3D Point" ) << "geom_to_wkt(project( make_point( 1, 2, 2), 5, radians(450), radians (450) ) )" << false << QVariant( "PointZ (6 2 2)" );
       QTest::newRow( "inclination not geom first" ) << "inclination( 'a', make_point( 1, 2, 2 ) )" << true << QVariant();
       QTest::newRow( "inclination not geom second" ) << " inclination( make_point( 1, 2, 2 ), 'a' )" << true << QVariant();

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -547,9 +547,9 @@ void TestQgsGeometryUtils::testMidPoint()
 {
   QgsPoint p1( 4, 6 );
   QCOMPARE( QgsGeometryUtils::midpoint( p1, QgsPoint( 2, 2 ) ), QgsPoint( 3, 4 ) );
-  QCOMPARE( QgsGeometryUtils::midpoint( p1, QgsPoint( QgsWkbTypes::PointZ, 2, 2, 2 ) ), QgsPoint( QgsWkbTypes::PointZ, 3, 4, 1 ) );
-  QCOMPARE( QgsGeometryUtils::midpoint( p1, QgsPoint( QgsWkbTypes::PointM, 2, 2, 0, 2 ) ), QgsPoint( QgsWkbTypes::PointM, 3, 4, 0, 1 ) );
-  QCOMPARE( QgsGeometryUtils::midpoint( p1, QgsPoint( QgsWkbTypes::PointZM, 2, 2, 2, 2 ) ), QgsPoint( QgsWkbTypes::PointZM, 3, 4, 1, 1 ) );
+  QCOMPARE( QgsGeometryUtils::midpoint( QgsPoint( 4, 6, 0 ), QgsPoint( QgsWkbTypes::PointZ, 2, 2, 2 ) ), QgsPoint( QgsWkbTypes::PointZ, 3, 4, 1 ) );
+  QCOMPARE( QgsGeometryUtils::midpoint( QgsPoint( QgsWkbTypes::PointM, 4, 6, 0, 0 ), QgsPoint( QgsWkbTypes::PointM, 2, 2, 0, 2 ) ), QgsPoint( QgsWkbTypes::PointM, 3, 4, 0, 1 ) );
+  QCOMPARE( QgsGeometryUtils::midpoint( QgsPoint( QgsWkbTypes::PointZM, 4, 6, 0, 0 ), QgsPoint( QgsWkbTypes::PointZM, 2, 2, 2, 2 ) ), QgsPoint( QgsWkbTypes::PointZM, 3, 4, 1, 1 ) );
 }
 
 void TestQgsGeometryUtils::testGradient()

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -35,7 +35,7 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(box.yMaximum(), 11.0)
         self.assertEqual(box.zMaximum(), 12.0)
 
-        box = QgsBox3d(QgsPoint(QgsWkbTypes.PointZ, 5, 6, 7), QgsPoint(QgsWkbTypes.PointZ, 10, 11, 12))
+        box = QgsBox3d(QgsPoint(5, 6, 7), QgsPoint(10, 11, 12))
         self.assertEqual(box.xMinimum(), 5.0)
         self.assertEqual(box.yMinimum(), 6.0)
         self.assertEqual(box.zMinimum(), 7.0)
@@ -44,7 +44,7 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(box.zMaximum(), 12.0)
 
         # point constructor should normalize
-        box = QgsBox3d(QgsPoint(QgsWkbTypes.PointZ, 10, 11, 12), QgsPoint(QgsWkbTypes.PointZ, 5, 6, 7))
+        box = QgsBox3d(QgsPoint(10, 11, 12), QgsPoint(5, 6, 7))
         self.assertEqual(box.xMinimum(), 5.0)
         self.assertEqual(box.yMinimum(), 6.0)
         self.assertEqual(box.zMinimum(), 7.0)
@@ -137,14 +137,14 @@ class TestQgsBox3d(unittest.TestCase):
 
     def testContainsPoint(self):
         box = QgsBox3d(5.0, 6.0, 7.0, 11.0, 13.0, 15.0)
-        self.assertTrue(box.contains(QgsPoint(QgsWkbTypes.PointZ, 6, 7, 8)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.PointZ, 16, 7, 8)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.PointZ, 6, 17, 8)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.PointZ, 6, 7, 18)))
+        self.assertTrue(box.contains(QgsPoint(6, 7, 8)))
+        self.assertFalse(box.contains(QgsPoint(16, 7, 8)))
+        self.assertFalse(box.contains(QgsPoint(6, 17, 8)))
+        self.assertFalse(box.contains(QgsPoint(6, 7, 18)))
         # 2d containment
-        self.assertTrue(box.contains(QgsPoint(QgsWkbTypes.Point, 6, 7)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.Point, 16, 7)))
-        self.assertFalse(box.contains(QgsPoint(QgsWkbTypes.Point, 6, 17)))
+        self.assertTrue(box.contains(QgsPoint(6, 7)))
+        self.assertFalse(box.contains(QgsPoint(16, 7)))
+        self.assertFalse(box.contains(QgsPoint(6, 17)))
 
     def testVolume(self):
         box = QgsBox3d(5.0, 6.0, 7.0, 11.0, 13.0, 15.0)

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4129,6 +4129,12 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertFalse(QgsGeometry.compare(lp, lp2))
         self.assertTrue(QgsGeometry.compare(lp, lp2, 1e-6))
 
+    def testPoint(self):
+        self.assertEqual(QgsPoint(1, 2).wkbType(), QgsWkbTypes.Point)
+        self.assertEqual(QgsPoint(1, 2, 3).wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(QgsPoint(1, 2, m=3).wkbType(), QgsWkbTypes.PointM)
+        self.assertEqual(QgsPoint(1, 2, 3, 4).wkbType(), QgsWkbTypes.PointZM)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1409,7 +1409,7 @@ class TestQgsGeometry(unittest.TestCase):
         # test adding a part with Z values
         point = QgsGeometry.fromPoint(points[0])
         point.geometry().addZValue(4.0)
-        self.assertEqual(point.addPointsV2([QgsPoint(QgsWkbTypes.PointZ, points[1][0], points[1][1], 3.0)]), 0)
+        self.assertEqual(point.addPointsV2([QgsPoint(points[1][0], points[1][1], 3.0, wkbType=QgsWkbTypes.PointZ)]), 0)
         expwkt = "MultiPointZ ((0 0 4), (1 0 3))"
         wkt = point.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
@@ -1438,7 +1438,7 @@ class TestQgsGeometry(unittest.TestCase):
         # test adding a part with Z values
         polyline = QgsGeometry.fromPolyline(points[0])
         polyline.geometry().addZValue(4.0)
-        points2 = [QgsPoint(QgsWkbTypes.PointZ, p[0], p[1], 3.0) for p in points[1]]
+        points2 = [QgsPoint(p[0], p[1], 3.0, wkbType=QgsWkbTypes.PointZ) for p in points[1]]
         self.assertEqual(polyline.addPointsV2(points2), 0)
         expwkt = "MultiLineStringZ ((0 0 4, 1 0 4, 1 1 4, 2 1 4, 2 0 4),(3 0 3, 3 1 3, 5 1 3, 5 0 3, 6 0 3))"
         wkt = polyline.exportToWkt()
@@ -1482,7 +1482,7 @@ class TestQgsGeometry(unittest.TestCase):
         # test adding a part with Z values
         polygon = QgsGeometry.fromPolygon(points[0])
         polygon.geometry().addZValue(4.0)
-        points2 = [QgsPoint(QgsWkbTypes.PointZ, pi[0], pi[1], 3.0) for pi in points[1][0]]
+        points2 = [QgsPoint(pi[0], pi[1], 3.0, wkbType=QgsWkbTypes.PointZ) for pi in points[1][0]]
         self.assertEqual(polygon.addPointsV2(points2), 0)
         expwkt = "MultiPolygonZ (((0 0 4, 1 0 4, 1 1 4, 2 1 4, 2 2 4, 0 2 4, 0 0 4)),((4 0 3, 5 0 3, 5 2 3, 3 2 3, 3 1 3, 4 1 3, 4 0 3)))"
         wkt = polygon.exportToWkt()
@@ -4130,10 +4130,40 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertTrue(QgsGeometry.compare(lp, lp2, 1e-6))
 
     def testPoint(self):
-        self.assertEqual(QgsPoint(1, 2).wkbType(), QgsWkbTypes.Point)
-        self.assertEqual(QgsPoint(1, 2, 3).wkbType(), QgsWkbTypes.PointZ)
-        self.assertEqual(QgsPoint(1, 2, m=3).wkbType(), QgsWkbTypes.PointM)
-        self.assertEqual(QgsPoint(1, 2, 3, 4).wkbType(), QgsWkbTypes.PointZM)
+        point = QgsPoint(1, 2)
+        self.assertEqual(point.wkbType(), QgsWkbTypes.Point)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+
+        point = QgsPoint(1, 2, wkbType=QgsWkbTypes.Point)
+        self.assertEqual(point.wkbType(), QgsWkbTypes.Point)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+
+        point_z = QgsPoint(1, 2, 3)
+        self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.z(), 3)
+
+        point_z = QgsPoint(1, 2, 3, 4, wkbType=QgsWkbTypes.PointZ)
+        self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.z(), 3)
+
+        point_m = QgsPoint(1, 2, m=3)
+        self.assertEqual(point_m.wkbType(), QgsWkbTypes.PointM)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.m(), 3)
+
+        point_zm = QgsPoint(1, 2, 3, 4)
+        self.assertEqual(point_zm.wkbType(), QgsWkbTypes.PointZM)
+        self.assertEqual(point.x(), 1)
+        self.assertEqual(point.y(), 2)
+        self.assertEqual(point.z(), 3)
+        self.assertEqual(point.m(), 4)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4142,28 +4142,28 @@ class TestQgsGeometry(unittest.TestCase):
 
         point_z = QgsPoint(1, 2, 3)
         self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.z(), 3)
+        self.assertEqual(point_z.x(), 1)
+        self.assertEqual(point_z.y(), 2)
+        self.assertEqual(point_z.z(), 3)
 
         point_z = QgsPoint(1, 2, 3, 4, wkbType=QgsWkbTypes.PointZ)
         self.assertEqual(point_z.wkbType(), QgsWkbTypes.PointZ)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.z(), 3)
+        self.assertEqual(point_z.x(), 1)
+        self.assertEqual(point_z.y(), 2)
+        self.assertEqual(point_z.z(), 3)
 
         point_m = QgsPoint(1, 2, m=3)
         self.assertEqual(point_m.wkbType(), QgsWkbTypes.PointM)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.m(), 3)
+        self.assertEqual(point_m.x(), 1)
+        self.assertEqual(point_m.y(), 2)
+        self.assertEqual(point_m.m(), 3)
 
         point_zm = QgsPoint(1, 2, 3, 4)
         self.assertEqual(point_zm.wkbType(), QgsWkbTypes.PointZM)
-        self.assertEqual(point.x(), 1)
-        self.assertEqual(point.y(), 2)
-        self.assertEqual(point.z(), 3)
-        self.assertEqual(point.m(), 4)
+        self.assertEqual(point_zm.x(), 1)
+        self.assertEqual(point_zm.y(), 2)
+        self.assertEqual(point_zm.z(), 3)
+        self.assertEqual(point_zm.m(), 4)
 
 
 if __name__ == '__main__':

--- a/tests/testdata/geom_data.csv
+++ b/tests/testdata/geom_data.csv
@@ -98,10 +98,10 @@ Point( 1 2 3 4 ),PointZM( 1 2 3 4 ),1,0,0,0,1,0,0,Point( 1 2 ),1,2,1,2,"4d coord
 PointM( 4 5 6 ),PointM ( 4 5 6 ),1,0,0,0,1,0,0,POINT(4 5),4,5,4,5,
 PointZ (1 2 3),POINT Z (1 2 3),1,0,0,0,1,0,0,POINT(1 2),1,2,1,2,
 PointZM( 7 8 9 10 ),PointZM( 7 8 9 10 ),1,0,0,0,1,0,0,POINT( 7 8 ),7,8,7,8,
-PointZ( 1 2 ),PointZ( 1 2 0 ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No z coordinate specified, set to 0"
-PointM( 1 2 ),PointM( 1 2 0 ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No m value specified, set to 0"
-PointZM( 1 2 ),PointZM( 1 2 0 0 ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No z or m value specified, set to 0"
-PointZM( 1 2 3 ),PointZM( 1 2 3 0 ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No m value specified, set to 0"
+PointZ( 1 2 ),PointZ( 1 2 nan ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No z coordinate specified, set to nan"
+PointM( 1 2 ),PointM( 1 2 nan ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No m value specified, set to nan"
+PointZM( 1 2 ),PointZM( 1 2 nan nan ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No z or m value specified, set to nan"
+PointZM( 1 2 3 ),PointZM( 1 2 3 nan ),1,0,0,0,1,0,0,Point(1 2),1,2,1,2,"No m value specified, set to nan"
 Polygon(),,,,,,,,,,,,,,Malformed WKT
 Polygon,,,,,,,,,,,,,,Malformed WKT
 "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0),(5 5, 7 5, 7 7 , 5 7, 5 5),(1 1,2 1, 2 2, 1 2, 1 1))","POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5),(1 1,2 1,2 2,1 2,1 1))",15,0,95,52,1,2,0,POINT(4.99473684210526 4.99473684210526),0,0,10,10,


### PR DESCRIPTION
## Description
In python, the wkb type of a QgsPoint will by default be determined from
the provided parameters, where Z and M will be added as required if the
wkbType is Undefined.

    QgsPoint(x, y, z=nan, m=nan, wkbType=QgsWkbTypes.Undefined)

Thanks to the python API support of named parameters, it's also
straightforward to specify z, m and wkbType in any desired combination.

    point = QgsPoint(300, 260, m=7)

On the other hand, on C++ side it's often preferable to use

    QgsPoint(QgsWkbTypes::WkbType wkbType, double x, double y, double z, double m);

due to the lack of named parameters which make it harder to specify a
specific type and the advantage of typesafety that makes it possible to
verload the first constructor with this one.

## Note

* Methods like `QgsPoint::project` or `QgsPoint::distance3D` assumed in the past a value of 0 for 2D points. This has been changed and 3D calculations will only return sensible results for 3D input.