### PR TITLE
[bugfix] backport from 3.0 Fix unit of sizes when reading a SLD file (fixes #8978)

### DIFF
--- a/python/core/symbology-ng/qgssymbollayerv2utils.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2utils.sip
@@ -57,6 +57,14 @@ class QgsSymbolLayerV2Utils
     static QString encodeSldUom( QgsSymbolV2::OutputUnit unit, double *scaleFactor );
     static QgsSymbolV2::OutputUnit decodeSldUom( const QString& str, double *scaleFactor );
 
+    /** Returns the size scaled in pixels according to the uom attribute.
+     * \param uom The uom attribute from SLD 1.1 version
+     * \param size The original size
+     * \returns the size in pixels
+     * \since QGIS 3.0
+     */
+    static double sizeInPixelsFromSldUom( const QString &uom, double size );
+
     static QString encodeScaleMethod( QgsSymbolV2::ScaleMethod scaleMethod );
     static QgsSymbolV2::ScaleMethod decodeScaleMethod( const QString& str );
 

--- a/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
@@ -490,6 +490,10 @@ QgsSymbolLayerV2* QgsEllipseSymbolLayerV2::createFromSld( QDomElement &element )
   if ( !QgsSymbolLayerV2Utils::wellKnownMarkerFromSld( graphicElem, name, fillColor, borderColor, borderStyle, borderWidth, size ) )
     return nullptr;
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  size = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, size );
+  borderWidth = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, borderWidth );
+
   double angle = 0.0;
   QString angleFunc;
   if ( QgsSymbolLayerV2Utils::rotationFromSldElement( graphicElem, angleFunc ) )
@@ -501,6 +505,7 @@ QgsSymbolLayerV2* QgsEllipseSymbolLayerV2::createFromSld( QDomElement &element )
   }
 
   QgsEllipseSymbolLayerV2 *m = new QgsEllipseSymbolLayerV2();
+  m->setOutputUnit( QgsSymbolV2::Pixel );
   m->setSymbolName( name );
   m->setFillColor( fillColor );
   m->setOutlineColor( borderColor );

--- a/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
@@ -390,7 +390,13 @@ QgsSymbolLayerV2* QgsSimpleFillSymbolLayerV2::createFromSld( QDomElement &elemen
   QPointF offset;
   QgsSymbolLayerV2Utils::displacementFromSldElement( element, offset );
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  offset.setX( QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset.x() ) );
+  offset.setY( QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset.y() ) );
+  borderWidth = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, borderWidth );
+
   QgsSimpleFillSymbolLayerV2* sl = new QgsSimpleFillSymbolLayerV2( color, fillStyle, borderColor, borderStyle, borderWidth );
+  sl->setOutputUnit( QgsSymbolV2::Pixel );
   sl->setOffset( offset );
   return sl;
 }
@@ -2159,6 +2165,10 @@ QgsSymbolLayerV2* QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
 
   QgsSymbolLayerV2Utils::lineFromSld( graphicElem, penStyle, borderColor, borderWidth );
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  size = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, size );
+  borderWidth = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, borderWidth );
+
   double angle = 0.0;
   QString angleFunc;
   if ( QgsSymbolLayerV2Utils::rotationFromSldElement( graphicElem, angleFunc ) )
@@ -2170,6 +2180,7 @@ QgsSymbolLayerV2* QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
   }
 
   QgsSVGFillSymbolLayer* sl = new QgsSVGFillSymbolLayer( path, size, angle );
+  sl->setOutputUnit( QgsSymbolV2::Pixel );
   sl->setSvgFillColor( fillColor );
   sl->setSvgOutlineColor( borderColor );
   sl->setSvgOutlineWidth( borderWidth );
@@ -3014,7 +3025,12 @@ QgsSymbolLayerV2* QgsLinePatternFillSymbolLayer::createFromSld( QDomElement &ele
     offset = sqrt( pow( vectOffset.x(), 2 ) + pow( vectOffset.y(), 2 ) );
   }
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  size = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, size );
+  lineWidth = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, lineWidth );
+
   QgsLinePatternFillSymbolLayer* sl = new QgsLinePatternFillSymbolLayer();
+  sl->setOutputUnit( QgsSymbolV2::Pixel );
   sl->setColor( lineColor );
   sl->setLineWidth( lineWidth );
   sl->setLineAngle( angle );

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -471,7 +471,12 @@ QgsSymbolLayerV2* QgsSimpleLineSymbolLayerV2::createFromSld( QDomElement &elemen
       offset = d;
   }
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  width = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, width );
+  offset = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset );
+
   QgsSimpleLineSymbolLayerV2* l = new QgsSimpleLineSymbolLayerV2( color, width, penStyle );
+  l->setOutputUnit( QgsSymbolV2::Pixel );
   l->setOffset( offset );
   l->setPenJoinStyle( penJoinStyle );
   l->setPenCapStyle( penCapStyle );
@@ -1551,7 +1556,12 @@ QgsSymbolLayerV2* QgsMarkerLineSymbolLayerV2::createFromSld( QDomElement &elemen
       offset = d;
   }
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  interval = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, interval );
+  offset = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset );
+
   QgsMarkerLineSymbolLayerV2* x = new QgsMarkerLineSymbolLayerV2( rotateMarker );
+  x->setOutputUnit( QgsSymbolV2::Pixel );
   x->setPlacement( placement );
   x->setInterval( interval );
   x->setSubSymbol( marker );

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -1239,7 +1239,13 @@ QgsSymbolLayerV2* QgsSimpleMarkerSymbolLayerV2::createFromSld( QDomElement &elem
 
   Shape shape = decodeShape( name );
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  size = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, size );
+  offset.setX( QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset.x() ) );
+  offset.setY( QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset.y() ) );
+
   QgsSimpleMarkerSymbolLayerV2 *m = new QgsSimpleMarkerSymbolLayerV2( shape, size );
+  m->setOutputUnit( QgsSymbolV2::Pixel );
   m->setColor( color );
   m->setBorderColor( borderColor );
   m->setAngle( angle );
@@ -2266,6 +2272,9 @@ QgsSymbolLayerV2* QgsSvgMarkerSymbolLayerV2::createFromSld( QDomElement &element
   if ( !QgsSymbolLayerV2Utils::externalGraphicFromSld( graphicElem, path, mimeType, fillColor, size ) )
     return nullptr;
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  size = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, size );
+
   if ( mimeType != "image/svg+xml" )
     return nullptr;
 
@@ -2283,6 +2292,7 @@ QgsSymbolLayerV2* QgsSvgMarkerSymbolLayerV2::createFromSld( QDomElement &element
   QgsSymbolLayerV2Utils::displacementFromSldElement( graphicElem, offset );
 
   QgsSvgMarkerSymbolLayerV2* m = new QgsSvgMarkerSymbolLayerV2( path, size );
+  m->setOutputUnit( QgsSymbolV2::Pixel );
   m->setFillColor( fillColor );
   //m->setOutlineColor( outlineColor );
   //m->setOutlineWidth( outlineWidth );
@@ -2945,7 +2955,13 @@ QgsSymbolLayerV2* QgsFontMarkerSymbolLayerV2::createFromSld( QDomElement &elemen
   QPointF offset;
   QgsSymbolLayerV2Utils::displacementFromSldElement( graphicElem, offset );
 
+  QString uom = element.attribute( QString( "uom" ), "" );
+  offset.setX( QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset.x() ) );
+  offset.setY( QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, offset.y() ) );
+  size = QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( uom, size );
+
   QgsMarkerSymbolLayerV2 *m = new QgsFontMarkerSymbolLayerV2( fontFamily, chr, size, color );
+  m->setOutputUnit( QgsSymbolV2::Pixel );
   m->setAngle( angle );
   m->setOffset( offset );
   return m;

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -4231,3 +4231,23 @@ void QgsSymbolLayerV2Utils::mergeScaleDependencies( int mScaleMinDenom, int mSca
       props[ "scaleMaxDenom" ] = QString::number( qMin( parentScaleMaxDenom, mScaleMaxDenom ) );
   }
 }
+
+double QgsSymbolLayerV2Utils::sizeInPixelsFromSldUom( const QString &uom, double size )
+{
+  double scale = 1.0;
+
+  if ( uom == QLatin1String( "http://www.opengeospatial.org/se/units/metre" ) )
+  {
+    scale = 1.0 / 0.00028; // from meters to pixels
+  }
+  else if ( uom == QLatin1String( "http://www.opengeospatial.org/se/units/foot" ) )
+  {
+    scale = 304.8 / 0.28; // from feet to pixels
+  }
+  else
+  {
+    scale = 1.0; // from pixels to pixels (default unit)
+  }
+
+  return size * scale;
+}

--- a/src/core/symbology-ng/qgssymbollayerv2utils.h
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.h
@@ -103,6 +103,14 @@ class CORE_EXPORT QgsSymbolLayerV2Utils
     static QString encodeScaleMethod( QgsSymbolV2::ScaleMethod scaleMethod );
     static QgsSymbolV2::ScaleMethod decodeScaleMethod( const QString& str );
 
+    /** Returns the size scaled in pixels according to the uom attribute.
+     * @param uom The uom attribute from SLD 1.1 version
+     * @param size The original size
+     * @returns the size in pixels
+     * @note added in QGIS 2.18 and 3.0
+     */
+    static double sizeInPixelsFromSldUom( const QString &uom, double size );
+
     static QPainter::CompositionMode decodeBlendMode( const QString& s );
 
     static QIcon symbolPreviewIcon( QgsSymbolV2* symbol, QSize size );

--- a/tests/src/python/test_qgssymbollayerv2_readsld.py
+++ b/tests/src/python/test_qgssymbollayerv2_readsld.py
@@ -331,13 +331,8 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
 
         sld_size_px = 6
 
-        # values for qgis 3.X
-        #sld_displacement_x_px = 3.3
-        #sld_displacement_y_px = 6.6
-
-        # values for qgis 2.x
-        sld_displacement_x_px = 0
-        sld_displacement_y_px = 0
+        sld_displacement_x_px = 3.3
+        sld_displacement_y_px = 6.6
 
         sl = layer.rendererV2().symbol().symbolLayers()[0]
         size = sl.size()

--- a/tests/src/python/test_qgssymbollayerv2_readsld.py
+++ b/tests/src/python/test_qgssymbollayerv2_readsld.py
@@ -26,11 +26,24 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 import os
+from qgis.PyQt.QtXml import QDomDocument
 from qgis.testing import start_app, unittest
 from qgis.core import (QgsVectorLayer,
                        QgsFeature,
                        QgsGeometry,
-                       QgsPoint
+                       QgsPoint,
+                       QgsUnitTypes,
+                       QgsPoint,
+                       QgsSvgMarkerSymbolLayerV2,
+                       QgsEllipseSymbolLayerV2,
+                       QgsSimpleFillSymbolLayerV2,
+                       QgsSVGFillSymbolLayer,
+                       QgsLinePatternFillSymbolLayer,
+                       QgsSimpleLineSymbolLayerV2,
+                       QgsMarkerLineSymbolLayerV2,
+                       QgsSimpleMarkerSymbolLayerV2,
+                       QgsFontMarkerSymbolLayerV2,
+                       QgsSymbolV2
                        )
 from qgis.testing import unittest
 from qgis.testing.mocked import get_iface
@@ -52,6 +65,28 @@ def createLayerWithOneLine():
     return linelayer
 
 
+def createLayerWithOnePoint():
+    layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer",
+                           "addfeat", "memory")
+    pr = layer.dataProvider()
+    f = QgsFeature()
+    f.setAttributes(["test", 123])
+    f.setGeometry(QgsGeometry.fromPoint(QgsPoint(100, 200)))
+    assert pr.addFeatures([f])
+    assert layer.pendingFeatureCount() == 1
+    return layer
+
+
+def createLayerWithOnePolygon():
+    layer = QgsVectorLayer("Polygon?crs=epsg:3111&field=pk:int", "vl", "memory")
+    assert layer.isValid()
+    f1 = QgsFeature(layer.dataProvider().fields(), 1)
+    f1.setAttribute("pk", 1)
+    f1.setGeometry(QgsGeometry.fromPolygon([[QgsPoint(2484588, 2425722), QgsPoint(2482767, 2398853), QgsPoint(2520109, 2397715), QgsPoint(2520792, 2425494), QgsPoint(2484588, 2425722)]]))
+    assert layer.dataProvider().addFeatures([f1])
+    return layer
+
+
 class TestQgsSymbolLayerReadSld(unittest.TestCase):
 
     """
@@ -70,17 +105,17 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         props = layer.rendererV2().symbol().symbolLayers()[0].properties()
 
         def testLineColor():
-            # stroke CSSParameter within ogc:Literal
+            # border CSSParameter within ogc:Literal
             # expected color is #003EBA, RGB 0,62,186
             self.assertEqual(layer.rendererV2().symbol().symbolLayers()[0].color().name(), '#003eba')
 
         def testLineWidth():
-            # stroke-width CSSParameter within ogc:Literal
+            # border-width CSSParameter within ogc:Literal
             self.assertEqual(props['line_width'], '2')
 
         def testLineOpacity():
-            # stroke-opacity CSSParameter NOT within ogc:Literal
-            # stroke-opacity=0.1
+            # border-opacity CSSParameter NOT within ogc:Literal
+            # border-opacity=0.1
             self.assertEqual(props['line_color'], '0,62,186,25')
 
         testLineColor()
@@ -111,6 +146,270 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         layer.loadSldStyle(mFilePath)
         props = layer.rendererV2().symbol().symbolLayers()[0].properties()
         self.assertEqual(props['angle'], '50')
+
+    def testSymbolSizeUom(self):
+        # create a layer
+        layer = createLayerWithOnePoint()
+
+         # load a sld with marker size without uom attribute (pixels)
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+
+        # load a sld with marker size with uom attribute in pixel
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerUomPixel.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+
+        # load a sld with marker size with uom attribute in meter
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerUomMetre.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12 / (0.28 * 0.001)
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertAlmostEqual(size, sld_size_px, delta=0.1)
+
+        # load a sld with marker size with uom attribute in foot
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerUomFoot.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12 * (304.8 / 0.28)
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertAlmostEqual(size, sld_size_px, delta=0.1)
+
+    def testSymbolSize(self):
+        # create a layers
+        layer = createLayerWithOnePoint()
+        player = createLayerWithOnePolygon()
+
+        # size test for QgsEllipseSymbolLayer
+        sld = 'symbol_layer/QgsEllipseSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 7
+        sld_border_width_px = 1
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.symbolWidth()
+        border_width = sl.outlineWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsEllipseSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(border_width, sld_border_width_px)
+
+        # size test for QgsVectorFieldSymbolLayer
+        # createFromSld not implemented
+
+        # size test for QgsSimpleFillSymbolLayer
+        sld = 'symbol_layer/QgsSimpleFillSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_border_width_px = 0.26
+
+        sl = player.rendererV2().symbol().symbolLayers()[0]
+        border_width = sl.borderWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSimpleFillSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(border_width, sld_border_width_px)
+
+        # size test for QgsSVGFillSymbolLayer
+        sld = 'symbol_layer/QgsSVGFillSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_size_px = 6
+        sld_border_width_px = 3
+
+        sl = player.rendererV2().symbol().symbolLayers()[0]
+        size = sl.patternWidth()
+        border_width = sl.svgOutlineWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSVGFillSymbolLayer))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(border_width, sld_border_width_px)
+
+        # size test for QgsSvgMarkerSymbolLayer
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSvgMarkerSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+
+        # size test for QgsPointPatternFillSymbolLayer
+        # createFromSld not implemented
+
+        # size test for QgsLinePatternFillSymbolLayer
+        sld = 'symbol_layer/QgsLinePatternFillSymbolLayer.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_size_px = 4
+        sld_border_width_px = 1.5
+
+        sl = player.rendererV2().symbol().symbolLayers()[0]
+        size = sl.distance()
+        border_width = sl.lineWidth()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsLinePatternFillSymbolLayer))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(border_width, sld_border_width_px)
+
+        # test size for QgsSimpleLineSymbolLayer
+        sld = 'symbol_layer/QgsSimpleLineSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_border_width_px = 1.26
+
+        sl = player.rendererV2().symbol().symbolLayers()[0]
+        border_width = sl.width()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSimpleLineSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(border_width, sld_border_width_px)
+
+        # test size for QgsMarkerLineSymbolLayer
+        sld = 'symbol_layer/QgsMarkerLineSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        player.loadSldStyle(mFilePath)
+
+        sld_interval_px = 3.3
+        sld_offset_px = 6.6
+
+        sl = player.rendererV2().symbol().symbolLayers()[0]
+        interval = sl.interval()
+        offset = sl.offset()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsMarkerLineSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(interval, sld_interval_px)
+        self.assertEqual(offset, sld_offset_px)
+
+        # test size for QgsSimpleMarkerSymbolLayer
+        sld = 'symbol_layer/QgsSimpleMarkerSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 6
+
+        # values for qgis 3.X
+        #sld_displacement_x_px = 3.3
+        #sld_displacement_y_px = 6.6
+
+        # values for qgis 2.x
+        sld_displacement_x_px = 0
+        sld_displacement_y_px = 0
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        offset = sl.offset()
+        unit = sl.outputUnit()
+        self.assertTrue(isinstance(sl, QgsSimpleMarkerSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+        self.assertEqual(offset.x(), sld_displacement_x_px)
+        self.assertEqual(offset.y(), sld_displacement_y_px)
+
+        # test size for QgsSVGMarkerSymbolLayer
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 12
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        self.assertTrue(isinstance(sl, QgsSvgMarkerSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+
+        # test size for QgsFontMarkerSymbolLayer
+        sld = 'symbol_layer/QgsFontMarkerSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sld_size_px = 6.23
+
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        size = sl.size()
+        self.assertTrue(isinstance(sl, QgsFontMarkerSymbolLayerV2))
+        self.assertEqual(unit, QgsSymbolV2.Pixel)
+        self.assertEqual(size, sld_size_px)
+
+    def testSymbolSizeAfterReload(self):
+        # create a layer
+        layer = createLayerWithOnePoint()
+
+        # load a sld with marker size
+        sld = 'symbol_layer/QgsSvgMarkerSymbolLayerV2.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        # get the size and unit of the symbol
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        first_size = sl.size()
+        first_unit = sl.outputUnit()  # in pixels
+
+        # export sld into a qdomdocument with namespace processing activated
+        doc = QDomDocument()
+        msg = ""
+        layer.exportSldStyle(doc, msg)
+        doc.setContent(doc.toString(), True)
+        self.assertTrue(msg == "")
+
+        # reload the same sld
+        root = doc.firstChildElement("StyledLayerDescriptor")
+        el = root.firstChildElement("NamedLayer")
+        layer.readSld(el, msg)
+
+        # extract the size and unit of symbol
+        sl = layer.rendererV2().symbol().symbolLayers()[0]
+        second_size = sl.size()
+        second_unit = sl.outputUnit()
+
+        # size and unit should be the same after export and reload the same
+        # sld description
+        self.assertEqual(first_size, second_size)
+        self.assertEqual(first_unit, second_unit)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssymbollayerv2_readsld.py
+++ b/tests/src/python/test_qgssymbollayerv2_readsld.py
@@ -151,7 +151,7 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         # create a layer
         layer = createLayerWithOnePoint()
 
-         # load a sld with marker size without uom attribute (pixels)
+        # load a sld with marker size without uom attribute (pixels)
         sld = 'symbol_layer/QgsSvgMarkerSymbolLayerV2.sld'
         mFilePath = os.path.join(TEST_DATA_DIR, sld)
         layer.loadSldStyle(mFilePath)

--- a/tests/testdata/symbol_layer/QgsMarkerLineSymbolLayerV2.sld
+++ b/tests/testdata/symbol_layer/QgsMarkerLineSymbolLayerV2.sld
@@ -11,6 +11,8 @@
             <VendorOption name="placement">centralPoint</VendorOption>
             <se:Stroke>
               <se:GraphicStroke>
+                <se:Gap>3.3</se:Gap>
+                <se:PerpendicularOffset>6.6</se:PerpendicularOffset>
                 <se:Graphic>
                   <se:Mark>
                     <se:WellKnownName>circle</se:WellKnownName>

--- a/tests/testdata/symbol_layer/QgsSimpleMarkerSymbolLayerV2.sld
+++ b/tests/testdata/symbol_layer/QgsSimpleMarkerSymbolLayerV2.sld
@@ -9,6 +9,10 @@
           <se:Name>Single symbol</se:Name>
           <se:PointSymbolizer>
             <se:Graphic>
+              <se:Displacement>
+                <se:DisplacementX>3.3</se:DisplacementX>
+                <se:DisplacementY>6.6</se:DisplacementY>
+              </se:Displacement>
               <se:Mark>
                 <se:WellKnownName>pentagon</se:WellKnownName>
                 <se:Fill>

--- a/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomFoot.sld
+++ b/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomFoot.sld
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <se:Name>022cs000</se:Name>
+    <UserStyle>
+      <se:Name>022cs000</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/foot">
+            <se:Graphic>
+              <se:ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="file:///gpsicons/skull.svg"/>
+                <Format>image/svg+xml</Format>
+              </se:ExternalGraphic>
+              <se:Size>12</se:Size>
+              <se:Rotation>
+                <ogc:Literal>45</ogc:Literal>
+              </se:Rotation>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomMetre.sld
+++ b/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomMetre.sld
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <se:Name>022cs000</se:Name>
+    <UserStyle>
+      <se:Name>022cs000</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+            <se:Graphic>
+              <se:ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="file:///gpsicons/skull.svg"/>
+                <Format>image/svg+xml</Format>
+              </se:ExternalGraphic>
+              <se:Size>12</se:Size>
+              <se:Rotation>
+                <ogc:Literal>45</ogc:Literal>
+              </se:Rotation>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomPixel.sld
+++ b/tests/testdata/symbol_layer/QgsSvgMarkerSymbolLayerUomPixel.sld
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <se:Name>022cs000</se:Name>
+    <UserStyle>
+      <se:Name>022cs000</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/pixel">
+            <se:Graphic>
+              <se:ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="file:///gpsicons/skull.svg"/>
+                <Format>image/svg+xml</Format>
+              </se:ExternalGraphic>
+              <se:Size>12</se:Size>
+              <se:Rotation>
+                <ogc:Literal>45</ogc:Literal>
+              </se:Rotation>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
## Description
This PR is the backport of https://github.com/qgis/QGIS/pull/4432 that add correct support for SLD "uom" parameters. e.g. unit size specified in the SLD.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
