### PR TITLE
[layouts] Add layout measurement and size classes

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -63,6 +63,7 @@ IF(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/core/geometry
       ${CMAKE_SOURCE_DIR}/src/core/gps
       ${CMAKE_SOURCE_DIR}/src/core/layertree
+      ${CMAKE_SOURCE_DIR}/src/core/layout
       ${CMAKE_SOURCE_DIR}/src/core/metadata
       ${CMAKE_SOURCE_DIR}/src/core/pal
       ${CMAKE_SOURCE_DIR}/src/core/processing

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -106,6 +106,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/gps
   ${CMAKE_SOURCE_DIR}/src/core/layertree
+  ${CMAKE_SOURCE_DIR}/src/core/layout
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/processing
   ${CMAKE_SOURCE_DIR}/src/core/providers

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -369,6 +369,11 @@ done:
 %Include layertree/qgslayertreeregistrybridge.sip
 %Include layertree/qgslayertreeutils.sip
 
+%Include layout/qgslayoutmeasurement.sip
+%Include layout/qgslayoutmeasurementconverter.sip
+%Include layout/qgslayoutpoint.sip
+%Include layout/qgslayoutsize.sip
+
 %Include metadata/qgslayermetadata.sip
 %Include metadata/qgslayermetadatavalidator.sip
 

--- a/python/core/layout/qgslayoutmeasurement.sip
+++ b/python/core/layout/qgslayoutmeasurement.sip
@@ -1,0 +1,123 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutmeasurement.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsLayoutMeasurement
+{
+%Docstring
+ This class provides a method of storing measurements for use in QGIS layouts
+ using a variety of different measurement units.
+.. seealso:: QgsLayoutMeasurementConverter
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgslayoutmeasurement.h"
+%End
+  public:
+
+    explicit QgsLayoutMeasurement( const double length, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+%Docstring
+ Constructor for QgsLayoutMeasurement.
+ \param length measurement length
+ \param units measurement units
+%End
+
+    ~QgsLayoutMeasurement();
+
+    double length() const;
+%Docstring
+ Returns the length of the measurement.
+.. seealso:: setLength()
+ :rtype: float
+%End
+
+    void setLength( const double length );
+%Docstring
+ Sets the ``length`` of the measurement.
+.. seealso:: length()
+%End
+
+    QgsUnitTypes::LayoutUnit units() const;
+%Docstring
+ Returns the units for the measurement.
+.. seealso:: setUnits()
+ :rtype: QgsUnitTypes.LayoutUnit
+%End
+
+    void setUnits( const QgsUnitTypes::LayoutUnit units );
+%Docstring
+ Sets the ``units`` for the measurement. Does not alter the stored length,
+ ie. no length conversion is done.
+.. seealso:: units()
+%End
+
+    QString encodeMeasurement() const;
+%Docstring
+ Encodes the layout measurement to a string
+.. seealso:: decodeMeasurement()
+ :rtype: str
+%End
+
+    static QgsLayoutMeasurement decodeMeasurement( const QString &string );
+%Docstring
+ Decodes a measurement from a ``string``.
+.. seealso:: encodeMeasurement()
+ :rtype: QgsLayoutMeasurement
+%End
+
+    bool operator==( const QgsLayoutMeasurement &other ) const;
+    bool operator!=( const QgsLayoutMeasurement &other ) const;
+%Docstring
+ :rtype: bool
+%End
+    QgsLayoutMeasurement operator+( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+    QgsLayoutMeasurement operator+=( const double v );
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+    QgsLayoutMeasurement operator-( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+    QgsLayoutMeasurement operator-=( const double v );
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+    QgsLayoutMeasurement operator*( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+    QgsLayoutMeasurement operator*=( const double v );
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+    QgsLayoutMeasurement operator/( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+    QgsLayoutMeasurement operator/=( const double v );
+%Docstring
+ :rtype: QgsLayoutMeasurement
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutmeasurement.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/layout/qgslayoutmeasurement.sip
+++ b/python/core/layout/qgslayoutmeasurement.sip
@@ -31,8 +31,6 @@ class QgsLayoutMeasurement
  \param units measurement units
 %End
 
-    ~QgsLayoutMeasurement();
-
     double length() const;
 %Docstring
  Returns the length of the measurement.
@@ -79,36 +77,52 @@ class QgsLayoutMeasurement
 %Docstring
  :rtype: bool
 %End
+
     QgsLayoutMeasurement operator+( const double v ) const;
 %Docstring
+ Adds a scalar value to the measurement.
  :rtype: QgsLayoutMeasurement
 %End
+
     QgsLayoutMeasurement operator+=( const double v );
 %Docstring
+ Adds a scalar value to the measurement.
  :rtype: QgsLayoutMeasurement
 %End
+
     QgsLayoutMeasurement operator-( const double v ) const;
 %Docstring
+ Subtracts a scalar value from the measurement.
  :rtype: QgsLayoutMeasurement
 %End
+
     QgsLayoutMeasurement operator-=( const double v );
 %Docstring
+ Subtracts a scalar value from the measurement.
  :rtype: QgsLayoutMeasurement
 %End
+
     QgsLayoutMeasurement operator*( const double v ) const;
 %Docstring
+ Multiplies the measurement by a scalar value.
  :rtype: QgsLayoutMeasurement
 %End
+
     QgsLayoutMeasurement operator*=( const double v );
 %Docstring
+ Multiplies the measurement by a scalar value.
  :rtype: QgsLayoutMeasurement
 %End
+
     QgsLayoutMeasurement operator/( const double v ) const;
 %Docstring
+ Divides the measurement by a scalar value.
  :rtype: QgsLayoutMeasurement
 %End
+
     QgsLayoutMeasurement operator/=( const double v );
 %Docstring
+ Divides the measurement by a scalar value.
  :rtype: QgsLayoutMeasurement
 %End
 

--- a/python/core/layout/qgslayoutmeasurementconverter.sip
+++ b/python/core/layout/qgslayoutmeasurementconverter.sip
@@ -27,6 +27,9 @@ class QgsLayoutMeasurementConverter
   public:
 
     QgsLayoutMeasurementConverter();
+%Docstring
+ Constructor for QgsLayoutMeasurementConverter.
+%End
 
     void setDpi( const double dpi );
 %Docstring

--- a/python/core/layout/qgslayoutmeasurementconverter.sip
+++ b/python/core/layout/qgslayoutmeasurementconverter.sip
@@ -1,0 +1,83 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutmeasurementconverter.h                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsLayoutMeasurementConverter
+{
+%Docstring
+ This class provides a method of converting QgsLayoutMeasurements from
+ one unit to another. Conversion to or from pixel units utilizes a specified
+ dots per inch (DPI) property for the converter. Converters default to using
+ 300 DPI.
+.. seealso:: QgsLayoutMeasurement
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgslayoutmeasurementconverter.h"
+%End
+  public:
+
+    QgsLayoutMeasurementConverter();
+
+    ~QgsLayoutMeasurementConverter();
+
+    void setDpi( const double dpi );
+%Docstring
+ Sets the dots per inch (``dpi``) for the measurement converter. This is used
+ when converting measurements to and from pixels.
+.. seealso:: dpi()
+%End
+
+    double dpi() const;
+%Docstring
+ Returns the Dots per inch (DPI) of the measurement converter. This is used
+ when converting measurements to and from pixels.
+.. seealso:: setDpi()
+ :rtype: float
+%End
+
+    QgsLayoutMeasurement convert( const QgsLayoutMeasurement &measurement, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+%Docstring
+ Converts a measurement from one unit to another.
+ \param measurement measurement to convert
+ \param targetUnits units to convert measurement into
+ :return: measurement converted to target units
+ :rtype: QgsLayoutMeasurement
+%End
+
+    QgsLayoutSize convert( const QgsLayoutSize &size, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+%Docstring
+ Converts a layout size from one unit to another.
+ \param size layout size to convert
+ \param targetUnits units to convert size into
+ :return: size converted to target units
+ :rtype: QgsLayoutSize
+%End
+
+    QgsLayoutPoint convert( const QgsLayoutPoint &point, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+%Docstring
+ Converts a layout point from one unit to another.
+ \param point layout point to convert
+ \param targetUnits units to convert point into
+ :return: point converted to target units
+ :rtype: QgsLayoutPoint
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutmeasurementconverter.h                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/layout/qgslayoutmeasurementconverter.sip
+++ b/python/core/layout/qgslayoutmeasurementconverter.sip
@@ -28,8 +28,6 @@ class QgsLayoutMeasurementConverter
 
     QgsLayoutMeasurementConverter();
 
-    ~QgsLayoutMeasurementConverter();
-
     void setDpi( const double dpi );
 %Docstring
  Sets the dots per inch (``dpi``) for the measurement converter. This is used

--- a/python/core/layout/qgslayoutpoint.sip
+++ b/python/core/layout/qgslayoutpoint.sip
@@ -1,0 +1,162 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutpoint.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsLayoutPoint
+{
+%Docstring
+ This class provides a method of storing points, consisting of an x and y coordinate,
+ for use in QGIS layouts. Measurement units are stored alongside the position.
+
+.. seealso:: QgsLayoutMeasurementConverter
+.. versionadded:: 3.0
+.. note::
+
+   This class does not inherit from QPointF since QPointF includes methods which should not apply
+ to positions with with units. For instance, the + and - operators would mislead users of this class
+ to believe that addition of two QgsLayoutPoints with different unit types would automatically convert
+ units. Instead, all unit conversion must be handled by a QgsLayoutMeasurementConverter so that
+ conversion between paper and screen units can be correctly performed.
+%End
+
+%TypeHeaderCode
+#include "qgslayoutpoint.h"
+%End
+  public:
+
+    QgsLayoutPoint( const double x, const double y, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+%Docstring
+ Constructor for QgsLayoutPoint.
+ \param x x coordinate
+ \param x y coordinate
+ \param units units for x and y
+%End
+
+    explicit QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+%Docstring
+ Constructor for an empty point, where both x and y are set to 0.
+ \param units units for measurement
+%End
+
+    ~QgsLayoutPoint();
+
+    void setPoint( const double x, const double y );
+%Docstring
+ Sets new x and y coordinates for the point.
+.. seealso:: setX()
+.. seealso:: setY()
+.. seealso:: setUnits()
+%End
+
+    double x() const;
+%Docstring
+ Returns x coordinate of point.
+.. seealso:: setX()
+.. seealso:: y()
+ :rtype: float
+%End
+
+    void setX( const double x );
+%Docstring
+ Sets the x coordinate of point.
+.. seealso:: x()
+.. seealso:: setY()
+%End
+
+    double y() const;
+%Docstring
+ Returns y coordinate of point.
+.. seealso:: setY()
+.. seealso:: x()
+ :rtype: float
+%End
+
+    void setY( const double y );
+%Docstring
+ Sets y coordinate of point.
+.. seealso:: y()
+.. seealso:: setX()
+%End
+
+    QgsUnitTypes::LayoutUnit units() const;
+%Docstring
+ Returns the units for the point.
+.. seealso:: setUnits()
+ :rtype: QgsUnitTypes.LayoutUnit
+%End
+
+    void setUnits( const QgsUnitTypes::LayoutUnit units );
+%Docstring
+ Sets the ``units`` for the point. Does not alter the stored coordinates,
+ ie. no conversion is done.
+.. seealso:: units()
+%End
+
+    bool isNull() const;
+%Docstring
+ Tests whether the position is null, ie both its x and y coordinates
+ are zero.
+ :return: true if point is null
+ :rtype: bool
+%End
+
+    QPointF toQPointF() const;
+%Docstring
+ Converts the layout point to a QPointF. The unit information is discarded
+ during this operation.
+ :return: QPointF with same x and y coordinates as layout point
+ :rtype: QPointF
+%End
+
+    QString encodePoint() const;
+%Docstring
+ Encodes the layout point to a string
+.. seealso:: decodePoint()
+ :rtype: str
+%End
+
+    static QgsLayoutPoint decodePoint( const QString &string );
+%Docstring
+ Decodes a point from a ``string``.
+.. seealso:: encodePoint()
+ :rtype: QgsLayoutPoint
+%End
+
+    bool operator==( const QgsLayoutPoint &other ) const;
+    bool operator!=( const QgsLayoutPoint &other ) const;
+%Docstring
+ :rtype: bool
+%End
+    QgsLayoutPoint operator*( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutPoint
+%End
+    QgsLayoutPoint operator*=( const double v );
+%Docstring
+ :rtype: QgsLayoutPoint
+%End
+    QgsLayoutPoint operator/( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutPoint
+%End
+    QgsLayoutPoint operator/=( const double v );
+%Docstring
+ :rtype: QgsLayoutPoint
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutpoint.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/layout/qgslayoutpoint.sip
+++ b/python/core/layout/qgslayoutpoint.sip
@@ -34,9 +34,6 @@ class QgsLayoutPoint
     QgsLayoutPoint( const double x, const double y, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
  Constructor for QgsLayoutPoint.
- \param x x coordinate
- \param x y coordinate
- \param units units for x and y
 %End
 
     explicit QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
@@ -44,8 +41,6 @@ class QgsLayoutPoint
  Constructor for an empty point, where both x and y are set to 0.
  \param units units for measurement
 %End
-
-    ~QgsLayoutPoint();
 
     void setPoint( const double x, const double y );
 %Docstring
@@ -134,20 +129,28 @@ class QgsLayoutPoint
 %Docstring
  :rtype: bool
 %End
+
     QgsLayoutPoint operator*( const double v ) const;
 %Docstring
+ Multiplies the x and y by a scalar value.
  :rtype: QgsLayoutPoint
 %End
+
     QgsLayoutPoint operator*=( const double v );
 %Docstring
+ Multiplies the x and y by a scalar value.
  :rtype: QgsLayoutPoint
 %End
+
     QgsLayoutPoint operator/( const double v ) const;
 %Docstring
+ Divides the x and y by a scalar value.
  :rtype: QgsLayoutPoint
 %End
+
     QgsLayoutPoint operator/=( const double v );
 %Docstring
+ Divides the x and y by a scalar value.
  :rtype: QgsLayoutPoint
 %End
 

--- a/python/core/layout/qgslayoutsize.sip
+++ b/python/core/layout/qgslayoutsize.sip
@@ -46,8 +46,6 @@ class QgsLayoutSize
  \param units units for measurement
 %End
 
-    ~QgsLayoutSize();
-
     void setSize( const double width, const double height );
 %Docstring
  Sets new ``width`` and ``height`` for the size.
@@ -135,20 +133,28 @@ class QgsLayoutSize
 %Docstring
  :rtype: bool
 %End
+
     QgsLayoutSize operator*( const double v ) const;
 %Docstring
+ Multiplies the width and height by a scalar value.
  :rtype: QgsLayoutSize
 %End
+
     QgsLayoutSize operator*=( const double v );
 %Docstring
+ Multiplies the width and height by a scalar value.
  :rtype: QgsLayoutSize
 %End
+
     QgsLayoutSize operator/( const double v ) const;
 %Docstring
+ Divides the width and height by a scalar value.
  :rtype: QgsLayoutSize
 %End
+
     QgsLayoutSize operator/=( const double v );
 %Docstring
+ Divides the width and height by a scalar value.
  :rtype: QgsLayoutSize
 %End
 

--- a/python/core/layout/qgslayoutsize.sip
+++ b/python/core/layout/qgslayoutsize.sip
@@ -1,0 +1,163 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutsize.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsLayoutSize
+{
+%Docstring
+ This class provides a method of storing sizes, consisting of a width and height,
+ for use in QGIS layouts. Measurement units are stored alongside the size.
+
+.. seealso:: QgsLayoutMeasurementConverter
+.. versionadded:: 3.0
+.. note::
+
+   This class does not inherit from QSizeF since QSizeF includes methods which should not apply to sizes
+ with units. For instance, the + and - operators would mislead users of this class to believe that
+ addition of two QgsLayoutSize with different unit types would automatically convert units. Instead,
+ all unit conversion must be handled by a QgsLayoutMeasurementConverter so that conversion between
+ paper and screen units can be correctly performed.
+%End
+
+%TypeHeaderCode
+#include "qgslayoutsize.h"
+%End
+  public:
+
+    QgsLayoutSize( const double width, const double height, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+%Docstring
+ Constructor for QgsLayoutSize.
+ \param width width
+ \param height height
+ \param units units for width and height
+%End
+
+    explicit QgsLayoutSize( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+%Docstring
+ Constructor for an empty layout size
+ \param units units for measurement
+%End
+
+    ~QgsLayoutSize();
+
+    void setSize( const double width, const double height );
+%Docstring
+ Sets new ``width`` and ``height`` for the size.
+.. seealso:: setWidth()
+.. seealso:: setHeight()
+.. seealso:: setUnits()
+%End
+
+    double width() const;
+%Docstring
+ Returns the width of the size.
+.. seealso:: setWidth()
+.. seealso:: height()
+ :rtype: float
+%End
+
+    void setWidth( const double width );
+%Docstring
+ Sets the ``width`` for the size.
+.. seealso:: width()
+.. seealso:: setHeight()
+%End
+
+    double height() const;
+%Docstring
+ Returns the height of the size.
+.. seealso:: setHeight()
+.. seealso:: width()
+ :rtype: float
+%End
+
+    void setHeight( const double height );
+%Docstring
+ Sets the ``height`` for the size.
+.. seealso:: height()
+.. seealso:: setWidth()
+%End
+
+    QgsUnitTypes::LayoutUnit units() const;
+%Docstring
+ Returns the units for the size.
+.. seealso:: setUnits()
+ :rtype: QgsUnitTypes.LayoutUnit
+%End
+
+    void setUnits( const QgsUnitTypes::LayoutUnit units );
+%Docstring
+ Sets the ``units`` for the size. Does not alter the stored width or height,
+ ie. no conversion is done.
+.. seealso:: units()
+%End
+
+    bool isEmpty() const;
+%Docstring
+ Tests whether the size is empty, ie both its width and height
+ are zero.
+ :return: true if size is empty
+ :rtype: bool
+%End
+
+    QSizeF toQSizeF() const;
+%Docstring
+ Converts the layout size to a QSizeF. The unit information is discarded
+ during this operation.
+ :return: QSizeF with same dimensions as layout size
+ :rtype: QSizeF
+%End
+
+    QString encodeSize() const;
+%Docstring
+ Encodes the layout size to a string
+.. seealso:: decodeSize()
+ :rtype: str
+%End
+
+    static QgsLayoutSize decodeSize( const QString &string );
+%Docstring
+ Decodes a size from a ``string``.
+.. seealso:: encodeSize()
+ :rtype: QgsLayoutSize
+%End
+
+    bool operator==( const QgsLayoutSize &other ) const;
+    bool operator!=( const QgsLayoutSize &other ) const;
+%Docstring
+ :rtype: bool
+%End
+    QgsLayoutSize operator*( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutSize
+%End
+    QgsLayoutSize operator*=( const double v );
+%Docstring
+ :rtype: QgsLayoutSize
+%End
+    QgsLayoutSize operator/( const double v ) const;
+%Docstring
+ :rtype: QgsLayoutSize
+%End
+    QgsLayoutSize operator/=( const double v );
+%Docstring
+ :rtype: QgsLayoutSize
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgslayoutsize.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/qgsunittypes.sip
+++ b/python/core/qgsunittypes.sip
@@ -81,6 +81,24 @@ class QgsUnitTypes
       RenderUnknownUnit,
     };
 
+    enum LayoutUnit
+    {
+      LayoutMillimeters,
+      LayoutCentimeters,
+      LayoutMeters,
+      LayoutInches,
+      LayoutFeet,
+      LayoutPoints,
+      LayoutPicas,
+      LayoutPixels
+    };
+
+    enum LayoutUnitType
+    {
+      LayoutPaperUnits,
+      LayoutScreenUnits
+    };
+
     struct DistanceValue
     {
 
@@ -368,6 +386,34 @@ class QgsUnitTypes
 .. versionadded:: 3.0
  :rtype: str
 %End
+
+
+
+    static QString encodeUnit( LayoutUnit unit );
+%Docstring
+ Encodes a layout unit to a string.
+ \param unit unit to encode
+ :return: encoded string
+.. seealso:: decodeLayoutUnit()
+ :rtype: str
+%End
+
+    static LayoutUnit decodeLayoutUnit( const QString &string, bool *ok /Out/ = 0 );
+%Docstring
+ Decodes a layout unit from a string.
+ \param string string to decode
+ \param ok optional boolean, will be set to true if string was converted successfully
+ :return: decoded units
+.. seealso:: encodeUnit()
+ :rtype: LayoutUnit
+%End
+
+    static LayoutUnitType unitType( const LayoutUnit units );
+%Docstring
+ Returns the type for a unit of measurement.
+ :rtype: LayoutUnitType
+%End
+
 };
 
 /************************************************************************

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -343,6 +343,11 @@ SET(QGIS_CORE_SRCS
   dxf/qgsdxfpaintengine.cpp
   dxf/qgsdxfpallabeling.cpp
 
+  layout/qgslayoutmeasurement.cpp
+  layout/qgslayoutmeasurementconverter.cpp
+  layout/qgslayoutpoint.cpp
+  layout/qgslayoutsize.cpp
+
   pal/costcalculator.cpp
   pal/feature.cpp
   pal/geomfunction.cpp
@@ -892,6 +897,11 @@ SET(QGIS_CORE_HDRS
   composer/qgscomposertexttable.h
   composer/qgspaperitem.h
 
+  layout/qgslayoutmeasurement.h
+  layout/qgslayoutmeasurementconverter.h
+  layout/qgslayoutpoint.h
+  layout/qgslayoutsize.h
+
   metadata/qgslayermetadata.h
   metadata/qgslayermetadatavalidator.h
 
@@ -1042,6 +1052,7 @@ INCLUDE_DIRECTORIES(
   fieldformatter
   geometry
   layertree
+  layout
   metadata
   pal
   processing

--- a/src/core/layout/qgslayoutmeasurement.cpp
+++ b/src/core/layout/qgslayoutmeasurement.cpp
@@ -1,0 +1,99 @@
+/***************************************************************************
+                         qgslayoutmeasurement.cpp
+                         --------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayoutmeasurement.h"
+
+#include <QStringList>
+
+QgsLayoutMeasurement::QgsLayoutMeasurement( const double length, const QgsUnitTypes::LayoutUnit units )
+  : mLength( length )
+  , mUnits( units )
+{
+}
+
+QgsLayoutMeasurement::~QgsLayoutMeasurement()
+{
+}
+
+QString QgsLayoutMeasurement::encodeMeasurement() const
+{
+  return QStringLiteral( "%1,%2" ).arg( mLength ).arg( QgsUnitTypes::encodeUnit( mUnits ) );
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::decodeMeasurement( const QString &string )
+{
+  QStringList parts = string.split( ',' );
+  if ( parts.count() != 2 )
+  {
+    return QgsLayoutMeasurement( 0 );
+  }
+  return QgsLayoutMeasurement( parts[0].toDouble(), QgsUnitTypes::decodeLayoutUnit( parts[1] ) );
+}
+
+bool QgsLayoutMeasurement::operator==( const QgsLayoutMeasurement &other ) const
+{
+  return other.units() == mUnits && other.length() == mLength;
+}
+
+bool QgsLayoutMeasurement::operator!=( const QgsLayoutMeasurement &other ) const
+{
+  return ( ! operator==( other ) );
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator+( const double v ) const
+{
+  return QgsLayoutMeasurement( mLength + v, mUnits );
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator+=( const double v )
+{
+  *this = *this + v;
+  return *this;
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator-( const double v ) const
+{
+  return QgsLayoutMeasurement( mLength - v, mUnits );
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator-=( const double v )
+{
+  *this = *this - v;
+  return *this;
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator*( const double v ) const
+{
+  return QgsLayoutMeasurement( mLength * v, mUnits );
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator*=( const double v )
+{
+  *this = *this * v;
+  return *this;
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator/( const double v ) const
+{
+  return QgsLayoutMeasurement( mLength / v, mUnits );
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurement::operator/=( const double v )
+{
+  *this = *this / v;
+  return *this;
+}

--- a/src/core/layout/qgslayoutmeasurement.cpp
+++ b/src/core/layout/qgslayoutmeasurement.cpp
@@ -25,10 +25,6 @@ QgsLayoutMeasurement::QgsLayoutMeasurement( const double length, const QgsUnitTy
 {
 }
 
-QgsLayoutMeasurement::~QgsLayoutMeasurement()
-{
-}
-
 QString QgsLayoutMeasurement::encodeMeasurement() const
 {
   return QStringLiteral( "%1,%2" ).arg( mLength ).arg( QgsUnitTypes::encodeUnit( mUnits ) );

--- a/src/core/layout/qgslayoutmeasurement.h
+++ b/src/core/layout/qgslayoutmeasurement.h
@@ -22,7 +22,8 @@
 
 #include "qgsunittypes.h"
 
-/** \ingroup Layout
+/**
+ * \ingroup core
  * \class QgsLayoutMeasurement
  * \brief This class provides a method of storing measurements for use in QGIS layouts
  * using a variety of different measurement units.
@@ -39,8 +40,6 @@ class CORE_EXPORT QgsLayoutMeasurement
      * \param units measurement units
     */
     explicit QgsLayoutMeasurement( const double length, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
-
-    ~QgsLayoutMeasurement();
 
     /**
      * Returns the length of the measurement.
@@ -81,13 +80,45 @@ class CORE_EXPORT QgsLayoutMeasurement
 
     bool operator==( const QgsLayoutMeasurement &other ) const;
     bool operator!=( const QgsLayoutMeasurement &other ) const;
+
+    /**
+     * Adds a scalar value to the measurement.
+     */
     QgsLayoutMeasurement operator+( const double v ) const;
+
+    /**
+     * Adds a scalar value to the measurement.
+     */
     QgsLayoutMeasurement operator+=( const double v );
+
+    /**
+     * Subtracts a scalar value from the measurement.
+     */
     QgsLayoutMeasurement operator-( const double v ) const;
+
+    /**
+     * Subtracts a scalar value from the measurement.
+     */
     QgsLayoutMeasurement operator-=( const double v );
+
+    /**
+     * Multiplies the measurement by a scalar value.
+     */
     QgsLayoutMeasurement operator*( const double v ) const;
+
+    /**
+     * Multiplies the measurement by a scalar value.
+     */
     QgsLayoutMeasurement operator*=( const double v );
+
+    /**
+     * Divides the measurement by a scalar value.
+     */
     QgsLayoutMeasurement operator/( const double v ) const;
+
+    /**
+     * Divides the measurement by a scalar value.
+     */
     QgsLayoutMeasurement operator/=( const double v );
 
   private:

--- a/src/core/layout/qgslayoutmeasurement.h
+++ b/src/core/layout/qgslayoutmeasurement.h
@@ -1,0 +1,100 @@
+/***************************************************************************
+                         qgslayoutmeasurement.h
+                         --------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYOUTMEASUREMENT_H
+#define QGSLAYOUTMEASUREMENT_H
+
+#include "qgis_core.h"
+
+#include "qgsunittypes.h"
+
+/** \ingroup Layout
+ * \class QgsLayoutMeasurement
+ * \brief This class provides a method of storing measurements for use in QGIS layouts
+ * using a variety of different measurement units.
+ * \see QgsLayoutMeasurementConverter
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsLayoutMeasurement
+{
+  public:
+
+    /**
+     * Constructor for QgsLayoutMeasurement.
+     * \param length measurement length
+     * \param units measurement units
+    */
+    explicit QgsLayoutMeasurement( const double length, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+
+    ~QgsLayoutMeasurement();
+
+    /**
+     * Returns the length of the measurement.
+     * \see setLength()
+    */
+    double length() const { return mLength; }
+
+    /**
+     * Sets the \a length of the measurement.
+     * \see length()
+    */
+    void setLength( const double length ) { mLength = length; }
+
+    /**
+     * Returns the units for the measurement.
+     * \see setUnits()
+    */
+    QgsUnitTypes::LayoutUnit units() const { return mUnits; }
+
+    /**
+     * Sets the \a units for the measurement. Does not alter the stored length,
+     * ie. no length conversion is done.
+     * \see units()
+    */
+    void setUnits( const QgsUnitTypes::LayoutUnit units ) { mUnits = units; }
+
+    /**
+     * Encodes the layout measurement to a string
+     * \see decodeMeasurement()
+    */
+    QString encodeMeasurement() const;
+
+    /**
+     * Decodes a measurement from a \a string.
+     * \see encodeMeasurement()
+    */
+    static QgsLayoutMeasurement decodeMeasurement( const QString &string );
+
+    bool operator==( const QgsLayoutMeasurement &other ) const;
+    bool operator!=( const QgsLayoutMeasurement &other ) const;
+    QgsLayoutMeasurement operator+( const double v ) const;
+    QgsLayoutMeasurement operator+=( const double v );
+    QgsLayoutMeasurement operator-( const double v ) const;
+    QgsLayoutMeasurement operator-=( const double v );
+    QgsLayoutMeasurement operator*( const double v ) const;
+    QgsLayoutMeasurement operator*=( const double v );
+    QgsLayoutMeasurement operator/( const double v ) const;
+    QgsLayoutMeasurement operator/=( const double v );
+
+  private:
+
+    double mLength;
+    QgsUnitTypes::LayoutUnit mUnits;
+
+};
+
+#endif // QGSLAYOUTMEASUREMENT_H

--- a/src/core/layout/qgslayoutmeasurement.h
+++ b/src/core/layout/qgslayoutmeasurement.h
@@ -123,8 +123,8 @@ class CORE_EXPORT QgsLayoutMeasurement
 
   private:
 
-    double mLength;
-    QgsUnitTypes::LayoutUnit mUnits;
+    double mLength = 0.0;
+    QgsUnitTypes::LayoutUnit mUnits = QgsUnitTypes::LayoutMillimeters;
 
 };
 

--- a/src/core/layout/qgslayoutmeasurementconverter.cpp
+++ b/src/core/layout/qgslayoutmeasurementconverter.cpp
@@ -1,0 +1,202 @@
+/***************************************************************************
+                         qgslayoutmeasurementconverter.cpp
+                         ---------------------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayoutmeasurementconverter.h"
+
+
+QgsLayoutMeasurementConverter::QgsLayoutMeasurementConverter()
+  : mDpi( 300.0 )
+{
+}
+
+QgsLayoutMeasurementConverter::~QgsLayoutMeasurementConverter()
+{
+}
+
+QgsLayoutMeasurement QgsLayoutMeasurementConverter::convert( const QgsLayoutMeasurement &measurement, const QgsUnitTypes::LayoutUnit targetUnits ) const
+{
+  if ( measurement.units() == targetUnits )
+  {
+    return measurement;
+  }
+
+  switch ( targetUnits )
+  {
+    case QgsUnitTypes::LayoutMillimeters:
+      return QgsLayoutMeasurement( convertToMillimeters( measurement ), QgsUnitTypes::LayoutMillimeters );
+    case QgsUnitTypes::LayoutCentimeters:
+      return QgsLayoutMeasurement( convertToCentimeters( measurement ), QgsUnitTypes::LayoutCentimeters );
+    case QgsUnitTypes::LayoutMeters:
+      return QgsLayoutMeasurement( convertToMeters( measurement ), QgsUnitTypes::LayoutMeters );
+    case QgsUnitTypes::LayoutInches:
+      return QgsLayoutMeasurement( convertToInches( measurement ), QgsUnitTypes::LayoutInches );
+    case QgsUnitTypes::LayoutFeet:
+      return QgsLayoutMeasurement( convertToFeet( measurement ), QgsUnitTypes::LayoutFeet );
+    case QgsUnitTypes::LayoutPoints:
+      return QgsLayoutMeasurement( convertToPoints( measurement ), QgsUnitTypes::LayoutPoints );
+    case QgsUnitTypes::LayoutPicas:
+      return QgsLayoutMeasurement( convertToPicas( measurement ), QgsUnitTypes::LayoutPicas );
+    case QgsUnitTypes::LayoutPixels:
+      return QgsLayoutMeasurement( convertToPixels( measurement ), QgsUnitTypes::LayoutPixels );
+  }
+
+  //will never be reached, but required to prevent warnings
+  return QgsLayoutMeasurement( convertToMillimeters( measurement ), QgsUnitTypes::LayoutMillimeters );
+}
+
+QgsLayoutSize QgsLayoutMeasurementConverter::convert( const QgsLayoutSize &size, const QgsUnitTypes::LayoutUnit targetUnits ) const
+{
+  if ( size.units() == targetUnits )
+  {
+    return size;
+  }
+
+  QgsLayoutSize result( size );
+  result.setUnits( targetUnits );
+  QgsLayoutMeasurement width = QgsLayoutMeasurement( size.width(), size.units() );
+  QgsLayoutMeasurement height = QgsLayoutMeasurement( size.height(), size.units() );
+  switch ( targetUnits )
+  {
+    case QgsUnitTypes::LayoutMillimeters:
+      result.setSize( convertToMillimeters( width ), convertToMillimeters( height ) );
+      break;
+    case QgsUnitTypes::LayoutCentimeters:
+      result.setSize( convertToCentimeters( width ), convertToCentimeters( height ) );
+      break;
+    case QgsUnitTypes::LayoutMeters:
+      result.setSize( convertToMeters( width ), convertToMeters( height ) );
+      break;
+    case QgsUnitTypes::LayoutInches:
+      result.setSize( convertToInches( width ), convertToInches( height ) );
+      break;
+    case QgsUnitTypes::LayoutFeet:
+      result.setSize( convertToFeet( width ), convertToFeet( height ) );
+      break;
+    case QgsUnitTypes::LayoutPoints:
+      result.setSize( convertToPoints( width ), convertToPoints( height ) );
+      break;
+    case QgsUnitTypes::LayoutPicas:
+      result.setSize( convertToPicas( width ), convertToPicas( height ) );
+      break;
+    case QgsUnitTypes::LayoutPixels:
+      result.setSize( convertToPixels( width ), convertToPixels( height ) );
+      break;
+  }
+  return result;
+}
+
+QgsLayoutPoint QgsLayoutMeasurementConverter::convert( const QgsLayoutPoint &point, const QgsUnitTypes::LayoutUnit targetUnits ) const
+{
+  if ( point.units() == targetUnits )
+  {
+    return point;
+  }
+
+  QgsLayoutPoint result( point );
+  result.setUnits( targetUnits );
+  QgsLayoutMeasurement x = QgsLayoutMeasurement( point.x(), point.units() );
+  QgsLayoutMeasurement y = QgsLayoutMeasurement( point.y(), point.units() );
+  switch ( targetUnits )
+  {
+    case QgsUnitTypes::LayoutMillimeters:
+      result.setPoint( convertToMillimeters( x ), convertToMillimeters( y ) );
+      break;
+    case QgsUnitTypes::LayoutCentimeters:
+      result.setPoint( convertToCentimeters( x ), convertToCentimeters( y ) );
+      break;
+    case QgsUnitTypes::LayoutMeters:
+      result.setPoint( convertToMeters( x ), convertToMeters( y ) );
+      break;
+    case QgsUnitTypes::LayoutInches:
+      result.setPoint( convertToInches( x ), convertToInches( y ) );
+      break;
+    case QgsUnitTypes::LayoutFeet:
+      result.setPoint( convertToFeet( x ), convertToFeet( y ) );
+      break;
+    case QgsUnitTypes::LayoutPoints:
+      result.setPoint( convertToPoints( x ), convertToPoints( y ) );
+      break;
+    case QgsUnitTypes::LayoutPicas:
+      result.setPoint( convertToPicas( x ), convertToPicas( y ) );
+      break;
+    case QgsUnitTypes::LayoutPixels:
+      result.setPoint( convertToPixels( x ), convertToPixels( y ) );
+      break;
+  }
+  return result;
+}
+
+double QgsLayoutMeasurementConverter::convertToMillimeters( const QgsLayoutMeasurement &measurement ) const
+{
+  switch ( measurement.units() )
+  {
+    case QgsUnitTypes::LayoutMillimeters:
+      return measurement.length();
+    case QgsUnitTypes::LayoutCentimeters:
+      return measurement.length() * 10.0;
+    case QgsUnitTypes::LayoutMeters:
+      return measurement.length() * 1000.0;
+    case QgsUnitTypes::LayoutInches:
+      return measurement.length() * 25.4;
+    case QgsUnitTypes::LayoutFeet:
+      return measurement.length() * 304.8;
+    case QgsUnitTypes::LayoutPoints:
+      return measurement.length() * 0.352777778;
+    case QgsUnitTypes::LayoutPicas:
+      return measurement.length() * 4.23333333;
+    case QgsUnitTypes::LayoutPixels:
+      return measurement.length() * 25.4 / mDpi;
+  }
+
+  //will never be reached, but required to prevent warnings
+  return measurement.length();
+}
+
+double QgsLayoutMeasurementConverter::convertToCentimeters( const QgsLayoutMeasurement &measurement ) const
+{
+  return convertToMillimeters( measurement ) / 10.0;
+}
+
+double QgsLayoutMeasurementConverter::convertToMeters( const QgsLayoutMeasurement &measurement ) const
+{
+  return convertToMillimeters( measurement ) / 1000.0;
+}
+
+double QgsLayoutMeasurementConverter::convertToInches( const QgsLayoutMeasurement &measurement ) const
+{
+  return convertToMillimeters( measurement ) / 25.4;
+}
+
+double QgsLayoutMeasurementConverter::convertToFeet( const QgsLayoutMeasurement &measurement ) const
+{
+  return convertToMillimeters( measurement ) / 304.8;
+}
+
+double QgsLayoutMeasurementConverter::convertToPoints( const QgsLayoutMeasurement &measurement ) const
+{
+  return convertToMillimeters( measurement ) * 2.83464567;
+}
+
+double QgsLayoutMeasurementConverter::convertToPicas( const QgsLayoutMeasurement &measurement ) const
+{
+  return convertToMillimeters( measurement ) * 0.236220472;
+}
+
+double QgsLayoutMeasurementConverter::convertToPixels( const QgsLayoutMeasurement &measurement ) const
+{
+  return convertToMillimeters( measurement ) * mDpi / 25.4;
+}

--- a/src/core/layout/qgslayoutmeasurementconverter.cpp
+++ b/src/core/layout/qgslayoutmeasurementconverter.cpp
@@ -23,10 +23,6 @@ QgsLayoutMeasurementConverter::QgsLayoutMeasurementConverter()
 {
 }
 
-QgsLayoutMeasurementConverter::~QgsLayoutMeasurementConverter()
-{
-}
-
 QgsLayoutMeasurement QgsLayoutMeasurementConverter::convert( const QgsLayoutMeasurement &measurement, const QgsUnitTypes::LayoutUnit targetUnits ) const
 {
   if ( measurement.units() == targetUnits )

--- a/src/core/layout/qgslayoutmeasurementconverter.cpp
+++ b/src/core/layout/qgslayoutmeasurementconverter.cpp
@@ -18,11 +18,6 @@
 #include "qgslayoutmeasurementconverter.h"
 
 
-QgsLayoutMeasurementConverter::QgsLayoutMeasurementConverter()
-  : mDpi( 300.0 )
-{
-}
-
 QgsLayoutMeasurement QgsLayoutMeasurementConverter::convert( const QgsLayoutMeasurement &measurement, const QgsUnitTypes::LayoutUnit targetUnits ) const
 {
   if ( measurement.units() == targetUnits )

--- a/src/core/layout/qgslayoutmeasurementconverter.h
+++ b/src/core/layout/qgslayoutmeasurementconverter.h
@@ -41,7 +41,10 @@ class CORE_EXPORT QgsLayoutMeasurementConverter
 {
   public:
 
-    QgsLayoutMeasurementConverter();
+    /**
+     * Constructor for QgsLayoutMeasurementConverter.
+     */
+    QgsLayoutMeasurementConverter() = default;
 
     /**
      * Sets the dots per inch (\a dpi) for the measurement converter. This is used
@@ -83,7 +86,7 @@ class CORE_EXPORT QgsLayoutMeasurementConverter
 
   private:
 
-    double mDpi;
+    double mDpi = 300.0;
 
     double convertToMillimeters( const QgsLayoutMeasurement &measurement ) const;
     double convertToCentimeters( const QgsLayoutMeasurement &measurement ) const;

--- a/src/core/layout/qgslayoutmeasurementconverter.h
+++ b/src/core/layout/qgslayoutmeasurementconverter.h
@@ -1,0 +1,101 @@
+/***************************************************************************
+                         qgslayoutmeasurementconverter.h
+                         -------------------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYOUTMEASUREMENTCONVERTER_H
+#define QGSLAYOUTMEASUREMENTCONVERTER_H
+
+#include "qgis_core.h"
+#include "qgsunittypes.h"
+#include "qgslayoutmeasurement.h"
+#include "qgslayoutsize.h"
+#include "qgslayoutpoint.h"
+#include <QSizeF>
+#include <QPointF>
+
+
+/**
+ * \ingroup Layout
+ * \class QgsLayoutMeasurementConverter
+ * \brief This class provides a method of converting QgsLayoutMeasurements from
+ * one unit to another. Conversion to or from pixel units utilizes a specified
+ * dots per inch (DPI) property for the converter. Converters default to using
+ * 300 DPI.
+ * \see QgsLayoutMeasurement
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsLayoutMeasurementConverter
+{
+  public:
+
+    QgsLayoutMeasurementConverter();
+
+    ~QgsLayoutMeasurementConverter();
+
+    /**
+     * Sets the dots per inch (\a dpi) for the measurement converter. This is used
+     * when converting measurements to and from pixels.
+     * \see dpi()
+    */
+    void setDpi( const double dpi ) { mDpi = dpi; }
+
+    /**
+     * Returns the Dots per inch (DPI) of the measurement converter. This is used
+     * when converting measurements to and from pixels.
+     * \see setDpi()
+    */
+    double dpi() const { return mDpi; }
+
+    /**
+     * Converts a measurement from one unit to another.
+     * \param measurement measurement to convert
+     * \param targetUnits units to convert measurement into
+     * \returns measurement converted to target units
+    */
+    QgsLayoutMeasurement convert( const QgsLayoutMeasurement &measurement, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+
+    /**
+     * Converts a layout size from one unit to another.
+     * \param size layout size to convert
+     * \param targetUnits units to convert size into
+     * \returns size converted to target units
+    */
+    QgsLayoutSize convert( const QgsLayoutSize &size, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+
+    /**
+     * Converts a layout point from one unit to another.
+     * \param point layout point to convert
+     * \param targetUnits units to convert point into
+     * \returns point converted to target units
+    */
+    QgsLayoutPoint convert( const QgsLayoutPoint &point, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+
+  private:
+
+    double mDpi;
+
+    double convertToMillimeters( const QgsLayoutMeasurement &measurement ) const;
+    double convertToCentimeters( const QgsLayoutMeasurement &measurement ) const;
+    double convertToMeters( const QgsLayoutMeasurement &measurement ) const;
+    double convertToInches( const QgsLayoutMeasurement &measurement ) const;
+    double convertToFeet( const QgsLayoutMeasurement &measurement ) const;
+    double convertToPoints( const QgsLayoutMeasurement &measurement ) const;
+    double convertToPicas( const QgsLayoutMeasurement &measurement ) const;
+    double convertToPixels( const QgsLayoutMeasurement &measurement ) const;
+
+};
+
+#endif // QGSLAYOUTMEASUREMENTCONVERTER_H

--- a/src/core/layout/qgslayoutmeasurementconverter.h
+++ b/src/core/layout/qgslayoutmeasurementconverter.h
@@ -28,7 +28,7 @@
 
 
 /**
- * \ingroup Layout
+ * \ingroup core
  * \class QgsLayoutMeasurementConverter
  * \brief This class provides a method of converting QgsLayoutMeasurements from
  * one unit to another. Conversion to or from pixel units utilizes a specified
@@ -42,8 +42,6 @@ class CORE_EXPORT QgsLayoutMeasurementConverter
   public:
 
     QgsLayoutMeasurementConverter();
-
-    ~QgsLayoutMeasurementConverter();
 
     /**
      * Sets the dots per inch (\a dpi) for the measurement converter. This is used

--- a/src/core/layout/qgslayoutpoint.cpp
+++ b/src/core/layout/qgslayoutpoint.cpp
@@ -36,11 +36,6 @@ QgsLayoutPoint::QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units )
 
 }
 
-QgsLayoutPoint::~QgsLayoutPoint()
-{
-
-}
-
 bool QgsLayoutPoint::isNull() const
 {
   return qgsDoubleNear( mX, 0 ) && qgsDoubleNear( mY, 0 );

--- a/src/core/layout/qgslayoutpoint.cpp
+++ b/src/core/layout/qgslayoutpoint.cpp
@@ -1,0 +1,99 @@
+/***************************************************************************
+                         qgslayoutpoint.cpp
+                         ------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayoutpoint.h"
+#include "qgis.h"
+
+#include <QStringList>
+
+QgsLayoutPoint::QgsLayoutPoint( const double x, const double y, const QgsUnitTypes::LayoutUnit units )
+  : mX( x )
+  , mY( y )
+  , mUnits( units )
+{
+
+}
+
+QgsLayoutPoint::QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units )
+  : mX( 0.0 )
+  , mY( 0.0 )
+  , mUnits( units )
+{
+
+}
+
+QgsLayoutPoint::~QgsLayoutPoint()
+{
+
+}
+
+bool QgsLayoutPoint::isNull() const
+{
+  return qgsDoubleNear( mX, 0 ) && qgsDoubleNear( mY, 0 );
+}
+
+QPointF QgsLayoutPoint::toQPointF() const
+{
+  return QPointF( mX, mY );
+}
+
+QString QgsLayoutPoint::encodePoint() const
+{
+  return QStringLiteral( "%1,%2,%3" ).arg( mX ).arg( mY ).arg( QgsUnitTypes::encodeUnit( mUnits ) );
+}
+
+QgsLayoutPoint QgsLayoutPoint::decodePoint( const QString &string )
+{
+  QStringList parts = string.split( ',' );
+  if ( parts.count() != 3 )
+  {
+    return QgsLayoutPoint();
+  }
+  return QgsLayoutPoint( parts[0].toDouble(), parts[1].toDouble(), QgsUnitTypes::decodeLayoutUnit( parts[2] ) );
+}
+
+bool QgsLayoutPoint::operator==( const QgsLayoutPoint &other ) const
+{
+  return other.units() == mUnits && other.x() == mX && other.y() == mY;
+}
+
+bool QgsLayoutPoint::operator!=( const QgsLayoutPoint &other ) const
+{
+  return ( ! operator==( other ) );
+}
+
+QgsLayoutPoint QgsLayoutPoint::operator*( const double v ) const
+{
+  return QgsLayoutPoint( mX * v, mY * v, mUnits );
+}
+
+QgsLayoutPoint QgsLayoutPoint::operator*=( const double v )
+{
+  *this = *this * v;
+  return *this;
+}
+
+QgsLayoutPoint QgsLayoutPoint::operator/( const double v ) const
+{
+  return QgsLayoutPoint( mX / v, mY / v, mUnits );
+}
+
+QgsLayoutPoint QgsLayoutPoint::operator/=( const double v )
+{
+  *this = *this / v;
+  return *this;
+}

--- a/src/core/layout/qgslayoutpoint.cpp
+++ b/src/core/layout/qgslayoutpoint.cpp
@@ -29,9 +29,7 @@ QgsLayoutPoint::QgsLayoutPoint( const double x, const double y, const QgsUnitTyp
 }
 
 QgsLayoutPoint::QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units )
-  : mX( 0.0 )
-  , mY( 0.0 )
-  , mUnits( units )
+  : mUnits( units )
 {
 
 }

--- a/src/core/layout/qgslayoutpoint.h
+++ b/src/core/layout/qgslayoutpoint.h
@@ -22,7 +22,8 @@
 #include "qgsunittypes.h"
 #include <QPointF>
 
-/** \ingroup Layout
+/**
+ * \ingroup core
  * \class QgsLayoutPoint
  * \brief This class provides a method of storing points, consisting of an x and y coordinate,
  * for use in QGIS layouts. Measurement units are stored alongside the position.
@@ -41,9 +42,6 @@ class CORE_EXPORT QgsLayoutPoint
 
     /**
      * Constructor for QgsLayoutPoint.
-     * \param x x coordinate
-     * \param x y coordinate
-     * \param units units for x and y
     */
     QgsLayoutPoint( const double x, const double y, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
@@ -52,8 +50,6 @@ class CORE_EXPORT QgsLayoutPoint
      * \param units units for measurement
     */
     explicit QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
-
-    ~QgsLayoutPoint();
 
     /**
      * Sets new x and y coordinates for the point.
@@ -132,9 +128,25 @@ class CORE_EXPORT QgsLayoutPoint
 
     bool operator==( const QgsLayoutPoint &other ) const;
     bool operator!=( const QgsLayoutPoint &other ) const;
+
+    /**
+     * Multiplies the x and y by a scalar value.
+     */
     QgsLayoutPoint operator*( const double v ) const;
+
+    /**
+     * Multiplies the x and y by a scalar value.
+     */
     QgsLayoutPoint operator*=( const double v );
+
+    /**
+     * Divides the x and y by a scalar value.
+     */
     QgsLayoutPoint operator/( const double v ) const;
+
+    /**
+     * Divides the x and y by a scalar value.
+     */
     QgsLayoutPoint operator/=( const double v );
 
   private:

--- a/src/core/layout/qgslayoutpoint.h
+++ b/src/core/layout/qgslayoutpoint.h
@@ -151,9 +151,9 @@ class CORE_EXPORT QgsLayoutPoint
 
   private:
 
-    double mX;
-    double mY;
-    QgsUnitTypes::LayoutUnit mUnits;
+    double mX = 0.0;
+    double mY = 0.0;
+    QgsUnitTypes::LayoutUnit mUnits = QgsUnitTypes::LayoutMillimeters;
 
 };
 

--- a/src/core/layout/qgslayoutpoint.h
+++ b/src/core/layout/qgslayoutpoint.h
@@ -1,0 +1,148 @@
+/***************************************************************************
+                         qgslayoutpoint.h
+                         ----------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYOUTPOINT_H
+#define QGSLAYOUTPOINT_H
+
+#include "qgis_core.h"
+#include "qgsunittypes.h"
+#include <QPointF>
+
+/** \ingroup Layout
+ * \class QgsLayoutPoint
+ * \brief This class provides a method of storing points, consisting of an x and y coordinate,
+ * for use in QGIS layouts. Measurement units are stored alongside the position.
+ *
+ * \see QgsLayoutMeasurementConverter
+ * \since QGIS 3.0
+ * \note This class does not inherit from QPointF since QPointF includes methods which should not apply
+ * to positions with with units. For instance, the + and - operators would mislead users of this class
+ * to believe that addition of two QgsLayoutPoints with different unit types would automatically convert
+ * units. Instead, all unit conversion must be handled by a QgsLayoutMeasurementConverter so that
+ * conversion between paper and screen units can be correctly performed.
+ */
+class CORE_EXPORT QgsLayoutPoint
+{
+  public:
+
+    /**
+     * Constructor for QgsLayoutPoint.
+     * \param x x coordinate
+     * \param x y coordinate
+     * \param units units for x and y
+    */
+    QgsLayoutPoint( const double x, const double y, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+
+    /**
+     * Constructor for an empty point, where both x and y are set to 0.
+     * \param units units for measurement
+    */
+    explicit QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+
+    ~QgsLayoutPoint();
+
+    /**
+     * Sets new x and y coordinates for the point.
+     * \see setX()
+     * \see setY()
+     * \see setUnits()
+    */
+    void setPoint( const double x, const double y ) { mX = x; mY = y; }
+
+    /**
+     * Returns x coordinate of point.
+     * \see setX()
+     * \see y()
+    */
+    double x() const { return mX; }
+
+    /**
+     * Sets the x coordinate of point.
+     * \see x()
+     * \see setY()
+    */
+    void setX( const double x ) { mX = x; }
+
+    /**
+     * Returns y coordinate of point.
+     * \see setY()
+     * \see x()
+    */
+    double y() const { return mY; }
+
+    /**
+     * Sets y coordinate of point.
+     * \see y()
+     * \see setX()
+    */
+    void setY( const double y ) { mY = y; }
+
+    /**
+     * Returns the units for the point.
+     * \see setUnits()
+    */
+    QgsUnitTypes::LayoutUnit units() const { return mUnits; }
+
+    /**
+     * Sets the \a units for the point. Does not alter the stored coordinates,
+     * ie. no conversion is done.
+     * \see units()
+    */
+    void setUnits( const QgsUnitTypes::LayoutUnit units ) { mUnits = units; }
+
+    /**
+     * Tests whether the position is null, ie both its x and y coordinates
+     * are zero.
+     * \returns true if point is null
+    */
+    bool isNull() const;
+
+    /**
+     * Converts the layout point to a QPointF. The unit information is discarded
+     * during this operation.
+     * \returns QPointF with same x and y coordinates as layout point
+    */
+    QPointF toQPointF() const;
+
+    /**
+     * Encodes the layout point to a string
+     * \see decodePoint()
+    */
+    QString encodePoint() const;
+
+    /**
+     * Decodes a point from a \a string.
+     * \see encodePoint()
+    */
+    static QgsLayoutPoint decodePoint( const QString &string );
+
+    bool operator==( const QgsLayoutPoint &other ) const;
+    bool operator!=( const QgsLayoutPoint &other ) const;
+    QgsLayoutPoint operator*( const double v ) const;
+    QgsLayoutPoint operator*=( const double v );
+    QgsLayoutPoint operator/( const double v ) const;
+    QgsLayoutPoint operator/=( const double v );
+
+  private:
+
+    double mX;
+    double mY;
+    QgsUnitTypes::LayoutUnit mUnits;
+
+};
+
+#endif // QGSLAYOUTPOINT_H

--- a/src/core/layout/qgslayoutsize.cpp
+++ b/src/core/layout/qgslayoutsize.cpp
@@ -34,10 +34,6 @@ QgsLayoutSize::QgsLayoutSize( const QgsUnitTypes::LayoutUnit units )
 
 }
 
-QgsLayoutSize::~QgsLayoutSize()
-{
-}
-
 bool QgsLayoutSize::isEmpty() const
 {
   return qgsDoubleNear( mWidth, 0 ) && qgsDoubleNear( mHeight, 0 );

--- a/src/core/layout/qgslayoutsize.cpp
+++ b/src/core/layout/qgslayoutsize.cpp
@@ -27,9 +27,7 @@ QgsLayoutSize::QgsLayoutSize( const double width, const double height, const Qgs
 }
 
 QgsLayoutSize::QgsLayoutSize( const QgsUnitTypes::LayoutUnit units )
-  : mWidth( 0.0 )
-  , mHeight( 0.0 )
-  , mUnits( units )
+  : mUnits( units )
 {
 
 }

--- a/src/core/layout/qgslayoutsize.cpp
+++ b/src/core/layout/qgslayoutsize.cpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+                         qgslayoutsize.cpp
+                         -----------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayoutsize.h"
+#include "qgis.h"
+#include <QStringList>
+
+QgsLayoutSize::QgsLayoutSize( const double width, const double height, const QgsUnitTypes::LayoutUnit units )
+  : mWidth( width )
+  , mHeight( height )
+  , mUnits( units )
+{
+}
+
+QgsLayoutSize::QgsLayoutSize( const QgsUnitTypes::LayoutUnit units )
+  : mWidth( 0.0 )
+  , mHeight( 0.0 )
+  , mUnits( units )
+{
+
+}
+
+QgsLayoutSize::~QgsLayoutSize()
+{
+}
+
+bool QgsLayoutSize::isEmpty() const
+{
+  return qgsDoubleNear( mWidth, 0 ) && qgsDoubleNear( mHeight, 0 );
+}
+
+QSizeF QgsLayoutSize::toQSizeF() const
+{
+  return QSizeF( mWidth, mHeight );
+}
+
+QString QgsLayoutSize::encodeSize() const
+{
+  return QStringLiteral( "%1,%2,%3" ).arg( mWidth ).arg( mHeight ).arg( QgsUnitTypes::encodeUnit( mUnits ) );
+}
+
+QgsLayoutSize QgsLayoutSize::decodeSize( const QString &string )
+{
+  QStringList parts = string.split( ',' );
+  if ( parts.count() != 3 )
+  {
+    return QgsLayoutSize();
+  }
+  return QgsLayoutSize( parts[0].toDouble(), parts[1].toDouble(), QgsUnitTypes::decodeLayoutUnit( parts[2] ) );
+
+}
+
+bool QgsLayoutSize::operator==( const QgsLayoutSize &other ) const
+{
+  return other.units() == mUnits && other.width() == mWidth && other.height() == mHeight;
+}
+
+bool QgsLayoutSize::operator!=( const QgsLayoutSize &other ) const
+{
+  return ( ! operator==( other ) );
+}
+
+QgsLayoutSize QgsLayoutSize::operator*( const double v ) const
+{
+  return QgsLayoutSize( mWidth * v, mHeight * v, mUnits );
+}
+
+QgsLayoutSize QgsLayoutSize::operator*=( const double v )
+{
+  *this = *this * v;
+  return *this;
+}
+
+QgsLayoutSize QgsLayoutSize::operator/( const double v ) const
+{
+  return QgsLayoutSize( mWidth / v, mHeight / v, mUnits );
+}
+
+QgsLayoutSize QgsLayoutSize::operator/=( const double v )
+{
+  *this = *this / v;
+  return *this;
+}

--- a/src/core/layout/qgslayoutsize.h
+++ b/src/core/layout/qgslayoutsize.h
@@ -155,9 +155,9 @@ class CORE_EXPORT QgsLayoutSize
 
   private:
 
-    double mWidth;
-    double mHeight;
-    QgsUnitTypes::LayoutUnit mUnits;
+    double mWidth = 0.0;
+    double mHeight = 0.0;
+    QgsUnitTypes::LayoutUnit mUnits = QgsUnitTypes::LayoutMillimeters;
 
 };
 

--- a/src/core/layout/qgslayoutsize.h
+++ b/src/core/layout/qgslayoutsize.h
@@ -1,0 +1,150 @@
+/***************************************************************************
+                         qgslayoutsize.h
+                         ---------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYOUTSIZE_H
+#define QGSLAYOUTSIZE_H
+
+#include "qgis_core.h"
+#include "qgsunittypes.h"
+#include <QSizeF>
+
+
+/**
+ * \ingroup Layout
+ * \class QgsLayoutSize
+ * \brief This class provides a method of storing sizes, consisting of a width and height,
+ * for use in QGIS layouts. Measurement units are stored alongside the size.
+ *
+ * \see QgsLayoutMeasurementConverter
+ * \since QGIS 3.0
+ * \note This class does not inherit from QSizeF since QSizeF includes methods which should not apply to sizes
+ * with units. For instance, the + and - operators would mislead users of this class to believe that
+ * addition of two QgsLayoutSize with different unit types would automatically convert units. Instead,
+ * all unit conversion must be handled by a QgsLayoutMeasurementConverter so that conversion between
+ * paper and screen units can be correctly performed.
+ */
+class CORE_EXPORT QgsLayoutSize
+{
+  public:
+
+    /**
+     * Constructor for QgsLayoutSize.
+     * \param width width
+     * \param height height
+     * \param units units for width and height
+    */
+    QgsLayoutSize( const double width, const double height, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+
+    /**
+     * Constructor for an empty layout size
+     * \param units units for measurement
+    */
+    explicit QgsLayoutSize( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+
+    ~QgsLayoutSize();
+
+    /**
+     * Sets new \a width and \a height for the size.
+     * \see setWidth()
+     * \see setHeight()
+     * \see setUnits()
+    */
+    void setSize( const double width, const double height ) { mWidth = width; mHeight = height; }
+
+    /**
+     * Returns the width of the size.
+     * \see setWidth()
+     * \see height()
+    */
+    double width() const { return mWidth; }
+
+    /**
+     * Sets the \a width for the size.
+     * \see width()
+     * \see setHeight()
+    */
+    void setWidth( const double width ) { mWidth = width; }
+
+    /**
+     * Returns the height of the size.
+     * \see setHeight()
+     * \see width()
+    */
+    double height() const { return mHeight; }
+
+    /**
+     * Sets the \a height for the size.
+     * \see height()
+     * \see setWidth()
+    */
+    void setHeight( const double height ) { mHeight = height; }
+
+    /**
+     * Returns the units for the size.
+     * \see setUnits()
+    */
+    QgsUnitTypes::LayoutUnit units() const { return mUnits; }
+
+    /**
+     * Sets the \a units for the size. Does not alter the stored width or height,
+     * ie. no conversion is done.
+     * \see units()
+    */
+    void setUnits( const QgsUnitTypes::LayoutUnit units ) { mUnits = units; }
+
+    /**
+     * Tests whether the size is empty, ie both its width and height
+     * are zero.
+     * \returns true if size is empty
+    */
+    bool isEmpty() const;
+
+    /**
+     * Converts the layout size to a QSizeF. The unit information is discarded
+     * during this operation.
+     * \returns QSizeF with same dimensions as layout size
+    */
+    QSizeF toQSizeF() const;
+
+    /**
+     * Encodes the layout size to a string
+     * \see decodeSize()
+    */
+    QString encodeSize() const;
+
+    /**
+     * Decodes a size from a \a string.
+     * \see encodeSize()
+    */
+    static QgsLayoutSize decodeSize( const QString &string );
+
+    bool operator==( const QgsLayoutSize &other ) const;
+    bool operator!=( const QgsLayoutSize &other ) const;
+    QgsLayoutSize operator*( const double v ) const;
+    QgsLayoutSize operator*=( const double v );
+    QgsLayoutSize operator/( const double v ) const;
+    QgsLayoutSize operator/=( const double v );
+
+  private:
+
+    double mWidth;
+    double mHeight;
+    QgsUnitTypes::LayoutUnit mUnits;
+
+};
+
+#endif // QGSLAYOUTSIZE_H

--- a/src/core/layout/qgslayoutsize.h
+++ b/src/core/layout/qgslayoutsize.h
@@ -24,7 +24,7 @@
 
 
 /**
- * \ingroup Layout
+ * \ingroup core
  * \class QgsLayoutSize
  * \brief This class provides a method of storing sizes, consisting of a width and height,
  * for use in QGIS layouts. Measurement units are stored alongside the size.
@@ -54,8 +54,6 @@ class CORE_EXPORT QgsLayoutSize
      * \param units units for measurement
     */
     explicit QgsLayoutSize( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
-
-    ~QgsLayoutSize();
 
     /**
      * Sets new \a width and \a height for the size.
@@ -134,9 +132,25 @@ class CORE_EXPORT QgsLayoutSize
 
     bool operator==( const QgsLayoutSize &other ) const;
     bool operator!=( const QgsLayoutSize &other ) const;
+
+    /**
+     * Multiplies the width and height by a scalar value.
+     */
     QgsLayoutSize operator*( const double v ) const;
+
+    /**
+     * Multiplies the width and height by a scalar value.
+     */
     QgsLayoutSize operator*=( const double v );
+
+    /**
+     * Divides the width and height by a scalar value.
+     */
     QgsLayoutSize operator/( const double v ) const;
+
+    /**
+     * Divides the width and height by a scalar value.
+     */
     QgsLayoutSize operator/=( const double v );
 
   private:

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -1773,3 +1773,80 @@ QString QgsUnitTypes::toString( QgsUnitTypes::RenderUnit unit )
   }
   return QString();
 }
+
+
+
+QString QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutUnit unit )
+{
+  switch ( unit )
+  {
+    case LayoutCentimeters:
+      return QStringLiteral( "cm" );
+    case LayoutMeters:
+      return QStringLiteral( "m" );
+    case LayoutInches:
+      return QStringLiteral( "in" );
+    case LayoutFeet:
+      return QStringLiteral( "ft" );
+    case LayoutPoints:
+      return QStringLiteral( "pt" );
+    case LayoutPicas:
+      return QStringLiteral( "pi" );
+    case LayoutPixels:
+      return QStringLiteral( "px" );
+    case  LayoutMillimeters:
+      return QStringLiteral( "mm" );
+  }
+  return QString();
+}
+
+QgsUnitTypes::LayoutUnit QgsUnitTypes::decodeLayoutUnit( const QString &string, bool *ok )
+{
+  QString normalized = string.trimmed().toLower();
+
+  if ( ok )
+    *ok = true;
+
+  if ( normalized == encodeUnit( LayoutMillimeters ).toLower() )
+    return LayoutMillimeters;
+  if ( normalized == encodeUnit( LayoutCentimeters ).toLower() )
+    return LayoutCentimeters;
+  if ( normalized == encodeUnit( LayoutMeters ).toLower() )
+    return LayoutMeters;
+  if ( normalized == encodeUnit( LayoutInches ).toLower() )
+    return LayoutInches;
+  if ( normalized == encodeUnit( LayoutFeet ).toLower() )
+    return LayoutFeet;
+  if ( normalized == encodeUnit( LayoutPoints ).toLower() )
+    return LayoutPoints;
+  if ( normalized == encodeUnit( LayoutPicas ).toLower() )
+    return LayoutPicas;
+  if ( normalized == encodeUnit( LayoutPixels ).toLower() )
+    return LayoutPixels;
+
+  if ( ok )
+    *ok = false;
+
+  // millimeters are default
+  return LayoutMillimeters;
+}
+
+QgsUnitTypes::LayoutUnitType QgsUnitTypes::unitType( const QgsUnitTypes::LayoutUnit units )
+{
+  switch ( units )
+  {
+    case LayoutPixels:
+      return LayoutScreenUnits;
+    case  LayoutMillimeters:
+    case LayoutCentimeters:
+    case LayoutMeters:
+    case LayoutInches:
+    case LayoutFeet:
+    case LayoutPoints:
+    case LayoutPicas:
+      return LayoutPaperUnits;
+  }
+
+  // avoid warnings
+  return LayoutPaperUnits;
+}

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -103,6 +103,26 @@ class CORE_EXPORT QgsUnitTypes
       RenderUnknownUnit, //!< Mixed or unknown units
     };
 
+    //! Layout measurement units
+    enum LayoutUnit
+    {
+      LayoutMillimeters = 0, //!< Millimeters
+      LayoutCentimeters, //!< Centimeters
+      LayoutMeters, //!< Meters
+      LayoutInches, //!< Inches
+      LayoutFeet, //!< Feet
+      LayoutPoints, //!< Typographic points
+      LayoutPicas, //!< Typographic picas
+      LayoutPixels //!< Pixels
+    };
+
+    //! Types of layout units
+    enum LayoutUnitType
+    {
+      LayoutPaperUnits = 0, //!< Unit is a paper based measurement unit
+      LayoutScreenUnits //!< Unit is a screen based measurement unit
+    };
+
     /**
      * A combination of distance value and unit.
      *
@@ -354,6 +374,31 @@ class CORE_EXPORT QgsUnitTypes
      * \since QGIS 3.0
      */
     Q_INVOKABLE static QString toString( RenderUnit unit );
+
+
+    // LAYOUT UNITS
+
+    /**
+     * Encodes a layout unit to a string.
+     * \param unit unit to encode
+     * \returns encoded string
+     * \see decodeLayoutUnit()
+     */
+    Q_INVOKABLE static QString encodeUnit( LayoutUnit unit );
+
+    /** Decodes a layout unit from a string.
+     * \param string string to decode
+     * \param ok optional boolean, will be set to true if string was converted successfully
+     * \returns decoded units
+     * \see encodeUnit()
+     */
+    Q_INVOKABLE static LayoutUnit decodeLayoutUnit( const QString &string, bool *ok SIP_OUT = 0 );
+
+    /**
+     * Returns the type for a unit of measurement.
+    */
+    Q_INVOKABLE static LayoutUnitType unitType( const LayoutUnit units );
+
 };
 
 #endif // QGSUNITTYPES_H

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -13,6 +13,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core/composer
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layout
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/effects
   ${CMAKE_SOURCE_DIR}/src/core/layertree
@@ -124,6 +125,7 @@ SET(TESTS
  testqgsjsonutils.cpp
  testqgslabelingengine.cpp
  testqgslayertree.cpp
+ testqgslayoutunits.cpp
  testqgslegendrenderer.cpp
  testqgscentroidfillsymbol.cpp
  testqgslinefillsymbol.cpp

--- a/tests/src/core/testqgslayoutunits.cpp
+++ b/tests/src/core/testqgslayoutunits.cpp
@@ -1,0 +1,879 @@
+/***************************************************************************
+                         testqgslayoutunits.cpp
+                         -----------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgsunittypes.h"
+#include "qgslayoutmeasurement.h"
+#include "qgslayoutpoint.h"
+#include "qgslayoutsize.h"
+#include "qgslayoutmeasurementconverter.h"
+#include "qgis.h"
+
+class TestQgsLayoutUnits : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+
+    //QgsLayoutUnits
+    void encodeDecode(); //test encoding and decoding layout units
+
+    //QgsLayoutMeasurement
+    void create(); //test creating new measurement
+    void gettersSetters(); //test getting/setting properties
+    void copyConstructor(); //test copy constructor
+    void equality(); //test measurement equality
+    void assignment(); //test measurement assignment
+    void operators(); //test measurement operators
+    void unitTypes(); //test unit types
+    void measurementEncodeDecode(); //test encoding and decoding measurement
+
+    //QgsLayoutSize
+    void createSize(); //test creating new layout size
+    void sizeGettersSetters(); //test getting/setting properties
+    void sizeCopyConstructor(); //test copy constructor
+    void sizeEquality(); //test size equality
+    void sizeAssignment(); //test size assignment
+    void sizeOperators(); //test size operators
+    void isEmpty(); //test isEmpty method
+    void toQSizeF(); //test conversion to QSizeF
+    void sizeEncodeDecode(); //test encoding and decoding size
+
+    //QgsLayoutPoint
+    void createPoint(); //test creating new layout point
+    void pointGettersSetters(); //test getting/setting properties
+    void pointCopyConstructor(); //test copy constructor
+    void pointEquality(); //test point equality
+    void pointAssignment(); //test point assignment
+    void pointOperators(); //test point operators
+    void isNull(); //test isEmpty method
+    void toQPointF(); //test conversion to QPointF
+    void pointEncodeDecode(); //test encoding and decoding point
+
+    void converterCreate(); //test creating new converter
+    void converterCopy(); //test creating new converter using copy constructor
+    void converterGettersSetters(); //test getting/setting converter properties
+    void conversionToMM(); //test conversion to mm
+    void conversionToCM(); //test conversion to cm
+    void conversionToM(); //test conversion to m
+    void conversionToInches(); //test conversion to inches
+    void conversionToFeet(); //test conversion to feet
+    void conversionToPoints(); //test conversion to points
+    void conversionToPicas(); //test conversion to picas
+    void conversionFromPixels(); //test conversion from pixels and handling of dpi
+    void conversionToPixels(); //test conversion to pixels and handling of dpi
+    void sizeConversion(); //test conversion of QgsLayoutSizes
+    void pointConversion(); //test conversion of QgsLayoutPoint
+
+  private:
+
+};
+
+void TestQgsLayoutUnits::initTestCase()
+{
+
+}
+
+void TestQgsLayoutUnits::cleanupTestCase()
+{
+
+}
+
+void TestQgsLayoutUnits::init()
+{
+
+}
+
+void TestQgsLayoutUnits::cleanup()
+{
+
+}
+
+void TestQgsLayoutUnits::encodeDecode()
+{
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutMillimeters ) ), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutCentimeters ) ), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutMeters ) ), QgsUnitTypes::LayoutMeters );
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutInches ) ), QgsUnitTypes::LayoutInches );
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutFeet ) ), QgsUnitTypes::LayoutFeet );
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutPoints ) ), QgsUnitTypes::LayoutPoints );
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutPicas ) ), QgsUnitTypes::LayoutPicas );
+  QCOMPARE( QgsUnitTypes::decodeLayoutUnit( QgsUnitTypes::encodeUnit( QgsUnitTypes::LayoutPixels ) ), QgsUnitTypes::LayoutPixels );
+}
+
+void TestQgsLayoutUnits::create()
+{
+  QgsLayoutMeasurement defaultUnits( 5.0 );
+  //default units should be millimeters
+  QCOMPARE( defaultUnits.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( defaultUnits.length(), 5.0 );
+
+  //test overriding default unit
+  QgsLayoutMeasurement inches( 7.0, QgsUnitTypes::LayoutInches );
+  QCOMPARE( inches.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( inches.length(), 7.0 );
+}
+
+void TestQgsLayoutUnits::gettersSetters()
+{
+  QgsLayoutMeasurement measurement( 5.0 );
+
+  measurement.setLength( 9.0 );
+  QCOMPARE( measurement.length(), 9.0 );
+  measurement.setUnits( QgsUnitTypes::LayoutInches );
+  QCOMPARE( measurement.units(), QgsUnitTypes::LayoutInches );
+}
+
+void TestQgsLayoutUnits::copyConstructor()
+{
+  QgsLayoutMeasurement source( 6.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement dest( source );
+  QCOMPARE( source, dest );
+}
+
+void TestQgsLayoutUnits::equality()
+{
+  QgsLayoutMeasurement m1( 6.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement m2( 6.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement m3( 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement m4( 6.0, QgsUnitTypes::LayoutPoints );
+
+  QVERIFY( m1 == m2 );
+  QVERIFY( !( m1 == m3 ) );
+  QVERIFY( !( m1 == m4 ) );
+  QVERIFY( !( m3 == m4 ) );
+  QVERIFY( !( m1 != m2 ) );
+  QVERIFY( m1 != m3 );
+  QVERIFY( m1 != m4 );
+  QVERIFY( m3 != m4 );
+}
+
+void TestQgsLayoutUnits::assignment()
+{
+  QgsLayoutMeasurement m1( 6.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement m2( 9.0, QgsUnitTypes::LayoutPoints );
+  m2 = m1;
+  QCOMPARE( m2, m1 );
+}
+
+void TestQgsLayoutUnits::operators()
+{
+  // +
+  QgsLayoutMeasurement m1( 6.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement m2 = m1 + 3.0;
+  QCOMPARE( m2.units(), m1.units() );
+  QCOMPARE( m2.length(), 9.0 );
+
+  // +=
+  QgsLayoutMeasurement m4( 6.0, QgsUnitTypes::LayoutInches );
+  m4 += 2.0;
+  QCOMPARE( m4.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( m4.length(), 8.0 );
+
+  // -
+  QgsLayoutMeasurement m3 = m1 - 3.0;
+  QCOMPARE( m3.units(), m1.units() );
+  QCOMPARE( m3.length(), 3.0 );
+
+  // -=
+  QgsLayoutMeasurement m5( 6.0, QgsUnitTypes::LayoutInches );
+  m5 -= 2.0;
+  QCOMPARE( m5.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( m5.length(), 4.0 );
+
+  // *
+  QgsLayoutMeasurement m6 = m1 * 3.0;
+  QCOMPARE( m6.units(), m1.units() );
+  QCOMPARE( m6.length(), 18.0 );
+
+  // *=
+  QgsLayoutMeasurement m7( 6.0, QgsUnitTypes::LayoutInches );
+  m7 *= 2.0;
+  QCOMPARE( m7.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( m7.length(), 12.0 );
+
+  // /
+  QgsLayoutMeasurement m8 = m1 / 3.0;
+  QCOMPARE( m8.units(), m1.units() );
+  QCOMPARE( m8.length(), 2.0 );
+
+  // /=
+  QgsLayoutMeasurement m9( 6.0, QgsUnitTypes::LayoutInches );
+  m9 /= 2.0;
+  QCOMPARE( m9.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( m9.length(), 3.0 );
+}
+
+void TestQgsLayoutUnits::unitTypes()
+{
+  QCOMPARE( QgsUnitTypes::unitType( QgsUnitTypes::LayoutCentimeters ), QgsUnitTypes::LayoutPaperUnits );
+  QCOMPARE( QgsUnitTypes::unitType( QgsUnitTypes::LayoutPixels ), QgsUnitTypes::LayoutScreenUnits );
+}
+
+void TestQgsLayoutUnits::measurementEncodeDecode()
+{
+  QgsLayoutMeasurement original( 6.0, QgsUnitTypes::LayoutPixels );
+  QgsLayoutMeasurement result = QgsLayoutMeasurement::decodeMeasurement( original.encodeMeasurement() );
+  QCOMPARE( original, result );
+
+  //test with bad string
+  result = QgsLayoutMeasurement::decodeMeasurement( QString( "1" ) );
+  QCOMPARE( result, QgsLayoutMeasurement( 0 ) );
+}
+
+void TestQgsLayoutUnits::createSize()
+{
+  QgsLayoutSize defaultUnits( 5.0, 6.0 );
+  //default units should be millimeters
+  QCOMPARE( defaultUnits.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( defaultUnits.width(), 5.0 );
+  QCOMPARE( defaultUnits.height(), 6.0 );
+
+  //test overriding default unit
+  QgsLayoutSize inches( 7.0, 8.0, QgsUnitTypes::LayoutInches );
+  QCOMPARE( inches.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( inches.width(), 7.0 );
+  QCOMPARE( inches.height(), 8.0 );
+
+  //test empty constructor
+  QgsLayoutSize empty( QgsUnitTypes::LayoutPixels );
+  QCOMPARE( empty.units(), QgsUnitTypes::LayoutPixels );
+  QCOMPARE( empty.width(), 0.0 );
+  QCOMPARE( empty.height(), 0.0 );
+}
+
+void TestQgsLayoutUnits::sizeGettersSetters()
+{
+  QgsLayoutSize size( 5.0, 6.0, QgsUnitTypes::LayoutPicas );
+
+  size.setWidth( 9.0 );
+  size.setHeight( 10.0 );
+  QCOMPARE( size.width(), 9.0 );
+  QCOMPARE( size.height(), 10.0 );
+  QCOMPARE( size.units(), QgsUnitTypes::LayoutPicas );
+
+  size.setUnits( QgsUnitTypes::LayoutInches );
+  QCOMPARE( size.width(), 9.0 );
+  QCOMPARE( size.height(), 10.0 );
+  QCOMPARE( size.units(), QgsUnitTypes::LayoutInches );
+
+  size.setSize( 11.0, 12.0 );
+  QCOMPARE( size.width(), 11.0 );
+  QCOMPARE( size.height(), 12.0 );
+  QCOMPARE( size.units(), QgsUnitTypes::LayoutInches );
+}
+
+void TestQgsLayoutUnits::sizeCopyConstructor()
+{
+  QgsLayoutSize source( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutSize dest( source );
+  QCOMPARE( source, dest );
+}
+
+void TestQgsLayoutUnits::sizeEquality()
+{
+  QgsLayoutSize s1( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutSize s2( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutSize s3( 7.0, 8.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutSize s4( 6.0, 7.0, QgsUnitTypes::LayoutPoints );
+
+  QVERIFY( s1 == s2 );
+  QVERIFY( !( s1 == s3 ) );
+  QVERIFY( !( s1 == s4 ) );
+  QVERIFY( !( s3 == s4 ) );
+  QVERIFY( !( s1 != s2 ) );
+  QVERIFY( s1 != s3 );
+  QVERIFY( s1 != s4 );
+  QVERIFY( s3 != s4 );
+}
+
+void TestQgsLayoutUnits::sizeAssignment()
+{
+  QgsLayoutSize s1( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutSize s2( 9.0, 10.0, QgsUnitTypes::LayoutPoints );
+  s2 = s1;
+  QCOMPARE( s2, s1 );
+}
+
+void TestQgsLayoutUnits::sizeOperators()
+{
+  QgsLayoutSize s1( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+
+  // *
+  QgsLayoutSize s2 = s1 * 3.0;
+  QCOMPARE( s2.units(), s1.units() );
+  QCOMPARE( s2.width(), 18.0 );
+  QCOMPARE( s2.height(), 36.0 );
+
+  // *=
+  QgsLayoutSize s3( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  s3 *= 2.0;
+  QCOMPARE( s3.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( s3.width(), 12.0 );
+  QCOMPARE( s3.height(), 24.0 );
+
+  // /
+  QgsLayoutSize s4 = s1 / 3.0;
+  QCOMPARE( s4.units(), s1.units() );
+  QCOMPARE( s4.width(), 2.0 );
+  QCOMPARE( s4.height(), 4.0 );
+
+  // /=
+  QgsLayoutSize s5( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  s5 /= 2.0;
+  QCOMPARE( s5.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( s5.width(), 3.0 );
+  QCOMPARE( s5.height(), 6.0 );
+}
+
+void TestQgsLayoutUnits::isEmpty()
+{
+  QgsLayoutSize size( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  QVERIFY( !size.isEmpty() );
+  size.setSize( 0, 0 );
+  QVERIFY( size.isEmpty() );
+  QgsLayoutSize size2( QgsUnitTypes::LayoutMillimeters ); //test empty constructor
+  QVERIFY( size2.isEmpty() );
+}
+
+void TestQgsLayoutUnits::toQSizeF()
+{
+  QgsLayoutSize size( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  QSizeF converted = size.toQSizeF();
+  QCOMPARE( converted.width(), size.width() );
+  QCOMPARE( converted.height(), size.height() );
+}
+
+void TestQgsLayoutUnits::sizeEncodeDecode()
+{
+  QgsLayoutSize original( 6.0, 12.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutSize result = QgsLayoutSize::decodeSize( original.encodeSize() );
+  QCOMPARE( original, result );
+
+  //test with bad string
+  result = QgsLayoutSize::decodeSize( QString( "1,2" ) );
+  QCOMPARE( result, QgsLayoutSize() );
+}
+
+void TestQgsLayoutUnits::createPoint()
+{
+  QgsLayoutPoint defaultUnits( 5.0, 6.0 );
+  //default units should be millimeters
+  QCOMPARE( defaultUnits.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( defaultUnits.x(), 5.0 );
+  QCOMPARE( defaultUnits.y(), 6.0 );
+
+  //test overriding default unit
+  QgsLayoutPoint inches( 7.0, 8.0, QgsUnitTypes::LayoutInches );
+  QCOMPARE( inches.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( inches.x(), 7.0 );
+  QCOMPARE( inches.y(), 8.0 );
+
+  //test empty constructor
+  QgsLayoutPoint empty( QgsUnitTypes::LayoutPixels );
+  QCOMPARE( empty.units(), QgsUnitTypes::LayoutPixels );
+  QCOMPARE( empty.x(), 0.0 );
+  QCOMPARE( empty.y(), 0.0 );
+}
+
+void TestQgsLayoutUnits::pointGettersSetters()
+{
+  QgsLayoutPoint point( 5.0, 6.0, QgsUnitTypes::LayoutPicas );
+
+  point.setX( 9.0 );
+  point.setY( 10.0 );
+  QCOMPARE( point.x(), 9.0 );
+  QCOMPARE( point.y(), 10.0 );
+  QCOMPARE( point.units(), QgsUnitTypes::LayoutPicas );
+
+  point.setUnits( QgsUnitTypes::LayoutInches );
+  QCOMPARE( point.x(), 9.0 );
+  QCOMPARE( point.y(), 10.0 );
+  QCOMPARE( point.units(), QgsUnitTypes::LayoutInches );
+
+  point.setPoint( 11.0, 12.0 );
+  QCOMPARE( point.x(), 11.0 );
+  QCOMPARE( point.y(), 12.0 );
+  QCOMPARE( point.units(), QgsUnitTypes::LayoutInches );
+}
+
+void TestQgsLayoutUnits::pointCopyConstructor()
+{
+  QgsLayoutPoint source( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutPoint dest( source );
+  QCOMPARE( source, dest );
+}
+
+void TestQgsLayoutUnits::pointEquality()
+{
+  QgsLayoutPoint p1( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutPoint p2( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutPoint p3( 7.0, 8.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutPoint p4( 6.0, 7.0, QgsUnitTypes::LayoutPoints );
+
+  QVERIFY( p1 == p2 );
+  QVERIFY( !( p1 == p3 ) );
+  QVERIFY( !( p1 == p4 ) );
+  QVERIFY( !( p3 == p4 ) );
+  QVERIFY( !( p1 != p2 ) );
+  QVERIFY( p1 != p3 );
+  QVERIFY( p1 != p4 );
+  QVERIFY( p3 != p4 );
+}
+
+void TestQgsLayoutUnits::pointAssignment()
+{
+  QgsLayoutPoint p1( 6.0, 7.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutPoint p2( 9.0, 10.0, QgsUnitTypes::LayoutPoints );
+  p2 = p1;
+  QCOMPARE( p2, p1 );
+}
+
+void TestQgsLayoutUnits::pointOperators()
+{
+  QgsLayoutPoint p1( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+
+  // *
+  QgsLayoutPoint p2 = p1 * 3.0;
+  QCOMPARE( p2.units(), p1.units() );
+  QCOMPARE( p2.x(), 18.0 );
+  QCOMPARE( p2.y(), 36.0 );
+
+  // *=
+  QgsLayoutPoint p3( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  p3 *= 2.0;
+  QCOMPARE( p3.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( p3.x(), 12.0 );
+  QCOMPARE( p3.y(), 24.0 );
+
+  // /
+  QgsLayoutPoint p4 = p1 / 3.0;
+  QCOMPARE( p4.units(), p1.units() );
+  QCOMPARE( p4.x(), 2.0 );
+  QCOMPARE( p4.y(), 4.0 );
+
+  // /=
+  QgsLayoutPoint p5( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  p5 /= 2.0;
+  QCOMPARE( p5.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( p5.x(), 3.0 );
+  QCOMPARE( p5.y(), 6.0 );
+}
+
+void TestQgsLayoutUnits::isNull()
+{
+  QgsLayoutPoint point( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  QVERIFY( !point.isNull() );
+  point.setPoint( 0, 0 );
+  QVERIFY( point.isNull() );
+  QgsLayoutPoint point2( QgsUnitTypes::LayoutMillimeters ); //test empty constructor
+  QVERIFY( point2.isNull() );
+}
+
+void TestQgsLayoutUnits::toQPointF()
+{
+  QgsLayoutPoint point( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  QPointF converted = point.toQPointF();
+  QCOMPARE( converted.x(), point.x() );
+  QCOMPARE( converted.y(), point.y() );
+}
+
+void TestQgsLayoutUnits::pointEncodeDecode()
+{
+  QgsLayoutPoint original( 6.0, 12.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutPoint result = QgsLayoutPoint::decodePoint( original.encodePoint() );
+  QCOMPARE( original, result );
+
+  //test with bad string
+  result = QgsLayoutPoint::decodePoint( QString( "1,2" ) );
+  QCOMPARE( result, QgsLayoutPoint() );
+}
+
+void TestQgsLayoutUnits::converterCreate()
+{
+  QgsLayoutMeasurementConverter *converter = new QgsLayoutMeasurementConverter();
+  QVERIFY( converter );
+  delete converter;
+}
+
+void TestQgsLayoutUnits::converterCopy()
+{
+  QgsLayoutMeasurementConverter source;
+  source.setDpi( 96.0 );
+  QgsLayoutMeasurementConverter copy( source );
+  QCOMPARE( copy.dpi(), source.dpi() );
+}
+
+void TestQgsLayoutUnits::conversionToMM()
+{
+  QgsLayoutMeasurement measurementInMillimeters( 1.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement measurementInCentimeters( 1.0, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement measurementInMeters( 1.0, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInFeet( 1.0, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement measurementInPoints( 1.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement measurementInPicas( 1.0, QgsUnitTypes::LayoutPicas );
+
+  QgsLayoutMeasurementConverter converter;
+  QgsLayoutMeasurement convertedFromMillimeters = converter.convert( measurementInMillimeters, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement convertedFromCentimeters = converter.convert( measurementInCentimeters, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement convertedFromMeters = converter.convert( measurementInMeters, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement convertedFromInches = converter.convert( measurementInInches, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement convertedFromFeet = converter.convert( measurementInFeet, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement convertedFromPoints = converter.convert( measurementInPoints, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement convertedFromPicas = converter.convert( measurementInPicas, QgsUnitTypes::LayoutMillimeters );
+
+  QCOMPARE( convertedFromMillimeters.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedFromCentimeters.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedFromMeters.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedFromInches.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedFromFeet.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedFromPoints.units(), QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedFromPicas.units(), QgsUnitTypes::LayoutMillimeters );
+
+  QCOMPARE( convertedFromMillimeters.length(), 1.0 );
+  QCOMPARE( convertedFromCentimeters.length(), 10.0 );
+  QCOMPARE( convertedFromMeters.length(), 1000.0 );
+  QCOMPARE( convertedFromInches.length(), 25.4 );
+  QCOMPARE( convertedFromFeet.length(), 304.8 );
+  QCOMPARE( convertedFromPoints.length(), 0.352777778 );
+  QCOMPARE( convertedFromPicas.length(), 4.23333333 );
+}
+
+void TestQgsLayoutUnits::conversionToCM()
+{
+  QgsLayoutMeasurement measurementInMillimeters( 1.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement measurementInCentimeters( 1.0, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement measurementInMeters( 1.0, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInFeet( 1.0, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement measurementInPoints( 1.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement measurementInPicas( 1.0, QgsUnitTypes::LayoutPicas );
+
+  QgsLayoutMeasurementConverter converter;
+  QgsLayoutMeasurement convertedFromMillimeters = converter.convert( measurementInMillimeters, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement convertedFromCentimeters = converter.convert( measurementInCentimeters, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement convertedFromMeters = converter.convert( measurementInMeters, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement convertedFromInches = converter.convert( measurementInInches, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement convertedFromFeet = converter.convert( measurementInFeet, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement convertedFromPoints = converter.convert( measurementInPoints, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement convertedFromPicas = converter.convert( measurementInPicas, QgsUnitTypes::LayoutCentimeters );
+
+  QCOMPARE( convertedFromMillimeters.units(), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedFromCentimeters.units(), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedFromMeters.units(), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedFromInches.units(), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedFromFeet.units(), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedFromPoints.units(), QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedFromPicas.units(), QgsUnitTypes::LayoutCentimeters );
+
+  QCOMPARE( convertedFromMillimeters.length(), 0.1 );
+  QCOMPARE( convertedFromCentimeters.length(), 1.0 );
+  QCOMPARE( convertedFromMeters.length(), 100.0 );
+  QCOMPARE( convertedFromInches.length(), 2.54 );
+  QCOMPARE( convertedFromFeet.length(), 30.48 );
+  QCOMPARE( convertedFromPoints.length(), 0.0352777778 );
+  QCOMPARE( convertedFromPicas.length(), 0.423333333 );
+}
+
+void TestQgsLayoutUnits::conversionToM()
+{
+  QgsLayoutMeasurement measurementInMillimeters( 1.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement measurementInCentimeters( 1.0, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement measurementInMeters( 1.0, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInFeet( 1.0, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement measurementInPoints( 1.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement measurementInPicas( 1.0, QgsUnitTypes::LayoutPicas );
+
+  QgsLayoutMeasurementConverter converter;
+  QgsLayoutMeasurement convertedFromMillimeters = converter.convert( measurementInMillimeters, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement convertedFromCentimeters = converter.convert( measurementInCentimeters, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement convertedFromMeters = converter.convert( measurementInMeters, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement convertedFromInches = converter.convert( measurementInInches, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement convertedFromFeet = converter.convert( measurementInFeet, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement convertedFromPoints = converter.convert( measurementInPoints, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement convertedFromPicas = converter.convert( measurementInPicas, QgsUnitTypes::LayoutMeters );
+
+  QCOMPARE( convertedFromMillimeters.units(), QgsUnitTypes::LayoutMeters );
+  QCOMPARE( convertedFromCentimeters.units(), QgsUnitTypes::LayoutMeters );
+  QCOMPARE( convertedFromMeters.units(), QgsUnitTypes::LayoutMeters );
+  QCOMPARE( convertedFromInches.units(), QgsUnitTypes::LayoutMeters );
+  QCOMPARE( convertedFromFeet.units(), QgsUnitTypes::LayoutMeters );
+  QCOMPARE( convertedFromPoints.units(), QgsUnitTypes::LayoutMeters );
+  QCOMPARE( convertedFromPicas.units(), QgsUnitTypes::LayoutMeters );
+
+  QCOMPARE( convertedFromMillimeters.length(), 0.001 );
+  QCOMPARE( convertedFromCentimeters.length(), 0.01 );
+  QCOMPARE( convertedFromMeters.length(), 1.0 );
+  QCOMPARE( convertedFromInches.length(), 0.0254 );
+  QCOMPARE( convertedFromFeet.length(), 0.3048 );
+  QCOMPARE( convertedFromPoints.length(), 0.000352777778 );
+  QCOMPARE( convertedFromPicas.length(), 0.00423333333 );
+}
+
+void TestQgsLayoutUnits::conversionToInches()
+{
+  QgsLayoutMeasurement measurementInMillimeters( 1.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement measurementInCentimeters( 1.0, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement measurementInMeters( 1.0, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInFeet( 1.0, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement measurementInPoints( 1.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement measurementInPicas( 1.0, QgsUnitTypes::LayoutPicas );
+
+  QgsLayoutMeasurementConverter converter;
+  QgsLayoutMeasurement convertedFromMillimeters = converter.convert( measurementInMillimeters, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement convertedFromCentimeters = converter.convert( measurementInCentimeters, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement convertedFromMeters = converter.convert( measurementInMeters, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement convertedFromInches = converter.convert( measurementInInches, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement convertedFromFeet = converter.convert( measurementInFeet, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement convertedFromPoints = converter.convert( measurementInPoints, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement convertedFromPicas = converter.convert( measurementInPicas, QgsUnitTypes::LayoutInches );
+
+  QCOMPARE( convertedFromMillimeters.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedFromCentimeters.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedFromMeters.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedFromInches.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedFromFeet.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedFromPoints.units(), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedFromPicas.units(), QgsUnitTypes::LayoutInches );
+
+  QVERIFY( qgsDoubleNear( convertedFromMillimeters.length(), 0.0393701, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromCentimeters.length(), 0.3937008, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromMeters.length(), 39.3700787, 0.000001 ) );
+  QCOMPARE( convertedFromInches.length(), 1.0 );
+  QCOMPARE( convertedFromFeet.length(), 12.0 );
+  QVERIFY( qgsDoubleNear( convertedFromPoints.length(), 0.0138888889, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromPicas.length(), 0.166666667, 0.000001 ) );
+}
+
+void TestQgsLayoutUnits::conversionToFeet()
+{
+  QgsLayoutMeasurement measurementInMillimeters( 1.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement measurementInCentimeters( 1.0, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement measurementInMeters( 1.0, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInFeet( 1.0, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement measurementInPoints( 1.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement measurementInPicas( 1.0, QgsUnitTypes::LayoutPicas );
+
+  QgsLayoutMeasurementConverter converter;
+  QgsLayoutMeasurement convertedFromMillimeters = converter.convert( measurementInMillimeters, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement convertedFromCentimeters = converter.convert( measurementInCentimeters, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement convertedFromMeters = converter.convert( measurementInMeters, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement convertedFromInches = converter.convert( measurementInInches, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement convertedFromFeet = converter.convert( measurementInFeet, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement convertedFromPoints = converter.convert( measurementInPoints, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement convertedFromPicas = converter.convert( measurementInPicas, QgsUnitTypes::LayoutFeet );
+
+  QCOMPARE( convertedFromMillimeters.units(), QgsUnitTypes::LayoutFeet );
+  QCOMPARE( convertedFromCentimeters.units(), QgsUnitTypes::LayoutFeet );
+  QCOMPARE( convertedFromMeters.units(), QgsUnitTypes::LayoutFeet );
+  QCOMPARE( convertedFromInches.units(), QgsUnitTypes::LayoutFeet );
+  QCOMPARE( convertedFromFeet.units(), QgsUnitTypes::LayoutFeet );
+  QCOMPARE( convertedFromPoints.units(), QgsUnitTypes::LayoutFeet );
+  QCOMPARE( convertedFromPicas.units(), QgsUnitTypes::LayoutFeet );
+
+  QVERIFY( qgsDoubleNear( convertedFromMillimeters.length(), 0.0032808399, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromCentimeters.length(), 0.032808399, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromMeters.length(), 3.2808399, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromInches.length(), 0.0833333, 0.000001 ) );
+  QCOMPARE( convertedFromFeet.length(), 1.0 );
+  QVERIFY( qgsDoubleNear( convertedFromPoints.length(), 0.00115740741, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromPicas.length(), 0.0138888889, 0.000001 ) );
+}
+
+void TestQgsLayoutUnits::conversionToPoints()
+{
+  QgsLayoutMeasurement measurementInMillimeters( 1.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement measurementInCentimeters( 1.0, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement measurementInMeters( 1.0, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInFeet( 1.0, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement measurementInPoints( 1.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement measurementInPicas( 1.0, QgsUnitTypes::LayoutPicas );
+
+  QgsLayoutMeasurementConverter converter;
+  QgsLayoutMeasurement convertedFromMillimeters = converter.convert( measurementInMillimeters, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement convertedFromCentimeters = converter.convert( measurementInCentimeters, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement convertedFromMeters = converter.convert( measurementInMeters, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement convertedFromInches = converter.convert( measurementInInches, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement convertedFromFeet = converter.convert( measurementInFeet, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement convertedFromPoints = converter.convert( measurementInPoints, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement convertedFromPicas = converter.convert( measurementInPicas, QgsUnitTypes::LayoutPoints );
+
+  QCOMPARE( convertedFromMillimeters.units(), QgsUnitTypes::LayoutPoints );
+  QCOMPARE( convertedFromCentimeters.units(), QgsUnitTypes::LayoutPoints );
+  QCOMPARE( convertedFromMeters.units(), QgsUnitTypes::LayoutPoints );
+  QCOMPARE( convertedFromInches.units(), QgsUnitTypes::LayoutPoints );
+  QCOMPARE( convertedFromFeet.units(), QgsUnitTypes::LayoutPoints );
+  QCOMPARE( convertedFromPoints.units(), QgsUnitTypes::LayoutPoints );
+  QCOMPARE( convertedFromPicas.units(), QgsUnitTypes::LayoutPoints );
+
+  QVERIFY( qgsDoubleNear( convertedFromMillimeters.length(), 2.83464567, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromCentimeters.length(), 28.3464567, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromMeters.length(), 2834.64567, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromInches.length(), 72.0, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromFeet.length(), 864.0, 0.000001 ) );
+  QCOMPARE( convertedFromPoints.length(), 1.0 );
+  QVERIFY( qgsDoubleNear( convertedFromPicas.length(), 12.0, 0.000001 ) );
+}
+
+void TestQgsLayoutUnits::conversionToPicas()
+{
+  QgsLayoutMeasurement measurementInMillimeters( 1.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurement measurementInCentimeters( 1.0, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutMeasurement measurementInMeters( 1.0, QgsUnitTypes::LayoutMeters );
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInFeet( 1.0, QgsUnitTypes::LayoutFeet );
+  QgsLayoutMeasurement measurementInPoints( 1.0, QgsUnitTypes::LayoutPoints );
+  QgsLayoutMeasurement measurementInPicas( 1.0, QgsUnitTypes::LayoutPicas );
+
+  QgsLayoutMeasurementConverter converter;
+  QgsLayoutMeasurement convertedFromMillimeters = converter.convert( measurementInMillimeters, QgsUnitTypes::LayoutPicas );
+  QgsLayoutMeasurement convertedFromCentimeters = converter.convert( measurementInCentimeters, QgsUnitTypes::LayoutPicas );
+  QgsLayoutMeasurement convertedFromMeters = converter.convert( measurementInMeters, QgsUnitTypes::LayoutPicas );
+  QgsLayoutMeasurement convertedFromInches = converter.convert( measurementInInches, QgsUnitTypes::LayoutPicas );
+  QgsLayoutMeasurement convertedFromFeet = converter.convert( measurementInFeet, QgsUnitTypes::LayoutPicas );
+  QgsLayoutMeasurement convertedFromPoints = converter.convert( measurementInPoints, QgsUnitTypes::LayoutPicas );
+  QgsLayoutMeasurement convertedFromPicas = converter.convert( measurementInPicas, QgsUnitTypes::LayoutPicas );
+
+  QCOMPARE( convertedFromMillimeters.units(), QgsUnitTypes::LayoutPicas );
+  QCOMPARE( convertedFromCentimeters.units(), QgsUnitTypes::LayoutPicas );
+  QCOMPARE( convertedFromMeters.units(), QgsUnitTypes::LayoutPicas );
+  QCOMPARE( convertedFromInches.units(), QgsUnitTypes::LayoutPicas );
+  QCOMPARE( convertedFromFeet.units(), QgsUnitTypes::LayoutPicas );
+  QCOMPARE( convertedFromPoints.units(), QgsUnitTypes::LayoutPicas );
+  QCOMPARE( convertedFromPicas.units(), QgsUnitTypes::LayoutPicas );
+
+  QVERIFY( qgsDoubleNear( convertedFromMillimeters.length(), 0.236220472, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromCentimeters.length(), 2.36220472, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromMeters.length(), 236.220472, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromInches.length(), 6.0, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromFeet.length(), 72.0, 0.000001 ) );
+  QVERIFY( qgsDoubleNear( convertedFromPoints.length(), 0.0833333333, 0.000001 ) );
+  QCOMPARE( convertedFromPicas.length(), 1.0 );
+}
+
+void TestQgsLayoutUnits::converterGettersSetters()
+{
+  QgsLayoutMeasurementConverter converter;
+  converter.setDpi( 96.0 );
+  QCOMPARE( converter.dpi(), 96.0 );
+}
+
+void TestQgsLayoutUnits::conversionFromPixels()
+{
+  QgsLayoutMeasurement measurementInPixels( 300.0, QgsUnitTypes::LayoutPixels );
+
+  QgsLayoutMeasurementConverter converter;
+  //try initially with 300 dpi
+  converter.setDpi( 300.0 );
+  QgsLayoutMeasurement convertedToInches = converter.convert( measurementInPixels, QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedToInches.units(), QgsUnitTypes::LayoutInches );
+  QVERIFY( qgsDoubleNear( convertedToInches.length(), 1.0, 0.000001 ) );
+  QgsLayoutMeasurement convertedToMM = converter.convert( measurementInPixels, QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedToMM.units(), QgsUnitTypes::LayoutMillimeters );
+  QVERIFY( qgsDoubleNear( convertedToMM.length(), 25.4, 0.000001 ) );
+
+  //try with 96 dpi
+  converter.setDpi( 96.0 );
+  convertedToInches = converter.convert( measurementInPixels, QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedToInches.units(), QgsUnitTypes::LayoutInches );
+  QVERIFY( qgsDoubleNear( convertedToInches.length(), 3.125, 0.000001 ) );
+  convertedToMM = converter.convert( measurementInPixels, QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedToMM.units(), QgsUnitTypes::LayoutMillimeters );
+  QVERIFY( qgsDoubleNear( convertedToMM.length(), 79.375, 0.000001 ) );
+}
+
+void TestQgsLayoutUnits::conversionToPixels()
+{
+  QgsLayoutMeasurement measurementInInches( 1.0, QgsUnitTypes::LayoutInches );
+  QgsLayoutMeasurement measurementInMM( 1.0, QgsUnitTypes::LayoutMillimeters );
+
+  QgsLayoutMeasurementConverter converter;
+  //try initially with 300 dpi
+  converter.setDpi( 300.0 );
+  QgsLayoutMeasurement convertedToPixels = converter.convert( measurementInInches, QgsUnitTypes::LayoutPixels );
+  QCOMPARE( convertedToPixels.units(), QgsUnitTypes::LayoutPixels );
+  QVERIFY( qgsDoubleNear( convertedToPixels.length(), 300.0, 0.000001 ) );
+  convertedToPixels = converter.convert( measurementInMM, QgsUnitTypes::LayoutPixels );
+  QCOMPARE( convertedToPixels.units(), QgsUnitTypes::LayoutPixels );
+  QVERIFY( qgsDoubleNear( convertedToPixels.length(), 11.811023622, 0.000001 ) );
+
+  //try with 96 dpi
+  converter.setDpi( 96.0 );
+  convertedToPixels = converter.convert( measurementInInches, QgsUnitTypes::LayoutPixels );
+  QCOMPARE( convertedToPixels.units(), QgsUnitTypes::LayoutPixels );
+  QVERIFY( qgsDoubleNear( convertedToPixels.length(), 96.0, 0.000001 ) );
+  convertedToPixels = converter.convert( measurementInMM, QgsUnitTypes::LayoutPixels );
+  QCOMPARE( convertedToPixels.units(), QgsUnitTypes::LayoutPixels );
+  QVERIFY( qgsDoubleNear( convertedToPixels.length(), 3.77952755906, 0.000001 ) );
+}
+
+void TestQgsLayoutUnits::sizeConversion()
+{
+  QgsLayoutSize sizeInMM( 1.0, 2.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurementConverter converter;
+
+  //test conversion to same units
+  QgsLayoutSize convertedSize = converter.convert( sizeInMM, QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedSize, sizeInMM );
+
+  //convert to other units
+  convertedSize = converter.convert( sizeInMM, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutSize expectedSize( 0.1, 0.2, QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedSize, expectedSize );
+
+  //pixel conversion
+  converter.setDpi( 96.0 );
+  QgsLayoutSize convertedToInches = converter.convert( QgsLayoutSize( 96, 192, QgsUnitTypes::LayoutPixels ), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedToInches.width(), 1.0 );
+  QCOMPARE( convertedToInches.height(), 2.0 );
+  QCOMPARE( convertedToInches.units(), QgsUnitTypes::LayoutInches );
+}
+
+void TestQgsLayoutUnits::pointConversion()
+{
+  QgsLayoutPoint pointInMM( 1.0, 2.0, QgsUnitTypes::LayoutMillimeters );
+  QgsLayoutMeasurementConverter converter;
+
+  //test conversion to same units
+  QgsLayoutPoint convertedPoint = converter.convert( pointInMM, QgsUnitTypes::LayoutMillimeters );
+  QCOMPARE( convertedPoint, pointInMM );
+
+  //convert to other units
+  convertedPoint = converter.convert( pointInMM, QgsUnitTypes::LayoutCentimeters );
+  QgsLayoutPoint expectedPoint( 0.1, 0.2, QgsUnitTypes::LayoutCentimeters );
+  QCOMPARE( convertedPoint, expectedPoint );
+
+  //pixel conversion
+  converter.setDpi( 96.0 );
+  QgsLayoutPoint convertedToInches = converter.convert( QgsLayoutPoint( 96, 192, QgsUnitTypes::LayoutPixels ), QgsUnitTypes::LayoutInches );
+  QCOMPARE( convertedToInches.x(), 1.0 );
+  QCOMPARE( convertedToInches.y(), 2.0 );
+  QCOMPARE( convertedToInches.units(), QgsUnitTypes::LayoutInches );
+}
+
+QTEST_MAIN( TestQgsLayoutUnits )
+#include "testqgslayoutunits.moc"

--- a/tests/src/python/test_qgsunittypes.py
+++ b/tests/src/python/test_qgsunittypes.py
@@ -630,6 +630,33 @@ class TestQgsUnitTypes(unittest.TestCase):
         self.assertEqual(QgsUnitTypes.formatAngle(1, 2, QgsUnitTypes.AngleTurn), '1.00 tr')
         self.assertEqual(QgsUnitTypes.formatAngle(1, 2, QgsUnitTypes.AngleUnknownUnit), '1.00')
 
+    def testEncodeDecodeLayoutUnits(self):
+        """Test encoding and decoding layout units"""
+        units = [QgsUnitTypes.LayoutMillimeters,
+                 QgsUnitTypes.LayoutCentimeters,
+                 QgsUnitTypes.LayoutMeters,
+                 QgsUnitTypes.LayoutInches,
+                 QgsUnitTypes.LayoutFeet,
+                 QgsUnitTypes.LayoutPoints,
+                 QgsUnitTypes.LayoutPicas,
+                 QgsUnitTypes.LayoutPixels]
+
+        for u in units:
+            res, ok = QgsUnitTypes.decodeLayoutUnit(QgsUnitTypes.encodeUnit(u))
+            assert ok
+            self.assertEqual(res, u)
+
+        # Test decoding bad units
+        res, ok = QgsUnitTypes.decodeLayoutUnit('bad')
+        self.assertFalse(ok)
+        # default units should be MM
+        self.assertEqual(res, QgsUnitTypes.LayoutMillimeters)
+
+        # Test that string is cleaned before decoding
+        res, ok = QgsUnitTypes.decodeLayoutUnit(' px  ')
+        assert ok
+        self.assertEqual(res, QgsUnitTypes.LayoutPixels)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
_Instead of dumping thousands of lines of new code in a single PR, I'm instead going to "drip-feed" the new layout work into master. These changes are all self contained and there's no risk of breaking existing composer funcionality while I do this. I'd prefer this approach as it makes reviewing more manageable, and hopefully encourages feedback on each section as I open PRs for them..._

These classes are used for storing measurements for a layout (QgsLayoutMeasurement), sizes for a layout (QgsLayoutSize) and points in a layout (QgsLayoutPoint)

They support storing a measurement unit alongside a measurement length/size. A new class QgsLayoutMeasurementConverter handles conversion between different units, including converting to and from pixels via a specified DPI property.
