### PR TITLE
Move flushBuffer method up to QgsFeatureSink

### DIFF
--- a/python/core/qgsfeaturesink.sip
+++ b/python/core/qgsfeaturesink.sip
@@ -55,6 +55,12 @@ class QgsFeatureSink
  :rtype: bool
 %End
 
+    virtual bool flushBuffer();
+%Docstring
+ Flushes any internal buffer which may exist in the sink, causing any buffered features to be added to the sink's destination.
+ :return: false if any buffered features could not be added to the sink.
+ :rtype: bool
+%End
 };
 
 QFlags<QgsFeatureSink::Flag> operator|(QgsFeatureSink::Flag f1, QFlags<QgsFeatureSink::Flag> f2);

--- a/python/core/qgsvectorlayerexporter.sip
+++ b/python/core/qgsvectorlayerexporter.sip
@@ -124,12 +124,8 @@ class QgsVectorLayerExporter : QgsFeatureSink
  Finalizes the export and closes the new created layer.
 %End
 
-    bool flushBuffer();
-%Docstring
- Flush the buffer writing the features to the new layer.
-.. versionadded:: 3.0
- :rtype: bool
-%End
+    virtual bool flushBuffer();
+
 
   private:
     QgsVectorLayerExporter( const QgsVectorLayerExporter &rh );

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -71,6 +71,11 @@ class CORE_EXPORT QgsFeatureSink
      */
     virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = 0 );
 
+    /**
+     * Flushes any internal buffer which may exist in the sink, causing any buffered features to be added to the sink's destination.
+     * \returns false if any buffered features could not be added to the sink.
+     */
+    virtual bool flushBuffer() { return true; }
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureSink::Flags )

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -141,11 +141,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
      */
     ~QgsVectorLayerExporter();
 
-    /**
-     * Flush the buffer writing the features to the new layer.
-     * \since QGIS 3.0
-     */
-    bool flushBuffer();
+    bool flushBuffer() override;
 
   private:
 


### PR DESCRIPTION
Allows calling flushBuffer on QgsFeatureSink objects, ensuring that any internal buffer the sink may have is flushed
