### PR TITLE
Fix postgres server imposed NOT NULL constraint

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1825,7 +1825,7 @@ bool QgsPostgresProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstrain
   {
     // stricter check - if we are evaluating default values only on commit then we can only bypass the check
     // if the attribute values matches the original default clause
-    return mDefaultValues.contains( fieldIndex ) && mDefaultValues.value( fieldIndex ) == value.toString();
+    return mDefaultValues.contains( fieldIndex ) && mDefaultValues.value( fieldIndex ) == value.toString() && !value.isNull();
   }
 }
 


### PR DESCRIPTION
Previously, the NOT NULL constraints imposed by the db were not respected for varchar, text, date fields. They were working for integer though (see screenshot, only `zustaendigkeitkataster` which is int works)

![screenshot from 2017-06-16 14-32-06](https://user-images.githubusercontent.com/588407/27226710-9d777206-52a0-11e7-8e14-42a59908dea7.png)
