### PR TITLE
WMS Server: Feature info with geometry filter

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -717,9 +717,9 @@ namespace QgsWms
 
     //read FILTER_GEOM
     std::unique_ptr<QgsGeometry> filterGeom;
-    if( mParameters.contains( QStringLiteral( "FILTER_GEOM" ) ) )
+    if ( mParameters.contains( QStringLiteral( "FILTER_GEOM" ) ) )
     {
-        filterGeom.reset( new QgsGeometry( QgsGeometry::fromWkt( mParameters.value( QStringLiteral( "FILTER_GEOM" ) ) ) ) );
+      filterGeom.reset( new QgsGeometry( QgsGeometry::fromWkt( mParameters.value( QStringLiteral( "FILTER_GEOM" ) ) ) ) );
     }
 
     //In case the output image is distorted (WIDTH/HEIGHT ratio not equal to BBOX width/height), I and J need to be adapted as well
@@ -743,7 +743,7 @@ namespace QgsWms
       {
         featuresRect.reset( new QgsRectangle() );
       }
-      else if( !filterGeom.get() )
+      else if ( !filterGeom.get() )
       {
         throw QgsBadRequestException( QStringLiteral( "ParameterMissing" ),
                                       QStringLiteral( "I/J parameters are required for GetFeatureInfo" ) );
@@ -1254,7 +1254,7 @@ namespace QgsWms
       const QString &version,
       const QString &infoFormat,
       QgsRectangle *featureBBox,
-      QgsGeometry* filterGeom ) const
+      QgsGeometry *filterGeom ) const
   {
     if ( !layer )
     {
@@ -1273,7 +1273,7 @@ namespace QgsWms
     {
       searchRect = featureInfoSearchRect( layer, mapSettings, renderContext, *infoPoint );
     }
-    else if( filterGeom )
+    else if ( filterGeom )
     {
       searchRect = filterGeom->boundingBox();
     }
@@ -1306,9 +1306,9 @@ namespace QgsWms
       fReq.setFlags( fReq.flags() & ~ QgsFeatureRequest::ExactIntersect );
     }
 
-    if( filterGeom )
+    if ( filterGeom )
     {
-        fReq.setFilterExpression( QString("intersects( $geometry, geom_from_wkt('%1') )").arg( filterGeom->exportToWkt() ) );
+      fReq.setFilterExpression( QString( "intersects( $geometry, geom_from_wkt('%1') )" ).arg( filterGeom->exportToWkt() ) );
     }
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -715,6 +715,17 @@ namespace QgsWms
       j = -1;
     }
 
+    //read FILTER_GEOM
+    QgsGeometry* filterGeom = 0;
+    if( mParameters.contains( QStringLiteral( "FILTER_GEOM" ) ) )
+    {
+        filterGeom = new QgsGeometry( QgsGeometry::fromWkt( mParameters.value( QStringLiteral( "FILTER_GEOM" ) ) ) );
+        if( filterGeom->isNull() )
+        {
+            delete filterGeom; filterGeom = nullptr;
+        }
+    }
+
     //In case the output image is distorted (WIDTH/HEIGHT ratio not equal to BBOX width/height), I and J need to be adapted as well
     int widthParam = mParameters.value( "WIDTH", "-1" ).toInt();
     int heightParam = mParameters.value( "HEIGHT", "-1" ).toInt();
@@ -736,7 +747,7 @@ namespace QgsWms
       {
         featuresRect.reset( new QgsRectangle() );
       }
-      else
+      else if( !filterGeom )
       {
         throw QgsBadRequestException( QStringLiteral( "ParameterMissing" ),
                                       QStringLiteral( "I/J parameters are required for GetFeatureInfo" ) );
@@ -871,7 +882,7 @@ namespace QgsWms
 
         if ( vectorLayer )
         {
-          if ( !featureInfoFromVectorLayer( vectorLayer, infoPoint.get(), featureCount, result, layerElement, mapSettings, renderContext, version, infoFormat, featuresRect.get() ) )
+          if ( !featureInfoFromVectorLayer( vectorLayer, infoPoint.get(), featureCount, result, layerElement, mapSettings, renderContext, version, infoFormat, featuresRect.get(), filterGeom ) )
           {
             continue;
           }
@@ -1246,7 +1257,8 @@ namespace QgsWms
       QgsRenderContext &renderContext,
       const QString &version,
       const QString &infoFormat,
-      QgsRectangle *featureBBox ) const
+      QgsRectangle *featureBBox,
+      QgsGeometry* filterGeom ) const
   {
     if ( !layer )
     {
@@ -1265,6 +1277,10 @@ namespace QgsWms
     {
       searchRect = featureInfoSearchRect( layer, mapSettings, renderContext, *infoPoint );
     }
+    else if( filterGeom )
+    {
+      searchRect = filterGeom->boundingBox();
+    }
     else if ( mParameters.contains( QStringLiteral( "BBOX" ) ) )
     {
       searchRect = layerRect;
@@ -1282,7 +1298,7 @@ namespace QgsWms
     const QSet<QString> &excludedAttributes = layer->excludeAttributesWms();
 
     QgsFeatureRequest fReq;
-    bool hasGeometry = addWktGeometry || featureBBox;
+    bool hasGeometry = addWktGeometry || featureBBox || filterGeom;
     fReq.setFlags( ( ( hasGeometry ) ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry ) | QgsFeatureRequest::ExactIntersect );
 
     if ( ! searchRect.isEmpty() )
@@ -1292,6 +1308,11 @@ namespace QgsWms
     else
     {
       fReq.setFlags( fReq.flags() & ~ QgsFeatureRequest::ExactIntersect );
+    }
+
+    if( filterGeom )
+    {
+        fReq.setFilterExpression( QString("intersects( $geometry, geom_from_wkt('%1') )").arg( filterGeom->exportToWkt() ) );
     }
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -716,14 +716,10 @@ namespace QgsWms
     }
 
     //read FILTER_GEOM
-    QgsGeometry* filterGeom = 0;
+    std::unique_ptr<QgsGeometry> filterGeom;
     if( mParameters.contains( QStringLiteral( "FILTER_GEOM" ) ) )
     {
-        filterGeom = new QgsGeometry( QgsGeometry::fromWkt( mParameters.value( QStringLiteral( "FILTER_GEOM" ) ) ) );
-        if( filterGeom->isNull() )
-        {
-            delete filterGeom; filterGeom = nullptr;
-        }
+        filterGeom.reset( new QgsGeometry( QgsGeometry::fromWkt( mParameters.value( QStringLiteral( "FILTER_GEOM" ) ) ) ) );
     }
 
     //In case the output image is distorted (WIDTH/HEIGHT ratio not equal to BBOX width/height), I and J need to be adapted as well
@@ -747,7 +743,7 @@ namespace QgsWms
       {
         featuresRect.reset( new QgsRectangle() );
       }
-      else if( !filterGeom )
+      else if( !filterGeom.get() )
       {
         throw QgsBadRequestException( QStringLiteral( "ParameterMissing" ),
                                       QStringLiteral( "I/J parameters are required for GetFeatureInfo" ) );
@@ -882,7 +878,7 @@ namespace QgsWms
 
         if ( vectorLayer )
         {
-          if ( !featureInfoFromVectorLayer( vectorLayer, infoPoint.get(), featureCount, result, layerElement, mapSettings, renderContext, version, infoFormat, featuresRect.get(), filterGeom ) )
+          if ( !featureInfoFromVectorLayer( vectorLayer, infoPoint.get(), featureCount, result, layerElement, mapSettings, renderContext, version, infoFormat, featuresRect.get(), filterGeom.get() ) )
           {
             continue;
           }

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -224,7 +224,7 @@ namespace QgsWms
                                        const QString &version,
                                        const QString &infoFormat,
                                        QgsRectangle *featureBBox = nullptr,
-                                       QgsGeometry* filterGeom = nullptr ) const;
+                                       QgsGeometry *filterGeom = nullptr ) const;
       //! Appends feature info xml for the layer to the layer element of the dom document
       bool featureInfoFromRasterLayer( QgsRasterLayer *layer,
                                        const QgsMapSettings &mapSettings,

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -223,7 +223,8 @@ namespace QgsWms
                                        QgsRenderContext &renderContext,
                                        const QString &version,
                                        const QString &infoFormat,
-                                       QgsRectangle *featureBBox = nullptr ) const;
+                                       QgsRectangle *featureBBox = nullptr,
+                                       QgsGeometry* filterGeom = nullptr ) const;
       //! Appends feature info xml for the layer to the layer element of the dom document
       bool featureInfoFromRasterLayer( QgsRasterLayer *layer,
                                        const QgsMapSettings &mapSettings,

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -125,7 +125,7 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'query_layers=testlayer%20%C3%A8%C3%A9&' +
                                  'FEATURE_COUNT=10&FILTER=testlayer%20%C3%A8%C3%A9' + urllib.parse.quote(':"NAME" = \'two\' OR "utf8nameè" = \'three èé↓\''),
                                  'wms_getfeatureinfo_filter_or_utf8')
-        
+
         # Test feature info request with filter geometry
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&' +

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -125,6 +125,15 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'query_layers=testlayer%20%C3%A8%C3%A9&' +
                                  'FEATURE_COUNT=10&FILTER=testlayer%20%C3%A8%C3%A9' + urllib.parse.quote(':"NAME" = \'two\' OR "utf8nameè" = \'three èé↓\''),
                                  'wms_getfeatureinfo_filter_or_utf8')
+        
+        # Test feature info request with filter geometry
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=text%2Fxml&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&FILTER_GEOM=POLYGON((8.2035381 44.901459,8.2035562 44.901459,8.2035562 44.901418,8.2035381 44.901418,8.2035381 44.901459))',
+                                 'wms_getfeatureinfo_geometry_filter')
 
         # Test DescribeLayer
         self.wms_request_compare('DescribeLayer',

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter.txt
@@ -1,0 +1,14 @@
+Content-Length: 261
+Content-Type: text/xml; charset=utf-8
+
+<GetFeatureInfoResponse>
+ <Layer name="testlayer èé">
+  <Feature id="1">
+   <Attribute name="id" value="2"/>
+   <Attribute name="name" value="two"/>
+   <Attribute name="utf8nameè" value="two àò"/>
+   <BoundingBox CRS="EPSG:3857" minx="913214.6741" maxx="913214.6741" miny="5606017.8743" maxy="5606017.8743"/>
+   <Attribute name="geometry" value="Point (913214.6741 5606017.8743)" type="derived"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>


### PR DESCRIPTION
Sometimes, web clients need to provide a feature identify tool that drags a rectangle (or another geometry shape). In WMS, there is however only the possibility of doing a GetFeatureInfo request with a I/J pixel coordinate. This PR introduces a new parameter (FILTER_GEOM) such that GetFeatureInfo returns the features intersecting the provided geometry. 