### PR TITLE
[Processing] Align the "Iterate over layer" button

### DIFF
--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -41,7 +41,7 @@ from qgis.core import (QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterVectorOutput)
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, Qt
 from qgis.PyQt.QtWidgets import (QWidget, QHBoxLayout, QToolButton,
                                  QLabel, QCheckBox)
 from qgis.PyQt.QtGui import QIcon
@@ -121,6 +121,7 @@ class ParametersPanel(BASE, WIDGET):
                         button.setToolTip(self.tr('Iterate over this layer, creating a separate output for every feature in the layer'))
                         button.setCheckable(True)
                         layout.addWidget(button)
+                        layout.setAlignment(button, Qt.AlignTop)
                         self.iterateButtons[param.name()] = button
                         button.toggled.connect(self.buttonToggled)
                         widget = QWidget()

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -89,7 +89,7 @@ from qgis.gui import (
     QgsMapLayerComboBox,
     QgsProjectionSelectionWidget,
 )
-from qgis.PyQt.QtCore import pyqtSignal, QObject, QVariant
+from qgis.PyQt.QtCore import pyqtSignal, QObject, QVariant, Qt
 from qgis.utils import iface
 
 from processing.gui.NumberInputPanel import NumberInputPanel, ModellerNumberInputPanel
@@ -762,11 +762,13 @@ class VectorWidgetWrapper(WidgetWrapper):
             layout.setSpacing(2)
             self.combo = QgsMapLayerComboBox()
             layout.addWidget(self.combo)
+            layout.setAlignment(self.combo, Qt.AlignTop)
             btn = QToolButton()
             btn.setText('...')
             btn.setToolTip(self.tr("Select file"))
             btn.clicked.connect(self.selectFile)
             layout.addWidget(btn)
+            layout.setAlignment(btn, Qt.AlignTop)
 
             vl = QVBoxLayout()
             vl.setMargin(0)


### PR DESCRIPTION
Vertically align the "Iterate over layer" button with the layer combobox and browser
Before vs After
![image](https://user-images.githubusercontent.com/7983394/27712380-10dc858e-5d27-11e7-9748-731fb37a8dd9.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
