### PR TITLE
Fix categorised render crash

### DIFF
--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -445,12 +445,6 @@ void QgsCategorizedSymbolRendererV2::startRender( QgsRenderContext& context, con
       mTempSymbols[ cat.symbol()] = tempSymbol;
     }
   }
-
-  Q_FOREACH ( QgsSymbolV2 *symbol, mSymbolHash.values() )
-  {
-    symbol->startRender( context, &fields );
-  }
-
   return;
 }
 
@@ -459,11 +453,6 @@ void QgsCategorizedSymbolRendererV2::stopRender( QgsRenderContext& context )
   Q_FOREACH ( const QgsRendererCategoryV2& cat, mCategories )
   {
     cat.symbol()->stopRender( context );
-  }
-
-  Q_FOREACH ( QgsSymbolV2 *symbol, mSymbolHash.values() )
-  {
-    symbol->stopRender( context );
   }
 
   // cleanup mTempSymbols

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -89,9 +89,9 @@ QgsSymbolV2::QgsSymbolV2( SymbolType type, const QgsSymbolLayerV2List& layers )
     , mRenderHints( 0 )
     , mClipFeaturesToExtent( true )
     , mLayer( nullptr )
+    , mStarted( false )
     , mSymbolRenderContext( nullptr )
 {
-
   // check they're all correct symbol layers
   for ( int i = 0; i < mLayers.count(); i++ )
   {
@@ -444,6 +444,9 @@ bool QgsSymbolV2::changeSymbolLayer( int index, QgsSymbolLayerV2* layer )
 
 void QgsSymbolV2::startRender( QgsRenderContext& context, const QgsFields* fields )
 {
+  Q_ASSERT_X( !mStarted, "startRender", "Rendering has already been started for this symbol instance!" );
+
+  mStarted = true;
   delete mSymbolRenderContext;
   mSymbolRenderContext = new QgsSymbolV2RenderContext( context, outputUnit(), mAlpha, false, mRenderHints, nullptr, fields, mapUnitScale() );
 
@@ -459,6 +462,9 @@ void QgsSymbolV2::startRender( QgsRenderContext& context, const QgsFields* field
 
 void QgsSymbolV2::stopRender( QgsRenderContext& context )
 {
+  Q_ASSERT_X( mStarted, "startRender", "startRender was not called for this symbol instance!" );
+  mStarted = false;
+
   Q_UNUSED( context )
   if ( mSymbolRenderContext )
   {

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -335,6 +335,9 @@ class CORE_EXPORT QgsSymbolV2
     const QgsVectorLayer* mLayer; //current vectorlayer
 
   private:
+    //! True if render has already been started - guards against multiple calls to
+    //! startRender() (usually a result of not cloning a shared symbol instance before rendering).
+    bool mStarted;
     //! Initialized in startRender, destroyed in stopRender
     QgsSymbolV2RenderContext* mSymbolRenderContext;
 


### PR DESCRIPTION
Fixes a regular crash encountered on 2.18 and master with the categorised renderer. There's a race condition where a startRender is called multiple times on a single symbol instance from different threads. I've tracked it down to commit c7c5244 - but the original intention behind that commit is unknown.

Given that the regular crash is a worse outcome, this reverts c7c5244 and adds a assert to flag if this race condition is introduced in other code.

Note that the whole code relating to QgsCategorizedSymbolRendererV2::skipRender() and the symbol hash is not thread safe - this needs to be reworked at some stage.