### PR TITLE
Convert processing tests to use native algs where they exist

### DIFF
--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -56,6 +56,7 @@ from processing.script.ScriptAlgorithmProvider import ScriptAlgorithmProvider  #
 
 from qgis.core import (QgsVectorLayer,
                        QgsRasterLayer,
+                       QgsFeatureRequest,
                        QgsMapLayer,
                        QgsProject,
                        QgsApplication,
@@ -123,6 +124,10 @@ class AlgorithmsTest(object):
         # ignore user setting for invalid geometry handling
         context = QgsProcessingContext()
         context.setProject(QgsProject.instance())
+
+        if 'skipInvalid' in defs and defs['skipInvalid']:
+            context.setInvalidGeometryCheck(QgsFeatureRequest.GeometrySkipInvalid)
+
         feedback = QgsProcessingFeedback()
 
         if expectFailure:

--- a/python/plugins/processing/tests/testdata/expected/nullGeometryDissolve_output.gfs
+++ b/python/plugins/processing/tests/testdata/expected/nullGeometryDissolve_output.gfs
@@ -2,7 +2,8 @@
   <GMLFeatureClass>
     <Name>nullGeometryDissolve_output</Name>
     <ElementPath>nullGeometryDissolve_output</ElementPath>
-    <GeometryType>3</GeometryType>
+    <!--MULTIPOLYGON-->
+    <GeometryType>6</GeometryType>
     <SRSName>EPSG:3003</SRSName>
     <DatasetSpecificInfo>
       <FeatureCount>1</FeatureCount>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -289,53 +289,48 @@ tests:
         name: expected/dissolve_two_fields.gml
         type: vector
 
-#  - name: Dissolve with geometries reported as valid but as invalid with isGeosValid
-#    algorithm: qgis:dissolve
-#    params:
-#      DISSOLVE_ALL: 'True'
-#      FIELD: None
-#      INPUT:
-#        name: custom/innerRingTouchesOuterRing.gml
-#        type: vector
-#    results:
-#      OUTPUT:
-#        type: vector
-#        name: expected/innerRingTouchesOuterRing_output.gml
-#        compare:
-#          geometry:
-#            precision: 0
-#
-#  - name: Dissolve with NULL geometries
-#    algorithm: qgis:dissolve
-#    params:
-#      DISSOLVE_ALL: 'True'
-#      FIELD: None
-#      INPUT:
-#        name: custom/nullGeometryDissolve.gml
-#        type: vector
-#    results:
-#      OUTPUT:
-#        type: vector
-#        name: expected/nullGeometryDissolve_output.gml
-#        compare:
-#          geometry:
-#            precision: 7
-#
-#  - name: Dissolve with invalid geometries
-#    algorithm: qgis:dissolve
-#    params:
-#      DISSOLVE_ALL: 'True'
-#      FIELD: None
-#      INPUT:
-#        name: custom/PolygonDissolveTest.gml
-#        type: vector
-#    results:
-#      OUTPUT:
-#        type: vector
-#        name: expected/PolygonDissolveTest_output.gml
-#        compare:
-#          geometry:
-#            precision: 7
+  - name: Dissolve with geometries reported as valid but as invalid with isGeosValid
+    algorithm: native:dissolve
+    params:
+      INPUT:
+        name: custom/innerRingTouchesOuterRing.gml
+        type: vector
+    results:
+      OUTPUT:
+        type: vector
+        name: expected/innerRingTouchesOuterRing_output.gml
+        compare:
+          geometry:
+            precision: 0
+
+  - name: Dissolve with NULL geometries
+    algorithm: native:dissolve
+    params:
+      INPUT:
+        name: custom/nullGeometryDissolve.gml
+        type: vector
+    results:
+      OUTPUT:
+        type: vector
+        name: expected/nullGeometryDissolve_output.gml
+        compare:
+          geometry:
+            precision: 7
+
+  - name: Dissolve with invalid geometries
+    algorithm: native:dissolve
+    skipInvalid: true
+    params:
+      INPUT:
+        name: custom/PolygonDissolveTest.gml
+        type: vector
+    results:
+      OUTPUT:
+        type: vector
+        name: expected/PolygonDissolveTest_output.gml
+        compare:
+          geometry:
+            precision: 7
 
   - algorithm: qgis:fixeddistancebuffer
     name: Basic polygon buffer


### PR DESCRIPTION
And fix a few identified issues in the native dissolve algorithm (consistently output multi geometries, handle null geometries correctly)