### PR TITLE
[needs-docs] Move diagram z-index option to a renamed Rendering tab

### DIFF
--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -938,7 +938,7 @@
                          <item>
                           <widget class="QLabel" name="label_8">
                            <property name="text">
-                            <string>Discourage labels from covering features</string>
+                            <string>Discourage diagrams and labels from covering features</string>
                            </property>
                           </widget>
                          </item>

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -499,7 +499,7 @@
               </item>
              </layout>
             </widget>
-            <widget class="QWidget" name="mDiagramPage_Appearance">
+            <widget class="QWidget" name="mDiagramPage_Rendering">
              <layout class="QVBoxLayout" name="verticalLayout_13">
               <property name="spacing">
                <number>6</number>
@@ -538,9 +538,9 @@
                  <property name="geometry">
                   <rect>
                    <x>0</x>
-                   <y>0</y>
+                   <y>-73</y>
                    <width>626</width>
-                   <height>465</height>
+                   <height>494</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
@@ -557,309 +557,290 @@
                    <number>0</number>
                   </property>
                   <item>
-                   <layout class="QGridLayout" name="gridLayout_7" rowstretch="0,0">
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="label_2">
-                      <property name="text">
-                       <string>Format</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QFrame" name="frame">
-                      <property name="frameShape">
-                       <enum>QFrame::NoFrame</enum>
-                      </property>
-                      <property name="frameShadow">
-                       <enum>QFrame::Raised</enum>
-                      </property>
-                      <layout class="QGridLayout" name="gridLayout_8">
-                       <property name="leftMargin">
-                        <number>20</number>
+                   <widget class="QgsCollapsibleGroupBox" name="mFormatGrpBox">
+                    <property name="title">
+                     <string>Format</string>
+                    </property>
+                    <property name="syncGroup" stdset="0">
+                     <string notr="true">labelrenderinggroup</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_7" rowstretch="0,0">
+                     <item row="1" column="0">
+                      <widget class="QFrame" name="frame">
+                       <property name="frameShape">
+                        <enum>QFrame::NoFrame</enum>
                        </property>
-                       <property name="topMargin">
-                        <number>0</number>
+                       <property name="frameShadow">
+                        <enum>QFrame::Raised</enum>
                        </property>
-                       <property name="rightMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="bottomMargin">
-                        <number>0</number>
-                       </property>
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="mTransparencyLabel">
-                         <property name="minimumSize">
-                          <size>
-                           <width>130</width>
-                           <height>0</height>
-                          </size>
-                         </property>
+                       <layout class="QGridLayout" name="gridLayout_8">
+                        <property name="leftMargin">
+                         <number>20</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
+                         <number>0</number>
+                        </property>
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="mOpacityLabel">
+                          <property name="minimumSize">
+                           <size>
+                            <width>130</width>
+                            <height>0</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>Opacity</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="4" column="2">
+                         <widget class="QgsUnitSelectionWidget" name="mDiagramLineUnitComboBox" native="true">
+                          <property name="focusPolicy">
+                           <enum>Qt::StrongFocus</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="4" column="0">
+                         <widget class="QLabel" name="mPenWidthLabel">
+                          <property name="text">
+                           <string>Line width</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="5" column="0">
+                         <widget class="QLabel" name="mAngleOffsetLabel">
+                          <property name="text">
+                           <string>Start angle</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="3">
+                         <widget class="QgsPropertyOverrideButton" name="mBackgroundColorDDBtn">
+                          <property name="text">
+                           <string>…</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="1" colspan="2">
+                         <widget class="QgsColorButton" name="mBackgroundColorButton">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>120</width>
+                            <height>0</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>16777215</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string/>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="4" column="1">
+                         <widget class="QgsDoubleSpinBox" name="mPenWidthSpinBox">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="decimals">
+                           <number>5</number>
+                          </property>
+                          <property name="maximum">
+                           <double>99999.990000000005239</double>
+                          </property>
+                          <property name="singleStep">
+                           <double>0.200000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1" colspan="3">
+                         <widget class="QgsDoubleSpinBox" name="mBarWidthSpinBox">
+                          <property name="minimum">
+                           <double>0.010000000000000</double>
+                          </property>
+                          <property name="value">
+                           <double>5.000000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="1" colspan="2">
+                         <widget class="QgsColorButton" name="mDiagramPenColorButton">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>0</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>16777215</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string/>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="0">
+                         <widget class="QLabel" name="mPenColorLabel">
+                          <property name="text">
+                           <string>Line color</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="4" column="3">
+                         <widget class="QgsPropertyOverrideButton" name="mLineWidthDDBtn">
+                          <property name="text">
+                           <string>…</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="3">
+                         <widget class="QgsPropertyOverrideButton" name="mLineColorDDBtn">
+                          <property name="text">
+                           <string>…</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="6" column="0" colspan="4">
+                         <widget class="QgsFontButton" name="mDiagramFontButton">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>Font</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="0">
+                         <widget class="QLabel" name="mBackgroundColorLabel">
+                          <property name="text">
+                           <string>Background color</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="0">
+                         <widget class="QLabel" name="mBarWidthLabel">
+                          <property name="text">
+                           <string>Bar width</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="5" column="3">
+                         <widget class="QgsPropertyOverrideButton" name="mStartAngleDDBtn">
+                          <property name="text">
+                           <string>…</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="5" column="1" colspan="2">
+                         <widget class="QComboBox" name="mAngleOffsetComboBox">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1" colspan="3">
+                         <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="focusPolicy">
+                           <enum>Qt::StrongFocus</enum>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QgsCollapsibleGroupBox" name="mVisiblityGrpBox">
+                    <property name="title">
+                     <string>Visibility</string>
+                    </property>
+                    <property name="syncGroup" stdset="0">
+                     <string notr="true">labelrenderinggroup</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_9">
+                     <property name="leftMargin">
+                      <number>8</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>8</number>
+                     </property>
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_3">
+                       <item row="0" column="2">
+                        <widget class="QgsPropertyOverrideButton" name="mZOrderDDBtn">
                          <property name="text">
-                          <string>Opacity</string>
+                          <string>…</string>
                          </property>
                         </widget>
                        </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="mBarWidthLabel">
-                         <property name="text">
-                          <string>Bar width</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QgsDoubleSpinBox" name="mBarWidthSpinBox">
-                         <property name="minimum">
-                          <double>0.010000000000000</double>
-                         </property>
-                         <property name="value">
-                          <double>5.000000000000000</double>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="4" column="0">
-                        <widget class="QLabel" name="mPenWidthLabel">
-                         <property name="text">
-                          <string>Line width</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="0">
-                        <widget class="QLabel" name="mBackgroundColorLabel">
-                         <property name="text">
-                          <string>Background color</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="3" column="0">
-                        <widget class="QLabel" name="mPenColorLabel">
-                         <property name="text">
-                          <string>Line color</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="5" column="0">
-                        <widget class="QLabel" name="mAngleOffsetLabel">
-                         <property name="text">
-                          <string>Start angle</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="4" column="2">
-                        <spacer name="horizontalSpacer_2">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                       <item row="2" column="1">
-                        <layout class="QHBoxLayout" name="horizontalLayout_7">
-                         <item>
-                          <widget class="QgsColorButton" name="mBackgroundColorButton">
-                           <property name="minimumSize">
-                            <size>
-                             <width>120</width>
-                             <height>0</height>
-                            </size>
-                           </property>
-                           <property name="maximumSize">
-                            <size>
-                             <width>120</width>
-                             <height>16777215</height>
-                            </size>
-                           </property>
-                           <property name="text">
-                            <string/>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QgsPropertyOverrideButton" name="mBackgroundColorDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <spacer name="horizontalSpacer_11">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>40</width>
-                             <height>20</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                        </layout>
-                       </item>
-                       <item row="3" column="1">
-                        <layout class="QHBoxLayout" name="horizontalLayout_9">
-                         <item>
-                          <widget class="QgsColorButton" name="mDiagramPenColorButton">
-                           <property name="minimumSize">
-                            <size>
-                             <width>120</width>
-                             <height>0</height>
-                            </size>
-                           </property>
-                           <property name="maximumSize">
-                            <size>
-                             <width>120</width>
-                             <height>16777215</height>
-                            </size>
-                           </property>
-                           <property name="text">
-                            <string/>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QgsPropertyOverrideButton" name="mLineColorDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <spacer name="horizontalSpacer_12">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>40</width>
-                             <height>20</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                        </layout>
-                       </item>
-                       <item row="4" column="1">
-                        <layout class="QHBoxLayout" name="horizontalLayout_10">
-                         <item>
-                          <widget class="QgsDoubleSpinBox" name="mPenWidthSpinBox">
-                           <property name="decimals">
-                            <number>5</number>
-                           </property>
-                           <property name="maximum">
-                            <double>99999.990000000005239</double>
-                           </property>
-                           <property name="singleStep">
-                            <double>0.200000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QgsUnitSelectionWidget" name="mDiagramLineUnitComboBox" native="true">
-                           <property name="focusPolicy">
-                            <enum>Qt::StrongFocus</enum>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QgsPropertyOverrideButton" name="mLineWidthDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <spacer name="horizontalSpacer_13">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                           </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>40</width>
-                             <height>20</height>
-                            </size>
-                           </property>
-                          </spacer>
-                         </item>
-                        </layout>
-                       </item>
-                       <item row="5" column="1">
-                        <layout class="QHBoxLayout" name="horizontalLayout_11">
-                         <item>
-                          <widget class="QComboBox" name="mAngleOffsetComboBox"/>
-                         </item>
-                         <item>
-                          <widget class="QgsPropertyOverrideButton" name="mStartAngleDDBtn">
-                           <property name="text">
-                            <string>…</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </item>
-                       <item row="0" column="1" colspan="2">
-                        <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
-                         <property name="focusPolicy">
-                          <enum>Qt::StrongFocus</enum>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="6" column="1">
-                        <widget class="QgsFontButton" name="mDiagramFontButton">
+                       <item row="0" column="1">
+                        <widget class="QgsDoubleSpinBox" name="mZIndexSpinBox">
                          <property name="sizePolicy">
                           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                            <horstretch>0</horstretch>
                            <verstretch>0</verstretch>
                           </sizepolicy>
                          </property>
-                         <property name="text">
-                          <string>Font</string>
+                         <property name="toolTip">
+                          <string>Controls how diagrams are drawn on top of each other. Diagrams with a higher z-index are drawn above diagrams and labels with a lower z-index.</string>
+                         </property>
+                         <property name="minimum">
+                          <double>-9999999.000000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>9999999.000000000000000</double>
                          </property>
                         </widget>
                        </item>
-                      </layout>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QGridLayout" name="gridLayout_9" rowstretch="0,1">
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="label_3">
-                      <property name="text">
-                       <string>Visibility</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QFrame" name="frame_2">
-                      <property name="frameShape">
-                       <enum>QFrame::NoFrame</enum>
-                      </property>
-                      <property name="frameShadow">
-                       <enum>QFrame::Raised</enum>
-                      </property>
-                      <layout class="QGridLayout" name="gridLayout_10">
-                       <property name="leftMargin">
-                        <number>20</number>
-                       </property>
-                       <property name="topMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="rightMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="bottomMargin">
-                        <number>0</number>
-                       </property>
-                       <item row="2" column="0">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_16">
+                         <property name="text">
+                          <string>Diagram z-index</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0" colspan="3">
                         <widget class="QgsCollapsibleGroupBox" name="mScaleVisibilityGroupBox">
                          <property name="title">
                           <string>Scale dependent visibility</string>
@@ -880,7 +861,7 @@
                          </layout>
                         </widget>
                        </item>
-                       <item row="1" column="0">
+                       <item row="1" column="0" colspan="3">
                         <widget class="QCheckBox" name="mShowAllCheckBox">
                          <property name="text">
                           <string>Show all diagrams</string>
@@ -890,37 +871,86 @@
                          </property>
                         </widget>
                        </item>
-                       <item row="0" column="0">
-                        <layout class="QHBoxLayout" name="horizontalLayout_8">
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QgsCollapsibleGroupBox" name="mRenderingDDGrpBox">
+                    <property name="title">
+                     <string>Data-Defined</string>
+                    </property>
+                    <property name="syncGroup" stdset="0">
+                     <string notr="true">labelrenderinggroup</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_9">
+                     <property name="leftMargin">
+                      <number>8</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>8</number>
+                     </property>
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_9">
+                       <item row="0" column="1">
+                        <widget class="QgsPropertyOverrideButton" name="mShowDiagramDDBtn">
+                         <property name="text">
+                          <string>…</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="3">
+                        <widget class="QLabel" name="mAlwaysShowLabel">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="text">
+                          <string>Always show</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="5">
+                        <spacer name="horizontalSpacer_23">
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>195</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="Line" name="line_4">
+                         <property name="orientation">
+                          <enum>Qt::Vertical</enum>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0" colspan="6">
+                        <layout class="QHBoxLayout" name="horizontalLayout_12">
                          <item>
-                          <widget class="QLabel" name="label_16">
+                          <widget class="QLabel" name="label_8">
                            <property name="text">
-                            <string>Diagram z-index</string>
+                            <string>Discourage labels from covering features</string>
                            </property>
                           </widget>
                          </item>
                          <item>
-                          <widget class="QgsDoubleSpinBox" name="mZIndexSpinBox">
-                           <property name="toolTip">
-                            <string>Controls how diagrams are drawn on top of each other. Diagrams with a higher z-index are drawn above diagrams and labels with a lower z-index.</string>
-                           </property>
-                           <property name="minimum">
-                            <double>-9999999.000000000000000</double>
-                           </property>
-                           <property name="maximum">
-                            <double>9999999.000000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QgsPropertyOverrideButton" name="mZOrderDDBtn">
+                          <widget class="QgsPropertyOverrideButton" name="mIsObstacleDDBtn">
                            <property name="text">
                             <string>…</string>
                            </property>
                           </widget>
                          </item>
                          <item>
-                          <spacer name="horizontalSpacer_10">
+                          <spacer name="horizontalSpacer">
                            <property name="orientation">
                             <enum>Qt::Horizontal</enum>
                            </property>
@@ -934,149 +964,28 @@
                          </item>
                         </layout>
                        </item>
-                      </layout>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <widget class="QFrame" name="mLabelRenderingDDFrame">
-                    <property name="frameShape">
-                     <enum>QFrame::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_5">
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="verticalSpacing">
-                      <number>6</number>
-                     </property>
-                     <item row="1" column="1">
-                      <widget class="QLabel" name="mShowLabelLabel">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="text">
-                        <string>Show diagram</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="2">
-                      <widget class="QgsPropertyOverrideButton" name="mShowDiagramDDBtn">
-                       <property name="text">
-                        <string>…</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="3">
-                      <widget class="Line" name="line_4">
-                       <property name="orientation">
-                        <enum>Qt::Vertical</enum>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="4">
-                      <widget class="QLabel" name="mAlwaysShowLabel">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="text">
-                        <string>Always show</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="5">
-                      <widget class="QgsPropertyOverrideButton" name="mAlwaysShowDDBtn">
-                       <property name="text">
-                        <string>…</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <spacer name="horizontalSpacer_14">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeType">
-                        <enum>QSizePolicy::Fixed</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>6</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                     <item row="0" column="0" colspan="7">
-                      <widget class="QLabel" name="label_7">
-                       <property name="text">
-                        <string>Data defined</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="6">
-                      <spacer name="horizontalSpacer_23">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>195</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                     <item row="4" column="1" colspan="6">
-                      <layout class="QHBoxLayout" name="horizontalLayout_12">
-                       <item>
-                        <widget class="QLabel" name="label_8">
-                         <property name="text">
-                          <string>Discourage labels from covering features</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QgsPropertyOverrideButton" name="mIsObstacleDDBtn">
+                       <item row="0" column="4">
+                        <widget class="QgsPropertyOverrideButton" name="mAlwaysShowDDBtn">
                          <property name="text">
                           <string>…</string>
                          </property>
                         </widget>
                        </item>
-                       <item>
-                        <spacer name="horizontalSpacer">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="mShowLabelLabel">
+                         <property name="enabled">
+                          <bool>true</bool>
                          </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
                          </property>
-                        </spacer>
+                         <property name="text">
+                          <string>Show diagram</string>
+                         </property>
+                        </widget>
                        </item>
                       </layout>
                      </item>
@@ -1175,6 +1084,12 @@
                     <property name="enabled">
                      <bool>false</bool>
                     </property>
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
                     <property name="decimals">
                      <number>5</number>
                     </property>
@@ -1185,12 +1100,6 @@
                   </item>
                   <item row="0" column="1">
                    <widget class="QgsUnitSelectionWidget" name="mDiagramUnitComboBox" native="true">
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -1259,36 +1168,6 @@
                          </property>
                         </widget>
                        </item>
-                       <item row="2" column="0">
-                        <widget class="QLabel" name="label_4">
-                         <property name="text">
-                          <string>Maximum value</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="0" rowspan="2">
-                        <widget class="QLabel" name="mSizeAttributeLabel">
-                         <property name="text">
-                          <string>Attribute</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1" rowspan="2" colspan="4">
-                        <widget class="QgsFieldExpressionWidget" name="mSizeFieldExpressionWidget" native="true">
-                         <property name="sizePolicy">
-                          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                           <horstretch>0</horstretch>
-                           <verstretch>0</verstretch>
-                          </sizepolicy>
-                         </property>
-                         <property name="maximumSize">
-                          <size>
-                           <width>16777215</width>
-                           <height>16777215</height>
-                          </size>
-                         </property>
-                        </widget>
-                       </item>
                        <item row="3" column="3">
                         <widget class="QLabel" name="mScaleDependencyLabel">
                          <property name="text">
@@ -1298,30 +1177,6 @@
                        </item>
                        <item row="3" column="4">
                         <widget class="QComboBox" name="mScaleDependencyComboBox"/>
-                       </item>
-                       <item row="2" column="1" colspan="2">
-                        <layout class="QHBoxLayout" name="horizontalLayout_2">
-                         <item>
-                          <widget class="QgsDoubleSpinBox" name="mMaxValueSpinBox">
-                           <property name="decimals">
-                            <number>6</number>
-                           </property>
-                           <property name="minimum">
-                            <double>-99999999.000000000000000</double>
-                           </property>
-                           <property name="maximum">
-                            <double>99999999.000000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QPushButton" name="mFindMaximumValueButton">
-                           <property name="text">
-                            <string>Find</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
                        </item>
                        <item row="4" column="0" colspan="5">
                         <widget class="QFrame" name="mFrameIncreaseSize">
@@ -1360,6 +1215,12 @@
                           </item>
                           <item>
                            <widget class="QgsDoubleSpinBox" name="mIncreaseMinimumSizeSpinBox">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
                             <property name="decimals">
                              <number>6</number>
                             </property>
@@ -1371,20 +1232,57 @@
                             </property>
                            </widget>
                           </item>
-                          <item>
-                           <spacer name="horizontalSpacer_4">
-                            <property name="orientation">
-                             <enum>Qt::Horizontal</enum>
-                            </property>
-                            <property name="sizeHint" stdset="0">
-                             <size>
-                              <width>40</width>
-                              <height>20</height>
-                             </size>
-                            </property>
-                           </spacer>
-                          </item>
                          </layout>
+                        </widget>
+                       </item>
+                       <item row="2" column="4">
+                        <widget class="QPushButton" name="mFindMaximumValueButton">
+                         <property name="text">
+                          <string>Find</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1" rowspan="2" colspan="4">
+                        <widget class="QgsFieldExpressionWidget" name="mSizeFieldExpressionWidget" native="true">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="maximumSize">
+                          <size>
+                           <width>16777215</width>
+                           <height>16777215</height>
+                          </size>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0" rowspan="2">
+                        <widget class="QLabel" name="mSizeAttributeLabel">
+                         <property name="text">
+                          <string>Attribute</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_4">
+                         <property name="text">
+                          <string>Maximum value</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1" colspan="3">
+                        <widget class="QgsDoubleSpinBox" name="mMaxValueSpinBox">
+                         <property name="decimals">
+                          <number>6</number>
+                         </property>
+                         <property name="minimum">
+                          <double>-99999999.000000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>99999999.000000000000000</double>
+                         </property>
                         </widget>
                        </item>
                       </layout>
@@ -1398,19 +1296,6 @@
                      <string>Scaled size</string>
                     </property>
                    </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_3">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
                   </item>
                  </layout>
                 </widget>
@@ -1472,7 +1357,7 @@
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item row="7" column="0">
+                  <item row="6" column="0">
                    <spacer name="verticalSpacer_4">
                     <property name="orientation">
                      <enum>Qt::Vertical</enum>
@@ -1503,18 +1388,15 @@
                      <property name="bottomMargin">
                       <number>0</number>
                      </property>
-                     <item row="0" column="2">
-                      <spacer name="horizontalSpacer_9">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
+                     <item row="1" column="1">
+                      <widget class="QgsDoubleSpinBox" name="mDiagramDistanceSpinBox">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
                        </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>40</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
+                      </widget>
                      </item>
                      <item row="0" column="0">
                       <widget class="QLabel" name="mPlacementLabel">
@@ -1530,92 +1412,25 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="1">
-                      <widget class="QComboBox" name="mPlacementComboBox"/>
+                     <item row="1" column="3">
+                      <widget class="QgsPropertyOverrideButton" name="mDistanceDDBtn">
+                       <property name="text">
+                        <string>…</string>
+                       </property>
+                      </widget>
                      </item>
-                     <item row="1" column="1">
-                      <layout class="QHBoxLayout" name="horizontalLayout_14">
-                       <item>
-                        <widget class="QgsDoubleSpinBox" name="mDiagramDistanceSpinBox"/>
-                       </item>
-                       <item>
-                        <widget class="QgsPropertyOverrideButton" name="mDistanceDDBtn">
-                         <property name="text">
-                          <string>…</string>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
+                     <item row="0" column="1" colspan="3">
+                      <widget class="QComboBox" name="mPlacementComboBox">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                      </widget>
                      </item>
                     </layout>
                    </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <layout class="QHBoxLayout" name="horizontalLayout_3">
-                    <item>
-                     <widget class="QLabel" name="mPriorityLabel">
-                      <property name="text">
-                       <string>Priority</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="mPriorityLowLabel">
-                      <property name="text">
-                       <string>Low</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSlider" name="mPrioritySlider">
-                      <property name="maximum">
-                       <number>10</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="invertedAppearance">
-                       <bool>false</bool>
-                      </property>
-                      <property name="invertedControls">
-                       <bool>false</bool>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>1</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="mPriorityHighLabel">
-                      <property name="text">
-                       <string>High</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsPropertyOverrideButton" name="mPriorityDDBtn">
-                      <property name="text">
-                       <string>…</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
                   </item>
                   <item row="1" column="0" colspan="2">
                    <widget class="QFrame" name="mLinePlacementFrame">
@@ -1790,6 +1605,67 @@
                         </spacer>
                        </item>
                       </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="5" column="0" colspan="2">
+                   <widget class="QgsCollapsibleGroupBox" name="mPriorityGrpBox">
+                    <property name="title">
+                     <string>Priority</string>
+                    </property>
+                    <property name="syncGroup" stdset="0">
+                     <string notr="true">labelplacementgroup</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_9">
+                     <property name="leftMargin">
+                      <number>8</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>8</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="mPriorityLowLabel">
+                       <property name="text">
+                        <string>Low</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="mPrioritySlider">
+                       <property name="maximum">
+                        <number>10</number>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="invertedAppearance">
+                        <bool>false</bool>
+                       </property>
+                       <property name="invertedControls">
+                        <bool>false</bool>
+                       </property>
+                       <property name="tickPosition">
+                        <enum>QSlider::TicksBelow</enum>
+                       </property>
+                       <property name="tickInterval">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="mPriorityHighLabel">
+                       <property name="text">
+                        <string>High</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QgsPropertyOverrideButton" name="mPriorityDDBtn">
+                       <property name="text">
+                        <string>…</string>
+                       </property>
+                      </widget>
                      </item>
                     </layout>
                    </widget>
@@ -2202,12 +2078,22 @@
   <tabstop>mOpacityWidget</tabstop>
   <tabstop>mBarWidthSpinBox</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>
+  <tabstop>mBackgroundColorDDBtn</tabstop>
   <tabstop>mDiagramPenColorButton</tabstop>
+  <tabstop>mLineColorDDBtn</tabstop>
   <tabstop>mPenWidthSpinBox</tabstop>
+  <tabstop>mDiagramLineUnitComboBox</tabstop>
+  <tabstop>mLineWidthDDBtn</tabstop>
   <tabstop>mAngleOffsetComboBox</tabstop>
+  <tabstop>mStartAngleDDBtn</tabstop>
   <tabstop>mDiagramFontButton</tabstop>
+  <tabstop>mZIndexSpinBox</tabstop>
+  <tabstop>mZOrderDDBtn</tabstop>
   <tabstop>mShowAllCheckBox</tabstop>
   <tabstop>mScaleVisibilityGroupBox</tabstop>
+  <tabstop>mShowDiagramDDBtn</tabstop>
+  <tabstop>mAlwaysShowDDBtn</tabstop>
+  <tabstop>mIsObstacleDDBtn</tabstop>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>mDiagramUnitComboBox</tabstop>
   <tabstop>mFixedSizeRadio</tabstop>
@@ -2222,12 +2108,15 @@
   <tabstop>scrollArea_6</tabstop>
   <tabstop>mPlacementComboBox</tabstop>
   <tabstop>mDiagramDistanceSpinBox</tabstop>
+  <tabstop>mDistanceDDBtn</tabstop>
   <tabstop>chkLineAbove</tabstop>
   <tabstop>chkLineOn</tabstop>
   <tabstop>chkLineBelow</tabstop>
   <tabstop>chkLineOrientationDependent</tabstop>
+  <tabstop>mCoordXDDBtn</tabstop>
+  <tabstop>mCoordYDDBtn</tabstop>
   <tabstop>mPrioritySlider</tabstop>
-  <tabstop>mZIndexSpinBox</tabstop>
+  <tabstop>mPriorityDDBtn</tabstop>
   <tabstop>scrollArea_7</tabstop>
   <tabstop>mOrientationUpButton</tabstop>
   <tabstop>mOrientationDownButton</tabstop>
@@ -2235,19 +2124,7 @@
   <tabstop>mOrientationLeftButton</tabstop>
   <tabstop>scrollArea_2</tabstop>
   <tabstop>mCheckBoxAttributeLegend</tabstop>
-  <tabstop>mBackgroundColorDDBtn</tabstop>
-  <tabstop>mLineColorDDBtn</tabstop>
-  <tabstop>mDiagramLineUnitComboBox</tabstop>
-  <tabstop>mLineWidthDDBtn</tabstop>
-  <tabstop>mStartAngleDDBtn</tabstop>
-  <tabstop>mShowDiagramDDBtn</tabstop>
-  <tabstop>mAlwaysShowDDBtn</tabstop>
-  <tabstop>mIsObstacleDDBtn</tabstop>
-  <tabstop>mDistanceDDBtn</tabstop>
-  <tabstop>mPriorityDDBtn</tabstop>
-  <tabstop>mZOrderDDBtn</tabstop>
-  <tabstop>mCoordXDDBtn</tabstop>
-  <tabstop>mCoordYDDBtn</tabstop>
+  <tabstop>mButtonSizeLegendSettings</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -185,7 +185,7 @@
             </item>
             <item>
              <property name="text">
-              <string>Appearance</string>
+              <string>Rendering</string>
              </property>
              <property name="toolTip">
               <string>Rendering</string>
@@ -267,7 +267,7 @@
           <item>
            <widget class="QStackedWidget" name="mDiagramStackedWidget">
             <property name="currentIndex">
-             <number>1</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="mDiagramPage_Attributes">
              <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -303,8 +303,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>640</width>
-                   <height>428</height>
+                   <width>642</width>
+                   <height>421</height>
                   </rect>
                  </property>
                  <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -522,7 +522,7 @@
                  <string notr="true">text-decoration: underline;</string>
                 </property>
                 <property name="text">
-                 <string>Appearance</string>
+                 <string>Rendering</string>
                 </property>
                </widget>
               </item>
@@ -539,8 +539,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>640</width>
-                   <height>428</height>
+                   <width>626</width>
+                   <height>465</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
@@ -859,17 +859,7 @@
                        <property name="bottomMargin">
                         <number>0</number>
                        </property>
-                       <item row="0" column="0">
-                        <widget class="QCheckBox" name="mShowAllCheckBox">
-                         <property name="text">
-                          <string>Show all diagrams</string>
-                         </property>
-                         <property name="checked">
-                          <bool>true</bool>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
+                       <item row="2" column="0">
                         <widget class="QgsCollapsibleGroupBox" name="mScaleVisibilityGroupBox">
                          <property name="title">
                           <string>Scale dependent visibility</string>
@@ -889,6 +879,60 @@
                           </item>
                          </layout>
                         </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QCheckBox" name="mShowAllCheckBox">
+                         <property name="text">
+                          <string>Show all diagrams</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <layout class="QHBoxLayout" name="horizontalLayout_8">
+                         <item>
+                          <widget class="QLabel" name="label_16">
+                           <property name="text">
+                            <string>Diagram z-index</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QgsDoubleSpinBox" name="mZIndexSpinBox">
+                           <property name="toolTip">
+                            <string>Controls how diagrams are drawn on top of each other. Diagrams with a higher z-index are drawn above diagrams and labels with a lower z-index.</string>
+                           </property>
+                           <property name="minimum">
+                            <double>-9999999.000000000000000</double>
+                           </property>
+                           <property name="maximum">
+                            <double>9999999.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QgsPropertyOverrideButton" name="mZOrderDDBtn">
+                           <property name="text">
+                            <string>…</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <spacer name="horizontalSpacer_10">
+                           <property name="orientation">
+                            <enum>Qt::Horizontal</enum>
+                           </property>
+                           <property name="sizeHint" stdset="0">
+                            <size>
+                             <width>40</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                          </spacer>
+                         </item>
+                        </layout>
                        </item>
                       </layout>
                      </widget>
@@ -1095,8 +1139,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>413</width>
-                   <height>238</height>
+                   <width>642</width>
+                   <height>421</height>
                   </rect>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
@@ -1411,8 +1455,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>213</width>
-                   <height>220</height>
+                   <width>642</width>
+                   <height>421</height>
                   </rect>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_12">
@@ -1560,50 +1604,6 @@
                     </item>
                     <item>
                      <spacer name="horizontalSpacer_6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="6" column="0">
-                   <layout class="QHBoxLayout" name="horizontalLayout_8">
-                    <item>
-                     <widget class="QLabel" name="label_16">
-                      <property name="text">
-                       <string>Diagram z-index</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsDoubleSpinBox" name="mZIndexSpinBox">
-                      <property name="toolTip">
-                       <string>Controls how labels are drawn on top of each other. Labels with a higher z-index are drawn above labels with a lower z-index.</string>
-                      </property>
-                      <property name="minimum">
-                       <double>-9999999.000000000000000</double>
-                      </property>
-                      <property name="maximum">
-                       <double>9999999.000000000000000</double>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsPropertyOverrideButton" name="mZOrderDDBtn">
-                      <property name="text">
-                       <string>…</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_10">
                       <property name="orientation">
                        <enum>Qt::Horizontal</enum>
                       </property>
@@ -1837,8 +1837,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>98</width>
-                   <height>137</height>
+                   <width>642</width>
+                   <height>421</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -2056,8 +2056,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>246</width>
-                   <height>72</height>
+                   <width>642</width>
+                   <height>421</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_12">

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -5686,7 +5686,7 @@ font-style: italic;</string>
                            <item>
                             <widget class="QgsDoubleSpinBox" name="mZIndexSpinBox">
                              <property name="toolTip">
-                              <string>Controls how labels are drawn on top of each other. Labels with a higher z-index are drawn above labels with a lower z-index.</string>
+                              <string>Controls how labels are drawn on top of each other. Labels with a higher z-index are drawn above labels and diagrams with a lower z-index.</string>
                              </property>
                              <property name="minimum">
                               <double>-9999999.000000000000000</double>


### PR DESCRIPTION
Trying to standardize Layer diagram properties tab with the Labels tab:
 * Rename the Appearance tab --> Rendering tab
 * Move the Diagram z-index option from the Placement tab to Rendering; i believe it's more about visibility than x-y placement (and it's there in Labels options)

Also Improve diagram and label z-index tooltip
![image](https://user-images.githubusercontent.com/7983394/27673221-baa01ad2-5c9f-11e7-820d-68b2ed5c08af.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

@nirvn @nyalldawson ?