### PR TITLE
[bugfix] Browsertree collapse network provider items

### DIFF
--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -143,7 +143,8 @@ class QgsDataItem : QObject
       NoCapabilities,
       SetCrs,  //!< Can set CRS on layer or group of layers
       Fertile, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
-      Fast     //!< createChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QSettings
+      Fast,    //!< createChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QSettings
+      Collapse //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
     };
     typedef QFlags<QgsDataItem::Capability> Capabilities;
 

--- a/python/gui/qgsbrowsertreeview.sip
+++ b/python/gui/qgsbrowsertreeview.sip
@@ -15,6 +15,10 @@ class QgsBrowserTreeView: QTreeView
     ~QgsBrowserTreeView();
 
     virtual void setModel( QAbstractItemModel* model );
+    //! Set the browser model
+    void setBrowserModel( QgsBrowserModel *model );
+    //! Return the browser model
+    QgsBrowserModel *browserModel( );
     virtual void showEvent( QShowEvent * e );
     virtual void hideEvent( QHideEvent * e );
 

--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -344,6 +344,7 @@ void QgsBrowserDockWidget::showEvent( QShowEvent * e )
     mProxyModel = new QgsBrowserTreeFilterProxyModel( this );
     mProxyModel->setBrowserModel( mModel );
     mBrowserView->setSettingsSection( objectName().toLower() ); // to distinguish 2 instances ow browser
+    mBrowserView->setBrowserModel( mModel );
     mBrowserView->setModel( mProxyModel );
     // provide a horizontal scroll bar instead of using ellipse (...) for longer items
     mBrowserView->setTextElideMode( Qt::ElideNone );

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -170,7 +170,8 @@ class CORE_EXPORT QgsDataItem : public QObject
       NoCapabilities = 0,
       SetCrs         = 1 << 0, //!< Can set CRS on layer or group of layers
       Fertile        = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
-      Fast           = 1 << 2  //!< createChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QSettings
+      Fast           = 1 << 2, //!< createChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QSettings
+      Collapse       = 1 << 3  //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
     };
     Q_DECLARE_FLAGS( Capabilities, Capability )
 

--- a/src/gui/qgsbrowsertreeview.h
+++ b/src/gui/qgsbrowsertreeview.h
@@ -18,7 +18,7 @@
 
 #include <QTreeView>
 
-//class QgsBrowserModel;
+class QgsBrowserModel;
 
 /** \ingroup gui
  * The QgsBrowserTreeView class extends QTreeView with save/restore tree state functionality.
@@ -34,6 +34,10 @@ class GUI_EXPORT QgsBrowserTreeView : public QTreeView
     ~QgsBrowserTreeView();
 
     virtual void setModel( QAbstractItemModel* model ) override;
+    //! Set the browser model
+    void setBrowserModel( QgsBrowserModel *model );
+    //! Return the browser model
+    QgsBrowserModel *browserModel( ) { return mBrowserModel; }
     virtual void showEvent( QShowEvent * e ) override;
     virtual void hideEvent( QHideEvent * e ) override;
 
@@ -63,6 +67,9 @@ class GUI_EXPORT QgsBrowserTreeView : public QTreeView
 
     // returns true if expanded from root to item
     bool treeExpanded( const QModelIndex & index );
+
+    // Stores the browser model
+    QgsBrowserModel *mBrowserModel;
 };
 
 #endif // QGSBROWSERTREEVIEW_H

--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -83,6 +83,7 @@ QgsAfsConnectionItem::QgsAfsConnectionItem( QgsDataItem* parent, const QString &
     , mUrl( url )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
 }
 
 QVector<QgsDataItem*> QgsAfsConnectionItem::createChildren()

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -80,6 +80,7 @@ QgsAmsConnectionItem::QgsAmsConnectionItem( QgsDataItem* parent, QString name, Q
     , mUrl( url )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
 }
 
 QVector<QgsDataItem*> QgsAmsConnectionItem::createChildren()

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -36,6 +36,7 @@ QgsDb2ConnectionItem::QgsDb2ConnectionItem( QgsDataItem *parent, const QString n
     : QgsDataCollectionItem( parent, name, path )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
   populate();
 }
 

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -41,7 +41,7 @@ QgsMssqlConnectionItem::QgsMssqlConnectionItem( QgsDataItem* parent, QString nam
     , mAllowGeometrylessTables( true )
     , mColumnTypeThread( nullptr )
 {
-  mCapabilities |= Fast;
+  mCapabilities |= Fast | Collapse;
   mIconName = "mIconConnect.png";
 }
 

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -33,6 +33,7 @@ QgsOracleConnectionItem::QgsOracleConnectionItem( QgsDataItem* parent, QString n
     , mColumnTypeThread( nullptr )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
 }
 
 QgsOracleConnectionItem::~QgsOracleConnectionItem()

--- a/src/providers/ows/qgsowsdataitems.cpp
+++ b/src/providers/ows/qgsowsdataitems.cpp
@@ -29,6 +29,7 @@ QgsOWSConnectionItem::QgsOWSConnectionItem( QgsDataItem* parent, QString name, Q
     : QgsDataCollectionItem( parent, name, path )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
 }
 
 QgsOWSConnectionItem::~QgsOWSConnectionItem()

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -38,6 +38,7 @@ QgsPGConnectionItem::QgsPGConnectionItem( QgsDataItem* parent, QString name, QSt
     : QgsDataCollectionItem( parent, name, path )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
 }
 
 QgsPGConnectionItem::~QgsPGConnectionItem()

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -75,6 +75,7 @@ QgsSLConnectionItem::QgsSLConnectionItem( QgsDataItem* parent, QString name, QSt
 {
   mDbPath = QgsSpatiaLiteConnection::connectionPath( name );
   mToolTip = mDbPath;
+  mCapabilities |= Collapse;
 }
 
 QgsSLConnectionItem::~QgsSLConnectionItem()

--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -30,6 +30,7 @@ QgsWCSConnectionItem::QgsWCSConnectionItem( QgsDataItem* parent, QString name, Q
     , mUri( uri )
 {
   mIconName = "mIconWcs.svg";
+  mCapabilities |= Collapse;
 }
 
 QgsWCSConnectionItem::~QgsWCSConnectionItem()
@@ -44,23 +45,23 @@ QVector<QgsDataItem*> QgsWCSConnectionItem::createChildren()
   uri.setEncodedUri( mUri );
   QgsDebugMsg( "mUri = " + mUri );
 
-  mCapabilities.setUri( uri );
+  mWcsCapabilities.setUri( uri );
 
   // Attention: supportedLayers() gives tree leafes, not top level
-  if ( !mCapabilities.lastError().isEmpty() )
+  if ( !mWcsCapabilities.lastError().isEmpty() )
   {
     //children.append( new QgsErrorItem( this, tr( "Failed to retrieve layers" ), mPath + "/error" ) );
     // TODO: show the error without adding child
     return children;
   }
 
-  Q_FOREACH ( const QgsWcsCoverageSummary& coverageSummary, mCapabilities.capabilities().contents.coverageSummary )
+  Q_FOREACH ( const QgsWcsCoverageSummary& coverageSummary, mWcsCapabilities.capabilities().contents.coverageSummary )
   {
     // Attention, the name may be empty
     QgsDebugMsg( QString::number( coverageSummary.orderId ) + ' ' + coverageSummary.identifier + ' ' + coverageSummary.title );
     QString pathName = coverageSummary.identifier.isEmpty() ? QString::number( coverageSummary.orderId ) : coverageSummary.identifier;
 
-    QgsWCSLayerItem * layer = new QgsWCSLayerItem( this, coverageSummary.title, mPath + '/' + pathName, mCapabilities.capabilities(), uri, coverageSummary );
+    QgsWCSLayerItem * layer = new QgsWCSLayerItem( this, coverageSummary.title, mPath + '/' + pathName, mWcsCapabilities.capabilities(), uri, coverageSummary );
 
     children.append( layer );
   }

--- a/src/providers/wcs/qgswcsdataitems.h
+++ b/src/providers/wcs/qgswcsdataitems.h
@@ -31,7 +31,7 @@ class QgsWCSConnectionItem : public QgsDataCollectionItem
 
     virtual QList<QAction*> actions() override;
 
-    QgsWcsCapabilities mCapabilities;
+    QgsWcsCapabilities mWcsCapabilities;
     QVector<QgsWcsCoverageSummary> mLayerProperties;
 
   public slots:

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -46,9 +46,10 @@ QgsWFSLayerItem::~QgsWFSLayerItem()
 QgsWFSConnectionItem::QgsWFSConnectionItem( QgsDataItem* parent, QString name, QString path, QString uri )
     : QgsDataCollectionItem( parent, name, path )
     , mUri( uri )
-    , mCapabilities( nullptr )
+    , mWfsCapabilities( nullptr )
 {
   mIconName = "mIconWfs.svg";
+  mCapabilities |= Collapse;
 }
 
 QgsWFSConnectionItem::~QgsWFSConnectionItem()

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -58,7 +58,7 @@ class QgsWFSConnectionItem : public QgsDataCollectionItem
   private:
     QString mUri;
 
-    QgsWFSCapabilities* mCapabilities;
+    QgsWFSCapabilities* mWfsCapabilities;
 };
 
 

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -35,6 +35,7 @@ QgsWMSConnectionItem::QgsWMSConnectionItem( QgsDataItem* parent, QString name, Q
     , mCapabilitiesDownload( nullptr )
 {
   mIconName = "mIconConnect.png";
+  mCapabilities |= Collapse;
   mCapabilitiesDownload = new QgsWmsCapabilitiesDownload( false );
 }
 


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/4742

Prevent expansion of WMS connection layers when restoring the browser.

This was causing unwanted connections to WMS and other providers when QGIS starts.