### PR TITLE
[processing] restore zonal statistics (qgis) alg

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2530,7 +2530,7 @@ Triangulation        {#qgis_api_break_3_0_Triangulation}
 QgsZonalStatistics        {#qgis_api_break_3_0_QgsZonalStatistics}
 ------------------
 - QgsZonalStatistics() сonstructor now accepts pointer to the QgsRasterLayer instance instead of path to the raster file
-
+- The calculateStatistics argument is now a QgsFeedback object
 
 QGIS 2.6        {#qgis_api_break_2_6}
 ========

--- a/python/analysis/vector/qgszonalstatistics.sip
+++ b/python/analysis/vector/qgszonalstatistics.sip
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsZonalStatistics
 {
 %Docstring
@@ -48,7 +50,7 @@ class QgsZonalStatistics
  Constructor for QgsZonalStatistics.
 %End
 
-    int calculateStatistics( QProgressDialog *p );
+    int calculateStatistics( QgsFeedback *feedback );
 %Docstring
  Starts the calculation
 :return: 0 in case of success*

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -71,6 +71,7 @@ from .Smooth import Smooth
 from .SpatialiteExecuteSQL import SpatialiteExecuteSQL
 from .SymmetricalDifference import SymmetricalDifference
 from .VectorSplit import VectorSplit
+from .ZonalStatisticsQgis import ZonalStatisticsQgis
 
 # from .ExtractByLocation import ExtractByLocation
 # from .PointsInPolygon import PointsInPolygon
@@ -152,7 +153,6 @@ from .VectorSplit import VectorSplit
 # from .Relief import Relief
 # from .IdwInterpolation import IdwInterpolation
 # from .TinInterpolation import TinInterpolation
-# from .ZonalStatisticsQgis import ZonalStatisticsQgis
 # from .RemoveNullGeometry import RemoveNullGeometry
 # from .ExtendLines import ExtendLines
 # from .ExtractSpecificNodes import ExtractSpecificNodes
@@ -227,7 +227,7 @@ class QGISAlgorithmProvider(QgsProcessingProvider):
         #         OffsetLine(), Translate(),
         #         SingleSidedBuffer(), PointsAlongGeometry(),
         #          Slope(), Ruggedness(), Hillshade(),
-        #         Relief(), ZonalStatisticsQgis(),
+        #         Relief(),
         #         IdwInterpolation(), TinInterpolation(),
         #         RemoveNullGeometry(),
         #         ExtendLines(), ExtractSpecificNodes(),
@@ -271,7 +271,8 @@ class QGISAlgorithmProvider(QgsProcessingProvider):
                 Smooth(),
                 SpatialiteExecuteSQL(),
                 SymmetricalDifference(),
-                VectorSplit()
+                VectorSplit(),
+                ZonalStatisticsQgis()
                 ]
 
         if hasPlotly:

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -20,9 +20,12 @@
 
 #include <QString>
 #include <QMap>
+
 #include <limits>
 #include <cfloat>
+
 #include "qgis_analysis.h"
+#include "qgsfeedback.h"
 
 class QgsGeometry;
 class QgsVectorLayer;
@@ -67,7 +70,7 @@ class ANALYSIS_EXPORT QgsZonalStatistics
 
     /** Starts the calculation
       \returns 0 in case of success*/
-    int calculateStatistics( QProgressDialog *p );
+    int calculateStatistics( QgsFeedback *feedback );
 
   private:
     QgsZonalStatistics() = default;


### PR DESCRIPTION
## Description
@nyalldawson , this restores the QgsZonalStatistics-based zonal statistics algorithm.

Porting was straightforward. Note that the addOutput() refers to the INPUT_VECTOR layer. Is that the right way to deal with this?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
