### PR TITLE
Fixes 16707, export of hairline results in a different visual thickness

### DIFF
--- a/src/core/symbology-ng/qgssymbollayerutils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerutils.cpp
@@ -1845,7 +1845,14 @@ void QgsSymbolLayerUtils::lineToSld( QDomDocument &doc, QDomElement &element,
       element.appendChild( createSvgParameterElement( doc, QStringLiteral( "stroke-opacity" ), encodeSldAlpha( color.alpha() ) ) );
   }
   if ( width > 0 )
+  {
     element.appendChild( createSvgParameterElement( doc, QStringLiteral( "stroke-width" ), qgsDoubleToString( width ) ) );
+  }
+  else if ( width == 0 )
+  {
+    // hairline, yet not zero. it's actually painted in qgis
+    element.appendChild( createSvgParameterElement( doc, QStringLiteral( "stroke-width" ), QStringLiteral( "0.5" ) ) );
+  }
   if ( penJoinStyle )
     element.appendChild( createSvgParameterElement( doc, QStringLiteral( "stroke-linejoin" ), encodeSldLineJoinStyle( *penJoinStyle ) ) );
   if ( penCapStyle )

--- a/tests/src/python/test_qgssymbollayer_createsld.py
+++ b/tests/src/python/test_qgssymbollayer_createsld.py
@@ -231,6 +231,15 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
         self.assertStrokeWidth(root, 2, 1)
         self.assertStaticDisplacement(root, 5, 10)
 
+    def testSimpleLineHairline(self):
+        symbol = QgsSimpleLineSymbolLayer(QColor("black"), 0)
+        dom, root = self.symbolToSld(symbol)
+
+        # print ("Simple line px: \n" + dom.toString())
+
+        # Hairline is turned into 0.5px
+        self.assertStrokeWidth(root, 1, 0.5)
+
     def testSimpleLineUnitDefault(self):
         symbol = QgsSimpleLineSymbolLayer(QColor("black"), 1)
         symbol.setCustomDashVector([10, 10])

--- a/tests/testdata/qgis_server/getstyles.txt
+++ b/tests/testdata/qgis_server/getstyles.txt
@@ -19,6 +19,7 @@ Content-Type: text/xml; charset=utf-8
         </se:Fill>
         <se:Stroke>
          <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+         <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
         </se:Stroke>
        </se:Mark>
        <se:Size>7</se:Size>


### PR DESCRIPTION
Exporting a layer using a "hairline" line width results in a LineSymbolizer with no stroke-width property.
That in turns kicks the SLD default of 1 pixel thickness, which is visually thicker than the one used by QGIS.
By trial and error it seems the proper value would be 0.5 pixels instead.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit