### PR TITLE
Rotate geometry before calculating bounding box in atlas

### DIFF
--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -436,9 +436,13 @@ bool QgsAtlasComposition::prepareForFeature( const int featureI, const bool upda
 void QgsAtlasComposition::computeExtent( QgsComposerMap *map )
 {
   // QgsGeometry::boundingBox is expressed in the geometry"s native CRS
-  // We have to transform the grometry to the destination CRS and ask for the bounding box
+  // We have to transform the geometry to the destination CRS and ask for the bounding box
   // Note: we cannot directly take the transformation of the bounding box, since transformations are not linear
-  mTransformedFeatureBounds = currentGeometry( map->crs() ).boundingBox();
+  QgsGeometry g(currentGeometry( map->crs() ));
+  // Rotating the geometry, so the bounding box is correct wrt map rotation
+  if ( map->mapRotation() != 0.0 )
+    g.rotate(map->mapRotation(), g.centroid().asPoint());
+  mTransformedFeatureBounds = g.boundingBox();
 }
 
 void QgsAtlasComposition::prepareMap( QgsComposerMap *map )

--- a/tests/src/python/test_qgsatlascomposition.py
+++ b/tests/src/python/test_qgsatlascomposition.py
@@ -22,9 +22,25 @@ import tempfile
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
 from qgis.PyQt.QtCore import QFileInfo, QRectF, qWarning
-from qgis.core import QgsVectorLayer, QgsProject, QgsCoordinateReferenceSystem, \
-    QgsComposition, QgsFillSymbol, QgsSingleSymbolRenderer, QgsComposerLabel, QgsComposerMap, QgsFontUtils, \
-    QgsRectangle, QgsComposerLegend, QgsFeature, QgsGeometry, QgsPointXY, QgsRendererCategory, QgsCategorizedSymbolRenderer, QgsMarkerSymbol
+from qgis.core import (
+    QgsCategorizedSymbolRenderer,
+    QgsComposerLabel,
+    QgsComposerLegend,
+    QgsComposerMap,
+    QgsComposition,
+    QgsCoordinateReferenceSystem,
+    QgsFeature,
+    QgsFillSymbol,
+    QgsFontUtils,
+    QgsGeometry,
+    QgsMarkerSymbol,
+    QgsPointXY,
+    QgsProject,
+    QgsRectangle,
+    QgsRendererCategory,
+    QgsSingleSymbolRenderer,
+    QgsVectorLayer,
+)
 from qgscompositionchecker import QgsCompositionChecker
 
 start_app()
@@ -113,6 +129,7 @@ class TestQgsAtlasComposition(unittest.TestCase):
         self.predefinedscales_render_test()
         self.hidden_render_test()
         self.legend_test()
+        self.rotation_test()
 
         shutil.rmtree(tmppath, True)
 
@@ -310,6 +327,53 @@ class TestQgsAtlasComposition(unittest.TestCase):
         self.mAtlasMap.setLayers([layers[1]])
         self.mComposition.removeComposerItem(legend)
         QgsProject.instance().removeMapLayer(ptLayer.id())
+
+    def rotation_test(self):
+        # We will create a polygon layer with a rotated rectangle.
+        # Then we will make it the object layer for the atlas,
+        # rotate the map and test that the bounding rectangle
+        # is smaller than the bounds without rotation.
+        polygonLayer = QgsVectorLayer('Polygon', 'test_polygon', 'memory')
+        poly = QgsFeature(polygonLayer.pendingFields())
+        points = [(10, 15), (15, 10), (45, 40), (40, 45)]
+        poly.setGeometry(QgsGeometry.fromPolygon([[QgsPointXY(x[0], x[1]) for x in points]]))
+        polygonLayer.dataProvider().addFeatures([poly])
+        QgsProject.instance().addMapLayer(polygonLayer)
+
+        # Recreating the composer locally
+        composition = QgsComposition(QgsProject.instance())
+        composition.setPaperSize(297, 210)
+
+        # the atlas map
+        atlasMap = QgsComposerMap(composition, 20, 20, 130, 130)
+        atlasMap.setFrameEnabled(True)
+        atlasMap.setLayers([polygonLayer])
+        atlasMap.setNewExtent(QgsRectangle(0, 0, 100, 50))
+        composition.addComposerMap(atlasMap)
+
+        # the atlas
+        atlas = composition.atlasComposition()
+        atlas.setCoverageLayer(polygonLayer)
+        atlas.setEnabled(True)
+        composition.setAtlasMode(QgsComposition.ExportAtlas)
+
+        atlasMap.setAtlasDriven(True)
+        atlasMap.setAtlasScalingMode(QgsComposerMap.Auto)
+        atlasMap.setAtlasMargin(0.0)
+
+        # Testing
+        atlasMap.setMapRotation(0.0)
+        atlas.firstFeature()
+        nonRotatedExtent = QgsRectangle(atlasMap.currentMapExtent())
+
+        atlasMap.setMapRotation(45.0)
+        atlas.firstFeature()
+        rotatedExtent = QgsRectangle(atlasMap.currentMapExtent())
+
+        assert rotatedExtent.width() < nonRotatedExtent.width() * 0.9
+        assert rotatedExtent.height() < nonRotatedExtent.height() * 0.9
+
+        QgsProject.instance().removeMapLayer(polygonLayer)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When maps in the composer were rotated based on current atlas object, the bounding box for the object was calculated without taking the rotation into account. This should fix bug [11954](https://issues.qgis.org/issues/11954).

Tested locally, it worked.