### PR TITLE
Forward port Sourcepole's work on map panning previews

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -639,10 +639,7 @@ void QgsMapCanvas::rendererJobFinished()
 void QgsMapCanvas::previewJobFinished()
 {
   QgsMapRendererQImageJob *job = qobject_cast<QgsMapRendererQImageJob *>( sender() );
-  if ( !job )
-  {
-    return;
-  }
+  Q_ASSERT( job );
 
   if ( mMap )
   {
@@ -2166,8 +2163,8 @@ void QgsMapCanvas::startPreviewJobs()
 
 void QgsMapCanvas::stopPreviewJobs()
 {
-  QList< QgsMapRendererQImageJob * >::iterator it = mPreviewJobs.begin();
-  for ( ; it != mPreviewJobs.end(); ++it )
+  QList< QgsMapRendererQImageJob * >::const_iterator it = mPreviewJobs.constBegin();
+  for ( ; it != mPreviewJobs.constEnd(); ++it )
   {
     if ( *it )
     {

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2157,7 +2157,7 @@ void QgsMapCanvas::startPreviewJobs()
 
       QgsMapRendererQImageJob *job = new QgsMapRendererParallelJob( jobSettings );
       mPreviewJobs.append( job );
-      connect( job, SIGNAL( finished() ), this, SLOT( previewJobFinished() ) );
+      connect( job, &QgsMapRendererJob::finished, this, &QgsMapCanvas::previewJobFinished );
       job->start();
     }
   }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2154,6 +2154,7 @@ void QgsMapCanvas::startPreviewJobs()
       jobExtent.setYMinimum( jobExtent.yMinimum() + dy );
 
       jobSettings.setExtent( jobExtent );
+      jobSettings.setFlag( QgsMapSettings::DrawLabeling, false );
 
       QgsMapRendererQImageJob *job = new QgsMapRendererParallelJob( jobSettings );
       mPreviewJobs.append( job );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2171,9 +2171,10 @@ void QgsMapCanvas::stopPreviewJobs()
   {
     if ( *it )
     {
-      ( *it )->cancel();
+      disconnect( *it, &QgsMapRendererJob::finished, this, &QgsMapCanvas::previewJobFinished );
+      connect( *it, &QgsMapRendererQImageJob::finished, *it, &QgsMapRendererQImageJob::deleteLater );
+      ( *it )->cancelWithoutBlocking();
     }
-    delete ( *it );
   }
   mPreviewJobs.clear();
 }

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -586,6 +586,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! called when a renderer job has finished successfully or when it was canceled
     void rendererJobFinished();
 
+    //! called when a preview job has been finished
+    void previewJobFinished();
+
     void mapUpdateTimeout();
 
     void refreshMap();
@@ -820,6 +823,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     QgsSnappingUtils *mSnappingUtils = nullptr;
 
+    QList< QgsMapRendererQImageJob * > mPreviewJobs;
+
     //! lock the scale, so zooming can be performed using magnication
     bool mScaleLocked;
 
@@ -867,6 +872,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     bool boundingBoxOfFeatureIds( const QgsFeatureIds &ids, QgsVectorLayer *layer, QgsRectangle &bbox, QString &errorMsg ) const;
 
     void setLayersPrivate( const QList<QgsMapLayer *> &layers );
+
+    void startPreviewJobs();
+    void stopPreviewJobs();
 
     friend class TestQgsMapCanvas;
 

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -70,17 +70,17 @@ void QgsMapCanvasMap::paint( QPainter *painter )
 
   /*Offset between 0/0 and mRect.xMinimum/mRect.yMinimum.
   We need to consider the offset, because mRect is not updated yet and there might be an offset*/
-  QgsPoint pt = toMapCoordinates( QPoint( 0, 0 ) );
+  QgsPointXY pt = toMapCoordinates( QPoint( 0, 0 ) );
   double offsetX = pt.x() - mRect.xMinimum();
   double offsetY = pt.y() - mRect.yMaximum();
 
   //draw preview images first
-  QMap< QgsRectangle, QImage >::const_iterator previewIt = mPreviewImages.constBegin();
-  for ( ; previewIt != mPreviewImages.constEnd(); ++previewIt )
+  QList< QPair< QImage, QgsRectangle > >::const_iterator imIt = mPreviewImages.constBegin();
+  for ( ; imIt != mPreviewImages.constEnd(); ++imIt )
   {
-    QPointF ul = toCanvasCoordinates( QgsPoint( previewIt.key().xMinimum() + offsetX, previewIt.key().yMaximum() + offsetY ) );
-    QPointF lr = toCanvasCoordinates( QgsPoint( previewIt.key().xMaximum() + offsetX, previewIt.key().yMinimum() + offsetY ) );
-    painter->drawImage( QRectF( ul.x(), ul.y(), lr.x() - ul.x(), lr.y() - ul.y() ), previewIt.value(), QRect( 0, 0, previewIt.value().width(), previewIt.value().height() ) );
+    QPointF ul = toCanvasCoordinates( QgsPoint( imIt->second.xMinimum() + offsetX, imIt->second.yMaximum() + offsetY ) );
+    QPointF lr = toCanvasCoordinates( QgsPoint( imIt->second.xMaximum() + offsetX, imIt->second.yMinimum() + offsetY ) );
+    painter->drawImage( QRectF( ul.x(), ul.y(), lr.x() - ul.x(), lr.y() - ul.y() ), imIt->first, QRect( 0, 0, imIt->first.width(), imIt->first.height() ) );
   }
 
   painter->drawImage( QRect( 0, 0, w, h ), mImage );

--- a/src/gui/qgsmapcanvasmap.h
+++ b/src/gui/qgsmapcanvasmap.h
@@ -47,7 +47,7 @@ class QgsMapCanvasMap : public QgsMapCanvasItem
 
     void addPreviewImage( const QImage &image, const QgsRectangle &rect );
 
-    QRectF boundingRect() const;
+    QRectF boundingRect() const override;
 
   private:
 

--- a/src/gui/qgsmapcanvasmap.h
+++ b/src/gui/qgsmapcanvasmap.h
@@ -45,9 +45,16 @@ class QgsMapCanvasMap : public QgsMapCanvasItem
 
     virtual void paint( QPainter *painter ) override;
 
+    void addPreviewImage( const QImage &image, const QgsRectangle &rect );
+
+    QRectF boundingRect() const;
+
   private:
 
     QImage mImage;
+
+    //! Preview images for panning. Usually cover area around the rendered image
+    QList< QPair< QImage, QgsRectangle > > mPreviewImages;
 };
 
 /// @endcond


### PR DESCRIPTION
## Description

This PR forward ports some recent work done in Sourcepole's downstream fork, which allows for previewing the map outside the current view extent while panning the map.

This makes for a more responsive and pleasing map panning experience.

After each main map canvas render is complete, a separate image for each adjacent map "tile" is rendered (in the background). These are shown only when panning the map, to display a preview of what will be visible when this panning operation ends.

Original credit to @mhugent and Sourcepole. The following changes were made from Sourcepole's implementation:

- We don't draw the labels for preview tiles. Labeling can be expensive and slow, and we want these preview tiles generated as quickly as possible.
- Don't disable previews for reprojected layers (not sure on the original logic here)
- Include all layers in previews - not just raster and wmts layers (not sure on the original logic here, but to me there's no reason to restrict the preview in this way)
- Cancel unfinished preview jobs in a non-blocking manner - otherwise the preview job cancelation can hang the interface while the preview jobs are canceled (sometimes slow)

@mhugent how's this look to you?