### PR TITLE
Various new expression functions and possibilities

### DIFF
--- a/python/core/expression/qgsexpressionfunction.sip
+++ b/python/core/expression/qgsexpressionfunction.sip
@@ -249,6 +249,11 @@ The help text for the function.
  :rtype: QVariant
 %End
 
+    virtual QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent );
+%Docstring
+ :rtype: QVariant
+%End
+
     bool operator==( const QgsExpressionFunction &other ) const;
 
     virtual bool handlesNull() const;

--- a/python/core/geometry/qgscompoundcurve.sip
+++ b/python/core/geometry/qgscompoundcurve.sip
@@ -77,7 +77,7 @@ class QgsCompoundCurve: QgsCurve
 
     void addCurve( QgsCurve *c /Transfer/ );
 %Docstring
- Adds a curve to the geometr (takes ownership)
+ Adds a curve to the geometry (takes ownership)
 %End
 
     void removeCurve( int i );

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -809,6 +809,15 @@ class QgsExpressionContextUtils
  :rtype: QgsExpressionContextScope
 %End
 
+    static QgsExpressionContextScope *mapToolCaptureScope( const QList<QgsPointLocator::Match> &matches ) /Factory/;
+%Docstring
+ Sets the expression context variables which are available for expressions triggered by
+ a map tool capture like add feature.
+
+.. versionadded:: 3.0
+ :rtype: QgsExpressionContextScope
+%End
+
     static QgsExpressionContextScope *updateSymbolScope( const QgsSymbol *symbol, QgsExpressionContextScope *symbolScope = 0 );
 %Docstring
  Updates a symbol scope related to a QgsSymbol to an expression context.

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -42,6 +42,14 @@ Adds a whole curve (e.g. circularstring) to the captured geometry. Curve must be
  :rtype: QgsCompoundCurve
 %End
 
+    QList<QgsPointLocator::Match> snappingMatches() const;
+%Docstring
+ Return a list of matches for each point on the captureCurve.
+
+.. versionadded:: 3.0
+ :rtype: list of QgsPointLocator.Match
+%End
+
     virtual void cadCanvasMoveEvent( QgsMapMouseEvent *e );
 
     virtual void keyPressEvent( QKeyEvent *e );

--- a/resources/function_help/json/array_first
+++ b/resources/function_help/json/array_first
@@ -1,0 +1,7 @@
+{
+  "name": "array_first",
+  "type": "function",
+  "description": "Returns the first value of an array.",
+  "arguments": [ {"arg":"array","description":"an array"} ],
+  "examples": [ { "expression":"array_first(array('a','b','c'))", "returns":"'a'"}]
+}

--- a/resources/function_help/json/array_last
+++ b/resources/function_help/json/array_last
@@ -1,0 +1,7 @@
+{
+  "name": "array_last",
+  "type": "function",
+  "description": "Returns the last value of an array.",
+  "arguments": [ {"arg":"array","description":"an array"} ],
+  "examples": [ { "expression":"array_last(array('a','b','c'))", "returns":"'c'"}]
+}

--- a/resources/function_help/json/get_feature_by_id
+++ b/resources/function_help/json/get_feature_by_id
@@ -1,0 +1,8 @@
+{
+  "name": "get_feature_by_id",
+  "type": "function",
+  "description": "Returns the feature with an id on a layer.",
+  "arguments": [ {"arg":"layer","description":"layer, layer name or layer id"},
+                 {"arg":"feature_id","description":"the id of the feature which should be returned"}],
+  "examples": [ { "expression":"get_feature('streets', 1)", "returns":"the feature with the id 1 on the layer \"streets\""}]
+}

--- a/resources/function_help/json/with_variable
+++ b/resources/function_help/json/with_variable
@@ -1,0 +1,11 @@
+{
+  "name": "with_variable",
+  "type": "function",
+  "description": "This function sets a variable for any expression code that will be provided as 3rd argument. This is only useful for complicated expressions, where the same calculated value needs to be used in different places.",
+  "arguments": [
+                 {"arg":"name","description":"the name of the variable to set"},
+                 {"arg":"value","description":"the value to set"},
+                 {"arg":"node","description":"the expression for which the variable will be available"}
+               ],
+  "examples": [ { "expression":"with_variable('my_sum', 1 + 2 + 3, @my_sum * 2 + @my_sum * 5)", "returns":"42"}]
+}

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -71,6 +71,8 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
     isFieldEditableCheckBox->setEnabled( false );
   }
 
+  mExpressionWidget->registerExpressionContextGenerator( this );
+
   connect( mExpressionWidget, &QgsExpressionLineEdit::expressionChanged, this, &QgsAttributeTypeDialog::defaultExpressionChanged );
   connect( mUniqueCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )
   {
@@ -291,6 +293,18 @@ QString QgsAttributeTypeDialog::defaultValueExpression() const
 void QgsAttributeTypeDialog::setDefaultValueExpression( const QString &expression )
 {
   mExpressionWidget->setExpression( expression );
+}
+
+QgsExpressionContext QgsAttributeTypeDialog::createExpressionContext() const
+{
+  QgsExpressionContext context;
+  context
+      << QgsExpressionContextUtils::globalScope()
+      << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+      << QgsExpressionContextUtils::layerScope( mLayer )
+      << QgsExpressionContextUtils::mapToolCaptureScope( QList<QgsPointLocator::Match>() );
+
+  return context;
 }
 
 QString QgsAttributeTypeDialog::constraintExpression() const

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -26,7 +26,7 @@
 
 class QDialog;
 
-class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttributeTypeDialog
+class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttributeTypeDialog, QgsExpressionContextGenerator
 {
     Q_OBJECT
 
@@ -162,6 +162,8 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
      * Sets the expression used for the field's default value
      */
     void setDefaultValueExpression( const QString &expression );
+
+    QgsExpressionContext createExpressionContext() const override;
 
   private slots:
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -161,7 +161,7 @@ bool QgsFeatureAction::editFeature( bool showModal )
   return true;
 }
 
-bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal )
+bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal, QgsExpressionContextScope *scope SIP_TRANSFER )
 {
   if ( !mLayer || !mLayer->isEditable() )
     return false;
@@ -188,6 +188,9 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
   // create new feature template - this will initialize the attributes to valid values, handling default
   // values and field constraints
   QgsExpressionContext context = mLayer->createExpressionContext();
+  if ( scope )
+    context.appendScope( scope );
+
   QgsFeature newFeature = QgsVectorLayerUtils::createFeature( mLayer, mFeature->geometry(), initialAttributeValues,
                           &context );
   *mFeature = newFeature;

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -29,6 +29,7 @@ class QgsIdentifyResultsDialog;
 class QgsVectorLayer;
 class QgsHighlight;
 class QgsAttributeDialog;
+class QgsExpressionContextScope;
 
 class APP_EXPORT QgsFeatureAction : public QAction
 {
@@ -51,7 +52,7 @@ class APP_EXPORT QgsFeatureAction : public QAction
      *
      * \returns true if feature was added if showModal is true. If showModal is false, returns true in every case
      */
-    bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(), bool showModal = true );
+    bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(), bool showModal = true, QgsExpressionContextScope *scope = nullptr );
 
   private slots:
     void onFeatureSaved( const QgsFeature &feature );

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -48,8 +48,9 @@ QgsMapToolAddFeature::~QgsMapToolAddFeature()
 
 bool QgsMapToolAddFeature::addFeature( QgsVectorLayer *vlayer, QgsFeature *f, bool showModal )
 {
+  QgsExpressionContextScope *scope = QgsExpressionContextUtils::mapToolCaptureScope( snappingMatches() );
   QgsFeatureAction *action = new QgsFeatureAction( tr( "add feature" ), *f, vlayer, QString(), -1, this );
-  bool res = action->addFeature( QgsAttributeMap(), showModal );
+  bool res = action->addFeature( QgsAttributeMap(), showModal, scope );
   if ( showModal )
     delete action;
   return res;
@@ -250,6 +251,7 @@ void QgsMapToolAddFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       bool hasCurvedSegments = captureCurve()->hasCurvedSegments();
       bool providerSupportsCurvedSegments = vlayer->dataProvider()->capabilities() & QgsVectorDataProvider::CircularGeometries;
 
+      QList<QgsPointLocator::Match> snappingMatchesList;
       QgsCurve *curveToAdd = nullptr;
       if ( hasCurvedSegments && providerSupportsCurvedSegments )
       {
@@ -258,13 +260,13 @@ void QgsMapToolAddFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       else
       {
         curveToAdd = captureCurve()->curveToLine();
+        snappingMatchesList = snappingMatches();
       }
 
       if ( mode() == CaptureLine )
       {
-        QgsGeometry *g = new QgsGeometry( curveToAdd );
-        f->setGeometry( *g );
-        delete g;
+        QgsGeometry g( curveToAdd );
+        f->setGeometry( g );
       }
       else
       {
@@ -278,9 +280,8 @@ void QgsMapToolAddFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           poly = new QgsPolygonV2();
         }
         poly->setExteriorRing( curveToAdd );
-        QgsGeometry *g = new QgsGeometry( poly );
-        f->setGeometry( *g );
-        delete g;
+        QgsGeometry g( poly );
+        f->setGeometry( g );
 
         QgsGeometry featGeom = f->geometry();
         int avoidIntersectionsReturn = featGeom.avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers() );

--- a/src/app/qgsmaptooladdfeature.h
+++ b/src/app/qgsmaptooladdfeature.h
@@ -44,7 +44,6 @@ class APP_EXPORT QgsMapToolAddFeature : public QgsMapToolCapture
     void setCheckGeometryType( bool checkGeometryType );
 
   private:
-    QVariant snappingMatchesAsVariable() const;
 
     /** Check if CaptureMode matches layer type. Default is true.
      * \since QGIS 2.12 */

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -673,6 +673,19 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "grid_number" ), QCoreApplication::translate( "variable_help", "Current grid annotation value." ) );
   sVariableHelpTexts.insert( QStringLiteral( "grid_axis" ), QCoreApplication::translate( "variable_help", "Current grid annotation axis (e.g., 'x' for longitude, 'y' for latitude)." ) );
 
+  // map tool capture variables
+  sVariableHelpTexts.insert( QStringLiteral( "snapping_results" ), QCoreApplication::translate( "variable_help",
+                             "<p>An array with an item for each snapped point.</p>"
+                             "<p>Each item is a map with the following keys:</p>"
+                             "<dl>"
+                             "<dt>valid</dt><dd>Boolean that indicates if the snapping result is valid</dd>"
+                             "<dt>layer</dt><dd>The layer on which the snapped feature is</dd>"
+                             "<dt>feature_id</dt><dd>The feature id of the snapped feature</dd>"
+                             "<dt>vertex_index</dt><dd>The index of the snapped vertex</dd>"
+                             "<dt>distance</dt><dd>The distance between the mouse cursor and the snapped point at the time of snapping</dd>"
+                             "</dl>" ) );
+
+
   //symbol variables
   sVariableHelpTexts.insert( QStringLiteral( "geometry_part_count" ), QCoreApplication::translate( "variable_help", "Number of parts in rendered feature's geometry." ) );
   sVariableHelpTexts.insert( QStringLiteral( "geometry_part_num" ), QCoreApplication::translate( "variable_help", "Current geometry part number for feature being rendered." ) );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4230,7 +4230,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 
     sFunctions
         << new QgsStaticExpressionFunction( QStringLiteral( "env" ), 1, fcnEnvVar, QStringLiteral( "General" ), QString() )
-        << new QgsSetVariableExpressionFunction()
+        << new QgsWithVariableExpressionFunction()
         << new QgsStaticExpressionFunction( QStringLiteral( "attribute" ), 2, fcnAttribute, QStringLiteral( "Record" ), QString(), false, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES )
 
         // functions for arrays
@@ -4276,13 +4276,13 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
   return sFunctions;
 }
 
-QgsSetVariableExpressionFunction::QgsSetVariableExpressionFunction()
-  : QgsExpressionFunction( "set_variable", 3, QCoreApplication::tr( "General" ), "help text TODODOODO" )
+QgsWithVariableExpressionFunction::QgsWithVariableExpressionFunction()
+  : QgsExpressionFunction( QStringLiteral("with_variable"), 3, QCoreApplication::tr( "General" ) )
 {
 
 }
 
-bool QgsSetVariableExpressionFunction::isStatic( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const
+bool QgsWithVariableExpressionFunction::isStatic( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const
 {
   bool isStatic = false;
 
@@ -4310,7 +4310,7 @@ bool QgsSetVariableExpressionFunction::isStatic( const QgsExpressionNodeFunction
   return false;
 }
 
-QVariant QgsSetVariableExpressionFunction::run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent )
+QVariant QgsWithVariableExpressionFunction::run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent )
 {
   QVariant result;
 
@@ -4332,7 +4332,7 @@ QVariant QgsSetVariableExpressionFunction::run( QgsExpressionNode::NodeList *arg
   return result;
 }
 
-QVariant QgsSetVariableExpressionFunction::func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+QVariant QgsWithVariableExpressionFunction::func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
 {
   // This is a dummy function, all the real handling is in run
   Q_UNUSED( values )
@@ -4343,7 +4343,7 @@ QVariant QgsSetVariableExpressionFunction::func( const QVariantList &values, con
   return QVariant();
 }
 
-bool QgsSetVariableExpressionFunction::prepare( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const
+bool QgsWithVariableExpressionFunction::prepare( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const
 {
   QgsExpressionNode::NodeList *args = node->args();
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4315,7 +4315,7 @@ bool QgsWithVariableExpressionFunction::isStatic( const QgsExpressionNodeFunctio
 
     if ( args->at( 2 )->isStatic( parent, updatedContext ) )
       isStatic = true;
-    updatedContext->popScope();
+    delete updatedContext->popScope();
   }
 
   return false;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3319,23 +3319,19 @@ static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressi
 {
   QVariant result;
   QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
-  if ( !vl )
-    return result;
-
-  QgsFeatureId fid = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
-
-  QgsFeatureRequest req;
-  req.setFilterFid( fid );
-  req.setLimit( 1 );
-  if ( !parent->needsGeometry() )
+  if ( vl )
   {
-    req.setFlags( QgsFeatureRequest::NoGeometry );
-  }
-  QgsFeatureIterator fIt = vl->getFeatures( req );
+    QgsFeatureId fid = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
 
-  QgsFeature fet;
-  if ( fIt.nextFeature( fet ) )
-    result = QVariant::fromValue( fet );
+    QgsFeatureRequest req;
+    req.setFilterFid( fid );
+    req.setLimit( 1 );
+    QgsFeatureIterator fIt = vl->getFeatures( req );
+
+    QgsFeature fet;
+    if ( fIt.nextFeature( fet ) )
+      result = QVariant::fromValue( fet );
+  }
 
   return result;
 }
@@ -3378,18 +3374,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
 
 static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
-  QString layerIdOrName = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
-
-  //try to find a matching layer by name
-  QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerIdOrName ); //search by id first
-  if ( !layer )
-  {
-    QList<QgsMapLayer *> layersByName = QgsProject::instance()->mapLayersByName( layerIdOrName );
-    if ( !layersByName.isEmpty() )
-    {
-      layer = layersByName.at( 0 );
-    }
-  }
+  QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), parent );
 
   if ( !layer )
     return QVariant();
@@ -4303,7 +4288,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 }
 
 QgsWithVariableExpressionFunction::QgsWithVariableExpressionFunction()
-  : QgsExpressionFunction( QStringLiteral("with_variable"), 3, QCoreApplication::tr( "General" ) )
+  : QgsExpressionFunction( QStringLiteral( "with_variable" ), 3, QCoreApplication::tr( "General" ) )
 {
 
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3325,7 +3325,6 @@ static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressi
 
     QgsFeatureRequest req;
     req.setFilterFid( fid );
-    req.setLimit( 1 );
     QgsFeatureIterator fIt = vl->getFeatures( req );
 
     QgsFeature fet;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3315,6 +3315,31 @@ static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpre
 }
 
 
+static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+{
+  QVariant result;
+  QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+  if ( !vl )
+    return result;
+
+  QgsFeatureId fid = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+
+  QgsFeatureRequest req;
+  req.setFilterFid( fid );
+  req.setLimit( 1 );
+  if ( !parent->needsGeometry() )
+  {
+    req.setFlags( QgsFeatureRequest::NoGeometry );
+  }
+  QgsFeatureIterator fIt = vl->getFeatures( req );
+
+  QgsFeature fet;
+  if ( fIt.nextFeature( fet ) )
+    result = QVariant::fromValue( fet );
+
+  return result;
+}
+
 static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   //arguments: 1. layer id / name, 2. key attribute, 3. eq value
@@ -4144,7 +4169,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     sFunctions << uuidFunc;
 
     sFunctions
-        << new QgsStaticExpressionFunction( QStringLiteral( "get_feature" ), 3, fcnGetFeature, QStringLiteral( "Record" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "QgsExpressionUtils::getFeature" ) );
+        << new QgsStaticExpressionFunction( QStringLiteral( "get_feature" ), 3, fcnGetFeature, QStringLiteral( "Record" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "QgsExpressionUtils::getFeature" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "get_feature_by_id" ), 2, fcnGetFeatureById, QStringLiteral( "Record" ), QString(), false, QSet<QString>(), false );
 
     QgsStaticExpressionFunction *isSelectedFunc = new QgsStaticExpressionFunction(
       QStringLiteral( "is_selected" ),

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3501,6 +3501,18 @@ static QVariant fcnArrayGet( const QVariantList &values, const QgsExpressionCont
   return list.at( pos );
 }
 
+static QVariant fcnArrayFirst( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+{
+  const QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
+  return list.value( 0 );
+}
+
+static QVariant fcnArrayLast( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+{
+  const QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
+  return list.value( list.size() - 1 );
+}
+
 static QVariant convertToSameType( const QVariant &value, QVariant::Type type )
 {
   QVariant result = value;
@@ -4198,6 +4210,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "array_contains" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnArrayContains, QStringLiteral( "Arrays" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "array_find" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnArrayFind, QStringLiteral( "Arrays" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "array_get" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "pos" ) ), fcnArrayGet, QStringLiteral( "Arrays" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "array_first" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ), fcnArrayFirst, QStringLiteral( "Arrays" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "array_last" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ), fcnArrayLast, QStringLiteral( "Arrays" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "array_append" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnArrayAppend, QStringLiteral( "Arrays" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "array_prepend" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnArrayPrepend, QStringLiteral( "Arrays" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "array_insert" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "pos" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnArrayInsert, QStringLiteral( "Arrays" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4313,7 +4313,7 @@ bool QgsWithVariableExpressionFunction::isStatic( const QgsExpressionNodeFunctio
     QgsExpressionContext *updatedContext = const_cast<QgsExpressionContext *>( context );
     updatedContext->appendScope( scope );
 
-    if ( args->at( 3 )->isStatic( parent, updatedContext ) )
+    if ( args->at( 2 )->isStatic( parent, updatedContext ) )
       isStatic = true;
     updatedContext->popScope();
   }
@@ -4336,9 +4336,13 @@ QVariant QgsWithVariableExpressionFunction::run( QgsExpressionNode::NodeList *ar
   scope->setVariable( name.toString(), value );
 
   QgsExpressionContext *updatedContext = const_cast<QgsExpressionContext *>( context );
+  if ( !context )
+    updatedContext = new QgsExpressionContext();
   updatedContext->appendScope( scope );
   result = args->at( 2 )->eval( parent, updatedContext );
   delete updatedContext->popScope();
+  if ( !context )
+    delete updatedContext;
 
   return result;
 }

--- a/src/core/expression/qgsexpressionfunction.h
+++ b/src/core/expression/qgsexpressionfunction.h
@@ -24,6 +24,7 @@
 
 #include "qgis.h"
 #include "qgis_core.h"
+#include "qgsexpressionnode.h"
 
 class QgsExpressionNodeFunction;
 class QgsExpression;
@@ -273,6 +274,8 @@ class CORE_EXPORT QgsExpressionFunction
      */
     virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) = 0;
 
+    virtual QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent );
+
     bool operator==( const QgsExpressionFunction &other ) const;
 
     virtual bool handlesNull() const;
@@ -451,6 +454,21 @@ class QgsStaticExpressionFunction : public QgsExpressionFunction
     QSet<QString> mReferencedColumns;
     bool mIsStatic = false;
 };
+
+class QgsSetVariableExpressionFunction : public QgsExpressionFunction
+{
+  public:
+    QgsSetVariableExpressionFunction();
+
+    bool isStatic( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
+
+    QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent ) override;
+
+    QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) override;
+
+    bool prepare( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
+};
+
 #endif
 
 #endif // QGSEXPRESSIONFUNCTION_H

--- a/src/core/expression/qgsexpressionfunction.h
+++ b/src/core/expression/qgsexpressionfunction.h
@@ -29,6 +29,7 @@
 class QgsExpressionNodeFunction;
 class QgsExpression;
 class QgsExpressionContext;
+class QgsExpressionContextScope;
 
 /** \ingroup core
   * A abstract base class for defining QgsExpression functions.
@@ -475,6 +476,18 @@ class QgsWithVariableExpressionFunction : public QgsExpressionFunction
     QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) override;
 
     bool prepare( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
+
+  private:
+
+    /**
+     * Append a scope with a single variable definition (``name``=``value``)
+     */
+    void appendTemporaryVariable( const QgsExpressionContext *context, const QString &name, const QVariant &value ) const;
+
+    /**
+     * Pop the temporary scope again
+     */
+    void popTemporaryVariable( const QgsExpressionContext *context ) const;
 };
 
 #endif

--- a/src/core/expression/qgsexpressionfunction.h
+++ b/src/core/expression/qgsexpressionfunction.h
@@ -455,6 +455,14 @@ class QgsStaticExpressionFunction : public QgsExpressionFunction
     bool mIsStatic = false;
 };
 
+/**
+ * Handles the ``with_variable(name, value, node)`` expression function.
+ * It temporarily appends a new scope to the expression context for all nested
+ * nodes.
+ *
+ * \note Not available in Python bindings
+ * \since QGIS 3.0
+ */
 class QgsWithVariableExpressionFunction : public QgsExpressionFunction
 {
   public:

--- a/src/core/expression/qgsexpressionfunction.h
+++ b/src/core/expression/qgsexpressionfunction.h
@@ -455,10 +455,10 @@ class QgsStaticExpressionFunction : public QgsExpressionFunction
     bool mIsStatic = false;
 };
 
-class QgsSetVariableExpressionFunction : public QgsExpressionFunction
+class QgsWithVariableExpressionFunction : public QgsExpressionFunction
 {
   public:
-    QgsSetVariableExpressionFunction();
+    QgsWithVariableExpressionFunction();
 
     bool isStatic( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
 

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -842,31 +842,7 @@ QVariant QgsExpressionNodeFunction::evalNode( QgsExpression *parent, const QgsEx
   QString name = QgsExpression::QgsExpression::Functions()[mFnIndex]->name();
   QgsExpressionFunction *fd = context && context->hasFunction( name ) ? context->function( name ) : QgsExpression::QgsExpression::Functions()[mFnIndex];
 
-  // evaluate arguments
-  QVariantList argValues;
-  if ( mArgs )
-  {
-    Q_FOREACH ( QgsExpressionNode *n, mArgs->list() )
-    {
-      QVariant v;
-      if ( fd->lazyEval() )
-      {
-        // Pass in the node for the function to eval as it needs.
-        v = QVariant::fromValue( n );
-      }
-      else
-      {
-        v = n->eval( parent, context );
-        ENSURE_NO_EVAL_ERROR;
-        if ( QgsExpressionUtils::isNull( v ) && !fd->handlesNull() )
-          return QVariant(); // all "normal" functions return NULL, when any QgsExpressionFunction::Parameter is NULL (so coalesce is abnormal)
-      }
-      argValues.append( v );
-    }
-  }
-
-  // run the function
-  QVariant res = fd->func( argValues, context, parent );
+  QVariant res = fd->run( mArgs, context, parent );
   ENSURE_NO_EVAL_ERROR;
 
   // everything went fine

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -333,26 +333,26 @@ class QgsExpressionUtils
       return nullptr;
     }
 
-    static QgsVectorLayer *getVectorLayer( const QVariant &value, QgsExpression * )
+    static QgsMapLayer *getMapLayer( const QVariant &value, QgsExpression * )
     {
+      // First check if we already received a layer pointer
       QgsMapLayer *ml = value.value< QgsWeakMapLayerPointer >().data();
-      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
-      if ( !vl )
-      {
-        QString layerString = value.toString();
-        vl = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerString ) ); //search by id first
+      QgsProject *project = QgsProject::instance();
 
-        if ( !vl )
-        {
-          QList<QgsMapLayer *> layersByName = QgsProject::instance()->mapLayersByName( layerString );
-          if ( !layersByName.isEmpty() )
-          {
-            vl = qobject_cast<QgsVectorLayer *>( layersByName.at( 0 ) );
-          }
-        }
-      }
+      // No pointer yet, maybe it's a layer id?
+      if ( !ml )
+        ml = project->mapLayer( value.toString() );
 
-      return vl;
+      // Still nothing? Check for layer name
+      if ( !ml )
+        ml = project->mapLayersByName( value.toString() ).value( 0 );
+
+      return ml;
+    }
+
+    static QgsVectorLayer *getVectorLayer( const QVariant &value, QgsExpression *e )
+    {
+      return qobject_cast<QgsVectorLayer *>( getMapLayer( value, e ) );
     }
 
 

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
      */
     const QgsCurve *curveAt( int i ) const;
 
-    /** Adds a curve to the geometr (takes ownership)
+    /** Adds a curve to the geometry (takes ownership)
      */
     void addCurve( QgsCurve *c SIP_TRANSFER );
 

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -912,6 +912,30 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   return scope;
 }
 
+QgsExpressionContextScope *QgsExpressionContextUtils::mapToolCaptureScope( const QList<QgsPointLocator::Match> &matches )
+{
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Map Tool Capture" ) );
+
+  QVariantList matchList;
+
+  for ( const QgsPointLocator::Match &match : matches )
+  {
+    QVariantMap matchMap;
+
+    matchMap.insert( QStringLiteral( "valid" ), match.isValid() );
+    matchMap.insert( QStringLiteral( "layer" ), QVariant::fromValue<QgsWeakMapLayerPointer>( QgsWeakMapLayerPointer( match.layer() ) ) );
+    matchMap.insert( QStringLiteral( "feature_id" ), match.featureId() );
+    matchMap.insert( QStringLiteral( "vertex_index" ), match.vertexIndex() );
+    matchMap.insert( QStringLiteral( "distance" ), match.distance() );
+
+    matchList.append( matchMap );
+  }
+
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "snapping_results" ), matchList ) );
+
+  return scope;
+}
+
 QgsExpressionContextScope *QgsExpressionContextUtils::updateSymbolScope( const QgsSymbol *symbol, QgsExpressionContextScope *symbolScope )
 {
   if ( !symbolScope )

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -26,6 +26,7 @@
 #include "qgsfeature.h"
 #include "qgsexpression.h"
 #include "qgsexpressionfunction.h"
+#include "qgspointlocator.h"
 
 class QgsExpression;
 class QgsExpressionNodeFunction;
@@ -742,6 +743,14 @@ class CORE_EXPORT QgsExpressionContextUtils
      * For instance, map scale and rotation.
      */
     static QgsExpressionContextScope *mapSettingsScope( const QgsMapSettings &mapSettings ) SIP_FACTORY;
+
+    /**
+     * Sets the expression context variables which are available for expressions triggered by
+     * a map tool capture like add feature.
+     *
+     * \since QGIS 3.0
+     */
+    static QgsExpressionContextScope *mapToolCaptureScope( const QList<QgsPointLocator::Match> &matches ) SIP_FACTORY;
 
     /**
      * Updates a symbol scope related to a QgsSymbol to an expression context.

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -164,21 +164,21 @@ static QgsPointLocator::Match _findClosestSegmentIntersection( const QgsPointXY 
 }
 
 
-static void _replaceIfBetter( QgsPointLocator::Match &mBest, const QgsPointLocator::Match &mNew, double maxDistance )
+static void _replaceIfBetter( QgsPointLocator::Match &bestMatch, const QgsPointLocator::Match &candidateMatch, double maxDistance )
 {
-  // is other match relevant?
-  if ( !mNew.isValid() || mNew.distance() > maxDistance )
+  // is candidate match relevant?
+  if ( !candidateMatch.isValid() || candidateMatch.distance() > maxDistance )
     return;
 
-  // is other match actually better?
-  if ( mBest.isValid() && mBest.type() == mNew.type() && mBest.distance() - 10e-6 < mNew.distance() )
+  // is candidate match actually better?
+  if ( bestMatch.isValid() && bestMatch.type() == candidateMatch.type() && bestMatch.distance() - 10e-6 < candidateMatch.distance() )
     return;
 
-  // prefer vertex matches to edge matches (even if they are closer)
-  if ( mBest.type() == QgsPointLocator::Vertex && mNew.type() == QgsPointLocator::Edge )
+  // prefer vertex matches over edge matches (even if they are closer)
+  if ( bestMatch.type() == QgsPointLocator::Vertex && candidateMatch.type() == QgsPointLocator::Edge )
     return;
 
-  mBest = mNew; // the other match is better!
+  bestMatch = candidateMatch; // the other match is better!
 }
 
 

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -56,6 +56,13 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      */
     const QgsCompoundCurve *captureCurve() const { return &mCaptureCurve; }
 
+    /**
+     * Return a list of matches for each point on the captureCurve.
+     *
+     * \since QGIS 3.0
+     */
+    QList<QgsPointLocator::Match> snappingMatches() const;
+
     virtual void cadCanvasMoveEvent( QgsMapMouseEvent *e ) override;
 
     /**
@@ -192,6 +199,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
     //! List to store the points of digitized lines and polygons (in layer coordinates)
     QgsCompoundCurve mCaptureCurve;
+
+    QList<QgsPointLocator::Match> mSnappingMatches;
 
     void validateGeometry();
     QStringList mValidationWarnings;

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1123,6 +1123,18 @@ class TestQgsExpression: public QObject
       // not like
       QTest::newRow( "'a' not like 'a%'" ) << QStringLiteral( "'a' not like 'a%'" ) << false << QVariant( 0 );
       QTest::newRow( "'a' not  like 'a%'" ) << QStringLiteral( "'a' not  like 'a%'" ) << false << QVariant( 0 );
+
+      // with_variable
+      QTest::newRow( "with_variable('five', 5, @five * 2)" ) << QStringLiteral( "with_variable('five', 5, @five * 2)" ) << false << QVariant( 10 );
+      QTest::newRow( "with_variable('nothing', NULL, COALESCE(@nothing, 'something'))" ) << QStringLiteral( "with_variable('nothing', NULL, COALESCE(@nothing, 'something'))" ) << false << QVariant( "something" );
+
+      // array_first, array_last
+      QTest::newRow( "array_first(array('a', 'b', 'c'))" ) << QStringLiteral( "array_first(array('a', 'b', 'c'))" ) << false << QVariant( "a" );
+      QTest::newRow( "array_first(array())" ) << QStringLiteral( "array_first(array())" ) << false << QVariant();
+      QTest::newRow( "array_last(array('a', 'b', 'c'))" ) << QStringLiteral( "array_last(array('a', 'b', 'c'))" ) << false << QVariant( "c" );
+      QTest::newRow( "array_last(array())" ) << QStringLiteral( "array_last(array())" ) << false << QVariant();
+
+      //
     }
 
     void run_evaluation_test( QgsExpression &exp, bool evalError, QVariant &expected )
@@ -1314,6 +1326,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "get_feature no match2" ) << "get_feature('test','col2','no match!')" << false << -1;
       //no matching layer
       QTest::newRow( "get_feature no match layer" ) << "get_feature('not a layer!','col1',10)" << false << -1;
+
+      // get_feature_by_id
+      QTest::newRow( "get_feature_by_id" ) << "get_feature_by_id('test', 1)" << true << 1;
     }
 
     void eval_get_feature()


### PR DESCRIPTION
# New expression functions and variables

* **`array_first(array)`** and **`array_last(array)`**
   not much to say here, nothing but shorthands
* **`with_variable(name, value, node)`**
   Allows setting a variable for usage within an expression. Allows to avoid recalculating the same value repeatedly.

```
with_variable(
    'fortytwo',
    42, -- normally this part will be some complex logic...
    'Two times ' || @fortytwo || ' equals ' || 2 * @fortytwo
)
```
* **`@snapping_results`**
   new variable only available in add feature (so far?). Gives access to snapping results while digitizing a feature.

```
    [
      {
        'valid': true
        'layer': QgsVectorLayer
        'feature_id': 22
        'distance': 5.2
      },
      {
        'valid': false
        'layer': NULL
        'feature_id': NULL
        'distance': NULL
      },
      # one entry in the array for each vertex
    ]
```

* **`get_feature_by_id(layer, fid)`**
   Retrieve a feature from a layer by its id.

# Example

Get the `object_id` of the first snapped point of a line.

```
with_variable(
  'first_snapped_point',
  array_first(@snapping_results),

  attribute(
    get_feature_by_id(
      map_get(@first_snapped_point, 'layer'),
      map_get(@first_snapped_point, 'feature_id')
    ),
    'object_id'
  )
)
```
