### PR TITLE
Because OK is neither spelled ok nor Ok

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -383,7 +383,7 @@ tools.
 
   cmake ..
 
-If everything went ok you can finally start to compile. (As usual append a -jX
+If everything went OK you can finally start to compile. (As usual append a -jX
 where X is the number of available cores option to make to speed up your build
 process)
 

--- a/NEWS
+++ b/NEWS
@@ -1526,7 +1526,7 @@ under construction.
     in ogr provider
 - 2004-12-05 [gsherman] 0.6.0rc2 Fixed bug 1079392 that caused QGIS to crash when a query was entered that
  resulted in the layer being created with no records. Additional validation
- of the SQL query was added to the query builder.  When Ok is clicked on
+ of the SQL query was added to the query builder.  When OK is clicked on
  the builder dialog, the query is sent to the database and the result
  checked to ensure that it will create a valid PostreSQL layer.  Added tr
  to a number of strings that weren't prepared for translation in the vector

--- a/NEWS
+++ b/NEWS
@@ -2128,7 +2128,7 @@ not need src parameter (this can be obtained from painter->device()).
 More work on print system - still only works well on A4 landscape.
 
 Northarrow and copyright label plugins now hidethemselves before emitting
-  update signals when ok is pressed.
+  update signals when OK is pressed.
 
 QGSMapCanvas can now return the (last calculated) scale using getScale
 

--- a/doc/INSTALL.html
+++ b/doc/INSTALL.html
@@ -621,7 +621,7 @@ cmake ..
 </PRE></div>
 
 <P>
-If everything went ok you can finally start to compile. (As usual append a -jX
+If everything went OK you can finally start to compile. (As usual append a -jX
 where X is the number of available cores option to make to speed up your build
 process)
 </P>

--- a/doc/linux.t2t
+++ b/doc/linux.t2t
@@ -271,7 +271,7 @@ tools.
 cmake ..
 ```
 
-If everything went ok you can finally start to compile. (As usual append a -jX
+If everything went OK you can finally start to compile. (As usual append a -jX
 where X is the number of available cores option to make to speed up your build
 process)
 

--- a/doc/news.html
+++ b/doc/news.html
@@ -2350,7 +2350,7 @@ More work on print system - still only works well on A4 landscape.
 </P>
 <P>
 Northarrow and copyright label plugins now hidethemselves before emitting
-  update signals when ok is pressed.
+  update signals when OK is pressed.
 </P>
 <P>
 QGSMapCanvas can now return the (last calculated) scale using getScale

--- a/doc/news.html
+++ b/doc/news.html
@@ -1695,7 +1695,7 @@ under construction.
     in ogr provider
 <LI>2004-12-05 [gsherman] 0.6.0rc2 Fixed bug 1079392 that caused QGIS to crash when a query was entered that
  resulted in the layer being created with no records. Additional validation
- of the SQL query was added to the query builder.  When Ok is clicked on
+ of the SQL query was added to the query builder.  When OK is clicked on
  the builder dialog, the query is sent to the database and the result
  checked to ensure that it will create a valid PostreSQL layer.  Added tr
  to a number of strings that weren't prepared for translation in the vector

--- a/doc/news.t2t
+++ b/doc/news.t2t
@@ -2081,7 +2081,7 @@ not need src parameter (this can be obtained from painter->device()).
 More work on print system - still only works well on A4 landscape.
 
 Northarrow and copyright label plugins now hidethemselves before emitting
-  update signals when ok is pressed.
+  update signals when OK is pressed.
 
 QGSMapCanvas can now return the (last calculated) scale using getScale
 

--- a/doc/news.t2t
+++ b/doc/news.t2t
@@ -1478,7 +1478,7 @@ under construction.
     in ogr provider
 - 2004-12-05 [gsherman] 0.6.0rc2 Fixed bug 1079392 that caused QGIS to crash when a query was entered that
  resulted in the layer being created with no records. Additional validation
- of the SQL query was added to the query builder.  When Ok is clicked on
+ of the SQL query was added to the query builder.  When OK is clicked on
  the builder dialog, the query is sent to the database and the result
  checked to ensure that it will create a valid PostreSQL layer.  Added tr
  to a number of strings that weren't prepared for translation in the vector

--- a/external/astyle/ASBeautifier.cpp
+++ b/external/astyle/ASBeautifier.cpp
@@ -131,7 +131,7 @@ ASBeautifier::ASBeautifier(const ASBeautifier& other) : ASBase(other)
 	*preprocIndentStack = *other.preprocIndentStack;
 
 	// Copy the pointers to vectors.
-	// This is ok because the original ASBeautifier object
+	// This is OK because the original ASBeautifier object
 	// is not deleted until end of job.
 	beautifierFileType = other.beautifierFileType;
 	headers = other.headers;
@@ -2611,7 +2611,7 @@ void ASBeautifier::parseCurrentLine(const string& line)
 			}
 			isInComment = false;
 			i++;
-			blockCommentNoIndent = false;           // ok to indent next comment
+			blockCommentNoIndent = false;           // OK to indent next comment
 			continue;
 		}
 		// treat indented preprocessor lines as a line comment

--- a/external/astyle/ASFormatter.cpp
+++ b/external/astyle/ASFormatter.cpp
@@ -5291,7 +5291,7 @@ void ASFormatter::convertTabToSpaces()
 }
 
 /**
-* is it ok to break this block?
+* is it OK to break this block?
 */
 bool ASFormatter::isOkToBreakBlock(BraceType braceType) const
 {

--- a/python/analysis/interpolation/DualEdgeTriangulation.sip
+++ b/python/analysis/interpolation/DualEdgeTriangulation.sip
@@ -157,7 +157,7 @@ Returns a value list with the numbers of the four points, which would be affecte
   protected:
     unsigned int insertEdge( int dual, int next, int point, bool mbreak, bool forced );
 %Docstring
-Inserts an edge and makes sure, everything is ok with the storage of the edge. The number of the HalfEdge is returned
+Inserts an edge and makes sure, everything is OK with the storage of the edge. The number of the HalfEdge is returned
 %End
     int insertForcedSegment( int p1, int p2, bool breakline );
 %Docstring

--- a/python/core/qgscachedfeatureiterator.sip
+++ b/python/core/qgscachedfeatureiterator.sip
@@ -33,7 +33,7 @@ class QgsCachedFeatureIterator : QgsAbstractFeatureIterator
 %Docstring
  Rewind to the beginning of the iterator
 
- :return: bool true if the operation was ok
+ :return: bool true if the operation was OK
  :rtype: bool
 %End
 
@@ -52,7 +52,7 @@ class QgsCachedFeatureIterator : QgsAbstractFeatureIterator
  Implementation for fetching a feature.
 
  \param f      Will write to this feature
- :return: bool  true if the operation was ok
+ :return: bool  true if the operation was OK
 
 .. seealso:: bool getFeature( QgsFeature& f )
  :rtype: bool
@@ -63,7 +63,7 @@ class QgsCachedFeatureIterator : QgsAbstractFeatureIterator
  We have a local special iterator for FilterFids, no need to run the generic.
 
  \param f      Will write to this feature
- :return: bool  true if the operation was ok
+ :return: bool  true if the operation was OK
  :rtype: bool
 %End
 
@@ -93,7 +93,7 @@ class QgsCachedFeatureWriterIterator : QgsAbstractFeatureIterator
 %Docstring
  Rewind to the beginning of the iterator
 
- :return: bool true if the operation was ok
+ :return: bool true if the operation was OK
  :rtype: bool
 %End
 
@@ -112,7 +112,7 @@ class QgsCachedFeatureWriterIterator : QgsAbstractFeatureIterator
  Implementation for fetching a feature.
 
  \param f      Will write to this feature
- :return: bool  true if the operation was ok
+ :return: bool  true if the operation was OK
 
 .. seealso:: bool getFeature( QgsFeature& f )
  :rtype: bool

--- a/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
+++ b/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
@@ -53,7 +53,7 @@ Direct copies are forbidden. Use clone() instead.
  \param layer the symbol layer to render, if that makes sense
  \param selected whether this feature has been selected (this will add decorations)
  \param drawVertexMarker whether this feature has vertex markers (in edit mode usually)
- :return: true if the rendering was ok
+ :return: true if the rendering was OK
  :rtype: bool
 %End
 

--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -190,7 +190,7 @@ class QgsDualView : QStackedWidget
 %Docstring
  saveEditChanges
 
- :return: true if the saving was ok. false is possible due to connected
+ :return: true if the saving was OK. false is possible due to connected
          validation logic.
  :rtype: bool
 %End

--- a/python/gui/symbology-ng/qgsrendererwidget.sip
+++ b/python/gui/symbology-ng/qgsrendererwidget.sip
@@ -18,7 +18,7 @@ WORKFLOW:
 - find out which widget to use
 - instantiate it and set in stacked widget
 - on any change of renderer type, create some default (dummy?) version and change the stacked widget
-- when clicked ok/apply, get the renderer from active widget and clone it for the layer
+- when clicked OK/Apply, get the renderer from active widget and clone it for the layer
 %End
 
 %TypeHeaderCode

--- a/src/analysis/interpolation/DualEdgeTriangulation.h
+++ b/src/analysis/interpolation/DualEdgeTriangulation.h
@@ -133,7 +133,7 @@ class ANALYSIS_EXPORT DualEdgeTriangulation: public Triangulation
     QColor mBreakEdgeColor;
     //! Pointer to the decorator using this triangulation. It it is used directly, mDecorator equals this
     Triangulation *mDecorator = nullptr;
-    //! Inserts an edge and makes sure, everything is ok with the storage of the edge. The number of the HalfEdge is returned
+    //! Inserts an edge and makes sure, everything is OK with the storage of the edge. The number of the HalfEdge is returned
     unsigned int insertEdge( int dual, int next, int point, bool mbreak, bool forced );
     //! Inserts a forced segment between the points with the numbers p1 and p2 into the triangulation and returns the number of a HalfEdge belonging to this forced edge or -100 in case of failure
     int insertForcedSegment( int p1, int p2, bool breakline );

--- a/src/app/dwg/libdxfrw/drw_entities.cpp
+++ b/src/app/dwg/libdxfrw/drw_entities.cpp
@@ -376,7 +376,7 @@ bool DRW_Entity::parseDwg( DRW::Version version, dwgBuffer *buf, dwgBuffer *strB
     QgsDebugMsg( QString( "haveNextLinks (forced): %1" ).arg( haveNextLinks ) );
   }
 //ENC color
-  color = buf->getEnColor( version, color24, transparency ); //BS or CMC //ok for R14 or negate
+  color = buf->getEnColor( version, color24, transparency ); //BS or CMC //OK for R14 or negate
   ltypeScale = buf->getBitDouble(); //BD
   QgsDebugMsg( QString( " entity color:%1 ltScale:%2" ).arg( color ).arg( ltypeScale ) );
 
@@ -2244,7 +2244,7 @@ bool DRW_Hatch::parseDwg( DRW::Version version, dwgBuffer *buf, duint32 bs )
 
   QgsDebugMsg( "***************************** parsing hatch *********************************************" );
 
-  //Gradient data, RLZ: is ok or if grad > 0 continue read ?
+  //Gradient data, RLZ: is OK or if grad > 0 continue read ?
   if ( version > DRW::AC1015 ) //2004+
   {
     dint32 isGradient = buf->getBitLong();
@@ -2675,7 +2675,7 @@ bool DRW_Spline::parseDwg( DRW::Version version, dwgBuffer *buf, duint32 bs )
   else
   {
     QgsDebugMsg( QString( "spline, unknown scenario %1" ).arg( scenario ) );
-    return false; //RLZ: from doc only 1 or 2 are ok ?
+    return false; //RLZ: from doc only 1 or 2 are OK ?
   }
 
   RESERVE( knotslist, nknots );

--- a/src/app/dwg/libdxfrw/intern/dwgutil.cpp
+++ b/src/app/dwg/libdxfrw/intern/dwgutil.cpp
@@ -452,28 +452,28 @@ void dwgCompressor::copyCompBytes21( duint8 *cbuf, duint8 *dbuf, duint32 l, duin
   {
     case 0:
       break;
-    case 1: //Ok
+    case 1: //OK
       dbuf[dix] = cbuf[six];
       break;
-    case 2: //Ok
+    case 2: //OK
       dbuf[dix++] = cbuf[six + 1];
       dbuf[dix] = cbuf[six];
       break;
-    case 3: //Ok
+    case 3: //OK
       dbuf[dix++] = cbuf[six + 2];
       dbuf[dix++] = cbuf[six + 1];
       dbuf[dix] = cbuf[six];
       break;
-    case 4: //Ok
+    case 4: //OK
       for ( int i = 0; i < 4; i++ ) //RLZ is OK, or are inverse?, OK
         dbuf[dix++] = cbuf[six++];
       break;
-    case 5: //Ok
+    case 5: //OK
       dbuf[dix++] = cbuf[six + 4];
       for ( int i = 0; i < 4; i++ )
         dbuf[dix++] = cbuf[six++];
       break;
-    case 6: //Ok
+    case 6: //OK
       dbuf[dix++] = cbuf[six + 5];
       for ( int i = 1; i < 5; i++ )
         dbuf[dix++] = cbuf[six + i];
@@ -486,16 +486,16 @@ void dwgCompressor::copyCompBytes21( duint8 *cbuf, duint8 *dbuf, duint32 l, duin
       for ( int i = 1; i < 5; i++ )
         dbuf[dix++] = cbuf[six + i];
       dbuf[dix] = cbuf[six];
-    case 8: //Ok
+    case 8: //OK
       for ( int i = 0; i < 8; i++ ) //RLZ 4[0],4[4] or 4[4],4[0]
         dbuf[dix++] = cbuf[six++];
       break;
-    case 9: //Ok
+    case 9: //OK
       dbuf[dix++] = cbuf[six + 8];
       for ( int i = 0; i < 8; i++ )
         dbuf[dix++] = cbuf[six++];
       break;
-    case 10: //Ok
+    case 10: //OK
       dbuf[dix++] = cbuf[six + 9];
       for ( int i = 1; i < 9; i++ )
         dbuf[dix++] = cbuf[six + i];
@@ -509,20 +509,20 @@ void dwgCompressor::copyCompBytes21( duint8 *cbuf, duint8 *dbuf, duint32 l, duin
         dbuf[dix++] = cbuf[six + i];
       dbuf[dix] = cbuf[six];
       break;
-    case 12: //Ok
+    case 12: //OK
       for ( int i = 8; i < 12; i++ )
         dbuf[dix++] = cbuf[six + i];
       for ( int i = 0; i < 8; i++ )
         dbuf[dix++] = cbuf[six++];
       break;
-    case 13: //Ok
+    case 13: //OK
       dbuf[dix++] = cbuf[six + 12];
       for ( int i = 8; i < 12; i++ )
         dbuf[dix++] = cbuf[six + i];
       for ( int i = 0; i < 8; i++ )
         dbuf[dix++] = cbuf[six++];
       break;
-    case 14: //Ok
+    case 14: //OK
       dbuf[dix++] = cbuf[six + 13];
       for ( int i = 9; i < 13; i++ )
         dbuf[dix++] = cbuf[six + i];
@@ -540,13 +540,13 @@ void dwgCompressor::copyCompBytes21( duint8 *cbuf, duint8 *dbuf, duint32 l, duin
         dbuf[dix++] = cbuf[six + i];
       dbuf[dix] = cbuf[six];
       break;
-    case 16: //Ok
+    case 16: //OK
       for ( int i = 8; i < 16; i++ )
         dbuf[dix++] = cbuf[six + i];
       for ( int i = 0; i < 8; i++ )
         dbuf[dix++] = cbuf[six++];
       break;
-    case 17: //Seems Ok
+    case 17: //Seems OK
       for ( int i = 9; i < 17; i++ )
         dbuf[dix++] = cbuf[six + i];
       dbuf[dix++] = cbuf[six + 8];

--- a/src/app/dwg/libdxfrw/intern/dxfreader.cpp
+++ b/src/app/dwg/libdxfrw/intern/dxfreader.cpp
@@ -83,7 +83,7 @@ bool dxfReader::readRec( int *codeData )
   else if ( code == 1071 ) //TODO this is an int 32b
     readInt32();
   else if ( skip )
-    //skip safely this dxf entry ( ok for ascii dxf)
+    //skip safely this dxf entry ( OK for ascii dxf)
     readString();
   else
     //break in binary files because the conduct is unpredictable

--- a/src/app/dwg/libdxfrw/intern/dxfwriter.cpp
+++ b/src/app/dwg/libdxfrw/intern/dxfwriter.cpp
@@ -82,7 +82,7 @@
     else if (code == 1071) //TODO this is an int 32b
         readInt32();
     else if (skip)
-        //skip safely this dxf entry ( ok for ascii dxf)
+        //skip safely this dxf entry ( OK for ascii dxf)
         readString();
     else
         //break in binary files because the conduct is unpredictable

--- a/src/app/dwg/libdxfrw/libdwgr.h
+++ b/src/app/dwg/libdxfrw/libdwgr.h
@@ -27,7 +27,7 @@ class dwgR
   public:
     explicit dwgR( const char *name );
     ~dwgR();
-    //read: return true if all ok
+    //read: return true if all OK
     bool read( DRW_Interface *interface_, bool ext );
     bool getPreview();
     DRW::Version getVersion() {return version;}

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
@@ -61,7 +61,7 @@ bool QgsPluginSortFilterProxyModel::filterByStatus( QModelIndex &index ) const
   if ( mAcceptedStatuses.contains( QStringLiteral( "invalid" ) )
        && sourceModel()->data( index, PLUGIN_ERROR_ROLE ).toString().isEmpty() )
   {
-    // Don't accept if the "invalid" filter is set and the plugin is ok
+    // Don't accept if the "invalid" filter is set and the plugin is OK
     return false;
   }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -188,7 +188,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /** Open a raster or vector file; ignore other files.
       Used to process a commandline argument, FileOpen or Drop event.
-      Set interactive to true if it is ok to ask the user for information (mostly for
+      Set interactive to true if it is OK to ask the user for information (mostly for
       when a vector layer has sublayers and we want to ask which sublayers to use).
       \returns true if the file is successfully opened
       */

--- a/src/app/qgsfieldcalculator.h
+++ b/src/app/qgsfieldcalculator.h
@@ -45,7 +45,7 @@ class APP_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
     void on_mButtonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
   private slots:
-    //! Sets the ok button enabled / disabled
+    //! Sets the OK button enabled / disabled
     void setOkButtonState();
     void setPrecisionMinMax();
 

--- a/src/app/qgsrastercalcdialog.h
+++ b/src/app/qgsrastercalcdialog.h
@@ -52,7 +52,7 @@ class APP_EXPORT QgsRasterCalcDialog: public QDialog, private Ui::QgsRasterCalcD
     void on_mCurrentLayerExtentButton_clicked();
     void on_mExpressionTextEdit_textChanged();
     void on_mOutputLayerLineEdit_textChanged( const QString &text );
-    //! Enables ok button if calculator expression is valid and output file path exists
+    //! Enables OK button if calculator expression is valid and output file path exists
     void setAcceptButtonState();
 
     //calculator buttons

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1708,7 +1708,7 @@ void QgsRasterLayerProperties::loadDefaultStyle_clicked()
 {
   bool defaultLoadedFlag = false;
   QString myMessage = mRasterLayer->loadDefaultStyle( defaultLoadedFlag );
-  //reset if the default style was loaded ok only
+  //reset if the default style was loaded OK only
   if ( defaultLoadedFlag )
   {
     syncToLayer();

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -804,10 +804,10 @@ void QgsVectorLayerProperties::loadDefaultStyle_clicked()
 
   QString myMessage = mLayer->loadNamedStyle( mLayer->styleURI(), defaultLoadedFlag, true );
 //  QString myMessage = layer->loadDefaultStyle( defaultLoadedFlag );
-  //reset if the default style was loaded ok only
+  //reset if the default style was loaded OK only
   if ( defaultLoadedFlag )
   {
-    // all worked ok so no need to inform user
+    // all worked OK so no need to inform user
     syncToLayer();
   }
   else
@@ -881,7 +881,7 @@ void QgsVectorLayerProperties::loadStyle_clicked()
   {
     myMessage = mLayer->loadNamedStyle( myFileName, defaultLoadedFlag );
   }
-  //reset if the default style was loaded ok only
+  //reset if the default style was loaded OK only
   if ( defaultLoadedFlag )
   {
     syncToLayer();
@@ -999,7 +999,7 @@ void QgsVectorLayerProperties::saveStyleAs( StyleType styleType )
       myMessage = mLayer->saveNamedStyle( myOutputFileName, defaultLoadedFlag );
     }
 
-    //reset if the default style was loaded ok only
+    //reset if the default style was loaded OK only
     if ( defaultLoadedFlag )
     {
       syncToLayer();

--- a/src/core/composer/qgscomposerhtml.cpp
+++ b/src/core/composer/qgscomposerhtml.cpp
@@ -408,7 +408,7 @@ double QgsComposerHtml::findNearbyPageBreak( double yPos )
   std::sort( candidates.begin(), candidates.end(), candidateSort );
   //first candidate is now the largest row with smallest number of changes
 
-  //ok, now take the mid point of the best candidate position
+  //OK, now take the mid point of the best candidate position
   //we do this so that the spacing between text lines is likely to be split in half
   //otherwise the html will be broken immediately above a line of text, which
   //looks a little messy

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -835,7 +835,7 @@ bool QgsComposerItem::shouldDrawItem() const
 {
   if ( ( mComposition && mComposition->plotStyle() == QgsComposition::Preview ) || !mComposition )
   {
-    //preview mode or no composition, so ok to draw item
+    //preview mode or no composition, so OK to draw item
     return true;
   }
 

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1600,7 +1600,7 @@ void QgsComposition::selectNextByZOrder( ZValueDirection direction )
     return;
   }
 
-  //ok, found a good target item
+  //OK, found a good target item
   setAllDeselected();
   selectedItem->setSelected( true );
   emit selectedItemChanged( selectedItem );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1711,7 +1711,7 @@ static QVariant fcnSegmentsToLines( const QVariantList &values, const QgsExpress
 
   QList< QgsLineString * > linesToProcess = QgsGeometryUtils::extractLineStrings( geom.geometry() );
 
-  //ok, now we have a complete list of segmentized lines from the geometry
+  //OK, now we have a complete list of segmentized lines from the geometry
   QgsMultiLineString *ml = new QgsMultiLineString();
   Q_FOREACH ( QgsLineString *line, linesToProcess )
   {

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -60,7 +60,7 @@ QgsLayerTreeModelLegendNode::ItemMetrics QgsLayerTreeModelLegendNode::draw( cons
 
   double textHeight = settings.fontHeightCharacterMM( symbolLabelFont, QChar( '0' ) );
   // itemHeight here is not really item height, it is only for symbol
-  // vertical alignment purpose, i.e. ok take single line height
+  // vertical alignment purpose, i.e. OK take single line height
   // if there are more lines, thos run under the symbol
   double itemHeight = qMax( static_cast< double >( settings.symbolSize().height() ), textHeight );
 

--- a/src/core/processing/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/qgsprocessingmodelalgorithm.cpp
@@ -535,7 +535,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       feedback->pushDebugInfo( QObject::tr( "OK. Execution took %1 s (%2 outputs)." ).arg( childTime.elapsed() / 1000.0 ).arg( results.count() ) );
     }
   }
-  feedback->pushDebugInfo( QObject::tr( "Model processed ok. Executed %1 algorithms total in %2 s." ).arg( executed.count() ).arg( totalTime.elapsed() / 1000.0 ) );
+  feedback->pushDebugInfo( QObject::tr( "Model processed OK. Executed %1 algorithms total in %2 s." ).arg( executed.count() ).arg( totalTime.elapsed() / 1000.0 ) );
 
   return finalResults;
 }

--- a/src/core/qgscachedfeatureiterator.h
+++ b/src/core/qgscachedfeatureiterator.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
     /**
      * Rewind to the beginning of the iterator
      *
-     * \returns bool true if the operation was ok
+     * \returns bool true if the operation was OK
      */
     virtual bool rewind() override;
 
@@ -60,7 +60,7 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
      * Implementation for fetching a feature.
      *
      * \param f      Will write to this feature
-     * \returns bool  true if the operation was ok
+     * \returns bool  true if the operation was OK
      *
      * \see bool getFeature( QgsFeature& f )
      */
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
      * We have a local special iterator for FilterFids, no need to run the generic.
      *
      * \param f      Will write to this feature
-     * \returns bool  true if the operation was ok
+     * \returns bool  true if the operation was OK
      */
     virtual bool nextFeatureFilterFids( QgsFeature &f ) override { return fetchFeature( f ); }
 
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsCachedFeatureWriterIterator : public QgsAbstractFeatureIter
     /**
      * Rewind to the beginning of the iterator
      *
-     * \returns bool true if the operation was ok
+     * \returns bool true if the operation was OK
      */
     virtual bool rewind() override;
 
@@ -119,7 +119,7 @@ class CORE_EXPORT QgsCachedFeatureWriterIterator : public QgsAbstractFeatureIter
      * Implementation for fetching a feature.
      *
      * \param f      Will write to this feature
-     * \returns bool  true if the operation was ok
+     * \returns bool  true if the operation was OK
      *
      * \see bool getFeature( QgsFeature& f )
      */

--- a/src/core/qgscolorramp.cpp
+++ b/src/core/qgscolorramp.cpp
@@ -453,7 +453,7 @@ void QgsRandomColorRamp::setTotalColorCount( const int colorCount )
   mPrecalculatedColors.clear();
   mTotalColorCount = colorCount;
 
-  //This works ok for low color counts, but for > 10 or so colors there's still a good chance of
+  //This works OK for low color counts, but for > 10 or so colors there's still a good chance of
   //similar colors being picked. TODO - investigate alternative "n-visually distinct color" routines
 
   //random offsets

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -586,7 +586,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
     return;
   }
 
-  QDomNode titleNode = nl.item( 0 );  // there should only be one, so zeroth element ok
+  QDomNode titleNode = nl.item( 0 );  // there should only be one, so zeroth element OK
 
   if ( !titleNode.hasChildNodes() ) // if not, then there's no actual text
   {
@@ -618,7 +618,7 @@ QgsProjectVersion getVersion( const QDomDocument &doc )
     return QgsProjectVersion( 0, 0, 0, QString() );
   }
 
-  QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element ok
+  QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element OK
 
   QDomElement qgisElement = qgisNode.toElement(); // qgis node should be element
   QgsProjectVersion projectVersion( qgisElement.attribute( QStringLiteral( "version" ) ) );

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -202,7 +202,7 @@ void QgsProviderRegistry::init()
       if ( !fileVectorFilters.isEmpty() )
         mVectorFileFilters += fileVectorFilters;
 
-      QgsDebugMsg( QString( "Checking %1: ...loaded ok (%2 file filters)" ).arg( myLib.fileName() ).arg( fileVectorFilters.split( ";;" ).count() ) );
+      QgsDebugMsg( QString( "Checking %1: ...loaded OK (%2 file filters)" ).arg( myLib.fileName() ).arg( fileVectorFilters.split( ";;" ).count() ) );
     }
 
     // now get raster file filters, if any
@@ -218,7 +218,7 @@ void QgsProviderRegistry::init()
       if ( !fileRasterFilters.isEmpty() )
         mRasterFileFilters += fileRasterFilters;
 
-      QgsDebugMsg( QString( "Checking %1: ...loaded ok (%2 file filters)" ).arg( myLib.fileName() ).arg( fileRasterFilters.split( ";;" ).count() ) );
+      QgsDebugMsg( QString( "Checking %1: ...loaded OK (%2 file filters)" ).arg( myLib.fileName() ).arg( fileRasterFilters.split( ";;" ).count() ) );
     }
   }
 } // QgsProviderRegistry ctor

--- a/src/core/raster/qgsrasterdrawer.cpp
+++ b/src/core/raster/qgsrasterdrawer.cpp
@@ -108,7 +108,7 @@ void QgsRasterDrawer::draw( QPainter *p, QgsRasterViewPort *viewPort, const QgsM
       p->setCompositionMode( QPainter::CompositionMode_SourceOver );
     }
 
-    // ok this does not matter much anyway as the tile size quite big so most of the time
+    // OK this does not matter much anyway as the tile size quite big so most of the time
     // there would be just one tile for the whole display area, but it won't hurt...
     if ( feedback && feedback->isCanceled() )
       break;

--- a/src/core/raster/qgsrasterpipe.cpp
+++ b/src/core/raster/qgsrasterpipe.cpp
@@ -98,7 +98,7 @@ bool QgsRasterPipe::insert( int idx, QgsRasterInterface *interface )
     success = true;
     mInterfaces.insert( idx, interface );
     setRole( interface, idx );
-    QgsDebugMsgLevel( "inserted ok", 4 );
+    QgsDebugMsgLevel( "inserted OK", 4 );
   }
 
   // Connect or reconnect (after the test) interfaces
@@ -125,7 +125,7 @@ bool QgsRasterPipe::replace( int idx, QgsRasterInterface *interface )
     delete mInterfaces.at( idx );
     mInterfaces[idx] = interface;
     setRole( interface, idx );
-    QgsDebugMsgLevel( "replaced ok", 4 );
+    QgsDebugMsgLevel( "replaced OK", 4 );
   }
 
   // Connect or reconnect (after the test) interfaces
@@ -285,7 +285,7 @@ bool QgsRasterPipe::remove( int idx )
     unsetRole( mInterfaces.at( idx ) );
     delete mInterfaces.at( idx );
     mInterfaces.remove( idx );
-    QgsDebugMsgLevel( "removed ok", 4 );
+    QgsDebugMsgLevel( "removed OK", 4 );
   }
 
   // Connect or reconnect (after the test) interfaces

--- a/src/core/simplify/effectivearea.cpp
+++ b/src/core/simplify/effectivearea.cpp
@@ -222,7 +222,7 @@ static void tune_areas( EFFECTIVE_AREAS *ea, int avoid_collaps, int set_area, do
     //LWDEBUGF( 4, "Check ordering qsort gives, area=%lf and belong to point %d", (( areanode* )tree.key_array[i] )->area, tree.key_array[i] - ea->initial_arealist );
   }
 
-  // Ok, now we have a minHeap, just need to keep it
+  // OK, now we have a minHeap, just need to keep it
   i = 0;
   while ( go_on )
   {

--- a/src/core/simplify/effectivearea.cpp
+++ b/src/core/simplify/effectivearea.cpp
@@ -114,7 +114,7 @@ static void down( MINHEAP *tree, areanode *arealist, int parent )
   }
   if ( swap > parent )
   {
-    // ok, we have to swap something
+    // OK, we have to swap something
     tmp = treearray[parent];
     treearray[parent] = treearray[swap];
     // Update reference
@@ -141,7 +141,7 @@ static void up( MINHEAP *tree, areanode *arealist, int c )
 
   while ( ( ( areanode * )treearray[c] )->area < ( ( areanode * )treearray[parent] )->area )
   {
-    // ok, we have to swap
+    // OK, we have to swap
     tmp = treearray[parent];
     treearray[parent] = treearray[c];
     // Update reference

--- a/src/core/symbology-ng/qgscptcityarchive.cpp
+++ b/src/core/symbology-ng/qgscptcityarchive.cpp
@@ -300,7 +300,7 @@ QgsStringMap QgsCptCityArchive::description( const QString &fileName )
     QgsDebugMsg( "Incorrect root tag: " + docElem.tagName() );
     return descMap;
   }
-  // should we make sure the <dir> tag is ok?
+  // should we make sure the <dir> tag is OK?
 
   QDomElement e = docElem.firstChildElement( QStringLiteral( "name" ) );
   if ( e.isNull() )

--- a/src/core/symbology-ng/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrenderer.h
@@ -35,7 +35,7 @@ class CORE_EXPORT QgsRendererRange
     QgsRendererRange( double lowerValue, double upperValue, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true );
     QgsRendererRange( const QgsRendererRange &range );
 
-    // default dtor is ok
+    // default dtor is OK
     QgsRendererRange &operator=( QgsRendererRange range );
 
     bool operator<( const QgsRendererRange &other ) const;

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRenderer
      * \param layer the symbol layer to render, if that makes sense
      * \param selected whether this feature has been selected (this will add decorations)
      * \param drawVertexMarker whether this feature has vertex markers (in edit mode usually)
-     * \returns true if the rendering was ok
+     * \returns true if the rendering was OK
      */
     virtual bool renderFeature( QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false ) override;
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -215,7 +215,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     /**
      * \brief saveEditChanges
      *
-     * \returns true if the saving was ok. false is possible due to connected
+     * \returns true if the saving was OK. false is possible due to connected
      *         validation logic.
      */
     bool saveEditChanges();

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -149,7 +149,7 @@ QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget *parent )
   mTopLayout->addWidget( mAttributeEditorFrame );
 
   // invalid label
-  mInvalidLabel = new QLabel( tr( "The relation is not valid. Please make sure your relation definitions are ok." ) );
+  mInvalidLabel = new QLabel( tr( "The relation is not valid. Please make sure your relation definitions are OK." ) );
   mInvalidLabel->setWordWrap( true );
   QFont font = mInvalidLabel->font();
   font.setItalic( true );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -726,7 +726,7 @@ void QgsAttributeForm::updateConstraints( QgsEditorWidgetWrapper *eww )
     Q_FOREACH ( QgsEditorWidgetWrapper *depsEww, deps )
       depsEww->updateConstraint( ft, constraintOrigin );
 
-    // sync ok button status
+    // sync OK button status
     synchronizeEnabledState();
 
     mExpressionContext.setFeature( ft );
@@ -1012,7 +1012,7 @@ void QgsAttributeForm::synchronizeEnabledState()
     isEditable = isEditable & validConstraint;
   }
 
-  // change ok button status
+  // change OK button status
   QPushButton *okButton = mButtonBox->button( QDialogButtonBox::Ok );
   if ( okButton )
     okButton->setEnabled( isEditable );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -70,21 +70,21 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     const QgsFeature &feature() { return mFeature; }
 
     /**
-     * Hides the button box (Ok/Cancel) and enables auto-commit
+     * Hides the button box (OK/Cancel) and enables auto-commit
      * \note set Embed in QgsAttributeEditorContext in constructor instead
      */
     // TODO QGIS 3.0 - make private
     void hideButtonBox();
 
     /**
-     * Shows the button box (Ok/Cancel) and disables auto-commit
+     * Shows the button box (OK/Cancel) and disables auto-commit
      * \note set Embed in QgsAttributeEditorContext in constructor instead
      */
     // TODO QGIS 3.0 - make private
     void showButtonBox();
 
     /**
-     * Disconnects the button box (Ok/Cancel) from the accept/resetValues slots
+     * Disconnects the button box (OK/Cancel) from the accept/resetValues slots
      * If this method is called, you have to create these connections from outside
      */
     // TODO QGIS 3.0 - make private

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -60,7 +60,7 @@ QgsManageConnectionsDialog::QgsManageConnectionsDialog( QWidget *parent, Mode mo
     QApplication::postEvent( this, new QCloseEvent() );
   }
 
-  // use Ok button for starting import and export operations
+  // use OK button for starting import and export operations
   disconnect( buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsManageConnectionsDialog::doExportImport );
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1900,7 +1900,7 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
     QgsDebugMsg( "Unable to find qgis element in project file" );
     return;
   }
-  QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element ok
+  QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element OK
 
   QDomElement mapcanvasNode = doc.createElement( QStringLiteral( "mapcanvas" ) );
   mapcanvasNode.setAttribute( QStringLiteral( "name" ), objectName() );

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -274,7 +274,7 @@ void QgsMapLayerStyleManagerWidget::loadDefault()
   }
 
 //  QString myMessage = layer->loadDefaultStyle( defaultLoadedFlag );
-  //reset if the default style was loaded ok only
+  //reset if the default style was loaded OK only
 
 
   if ( !defaultLoadedFlag )
@@ -318,7 +318,7 @@ void QgsMapLayerStyleManagerWidget::loadStyle()
   {
     myMessage = mLayer->loadNamedStyle( myFileName, defaultLoadedFlag );
   }
-  //reset if the default style was loaded ok only
+  //reset if the default style was loaded OK only
   if ( defaultLoadedFlag )
   {
     emit widgetChanged();

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -236,7 +236,7 @@ long QgsSearchQueryBuilder::countRecords( const QString &searchString )
 
 void QgsSearchQueryBuilder::on_btnOk_clicked()
 {
-  // if user hits Ok and there is no query, skip the validation
+  // if user hits OK and there is no query, skip the validation
   if ( txtSQL->text().trimmed().length() > 0 )
   {
     accept();

--- a/src/gui/symbology-ng/qgsrendererwidget.h
+++ b/src/gui/symbology-ng/qgsrendererwidget.h
@@ -39,7 +39,7 @@ WORKFLOW:
 - find out which widget to use
 - instantiate it and set in stacked widget
 - on any change of renderer type, create some default (dummy?) version and change the stacked widget
-- when clicked ok/apply, get the renderer from active widget and clone it for the layer
+- when clicked OK/Apply, get the renderer from active widget and clone it for the layer
 */
 class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
 {

--- a/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.cpp
+++ b/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.cpp
@@ -78,7 +78,7 @@ void eVisDatabaseLayerFieldSelectionGui::setFieldList( QStringList *fieldList )
  */
 
 /**
-* Slot called when the ok/accept button is pressed
+* Slot called when the OK/Accept button is pressed
 */
 void eVisDatabaseLayerFieldSelectionGui::on_buttonBox_accepted()
 {

--- a/src/plugins/georeferencer/qgsgcpcanvasitem.cpp
+++ b/src/plugins/georeferencer/qgsgcpcanvasitem.cpp
@@ -108,7 +108,7 @@ QRectF QgsGCPCanvasItem::boundingRect() const
     residual = mDataPoint->residual();
   }
 
-  //only considering screen resolution is ok for the bounding box function
+  //only considering screen resolution is OK for the bounding box function
   double rf = residualToScreenFactor();
 
   if ( residual.x() > 0 )

--- a/src/plugins/grass/qgsgrassutils.cpp
+++ b/src/plugins/grass/qgsgrassutils.cpp
@@ -161,7 +161,7 @@ void QgsGrassElementDialog::textChanged()
   QString text = mLineEdit->text().trimmed();
 
   mErrorLabel->setText( QStringLiteral( "   " ) );
-  mOkButton->setText( tr( "Ok" ) );
+  mOkButton->setText( tr( "OK" ) );
   mOkButton->setEnabled( true );
 
   if ( text.length() == 0 )

--- a/src/plugins/grass/qtermwidget/Session.cpp
+++ b/src/plugins/grass/qtermwidget/Session.cpp
@@ -284,7 +284,7 @@ void Session::run()
     // Check to see if the given program is executable.
 
 
-    /* ok iam not exactly sure where _program comes from - however it was set to /bin/bash on my system
+    /* OK i am not exactly sure where _program comes from - however it was set to /bin/bash on my system
      * Thats bad for BSD as its /usr/local/bin/bash there - its also bad for arch as its /usr/bin/bash there too!
      * So i added a check to see if /bin/bash exists - if no then we use $SHELL - if that does not exist either, we fall back to /bin/sh
      * As far as i know /bin/sh exists on every unix system.. You could also just put some ifdef __FREEBSD__ here but i think these 2 filechecks are worth

--- a/src/plugins/grass/qtermwidget/TerminalDisplay.cpp
+++ b/src/plugins/grass/qtermwidget/TerminalDisplay.cpp
@@ -1922,7 +1922,7 @@ void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
         ev->y() > dragInfo.start.y() + distance || ev->y() < dragInfo.start.y() - distance)
    {
       // we've left the drag square, we can start a real drag operation now
-      emit isBusySelecting(false); // Ok.. we can breath again.
+      emit isBusySelecting(false); // OK.. we can breath again.
 
        _screenWindow->clearSelection();
       doDrag();

--- a/src/plugins/grass/qtermwidget/Vt102Emulation.cpp
+++ b/src/plugins/grass/qtermwidget/Vt102Emulation.cpp
@@ -238,7 +238,7 @@ void Vt102Emulation::initTokenizer()
   resetTokenizer();
 }
 
-/* Ok, here comes the nasty part of the decoder.
+/* OK, here comes the nasty part of the decoder.
 
    Instead of keeping an explicit state, we deduce it from the
    token scanned so far. It is then immediately combined with

--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -49,7 +49,7 @@ rulesDialog::rulesDialog( const QMap<QString, TopologyRule> &testMap, QgisInterf
 
   connect( mAddTestButton, &QAbstractButton::clicked, this, &rulesDialog::addRule );
   connect( mAddTestButton, &QAbstractButton::clicked, mRulesTable, &QTableView::resizeColumnsToContents );
-  // attempt to add new test when Ok clicked
+  // attempt to add new test when OK clicked
   //connect( buttonBox, SIGNAL( accepted() ), this, SLOT( addTest() ) );
   connect( mDeleteTestButton, &QAbstractButton::clicked, this, &rulesDialog::deleteTest );
 

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -107,7 +107,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeo
       QVariantMap geometryData = featureData[QStringLiteral( "geometry" )].toMap();
       QgsAbstractGeometry *geometry = QgsArcGisRestUtils::parseEsriGeoJSON( geometryData, queryData[QStringLiteral( "geometryType" )].toString(),
                                       QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ) );
-      // Above might return 0, which is ok since in theory empty geometries are allowed
+      // Above might return 0, which is OK since in theory empty geometries are allowed
       feature.setGeometry( QgsGeometry( geometry ) );
     }
     feature.setValid( true );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -587,7 +587,7 @@ void QgsArcGisAsyncParallelQuery::handleReply()
   }
   else
   {
-    // All ok
+    // All OK
     ( *mResults )[idx] = reply->readAll();
     --mPendingRequests;
   }

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
@@ -455,9 +455,9 @@ void QgsDelimitedTextFile::setFieldNames( const QStringList &names )
       {
         suffix++;
         name = basename.arg( suffix );
-        // Not ok if it is already in the name list
+        // Not OK if it is already in the name list
         if ( mFieldNames.contains( name, Qt::CaseInsensitive ) ) continue;
-        // Not ok if it is already in proposed names
+        // Not OK if it is already in proposed names
         if ( names.contains( name, Qt::CaseInsensitive ) ) continue;
         break;
       }

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -304,7 +304,7 @@ bool QgsDelimitedTextProvider::createSpatialIndex()
   if ( mBuildSpatialIndex ) return true; // Already built
   if ( mGeomRep == GeomNone ) return false; // Cannot build index - no geometries
 
-  // Ok, set the spatial index option, set the Uri parameter so that the index is
+  // OK, set the spatial index option, set the Uri parameter so that the index is
   // rebuilt when theproject is reloaded, and rescan the file to populate the index
 
   mBuildSpatialIndex = true;

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -982,7 +982,7 @@ bool QgsDelimitedTextProvider::setSubsetString( const QString &subset, bool upda
 {
   QString nonNullSubset = subset.isNull() ? QLatin1String( "" ) : subset;
 
-  // If not changing string, then oll ok, nothing to do
+  // If not changing string, then all OK, nothing to do
   if ( nonNullSubset == mSubsetString )
     return true;
 

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -945,7 +945,7 @@ QString QgsGrass::openMapset( const QString &gisdbase,
   QgsDebugMsg( "processResult: " + processResult );
 
   // lock exit code:
-  // 0 - ok
+  // 0 - OK
   // 1 - error
   // 2 - mapset in use
   if ( process.exitCode() == 2 )

--- a/src/providers/grass/qgsgrassimport.cpp
+++ b/src/providers/grass/qgsgrassimport.cpp
@@ -411,7 +411,7 @@ bool QgsGrassRasterImport::import()
 
         outStream << byteArray;
 
-        // Without waitForBytesWritten() it does not finish ok on Windows (process timeout)
+        // Without waitForBytesWritten() it does not finish OK on Windows (process timeout)
         mProcess->waitForBytesWritten( -1 );
 
 #ifndef Q_OS_WIN
@@ -652,14 +652,14 @@ bool QgsGrassVectorImport::import()
       outStream << false; // not canceled
       outStream << feature;
 
-      // Without waitForBytesWritten() it does not finish ok on Windows (data lost)
+      // Without waitForBytesWritten() it does not finish OK on Windows (data lost)
       mProcess->waitForBytesWritten( -1 );
 
 #ifndef Q_OS_WIN
       // wait until the feature is written to allow quick cancel (don't send data to buffer)
 
       // Feedback disabled because it was sometimes hanging on Linux, for example, when importing polygons
-      // the features were written ok in the first run, but after cleaning of polygons, which takes some time
+      // the features were written OK in the first run, but after cleaning of polygons, which takes some time
       // it was hanging here for few seconds after each feature, but data did not arrive to the modulee anyway,
       // QFSFileEnginePrivate::nativeRead() was hanging on fgetc()
 

--- a/src/providers/grass/qgsgrassrasterprovider.h
+++ b/src/providers/grass/qgsgrassrasterprovider.h
@@ -64,7 +64,7 @@ class GRASS_LIB_EXPORT QgsGrassRasterValue
     void set( const QString &gisdbase, const QString &location, const QString &mapset, const QString &map );
     void stop();
     // returns raster value, NaN for no data
-    // ok is set to true if ok or false on error
+    // OK is set to true if OK or false on error
     double value( double x, double y, bool *ok );
   private:
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1783,7 +1783,7 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
 
     OGRGeometryH newGeometry = nullptr;
     QByteArray wkb = it->exportToWkb();
-    // We might receive null geometries. It is ok, but don't go through the
+    // We might receive null geometries. It is OK, but don't go through the
     // OGR_G_CreateFromWkb() route then
     if ( !wkb.isEmpty() )
     {

--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -663,7 +663,7 @@ int QOCISpatialResultPrivate::bindValue( OCIStmt *sql, OCIBind **hbnd, OCIError 
         const QOCISpatialRowIdPointer rptr = qvariant_cast<QOCISpatialRowIdPointer>( val );
         r = OCIBindByPos( sql, hbnd, err,
                           pos + 1,
-                          // it's an IN value, so const_cast is ok
+                          // it's an IN value, so const_cast is OK
                           const_cast<OCIRowid **>( &rptr->id ),
                           -1,
                           SQLT_RDD, indPtr, 0, 0, 0, 0, OCI_DEFAULT );

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -609,7 +609,7 @@ bool QgsSpatiaLiteConnection::isRasterlite1Datasource( sqlite3 *handle, const ch
     return false;
   if ( strcmp( table_raster + len - 9, "_metadata" ) != 0 )
     return false;
-  // ok, possible candidate
+  // OK, possible candidate
   strcpy( table_raster + len - 9, "_rasters" );
 
   // checking if the related "_RASTERS table exists

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -367,7 +367,7 @@ QgsWcsProvider::QgsWcsProvider( const QString &uri )
   }
 
   mValid = true;
-  QgsDebugMsg( "Constructed ok, provider valid." );
+  QgsDebugMsg( "Constructed OK, provider valid." );
 }
 
 bool QgsWcsProvider::parseUri( const QString &uriString )

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -224,7 +224,7 @@ void QgsWfsRequest::replyFinished()
   {
     if ( mReply->error() == QNetworkReply::NoError )
     {
-      QgsDebugMsg( "reply ok" );
+      QgsDebugMsg( "reply OK" );
       QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
       if ( !redirect.isNull() )
       {

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1996,7 +1996,7 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
   {
     if ( mCapabilitiesReply->error() == QNetworkReply::NoError )
     {
-      QgsDebugMsg( "reply ok" );
+      QgsDebugMsg( "reply OK" );
       QVariant redirect = mCapabilitiesReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
       if ( !redirect.isNull() )
       {

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4164,7 +4164,7 @@ QgsWmsLegendDownloadHandler::finished()
   // or ::errored() should have been called before ::finished
   Q_ASSERT( mReply->error() == QNetworkReply::NoError );
 
-  QgsDebugMsg( "reply ok" );
+  QgsDebugMsg( "reply OK" );
   QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
   if ( !redirect.isNull() )
   {

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1788,7 +1788,7 @@ namespace QgsWms
         continue;
       }
 
-      //numbers are ok
+      //numbers are OK
       bool isNumeric;
       tokenIt->toDouble( &isNumeric );
       if ( isNumeric )
@@ -1798,7 +1798,7 @@ namespace QgsWms
 
       //numeric strings need to be quoted once either with single or with double quotes
 
-      //empty strings are ok
+      //empty strings are OK
       if ( *tokenIt == QLatin1String( "''" ) )
       {
         continue;

--- a/src/ui/qgsfieldcalculatorbase.ui
+++ b/src/ui/qgsfieldcalculatorbase.ui
@@ -46,7 +46,7 @@
       <item row="0" column="1">
        <widget class="QLabel" name="mEditModeAutoTurnOnLabel">
         <property name="text">
-         <string>You are editing information on this layer but the layer is currently not in edit mode. If you click Ok, edit mode will automatically be turned on.</string>
+         <string>You are editing information on this layer but the layer is currently not in edit mode. If you click OK, edit mode will automatically be turned on.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -5377,7 +5377,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <item>
                   <widget class="QLabel" name="label_44">
                    <property name="text">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Changes on this page are dangerous and can break your QGIS installation in various ways. Any change you make is applied immediately, without clicking the &lt;span style=&quot; font-style:italic;&quot;&gt;ok&lt;/span&gt; button.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Changes on this page are dangerous and can break your QGIS installation in various ways. Any change you make is applied immediately, without clicking the &lt;span style=&quot; font-style:italic;&quot;&gt;OK&lt;/span&gt; button.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="wordWrap">
                     <bool>true</bool>

--- a/tests/qt_modeltest/modeltest.cpp
+++ b/tests/qt_modeltest/modeltest.cpp
@@ -376,7 +376,7 @@ void ModelTest::checkChildren( const QModelIndex &parent, int currentDepth )
       Q_ASSERT( index.row() == r );
       Q_ASSERT( index.column() == c );
       // While you can technically return a QVariant usually this is a sign
-      // of an bug in data()  Disable if this really is ok in your model.
+      // of an bug in data()  Disable if this really is OK in your model.
 //            Q_ASSERT ( model->data ( index, Qt::DisplayRole ).isValid() );
 
       // If the next test fails here is some somewhat useful debug you play with.

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -390,7 +390,7 @@ void TestQgsCoordinateReferenceSystem::createFromESRIWkt()
     CPLSetConfigOption( "GDAL_FIX_ESRI_WKT", configOld );
     if ( myFiles[i] != QLatin1String( "" ) )
     {
-      // use ogr to open file, make sure CRS is ok
+      // use ogr to open file, make sure CRS is OK
       // this probably could be in another test, but leaving it here since it deals with CRS
       QString fileStr = QStringLiteral( TEST_DATA_DIR ) + '/' + myFiles[i];
       QgsDebugMsg( QString( "i=%1 file=%2" ).arg( i ).arg( fileStr ) );

--- a/tests/src/core/testqgsproperty.cpp
+++ b/tests/src/core/testqgsproperty.cpp
@@ -1694,7 +1694,7 @@ void TestQgsProperty::curveTransform()
                     QVector< double >() << -1 << 0 << 0.2 << 0.5 << 0.8 << 1 << 2,
                     QVector< double >() << 1.0 << 1.0 << 0.8 << 0.5 << 0.2 << 0.0 << 0.0 );
 
-  // ok, time for some more complex tests...
+  // OK, time for some more complex tests...
 
   // 3 control points, but linear
   checkCurveResult( QList< QgsPointXY >() << QgsPointXY( 0, 0.0 ) << QgsPointXY( 0.2, 0.2 ) << QgsPointXY( 1.0, 1.0 ),
@@ -1740,7 +1740,7 @@ void TestQgsProperty::curveTransform()
   // copy constructor
   QgsCurveTransform dest( src );
   QCOMPARE( dest.controlPoints(), QList< QgsPointXY >() << QgsPointXY( 0.0, 0.0 ) << QgsPointXY( 0.2, 0.3 ) << QgsPointXY( 1.0, 1.0 ) );
-  // check a value to ensure that derivative matrix was copied ok
+  // check a value to ensure that derivative matrix was copied OK
   QGSCOMPARENEAR( dest.y( 0.5 ), 0.1, 0.638672 );
 
   // assignment operator

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -505,7 +505,7 @@ void TestQgsRasterLayer::buildExternalOverviews()
   QVERIFY( mypLayer->isValid() );
 
   //
-  // Ok now we can go on to test
+  // OK now we can go on to test
   //
 
   QgsRaster::RasterPyramidsFormat myFormatFlag = QgsRaster::PyramidsGTiff;

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -136,7 +136,7 @@ void TestQgsStringUtils::insertLinks()
   QVERIFY( found );
   QCOMPARE( QgsStringUtils::insertLinks( QString( "this http://north-road.com is a link" ), &found ), QString( "this <a href=\"http://north-road.com\">http://north-road.com</a> is a link" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this http://north-road.com is a link, so is http://qgis.org, ok?" ), &found ), QString( "this <a href=\"http://north-road.com\">http://north-road.com</a> is a link, so is <a href=\"http://qgis.org\">http://qgis.org</a>, ok?" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QString( "this http://north-road.com is a link, so is http://qgis.org, OK?" ), &found ), QString( "this <a href=\"http://north-road.com\">http://north-road.com</a> is a link, so is <a href=\"http://qgis.org\">http://qgis.org</a>, OK?" ) );
   QVERIFY( found );
   QCOMPARE( QgsStringUtils::insertLinks( QString( "this north-road.com might not be a link" ), &found ), QString( "this north-road.com might not be a link" ) );
   QVERIFY( !found );

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -456,7 +456,7 @@ void TestQgsVectorFileWriter::regression1141()
     QVERIFY( error == QgsVectorFileWriter::NoError );
   }
 
-  // Now check we can delete it again ok
+  // Now check we can delete it again OK
   QVERIFY( QgsVectorFileWriter::deleteShapeFile( fileName ) );
 }
 

--- a/tests/src/providers/grass/testqgsgrassprovider.cpp
+++ b/tests/src/providers/grass/testqgsgrassprovider.cpp
@@ -1407,7 +1407,7 @@ void TestQgsGrassProvider::edit()
             }
             else
             {
-              reportRow( QStringLiteral( "undo ok" ) );
+              reportRow( QStringLiteral( "undo OK" ) );
             }
           }
         }
@@ -1436,7 +1436,7 @@ void TestQgsGrassProvider::edit()
             }
             else
             {
-              reportRow( QStringLiteral( "redo ok" ) );
+              reportRow( QStringLiteral( "redo OK" ) );
             }
           }
         }
@@ -1464,7 +1464,7 @@ void TestQgsGrassProvider::edit()
         }
         else
         {
-          reportRow( QStringLiteral( "command ok" ) );
+          reportRow( QStringLiteral( "command OK" ) );
         }
       }
     }
@@ -1591,7 +1591,7 @@ bool TestQgsGrassProvider::compare( QMap<QString, QgsVectorLayer *> layers, bool
     }
     else
     {
-      reportRow( "comparison ok: " + grassUri );
+      reportRow( "comparison OK: " + grassUri );
     }
   }
   return ok;
@@ -1618,7 +1618,7 @@ bool TestQgsGrassProvider::compare( QString uri, QgsVectorLayer *expectedLayer, 
   bool sharedOk = compare( features, expectedFeatures, ok );
   if ( sharedOk )
   {
-    //reportRow( "comparison with shared layer ok" );
+    //reportRow( "comparison with shared layer OK" );
   }
   else
   {
@@ -1678,7 +1678,7 @@ bool TestQgsGrassProvider::compare( QString uri, QgsVectorLayer *expectedLayer, 
   independentOk = compare( features, expectedFeatures, ok );
   if ( independentOk )
   {
-    //reportRow( "comparison with independent layer ok" );
+    //reportRow( "comparison with independent layer OK" );
   }
   else
   {

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -147,7 +147,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.linesLayer.startEditing()
         self.linesLayer.addFeatures([f])
         self.linesLayer.commitChanges()
-        # check the snapped point is ok
+        # check the snapped point is OK
         m = u.snapToMap(QPoint(45, 50))
         self.assertTrue(m.isValid())
         self.assertTrue(m.hasVertex())
@@ -169,7 +169,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.linesLayer.startEditing()
         self.linesLayer.addFeatures([f])
         self.linesLayer.commitChanges()
-        # check the second snapped point is ok
+        # check the second snapped point is OK
         m = u.snapToMap(QPoint(75, 100 - 80))
         self.assertTrue(m.isValid())
         self.assertTrue(m.hasVertex())
@@ -250,7 +250,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.linesLayer.startEditing()
         self.linesLayer.addFeatures([f])
         self.linesLayer.commitChanges()
-        # check the second snapped point is ok
+        # check the second snapped point is OK
         m = u.snapToMap(QPoint(75, 100 - 0))
         self.assertTrue(m.isValid())
         self.assertTrue(m.hasVertex())

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -175,7 +175,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         ref_sum3 = sum(f.id() for f in l2.getFeatures())
         # check we have the same rows
         self.assertEqual(ref_sum, ref_sum2)
-        # check the id is ok
+        # check the id is OK
         self.assertEqual(ref_sum, ref_sum3)
 
         # the same, without specifying the geometry column name
@@ -186,7 +186,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         ref_sum3 = sum(f.id() for f in l2.getFeatures())
         # check we have the same rows
         self.assertEqual(ref_sum, ref_sum2)
-        # check the id is ok
+        # check the id is OK
         self.assertEqual(ref_sum, ref_sum3)
 
         # with two geometry columns
@@ -198,7 +198,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         ref_sum3 = sum(f.id() for f in l2.getFeatures())
         # check we have the same rows
         self.assertEqual(ref_sum, ref_sum2)
-        # check the id is ok
+        # check the id is OK
         self.assertEqual(ref_sum, ref_sum3)
 
         # with two geometry columns, but no geometry column specified (will take the first)
@@ -209,7 +209,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         ref_sum3 = sum(f.id() for f in l2.getFeatures())
         # check we have the same rows
         self.assertEqual(ref_sum, ref_sum2)
-        # check the id is ok
+        # check the id is OK
         self.assertEqual(ref_sum, ref_sum3)
 
         # the same, without geometry

--- a/tests/src/python/test_qgis_local_server.py
+++ b/tests/src/python/test_qgis_local_server.py
@@ -121,7 +121,7 @@ class TestQgisLocalServer(unittest.TestCase):
         chk.setControlName('expected_' + test_name)
         # chk.setMapRenderer(None)
         res = chk.compareImages(test_name, 0, img_path)
-        if QGIS_TEST_REPORT and not res:  # don't report ok checks
+        if QGIS_TEST_REPORT and not res:  # don't report OK checks
             TESTREPORTS[test_name] = chk.report()
         msg = '\nRender check failed for "{0}"'.format(test_name)
         assert res, msg

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -348,7 +348,7 @@ class TestQgsGeometry(unittest.TestCase):
 
         Interestingly we could replicate the issue in PostGIS too:
          - doing straight simplify returned no feature
-         - transforming to UTM49, then simplify with e.g. 200 threshold is ok
+         - transforming to UTM49, then simplify with e.g. 200 threshold is OK
          - as above with 500 threshold drops the feature
 
          pgsql2shp -f /tmp/dissolve500.shp gis 'select *,

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -225,7 +225,7 @@ class TestQgsMapCanvas(unittest.TestCase):
         canvas.waitWhileRendering()
         self.assertTrue(self.canvasImageCheck('theme1', 'theme1', canvas))
 
-        # ok, so all good with setting/rendering map styles
+        # OK, so all good with setting/rendering map styles
         # try setting canvas to a particular theme
 
         # make some themes...

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -361,7 +361,7 @@ class TestQgsPalLabeling(unittest.TestCase):
         chk.setColorTolerance(colortol)
         # noinspection PyUnusedLocal
         res = chk.runTest(self._Test, mismatch)
-        if PALREPORT and not res:  # don't report ok checks
+        if PALREPORT and not res:  # don't report OK checks
             testname = self._TestGroup + ' . ' + self._Test
             PALREPORTS[testname] = chk.report()
         msg = '\nRender check failed for "{0}"'.format(self._Test)

--- a/tests/src/python/test_qgsrenderer.py
+++ b/tests/src/python/test_qgsrenderer.py
@@ -100,7 +100,7 @@ class TestQgsRendererV2Registry(unittest.TestCase):
         self.assertTrue(QgsApplication.rendererRegistry().addRenderer(TestRenderer('test3')))
         self.assertTrue('test3' in QgsApplication.rendererRegistry().renderersList())
 
-        # try removing it again - should be ok this time
+        # try removing it again - should be OK this time
         self.assertTrue(QgsApplication.rendererRegistry().removeRenderer('test3'))
         self.assertFalse('test3' in QgsApplication.rendererRegistry().renderersList())
 


### PR DESCRIPTION
refs https://github.com/qgis/qgis3_UIX_discussion/issues/19
I think I've caught all the OK in GUI (and more, especially in comment and doc string but most of the ok/Ok are used as parameter).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
