### PR TITLE
Always expand out browser favorites node on startup

### DIFF
--- a/src/gui/qgsbrowsertreeview.cpp
+++ b/src/gui/qgsbrowsertreeview.cpp
@@ -107,12 +107,10 @@ void QgsBrowserTreeView::restoreState()
       expandTree( expandIndex );
     }
   }
-  else
-  {
-    // expand root favorites item
-    QModelIndex index = QgsBrowserModel::findPath( model(), QStringLiteral( "favorites:" ) );
-    expand( index );
-  }
+
+  // expand root favorites item
+  QModelIndex index = QgsBrowserModel::findPath( model(), QStringLiteral( "favorites:" ) );
+  expand( index );
 }
 
 void QgsBrowserTreeView::expandTree( const QModelIndex &index )


### PR DESCRIPTION
It's the user-set favorites, so they should be accessible as quickly as possible!

Previously there was logic that the favorites are only expanded when no other nodes are expanded at startup. This seems like an artificial limitation to me. I also think that a user is unlikely to have so many favorites that expanding out this node would become an annoyance.