### PR TITLE
Changes resampling methods to be like SAGA default - #16646 - backport to 2.18

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -327,7 +327,7 @@ class SagaAlgorithm(GeoAlgorithm):
         destFilename = getTempFilenameInTempFolder(filename + '.sgrd')
         self.exportedLayers[source] = destFilename
         sessionExportedLayers[source] = destFilename
-        return 'io_gdal 0 -TRANSFORM 1 -RESAMPLING 0 -GRIDS "' + destFilename + '" -FILES "' + source + '"'
+        return 'io_gdal 0 -TRANSFORM 1 -RESAMPLING 3 -GRIDS "' + destFilename + '" -FILES "' + source + '"'
 
     def checkParameterValuesBeforeExecuting(self):
         """

--- a/python/plugins/processing/algs/saga/description/GridCalculator.txt
+++ b/python/plugins/processing/algs/saga/description/GridCalculator.txt
@@ -4,6 +4,7 @@ AllowUnmatching
 ParameterRaster|GRIDS|Main input layer|False
 ParameterMultipleInput|XGRIDS|Additional layers|3|True
 ParameterString|FORMULA|Formula|
+ParameterSelection|RESAMPLING|Resampling Method|[0] Nearest Neighbour;[1] Bilinear Interpolation;[2] Bicubic Spline Interpolation;[3] B-Spline Interpolation|3
 ParameterBoolean|USE_NODATA|Use NoData|False
 ParameterSelection|TYPE|Output Data Type|[0] bit;[1] unsigned 1 byte integer;[2] signed 1 byte integer;[3] unsigned 2 byte integer;[4] signed 2 byte integer;[5] unsigned 4 byte integer;[6] signed 4 byte integer;[7] 4 byte floating point number;[8] 8 byte floating point number|7
 OutputRaster|RESULT|Calculated


### PR DESCRIPTION
## Description
Changes SAGA io_gdal RESAMPLING method to B-Spline Interpolation, as SAGA default, and adds the Resampling Method parameter to SAGA Raster Calculator, as explained in https://issues.qgis.org/issues/16646