### PR TITLE
Allow keyword arguments for all arguments in PyQGIS bindings

### DIFF
--- a/python/analysis/analysis.sip
+++ b/python/analysis/analysis.sip
@@ -1,5 +1,5 @@
 %Module(name=qgis._analysis,
-        keyword_arguments="Optional")
+        keyword_arguments="All")
 
 %Import QtCore/QtCoremod.sip
 %Import QtGui/QtGuimod.sip

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -1,5 +1,5 @@
 %Module(name=qgis._core,
-        keyword_arguments="Optional")
+        keyword_arguments="All")
 
 %ModuleCode
 

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -1,5 +1,5 @@
 %Module(name=qgis._gui,
-        keyword_arguments="Optional")
+        keyword_arguments="All")
 
 %Feature HAVE_QSCI_SIP
 

--- a/python/server/server.sip
+++ b/python/server/server.sip
@@ -1,5 +1,5 @@
 %Module(name=qgis._server,
-        keyword_arguments="Optional")
+        keyword_arguments="All")
 
 
 %Import QtCore/QtCoremod.sip


### PR DESCRIPTION
Previously this was only enabled for optional arguments (i.e. those with default values). Enabling them for all arguments allows for more readable PyQGIS code, and there seems no downside given that we already have this support partly enabled.

The consequence of this change is that when 3.0 API is frozen the freeze must also include the naming of function arguments, since that's effectively now part of public API.

This was recently discussed on the qgis-dev mailing list with widespread support.