### PR TITLE
Browsertree collapse network provider items

### DIFF
--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -176,7 +176,8 @@ Create new data item.
       NoCapabilities,
       SetCrs,
       Fertile,
-      Fast
+      Fast,
+      Collapse
     };
     typedef QFlags<QgsDataItem::Capability> Capabilities;
 

--- a/python/gui/qgsbrowsertreeview.sip
+++ b/python/gui/qgsbrowsertreeview.sip
@@ -25,6 +25,11 @@ class QgsBrowserTreeView : QTreeView
     QgsBrowserTreeView( QWidget *parent /TransferThis/ = 0 );
 
     virtual void setModel( QAbstractItemModel *model );
+    void setBrowserModel( QgsBrowserModel *model );
+    QgsBrowserModel *browserModel( );
+%Docstring
+ :rtype: QgsBrowserModel
+%End
     virtual void showEvent( QShowEvent *e );
     virtual void hideEvent( QHideEvent *e );
 

--- a/python/gui/qgsbrowsertreeview.sip
+++ b/python/gui/qgsbrowsertreeview.sip
@@ -26,8 +26,12 @@ class QgsBrowserTreeView : QTreeView
 
     virtual void setModel( QAbstractItemModel *model );
     void setBrowserModel( QgsBrowserModel *model );
+%Docstring
+Set the browser model
+%End
     QgsBrowserModel *browserModel( );
 %Docstring
+Return the browser model
  :rtype: QgsBrowserModel
 %End
     virtual void showEvent( QShowEvent *e );

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -169,10 +169,11 @@ class CORE_EXPORT QgsDataItem : public QObject
 
     enum Capability
     {
-      NoCapabilities = 0,
-      SetCrs         = 1 << 0, //!< Can set CRS on layer or group of layers
-      Fertile        = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
-      Fast           = 1 << 2  //!< CreateChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QgsSettings
+      NoCapabilities    = 0,
+      SetCrs            = 1 << 0, //!< Can set CRS on layer or group of layers
+      Fertile           = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
+      Fast              = 1 << 2, //!< CreateChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QgsSettings
+      Collapse          = 1 << 3  //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
     };
     Q_DECLARE_FLAGS( Capabilities, Capability )
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -746,7 +746,6 @@ SET(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsquerybuilderbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssqlcomposerdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssublayersdialogbase.h
-  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstablewidgetuibase.h
 )
 
 IF(ENABLE_MODELTEST)

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -118,6 +118,7 @@ void QgsBrowserDockWidget::showEvent( QShowEvent *e )
     mProxyModel = new QgsBrowserTreeFilterProxyModel( this );
     mProxyModel->setBrowserModel( mModel );
     mBrowserView->setSettingsSection( objectName().toLower() ); // to distinguish 2 instances ow browser
+    mBrowserView->setBrowserModel( mModel );
     mBrowserView->setModel( mProxyModel );
     // provide a horizontal scroll bar instead of using ellipse (...) for longer items
     mBrowserView->setTextElideMode( Qt::ElideNone );

--- a/src/gui/qgsbrowserdockwidget_p.h
+++ b/src/gui/qgsbrowserdockwidget_p.h
@@ -212,6 +212,8 @@ class QgsBrowserTreeFilterProxyModel : public QSortFilterProxyModel
     explicit QgsBrowserTreeFilterProxyModel( QObject *parent );
     //! Set the browser model
     void setBrowserModel( QgsBrowserModel *model );
+    //! Get the browser model
+    QgsBrowserModel *browserModel( ) { return mModel; }
     //! Set the filter syntax
     void setFilterSyntax( const QString &syntax );
     //! Set the filter

--- a/src/gui/qgsbrowsertreeview.cpp
+++ b/src/gui/qgsbrowsertreeview.cpp
@@ -22,6 +22,7 @@
 QgsBrowserTreeView::QgsBrowserTreeView( QWidget *parent )
   : QTreeView( parent )
   , mSettingsSection( QStringLiteral( "browser" ) )
+  , mBrowserModel( nullptr )
 {
 }
 
@@ -31,6 +32,11 @@ void QgsBrowserTreeView::setModel( QAbstractItemModel *model )
   QTreeView::setModel( model );
 
   restoreState();
+}
+
+void QgsBrowserTreeView::setBrowserModel( QgsBrowserModel *model )
+{
+  mBrowserModel = model;
 }
 
 void QgsBrowserTreeView::showEvent( QShowEvent *e )
@@ -72,7 +78,24 @@ void QgsBrowserTreeView::restoreState()
     {
       QModelIndex expandIndex = QgsBrowserModel::findPath( model(), path, Qt::MatchStartsWith );
       if ( expandIndex.isValid() )
-        expandIndexSet.insert( expandIndex );
+      {
+        QModelIndex modelIndex = browserModel()->findPath( path, Qt::MatchExactly );
+        if ( modelIndex.isValid() )
+        {
+          QgsDataItem *ptr = browserModel()->dataItem( modelIndex );
+          if ( ptr && ( ptr->capabilities2() & QgsDataItem::Capability::Collapse ) )
+          {
+            QgsDebugMsgLevel( "do not expand index for path " + path, 4 );
+            QModelIndex parentIndex = model()->parent( expandIndex );
+            if ( parentIndex.isValid() )
+              expandIndexSet.insert( parentIndex );
+          }
+          else
+          {
+            expandIndexSet.insert( expandIndex );
+          }
+        }
+      }
       else
       {
         QgsDebugMsgLevel( "index for path " + path + " not found", 4 );

--- a/src/gui/qgsbrowsertreeview.cpp
+++ b/src/gui/qgsbrowsertreeview.cpp
@@ -87,6 +87,7 @@ void QgsBrowserTreeView::restoreState()
           {
             QgsDebugMsgLevel( "do not expand index for path " + path, 4 );
             QModelIndex parentIndex = model()->parent( expandIndex );
+            // Still we need to store the parent in order to expand it
             if ( parentIndex.isValid() )
               expandIndexSet.insert( parentIndex );
           }

--- a/src/gui/qgsbrowsertreeview.h
+++ b/src/gui/qgsbrowsertreeview.h
@@ -35,7 +35,9 @@ class GUI_EXPORT QgsBrowserTreeView : public QTreeView
     QgsBrowserTreeView( QWidget *parent SIP_TRANSFERTHIS = 0 );
 
     virtual void setModel( QAbstractItemModel *model ) override;
+    //! Set the browser model
     void setBrowserModel( QgsBrowserModel *model );
+    //! Return the browser model
     QgsBrowserModel *browserModel( ) { return mBrowserModel; }
     virtual void showEvent( QShowEvent *e ) override;
     virtual void hideEvent( QHideEvent *e ) override;

--- a/src/gui/qgsbrowsertreeview.h
+++ b/src/gui/qgsbrowsertreeview.h
@@ -20,7 +20,7 @@
 #include "qgis.h"
 #include "qgis_gui.h"
 
-//class QgsBrowserModel;
+class QgsBrowserModel;
 
 /** \ingroup gui
  * The QgsBrowserTreeView class extends QTreeView with save/restore tree state functionality.
@@ -35,6 +35,8 @@ class GUI_EXPORT QgsBrowserTreeView : public QTreeView
     QgsBrowserTreeView( QWidget *parent SIP_TRANSFERTHIS = 0 );
 
     virtual void setModel( QAbstractItemModel *model ) override;
+    void setBrowserModel( QgsBrowserModel *model );
+    QgsBrowserModel *browserModel( ) { return mBrowserModel; }
     virtual void showEvent( QShowEvent *e ) override;
     virtual void hideEvent( QHideEvent *e ) override;
 
@@ -64,6 +66,7 @@ class GUI_EXPORT QgsBrowserTreeView : public QTreeView
 
     // returns true if expanded from root to item
     bool treeExpanded( const QModelIndex &index );
+    QgsBrowserModel *mBrowserModel;
 };
 
 #endif // QGSBROWSERTREEVIEW_H

--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -83,6 +83,7 @@ QgsAfsConnectionItem::QgsAfsConnectionItem( QgsDataItem *parent, const QString &
   , mUrl( url )
 {
   mIconName = QStringLiteral( "mIconConnect.png" );
+  mCapabilities |= Collapse;
 }
 
 QVector<QgsDataItem *> QgsAfsConnectionItem::createChildren()

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -26,7 +26,7 @@
 QgsAmsRootItem::QgsAmsRootItem( QgsDataItem *parent, QString name, QString path )
   : QgsDataCollectionItem( parent, name, path )
 {
-  mCapabilities |= Fast;
+  mCapabilities |= Fast | Collapse;
   mIconName = QStringLiteral( "mIconAms.svg" );
   populate();
 }

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -35,6 +35,7 @@ QgsDb2ConnectionItem::QgsDb2ConnectionItem( QgsDataItem *parent, const QString n
   : QgsDataCollectionItem( parent, name, path )
 {
   mIconName = QStringLiteral( "mIconConnect.png" );
+  mCapabilities |= Collapse;
   populate();
 }
 

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -41,7 +41,7 @@ QgsMssqlConnectionItem::QgsMssqlConnectionItem( QgsDataItem *parent, QString nam
   , mAllowGeometrylessTables( true )
   , mColumnTypeThread( nullptr )
 {
-  mCapabilities |= Fast;
+  mCapabilities |= Fast | Collapse;
   mIconName = QStringLiteral( "mIconConnect.png" );
 }
 

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -34,6 +34,7 @@ QgsOracleConnectionItem::QgsOracleConnectionItem( QgsDataItem *parent, QString n
   , mColumnTypeThread( nullptr )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
 }
 
 QgsOracleConnectionItem::~QgsOracleConnectionItem()

--- a/src/providers/ows/qgsowsdataitems.cpp
+++ b/src/providers/ows/qgsowsdataitems.cpp
@@ -29,6 +29,7 @@ QgsOWSConnectionItem::QgsOWSConnectionItem( QgsDataItem *parent, QString name, Q
   : QgsDataCollectionItem( parent, name, path )
 {
   mIconName = QStringLiteral( "mIconConnect.png" );
+  mCapabilities |= Collapse;
 }
 
 QgsOWSConnectionItem::~QgsOWSConnectionItem()

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -39,6 +39,7 @@ QgsPGConnectionItem::QgsPGConnectionItem( QgsDataItem *parent, QString name, QSt
   : QgsDataCollectionItem( parent, name, path )
 {
   mIconName = QStringLiteral( "mIconConnect.png" );
+  mCapabilities |= Collapse;
 }
 
 QVector<QgsDataItem *> QgsPGConnectionItem::createChildren()

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -75,6 +75,7 @@ QgsSLConnectionItem::QgsSLConnectionItem( QgsDataItem *parent, QString name, QSt
 {
   mDbPath = QgsSpatiaLiteConnection::connectionPath( name );
   mToolTip = mDbPath;
+  mCapabilities |= Collapse;
 }
 
 static QgsLayerItem::LayerType _layerTypeFromDb( const QString &dbType )

--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -29,6 +29,7 @@ QgsWCSConnectionItem::QgsWCSConnectionItem( QgsDataItem *parent, QString name, Q
   , mUri( uri )
 {
   mIconName = QStringLiteral( "mIconWcs.svg" );
+  mCapabilities |= Collapse;
 }
 
 QgsWCSConnectionItem::~QgsWCSConnectionItem()
@@ -43,23 +44,23 @@ QVector<QgsDataItem *> QgsWCSConnectionItem::createChildren()
   uri.setEncodedUri( mUri );
   QgsDebugMsg( "mUri = " + mUri );
 
-  mCapabilities.setUri( uri );
+  mWcsCapabilities.setUri( uri );
 
   // Attention: supportedLayers() gives tree leafes, not top level
-  if ( !mCapabilities.lastError().isEmpty() )
+  if ( !mWcsCapabilities.lastError().isEmpty() )
   {
     //children.append( new QgsErrorItem( this, tr( "Failed to retrieve layers" ), mPath + "/error" ) );
     // TODO: show the error without adding child
     return children;
   }
 
-  Q_FOREACH ( const QgsWcsCoverageSummary &coverageSummary, mCapabilities.capabilities().contents.coverageSummary )
+  Q_FOREACH ( const QgsWcsCoverageSummary &coverageSummary, mWcsCapabilities.capabilities().contents.coverageSummary )
   {
     // Attention, the name may be empty
     QgsDebugMsg( QString::number( coverageSummary.orderId ) + ' ' + coverageSummary.identifier + ' ' + coverageSummary.title );
     QString pathName = coverageSummary.identifier.isEmpty() ? QString::number( coverageSummary.orderId ) : coverageSummary.identifier;
 
-    QgsWCSLayerItem *layer = new QgsWCSLayerItem( this, coverageSummary.title, mPath + '/' + pathName, mCapabilities.capabilities(), uri, coverageSummary );
+    QgsWCSLayerItem *layer = new QgsWCSLayerItem( this, coverageSummary.title, mPath + '/' + pathName, mWcsCapabilities.capabilities(), uri, coverageSummary );
 
     children.append( layer );
   }

--- a/src/providers/wcs/qgswcsdataitems.h
+++ b/src/providers/wcs/qgswcsdataitems.h
@@ -31,7 +31,7 @@ class QgsWCSConnectionItem : public QgsDataCollectionItem
 
     virtual QList<QAction *> actions() override;
 
-    QgsWcsCapabilities mCapabilities;
+    QgsWcsCapabilities mWcsCapabilities;
     QVector<QgsWcsCoverageSummary> mLayerProperties;
 
   public slots:

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -46,9 +46,10 @@ QgsWfsLayerItem::~QgsWfsLayerItem()
 QgsWfsConnectionItem::QgsWfsConnectionItem( QgsDataItem *parent, QString name, QString path, QString uri )
   : QgsDataCollectionItem( parent, name, path )
   , mUri( uri )
-  , mCapabilities( nullptr )
+  , mWfsCapabilities( nullptr )
 {
   mIconName = QStringLiteral( "mIconWfs.svg" );
+  mCapabilities |= Collapse;
 }
 
 QgsWfsConnectionItem::~QgsWfsConnectionItem()

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -58,7 +58,7 @@ class QgsWfsConnectionItem : public QgsDataCollectionItem
   private:
     QString mUri;
 
-    QgsWfsCapabilities *mCapabilities = nullptr;
+    QgsWfsCapabilities *mWfsCapabilities = nullptr;
 };
 
 

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -35,6 +35,7 @@ QgsWMSConnectionItem::QgsWMSConnectionItem( QgsDataItem *parent, QString name, Q
   , mCapabilitiesDownload( nullptr )
 {
   mIconName = QStringLiteral( "mIconConnect.png" );
+  mCapabilities |= Collapse;
   mCapabilitiesDownload = new QgsWmsCapabilitiesDownload( false );
 }
 


### PR DESCRIPTION
Fixes a problem with the browser tree: when WMS items (and the other providers that require network connection) are stored as expanded, every time QGIS starts a GetCapabilities is initiated to retrieve the list of layers. This triggers a network connection that might also trigger a master password request if the layer is protected by the auth system.

The proposed solution restore the items as collapsed, so that the network connection will only be initiated when the user click on the WMS item.

# Before this PR
![wms-before](https://user-images.githubusercontent.com/142164/27234230-8f8417aa-52bc-11e7-860b-40a5eafa673a.png)

# After this PR
![wms-after](https://user-images.githubusercontent.com/142164/27234351-fa8df7fa-52bc-11e7-9ba8-18cc44fdd526.png)





