### PR TITLE
Fix incorrect layer names used when loading result layers from models

### DIFF
--- a/python/core/processing/qgsprocessingparameters.sip
+++ b/python/core/processing/qgsprocessingparameters.sip
@@ -95,6 +95,11 @@ class QgsProcessingOutputLayerDefinition
  The default behavior is not to load the result into any project (None).
 %End
 
+    QString destinationName;
+%Docstring
+ Name to use for sink if it's to be loaded into a destination project.
+%End
+
     QVariantMap createOptions;
 %Docstring
  Map of optional sink/layer creation options, which

--- a/src/core/processing/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/qgsprocessingmodelalgorithm.cpp
@@ -407,7 +407,18 @@ QVariantMap QgsProcessingModelAlgorithm::parametersForChildAlgorithm( const Chil
         {
           QString paramName = child.childId() + ':' + outputIt.key();
           if ( modelParameters.contains( paramName ) )
-            childParams.insert( destParam->name(), modelParameters.value( paramName ) );
+          {
+            QVariant value = modelParameters.value( paramName );
+            if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
+            {
+              // make sure layout output name is correctly set
+              QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( value );
+              fromVar.destinationName = outputIt.key();
+              value = QVariant::fromValue( fromVar );
+            }
+
+            childParams.insert( destParam->name(), value );
+          }
           isFinalOutput = true;
           break;
         }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -219,6 +219,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   }
 
   QgsProject *destinationProject = nullptr;
+  QString destName;
   QVariantMap createOptions;
   if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
   {
@@ -227,6 +228,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
     destinationProject = fromVar.destinationProject;
     createOptions = fromVar.createOptions;
     val = fromVar.sink;
+    destName = fromVar.destinationName;
   }
 
   QString dest;
@@ -256,7 +258,13 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   destinationIdentifier = dest;
 
   if ( destinationProject )
-    context.addLayerToLoadOnCompletion( destinationIdentifier, QgsProcessingContext::LayerDetails( definition ? definition->description() : QString(), destinationProject ) );
+  {
+    if ( destName.isEmpty() && definition )
+    {
+      destName = definition->description();
+    }
+    context.addLayerToLoadOnCompletion( destinationIdentifier, QgsProcessingContext::LayerDetails( destName, destinationProject ) );
+  }
 
   return sink.release();
 }
@@ -371,6 +379,7 @@ QString QgsProcessingParameters::parameterAsRasterOutputLayer( const QgsProcessi
 
   QgsProject *destinationProject = nullptr;
   QVariantMap createOptions;
+  QString destName;
   if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
@@ -378,6 +387,7 @@ QString QgsProcessingParameters::parameterAsRasterOutputLayer( const QgsProcessi
     destinationProject = fromVar.destinationProject;
     createOptions = fromVar.createOptions;
     val = fromVar.sink;
+    destName = fromVar.destinationName;
   }
 
   QString dest;
@@ -396,7 +406,13 @@ QString QgsProcessingParameters::parameterAsRasterOutputLayer( const QgsProcessi
   }
 
   if ( destinationProject )
-    context.addLayerToLoadOnCompletion( dest, QgsProcessingContext::LayerDetails( definition ? definition->description() : QString(), destinationProject ) );
+  {
+    if ( destName.isEmpty() && definition )
+    {
+      destName = definition->description();
+    }
+    context.addLayerToLoadOnCompletion( dest, QgsProcessingContext::LayerDetails( destName, destinationProject ) );
+  }
 
   return dest;
 }

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -129,6 +129,11 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
     QgsProject *destinationProject;
 
     /**
+     * Name to use for sink if it's to be loaded into a destination project.
+     */
+    QString destinationName;
+
+    /**
      * Map of optional sink/layer creation options, which
      * are passed to the underlying provider when creating new layers. Known options also
      * include 'fileEncoding', which is used to specify a file encoding to use for created


### PR DESCRIPTION
Outputs were using child algorithm output names, instead of defined model parameter names