### PR TITLE
[FEATURE] Dynamic form for joined fields

### DIFF
--- a/python/core/qgsvectorlayerjoinbuffer.sip
+++ b/python/core/qgsvectorlayerjoinbuffer.sip
@@ -99,6 +99,24 @@ Quick way to test if there is any join at all
  :rtype: list of int
 %End
 
+    QList<const QgsVectorLayerJoinInfo *> joinsWhereFieldIsId( const QgsField &field ) const;
+%Docstring
+ Returns joins where the field of a target layer is considered as an id.
+ \param field the field of a target layer
+ :return: a list of vector joins
+.. versionadded:: 3.0
+ :rtype: list of const QgsVectorLayerJoinInfo
+%End
+
+    QgsFeature joinedFeatureOf( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const;
+%Docstring
+ Returns the joined feature corresponding to the feature.
+ \param info the vector join information
+ \param feature the feature of the target layer
+.. versionadded:: 3.0
+ :rtype: QgsFeature
+%End
+
     QgsVectorLayerJoinBuffer *clone() const /Factory/;
 %Docstring
 .. versionadded:: 2.6

--- a/python/core/qgsvectorlayerjoinbuffer.sip
+++ b/python/core/qgsvectorlayerjoinbuffer.sip
@@ -108,7 +108,7 @@ Quick way to test if there is any join at all
  :rtype: list of const QgsVectorLayerJoinInfo
 %End
 
-    QgsFeature joinedFeatureOf( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const;
+    QgsFeature joinedFeatureOf( const QgsVectorLayerJoinInfo *info, const QgsFeature &feature ) const;
 %Docstring
  Returns the joined feature corresponding to the feature.
  \param info the vector join information

--- a/python/core/qgsvectorlayerjoininfo.sip
+++ b/python/core/qgsvectorlayerjoininfo.sip
@@ -84,6 +84,21 @@ Returns whether values from the joined layer should be cached in memory to speed
  :rtype: bool
 %End
 
+    bool isDynamicFormEnabled() const;
+%Docstring
+ Returns whether the form has to be dynamically updated with joined fields
+  when  a feature is being created in the target layer.
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
+    void setDynamicFormEnabled( bool enabled );
+%Docstring
+ Sets whether the form has to be dynamically updated with joined fields
+  when a feature is being created in the target layer.
+.. versionadded:: 3.0
+%End
+
     bool operator==( const QgsVectorLayerJoinInfo &other ) const;
 
     void setJoinFieldNamesSubset( QStringList *fieldNamesSubset /Transfer/ );
@@ -100,6 +115,7 @@ Returns whether values from the joined layer should be cached in memory to speed
 %End
 
   protected:
+
 
 
 

--- a/python/core/qgsvectorlayerjoininfo.sip
+++ b/python/core/qgsvectorlayerjoininfo.sip
@@ -99,6 +99,15 @@ Returns whether values from the joined layer should be cached in memory to speed
 .. versionadded:: 3.0
 %End
 
+    QString prefixedFieldName( const QgsField &field ) const;
+%Docstring
+ Returns the prefixed name of the field.
+ \param field the field
+ :return: the prefixed name of the field
+.. versionadded:: 3.0
+ :rtype: str
+%End
+
     bool operator==( const QgsVectorLayerJoinInfo &other ) const;
 
     void setJoinFieldNamesSubset( QStringList *fieldNamesSubset /Transfer/ );

--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -156,6 +156,13 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
  :rtype: str
 %End
 
+    virtual void setHint( const QString &hintText );
+%Docstring
+ Add a hint text on the widget
+ \param hintText The hint text to display
+.. versionadded:: 3.0
+%End
+
   signals:
 
     void valueChanged( const QVariant &value );

--- a/python/gui/qgsattributeform.sip
+++ b/python/gui/qgsattributeform.sip
@@ -167,7 +167,7 @@ class QgsAttributeForm : QWidget
 
   public slots:
 
-    void changeAttribute( const QString &field, const QVariant &value );
+    void changeAttribute( const QString &field, const QVariant &value, const QString &hintText = QString() );
 %Docstring
  Call this to change the content of a given attribute. Will update the editor(s) related to this field.
 

--- a/src/app/qgsjoindialog.cpp
+++ b/src/app/qgsjoindialog.cpp
@@ -42,7 +42,7 @@ QgsJoinDialog::QgsJoinDialog( QgsVectorLayer *layer, QList<QgsMapLayer *> alread
 
   mTargetFieldComboBox->setLayer( mLayer );
 
-  mDynamicFormCheckBox->setToolTip( tr( "This option allows values of the joined fields to be automatically updated when the \"Target Field\" is updated" ) );
+  mDynamicFormCheckBox->setToolTip( tr( "This option allows values of the joined fields to be automatically reloaded when the \"Target Field\" is changed" ) );
 
   mJoinLayerComboBox->setFilters( QgsMapLayerProxyModel::VectorLayer );
   mJoinLayerComboBox->setExceptedLayerList( alreadyJoinedLayers );

--- a/src/app/qgsjoindialog.cpp
+++ b/src/app/qgsjoindialog.cpp
@@ -42,6 +42,8 @@ QgsJoinDialog::QgsJoinDialog( QgsVectorLayer *layer, QList<QgsMapLayer *> alread
 
   mTargetFieldComboBox->setLayer( mLayer );
 
+  mDynamicFormCheckBox->setToolTip( tr( "This option allows values of the joined fields to be automatically updated when the \"Target Field\" is updated" ) );
+
   mJoinLayerComboBox->setFilters( QgsMapLayerProxyModel::VectorLayer );
   mJoinLayerComboBox->setExceptedLayerList( alreadyJoinedLayers );
   connect( mJoinLayerComboBox, &QgsMapLayerComboBox::layerChanged, mJoinFieldComboBox, &QgsFieldComboBox::setLayer );
@@ -73,6 +75,7 @@ void QgsJoinDialog::setJoinInfo( const QgsVectorLayerJoinInfo &joinInfo )
   mJoinFieldComboBox->setField( joinInfo.joinFieldName() );
   mTargetFieldComboBox->setField( joinInfo.targetFieldName() );
   mCacheInMemoryCheckBox->setChecked( joinInfo.isUsingMemoryCache() );
+  mDynamicFormCheckBox->setChecked( joinInfo.isDynamicFormEnabled() );
   if ( joinInfo.prefix().isNull() )
   {
     mUseCustomPrefix->setChecked( false );
@@ -110,6 +113,7 @@ QgsVectorLayerJoinInfo QgsJoinDialog::joinInfo() const
   info.setJoinFieldName( mJoinFieldComboBox->currentField() );
   info.setTargetFieldName( mTargetFieldComboBox->currentField() );
   info.setUsingMemoryCache( mCacheInMemoryCheckBox->isChecked() );
+  info.setDynamicFormEnabled( mDynamicFormCheckBox->isChecked() );
 
   if ( mUseCustomPrefix->isChecked() )
     info.setPrefix( mCustomPrefix->text() );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1235,16 +1235,21 @@ void QgsVectorLayerProperties::addJoinToTreeWidget( const QgsVectorLayerJoinInfo
     joinItem->setText( 3, QChar( 0x2714 ) );
   }
 
-  joinItem->setText( 4, join.prefix() );
+  if ( join.isDynamicFormEnabled() )
+  {
+    joinItem->setText( 4, QChar( 0x2714 ) );
+  }
+
+  joinItem->setText( 5, join.prefix() );
 
   const QStringList *list = join.joinFieldNamesSubset();
   if ( list )
   {
-    joinItem->setText( 5, QStringLiteral( "%1" ).arg( list->count() ) );
+    joinItem->setText( 6, QStringLiteral( "%1" ).arg( list->count() ) );
   }
   else
   {
-    joinItem->setText( 5, tr( "all" ) );
+    joinItem->setText( 6, tr( "all" ) );
   }
 
   if ( insertIndex >= 0 )
@@ -1255,7 +1260,7 @@ void QgsVectorLayerProperties::addJoinToTreeWidget( const QgsVectorLayerJoinInfo
   {
     mJoinTreeWidget->addTopLevelItem( joinItem );
   }
-  for ( int c = 0; c < 5; c++ )
+  for ( int c = 0; c < 6; c++ )
   {
     mJoinTreeWidget->resizeColumnToContents( c );
   }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -286,6 +286,7 @@ SET(QGIS_CORE_SRCS
   qgsvectorlayerfeatureiterator.cpp
   qgsvectorlayerexporter.cpp
   qgsvectorlayerjoinbuffer.cpp
+  qgsvectorlayerjoininfo.cpp
   qgsvectorlayerlabeling.cpp
   qgsvectorlayerlabelprovider.cpp
   qgsvectorlayerrenderer.cpp

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -419,7 +419,7 @@ QgsFeature QgsVectorLayerJoinBuffer::joinedFeatureOf( const QgsVectorLayerJoinIn
     const QVariant targetValue = feature.attribute( info->targetFieldName() );
     QString fieldRef = QgsExpression::quotedColumnRef( info->joinFieldName() );
     QString quotedVal = QgsExpression::quotedValue( targetValue.toString() );
-    const QString filter = QString( "%1 = %2" ).arg( fieldRef, quotedVal );
+    const QString filter = QStringLiteral( "%1 = %2" ).arg( fieldRef, quotedVal );
 
     QgsFeatureRequest request;
     request.setFilterExpression( filter );

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -398,15 +398,13 @@ QList<const QgsVectorLayerJoinInfo *> QgsVectorLayerJoinBuffer::joinsWhereFieldI
 {
   QList<const QgsVectorLayerJoinInfo *> infos;
 
-  for ( int i = 0; i < mVectorJoins.count(); i++ )
+  Q_FOREACH ( const QgsVectorLayerJoinInfo &info, mVectorJoins )
   {
-    const QgsVectorLayerJoinInfo *info = &( mVectorJoins[i] );
-
-    if ( infos.contains( info ) )
+    if ( infos.contains( &info ) )
       continue;
 
-    if ( info->targetFieldName() == field.name() )
-      infos.append( info );
+    if ( info.targetFieldName() == field.name() )
+      infos.append( &info );
   }
 
   return infos;

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -412,14 +412,14 @@ QList<const QgsVectorLayerJoinInfo *> QgsVectorLayerJoinBuffer::joinsWhereFieldI
   return infos;
 }
 
-QgsFeature QgsVectorLayerJoinBuffer::joinedFeatureOf( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const
+QgsFeature QgsVectorLayerJoinBuffer::joinedFeatureOf( const QgsVectorLayerJoinInfo *info, const QgsFeature &feature ) const
 {
   QgsFeature joinedFeature;
 
-  if ( info.joinLayer() )
+  if ( info->joinLayer() )
   {
-    const QVariant targetValue = feature.attribute( info.targetFieldName() );
-    QString fieldRef = QgsExpression::quotedColumnRef( info.joinFieldName() );
+    const QVariant targetValue = feature.attribute( info->targetFieldName() );
+    QString fieldRef = QgsExpression::quotedColumnRef( info->joinFieldName() );
     QString quotedVal = QgsExpression::quotedValue( targetValue.toString() );
     const QString filter = QString( "%1 = %2" ).arg( fieldRef, quotedVal );
 
@@ -427,7 +427,7 @@ QgsFeature QgsVectorLayerJoinBuffer::joinedFeatureOf( const QgsVectorLayerJoinIn
     request.setFilterExpression( filter );
     request.setLimit( 1 );
 
-    QgsFeatureIterator it = info.joinLayer()->getFeatures( request );
+    QgsFeatureIterator it = info->joinLayer()->getFeatures( request );
     it.nextFeature( joinedFeature );
   }
 

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -275,6 +275,7 @@ void QgsVectorLayerJoinBuffer::writeXml( QDomNode &layer_node, QDomDocument &doc
     joinElem.setAttribute( QStringLiteral( "joinFieldName" ), joinIt->joinFieldName() );
 
     joinElem.setAttribute( QStringLiteral( "memoryCache" ), joinIt->isUsingMemoryCache() );
+    joinElem.setAttribute( QStringLiteral( "dynamicForm" ), joinIt->isDynamicFormEnabled() );
 
     if ( joinIt->joinFieldNamesSubset() )
     {
@@ -315,6 +316,7 @@ void QgsVectorLayerJoinBuffer::readXml( const QDomNode &layer_node )
       info.setJoinLayerId( infoElem.attribute( QStringLiteral( "joinLayerId" ) ) );
       info.setTargetFieldName( infoElem.attribute( QStringLiteral( "targetFieldName" ) ) );
       info.setUsingMemoryCache( infoElem.attribute( QStringLiteral( "memoryCache" ) ).toInt() );
+      info.setDynamicFormEnabled( infoElem.attribute( QStringLiteral( "dynamicForm" ) ).toInt() );
 
       QDomElement subsetElem = infoElem.firstChildElement( QStringLiteral( "joinFieldsSubset" ) );
       if ( !subsetElem.isNull() )

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -419,7 +419,9 @@ QgsFeature QgsVectorLayerJoinBuffer::joinedFeatureOf( const QgsVectorLayerJoinIn
   if ( info.joinLayer() )
   {
     const QVariant targetValue = feature.attribute( info.targetFieldName() );
-    const QString filter = QString( "\"%1\" = %2" ).arg( info.joinFieldName(), targetValue.toString() );
+    QString fieldRef = QgsExpression::quotedColumnRef( info.joinFieldName() );
+    QString quotedVal = QgsExpression::quotedValue( targetValue.toString() );
+    const QString filter = QString( "%1 = %2" ).arg( fieldRef, quotedVal );
 
     QgsFeatureRequest request;
     request.setFilterExpression( filter );

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -394,6 +394,44 @@ const QgsVectorLayerJoinInfo *QgsVectorLayerJoinBuffer::joinForFieldIndex( int i
   return &( mVectorJoins[sourceJoinIndex] );
 }
 
+QList<const QgsVectorLayerJoinInfo *> QgsVectorLayerJoinBuffer::joinsWhereFieldIsId( const QgsField &field ) const
+{
+  QList<const QgsVectorLayerJoinInfo *> infos;
+
+  for ( int i = 0; i < mVectorJoins.count(); i++ )
+  {
+    const QgsVectorLayerJoinInfo *info = &( mVectorJoins[i] );
+
+    if ( infos.contains( info ) )
+      continue;
+
+    if ( info->targetFieldName() == field.name() )
+      infos.append( info );
+  }
+
+  return infos;
+}
+
+QgsFeature QgsVectorLayerJoinBuffer::joinedFeatureOf( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const
+{
+  QgsFeature joinedFeature;
+
+  if ( info.joinLayer() )
+  {
+    const QVariant targetValue = feature.attribute( info.targetFieldName() );
+    const QString filter = QString( "\"%1\" = %2" ).arg( info.joinFieldName(), targetValue.toString() );
+
+    QgsFeatureRequest request;
+    request.setFilterExpression( filter );
+    request.setLimit( 1 );
+
+    QgsFeatureIterator it = info.joinLayer()->getFeatures( request );
+    it.nextFeature( joinedFeature );
+  }
+
+  return joinedFeature;
+}
+
 QgsVectorLayerJoinBuffer *QgsVectorLayerJoinBuffer::clone() const
 {
   QgsVectorLayerJoinBuffer *cloned = new QgsVectorLayerJoinBuffer( mLayer );

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -84,6 +84,20 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject
     //! \since QGIS 2.6
     static QVector<int> joinSubsetIndices( QgsVectorLayer *joinLayer, const QStringList &joinFieldsSubset );
 
+    /** Returns joins where the field of a target layer is considered as an id.
+     * \param field the field of a target layer
+     * \returns a list of vector joins
+     * \since QGIS3.0
+     */
+    QList<const QgsVectorLayerJoinInfo *> joinsWhereFieldIsId( const QgsField &field ) const;
+
+    /** Returns the joined feature corresponding to the feature.
+     * \param info the vector join information
+     * \param feature the feature of the target layer
+     * \since QGIS 3.0
+     */
+    QgsFeature joinedFeatureOf( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const;
+
     //! Create a copy of the join buffer
     //! \since QGIS 2.6
     QgsVectorLayerJoinBuffer *clone() const SIP_FACTORY;

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject
      * \param feature the feature of the target layer
      * \since QGIS 3.0
      */
-    QgsFeature joinedFeatureOf( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const;
+    QgsFeature joinedFeatureOf( const QgsVectorLayerJoinInfo *info, const QgsFeature &feature ) const;
 
     //! Create a copy of the join buffer
     //! \since QGIS 2.6

--- a/src/core/qgsvectorlayerjoininfo.cpp
+++ b/src/core/qgsvectorlayerjoininfo.cpp
@@ -1,0 +1,35 @@
+/***************************************************************************
+                          qgsvectorlayerjoininfo.cpp
+                          --------------------------
+    begin                : Jun 29, 2017
+    copyright            : (C) 2017 by Paul Blottiere
+    email                : paul.blottiere@oslandia.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectorlayerjoininfo.h"
+
+QString QgsVectorLayerJoinInfo::prefixedFieldName( const QgsField &f ) const
+{
+  QString name;
+
+  if ( joinLayer() )
+  {
+    if ( prefix().isNull() )
+      name = joinLayer()->name() + '_';
+    else
+      name = prefix();
+
+    name += f.name();
+  }
+
+  return name;
+}

--- a/src/core/qgsvectorlayerjoininfo.h
+++ b/src/core/qgsvectorlayerjoininfo.h
@@ -54,6 +54,18 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
     //! Returns whether values from the joined layer should be cached in memory to speed up lookups
     bool isUsingMemoryCache() const { return mMemoryCache; }
 
+    /** Returns whether the form has to be dynamically updated with joined fields
+     *  when  a feature is being created in the target layer.
+     * \since QGIS 3.0
+     */
+    bool isDynamicFormEnabled() const { return mDynamicForm; }
+
+    /** Sets whether the form has to be dynamically updated with joined fields
+     *  when a feature is being created in the target layer.
+     * \since QGIS 3.0
+     */
+    void setDynamicFormEnabled( bool enabled ) { mDynamicForm = enabled; }
+
     bool operator==( const QgsVectorLayerJoinInfo &other ) const
     {
       return mTargetFieldName == other.mTargetFieldName &&
@@ -98,6 +110,8 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
 
     //! True if the cached join attributes need to be updated
     bool cacheDirty;
+
+    bool mDynamicForm;
 
     //! Cache for joined attributes to provide fast lookup (size is 0 if no memory caching)
     QHash< QString, QgsAttributes> cachedAttributes;

--- a/src/core/qgsvectorlayerjoininfo.h
+++ b/src/core/qgsvectorlayerjoininfo.h
@@ -66,6 +66,13 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
      */
     void setDynamicFormEnabled( bool enabled ) { mDynamicForm = enabled; }
 
+    /** Returns the prefixed name of the field.
+     * \param field the field
+     * \returns the prefixed name of the field
+     * \since QGIS 3.0
+     */
+    QString prefixedFieldName( const QgsField &field ) const;
+
     bool operator==( const QgsVectorLayerJoinInfo &other ) const
     {
       return mTargetFieldName == other.mTargetFieldName &&

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -211,3 +211,8 @@ bool QgsEditorWidgetWrapper::isInTable( const QWidget *parent )
   if ( qobject_cast<const QTableView *>( parent ) ) return true;
   return isInTable( parent->parentWidget() );
 }
+
+void QgsEditorWidgetWrapper::setHint( const QString &hintText )
+{
+  widget()->setToolTip( hintText );
+}

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -164,6 +164,13 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     QString constraintFailureReason() const;
 
+    /**
+     * Add a hint text on the widget
+     * \param hintText The hint text to display
+     * \since QGIS 3.0
+     */
+    virtual void setHint( const QString &hintText );
+
   signals:
 
     /**

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -240,3 +240,16 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
   if ( mLineEdit )
     mLineEdit->setText( v );
 }
+
+void QgsTextEditWrapper::setHint( const QString &hintText )
+{
+  if ( hintText.isNull() )
+    mPlaceholderText = mPlaceholderTextBackup;
+  else
+  {
+    mPlaceholderTextBackup = mPlaceholderText;
+    mPlaceholderText = hintText;
+  }
+
+  mLineEdit->setPlaceholderText( mPlaceholderText );
+}

--- a/src/gui/editorwidgets/qgstexteditwrapper.h
+++ b/src/gui/editorwidgets/qgstexteditwrapper.h
@@ -47,6 +47,13 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
     QVariant value() const override;
     void showIndeterminateState() override;
 
+    /**
+     * Add a hint text on the widget
+     * \param hintText The hint text to display
+     * \since QGIS 3.0
+     */
+    void setHint( const QString &hintText ) override;
+
   protected:
     QWidget *createWidget( QWidget *parent ) override;
     void initWidget( QWidget *editor ) override;
@@ -66,6 +73,7 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
     QPalette mReadOnlyPalette;
     QPalette mWritablePalette;
     QString mPlaceholderText;
+    QString mPlaceholderTextBackup;
 
     void setWidgetValue( const QVariant &value );
 };

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1936,12 +1936,12 @@ void QgsAttributeForm::ContainerInformation::apply( QgsExpressionContext *expres
   }
 }
 
-QgsFeature QgsAttributeForm::joinedFeature( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const
+QgsFeature QgsAttributeForm::joinedFeature( const QgsVectorLayerJoinInfo *info, const QgsFeature &feature ) const
 {
   QgsFeature joinedFeature = mLayer->joinBuffer()->joinedFeatureOf( info, feature );
 
   if ( !joinedFeature.isValid() )
-    joinedFeature = QgsVectorLayerUtils::createFeature( info.joinLayer(), QgsGeometry(), QgsAttributeMap() );
+    joinedFeature = QgsVectorLayerUtils::createFeature( info->joinLayer(), QgsGeometry(), QgsAttributeMap() );
 
   return joinedFeature;
 }
@@ -1960,7 +1960,7 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
     if ( !info->isDynamicFormEnabled() )
       continue;
 
-    QgsFeature joinFeature = joinedFeature( *info, formFeature );
+    QgsFeature joinFeature = joinedFeature( info, formFeature );
 
     QStringList *subsetFields = info->joinFieldNamesSubset();
     if ( subsetFields )

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1973,9 +1973,8 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
     }
     else
     {
-      for ( int i = 0; i < joinFeature.fields().count(); i++ )
+      Q_FOREACH ( const QgsField &field, joinFeature.fields() )
       {
-        QgsField field = joinFeature.fields().field( i );
         QString prefixedName = info->prefixedFieldName( field );
         changeAttribute( prefixedName, joinFeature.attribute( field.name() ) );
       }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -223,7 +223,7 @@ void QgsAttributeForm::setMode( QgsAttributeForm::Mode mode )
   emit modeChanged( mMode );
 }
 
-void QgsAttributeForm::changeAttribute( const QString &field, const QVariant &value )
+void QgsAttributeForm::changeAttribute( const QString &field, const QVariant &value, const QString &hintText )
 {
   Q_FOREACH ( QgsWidgetWrapper *ww, mWidgets )
   {
@@ -231,6 +231,7 @@ void QgsAttributeForm::changeAttribute( const QString &field, const QVariant &va
     if ( eww && eww->field().name() == field )
     {
       eww->setValue( value );
+      eww->setHint( hintText );
     }
   }
 }
@@ -1945,6 +1946,7 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
   if ( infos.count() == 0 || !currentFormFeature( formFeature ) )
     return;
 
+  const QString hint = tr( "No feature joined" );
   Q_FOREACH ( const QgsVectorLayerJoinInfo *info, infos )
   {
     if ( !info->isDynamicFormEnabled() )
@@ -1959,11 +1961,15 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
       {
         QString prefixedName = info->prefixedFieldName( field );
         QVariant val;
+        QString hintText = hint;
 
         if ( joinFeature.isValid() )
+        {
           val = joinFeature.attribute( field );
+          hintText.clear();
+        }
 
-        changeAttribute( prefixedName, val );
+        changeAttribute( prefixedName, val, hintText );
       }
     }
     else
@@ -1972,11 +1978,15 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
       {
         QString prefixedName = info->prefixedFieldName( field );
         QVariant val;
+        QString hintText = hint;
 
         if ( joinFeature.isValid() )
+        {
           val = joinFeature.attribute( field.name() );
+          hintText.clear();
+        }
 
-        changeAttribute( prefixedName, val );
+        changeAttribute( prefixedName, val, hintText );
       }
     }
   }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1936,16 +1936,6 @@ void QgsAttributeForm::ContainerInformation::apply( QgsExpressionContext *expres
   }
 }
 
-QgsFeature QgsAttributeForm::joinedFeature( const QgsVectorLayerJoinInfo *info, const QgsFeature &feature ) const
-{
-  QgsFeature joinedFeature = mLayer->joinBuffer()->joinedFeatureOf( info, feature );
-
-  if ( !joinedFeature.isValid() )
-    joinedFeature = QgsVectorLayerUtils::createFeature( info->joinLayer(), QgsGeometry(), QgsAttributeMap() );
-
-  return joinedFeature;
-}
-
 void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
 {
   QgsFeature formFeature;
@@ -1960,7 +1950,7 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
     if ( !info->isDynamicFormEnabled() )
       continue;
 
-    QgsFeature joinFeature = joinedFeature( info, formFeature );
+    QgsFeature joinFeature = mLayer->joinBuffer()->joinedFeatureOf( info, formFeature );
 
     QStringList *subsetFields = info->joinFieldNamesSubset();
     if ( subsetFields )
@@ -1968,7 +1958,12 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
       Q_FOREACH ( const QString &field, *subsetFields )
       {
         QString prefixedName = info->prefixedFieldName( field );
-        changeAttribute( prefixedName, joinFeature.attribute( field ) );
+        QVariant val;
+
+        if ( joinFeature.isValid() )
+          val = joinFeature.attribute( field );
+
+        changeAttribute( prefixedName, val );
       }
     }
     else
@@ -1976,7 +1971,12 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
       Q_FOREACH ( const QgsField &field, joinFeature.fields() )
       {
         QString prefixedName = info->prefixedFieldName( field );
-        changeAttribute( prefixedName, joinFeature.attribute( field.name() ) );
+        QVariant val;
+
+        if ( joinFeature.isValid() )
+          val = joinFeature.attribute( field.name() );
+
+        changeAttribute( prefixedName, val );
       }
     }
   }

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -273,8 +273,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     void initPython();
 
-    QgsFeature joinedFeature( const QgsVectorLayerJoinInfo *info, const QgsFeature &feature ) const;
-
     void updateJoinedFields( const QgsEditorWidgetWrapper &eww );
 
     struct WidgetInfo

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -209,7 +209,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      * \param field The field to change
      * \param value The new value
      */
-    void changeAttribute( const QString &field, const QVariant &value );
+    void changeAttribute( const QString &field, const QVariant &value, const QString &hintText = QString() );
 
     /**
      * Update all editors to correspond to a different feature.

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -273,7 +273,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     void initPython();
 
-    QgsFeature joinedFeature( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const;
+    QgsFeature joinedFeature( const QgsVectorLayerJoinInfo *info, const QgsFeature &feature ) const;
 
     void updateJoinedFields( const QgsEditorWidgetWrapper &eww );
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -273,6 +273,10 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     void initPython();
 
+    QgsFeature joinedFeature( const QgsVectorLayerJoinInfo &info, const QgsFeature &feature ) const;
+
+    void updateJoinedFields( const QgsEditorWidgetWrapper &eww );
+
     struct WidgetInfo
     {
       WidgetInfo()

--- a/src/ui/qgsjoindialogbase.ui
+++ b/src/ui/qgsjoindialogbase.ui
@@ -44,10 +44,10 @@
    <item row="2" column="1">
     <widget class="QgsFieldComboBox" name="mTargetFieldComboBox"/>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mUseJoinFieldsSubset">
      <property name="title">
-      <string>Choose which fields are joined</string>
+      <string>Choose which fields are &amp;joined</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -65,10 +65,10 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mUseCustomPrefix">
      <property name="title">
-      <string>Custom field name prefix</string>
+      <string>Custom field &amp;name prefix</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -86,7 +86,7 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -116,13 +116,20 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="mDynamicFormCheckBox">
+     <property name="text">
+      <string>Dynamic form</string>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -303,7 +303,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>9</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -379,8 +379,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>639</width>
-                <height>592</height>
+                <width>653</width>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -831,7 +831,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>536</height>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -1069,7 +1069,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>536</height>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -1170,7 +1170,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>536</height>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1229,8 +1229,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>671</width>
-                <height>522</height>
+                <width>653</width>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1249,7 +1249,7 @@ border-radius: 2px;</string>
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="mScaleVisibilityGroupBox">
                  <property name="title">
-                  <string>Scale dependent visibility</string>
+                  <string>Scale dependen&amp;t visibility</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -1268,7 +1268,7 @@ border-radius: 2px;</string>
                <item>
                 <widget class="QGroupBox" name="mSimplifyDrawingGroupBox">
                  <property name="title">
-                  <string>Simplify geometry</string>
+                  <string>Simplify &amp;geometry</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -1590,7 +1590,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>536</height>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1656,7 +1656,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>536</height>
+                <height>542</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1675,7 +1675,7 @@ border-radius: 2px;</string>
                <item>
                 <widget class="QTreeWidget" name="mJoinTreeWidget">
                  <property name="columnCount">
-                  <number>6</number>
+                  <number>7</number>
                  </property>
                  <column>
                   <property name="text">
@@ -1695,6 +1695,11 @@ border-radius: 2px;</string>
                  <column>
                   <property name="text">
                    <string>Memory cache</string>
+                  </property>
+                 </column>
+                 <column>
+                  <property name="text">
+                   <string>Dynamic form</string>
                   </property>
                  </column>
                  <column>


### PR DESCRIPTION
## Description

This PR add a new UI option allowing to activate a dynamic form for joined fields. 

When this option is activated, joined fields are automatically updated according to the "target field".

![optimised](https://user-images.githubusercontent.com/9266424/27697713-f51f0464-5cec-11e7-9b5c-b827603df35f.gif)


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
