### PR TITLE
Fix include for case sensitive HFS+ builds

### DIFF
--- a/src/native/mac/cocoainitializer.mm
+++ b/src/native/mac/cocoainitializer.mm
@@ -36,7 +36,7 @@
     POSSIBILITY OF SUCH DAMAGE.
  ***************************************************************************/
 
-#include "CocoaInitializer.h"
+#include "cocoainitializer.h"
 
 #include <AppKit/AppKit.h>
 #include <Cocoa/Cocoa.h>


### PR DESCRIPTION
CocoaInitializer.h != cocoainitializer.h on case sensitive filesystems.

## Description
Build fails on HFS+ case sensitive file systems due to this naming inconsistency. This appears to be the only change required. Have successfully built on a case-sensitive HFS+ volume after this change.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
