### PR TITLE
[layout] Create a page size registry for layout

### DIFF
--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -153,6 +153,11 @@
 %Include composer/qgscomposermultiframecommand.sip
 %Include composer/qgscomposertexttable.sip
 %Include composer/qgspaperitem.sip
+%Include layout/qgslayoutmeasurement.sip
+%Include layout/qgslayoutmeasurementconverter.sip
+%Include layout/qgspagesizeregistry.sip
+%Include layout/qgslayoutpoint.sip
+%Include layout/qgslayoutsize.sip
 %Include metadata/qgslayermetadata.sip
 %Include metadata/qgslayermetadatavalidator.sip
 %Include processing/qgsprocessingalgorithm.sip
@@ -378,7 +383,3 @@
 %Include layertree/qgslayertreeregistrybridge.sip
 %Include symbology-ng/qgsarrowsymbollayer.sip
 %Include composer/qgscomposerutils.sip
-%Include layout/qgslayoutmeasurement.sip
-%Include layout/qgslayoutmeasurementconverter.sip
-%Include layout/qgslayoutpoint.sip
-%Include layout/qgslayoutsize.sip

--- a/python/core/layout/qgspagesizeregistry.sip
+++ b/python/core/layout/qgspagesizeregistry.sip
@@ -1,0 +1,109 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgspagesizeregistry.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsPageSize
+{
+%Docstring
+ A named page size for layouts.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgspagesizeregistry.h"
+%End
+  public:
+
+    QgsPageSize();
+
+    QgsPageSize( const QString &name, const QgsLayoutSize &size );
+%Docstring
+ Constructor for QgsPageSize, accepting the ``name`` of the page size and
+ page ``size``.
+%End
+
+    QgsPageSize( const QgsLayoutSize &size );
+%Docstring
+ Constructor for QgsPageSize, accepting a page ``size``.
+%End
+
+    QString name;
+%Docstring
+Name of page size
+%End
+
+    QgsLayoutSize size;
+%Docstring
+Page size
+%End
+
+    bool operator==( const QgsPageSize &other ) const;
+    bool operator!=( const QgsPageSize &other ) const;
+%Docstring
+ :rtype: bool
+%End
+};
+
+class QgsPageSizeRegistry
+{
+%Docstring
+ A registry for known page sizes.
+
+ QgsPageSizeRegistry is not usually directly created, but rather accessed through
+ QgsApplication.pageSizeRegistry().
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgspagesizeregistry.h"
+%End
+  public:
+
+    QgsPageSizeRegistry();
+%Docstring
+ Creates a registry and populates it with known sizes
+%End
+
+    void add( const QgsPageSize &size );
+%Docstring
+ Adds a page ``size`` to the registry.
+%End
+
+    QList< QgsPageSize > entries() const;
+%Docstring
+ Returns a list of page sizes in the registry.
+ :rtype: list of QgsPageSize
+%End
+
+    QList< QgsPageSize > find( const QString &name ) const;
+%Docstring
+ Finds matching page sizes from the registry, using a case insensitive match
+ on the page size ``name``.
+ :rtype: list of QgsPageSize
+%End
+
+    bool decodePageSize( const QString &string, QgsPageSize &size );
+%Docstring
+ Decodes a ``string`` representing a preset page size.
+ The decoded page size will be stored in the ``size`` argument.
+ :return: true if string was successfully decoded
+ :rtype: bool
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/layout/qgspagesizeregistry.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -675,6 +675,13 @@ Returns path to the build output directory. Valid only when running from build d
  :rtype: QgsProcessingRegistry
 %End
 
+    static QgsPageSizeRegistry *pageSizeRegistry();
+%Docstring
+ Returns the application's page size registry, used for managing layout page sizes.
+.. versionadded:: 3.0
+ :rtype: QgsPageSizeRegistry
+%End
+
 
     static QgsActionScopeRegistry *actionScopeRegistry();
 %Docstring

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -345,6 +345,7 @@ SET(QGIS_CORE_SRCS
 
   layout/qgslayoutmeasurement.cpp
   layout/qgslayoutmeasurementconverter.cpp
+  layout/qgspagesizeregistry.cpp
   layout/qgslayoutpoint.cpp
   layout/qgslayoutsize.cpp
 
@@ -900,6 +901,12 @@ SET(QGIS_CORE_HDRS
   composer/qgscomposertexttable.h
   composer/qgspaperitem.h
 
+  layout/qgslayoutmeasurement.h
+  layout/qgslayoutmeasurementconverter.h
+  layout/qgspagesizeregistry.h
+  layout/qgslayoutpoint.h
+  layout/qgslayoutsize.h
+
   metadata/qgslayermetadata.h
   metadata/qgslayermetadatavalidator.h
 
@@ -1050,6 +1057,7 @@ INCLUDE_DIRECTORIES(
   fieldformatter
   geometry
   layertree
+  layout
   metadata
   pal
   processing

--- a/src/core/layout/qgspagesizeregistry.cpp
+++ b/src/core/layout/qgspagesizeregistry.cpp
@@ -1,0 +1,126 @@
+/***************************************************************************
+                            qgspagesizeregistry.cpp
+                            ------------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspagesizeregistry.h"
+
+//
+// QgsPageSizeRegistry
+//
+
+QgsPageSizeRegistry::QgsPageSizeRegistry()
+{
+  add( QgsPageSize( QStringLiteral( "A6" ), QgsLayoutSize( 105, 148 ) ) );
+  add( QgsPageSize( QStringLiteral( "A5" ), QgsLayoutSize( 148, 210 ) ) );
+  add( QgsPageSize( QStringLiteral( "A4" ), QgsLayoutSize( 210, 297 ) ) );
+  add( QgsPageSize( QStringLiteral( "A3" ), QgsLayoutSize( 297, 420 ) ) );
+  add( QgsPageSize( QStringLiteral( "A2" ), QgsLayoutSize( 420, 594 ) ) );
+  add( QgsPageSize( QStringLiteral( "A1" ), QgsLayoutSize( 594, 841 ) ) );
+  add( QgsPageSize( QStringLiteral( "A0" ), QgsLayoutSize( 841, 1189 ) ) );
+  add( QgsPageSize( QStringLiteral( "B6" ), QgsLayoutSize( 125, 176 ) ) );
+  add( QgsPageSize( QStringLiteral( "B5" ), QgsLayoutSize( 176, 250 ) ) );
+  add( QgsPageSize( QStringLiteral( "B4" ), QgsLayoutSize( 250, 353 ) ) );
+  add( QgsPageSize( QStringLiteral( "B3" ), QgsLayoutSize( 353, 500 ) ) );
+  add( QgsPageSize( QStringLiteral( "B2" ), QgsLayoutSize( 500, 707 ) ) );
+  add( QgsPageSize( QStringLiteral( "B1" ), QgsLayoutSize( 707, 1000 ) ) );
+  add( QgsPageSize( QStringLiteral( "B0" ), QgsLayoutSize( 1000, 1414 ) ) );
+  add( QgsPageSize( QStringLiteral( "Legal" ), QgsLayoutSize( 215.9, 355.6 ) ) );
+  add( QgsPageSize( QStringLiteral( "Letter" ), QgsLayoutSize( 215.9, 279.4 ) ) );
+  add( QgsPageSize( QStringLiteral( "ANSI A" ), QgsLayoutSize( 215.9, 279.4 ) ) );
+  add( QgsPageSize( QStringLiteral( "ANSI B" ), QgsLayoutSize( 279.4, 431.8 ) ) );
+  add( QgsPageSize( QStringLiteral( "ANSI C" ), QgsLayoutSize( 431.8, 558.8 ) ) );
+  add( QgsPageSize( QStringLiteral( "ANSI D" ), QgsLayoutSize( 558.8, 863.6 ) ) );
+  add( QgsPageSize( QStringLiteral( "ANSI E" ), QgsLayoutSize( 863.6, 1117.6 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch A" ), QgsLayoutSize( 228.6, 304.8 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch B" ), QgsLayoutSize( 304.8, 457.2 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch C" ), QgsLayoutSize( 457.2, 609.6 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch D" ), QgsLayoutSize( 609.6, 914.4 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch E" ), QgsLayoutSize( 914.4, 1219.2 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch E1" ), QgsLayoutSize( 762, 1066.8 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch E2" ), QgsLayoutSize( 660, 965 ) ) );
+  add( QgsPageSize( QStringLiteral( "Arch E3" ), QgsLayoutSize( 686, 991 ) ) );
+}
+
+void QgsPageSizeRegistry::add( const QgsPageSize &size )
+{
+  mPageSizes.append( size );
+}
+
+QList<QgsPageSize> QgsPageSizeRegistry::entries() const
+{
+  QList< QgsPageSize > result;
+  QList< QgsPageSize >::const_iterator it = mPageSizes.constBegin();
+  for ( ; it != mPageSizes.constEnd(); ++it )
+  {
+    result.push_back( *it );
+  }
+  return result;
+}
+
+QList<QgsPageSize> QgsPageSizeRegistry::find( const QString &name ) const
+{
+  QList< QgsPageSize > result;
+  QList< QgsPageSize >::const_iterator it = mPageSizes.constBegin();
+  for ( ; it != mPageSizes.constEnd(); ++it )
+  {
+    if ( ( *it ).name.compare( name, Qt::CaseInsensitive ) == 0 )
+    {
+      result.push_back( *it );
+    }
+  }
+  return result;
+}
+
+bool QgsPageSizeRegistry::decodePageSize( const QString &pageSizeName, QgsPageSize &pageSize )
+{
+  QList< QgsPageSize > matches = find( pageSizeName.trimmed() );
+  if ( matches.length() > 0 )
+  {
+    pageSize = matches.at( 0 );
+    return true;
+  }
+  return false;
+}
+
+//
+// QgsPageSize
+//
+
+QgsPageSize::QgsPageSize()
+  : size( QgsLayoutSize( 0.0, 0.0 ) )
+{
+}
+
+QgsPageSize::QgsPageSize( const QString &pageName, const QgsLayoutSize &pageSize )
+  : name( pageName )
+  , size( pageSize )
+{
+}
+
+QgsPageSize::QgsPageSize( const QgsLayoutSize &pageSize )
+  :  size( pageSize )
+{
+
+}
+
+bool QgsPageSize::operator==( const QgsPageSize &other ) const
+{
+  return ( name == other.name && size == other.size );
+}
+
+bool QgsPageSize::operator!=( const QgsPageSize &other ) const
+{
+  return ( ! operator==( other ) );
+}

--- a/src/core/layout/qgspagesizeregistry.h
+++ b/src/core/layout/qgspagesizeregistry.h
@@ -1,0 +1,107 @@
+/***************************************************************************
+                         qgspagesizeregistry.h
+                         --------------------
+    begin                : June 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPAGESIZEREGISTRY_H
+#define QGSPAGESIZEREGISTRY_H
+
+#include "qgslayoutsize.h"
+#include <QString>
+#include <QSizeF>
+#include <QList>
+
+/**
+ * \ingroup core
+ * \class QgsPageSize
+ * \brief A named page size for layouts.
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsPageSize
+{
+
+  public:
+
+    QgsPageSize();
+
+    /**
+     * Constructor for QgsPageSize, accepting the \a name of the page size and
+     * page \a size.
+    */
+    QgsPageSize( const QString &name, const QgsLayoutSize &size );
+
+    /**
+     * Constructor for QgsPageSize, accepting a page \a size.
+    */
+    QgsPageSize( const QgsLayoutSize &size );
+
+    //! Name of page size
+    QString name;
+
+    //! Page size
+    QgsLayoutSize size;
+
+    bool operator==( const QgsPageSize &other ) const;
+    bool operator!=( const QgsPageSize &other ) const;
+};
+
+/**
+ * \ingroup core
+ * \class QgsPageSizeRegistry
+ * \brief A registry for known page sizes.
+ *
+ * QgsPageSizeRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::pageSizeRegistry().
+ *
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsPageSizeRegistry
+{
+  public:
+
+    /**
+     * Creates a registry and populates it with known sizes
+     */
+    QgsPageSizeRegistry();
+
+    /**
+     * Adds a page \a size to the registry.
+     */
+    void add( const QgsPageSize &size );
+
+    /**
+     * Returns a list of page sizes in the registry.
+     */
+    QList< QgsPageSize > entries() const;
+
+    /**
+     * Finds matching page sizes from the registry, using a case insensitive match
+     * on the page size \a name.
+     */
+    QList< QgsPageSize > find( const QString &name ) const;
+
+    /**
+     * Decodes a \a string representing a preset page size.
+     * The decoded page size will be stored in the \a size argument.
+     * \returns true if string was successfully decoded
+    */
+    bool decodePageSize( const QString &string, QgsPageSize &size );
+
+  private:
+
+    QList< QgsPageSize > mPageSizes;
+};
+
+#endif //QGSPAGESIZEREGISTRY_H

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -42,6 +42,8 @@
 #include "processing/qgsprocessingregistry.h"
 #include "processing/qgsnativealgorithms.h"
 
+#include "layout/qgspagesizeregistry.h"
+
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -1552,6 +1554,11 @@ QgsProcessingRegistry *QgsApplication::processingRegistry()
   return members()->mProcessingRegistry;
 }
 
+QgsPageSizeRegistry *QgsApplication::pageSizeRegistry()
+{
+  return members()->mPageSizeRegistry;
+}
+
 QgsAnnotationRegistry *QgsApplication::annotationRegistry()
 {
   return members()->mAnnotationRegistry;
@@ -1581,6 +1588,7 @@ QgsApplication::ApplicationMembers::ApplicationMembers()
   mGpsConnectionRegistry = new QgsGPSConnectionRegistry();
   mPluginLayerRegistry = new QgsPluginLayerRegistry();
   mProcessingRegistry = new QgsProcessingRegistry();
+  mPageSizeRegistry = new QgsPageSizeRegistry();
   mProcessingRegistry->addProvider( new QgsNativeAlgorithms( mProcessingRegistry ) );
   mAnnotationRegistry = new QgsAnnotationRegistry();
 }
@@ -1596,6 +1604,7 @@ QgsApplication::ApplicationMembers::~ApplicationMembers()
   delete mPaintEffectRegistry;
   delete mPluginLayerRegistry;
   delete mProcessingRegistry;
+  delete mPageSizeRegistry;
   delete mProfiler;
   delete mRasterRendererRegistry;
   delete mRendererRegistry;

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -39,6 +39,7 @@ class QgsPluginLayerRegistry;
 class QgsMessageLog;
 class QgsProcessingRegistry;
 class QgsAnnotationRegistry;
+class QgsPageSizeRegistry;
 
 
 /** \ingroup core
@@ -547,6 +548,12 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QgsProcessingRegistry *processingRegistry();
 
     /**
+     * Returns the application's page size registry, used for managing layout page sizes.
+     * \since QGIS 3.0
+     */
+    static QgsPageSizeRegistry *pageSizeRegistry();
+
+    /**
      * Returns the application's annotation registry, used for managing annotation types.
      * \since QGIS 3.0
      * \note not available in Python bindings
@@ -695,6 +702,7 @@ class CORE_EXPORT QgsApplication : public QApplication
       QgsPaintEffectRegistry *mPaintEffectRegistry = nullptr;
       QgsPluginLayerRegistry *mPluginLayerRegistry = nullptr;
       QgsProcessingRegistry *mProcessingRegistry = nullptr;
+      QgsPageSizeRegistry *mPageSizeRegistry = nullptr;
       QgsRasterRendererRegistry *mRasterRendererRegistry = nullptr;
       QgsRendererRegistry *mRendererRegistry = nullptr;
       QgsRuntimeProfiler *mProfiler = nullptr;

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -141,6 +141,7 @@ SET(TESTS
  testqgsnetworkcontentfetcher.cpp
  testqgsogcutils.cpp
  testqgsogrutils.cpp
+ testqgspagesizeregistry.cpp
  testqgspainteffectregistry.cpp
  testqgspainteffect.cpp
  testqgspallabeling.cpp

--- a/tests/src/core/testqgspagesizeregistry.cpp
+++ b/tests/src/core/testqgspagesizeregistry.cpp
@@ -1,0 +1,143 @@
+/***************************************************************************
+                         testqgspagesizeregistry.cpp
+                         ----------------------------
+    begin                : November 2014
+    copyright            : (C) 2014 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspagesizeregistry.h"
+#include "qgis.h"
+#include "qgsapplication.h"
+#include <QObject>
+#include <QtTest>
+
+class TestQgsPageSizeRegistry : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+    void pageSizeEquality(); //test equality of QgsPageSize
+    void pageCopyConstructor(); //test copy constructor of QgsPageSize
+    void createInstance(); // create global instance of QgsPageSizeRegistry
+    void instanceHasDefaultSizes(); // check that global instance is populated with default page sizes
+    void addSize(); // check adding a size to the registry
+    void findSize(); //find a size in the registry
+    void decodePageSize(); //test decoding a page size string
+
+  private:
+
+};
+
+void TestQgsPageSizeRegistry::initTestCase()
+{
+
+}
+
+void TestQgsPageSizeRegistry::cleanupTestCase()
+{
+
+}
+
+void TestQgsPageSizeRegistry::init()
+{
+
+}
+
+void TestQgsPageSizeRegistry::cleanup()
+{
+
+}
+
+void TestQgsPageSizeRegistry::pageSizeEquality()
+{
+  QgsPageSize size1( QString( "test" ), QgsLayoutSize( 1, 2 ) );
+  QgsPageSize size2( QString( "test" ), QgsLayoutSize( 1, 2 ) );
+  QCOMPARE( size1, size2 );
+  QVERIFY( !( size1 != size2 ) );
+  QgsPageSize size3( QString( "no match" ), QgsLayoutSize( 1, 2 ) );
+  QgsPageSize size4( QString( "test" ), QgsLayoutSize( 3, 4 ) );
+  QVERIFY( !( size1 == size3 ) );
+  QVERIFY( size1 != size3 );
+  QVERIFY( !( size1 == size4 ) );
+  QVERIFY( size1 != size4 );
+  QVERIFY( !( size3 == size4 ) );
+  QVERIFY( size3 != size4 );
+}
+
+void TestQgsPageSizeRegistry::pageCopyConstructor()
+{
+  QgsPageSize size1( QString( "test" ), QgsLayoutSize( 1, 2 ) );
+  QgsPageSize size2( size1 );
+  QCOMPARE( size1.name, size2.name );
+  QCOMPARE( size1.size, size2.size );
+}
+
+void TestQgsPageSizeRegistry::createInstance()
+{
+  QVERIFY( QgsApplication::pageSizeRegistry() );
+}
+
+void TestQgsPageSizeRegistry::instanceHasDefaultSizes()
+{
+  //check that registry instance is initially populated with some known page sizes
+  QgsPageSizeRegistry *registry = QgsApplication::pageSizeRegistry();
+  QVERIFY( registry->entries().length() > 0 );
+}
+
+void TestQgsPageSizeRegistry::addSize()
+{
+  QgsPageSizeRegistry *registry = QgsApplication::pageSizeRegistry();
+  int oldSize = registry->entries().length();
+  QgsPageSize newSize( QString( "new" ), QgsLayoutSize( 1, 2 ) );
+  registry->add( newSize );
+  QCOMPARE( registry->entries().length(), oldSize + 1 );
+  QVERIFY( registry->entries().indexOf( newSize ) >= 0 );
+}
+
+void TestQgsPageSizeRegistry::findSize()
+{
+  QgsPageSizeRegistry *registry = QgsApplication::pageSizeRegistry();
+  QgsPageSize newSize( QString( "test size" ), QgsLayoutSize( 1, 2 ) );
+  registry->add( newSize );
+  QList< QgsPageSize > results = registry->find( QString( "test size" ) );
+  QVERIFY( results.length() > 0 );
+  QCOMPARE( results.at( 0 ), newSize );
+  //check that match is case insensitive
+  QList< QgsPageSize > results2 = registry->find( QString( "tEsT Size" ) );
+  QVERIFY( results2.length() > 0 );
+  QCOMPARE( results2.at( 0 ), newSize );
+}
+
+void TestQgsPageSizeRegistry::decodePageSize()
+{
+  QgsPageSizeRegistry *registry = QgsApplication::pageSizeRegistry();
+
+  //test with good string
+  QgsPageSize result;
+  QVERIFY( registry->decodePageSize( QString( " a3 " ), result ) );
+  QCOMPARE( result.name, QString( "A3" ) );
+  QCOMPARE( result.size, QgsLayoutSize( 297.0, 420.0 ) );
+
+  //test with bad string
+  QgsPageSize result2( QString( "nomatch" ), QgsLayoutSize( 10.0, 20.0 ) );
+  QgsPageSize expected( result2 ); //for a bad match, expect page size to be unchanged
+  QVERIFY( !registry->decodePageSize( QString( "bad" ), result2 ) );
+  QCOMPARE( result2, expected );
+}
+
+QTEST_MAIN( TestQgsPageSizeRegistry )
+#include "testqgspagesizeregistry.moc"


### PR DESCRIPTION
## Description

Adds a new QgsPageSize class and QgsPageSizeRegistry registry (attached to QgsApplication), which stores and manages known page sizes

Builds off the classes introduced in #4767
