### PR TITLE
[atlas] move file format for image export to atlas widget

### DIFF
--- a/python/auto_sip.blacklist
+++ b/python/auto_sip.blacklist
@@ -3,7 +3,6 @@ core/qgsexception.sip
 core/composer/qgsaddremoveitemcommand.sip
 core/composer/qgsgroupungroupitemscommand.sip
 core/composer/qgsaddremovemultiframecommand.sip
-core/composer/qgsatlascomposition.sip
 core/composer/qgscomposerarrow.sip
 core/composer/qgscomposerattributetablemodelv2.sip
 core/composer/qgscomposerattributetablev2.sip

--- a/python/core/composer/qgsatlascomposition.sip
+++ b/python/core/composer/qgsatlascomposition.sip
@@ -1,228 +1,348 @@
-/** \ingroup core
- * Class used to render an Atlas, iterating over geometry features.
- * prepareForFeature() modifies the atlas map's extent to zoom on the given feature.
- * This class is used for printing, exporting to PDF and images.
- * @note This class should not be created directly. For the atlas to function correctly
- * the atlasComposition() property for QgsComposition should be used to retrieve a
- * QgsAtlasComposition which is automatically created and attached to the composition.
- */
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/composer/qgsatlascomposition.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
 class QgsAtlasComposition : QObject
 {
-%TypeHeaderCode
-#include <qgsatlascomposition.h>
+%Docstring
+ Class used to render an Atlas, iterating over geometry features.
+ prepareForFeature() modifies the atlas map's extent to zoom on the given feature.
+ This class is used for printing, exporting to PDF and images.
+.. note::
+
+   This class should not be created directly. For the atlas to function correctly
+ the atlasComposition() property for QgsComposition should be used to retrieve a
+ QgsAtlasComposition which is automatically created and attached to the composition.
 %End
 
-public:
+%TypeHeaderCode
+#include "qgsatlascomposition.h"
+%End
+  public:
     QgsAtlasComposition( QgsComposition *composition );
-    ~QgsAtlasComposition();
 
-    /** Returns whether the atlas generation is enabled
-     * @returns true if atlas is enabled
-     * @see setEnabled
-     */
     bool enabled() const;
+%Docstring
+ Returns whether the atlas generation is enabled
+ :return: true if atlas is enabled
+.. seealso:: setEnabled
+ :rtype: bool
+%End
 
-    /** Sets whether the atlas is enabled
-     * @param enabled set to true to enable to atlas
-     * @see enabled
-     */
     void setEnabled( bool enabled );
+%Docstring
+ Sets whether the atlas is enabled
+ \param enabled set to true to enable to atlas
+.. seealso:: enabled
+%End
 
-    /** Returns true if the atlas is set to hide the coverage layer
-     * @returns true if coverage layer is hidden
-     * @see setHideCoverage
-     */
     bool hideCoverage() const;
+%Docstring
+ Returns true if the atlas is set to hide the coverage layer
+ :return: true if coverage layer is hidden
+.. seealso:: setHideCoverage
+ :rtype: bool
+%End
 
-    /** Sets whether the coverage layer should be hidden in map items in the composition
-     * @param hide set to true to hide the coverage layer
-     * @see hideCoverage
-     */
     void setHideCoverage( bool hide );
+%Docstring
+ Sets whether the coverage layer should be hidden in map items in the composition
+ \param hide set to true to hide the coverage layer
+.. seealso:: hideCoverage
+%End
 
-    /** Returns the filename expression used for generating output filenames for each
-     * atlas page.
-     * @returns filename pattern
-     * @see setFilenamePattern
-     * @see filenamePatternErrorString
-     * @note This property has no effect when exporting to PDF if singleFile() is true
-     */
     QString filenamePattern() const;
+%Docstring
+ Returns the filename expression used for generating output filenames for each
+ atlas page.
+ :return: filename pattern
+.. seealso:: setFilenamePattern
+.. seealso:: filenamePatternErrorString
+.. note::
 
-    /** Sets the filename expression used for generating output filenames for each
-     * atlas page.
-     * @returns true if filename expression could be successful set, false if expression is invalid
-     * @param pattern expression to use for output filenames
-     * @see filenamePattern
-     * @see filenamePatternErrorString
-     * @note This method has no effect when exporting to PDF if singleFile() is true
-     */
+   This property has no effect when exporting to PDF if singleFile() is true
+ :rtype: str
+%End
+
     bool setFilenamePattern( const QString &pattern );
+%Docstring
+ Sets the filename expression used for generating output filenames for each
+ atlas page.
+ :return: true if filename expression could be successful set, false if expression is invalid
+ \param pattern expression to use for output filenames
+.. seealso:: filenamePattern
+.. seealso:: filenamePatternErrorString
+.. note::
 
-    /** Returns an error string from parsing the filename expression.
-     * @returns filename pattern parser error
-     * @see setFilenamePattern
-     * @see filenamePattern
-     */
+   This method has no effect when exporting to PDF if singleFile() is true
+ :rtype: bool
+%End
+
     QString filenamePatternErrorString() const;
+%Docstring
+ Returns an error string from parsing the filename expression.
+ :return: filename pattern parser error
+.. seealso:: setFilenamePattern
+.. seealso:: filenamePattern
+ :rtype: str
+%End
 
-    /** Returns the coverage layer used for the atlas features
-     * @returns atlas coverage layer
-     * @see setCoverageLayer
-     */
     QgsVectorLayer *coverageLayer() const;
+%Docstring
+ Returns the coverage layer used for the atlas features
+ :return: atlas coverage layer
+.. seealso:: setCoverageLayer
+ :rtype: QgsVectorLayer
+%End
 
-    /** Sets the coverage layer to use for the atlas features
-     * @param layer vector coverage layer
-     * @see coverageLayer
-     */
     void setCoverageLayer( QgsVectorLayer *layer );
+%Docstring
+ Sets the coverage layer to use for the atlas features
+ \param layer vector coverage layer
+.. seealso:: coverageLayer
+%End
 
-    /** Returns the expression used for calculating the page name.
-     * @returns expression string, or field name from coverage layer
-     * @see setPageNameExpression
-     * @see nameForPage
-     * @note added in QGIS 2.12
-     */
     QString pageNameExpression() const;
+%Docstring
+ Returns the expression used for calculating the page name.
+ :return: expression string, or field name from coverage layer
+.. seealso:: setPageNameExpression
+.. seealso:: nameForPage
+.. versionadded:: 2.12
+ :rtype: str
+%End
 
-    /** Sets the expression used for calculating the page name.
-     * @param pageNameExpression expression string, or field name from coverage layer
-     * @see pageNameExpression
-     * @note added in QGIS 2.12
-     */
     void setPageNameExpression( const QString &pageNameExpression );
+%Docstring
+ Sets the expression used for calculating the page name.
+ \param pageNameExpression expression string, or field name from coverage layer
+.. seealso:: pageNameExpression
+.. versionadded:: 2.12
+%End
 
-    /** Returns the calculated name for a specified atlas page number.
-     * @param pageNumber number of page, where 0 = first page
-     * @returns page name
-     * @see pageNameExpression
-     * @note added in QGIS 2.12
-     */
     QString nameForPage( int pageNumber ) const;
+%Docstring
+ Returns the calculated name for a specified atlas page number.
+ \param pageNumber number of page, where 0 = first page
+ :return: page name
+.. seealso:: pageNameExpression
+.. versionadded:: 2.12
+ :rtype: str
+%End
 
-    /** Returns whether the atlas will be exported to a single file. This is only
-     * applicable for PDF exports.
-     * @returns true if atlas will be exported to a single file
-     * @see setSingleFile
-     * @note This property is only used for PDF exports.
-     */
     bool singleFile() const;
+%Docstring
+ Returns whether the atlas will be exported to a single file. This is only
+ applicable for PDF exports.
+ :return: true if atlas will be exported to a single file
+.. seealso:: setSingleFile
+.. note::
 
-    /** Sets whether the atlas should be exported to a single file. This is only
-     * applicable for PDF exports.
-     * @param single set to true to export atlas to a single file.
-     * @see singleFile
-     * @note This method is only used for PDF exports.
-     */
+   This property is only used for PDF exports.
+ :rtype: bool
+%End
+
     void setSingleFile( bool single );
+%Docstring
+ Sets whether the atlas should be exported to a single file. This is only
+ applicable for PDF exports.
+ \param single set to true to export atlas to a single file.
+.. seealso:: singleFile
+.. note::
+
+   This method is only used for PDF exports.
+%End
+
+    QString fileFormat() const;
+%Docstring
+ Returns the  atlas file format used for image exports.
+ :return: true if atlas will be exported to a single file
+.. seealso:: setFileFormat
+.. note::
+
+   This property is only used for image exports.
+.. versionadded:: 3.0
+ :rtype: str
+%End
+
+    void setFileFormat( QString format );
+%Docstring
+ Sets the  atlas file format used for image exports.
+ \param format set the file format extension
+.. seealso:: fileFormat
+.. note::
+
+   This property is only used for image exports.
+.. versionadded:: 3.0
+%End
 
     bool sortFeatures() const;
+%Docstring
+ :rtype: bool
+%End
     void setSortFeatures( bool doSort );
 
     bool sortAscending() const;
+%Docstring
+ :rtype: bool
+%End
     void setSortAscending( bool ascending );
 
     bool filterFeatures() const;
+%Docstring
+ :rtype: bool
+%End
     void setFilterFeatures( bool doFilter );
 
     QString featureFilter() const;
+%Docstring
+ :rtype: str
+%End
     void setFeatureFilter( const QString &expression );
 
-    /** Returns an error string from parsing the feature filter expression.
-     * @returns filename pattern parser error
-     * @see setFilenamePattern
-     * @see filenamePattern
-     */
     QString featureFilterErrorString() const;
+%Docstring
+ Returns an error string from parsing the feature filter expression.
+ :return: filename pattern parser error
+.. seealso:: setFilenamePattern
+.. seealso:: filenamePattern
+ :rtype: str
+%End
 
     QString sortKeyAttributeName() const;
+%Docstring
+ :rtype: str
+%End
     void setSortKeyAttributeName( const QString &fieldName );
 
-    /** Returns the current list of predefined scales for the atlas. This is used
-     * for maps which are set to the predefined atlas scaling mode.
-     * @returns a vector of doubles representing predefined scales
-     * @see setPredefinedScales
-     * @see QgsComposerMap::atlasScalingMode
-     */
     QVector<qreal> predefinedScales() const;
+%Docstring
+ Returns the current list of predefined scales for the atlas. This is used
+ for maps which are set to the predefined atlas scaling mode.
+ :return: a vector of doubles representing predefined scales
+.. seealso:: setPredefinedScales
+.. seealso:: QgsComposerMap.atlasScalingMode
+ :rtype: list of qreal
+%End
 
-    /** Sets the list of predefined scales for the atlas. This is used
-     * for maps which are set to the predefined atlas scaling mode.
-     * @param scales a vector of doubles representing predefined scales
-     * @see predefinedScales
-     * @see QgsComposerMap::atlasScalingMode
-     */
     void setPredefinedScales( const QVector<qreal> &scales );
+%Docstring
+ Sets the list of predefined scales for the atlas. This is used
+ for maps which are set to the predefined atlas scaling mode.
+ \param scales a vector of doubles representing predefined scales
+.. seealso:: predefinedScales
+.. seealso:: QgsComposerMap.atlasScalingMode
+%End
 
-    /** Begins the rendering. Returns true if successful, false if no matching atlas
-      features found.*/
     bool beginRender();
-    /** Ends the rendering. Restores original extent */
+%Docstring
+ Begins the rendering. Returns true if successful, false if no matching atlas
+features found.*
+ :rtype: bool
+%End
     void endRender();
+%Docstring
+Ends the rendering. Restores original extent
+%End
 
-    /** Returns the number of features in the coverage layer */
     int numFeatures() const;
+%Docstring
+Returns the number of features in the coverage layer
+ :rtype: int
+%End
 
-    /** Prepare the atlas map for the given feature. Sets the extent and context variables
-     * @param i feature number
-     * @param updateMaps set to true to redraw maps and recalculate their extent
-     * @returns true if feature was successfully prepared
-     */
     bool prepareForFeature( const int i, const bool updateMaps = true );
+%Docstring
+ Prepare the atlas map for the given feature. Sets the extent and context variables
+ \param i feature number
+ \param updateMaps set to true to redraw maps and recalculate their extent
+ :return: true if feature was successfully prepared
+ :rtype: bool
+%End
 
-    /** Prepare the atlas map for the given feature. Sets the extent and context variables
-     * @returns true if feature was successfully prepared
-     */
     bool prepareForFeature( const QgsFeature *feat );
+%Docstring
+ Prepare the atlas map for the given feature. Sets the extent and context variables
+ :return: true if feature was successfully prepared
+ :rtype: bool
+%End
 
-    /** Returns the current filename. Must be called after prepareForFeature() */
     QString currentFilename() const;
+%Docstring
+Returns the current filename. Must be called after prepareForFeature()
+ :rtype: str
+%End
 
     void writeXml( QDomElement &elem, QDomDocument &doc ) const;
 
-    /** Reads general atlas settings from xml
-     * @param elem a QDomElement holding the atlas properties.
-     * @param doc QDomDocument for the source xml.
-     * @see readXMLMapSettings
-     * @note This method should be called before restoring composer item properties
-     */
     void readXml( const QDomElement &elem, const QDomDocument &doc );
+%Docstring
+ Reads general atlas settings from xml
+ \param elem a QDomElement holding the atlas properties.
+ \param doc QDomDocument for the source xml.
+.. seealso:: readXMLMapSettings
+.. note::
+
+   This method should be called before restoring composer item properties
+%End
 
     QgsComposition *composition();
+%Docstring
+ :rtype: QgsComposition
+%End
 
-    /** Requeries the current atlas coverage layer and applies filtering and sorting. Returns
-     * number of matching features. Must be called after prepareForFeature()
-     */
     int updateFeatures();
+%Docstring
+ Requeries the current atlas coverage layer and applies filtering and sorting. Returns
+ number of matching features. Must be called after prepareForFeature()
+ :rtype: int
+%End
 
-    /** Returns the current atlas feature. Must be called after prepareForFeature().
-     * @note added in QGIS 2.12
-     */
     QgsFeature feature() const;
+%Docstring
+ Returns the current atlas feature. Must be called after prepareForFeature().
+.. versionadded:: 2.12
+ :rtype: QgsFeature
+%End
 
-    /** Returns the name of the page for the current atlas feature. Must be called after prepareForFeature().
-     * @note added in QGIS 2.12
-     */
     QString currentPageName() const;
+%Docstring
+ Returns the name of the page for the current atlas feature. Must be called after prepareForFeature().
+.. versionadded:: 2.12
+ :rtype: str
+%End
 
-    /** Returns the current feature number, where a value of 0 corresponds to the first feature.
-     * @note added in QGIS 2.12
-     */
     int currentFeatureNumber() const;
+%Docstring
+ Returns the current feature number, where a value of 0 corresponds to the first feature.
+.. versionadded:: 2.12
+ :rtype: int
+%End
 
-    /** Recalculates the bounds of an atlas driven map */
     void prepareMap( QgsComposerMap *map );
+%Docstring
+Recalculates the bounds of an atlas driven map
+%End
 
-    /** Returns the current atlas geometry in the given projection system (default to the coverage layer's CRS) */
     QgsGeometry currentGeometry( const QgsCoordinateReferenceSystem &projectedTo = QgsCoordinateReferenceSystem() ) const;
+%Docstring
+Returns the current atlas geometry in the given projection system (default to the coverage layer's CRS)
+ :rtype: QgsGeometry
+%End
 
   public slots:
 
-    /** Refreshes the current atlas feature, by refetching its attributes from the vector layer provider
-     * @note added in QGIS 2.5
-     */
     void refreshFeature();
+%Docstring
+ Refreshes the current atlas feature, by refetching its attributes from the vector layer provider
+.. versionadded:: 2.5
+%End
 
     void nextFeature();
     void prevFeature();
@@ -230,29 +350,59 @@ public:
     void firstFeature();
 
   signals:
-    /** Emitted when one of the parameters changes */
     void parameterChanged();
+%Docstring
+Emitted when one of the parameters changes
+%End
 
-    /** Emitted when atlas is enabled or disabled */
     void toggled( bool );
+%Docstring
+Emitted when atlas is enabled or disabled
+%End
 
-    /** Is emitted when the atlas has an updated status bar message for the composer window*/
     void statusMsgChanged( const QString &message );
+%Docstring
+Is emitted when the atlas has an updated status bar message for the composer window
+%End
 
-    /** Is emitted when the coverage layer for an atlas changes*/
     void coverageLayerChanged( QgsVectorLayer *layer );
+%Docstring
+Is emitted when the coverage layer for an atlas changes
+%End
 
-    /** Is emitted when atlas rendering has begun*/
     void renderBegun();
+%Docstring
+Is emitted when atlas rendering has begun
+%End
 
-    /** Is emitted when atlas rendering has ended*/
     void renderEnded();
+%Docstring
+Is emitted when atlas rendering has ended
+%End
 
-    /** Is emitted when the current atlas feature changes*/
     void featureChanged( QgsFeature *feature );
+%Docstring
+Is emitted when the current atlas feature changes
+%End
 
-    /** Is emitted when the number of features for the atlas changes.
-     * @note added in QGIS 2.12
-     */
     void numberFeaturesChanged( int numFeatures );
+%Docstring
+ Is emitted when the number of features for the atlas changes.
+.. versionadded:: 2.12
+%End
+
+  public:
+    typedef QMap< QgsFeatureId, QVariant > SorterKeys;
+
 };
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/composer/qgsatlascomposition.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/app/composer/qgsatlascompositionwidget.cpp
+++ b/src/app/composer/qgsatlascompositionwidget.cpp
@@ -14,6 +14,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QComboBox>
+#include <QImageWriter>
 #include <QMessageBox>
 
 #include "qgsatlascompositionwidget.h"
@@ -46,6 +48,13 @@ QgsAtlasCompositionWidget::QgsAtlasCompositionWidget( QWidget *parent, QgsCompos
   connect( &mComposition->atlasComposition(), &QgsAtlasComposition::parameterChanged, this, &QgsAtlasCompositionWidget::updateGuiElements );
 
   mPageNameWidget->registerExpressionContextGenerator( mComposition );
+
+  QList<QByteArray> formats = QImageWriter::supportedImageFormats();
+  for ( int i = 0; i < formats.size(); ++i )
+  {
+    mAtlasFileFormat->addItem( QString( formats.at( i ) ) );
+  }
+  connect( mAtlasFileFormat, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [ = ]( int ) { changeFileFormat(); } );
 
   updateGuiElements();
 }
@@ -325,6 +334,11 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureDirectionButton_clicked()
   updateAtlasFeatures();
 }
 
+void QgsAtlasCompositionWidget::changeFileFormat()
+{
+  QgsAtlasComposition *atlasMap = &mComposition->atlasComposition();
+  atlasMap->setFileFormat( mAtlasFileFormat->currentText() );
+}
 void QgsAtlasCompositionWidget::updateGuiElements()
 {
   blockAllSignals( true );
@@ -358,6 +372,8 @@ void QgsAtlasCompositionWidget::updateGuiElements()
   mAtlasFeatureFilterCheckBox->setCheckState( atlasMap->filterFeatures() ? Qt::Checked : Qt::Unchecked );
   mAtlasFeatureFilterEdit->setEnabled( atlasMap->filterFeatures() );
   mAtlasFeatureFilterButton->setEnabled( atlasMap->filterFeatures() );
+
+  mAtlasFileFormat->setCurrentIndex( mAtlasFileFormat->findText( atlasMap->fileFormat() ) );
 
   blockAllSignals( false );
 }

--- a/src/app/composer/qgsatlascompositionwidget.h
+++ b/src/app/composer/qgsatlascompositionwidget.h
@@ -49,6 +49,8 @@ class QgsAtlasCompositionWidget:
     void on_mAtlasFeatureFilterCheckBox_stateChanged( int state );
     void pageNameExpressionChanged( const QString &expression, bool valid );
 
+    void changeFileFormat();
+
   private slots:
     void updateGuiElements();
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -77,7 +77,6 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QIcon>
-#include <QImageWriter>
 #include <QLabel>
 #include <QMatrix>
 #include <QMenuBar>
@@ -2136,33 +2135,7 @@ void QgsComposer::exportCompositionAsImage( QgsComposer::OutputMode mode )
     QFileDialog dlg( this, tr( "Export atlas to directory" ) );
     dlg.setFileMode( QFileDialog::Directory );
     dlg.setOption( QFileDialog::ShowDirsOnly, true );
-    dlg.setOption( QFileDialog::DontUseNativeDialog, true );
     dlg.setDirectory( lastUsedDir );
-
-    //
-    // Build an augmented FileDialog with a combo box to select the output format
-    QComboBox *box = new QComboBox();
-    QHBoxLayout *hlayout = new QHBoxLayout();
-    QWidget *widget = new QWidget();
-
-    QList<QByteArray> formats = QImageWriter::supportedImageFormats();
-    int selectedFormat = 0;
-    for ( int i = 0; i < formats.size(); ++i )
-    {
-      QString format = QString( formats.at( i ) );
-      if ( format == lastUsedFormat )
-      {
-        selectedFormat = i;
-      }
-      box->addItem( format );
-    }
-    box->setCurrentIndex( selectedFormat );
-
-    hlayout->setMargin( 0 );
-    hlayout->addWidget( new QLabel( tr( "Image format: " ) ) );
-    hlayout->addWidget( box );
-    widget->setLayout( hlayout );
-    dlg.layout()->addWidget( widget );
 
     if ( !dlg.exec() )
     {
@@ -2174,7 +2147,7 @@ void QgsComposer::exportCompositionAsImage( QgsComposer::OutputMode mode )
       return;
     }
     QString dir = s.at( 0 );
-    QString format = box->currentText();
+    QString format = atlasMap->fileFormat();
     QString fileExt = '.' + format;
 
     if ( dir.isEmpty() )

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -37,6 +37,7 @@ QgsAtlasComposition::QgsAtlasComposition( QgsComposition *composition )
   , mHideCoverage( false )
   , mFilenamePattern( QStringLiteral( "'output_'||@atlas_featurenumber" ) )
   , mSingleFile( false )
+  , mFileFormat( QStringLiteral( "png" ) )
   , mSortFeatures( false )
   , mSortAscending( true )
   , mCurrentFeatureNo( 0 )
@@ -612,6 +613,8 @@ void QgsAtlasComposition::writeXml( QDomElement &elem, QDomDocument &doc ) const
     atlasElem.setAttribute( QStringLiteral( "featureFilter" ), mFeatureFilter );
   }
 
+  atlasElem.setAttribute( QStringLiteral( "fileFormat" ), mFileFormat );
+
   elem.appendChild( atlasElem );
 }
 
@@ -664,6 +667,8 @@ void QgsAtlasComposition::readXml( const QDomElement &atlasElem, const QDomDocum
   }
 
   mHideCoverage = atlasElem.attribute( QStringLiteral( "hideCoverage" ), QStringLiteral( "false" ) ) == QLatin1String( "true" );
+
+  mFileFormat = atlasElem.attribute( QStringLiteral( "fileFormat" ), QStringLiteral( "png" ) );
 
   emit parameterChanged();
 }

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -148,6 +148,22 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
      */
     void setSingleFile( bool single ) { mSingleFile = single; }
 
+    /** Returns the  atlas file format used for image exports.
+     * \returns true if atlas will be exported to a single file
+     * \see setFileFormat
+     * \note This property is only used for image exports.
+     * \since QGIS 3.0
+     */
+    QString fileFormat() const { return mFileFormat; }
+
+    /** Sets the  atlas file format used for image exports.
+     * \param format set the file format extension
+     * \see fileFormat
+     * \note This property is only used for image exports.
+     * \since QGIS 3.0
+     */
+    void setFileFormat( QString format ) { mFileFormat = format; }
+
     bool sortFeatures() const { return mSortFeatures; }
     void setSortFeatures( bool doSort ) { mSortFeatures = doSort; }
 
@@ -306,6 +322,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     QString mFilenamePattern;
     QgsVectorLayerRef mCoverageLayer;
     bool mSingleFile;
+    QString mFileFormat;
 
     QString mCurrentFilename;
     // feature ordering

--- a/src/ui/composer/qgsatlascompositionwidgetbase.ui
+++ b/src/ui/composer/qgsatlascompositionwidgetbase.ui
@@ -289,6 +289,16 @@
                </property>
               </widget>
              </item>
+             <item row="3" column="1" colspan="2">
+              <widget class="QComboBox" name="mAtlasFileFormat"/>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="mFileFormatLabel">
+               <property name="text">
+                <string>Image export format</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>


### PR DESCRIPTION
Two big wins:
- remember file format across sessions (no more accidental .bmp atlas export!)
- use native directory picker

![screenshot from 2017-06-19 16-31-18](https://user-images.githubusercontent.com/1728657/27278858-d5476f88-550c-11e7-8b30-2f73abb4a2ed.png)

@nyalldawson , we discussed this a few weeks ago when I band-aided a crasher. Here comes the proper-thing-to-do :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
