### PR TITLE
Rectangle moving operators

### DIFF
--- a/python/core/geometry/qgsrectangle.sip
+++ b/python/core/geometry/qgsrectangle.sip
@@ -210,6 +210,34 @@ Copy constructor
  Expand the rectangle so that covers both the original rectangle and the given point.
 %End
 
+    QgsRectangle operator-( const QgsVector v ) const;
+%Docstring
+ Returns a rectangle offset from this one in the direction of the reversed vector.
+.. versionadded:: 3.0
+ :rtype: QgsRectangle
+%End
+
+    QgsRectangle operator+( const QgsVector v ) const;
+%Docstring
+ Returns a rectangle offset from this one in the direction of the vector.
+.. versionadded:: 3.0
+ :rtype: QgsRectangle
+%End
+
+    QgsRectangle &operator-=( const QgsVector v );
+%Docstring
+ Moves this rectangle in the direction of the reversed vector.
+.. versionadded:: 3.0
+ :rtype: QgsRectangle
+%End
+
+    QgsRectangle &operator+=( const QgsVector v );
+%Docstring
+ Moves this rectangle in the direction of the vector.
+.. versionadded:: 3.0
+ :rtype: QgsRectangle
+%End
+
     bool isEmpty() const;
 %Docstring
  Returns true if the rectangle is empty.

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -222,6 +222,42 @@ void QgsRectangle::combineExtentWith( double x, double y )
   }
 }
 
+QgsRectangle QgsRectangle::operator-( const QgsVector v ) const
+{
+  double xmin = mXmin - v.x();
+  double xmax = mXmax - v.x();
+  double ymin = mYmin - v.y();
+  double ymax = mYmax - v.y();
+  return QgsRectangle( xmin, ymin, xmax, ymax );
+}
+
+QgsRectangle QgsRectangle::operator+( const QgsVector v ) const
+{
+  double xmin = mXmin + v.x();
+  double xmax = mXmax + v.x();
+  double ymin = mYmin + v.y();
+  double ymax = mYmax + v.y();
+  return QgsRectangle( xmin, ymin, xmax, ymax );
+}
+
+QgsRectangle &QgsRectangle::operator-=( const QgsVector v )
+{
+  mXmin -= v.x();
+  mXmax -= v.x();
+  mYmin -= v.y();
+  mYmax -= v.y();
+  return *this;
+}
+
+QgsRectangle &QgsRectangle::operator+=( const QgsVector v )
+{
+  mXmin += v.x();
+  mXmax += v.x();
+  mYmin += v.y();
+  mYmax += v.y();
+  return *this;
+}
+
 bool QgsRectangle::isEmpty() const
 {
   return mXmax <= mXmin || mYmax <= mYmin;

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -202,6 +202,30 @@ class CORE_EXPORT QgsRectangle
     void combineExtentWith( double x, double y );
 
     /**
+     * Returns a rectangle offset from this one in the direction of the reversed vector.
+     * \since QGIS 3.0
+     */
+    QgsRectangle operator-( const QgsVector v ) const;
+
+    /**
+     * Returns a rectangle offset from this one in the direction of the vector.
+     * \since QGIS 3.0
+     */
+    QgsRectangle operator+( const QgsVector v ) const;
+
+    /**
+     * Moves this rectangle in the direction of the reversed vector.
+     * \since QGIS 3.0
+     */
+    QgsRectangle &operator-=( const QgsVector v );
+
+    /**
+     * Moves this rectangle in the direction of the vector.
+     * \since QGIS 3.0
+     */
+    QgsRectangle &operator+=( const QgsVector v );
+
+    /**
      * Returns true if the rectangle is empty.
      * An empty rectangle may still be non-null if it contains valid information (e.g. bounding box of a point).
      */

--- a/tests/src/core/testqgsrectangle.cpp
+++ b/tests/src/core/testqgsrectangle.cpp
@@ -26,6 +26,7 @@ class TestQgsRectangle: public QObject
   private slots:
     void manipulate();
     void regression6194();
+    void operators();
 };
 
 void TestQgsRectangle::manipulate()
@@ -85,9 +86,30 @@ void TestQgsRectangle::regression6194()
   QVERIFY( rect1 == rect2 );
 }
 
+void TestQgsRectangle::operators()
+{
+  QgsRectangle rect1 = QgsRectangle( 10.0, 20.0, 110.0, 220.0 );
+  QgsVector v = QgsVector( 1.0, 2.0 );
+  QgsRectangle rect2 = rect1 + v;
+  QVERIFY( rect1 != rect2 );
+  QCOMPARE( rect2.height(), rect1.height() );
+  QCOMPARE( rect2.width(), rect1.width() );
+  QCOMPARE( rect2.xMinimum(), 11.0 );
+  QCOMPARE( rect2.yMinimum(), 22.0 );
+
+  rect2 -= rect2.center() - rect1.center();
+  QVERIFY( rect1 == rect2 );
+
+  rect2 += v * 2.5;
+  QCOMPARE( rect2.xMinimum(), 12.5 );
+  QCOMPARE( rect2.yMinimum(), 25.0 );
+
+  rect2 = rect1 - v;
+  QCOMPARE( rect2.xMinimum(), 9.0 );
+  QCOMPARE( rect2.yMinimum(), 18.0 );
+  QCOMPARE( rect2.height(), rect1.height() );
+  QCOMPARE( rect2.width(), rect1.width() );
+}
+
 QGSTEST_MAIN( TestQgsRectangle )
 #include "testqgsrectangle.moc"
-
-
-
-

--- a/tests/src/python/test_qgsrectangle.py
+++ b/tests/src/python/test_qgsrectangle.py
@@ -14,7 +14,7 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
 
-from qgis.core import QgsRectangle, QgsPointXY
+from qgis.core import QgsRectangle, QgsPointXY, QgsVector
 
 from qgis.testing import start_app, unittest
 from utilities import compareWkt
@@ -251,6 +251,15 @@ class TestQgsRectangle(unittest.TestCase):
         self.assertEqual(box.xMaximum(), 0.2)
         self.assertEqual(box.yMaximum(), 0.3)
         self.assertEqual(box.zMaximum(), 0.5)
+
+    def testOperators(self):
+        rect1 = QgsRectangle(10, 20, 40, 40)
+        rect2 = rect1 + QgsVector(3, 5.5)
+        assert rect2 == QgsRectangle(13, 25.5, 43, 45.5), "QgsRectangle + operator does no work"
+
+        # Subtracting the center point, so it becomes zero.
+        rect1 -= rect1.center() - QgsPointXY(0, 0)
+        assert rect1.center() == QgsPointXY(0, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While testing options for #4730, I discovered that there is no easy way to move a rectangle, except changing all of its corner coords one by one. Since in QGIS 3.0 the `QgsVector` class was introduced, with support in `QgsPointXY`, I decided to add the support to the `QgsRectangle` class as well. To me, using arithmetic operators for moving a rectangle seems pretty obvious.