### PR TITLE
remove precise ppa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ matrix:
       addons:
         apt:
           sources:
-            - george-edison55-precise-backports # doxygen 1.8.3
             - sourceline: 'ppa:jonathonf/backports'  # silversearcher-ag backport
           packages:
             - doxygen


### PR DESCRIPTION
doxygen has sufficient minimum version in trusty
