### PR TITLE
[bugfix] Fixes relation widget when switching between layer styles #16100

### DIFF
--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -355,6 +355,8 @@ void QgsEditFormConfig::readXml( const QDomNode &node, const QgsReadWriteContext
         QgsAttributeEditorElement *attributeEditorWidget = attributeEditorElementFromDomElement( elem, nullptr );
         addTab( attributeEditorWidget );
       }
+
+      onRelationsLoaded();
     }
   }
 }

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -19,9 +19,12 @@ from qgis.core import (QgsVectorLayer,
                        QgsRelation,
                        QgsGeometry,
                        QgsPointXY,
+                       QgsAttributeEditorElement,
                        QgsProject
                        )
+from utilities import unitTestDataPath
 from qgis.testing import start_app, unittest
+import os
 
 start_app()
 
@@ -137,6 +140,36 @@ class TestQgsRelation(unittest.TestCase):
         rel.addFieldPair('foreignkey', 'y')
 
         assert (rel.fieldPairs() == {'foreignkey': 'y'})
+
+    def testValidRelationAfterChangingStyle(self):
+        # load project
+        myPath = os.path.join(unitTestDataPath(), 'relations.qgs')
+        QgsProject.instance().read(myPath)
+
+        # get referenced layer
+        relations = QgsProject.instance().relationManager().relations()
+        relation = relations[list(relations.keys())[0]]
+        referencedLayer = relation.referencedLayer()
+
+        # check that the relation is valid
+        valid = False
+        for tab in referencedLayer.editFormConfig().tabs():
+            for t in tab.children():
+                if (t.type() == QgsAttributeEditorElement.AeTypeRelation):
+                    valid = t.relation().isValid()
+        self.assertTrue(valid)
+
+        # update style
+        referencedLayer.styleManager().setCurrentStyle("custom")
+
+        # check that the relation is still valid
+        referencedLayer = relation.referencedLayer()
+        valid = False
+        for tab in referencedLayer.editFormConfig().tabs():
+            for t in tab.children():
+                if (t.type() == QgsAttributeEditorElement.AeTypeRelation):
+                    valid = t.relation().isValid()
+        self.assertTrue(valid)
 
 
 if __name__ == '__main__':

--- a/tests/testdata/relations.qgs
+++ b/tests/testdata/relations.qgs
@@ -1,0 +1,1207 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="2.99.0-Master" projectname="">
+  <title></title>
+  <autotransaction active="0"/>
+  <evaluateDefaultValues active="0"/>
+  <layer-tree-group>
+    <customproperties/>
+    <layer-tree-layer id="points_97805748_6b30_49b8_a80b_bdbb4e8e78a3" providerKey="ogr" source="/home/blottiere/devel/packages/QGIS_pbl_bugfix_relationwidget/tests/testdata/points.shp" checked="Qt::Checked" name="points" expanded="1">
+      <customproperties/>
+    </layer-tree-layer>
+    <layer-tree-layer id="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834" providerKey="ogr" source="/home/blottiere/devel/packages/QGIS_pbl_bugfix_relationwidget/tests/testdata/points_relations.shp" checked="Qt::Checked" name="points_relations" expanded="1">
+      <customproperties/>
+    </layer-tree-layer>
+    <custom-order enabled="0">
+      <item>points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834</item>
+      <item>points_97805748_6b30_49b8_a80b_bdbb4e8e78a3</item>
+    </custom-order>
+  </layer-tree-group>
+  <snapping-settings unit="2" enabled="0" mode="2" intersection-snapping="0" tolerance="0" type="1">
+    <individual-layer-settings>
+      <layer-setting id="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834" enabled="0" units="2" tolerance="0" type="1"/>
+      <layer-setting id="points_97805748_6b30_49b8_a80b_bdbb4e8e78a3" enabled="0" units="2" tolerance="0" type="1"/>
+    </individual-layer-settings>
+  </snapping-settings>
+  <relations>
+    <relation id="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834_Class_points_97805748_6b30_49b8_a80b_bdbb4e8e78a3_Class" referencedLayer="points_97805748_6b30_49b8_a80b_bdbb4e8e78a3" referencingLayer="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834" name="planerel">
+      <fieldRef referencingField="Class" referencedField="Class"/>
+    </relation>
+  </relations>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+    <units>degrees</units>
+    <extent>
+      <xmin>-154.12487007385504967</xmin>
+      <ymin>6.46638006522830722</ymin>
+      <xmax>-31.90147730603621312</xmax>
+      <ymax>58.45237830223271658</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>WGS84</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <layer_coordinate_transform_info>
+      <layer_coordinate_transform srcAuthId="EPSG:4326" destAuthId="EPSG:4326" srcDatumTransform="-1" destDatumTransform="-1" layerid="points_97805748_6b30_49b8_a80b_bdbb4e8e78a3"/>
+      <layer_coordinate_transform srcAuthId="EPSG:4326" destAuthId="EPSG:4326" srcDatumTransform="-1" destDatumTransform="-1" layerid="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834"/>
+    </layer_coordinate_transform_info>
+  </mapcanvas>
+  <legend updateDrawingOrder="true">
+    <legendlayer checked="Qt::Checked" showFeatureCount="0" open="true" drawingOrder="-1" name="points">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile visible="1" layerid="points_97805748_6b30_49b8_a80b_bdbb4e8e78a3" isInOverview="0"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer checked="Qt::Checked" showFeatureCount="0" open="true" drawingOrder="-1" name="points_relations">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile visible="1" layerid="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834" isInOverview="0"/>
+      </filegroup>
+    </legendlayer>
+  </legend>
+  <mapViewDocks/>
+  <projectlayers>
+    <maplayer readOnly="0" minScale="0" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" simplifyDrawingHints="0" maxScale="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" autoRefreshEnabled="0" simplifyAlgorithm="0" type="vector">
+      <extent>
+        <xmin>-118.88888888888877204</xmin>
+        <ymin>22.80020703933767834</ymin>
+        <xmax>-83.33333333333315807</xmax>
+        <ymax>46.87198067632875365</ymax>
+      </extent>
+      <id>points_97805748_6b30_49b8_a80b_bdbb4e8e78a3</id>
+      <datasource>./points.shp</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>points</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="custom2">
+        <map-layer-style name="">
+          <qgis readOnly="0" version="2.99.0-Master" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" maxScale="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" simplifyAlgorithm="0" mincale="0">
+            <renderer-v2 symbollevels="0" attr="Class" enableorderby="0" forceraster="0" type="categorizedSymbol">
+              <categories>
+                <category label="B52" value="B52" symbol="0" render="true"/>
+                <category label="Biplane" value="Biplane" symbol="1" render="true"/>
+                <category label="Jet" value="Jet" symbol="2" render="true"/>
+              </categories>
+              <symbols>
+                <symbol clip_to_extent="1" alpha="1" name="0" type="marker">
+                  <layer enabled="1" pass="0" locked="0" class="SvgMarker">
+                    <prop k="angle" v="0"/>
+                    <prop k="color" v="0,0,0,255"/>
+                    <prop k="horizontal_anchor_point" v="1"/>
+                    <prop k="name" v="gpsicons/plane.svg"/>
+                    <prop k="offset" v="0,0"/>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="offset_unit" v="MM"/>
+                    <prop k="outline_color" v="0,0,0,255"/>
+                    <prop k="outline_width" v="0.2"/>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="outline_width_unit" v="MM"/>
+                    <prop k="scale_method" v="diameter"/>
+                    <prop k="size" v="11"/>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="size_unit" v="MM"/>
+                    <prop k="vertical_anchor_point" v="1"/>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option value="" name="name" type="QString"/>
+                        <Option name="properties"/>
+                        <Option value="collection" name="type" type="QString"/>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+                <symbol clip_to_extent="1" alpha="1" name="1" type="marker">
+                  <layer enabled="1" pass="0" locked="0" class="SvgMarker">
+                    <prop k="angle" v="0"/>
+                    <prop k="color" v="0,0,0,255"/>
+                    <prop k="horizontal_anchor_point" v="1"/>
+                    <prop k="name" v="gpsicons/plane_orange.svg"/>
+                    <prop k="offset" v="0,0"/>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="offset_unit" v="MM"/>
+                    <prop k="outline_color" v="0,0,0,255"/>
+                    <prop k="outline_width" v="0.2"/>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="outline_width_unit" v="MM"/>
+                    <prop k="scale_method" v="diameter"/>
+                    <prop k="size" v="18"/>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="size_unit" v="MM"/>
+                    <prop k="vertical_anchor_point" v="1"/>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option value="" name="name" type="QString"/>
+                        <Option name="properties"/>
+                        <Option value="collection" name="type" type="QString"/>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+                <symbol clip_to_extent="1" alpha="1" name="2" type="marker">
+                  <layer enabled="1" pass="0" locked="0" class="SvgMarker">
+                    <prop k="angle" v="0"/>
+                    <prop k="color" v="0,0,0,255"/>
+                    <prop k="horizontal_anchor_point" v="1"/>
+                    <prop k="name" v="gpsicons/plane.svg"/>
+                    <prop k="offset" v="0,0"/>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="offset_unit" v="MM"/>
+                    <prop k="outline_color" v="0,0,0,255"/>
+                    <prop k="outline_width" v="0.2"/>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="outline_width_unit" v="MM"/>
+                    <prop k="scale_method" v="diameter"/>
+                    <prop k="size" v="11"/>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="size_unit" v="MM"/>
+                    <prop k="vertical_anchor_point" v="1"/>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option value="" name="name" type="QString"/>
+                        <Option name="properties"/>
+                        <Option value="collection" name="type" type="QString"/>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+              </symbols>
+              <rotation/>
+              <sizescale/>
+            </renderer-v2>
+            <customproperties>
+              <property value="0" key="embeddedWidgets/count"/>
+              <property key="variableNames"/>
+              <property key="variableValues"/>
+            </customproperties>
+            <blendMode>0</blendMode>
+            <featureBlendMode>0</featureBlendMode>
+            <layerOpacity>1</layerOpacity>
+            <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+              <DiagramCategory maxScaleDenominator="1e+8" opacity="1" lineSizeScale="3x:0,0,0,0,0,0" height="15" rotationOffset="270" penColor="#000000" backgroundColor="#ffffff" sizeType="MM" minimumSize="0" penWidth="0" backgroundAlpha="255" minScaleDenominator="1" labelPlacementMethod="XHeight" diagramOrientation="Up" width="15" penAlpha="255" lineSizeType="MM" scaleBasedVisibility="0" enabled="0" sizeScale="3x:0,0,0,0,0,0" barWidth="5" scaleDependency="Area">
+                <fontProperties style="" description="Noto Sans,10,-1,5,50,0,0,0,0,0"/>
+                <attribute label="" color="#000000" field=""/>
+              </DiagramCategory>
+            </SingleCategoryDiagramRenderer>
+            <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" dist="0" linePlacementFlags="10" placement="0" showAll="1">
+              <properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </properties>
+            </DiagramLayerSettings>
+            <fieldConfiguration>
+              <field name="Class">
+                <editWidget type="">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Heading">
+                <editWidget type="">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Importance">
+                <editWidget type="">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Pilots">
+                <editWidget type="">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Cabin Crew">
+                <editWidget type="">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Staff">
+                <editWidget type="">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+            </fieldConfiguration>
+            <aliases>
+              <alias field="Class" name="" index="0"/>
+              <alias field="Heading" name="" index="1"/>
+              <alias field="Importance" name="" index="2"/>
+              <alias field="Pilots" name="" index="3"/>
+              <alias field="Cabin Crew" name="" index="4"/>
+              <alias field="Staff" name="" index="5"/>
+            </aliases>
+            <excludeAttributesWMS/>
+            <excludeAttributesWFS/>
+            <defaults>
+              <default field="Class" expression=""/>
+              <default field="Heading" expression=""/>
+              <default field="Importance" expression=""/>
+              <default field="Pilots" expression=""/>
+              <default field="Cabin Crew" expression=""/>
+              <default field="Staff" expression=""/>
+            </defaults>
+            <constraints>
+              <constraint field="Class" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+              <constraint field="Heading" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+              <constraint field="Importance" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+              <constraint field="Pilots" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+              <constraint field="Cabin Crew" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+              <constraint field="Staff" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+            </constraints>
+            <constraintExpressions>
+              <constraint exp="" field="Class" desc=""/>
+              <constraint exp="" field="Heading" desc=""/>
+              <constraint exp="" field="Importance" desc=""/>
+              <constraint exp="" field="Pilots" desc=""/>
+              <constraint exp="" field="Cabin Crew" desc=""/>
+              <constraint exp="" field="Staff" desc=""/>
+            </constraintExpressions>
+            <attributeactions>
+              <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+            </attributeactions>
+            <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+              <columns>
+                <column width="-1" hidden="0" name="Class" type="field"/>
+                <column width="-1" hidden="0" name="Heading" type="field"/>
+                <column width="-1" hidden="0" name="Importance" type="field"/>
+                <column width="-1" hidden="0" name="Pilots" type="field"/>
+                <column width="-1" hidden="0" name="Cabin Crew" type="field"/>
+                <column width="-1" hidden="0" name="Staff" type="field"/>
+                <column width="-1" hidden="1" type="actions"/>
+              </columns>
+            </attributetableconfig>
+            <editform/>
+            <editforminit/>
+            <editforminitcodesource>0</editforminitcodesource>
+            <editforminitfilepath/>
+            <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+            <featformsuppress>0</featformsuppress>
+            <editorlayout>generatedlayout</editorlayout>
+            <attributeEditorForm>
+              <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" name="tab">
+                <attributeEditorField showLabel="1" name="Heading" index="1"/>
+                <attributeEditorField showLabel="1" name="Class" index="0"/>
+                <attributeEditorField showLabel="1" name="Importance" index="2"/>
+                <attributeEditorField showLabel="1" name="Cabin Crew" index="4"/>
+                <attributeEditorField showLabel="1" name="Staff" index="5"/>
+                <attributeEditorField showLabel="1" name="Pilots" index="3"/>
+                <attributeEditorRelation showLabel="1" relation="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834_Class_points_97805748_6b30_49b8_a80b_bdbb4e8e78a3_Class" showUnlinkButton="1" name="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834_Class_points_97805748_6b30_49b8_a80b_bdbb4e8e78a3_Class" showLinkButton="1"/>
+              </attributeEditorContainer>
+            </attributeEditorForm>
+            <widgets/>
+            <conditionalstyles>
+              <rowstyles/>
+              <fieldstyles/>
+            </conditionalstyles>
+            <expressionfields/>
+            <previewExpression>"Class"</previewExpression>
+            <mapTip/>
+            <layerGeometryType>0</layerGeometryType>
+          </qgis>
+        </map-layer-style>
+        <map-layer-style name="custom">
+          <qgis readOnly="0" version="2.99.0-Master" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" maxScale="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" simplifyAlgorithm="0" mincale="0">
+            <renderer-v2 symbollevels="0" attr="Class" enableorderby="0" forceraster="0" type="categorizedSymbol">
+              <categories>
+                <category label="B52" value="B52" symbol="0" render="true"/>
+                <category label="Biplane" value="Biplane" symbol="1" render="true"/>
+                <category label="Jet" value="Jet" symbol="2" render="true"/>
+              </categories>
+              <symbols>
+                <symbol clip_to_extent="1" alpha="1" name="0" type="marker">
+                  <layer enabled="1" pass="0" class="SvgMarker" locked="0">
+                    <prop k="angle" v="0"/>
+                    <prop k="color" v="0,0,0,255"/>
+                    <prop k="horizontal_anchor_point" v="1"/>
+                    <prop k="name" v="gpsicons/plane.svg"/>
+                    <prop k="offset" v="0,0"/>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="offset_unit" v="MM"/>
+                    <prop k="outline_color" v="0,0,0,255"/>
+                    <prop k="outline_width" v="0.2"/>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="outline_width_unit" v="MM"/>
+                    <prop k="scale_method" v="diameter"/>
+                    <prop k="size" v="11"/>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="size_unit" v="MM"/>
+                    <prop k="vertical_anchor_point" v="1"/>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option value="" name="name" type="QString"/>
+                        <Option name="properties"/>
+                        <Option value="collection" name="type" type="QString"/>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+                <symbol clip_to_extent="1" alpha="1" name="1" type="marker">
+                  <layer enabled="1" pass="0" class="SvgMarker" locked="0">
+                    <prop k="angle" v="0"/>
+                    <prop k="color" v="0,0,0,255"/>
+                    <prop k="horizontal_anchor_point" v="1"/>
+                    <prop k="name" v="gpsicons/plane_orange.svg"/>
+                    <prop k="offset" v="0,0"/>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="offset_unit" v="MM"/>
+                    <prop k="outline_color" v="0,0,0,255"/>
+                    <prop k="outline_width" v="0.2"/>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="outline_width_unit" v="MM"/>
+                    <prop k="scale_method" v="diameter"/>
+                    <prop k="size" v="18"/>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="size_unit" v="MM"/>
+                    <prop k="vertical_anchor_point" v="1"/>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option value="" name="name" type="QString"/>
+                        <Option name="properties"/>
+                        <Option value="collection" name="type" type="QString"/>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+                <symbol clip_to_extent="1" alpha="1" name="2" type="marker">
+                  <layer enabled="1" pass="0" class="SvgMarker" locked="0">
+                    <prop k="angle" v="0"/>
+                    <prop k="color" v="0,0,0,255"/>
+                    <prop k="horizontal_anchor_point" v="1"/>
+                    <prop k="name" v="gpsicons/plane.svg"/>
+                    <prop k="offset" v="0,0"/>
+                    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="offset_unit" v="MM"/>
+                    <prop k="outline_color" v="0,0,0,255"/>
+                    <prop k="outline_width" v="0.2"/>
+                    <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="outline_width_unit" v="MM"/>
+                    <prop k="scale_method" v="diameter"/>
+                    <prop k="size" v="11"/>
+                    <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                    <prop k="size_unit" v="MM"/>
+                    <prop k="vertical_anchor_point" v="1"/>
+                    <data_defined_properties>
+                      <Option type="Map">
+                        <Option value="" name="name" type="QString"/>
+                        <Option name="properties"/>
+                        <Option value="collection" name="type" type="QString"/>
+                      </Option>
+                    </data_defined_properties>
+                  </layer>
+                </symbol>
+              </symbols>
+              <rotation/>
+              <sizescale/>
+            </renderer-v2>
+            <customproperties>
+              <property value="0" key="embeddedWidgets/count"/>
+              <property key="variableNames"/>
+              <property key="variableValues"/>
+            </customproperties>
+            <blendMode>0</blendMode>
+            <featureBlendMode>0</featureBlendMode>
+            <layerOpacity>1</layerOpacity>
+            <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+              <DiagramCategory maxScaleDenominator="1e+8" opacity="1" lineSizeScale="3x:0,0,0,0,0,0" height="15" rotationOffset="270" penColor="#000000" backgroundColor="#ffffff" sizeType="MM" minimumSize="0" penWidth="0" backgroundAlpha="255" minScaleDenominator="1" labelPlacementMethod="XHeight" diagramOrientation="Up" width="15" penAlpha="255" lineSizeType="MM" scaleBasedVisibility="0" enabled="0" sizeScale="3x:0,0,0,0,0,0" barWidth="5" scaleDependency="Area">
+                <fontProperties style="" description="Noto Sans,10,-1,5,50,0,0,0,0,0"/>
+                <attribute label="" color="#000000" field=""/>
+              </DiagramCategory>
+            </SingleCategoryDiagramRenderer>
+            <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" dist="0" linePlacementFlags="2" placement="0" showAll="1">
+              <properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </properties>
+            </DiagramLayerSettings>
+            <fieldConfiguration>
+              <field name="Class">
+                <editWidget type="TextEdit">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Heading">
+                <editWidget type="TextEdit">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Importance">
+                <editWidget type="Range">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Pilots">
+                <editWidget type="Range">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Cabin Crew">
+                <editWidget type="Range">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+              <field name="Staff">
+                <editWidget type="Range">
+                  <config>
+                    <Option/>
+                  </config>
+                </editWidget>
+              </field>
+            </fieldConfiguration>
+            <aliases>
+              <alias field="Class" name="" index="0"/>
+              <alias field="Heading" name="" index="1"/>
+              <alias field="Importance" name="" index="2"/>
+              <alias field="Pilots" name="" index="3"/>
+              <alias field="Cabin Crew" name="" index="4"/>
+              <alias field="Staff" name="" index="5"/>
+            </aliases>
+            <excludeAttributesWMS/>
+            <excludeAttributesWFS/>
+            <defaults>
+              <default field="Class" expression=""/>
+              <default field="Heading" expression=""/>
+              <default field="Importance" expression=""/>
+              <default field="Pilots" expression=""/>
+              <default field="Cabin Crew" expression=""/>
+              <default field="Staff" expression=""/>
+            </defaults>
+            <constraints>
+              <constraint field="Class" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+              <constraint field="Heading" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+              <constraint field="Importance" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+              <constraint field="Pilots" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+              <constraint field="Cabin Crew" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+              <constraint field="Staff" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+            </constraints>
+            <constraintExpressions>
+              <constraint exp="" field="Class" desc=""/>
+              <constraint exp="" field="Heading" desc=""/>
+              <constraint exp="" field="Importance" desc=""/>
+              <constraint exp="" field="Pilots" desc=""/>
+              <constraint exp="" field="Cabin Crew" desc=""/>
+              <constraint exp="" field="Staff" desc=""/>
+            </constraintExpressions>
+            <attributeactions>
+              <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+            </attributeactions>
+            <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+              <columns>
+                <column width="-1" name="Class" hidden="0" type="field"/>
+                <column width="-1" name="Heading" hidden="0" type="field"/>
+                <column width="-1" name="Importance" hidden="0" type="field"/>
+                <column width="-1" name="Pilots" hidden="0" type="field"/>
+                <column width="-1" name="Cabin Crew" hidden="0" type="field"/>
+                <column width="-1" name="Staff" hidden="0" type="field"/>
+                <column width="-1" hidden="1" type="actions"/>
+              </columns>
+            </attributetableconfig>
+            <editform/>
+            <editforminit/>
+            <editforminitcodesource>0</editforminitcodesource>
+            <editforminitfilepath/>
+            <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+            <featformsuppress>0</featformsuppress>
+            <editorlayout>tablayout</editorlayout>
+            <attributeEditorForm>
+              <attributeEditorContainer visibilityExpression="" showLabel="1" columnCount="1" groupBox="0" visibilityExpressionEnabled="0" name="tab">
+                <attributeEditorField showLabel="1" name="Heading" index="1"/>
+                <attributeEditorField showLabel="1" name="Class" index="0"/>
+                <attributeEditorField showLabel="1" name="Importance" index="2"/>
+                <attributeEditorField showLabel="1" name="Cabin Crew" index="4"/>
+                <attributeEditorField showLabel="1" name="Staff" index="5"/>
+                <attributeEditorField showLabel="1" name="Pilots" index="3"/>
+                <attributeEditorRelation showLabel="1" relation="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834_Class_points_97805748_6b30_49b8_a80b_bdbb4e8e78a3_Class" showUnlinkButton="1" name="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834_Class_points_97805748_6b30_49b8_a80b_bdbb4e8e78a3_Class" showLinkButton="1"/>
+              </attributeEditorContainer>
+            </attributeEditorForm>
+            <widgets/>
+            <conditionalstyles>
+              <rowstyles/>
+              <fieldstyles/>
+            </conditionalstyles>
+            <expressionfields/>
+            <previewExpression>Class</previewExpression>
+            <mapTip/>
+            <layerGeometryType>0</layerGeometryType>
+          </qgis>
+        </map-layer-style>
+        <map-layer-style name="custom2"/>
+      </map-layer-style-manager>
+      <renderer-v2 symbollevels="0" attr="Class" enableorderby="0" forceraster="0" type="categorizedSymbol">
+        <categories>
+          <category label="B52" value="B52" symbol="0" render="true"/>
+          <category label="Biplane" value="Biplane" symbol="1" render="true"/>
+          <category label="Jet" value="Jet" symbol="2" render="true"/>
+        </categories>
+        <symbols>
+          <symbol clip_to_extent="1" alpha="1" name="0" type="marker">
+            <layer enabled="1" pass="0" class="SvgMarker" locked="0">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="0,0,0,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="name" v="gpsicons/plane.svg"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_width" v="0.2"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="diameter"/>
+              <prop k="size" v="11"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol clip_to_extent="1" alpha="1" name="1" type="marker">
+            <layer enabled="1" pass="0" class="SvgMarker" locked="0">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="0,0,0,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="name" v="gpsicons/plane_orange.svg"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_width" v="0.2"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="diameter"/>
+              <prop k="size" v="18"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol clip_to_extent="1" alpha="1" name="2" type="marker">
+            <layer enabled="1" pass="0" class="SvgMarker" locked="0">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="0,0,0,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="name" v="gpsicons/plane.svg"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_width" v="0.2"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="diameter"/>
+              <prop k="size" v="11"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties>
+        <property value="0" key="embeddedWidgets/count"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory maxScaleDenominator="1e+8" opacity="1" lineSizeScale="3x:0,0,0,0,0,0" height="15" rotationOffset="270" penColor="#000000" backgroundColor="#ffffff" sizeType="MM" minimumSize="0" penWidth="0" backgroundAlpha="255" minScaleDenominator="1" labelPlacementMethod="XHeight" diagramOrientation="Up" width="15" penAlpha="255" lineSizeType="MM" scaleBasedVisibility="0" enabled="0" sizeScale="3x:0,0,0,0,0,0" barWidth="5" scaleDependency="Area">
+          <fontProperties style="" description="Noto Sans,10,-1,5,50,0,0,0,0,0"/>
+          <attribute label="" color="#000000" field=""/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" dist="0" linePlacementFlags="2" placement="0" showAll="1">
+        <properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <fieldConfiguration>
+        <field name="Class">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Heading">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Importance">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Pilots">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Cabin Crew">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Staff">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="Class" name="" index="0"/>
+        <alias field="Heading" name="" index="1"/>
+        <alias field="Importance" name="" index="2"/>
+        <alias field="Pilots" name="" index="3"/>
+        <alias field="Cabin Crew" name="" index="4"/>
+        <alias field="Staff" name="" index="5"/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="Class" expression=""/>
+        <default field="Heading" expression=""/>
+        <default field="Importance" expression=""/>
+        <default field="Pilots" expression=""/>
+        <default field="Cabin Crew" expression=""/>
+        <default field="Staff" expression=""/>
+      </defaults>
+      <constraints>
+        <constraint field="Class" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Heading" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Importance" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Pilots" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Cabin Crew" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Staff" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint exp="" field="Class" desc=""/>
+        <constraint exp="" field="Heading" desc=""/>
+        <constraint exp="" field="Importance" desc=""/>
+        <constraint exp="" field="Pilots" desc=""/>
+        <constraint exp="" field="Cabin Crew" desc=""/>
+        <constraint exp="" field="Staff" desc=""/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+        <columns>
+          <column width="-1" name="Class" hidden="0" type="field"/>
+          <column width="-1" name="Heading" hidden="0" type="field"/>
+          <column width="-1" name="Importance" hidden="0" type="field"/>
+          <column width="-1" name="Pilots" hidden="0" type="field"/>
+          <column width="-1" name="Cabin Crew" hidden="0" type="field"/>
+          <column width="-1" name="Staff" hidden="0" type="field"/>
+          <column width="-1" hidden="1" type="actions"/>
+        </columns>
+      </attributetableconfig>
+      <editform></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>tablayout</editorlayout>
+      <attributeEditorForm>
+        <attributeEditorContainer visibilityExpression="" showLabel="1" columnCount="1" groupBox="0" visibilityExpressionEnabled="0" name="tab">
+          <attributeEditorField showLabel="1" name="Heading" index="1"/>
+          <attributeEditorField showLabel="1" name="Class" index="0"/>
+          <attributeEditorField showLabel="1" name="Importance" index="2"/>
+          <attributeEditorField showLabel="1" name="Cabin Crew" index="4"/>
+          <attributeEditorField showLabel="1" name="Staff" index="5"/>
+          <attributeEditorField showLabel="1" name="Pilots" index="3"/>
+          <attributeEditorRelation showLabel="1" relation="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834_Class_points_97805748_6b30_49b8_a80b_bdbb4e8e78a3_Class" showUnlinkButton="1" name="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834_Class_points_97805748_6b30_49b8_a80b_bdbb4e8e78a3_Class" showLinkButton="1"/>
+        </attributeEditorContainer>
+      </attributeEditorForm>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression>Class</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer readOnly="0" minScale="1e+8" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" simplifyDrawingHints="1" maxScale="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" autoRefreshEnabled="0" simplifyAlgorithm="0" type="vector">
+      <extent>
+        <xmin>-117.23257418909581418</xmin>
+        <ymin>22.80020703933767834</ymin>
+        <xmax>-83.33333333333315807</xmax>
+        <ymax>37.21877156659789421</ymax>
+      </extent>
+      <id>points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834</id>
+      <datasource>./points_relations.shp</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>points_relations</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="">
+        <map-layer-style name=""/>
+      </map-layer-style-manager>
+      <renderer-v2 symbollevels="0" enableorderby="0" forceraster="0" type="singleSymbol">
+        <symbols>
+          <symbol clip_to_extent="1" alpha="1" name="0" type="marker">
+            <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="151,48,81,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="name" v="circle"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="diameter"/>
+              <prop k="size" v="2"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties/>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <fieldConfiguration>
+        <field name="Class">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="id">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="Class" name="" index="0"/>
+        <alias field="id" name="" index="1"/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="Class" expression=""/>
+        <default field="id" expression=""/>
+      </defaults>
+      <constraints>
+        <constraint field="Class" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="id" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint exp="" field="Class" desc=""/>
+        <constraint exp="" field="id" desc=""/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+        <columns>
+          <column width="-1" name="Class" hidden="0" type="field"/>
+          <column width="-1" name="id" hidden="0" type="field"/>
+          <column width="-1" hidden="1" type="actions"/>
+        </columns>
+      </attributetableconfig>
+      <editform></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression>"id"</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+  </projectlayers>
+  <layerorder>
+    <layer id="points_relations_0ebfed2f_fa7e_4802_91ad_8e044db5d834"/>
+    <layer id="points_97805748_6b30_49b8_a80b_bdbb4e8e78a3"/>
+  </layerorder>
+  <properties>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <PositionPrecision>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+      <DegreeFormat type="QString">MU</DegreeFormat>
+      <Automatic type="bool">true</Automatic>
+    </PositionPrecision>
+    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
+    <WMSPrecision type="QString">8</WMSPrecision>
+    <WMSContactMail type="QString"></WMSContactMail>
+    <SpatialRefSys>
+      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
+      <ProjectCRSID type="int">3452</ProjectCRSID>
+      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+    </SpatialRefSys>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <WMSContactPerson type="QString"></WMSContactPerson>
+    <PAL>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <CandidatesLine type="int">50</CandidatesLine>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <SearchMethod type="int">0</SearchMethod>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+    </PAL>
+    <WMSAddWktGeometry type="bool">false</WMSAddWktGeometry>
+    <WMSServiceAbstract type="QString"></WMSServiceAbstract>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <Identify>
+      <disabledLayers type="QStringList"/>
+    </Identify>
+    <WMSUrl type="QString"></WMSUrl>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <DefaultStyles>
+      <Marker type="QString"></Marker>
+      <Opacity type="double">1</Opacity>
+      <RandomColors type="bool">true</RandomColors>
+      <Fill type="QString"></Fill>
+      <ColorRamp type="QString"></ColorRamp>
+      <Line type="QString"></Line>
+    </DefaultStyles>
+    <WMSServiceCapabilities type="bool">false</WMSServiceCapabilities>
+    <WFSTLayers>
+      <Insert type="QStringList"/>
+      <Update type="QStringList"/>
+      <Delete type="QStringList"/>
+    </WFSTLayers>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <WFSLayers type="QStringList"/>
+    <WMSServiceTitle type="QString"></WMSServiceTitle>
+    <WMSContactPosition type="QString"></WMSContactPosition>
+    <WMSContactOrganization type="QString"></WMSContactOrganization>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
+    <WMSImageQuality type="int">90</WMSImageQuality>
+    <Gui>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+    </Gui>
+    <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <Measure>
+      <Ellipsoid type="QString">NONE</Ellipsoid>
+    </Measure>
+    <WCSLayers type="QStringList"/>
+    <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
+    <WFSUrl type="QString"></WFSUrl>
+    <WCSUrl type="QString"></WCSUrl>
+  </properties>
+  <visibility-presets/>
+  <Annotations/>
+  <Layouts>
+    <Composer>
+      <Composition showPages="1" snapGridOffsetX="0" printResolution="300" alignmentSnap="1" paperHeight="210" smartGuides="1" resizeToContentsMarginBottom="0" printAsRaster="0" snapGridOffsetY="0" generateWorldFile="0" resizeToContentsMarginRight="0" paperWidth="297" snapping="0" guidesVisible="1" name="composer" snapTolerancePixels="5" resizeToContentsMarginLeft="0" worldFileMap="{b0ef25f7-05c5-42d6-a548-cc9d209dc84b}" snapGridResolution="10" gridVisible="0" resizeToContentsMarginTop="0" numPages="1">
+        <symbol clip_to_extent="1" alpha="1" name="" type="fill">
+          <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+            <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="color" v="255,255,255,255"/>
+            <prop k="joinstyle" v="miter"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="no"/>
+            <prop k="outline_width" v="0.26"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="style" v="solid"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option value="" name="name" type="QString"/>
+                <Option name="properties"/>
+                <Option value="collection" name="type" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+        <ComposerMap id="0" mapRotation="0" drawCanvasItems="true" followPresetName="" keepLayerSet="false" followPreset="false">
+          <Extent ymax="71.63354353239040506" xmax="-31.90147730603621312" xmin="-154.12487007385504967" ymin="-6.7147851649293635"/>
+          <LayerSet/>
+          <Grid/>
+          <ComposerMapGrid frameFillColor1="255,255,255,255" bottomAnnotationDirection="0" showAnnotation="0" gridFramePenThickness="0.5" gridFramePenColor="0,0,0,255" rightAnnotationDirection="0" leftAnnotationPosition="1" intervalY="0" topAnnotationDirection="0" bottomFrameDivisions="0" topAnnotationDisplay="0" annotationFormat="0" rightFrameDivisions="0" annotationPrecision="3" gridFrameWidth="2" bottomAnnotationPosition="1" rightAnnotationDisplay="0" gridFrameStyle="0" gridStyle="0" offsetY="0" uuid="{c58b03e6-08ff-4116-946e-f15953cf34f1}" offsetX="0" show="0" unit="0" leftAnnotationDisplay="0" blendMode="0" annotationFontColor="0,0,0,255" crossLength="3" intervalX="0" annotationExpression="" leftFrameDivisions="0" leftAnnotationDirection="0" frameAnnotationDistance="1" name="Grid 1" frameFillColor2="0,0,0,255" topFrameDivisions="0" gridFrameSideFlags="15" topAnnotationPosition="1" bottomAnnotationDisplay="0" rightAnnotationPosition="1">
+            <lineStyle>
+              <symbol clip_to_extent="1" alpha="1" name="" type="line">
+                <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+                  <prop k="capstyle" v="square"/>
+                  <prop k="customdash" v="5;2"/>
+                  <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <prop k="customdash_unit" v="MM"/>
+                  <prop k="draw_inside_polygon" v="0"/>
+                  <prop k="joinstyle" v="bevel"/>
+                  <prop k="line_color" v="0,0,0,255"/>
+                  <prop k="line_style" v="solid"/>
+                  <prop k="line_width" v="0"/>
+                  <prop k="line_width_unit" v="MM"/>
+                  <prop k="offset" v="0"/>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <prop k="offset_unit" v="MM"/>
+                  <prop k="use_custom_dash" v="0"/>
+                  <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option value="" name="name" type="QString"/>
+                      <Option name="properties"/>
+                      <Option value="collection" name="type" type="QString"/>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </lineStyle>
+            <markerStyle>
+              <symbol clip_to_extent="1" alpha="1" name="" type="marker">
+                <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+                  <prop k="angle" v="0"/>
+                  <prop k="color" v="0,0,0,255"/>
+                  <prop k="horizontal_anchor_point" v="1"/>
+                  <prop k="joinstyle" v="bevel"/>
+                  <prop k="name" v="circle"/>
+                  <prop k="offset" v="0,0"/>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <prop k="offset_unit" v="MM"/>
+                  <prop k="outline_color" v="0,0,0,255"/>
+                  <prop k="outline_style" v="solid"/>
+                  <prop k="outline_width" v="0"/>
+                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <prop k="outline_width_unit" v="MM"/>
+                  <prop k="scale_method" v="diameter"/>
+                  <prop k="size" v="2"/>
+                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+                  <prop k="size_unit" v="MM"/>
+                  <prop k="vertical_anchor_point" v="1"/>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option value="" name="name" type="QString"/>
+                      <Option name="properties"/>
+                      <Option value="collection" name="type" type="QString"/>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </markerStyle>
+            <annotationFontProperties style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0"/>
+          </ComposerMapGrid>
+          <AtlasMap atlasDriven="0" margin="0.10000000000000001" scalingMode="2"/>
+          <ComposerItem frameJoinStyle="miter" id="" uuid="{b0ef25f7-05c5-42d6-a548-cc9d209dc84b}" opacity="1" page="1" positionMode="0" frame="false" height="125" lastValidViewScaleFactor="3.89413" y="36.2083" x="59.7976" outlineWidth="0.3" background="true" positionLock="false" width="195" visibility="1" excludeFromExports="0" pagey="36.2083" zValue="1" blendMode="0" pagex="59.7976" itemRotation="0">
+            <FrameColor red="0" blue="0" green="0" alpha="255"/>
+            <BackgroundColor red="255" blue="255" green="255" alpha="255"/>
+            <dataDefinedProperties>
+              <Option type="Map">
+                <Option value="" name="name" type="QString"/>
+                <Option name="properties"/>
+                <Option value="collection" name="type" type="QString"/>
+              </Option>
+            </dataDefinedProperties>
+            <customproperties/>
+          </ComposerItem>
+        </ComposerMap>
+        <dataDefinedProperties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </dataDefinedProperties>
+        <customproperties/>
+      </Composition>
+    </Composer>
+  </Layouts>
+</qgis>


### PR DESCRIPTION
## Description

This PR fixes the relation widget when switching between layer styles (see https://issues.qgis.org/issues/16100).

Moreover, a unit test has been added to highlight the issue.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
