### PR TITLE
Minor refactoring to processing algorithms, future proofing some API

### DIFF
--- a/cmake_templates/Doxyfile.in
+++ b/cmake_templates/Doxyfile.in
@@ -2073,6 +2073,7 @@ EXPAND_AS_DEFINED      = "SIP_ABSTRACT" \
                          "SIP_TRANSFER" \
                          "SIP_TRANSFERBACK" \
                          "SIP_TRANSFERTHIS" \
+                         "SIP_VIRTUAL_CATCHER_CODE" \
                          "SIP_VIRTUALERRORHANDLER" \
                          "SIP_WHEN_FEATURE"
 

--- a/python/core/processing/models/qgsprocessingmodelalgorithm.sip
+++ b/python/core/processing/models/qgsprocessingmodelalgorithm.sip
@@ -46,7 +46,7 @@ class QgsProcessingModelAlgorithm : QgsProcessingAlgorithm
 
     virtual QString asPythonCommand( const QVariantMap &parameters, QgsProcessingContext &context ) const;
 
-    virtual QgsProcessingModelAlgorithm *create() const /Factory/;
+    virtual QgsProcessingModelAlgorithm *createInstance() const /Factory/;
 
 
     void setName( const QString &name );

--- a/python/core/processing/models/qgsprocessingmodelalgorithm.sip
+++ b/python/core/processing/models/qgsprocessingmodelalgorithm.sip
@@ -27,6 +27,9 @@ class QgsProcessingModelAlgorithm : QgsProcessingAlgorithm
  Constructor for QgsProcessingModelAlgorithm.
 %End
 
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() );  //#spellok
+
+
     virtual QString name() const;
 
     virtual QString displayName() const;
@@ -45,8 +48,6 @@ class QgsProcessingModelAlgorithm : QgsProcessingAlgorithm
     virtual bool canExecute( QString *errorMessage /Out/ = 0 ) const;
 
     virtual QString asPythonCommand( const QVariantMap &parameters, QgsProcessingContext &context ) const;
-
-    virtual QgsProcessingModelAlgorithm *createInstance() const /Factory/;
 
 
     void setName( const QString &name );
@@ -363,6 +364,9 @@ Translated description of variable
 %End
 
   protected:
+
+    virtual QgsProcessingAlgorithm *createInstance() const /Factory/;
+
 
     virtual QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
 

--- a/python/core/processing/models/qgsprocessingmodelchildalgorithm.sip
+++ b/python/core/processing/models/qgsprocessingmodelchildalgorithm.sip
@@ -72,6 +72,31 @@ class QgsProcessingModelChildAlgorithm : QgsProcessingModelComponent
 .. seealso:: algorithmId()
 %End
 
+    QVariantMap configuration() const;
+%Docstring
+ Returns the child algorithm's configuration map.
+
+ This map specifies configuration settings which are passed
+ to the algorithm, allowing it to dynamically adjust its initialized parameters
+ and outputs according to this configuration. This allows child algorithms in the model
+ to adjust their behavior at run time according to some user configuration.
+
+.. seealso:: setConfiguration()
+ :rtype: QVariantMap
+%End
+
+    void setConfiguration( const QVariantMap &configuration );
+%Docstring
+ Sets the child algorithm's ``configuration`` map.
+
+ This map specifies configuration settings which are passed
+ to the algorithm, allowing it to dynamically adjust its initialized parameters
+ and outputs according to this configuration. This allows child algorithms in the model
+ to adjust their behavior at run time according to some user configuration.
+
+.. seealso:: configuration()
+%End
+
     const QgsProcessingAlgorithm *algorithm() const;
 %Docstring
  Returns the underlying child algorithm, or a None

--- a/python/core/processing/models/qgsprocessingmodelchildalgorithm.sip
+++ b/python/core/processing/models/qgsprocessingmodelchildalgorithm.sip
@@ -29,6 +29,8 @@ class QgsProcessingModelChildAlgorithm : QgsProcessingModelComponent
  should be set to a QgsProcessingAlgorithm algorithm ID.
 %End
 
+    QgsProcessingModelChildAlgorithm( const QgsProcessingModelChildAlgorithm &other );
+
     QString childId() const;
 %Docstring
  Returns the child algorithm's unique ID string, used the identify

--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -43,8 +43,7 @@ class QgsProcessingAlgorithm
     virtual ~QgsProcessingAlgorithm();
 
 
-
-    virtual QgsProcessingAlgorithm *create() const = 0 /Factory/;
+    QgsProcessingAlgorithm *create() const /Factory/;
 %Docstring
  Creates a copy of the algorithm, ready for execution.
  :rtype: QgsProcessingAlgorithm
@@ -331,6 +330,14 @@ class QgsProcessingAlgorithm
 %End
 
   protected:
+
+    virtual QgsProcessingAlgorithm *createInstance() const = 0 /Factory/;
+%Docstring
+ Creates a new instance of the algorithm class.
+
+ This method should return a 'pristine' instance of the algorithm class.
+ :rtype: QgsProcessingAlgorithm
+%End
 
     bool addParameter( QgsProcessingParameterDefinition *parameterDefinition /Transfer/ );
 %Docstring

--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -11,6 +11,11 @@
 
 
 
+%ModuleHeaderCode
+#include <qgsprocessingmodelalgorithm.h>
+%End
+
+
 class QgsProcessingAlgorithm
 {
 %Docstring
@@ -20,6 +25,13 @@ class QgsProcessingAlgorithm
 
 %TypeHeaderCode
 #include "qgsprocessingalgorithm.h"
+%End
+
+%ConvertToSubClassCode
+    if ( dynamic_cast< QgsProcessingModelAlgorithm * >( sipCpp ) != NULL )
+      sipType = sipType_QgsProcessingModelAlgorithm;
+    else
+      sipType = sipType_QgsProcessingAlgorithm;
 %End
   public:
 

--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -47,12 +47,18 @@ class QgsProcessingAlgorithm
     virtual ~QgsProcessingAlgorithm();
 
 
-    QgsProcessingAlgorithm *create() const /Factory/;
+    QgsProcessingAlgorithm *create( const QVariantMap &configuration = QVariantMap() ) const /Factory/;
 %Docstring
  Creates a copy of the algorithm, ready for execution.
 
  This method returns a new, preinitialized copy of the algorithm, ready for
  executing.
+
+ The ``configuration`` argument allows passing of a map of configuration settings
+ to the algorithm, allowing it to dynamically adjust its initialized parameters
+ and outputs according to this configuration. This is generally used only for
+ algorithms in a model, allowing them to adjust their behavior at run time
+ according to some user configuration.
 
 .. seealso:: initAlgorithm()
  :rtype: QgsProcessingAlgorithm

--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -38,6 +38,10 @@ class QgsProcessingAlgorithm
     QgsProcessingAlgorithm();
 %Docstring
  Constructor for QgsProcessingAlgorithm.
+
+ initAlgorithm() should be called after creating an algorithm to ensure it can correctly configure
+ its parameterDefinitions() and outputDefinitions(). Alternatively, calling create() will return
+ a pre-initialized copy of the algorithm.
 %End
 
     virtual ~QgsProcessingAlgorithm();
@@ -46,6 +50,11 @@ class QgsProcessingAlgorithm
     QgsProcessingAlgorithm *create() const /Factory/;
 %Docstring
  Creates a copy of the algorithm, ready for execution.
+
+ This method returns a new, preinitialized copy of the algorithm, ready for
+ executing.
+
+.. seealso:: initAlgorithm()
  :rtype: QgsProcessingAlgorithm
 %End
 
@@ -345,11 +354,35 @@ class QgsProcessingAlgorithm
       sipTransferTo( resObj, Py_None );
 %End
 
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) = 0;
+%Docstring
+ Initializes the algorithm using the specified ``configuration``.
+
+ This should be called directly after creating algorithms and before retrieving
+ any parameterDefinitions() or outputDefinitions().
+
+ Subclasses should use their implementations to add all required input parameter and output
+ definitions (which can be dynamically adjusted according to ``configuration``).
+
+ Dynamic configuration can be used by algorithms which alter their behavior
+ when used inside processing models. For instance, a "feature router" type
+ algorithm which sends input features to one of any number of outputs sinks
+ based on some preconfigured filter parameters can use the init method to
+ create these outputs based on the specified ``configuration``.
+
+.. seealso:: addParameter()
+.. seealso:: addOutput()
+%End
+
     bool addParameter( QgsProcessingParameterDefinition *parameterDefinition /Transfer/ );
 %Docstring
  Adds a parameter ``definition`` to the algorithm. Ownership of the definition is transferred to the algorithm.
  Returns true if parameter could be successfully added, or false if the parameter could not be added (e.g.
  as a result of a duplicate name).
+
+ This should usually be called from a subclass' initAlgorithm() implementation.
+
+.. seealso:: initAlgorithm()
 .. seealso:: addOutput()
  :rtype: bool
 %End
@@ -365,7 +398,11 @@ class QgsProcessingAlgorithm
  Adds an output ``definition`` to the algorithm. Ownership of the definition is transferred to the algorithm.
  Returns true if the output could be successfully added, or false if the output could not be added (e.g.
  as a result of a duplicate name).
+
+ This should usually be called from a subclass' initAlgorithm() implementation.
+
 .. seealso:: addParameter()
+.. seealso:: initAlgorithm()
  :rtype: bool
 %End
 

--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -331,12 +331,18 @@ class QgsProcessingAlgorithm
 
   protected:
 
-    virtual QgsProcessingAlgorithm *createInstance() const = 0 /Factory/;
+    virtual QgsProcessingAlgorithm *createInstance() const = 0;
 %Docstring
  Creates a new instance of the algorithm class.
 
  This method should return a 'pristine' instance of the algorithm class.
  :rtype: QgsProcessingAlgorithm
+%End
+%VirtualCatcherCode
+    PyObject *resObj = sipCallMethod( 0, sipMethod, "" );
+    sipIsErr = !resObj || sipParseResult( 0, sipMethod, resObj, "H2", sipType_QgsProcessingAlgorithm, &sipRes ) < 0;
+    if ( !sipIsErr )
+      sipTransferTo( resObj, Py_None );
 %End
 
     bool addParameter( QgsProcessingParameterDefinition *parameterDefinition /Transfer/ );

--- a/python/core/processing/qgsprocessingregistry.sip
+++ b/python/core/processing/qgsprocessingregistry.sip
@@ -89,10 +89,17 @@ class QgsProcessingRegistry : QObject
  :rtype: QgsProcessingAlgorithm
 %End
 
-    QgsProcessingAlgorithm *createAlgorithmById( const QString &id ) const /Factory/;
+    QgsProcessingAlgorithm *createAlgorithmById( const QString &id, const QVariantMap &configuration = QVariantMap() ) const /Factory/;
 %Docstring
  Creates a new instance of an algorithm by its ID. If no matching algorithm is found, a None
- is returned. Callers take responsibility for deleting the returned object.`
+ is returned. Callers take responsibility for deleting the returned object.
+
+ The ``configuration`` argument allows passing of a map of configuration settings
+ to the algorithm, allowing it to dynamically adjust its initialized parameters
+ and outputs according to this configuration. This is generally used only for
+ algorithms in a model, allowing them to adjust their behavior at run time
+ according to some user configuration.
+
 .. seealso:: algorithms()
 .. seealso:: algorithmById()
  :rtype: QgsProcessingAlgorithm

--- a/python/core/processing/qgsprocessingregistry.sip
+++ b/python/core/processing/qgsprocessingregistry.sip
@@ -85,6 +85,16 @@ class QgsProcessingRegistry : QObject
  Finds an algorithm by its ID. If no matching algorithm is found, a None
  is returned.
 .. seealso:: algorithms()
+.. seealso:: createAlgorithmById()
+ :rtype: QgsProcessingAlgorithm
+%End
+
+    QgsProcessingAlgorithm *createAlgorithmById( const QString &id ) const /Factory/;
+%Docstring
+ Creates a new instance of an algorithm by its ID. If no matching algorithm is found, a None
+ is returned. Callers take responsibility for deleting the returned object.`
+.. seealso:: algorithms()
+.. seealso:: algorithmById()
  :rtype: QgsProcessingAlgorithm
 %End
 

--- a/python/plugins/processing/algs/qgis/AddTableField.py
+++ b/python/plugins/processing/algs/qgis/AddTableField.py
@@ -60,6 +60,7 @@ class AddTableField(QgisAlgorithm):
                            self.tr('Float'),
                            self.tr('String')]
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER,
                                                               self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterString(self.FIELD_NAME,

--- a/python/plugins/processing/algs/qgis/Aspect.py
+++ b/python/plugins/processing/algs/qgis/Aspect.py
@@ -60,6 +60,7 @@ class Aspect(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT,
                                                             self.tr('Elevation layer')))
         self.addParameter(QgsProcessingParameterNumber(self.Z_FACTOR,

--- a/python/plugins/processing/algs/qgis/AutoincrementalField.py
+++ b/python/plugins/processing/algs/qgis/AutoincrementalField.py
@@ -45,6 +45,7 @@ class AutoincrementalField(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer')))
 

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -53,6 +53,7 @@ class BarPlot(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterField(self.NAME_FIELD,

--- a/python/plugins/processing/algs/qgis/BasicStatistics.py
+++ b/python/plugins/processing/algs/qgis/BasicStatistics.py
@@ -88,6 +88,7 @@ class BasicStatisticsForField(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER,
                                                               self.tr('Input layer')))
 

--- a/python/plugins/processing/algs/qgis/Boundary.py
+++ b/python/plugins/processing/algs/qgis/Boundary.py
@@ -55,6 +55,8 @@ class Boundary(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER, self.tr('Input layer'), [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT_LAYER, self.tr('Boundary')))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT_LAYER, self.tr("Boundaries")))

--- a/python/plugins/processing/algs/qgis/BoundingBox.py
+++ b/python/plugins/processing/algs/qgis/BoundingBox.py
@@ -63,6 +63,7 @@ class BoundingBox(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER, self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT_LAYER, self.tr('Bounds'), QgsProcessing.TypeVectorPolygon))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT_LAYER, self.tr("Bounds")))

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -52,6 +52,8 @@ class BoxPlot(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterTable(self.INPUT, self.tr('Input table')))
         self.addParameter(ParameterTableField(self.NAME_FIELD,
                                               self.tr('Category name field'),

--- a/python/plugins/processing/algs/qgis/CheckValidity.py
+++ b/python/plugins/processing/algs/qgis/CheckValidity.py
@@ -73,6 +73,8 @@ class CheckValidity(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.methods = [self.tr('The one selected in digitizing settings'),
                         'QGIS',
                         'GEOS']

--- a/python/plugins/processing/algs/qgis/ConcaveHull.py
+++ b/python/plugins/processing/algs/qgis/ConcaveHull.py
@@ -61,6 +61,7 @@ class ConcaveHull(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input point layer'), [QgsProcessing.TypeVectorPoint]))
         self.addParameter(QgsProcessingParameterNumber(self.ALPHA,
                                                        self.tr('Threshold (0-1, where 1 is equivalent with Convex Hull)'),

--- a/python/plugins/processing/algs/qgis/ConvexHull.py
+++ b/python/plugins/processing/algs/qgis/ConvexHull.py
@@ -65,6 +65,8 @@ class ConvexHull(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.methods = [self.tr('Create single minimum convex hull'),
                         self.tr('Create convex hulls based on field')]
 

--- a/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
+++ b/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
@@ -47,6 +47,8 @@ class CreateAttributeIndex(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT,
                                                             self.tr('Input Layer')))
         self.addParameter(QgsProcessingParameterField(self.FIELD,

--- a/python/plugins/processing/algs/qgis/CreateConstantRaster.py
+++ b/python/plugins/processing/algs/qgis/CreateConstantRaster.py
@@ -47,6 +47,8 @@ class CreateConstantRaster(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT,
                                           self.tr('Reference layer')))
         self.addParameter(ParameterNumber(self.NUMBER,

--- a/python/plugins/processing/algs/qgis/Datasources2Vrt.py
+++ b/python/plugins/processing/algs/qgis/Datasources2Vrt.py
@@ -53,6 +53,8 @@ class Datasources2Vrt(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterMultipleInput(self.DATASOURCES,
                                                  self.tr('Input datasources'),
                                                  dataobjects.TYPE_TABLE))

--- a/python/plugins/processing/algs/qgis/DefineProjection.py
+++ b/python/plugins/processing/algs/qgis/DefineProjection.py
@@ -52,6 +52,8 @@ class DefineProjection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input Layer')))
         self.addParameter(ParameterCrs(self.CRS, 'Output CRS'))

--- a/python/plugins/processing/algs/qgis/Delaunay.py
+++ b/python/plugins/processing/algs/qgis/Delaunay.py
@@ -68,6 +68,7 @@ class Delaunay(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorPoint]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Delaunay triangulation'), type=QgsProcessing.TypeVectorPolygon))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Delaunay triangulation"), type=QgsProcessing.TypeVectorPolygon))

--- a/python/plugins/processing/algs/qgis/DeleteColumn.py
+++ b/python/plugins/processing/algs/qgis/DeleteColumn.py
@@ -50,6 +50,7 @@ class DeleteColumn(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterField(self.COLUMNS,
                                                       self.tr('Fields to drop'),

--- a/python/plugins/processing/algs/qgis/DeleteDuplicateGeometries.py
+++ b/python/plugins/processing/algs/qgis/DeleteDuplicateGeometries.py
@@ -44,6 +44,8 @@ class DeleteDuplicateGeometries(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addOutput(OutputVector(self.OUTPUT, self.tr('Cleaned')))

--- a/python/plugins/processing/algs/qgis/DeleteHoles.py
+++ b/python/plugins/processing/algs/qgis/DeleteHoles.py
@@ -42,14 +42,10 @@ class DeleteHoles(QgisAlgorithm):
     MIN_AREA = 'MIN_AREA'
     OUTPUT = 'OUTPUT'
 
-    def tags(self):
-        return self.tr('remove,delete,drop,holes,rings,fill').split(',')
-
-    def group(self):
-        return self.tr('Vector geometry tools')
-
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer'), [QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterNumber(self.MIN_AREA,
@@ -58,6 +54,12 @@ class DeleteHoles(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Cleaned'), QgsProcessing.TypeVectorPolygon))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Cleaned'), QgsProcessing.TypeVectorPolygon))
+
+    def tags(self):
+        return self.tr('remove,delete,drop,holes,rings,fill').split(',')
+
+    def group(self):
+        return self.tr('Vector geometry tools')
 
     def name(self):
         return 'deleteholes'

--- a/python/plugins/processing/algs/qgis/DensifyGeometries.py
+++ b/python/plugins/processing/algs/qgis/DensifyGeometries.py
@@ -55,6 +55,7 @@ class DensifyGeometries(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer'), [QgsProcessing.TypeVectorPolygon, QgsProcessing.TypeVectorLine]))
         self.addParameter(QgsProcessingParameterNumber(self.VERTICES,

--- a/python/plugins/processing/algs/qgis/DensifyGeometriesInterval.py
+++ b/python/plugins/processing/algs/qgis/DensifyGeometriesInterval.py
@@ -53,6 +53,7 @@ class DensifyGeometriesInterval(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer'), [QgsProcessing.TypeVectorPolygon, QgsProcessing.TypeVectorLine]))
         self.addParameter(QgsProcessingParameterNumber(self.INTERVAL,

--- a/python/plugins/processing/algs/qgis/Difference.py
+++ b/python/plugins/processing/algs/qgis/Difference.py
@@ -58,6 +58,8 @@ class Difference(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(Difference.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterVector(Difference.OVERLAY,

--- a/python/plugins/processing/algs/qgis/DropGeometry.py
+++ b/python/plugins/processing/algs/qgis/DropGeometry.py
@@ -52,6 +52,7 @@ class DropGeometry(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorPoint, QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Dropped geometry')))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Dropped geometry")))

--- a/python/plugins/processing/algs/qgis/EliminateSelection.py
+++ b/python/plugins/processing/algs/qgis/EliminateSelection.py
@@ -65,6 +65,8 @@ class EliminateSelection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.modes = [self.tr('Largest area'),
                       self.tr('Smallest Area'),
                       self.tr('Largest common boundary')]

--- a/python/plugins/processing/algs/qgis/EquivalentNumField.py
+++ b/python/plugins/processing/algs/qgis/EquivalentNumField.py
@@ -48,6 +48,8 @@ class EquivalentNumField(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.FIELD,

--- a/python/plugins/processing/algs/qgis/ExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/ExecuteSQL.py
@@ -61,6 +61,8 @@ class ExecuteSQL(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterMultipleInput(name=self.INPUT_DATASOURCES,
                                                  description=self.tr('Additional input datasources (called input1, .., inputN in the query)'),
                                                  optional=True))

--- a/python/plugins/processing/algs/qgis/Explode.py
+++ b/python/plugins/processing/algs/qgis/Explode.py
@@ -48,6 +48,8 @@ class Explode(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer'),
                                           [dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
+++ b/python/plugins/processing/algs/qgis/ExportGeometryInfo.py
@@ -59,6 +59,8 @@ class ExportGeometryInfo(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.calc_methods = [self.tr('Layer CRS'),
                              self.tr('Project CRS'),
                              self.tr('Ellipsoidal')]

--- a/python/plugins/processing/algs/qgis/ExtendLines.py
+++ b/python/plugins/processing/algs/qgis/ExtendLines.py
@@ -47,6 +47,8 @@ class ExtendLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterNumber(self.START_DISTANCE,

--- a/python/plugins/processing/algs/qgis/ExtentFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ExtentFromLayer.py
@@ -73,6 +73,7 @@ class ExtentFromLayer(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER, self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterBoolean(self.BY_FEATURE,
                                                         self.tr('Calculate extent for each feature separately'), False))

--- a/python/plugins/processing/algs/qgis/ExtractByLocation.py
+++ b/python/plugins/processing/algs/qgis/ExtractByLocation.py
@@ -53,6 +53,8 @@ class ExtractByLocation(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.predicates = (
             ('intersects', self.tr('intersects')),
             ('contains', self.tr('contains')),

--- a/python/plugins/processing/algs/qgis/ExtractNodes.py
+++ b/python/plugins/processing/algs/qgis/ExtractNodes.py
@@ -54,6 +54,8 @@ class ExtractNodes(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer'),
                                           [dataobjects.TYPE_VECTOR_POLYGON,

--- a/python/plugins/processing/algs/qgis/ExtractSpecificNodes.py
+++ b/python/plugins/processing/algs/qgis/ExtractSpecificNodes.py
@@ -53,6 +53,8 @@ class ExtractSpecificNodes(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_ANY]))
         self.addParameter(ParameterString(self.NODES,

--- a/python/plugins/processing/algs/qgis/FieldPyculator.py
+++ b/python/plugins/processing/algs/qgis/FieldPyculator.py
@@ -62,6 +62,8 @@ class FieldsPyculator(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.type_names = [self.tr('Integer'),
                            self.tr('Float'),
                            self.tr('String')]

--- a/python/plugins/processing/algs/qgis/FieldsCalculator.py
+++ b/python/plugins/processing/algs/qgis/FieldsCalculator.py
@@ -66,6 +66,8 @@ class FieldsCalculator(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.type_names = [self.tr('Float'),
                            self.tr('Integer'),
                            self.tr('String'),

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -59,6 +59,8 @@ class FieldsMapper(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterTable(self.INPUT_LAYER,
                                          self.tr('Input layer'),
                                          False))

--- a/python/plugins/processing/algs/qgis/FindProjection.py
+++ b/python/plugins/processing/algs/qgis/FindProjection.py
@@ -60,6 +60,8 @@ class FindProjection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))
         extent_parameter = ParameterExtent(self.TARGET_AREA,

--- a/python/plugins/processing/algs/qgis/FixGeometry.py
+++ b/python/plugins/processing/algs/qgis/FixGeometry.py
@@ -52,6 +52,8 @@ class FixGeometry(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Fixed geometries')))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Fixed geometries")))

--- a/python/plugins/processing/algs/qgis/FixedDistanceBuffer.py
+++ b/python/plugins/processing/algs/qgis/FixedDistanceBuffer.py
@@ -66,6 +66,8 @@ class FixedDistanceBuffer(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterNumber(self.DISTANCE,

--- a/python/plugins/processing/algs/qgis/GeometryByExpression.py
+++ b/python/plugins/processing/algs/qgis/GeometryByExpression.py
@@ -54,6 +54,8 @@ class GeometryByExpression(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))
 

--- a/python/plugins/processing/algs/qgis/GeometryConvert.py
+++ b/python/plugins/processing/algs/qgis/GeometryConvert.py
@@ -48,6 +48,8 @@ class GeometryConvert(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.types = [self.tr('Centroids'),
                       self.tr('Nodes'),
                       self.tr('Linestrings'),

--- a/python/plugins/processing/algs/qgis/GridLine.py
+++ b/python/plugins/processing/algs/qgis/GridLine.py
@@ -71,6 +71,8 @@ class GridLine(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterExtent(self.EXTENT,
                                           self.tr('Grid extent'), optional=False))
         self.addParameter(ParameterNumber(self.HSPACING,

--- a/python/plugins/processing/algs/qgis/GridPolygon.py
+++ b/python/plugins/processing/algs/qgis/GridPolygon.py
@@ -76,6 +76,8 @@ class GridPolygon(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.types = [self.tr('Rectangle (polygon)'),
                       self.tr('Diamond (polygon)'),
                       self.tr('Hexagon (polygon)')]

--- a/python/plugins/processing/algs/qgis/Gridify.py
+++ b/python/plugins/processing/algs/qgis/Gridify.py
@@ -51,6 +51,8 @@ class Gridify(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input Layer')))
         self.addParameter(ParameterNumber(self.HSPACING,

--- a/python/plugins/processing/algs/qgis/Heatmap.py
+++ b/python/plugins/processing/algs/qgis/Heatmap.py
@@ -81,6 +81,8 @@ class Heatmap(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Point layer'), [dataobjects.TYPE_VECTOR_POINT]))
         self.addParameter(ParameterNumber(self.RADIUS,

--- a/python/plugins/processing/algs/qgis/Hillshade.py
+++ b/python/plugins/processing/algs/qgis/Hillshade.py
@@ -56,6 +56,8 @@ class Hillshade(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT_LAYER,
                                           self.tr('Elevation layer')))
         self.addParameter(ParameterNumber(self.Z_FACTOR,

--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -68,6 +68,8 @@ class HubDistanceLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.units = [self.tr('Meters'),
                       self.tr('Feet'),
                       self.tr('Miles'),

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -68,6 +68,8 @@ class HubDistancePoints(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.units = [self.tr('Meters'),
                       self.tr('Feet'),
                       self.tr('Miles'),

--- a/python/plugins/processing/algs/qgis/HubLines.py
+++ b/python/plugins/processing/algs/qgis/HubLines.py
@@ -54,6 +54,8 @@ class HubLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.HUBS,
                                           self.tr('Hub layer')))
         self.addParameter(ParameterTableField(self.HUB_FIELD,

--- a/python/plugins/processing/algs/qgis/HypsometricCurves.py
+++ b/python/plugins/processing/algs/qgis/HypsometricCurves.py
@@ -60,6 +60,8 @@ class HypsometricCurves(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT_DEM,
                                           self.tr('DEM to analyze')))
         self.addParameter(ParameterVector(self.BOUNDARY_LAYER,

--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -68,6 +68,7 @@ class IdwInterpolation(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         class ParameterInterpolationData(Parameter):
             default_metadata = {
                 'widget_wrapper': 'processing.algs.qgis.ui.InterpolationDataWidget.InterpolationDataWidgetWrapper'

--- a/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
@@ -61,6 +61,8 @@ class ImportIntoPostGIS(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Layer to import')))
 

--- a/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
@@ -59,6 +59,8 @@ class ImportIntoSpatialite(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Layer to import')))
         self.addParameter(QgsProcessingParameterVectorLayer(self.DATABASE, self.tr('File database'), False, False))
         self.addParameter(QgsProcessingParameterString(self.TABLENAME, self.tr('Table to import to (leave blank to use layer name)'), optional=True))

--- a/python/plugins/processing/algs/qgis/Intersection.py
+++ b/python/plugins/processing/algs/qgis/Intersection.py
@@ -69,6 +69,8 @@ class Intersection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterVector(self.INPUT2,

--- a/python/plugins/processing/algs/qgis/JoinAttributes.py
+++ b/python/plugins/processing/algs/qgis/JoinAttributes.py
@@ -56,6 +56,8 @@ class JoinAttributes(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTable(self.INPUT_LAYER_2,

--- a/python/plugins/processing/algs/qgis/LinesIntersection.py
+++ b/python/plugins/processing/algs/qgis/LinesIntersection.py
@@ -60,6 +60,8 @@ class LinesIntersection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_A,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterVector(self.INPUT_B,

--- a/python/plugins/processing/algs/qgis/LinesToPolygons.py
+++ b/python/plugins/processing/algs/qgis/LinesToPolygons.py
@@ -55,6 +55,8 @@ class LinesToPolygons(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer'),
                                           [dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
+++ b/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
@@ -51,6 +51,8 @@ class MeanAndStdDevPlot(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterTable(self.INPUT,
                                          self.tr('Input table')))
         self.addParameter(ParameterTableField(self.NAME_FIELD,

--- a/python/plugins/processing/algs/qgis/MeanCoords.py
+++ b/python/plugins/processing/algs/qgis/MeanCoords.py
@@ -59,6 +59,8 @@ class MeanCoords(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.POINTS,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.WEIGHT,

--- a/python/plugins/processing/algs/qgis/Merge.py
+++ b/python/plugins/processing/algs/qgis/Merge.py
@@ -62,6 +62,8 @@ class Merge(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterMultipleLayers(self.LAYERS,
                                                                self.tr('Layers to merge'),
                                                                QgsProcessing.TypeVectorAny))

--- a/python/plugins/processing/algs/qgis/MergeLines.py
+++ b/python/plugins/processing/algs/qgis/MergeLines.py
@@ -56,6 +56,8 @@ class MergeLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addOutput(OutputVector(self.OUTPUT_LAYER, self.tr('Merged'), datatype=[dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/algs/qgis/NearestNeighbourAnalysis.py
+++ b/python/plugins/processing/algs/qgis/NearestNeighbourAnalysis.py
@@ -62,6 +62,8 @@ class NearestNeighbourAnalysis(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.POINTS,
                                           self.tr('Points'), [dataobjects.TYPE_VECTOR_POINT]))
 

--- a/python/plugins/processing/algs/qgis/OffsetLine.py
+++ b/python/plugins/processing/algs/qgis/OffsetLine.py
@@ -55,6 +55,8 @@ class OffsetLine(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterNumber(self.DISTANCE,

--- a/python/plugins/processing/algs/qgis/OrientedMinimumBoundingBox.py
+++ b/python/plugins/processing/algs/qgis/OrientedMinimumBoundingBox.py
@@ -55,6 +55,8 @@ class OrientedMinimumBoundingBox(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))
         self.addParameter(ParameterBoolean(self.BY_FEATURE,

--- a/python/plugins/processing/algs/qgis/Orthogonalize.py
+++ b/python/plugins/processing/algs/qgis/Orthogonalize.py
@@ -52,6 +52,8 @@ class Orthogonalize(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE,
                                                                    dataobjects.TYPE_VECTOR_POLYGON]))

--- a/python/plugins/processing/algs/qgis/PointDistance.py
+++ b/python/plugins/processing/algs/qgis/PointDistance.py
@@ -64,6 +64,8 @@ class PointDistance(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.mat_types = [self.tr('Linear (N*k x 3) distance matrix'),
                           self.tr('Standard (N x T) distance matrix'),
                           self.tr('Summary distance matrix (mean, std. dev., min, max)')]

--- a/python/plugins/processing/algs/qgis/PointOnSurface.py
+++ b/python/plugins/processing/algs/qgis/PointOnSurface.py
@@ -53,6 +53,8 @@ class PointOnSurface(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))
         self.addOutput(OutputVector(self.OUTPUT_LAYER, self.tr('Point'), datatype=[dataobjects.TYPE_VECTOR_POINT]))

--- a/python/plugins/processing/algs/qgis/PointsAlongGeometry.py
+++ b/python/plugins/processing/algs/qgis/PointsAlongGeometry.py
@@ -60,6 +60,8 @@ class PointsAlongGeometry(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer'),
                                           [dataobjects.TYPE_VECTOR_POLYGON, dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/algs/qgis/PointsDisplacement.py
+++ b/python/plugins/processing/algs/qgis/PointsDisplacement.py
@@ -54,6 +54,8 @@ class PointsDisplacement(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_POINT]))
         self.addParameter(ParameterNumber(self.DISTANCE,

--- a/python/plugins/processing/algs/qgis/PointsFromLines.py
+++ b/python/plugins/processing/algs/qgis/PointsFromLines.py
@@ -57,6 +57,8 @@ class PointsFromLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT_RASTER,
                                           self.tr('Raster layer')))
         self.addParameter(ParameterVector(self.INPUT_VECTOR,

--- a/python/plugins/processing/algs/qgis/PointsFromPolygons.py
+++ b/python/plugins/processing/algs/qgis/PointsFromPolygons.py
@@ -57,6 +57,8 @@ class PointsFromPolygons(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT_RASTER,
                                           self.tr('Raster layer')))
         self.addParameter(ParameterVector(self.INPUT_VECTOR,

--- a/python/plugins/processing/algs/qgis/PointsInPolygon.py
+++ b/python/plugins/processing/algs/qgis/PointsInPolygon.py
@@ -56,6 +56,8 @@ class PointsInPolygon(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.POLYGONS,
                                           self.tr('Polygons'), [dataobjects.TYPE_VECTOR_POLYGON]))
         self.addParameter(ParameterVector(self.POINTS,

--- a/python/plugins/processing/algs/qgis/PointsInPolygonUnique.py
+++ b/python/plugins/processing/algs/qgis/PointsInPolygonUnique.py
@@ -54,6 +54,8 @@ class PointsInPolygonUnique(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.POLYGONS,
                                           self.tr('Polygons'), [dataobjects.TYPE_VECTOR_POLYGON]))
         self.addParameter(ParameterVector(self.POINTS,

--- a/python/plugins/processing/algs/qgis/PointsInPolygonWeighted.py
+++ b/python/plugins/processing/algs/qgis/PointsInPolygonWeighted.py
@@ -55,6 +55,8 @@ class PointsInPolygonWeighted(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.POLYGONS,
                                           self.tr('Polygons'), [dataobjects.TYPE_VECTOR_POLYGON]))
         self.addParameter(ParameterVector(self.POINTS,

--- a/python/plugins/processing/algs/qgis/PointsLayerFromTable.py
+++ b/python/plugins/processing/algs/qgis/PointsLayerFromTable.py
@@ -65,6 +65,7 @@ class PointsLayerFromTable(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), types=[QgsProcessing.TypeTable]))
 
         self.addParameter(QgsProcessingParameterField(self.XFIELD,

--- a/python/plugins/processing/algs/qgis/PointsToPaths.py
+++ b/python/plugins/processing/algs/qgis/PointsToPaths.py
@@ -64,6 +64,8 @@ class PointsToPaths(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.VECTOR,
                                           self.tr('Input point layer'), [dataobjects.TYPE_VECTOR_POINT]))
         self.addParameter(ParameterTableField(self.GROUP_FIELD,

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -50,6 +50,8 @@ class PolarPlot(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterTable(self.INPUT,
                                          self.tr('Input table')))
         self.addParameter(ParameterTableField(self.NAME_FIELD,

--- a/python/plugins/processing/algs/qgis/PoleOfInaccessibility.py
+++ b/python/plugins/processing/algs/qgis/PoleOfInaccessibility.py
@@ -58,6 +58,8 @@ class PoleOfInaccessibility(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'),
                                           [dataobjects.TYPE_VECTOR_POLYGON]))

--- a/python/plugins/processing/algs/qgis/Polygonize.py
+++ b/python/plugins/processing/algs/qgis/Polygonize.py
@@ -58,6 +58,8 @@ class Polygonize(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterBoolean(self.FIELDS,

--- a/python/plugins/processing/algs/qgis/PolygonsToLines.py
+++ b/python/plugins/processing/algs/qgis/PolygonsToLines.py
@@ -55,6 +55,8 @@ class PolygonsToLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_POLYGON]))
 

--- a/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
@@ -44,6 +44,7 @@ class PostGISExecuteSQL(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         db_param = QgsProcessingParameterString(
             self.DATABASE,
             self.tr('Database (connection name)'))

--- a/python/plugins/processing/algs/qgis/QgisAlgorithm.py
+++ b/python/plugins/processing/algs/qgis/QgisAlgorithm.py
@@ -48,5 +48,5 @@ class QgisAlgorithm(QgsProcessingAlgorithm):
             context = self.__class__.__name__
         return string, QCoreApplication.translate(context, string)
 
-    def create(self):
+    def createInstance(self):
         return type(self)()

--- a/python/plugins/processing/algs/qgis/RandomExtract.py
+++ b/python/plugins/processing/algs/qgis/RandomExtract.py
@@ -50,6 +50,8 @@ class RandomExtract(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.methods = [self.tr('Number of selected features'),
                         self.tr('Percentage of selected features')]
 

--- a/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
@@ -55,6 +55,8 @@ class RandomExtractWithinSubsets(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.methods = [self.tr('Number of selected features'),
                         self.tr('Percentage of selected features')]
 

--- a/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
@@ -62,6 +62,8 @@ class RandomPointsAlongLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.VECTOR,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterNumber(self.POINT_NUMBER,

--- a/python/plugins/processing/algs/qgis/RandomPointsExtent.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsExtent.py
@@ -63,6 +63,8 @@ class RandomPointsExtent(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterExtent(self.EXTENT,
                                           self.tr('Input extent'), optional=False))
         self.addParameter(ParameterNumber(self.POINT_NUMBER,

--- a/python/plugins/processing/algs/qgis/RandomPointsLayer.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsLayer.py
@@ -59,6 +59,8 @@ class RandomPointsLayer(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.VECTOR,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_POLYGON]))
         self.addParameter(ParameterNumber(self.POINT_NUMBER,

--- a/python/plugins/processing/algs/qgis/RandomPointsPolygonsFixed.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygonsFixed.py
@@ -61,6 +61,8 @@ class RandomPointsPolygonsFixed(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.strategies = [self.tr('Points count'),
                            self.tr('Points density')]
 

--- a/python/plugins/processing/algs/qgis/RandomPointsPolygonsVariable.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygonsVariable.py
@@ -62,6 +62,8 @@ class RandomPointsPolygonsVariable(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.strategies = [self.tr('Points count'),
                            self.tr('Points density')]
 

--- a/python/plugins/processing/algs/qgis/RandomSelection.py
+++ b/python/plugins/processing/algs/qgis/RandomSelection.py
@@ -56,6 +56,8 @@ class RandomSelection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.methods = [self.tr('Number of selected features'),
                         self.tr('Percentage of selected features')]
 

--- a/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
@@ -60,6 +60,8 @@ class RandomSelectionWithinSubsets(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.methods = [self.tr('Number of selected features'),
                         self.tr('Percentage of selected features')]
 

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -55,6 +55,8 @@ class RasterCalculator(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterMultipleInput(self.LAYERS,
                                                  self.tr('Input layers'),
                                                  datatype=dataobjects.TYPE_RASTER,

--- a/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
@@ -48,6 +48,8 @@ class RasterLayerHistogram(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterNumber(self.BINS,

--- a/python/plugins/processing/algs/qgis/RasterLayerStatistics.py
+++ b/python/plugins/processing/algs/qgis/RasterLayerStatistics.py
@@ -56,6 +56,8 @@ class RasterLayerStatistics(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT, self.tr('Input layer')))
 
         self.addOutput(OutputHTML(self.OUTPUT_HTML_FILE, self.tr('Statistics')))

--- a/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsFixed.py
+++ b/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsFixed.py
@@ -59,6 +59,8 @@ class RectanglesOvalsDiamondsFixed(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.shapes = [self.tr('Rectangles'), self.tr('Diamonds'), self.tr('Ovals')]
 
         self.addParameter(ParameterVector(self.INPUT_LAYER,

--- a/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsVariable.py
+++ b/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsVariable.py
@@ -61,6 +61,8 @@ class RectanglesOvalsDiamondsVariable(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.shapes = [self.tr('Rectangles'), self.tr('Diamonds'), self.tr('Ovals')]
 
         self.addParameter(ParameterVector(self.INPUT_LAYER,

--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -66,6 +66,8 @@ class RegularPoints(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Input extent'), optional=False))
         self.addParameter(QgsProcessingParameterNumber(self.SPACING,

--- a/python/plugins/processing/algs/qgis/Relief.py
+++ b/python/plugins/processing/algs/qgis/Relief.py
@@ -62,6 +62,7 @@ class Relief(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         class ParameterReliefColors(Parameter):
             default_metadata = {
                 'widget_wrapper': 'processing.algs.qgis.ui.ReliefColorsWidget.ReliefColorsWidgetWrapper'

--- a/python/plugins/processing/algs/qgis/RemoveNullGeometry.py
+++ b/python/plugins/processing/algs/qgis/RemoveNullGeometry.py
@@ -47,6 +47,8 @@ class RemoveNullGeometry(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_ANY]))
         self.addOutput(OutputVector(self.OUTPUT_LAYER, self.tr('Removed null geometry')))

--- a/python/plugins/processing/algs/qgis/ReverseLineDirection.py
+++ b/python/plugins/processing/algs/qgis/ReverseLineDirection.py
@@ -47,6 +47,8 @@ class ReverseLineDirection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addOutput(OutputVector(self.OUTPUT_LAYER, self.tr('Reversed'), datatype=[dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/algs/qgis/Ruggedness.py
+++ b/python/plugins/processing/algs/qgis/Ruggedness.py
@@ -54,6 +54,8 @@ class Ruggedness(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT_LAYER,
                                           self.tr('Elevation layer')))
         self.addParameter(ParameterNumber(self.Z_FACTOR,

--- a/python/plugins/processing/algs/qgis/SaveSelectedFeatures.py
+++ b/python/plugins/processing/algs/qgis/SaveSelectedFeatures.py
@@ -43,6 +43,7 @@ class SaveSelectedFeatures(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT, self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Selection')))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Selection")))

--- a/python/plugins/processing/algs/qgis/SelectByAttribute.py
+++ b/python/plugins/processing/algs/qgis/SelectByAttribute.py
@@ -69,6 +69,8 @@ class SelectByAttribute(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.i18n_operators = ['=',
                                '!=',
                                '>',

--- a/python/plugins/processing/algs/qgis/SelectByAttributeSum.py
+++ b/python/plugins/processing/algs/qgis/SelectByAttributeSum.py
@@ -49,6 +49,8 @@ class SelectByAttributeSum(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input Layer')))
         self.addParameter(ParameterTableField(self.FIELD,

--- a/python/plugins/processing/algs/qgis/SelectByExpression.py
+++ b/python/plugins/processing/algs/qgis/SelectByExpression.py
@@ -46,6 +46,8 @@ class SelectByExpression(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.methods = [self.tr('creating new selection'),
                         self.tr('adding to current selection'),
                         self.tr('removing from current selection'),

--- a/python/plugins/processing/algs/qgis/SelectByLocation.py
+++ b/python/plugins/processing/algs/qgis/SelectByLocation.py
@@ -58,6 +58,8 @@ class SelectByLocation(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.predicates = (
             ('intersects', self.tr('intersects')),
             ('contains', self.tr('contains')),

--- a/python/plugins/processing/algs/qgis/ServiceAreaFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ServiceAreaFromLayer.py
@@ -87,6 +87,8 @@ class ServiceAreaFromLayer(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.DIRECTIONS = OrderedDict([
             (self.tr('Forward direction'), QgsVectorLayerDirector.DirectionForward),
             (self.tr('Backward direction'), QgsVectorLayerDirector.DirectionForward),

--- a/python/plugins/processing/algs/qgis/ServiceAreaFromPoint.py
+++ b/python/plugins/processing/algs/qgis/ServiceAreaFromPoint.py
@@ -88,6 +88,8 @@ class ServiceAreaFromPoint(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.DIRECTIONS = OrderedDict([
             (self.tr('Forward direction'), QgsVectorLayerDirector.DirectionForward),
             (self.tr('Backward direction'), QgsVectorLayerDirector.DirectionForward),

--- a/python/plugins/processing/algs/qgis/SetRasterStyle.py
+++ b/python/plugins/processing/algs/qgis/SetRasterStyle.py
@@ -50,6 +50,8 @@ class SetRasterStyle(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT,
                                           self.tr('Raster layer')))
         self.addParameter(ParameterFile(self.STYLE,

--- a/python/plugins/processing/algs/qgis/SetVectorStyle.py
+++ b/python/plugins/processing/algs/qgis/SetVectorStyle.py
@@ -47,6 +47,8 @@ class SetVectorStyle(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Vector layer')))
         self.addParameter(ParameterFile(self.STYLE,

--- a/python/plugins/processing/algs/qgis/ShortestPathLayerToPoint.py
+++ b/python/plugins/processing/algs/qgis/ShortestPathLayerToPoint.py
@@ -89,6 +89,8 @@ class ShortestPathLayerToPoint(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.DIRECTIONS = OrderedDict([
             (self.tr('Forward direction'), QgsVectorLayerDirector.DirectionForward),
             (self.tr('Backward direction'), QgsVectorLayerDirector.DirectionForward),

--- a/python/plugins/processing/algs/qgis/ShortestPathPointToLayer.py
+++ b/python/plugins/processing/algs/qgis/ShortestPathPointToLayer.py
@@ -81,6 +81,8 @@ class ShortestPathPointToLayer(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.DIRECTIONS = OrderedDict([
             (self.tr('Forward direction'), QgsVectorLayerDirector.DirectionForward),
             (self.tr('Backward direction'), QgsVectorLayerDirector.DirectionForward),

--- a/python/plugins/processing/algs/qgis/ShortestPathPointToPoint.py
+++ b/python/plugins/processing/algs/qgis/ShortestPathPointToPoint.py
@@ -91,6 +91,8 @@ class ShortestPathPointToPoint(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.DIRECTIONS = OrderedDict([
             (self.tr('Forward direction'), QgsVectorLayerDirector.DirectionForward),
             (self.tr('Backward direction'), QgsVectorLayerDirector.DirectionForward),

--- a/python/plugins/processing/algs/qgis/SimplifyGeometries.py
+++ b/python/plugins/processing/algs/qgis/SimplifyGeometries.py
@@ -60,6 +60,8 @@ class SimplifyGeometries(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer'),
                                                               [dataobjects.TYPE_VECTOR_POLYGON, dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/algs/qgis/SinglePartsToMultiparts.py
+++ b/python/plugins/processing/algs/qgis/SinglePartsToMultiparts.py
@@ -54,6 +54,8 @@ class SinglePartsToMultiparts(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT, self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.FIELD,
                                               self.tr('Unique ID field'), self.INPUT))

--- a/python/plugins/processing/algs/qgis/SingleSidedBuffer.py
+++ b/python/plugins/processing/algs/qgis/SingleSidedBuffer.py
@@ -57,6 +57,8 @@ class SingleSidedBuffer(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterNumber(self.DISTANCE,

--- a/python/plugins/processing/algs/qgis/Slope.py
+++ b/python/plugins/processing/algs/qgis/Slope.py
@@ -54,6 +54,8 @@ class Slope(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterRaster(self.INPUT_LAYER,
                                           self.tr('Elevation layer')))
         self.addParameter(ParameterNumber(self.Z_FACTOR,

--- a/python/plugins/processing/algs/qgis/Smooth.py
+++ b/python/plugins/processing/algs/qgis/Smooth.py
@@ -51,6 +51,8 @@ class Smooth(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer'), [dataobjects.TYPE_VECTOR_POLYGON, dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(QgsProcessingParameterNumber(self.ITERATIONS,

--- a/python/plugins/processing/algs/qgis/SnapGeometries.py
+++ b/python/plugins/processing/algs/qgis/SnapGeometries.py
@@ -53,6 +53,7 @@ class SnapGeometriesToLayer(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorPoint, QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterFeatureSource(self.REFERENCE_LAYER, self.tr('Reference layer'),
                                                               [QgsProcessing.TypeVectorPoint,

--- a/python/plugins/processing/algs/qgis/SpatialIndex.py
+++ b/python/plugins/processing/algs/qgis/SpatialIndex.py
@@ -48,6 +48,8 @@ class SpatialIndex(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input Layer')))
         self.addOutput(OutputVector(self.OUTPUT,

--- a/python/plugins/processing/algs/qgis/SpatialJoin.py
+++ b/python/plugins/processing/algs/qgis/SpatialJoin.py
@@ -64,6 +64,8 @@ class SpatialJoin(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.predicates = (
             ('intersects', self.tr('intersects')),
             ('contains', self.tr('contains')),

--- a/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
@@ -46,6 +46,8 @@ class SpatialiteExecuteSQL(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.DATABASE, self.tr('File Database'), False, False))
         self.addParameter(QgsProcessingParameterString(self.SQL, self.tr('SQL query'), '', True))
 

--- a/python/plugins/processing/algs/qgis/SplitWithLines.py
+++ b/python/plugins/processing/algs/qgis/SplitWithLines.py
@@ -54,6 +54,8 @@ class SplitWithLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_A,
                                           self.tr('Input layer, single geometries only'), [dataobjects.TYPE_VECTOR_POLYGON,
                                                                                            dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/algs/qgis/StatisticsByCategories.py
+++ b/python/plugins/processing/algs/qgis/StatisticsByCategories.py
@@ -48,6 +48,8 @@ class StatisticsByCategories(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input vector layer')))
         self.addParameter(ParameterTableField(self.VALUES_FIELD_NAME,

--- a/python/plugins/processing/algs/qgis/SumLines.py
+++ b/python/plugins/processing/algs/qgis/SumLines.py
@@ -56,6 +56,8 @@ class SumLines(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.LINES,
                                           self.tr('Lines'), [dataobjects.TYPE_VECTOR_LINE]))
         self.addParameter(ParameterVector(self.POLYGONS,

--- a/python/plugins/processing/algs/qgis/SymmetricalDifference.py
+++ b/python/plugins/processing/algs/qgis/SymmetricalDifference.py
@@ -62,6 +62,7 @@ class SymmetricalDifference(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterFeatureSource(self.OVERLAY,

--- a/python/plugins/processing/algs/qgis/TextToFloat.py
+++ b/python/plugins/processing/algs/qgis/TextToFloat.py
@@ -46,6 +46,8 @@ class TextToFloat(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input Layer')))
         self.addParameter(ParameterTableField(self.FIELD,

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -72,6 +72,8 @@ class TinInterpolation(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.METHODS = [self.tr('Linear'),
                         self.tr('Clough-Toucher (cubic)')
                         ]

--- a/python/plugins/processing/algs/qgis/TopoColors.py
+++ b/python/plugins/processing/algs/qgis/TopoColors.py
@@ -67,6 +67,8 @@ class TopoColor(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_POLYGON]))
         self.addParameter(ParameterNumber(self.MIN_COLORS,

--- a/python/plugins/processing/algs/qgis/Translate.py
+++ b/python/plugins/processing/algs/qgis/Translate.py
@@ -50,6 +50,8 @@ class Translate(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))
         self.addParameter(ParameterNumber(self.DELTA_X,

--- a/python/plugins/processing/algs/qgis/TruncateTable.py
+++ b/python/plugins/processing/algs/qgis/TruncateTable.py
@@ -47,6 +47,8 @@ class TruncateTable(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterTable(self.INPUT,
                                          self.tr('Input Layer')))
         self.addOutput(OutputVector(self.OUTPUT,

--- a/python/plugins/processing/algs/qgis/Union.py
+++ b/python/plugins/processing/algs/qgis/Union.py
@@ -68,6 +68,8 @@ class Union(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(Union.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterVector(Union.INPUT2,

--- a/python/plugins/processing/algs/qgis/UniqueValues.py
+++ b/python/plugins/processing/algs/qgis/UniqueValues.py
@@ -59,6 +59,8 @@ class UniqueValues(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.FIELD_NAME,

--- a/python/plugins/processing/algs/qgis/VariableDistanceBuffer.py
+++ b/python/plugins/processing/algs/qgis/VariableDistanceBuffer.py
@@ -61,6 +61,8 @@ class VariableDistanceBuffer(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.FIELD,

--- a/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
@@ -51,6 +51,8 @@ class VectorLayerHistogram(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.FIELD,

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -51,6 +51,8 @@ class VectorLayerScatterplot(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.XFIELD,

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -52,6 +52,8 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input layer')))
         self.addParameter(ParameterTableField(self.XFIELD,

--- a/python/plugins/processing/algs/qgis/VectorSplit.py
+++ b/python/plugins/processing/algs/qgis/VectorSplit.py
@@ -55,6 +55,7 @@ class VectorSplit(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer')))
 

--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -67,6 +67,7 @@ class VoronoiPolygons(QgisAlgorithm):
     def __init__(self):
         super().__init__()
 
+    def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorPoint]))
         self.addParameter(QgsProcessingParameterNumber(self.BUFFER, self.tr('Buffer region'), type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0, maxValue=9999999999, defaultValue=0.0))

--- a/python/plugins/processing/algs/qgis/ZonalStatistics.py
+++ b/python/plugins/processing/algs/qgis/ZonalStatistics.py
@@ -63,6 +63,8 @@ class ZonalStatistics(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def initAlgorithm(self, config=None):
         self.STATS = OrderedDict([(self.tr('Count'), QgsZonalStatistics.Count),
                                   (self.tr('Sum'), QgsZonalStatistics.Sum),
                                   (self.tr('Mean'), QgsZonalStatistics.Mean),

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -130,7 +130,7 @@ class Processing(object):
         if isinstance(algOrName, QgsProcessingAlgorithm):
             alg = algOrName
         else:
-            alg = QgsApplication.processingRegistry().algorithmById(algOrName)
+            alg = QgsApplication.processingRegistry().createAlgorithmById(algOrName)
 
         if feedback is None:
             feedback = MessageBarProgress(alg.displayName() if alg else Processing.tr('Processing'))

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -72,7 +72,7 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
                 self.resultFetched.emit(result)
 
     def triggerResult(self, result):
-        alg = QgsApplication.processingRegistry().algorithmById(result.userData)
+        alg = QgsApplication.processingRegistry().createAlgorithmById(result.userData)
         if alg:
             ok, message = alg.canExecute()
             if not ok:

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -238,22 +238,26 @@ class ProcessingToolbox(BASE, WIDGET):
     def editRenderingStyles(self):
         item = self.algorithmTree.currentItem()
         if isinstance(item, TreeAlgorithmItem):
-            alg = QgsApplication.processingRegistry().algorithmById(item.alg.id())
+            alg = QgsApplication.processingRegistry().createAlgorithmById(item.alg.id())
             dlg = EditRenderingStylesDialog(alg)
             dlg.exec_()
 
     def executeAlgorithmAsBatchProcess(self):
         item = self.algorithmTree.currentItem()
         if isinstance(item, TreeAlgorithmItem):
-            alg = QgsApplication.processingRegistry().algorithmById(item.alg.id())
-            dlg = BatchAlgorithmDialog(alg)
-            dlg.show()
-            dlg.exec_()
+            alg = QgsApplication.processingRegistry().createAlgorithmById(item.alg.id())
+            if alg:
+                dlg = BatchAlgorithmDialog(alg)
+                dlg.show()
+                dlg.exec_()
 
     def executeAlgorithm(self):
         item = self.algorithmTree.currentItem()
         if isinstance(item, TreeAlgorithmItem):
-            alg = QgsApplication.processingRegistry().algorithmById(item.alg.id())
+            alg = QgsApplication.processingRegistry().createAlgorithmById(item.alg.id())
+            if not alg:
+                return
+
             ok, message = alg.canExecute()
             if not ok:
                 dlg = MessageDialog()
@@ -317,7 +321,7 @@ class ProcessingToolbox(BASE, WIDGET):
                 recentItem = QTreeWidgetItem()
                 recentItem.setText(0, self.tr('Recently used algorithms'))
                 for algname in recent:
-                    alg = QgsApplication.processingRegistry().algorithmById(algname)
+                    alg = QgsApplication.processingRegistry().createAlgorithmById(algname)
                     if alg is not None:
                         algItem = TreeAlgorithmItem(alg)
                         recentItem.addChild(algItem)

--- a/python/plugins/processing/gui/TestTools.py
+++ b/python/plugins/processing/gui/TestTools.py
@@ -137,7 +137,7 @@ def createTest(text):
 
     tokens = list(parseParameters(text[len('processing.run('):-1]))
     cmdname = tokens[0]
-    alg = QgsApplication.processingRegistry().algorithmById(cmdname)
+    alg = QgsApplication.processingRegistry().createAlgorithmById(cmdname)
 
     definition['name'] = 'Test ({})'.format(cmdname)
     definition['algorithm'] = cmdname

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -114,7 +114,7 @@ class ModelerDialog(BASE, WIDGET):
                 if text in ModelerParameterDefinitionDialog.paramTypes:
                     self.addInputOfType(text, event.pos())
                 else:
-                    alg = QgsApplication.processingRegistry().algorithmById(text)
+                    alg = QgsApplication.processingRegistry().createAlgorithmById(text)
                     if alg is not None:
                         self._addAlgorithm(alg, event.pos())
                 event.accept()
@@ -549,7 +549,7 @@ class ModelerDialog(BASE, WIDGET):
     def addAlgorithm(self):
         item = self.algorithmTree.currentItem()
         if isinstance(item, TreeAlgorithmItem):
-            alg = QgsApplication.processingRegistry().algorithmById(item.alg.id())
+            alg = QgsApplication.processingRegistry().createAlgorithmById(item.alg.id())
             self._addAlgorithm(alg)
 
     def _addAlgorithm(self, alg, pos=None):

--- a/python/plugins/processing/preconfigured/PreconfiguredAlgorithm.py
+++ b/python/plugins/processing/preconfigured/PreconfiguredAlgorithm.py
@@ -59,7 +59,7 @@ class PreconfiguredAlgorithm(GeoAlgorithm):
 
     def execute(self, parameters, context=None, feedback=None, model=None):
         new_parameters = deepcopy(parameters)
-        self.alg = QgsApplication.processingRegistry().algorithmById(self.description["algname"])
+        self.alg = QgsApplication.processingRegistry().createAlgorithmById(self.description["algname"])
         for name, value in list(self.description["parameters"].items()):
             new_parameters[name] = value
         for name, value in list(self.description["outputs"].items()):

--- a/python/plugins/processing/script/ScriptAlgorithm.py
+++ b/python/plugins/processing/script/ScriptAlgorithm.py
@@ -82,6 +82,9 @@ class ScriptAlgorithm(QgsProcessingAlgorithm):
     def createInstance(self):
         return ScriptAlgorithm(self.descriptionFile)
 
+    def initAlgorithm(self, config=None):
+        pass
+
     def icon(self):
         return self._icon
 

--- a/python/plugins/processing/script/ScriptAlgorithm.py
+++ b/python/plugins/processing/script/ScriptAlgorithm.py
@@ -79,7 +79,7 @@ class ScriptAlgorithm(QgsProcessingAlgorithm):
         self.cleaned_script = None
         self.results = {}
 
-    def create(self):
+    def createInstance(self):
         return ScriptAlgorithm(self.descriptionFile)
 
     def icon(self):

--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -102,8 +102,9 @@ class AlgorithmsTest(object):
         if defs['algorithm'].startswith('script:'):
             filePath = os.path.join(processingTestDataPath(), 'scripts', '{}.py'.format(defs['algorithm'][len('script:'):]))
             alg = ScriptAlgorithm(filePath)
+            alg.initAlgorithm()
         else:
-            alg = QgsApplication.processingRegistry().algorithmById(defs['algorithm'])
+            alg = QgsApplication.processingRegistry().createAlgorithmById(defs['algorithm'])
 
         parameters = {}
         if isinstance(params, list):

--- a/python/plugins/processing/tests/QgisAlgorithmsTest.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest.py
@@ -48,6 +48,9 @@ class TestAlg(QgsProcessingAlgorithm):
     def displayName(self):
         return 'testalg'
 
+    def initAlgorithm(self):
+        pass
+
     def createInstance(self):
         return TestAlg()
 

--- a/python/plugins/processing/tests/QgisAlgorithmsTest.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest.py
@@ -48,7 +48,7 @@ class TestAlg(QgsProcessingAlgorithm):
     def displayName(self):
         return 'testalg'
 
-    def create(self):
+    def createInstance(self):
         return TestAlg()
 
     def processAlgorithm(self, parameters, context, feedback):

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -50,7 +50,7 @@ from processing.gui.Postprocessing import handleAlgorithmResults
 def algorithmOptions(id):
     """Prints all algorithm options with their values.
     """
-    alg = QgsApplication.processingRegistry().algorithmById(id)
+    alg = QgsApplication.processingRegistry().createAlgorithmById(id)
     if alg is not None:
         opts = ''
         for param in alg.parameterDefinitions():
@@ -67,7 +67,7 @@ def algorithmHelp(id):
     """Prints algorithm parameters with their types. Also
     provides information about options if any.
     """
-    alg = QgsApplication.processingRegistry().algorithmById(id)
+    alg = QgsApplication.processingRegistry().createAlgorithmById(id)
     if alg is not None:
         print(str(alg))
         algorithmOptions(id)
@@ -89,7 +89,7 @@ def runAndLoadResults(algOrName, parameters, feedback=None, context=None):
     if isinstance(algOrName, QgsProcessingAlgorithm):
         alg = algOrName
     else:
-        alg = QgsApplication.processingRegistry().algorithmById(algOrName)
+        alg = QgsApplication.processingRegistry().createAlgorithmById(algOrName)
 
     # output destination parameters to point to current project
     for param in alg.parameterDefinitions():

--- a/python/plugins/processing/tools/help.py
+++ b/python/plugins/processing/tools/help.py
@@ -115,5 +115,5 @@ def createBaseHelpFiles(folder):
 
 
 def createAlgorithmHelp(algName, folder):
-    alg = QgsApplication.processingRegistry().algorithmById(algName)
+    alg = QgsApplication.processingRegistry().createAlgorithmById(algName)
     baseHelpForAlgorithm(alg, folder)

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -310,6 +310,10 @@ while ($LINE_IDX < $LINE_COUNT){
         $LINE = "%ConvertToSubClassCode$1";
         # do not go next, let run the "do not process SIP code"
     }
+    if ($LINE =~ m/^\s*SIP_VIRTUAL_CATCHER_CODE(.*)$/){
+        $LINE = "%VirtualCatcherCode$1";
+        # do not go next, let run the "do not process SIP code"
+    }
 
     if ($LINE =~ m/^\s*SIP_END(.*)$/){
         write_output("SEN", "%End$1\n");

--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -3739,7 +3739,7 @@ inherantly:inherently
 inheritage:inheritance
 inheritence:inheritance
 inifinite:infinite
-inital:initial
+inital:initial:*
 initalisation:initialization
 initalise:initialize
 initalised:initialized

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -259,7 +259,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       childTime.start();
 
       bool ok = false;
-      std::unique_ptr< QgsProcessingAlgorithm > childAlg( child.algorithm()->create() );
+      std::unique_ptr< QgsProcessingAlgorithm > childAlg( child.algorithm()->create( child.configuration() ) );
       QVariantMap results = childAlg->run( childParams, context, feedback, &ok );
       childAlg.reset( nullptr );
       if ( !ok )

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1031,7 +1031,7 @@ QSet<QString> QgsProcessingModelAlgorithm::dependentChildAlgorithms( const QStri
 
 void QgsProcessingModelAlgorithm::dependsOnChildAlgorithmsRecursive( const QString &childId, QSet< QString > &depends ) const
 {
-  QgsProcessingModelChildAlgorithm alg = mChildAlgorithms.value( childId );
+  const QgsProcessingModelChildAlgorithm &alg = mChildAlgorithms.value( childId );
 
   // add direct dependencies
   Q_FOREACH ( const QString &c, alg.dependencies() )

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1100,7 +1100,7 @@ QString QgsProcessingModelAlgorithm::asPythonCommand( const QVariantMap &paramet
   return QgsProcessingAlgorithm::asPythonCommand( parameters, context );
 }
 
-QgsProcessingModelAlgorithm *QgsProcessingModelAlgorithm::create() const
+QgsProcessingAlgorithm *QgsProcessingModelAlgorithm::createInstance() const
 {
   QgsProcessingModelAlgorithm *alg = new QgsProcessingModelAlgorithm();
   alg->loadVariant( toVariant() );

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -32,6 +32,10 @@ QgsProcessingModelAlgorithm::QgsProcessingModelAlgorithm( const QString &name, c
   , mModelGroup( group )
 {}
 
+void QgsProcessingModelAlgorithm::initAlgorithm( const QVariantMap & )
+{
+}
+
 QString QgsProcessingModelAlgorithm::name() const
 {
   return mModelName;

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -52,7 +52,7 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
 
     bool canExecute( QString *errorMessage SIP_OUT = nullptr ) const override;
     QString asPythonCommand( const QVariantMap &parameters, QgsProcessingContext &context ) const override;
-    QgsProcessingModelAlgorithm *create() const override SIP_FACTORY;
+    QgsProcessingAlgorithm *createInstance() const override SIP_FACTORY;
 
     /**
      * Sets the model \a name.

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -42,6 +42,8 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
      */
     QgsProcessingModelAlgorithm( const QString &name = QString(), const QString &group = QString() );
 
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;  //#spellok
+
     QString name() const override;
     QString displayName() const override;
     QString group() const override;
@@ -52,7 +54,6 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
 
     bool canExecute( QString *errorMessage SIP_OUT = nullptr ) const override;
     QString asPythonCommand( const QVariantMap &parameters, QgsProcessingContext &context ) const override;
-    QgsProcessingAlgorithm *createInstance() const override SIP_FACTORY;
 
     /**
      * Sets the model \a name.
@@ -350,6 +351,8 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
         const QVariantMap &results = QVariantMap() ) const SIP_FACTORY;
 
   protected:
+
+    QgsProcessingAlgorithm *createInstance() const override SIP_FACTORY;
 
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -23,14 +23,40 @@
 ///@cond NOT_STABLE
 
 QgsProcessingModelChildAlgorithm::QgsProcessingModelChildAlgorithm( const QString &algorithmId )
-  : mAlgorithmId( algorithmId )
 {
+  setAlgorithmId( algorithmId );
+}
 
+QgsProcessingModelChildAlgorithm::QgsProcessingModelChildAlgorithm( const QgsProcessingModelChildAlgorithm &other )
+  : QgsProcessingModelComponent( other )
+  , mId( other.mId )
+  , mParams( other.mParams )
+  , mModelOutputs( other.mModelOutputs )
+  , mActive( other.mActive )
+  , mDependencies( other.mDependencies )
+  , mParametersCollapsed( other.mParametersCollapsed )
+  , mOutputsCollapsed( other.mOutputsCollapsed )
+{
+  setAlgorithmId( other.algorithmId() );
+}
+
+QgsProcessingModelChildAlgorithm &QgsProcessingModelChildAlgorithm::operator=( const QgsProcessingModelChildAlgorithm &other )
+{
+  QgsProcessingModelComponent::operator =( other );
+  mId = other.mId;
+  setAlgorithmId( other.algorithmId() );
+  mParams = other.mParams;
+  mModelOutputs = other.mModelOutputs;
+  mActive = other.mActive;
+  mDependencies = other.mDependencies;
+  mParametersCollapsed = other.mParametersCollapsed;
+  mOutputsCollapsed = other.mOutputsCollapsed;
+  return *this;
 }
 
 const QgsProcessingAlgorithm *QgsProcessingModelChildAlgorithm::algorithm() const
 {
-  return QgsApplication::processingRegistry()->algorithmById( mAlgorithmId );
+  return mAlgorithm.get();
 }
 
 void QgsProcessingModelChildAlgorithm::setModelOutputs( const QMap<QString, QgsProcessingModelOutput> &modelOutputs )
@@ -86,7 +112,7 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   QVariantMap map = child.toMap();
 
   mId = map.value( QStringLiteral( "id" ) ).toString();
-  mAlgorithmId = map.value( QStringLiteral( "alg_id" ) ).toString();
+  setAlgorithmId( map.value( QStringLiteral( "alg_id" ) ).toString() );
   mActive = map.value( QStringLiteral( "active" ) ).toBool();
   mDependencies = map.value( QStringLiteral( "dependencies" ) ).toStringList();
   mParametersCollapsed = map.value( QStringLiteral( "parameters_collapsed" ) ).toBool();
@@ -176,6 +202,16 @@ void QgsProcessingModelChildAlgorithm::generateChildId( const QgsProcessingModel
     i++;
   }
   mId = id;
+}
+
+void QgsProcessingModelChildAlgorithm::setAlgorithmId( const QString &algorithmId )
+{
+  mAlgorithmId = algorithmId;
+  mAlgorithm.reset( QgsApplication::processingRegistry()->createAlgorithmById( mAlgorithmId ) );
+  if ( mAlgorithm )
+  {
+    mAlgorithm->init( QVariantMap() );
+  }
 }
 
 ///@endcond

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -30,6 +30,7 @@ QgsProcessingModelChildAlgorithm::QgsProcessingModelChildAlgorithm( const QStrin
 QgsProcessingModelChildAlgorithm::QgsProcessingModelChildAlgorithm( const QgsProcessingModelChildAlgorithm &other )
   : QgsProcessingModelComponent( other )
   , mId( other.mId )
+  , mConfiguration( other.mConfiguration )
   , mParams( other.mParams )
   , mModelOutputs( other.mModelOutputs )
   , mActive( other.mActive )
@@ -44,6 +45,7 @@ QgsProcessingModelChildAlgorithm &QgsProcessingModelChildAlgorithm::operator=( c
 {
   QgsProcessingModelComponent::operator =( other );
   mId = other.mId;
+  mConfiguration = other.mConfiguration;
   setAlgorithmId( other.algorithmId() );
   mParams = other.mParams;
   mModelOutputs = other.mModelOutputs;
@@ -76,6 +78,7 @@ QVariant QgsProcessingModelChildAlgorithm::toVariant() const
   QVariantMap map;
   map.insert( QStringLiteral( "id" ), mId );
   map.insert( QStringLiteral( "alg_id" ), mAlgorithmId );
+  map.insert( QStringLiteral( "alg_config" ), mConfiguration );
   map.insert( QStringLiteral( "active" ), mActive );
   map.insert( QStringLiteral( "dependencies" ), mDependencies );
   map.insert( QStringLiteral( "parameters_collapsed" ), mParametersCollapsed );
@@ -112,6 +115,7 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   QVariantMap map = child.toMap();
 
   mId = map.value( QStringLiteral( "id" ) ).toString();
+  mConfiguration = map.value( QStringLiteral( "alg_config" ) ).toMap();
   setAlgorithmId( map.value( QStringLiteral( "alg_id" ) ).toString() );
   mActive = map.value( QStringLiteral( "active" ) ).toBool();
   mDependencies = map.value( QStringLiteral( "dependencies" ) ).toStringList();
@@ -186,9 +190,16 @@ QString QgsProcessingModelChildAlgorithm::asPythonCode() const
   return lines.join( '\n' );
 }
 
+QVariantMap QgsProcessingModelChildAlgorithm::configuration() const
+{
+  return mConfiguration;
+}
 
-
-
+void QgsProcessingModelChildAlgorithm::setConfiguration( const QVariantMap &configuration )
+{
+  mConfiguration = configuration;
+  mAlgorithm.reset( QgsApplication::processingRegistry()->createAlgorithmById( mAlgorithmId, mConfiguration ) );
+}
 
 void QgsProcessingModelChildAlgorithm::generateChildId( const QgsProcessingModelAlgorithm &model )
 {
@@ -207,7 +218,7 @@ void QgsProcessingModelChildAlgorithm::generateChildId( const QgsProcessingModel
 void QgsProcessingModelChildAlgorithm::setAlgorithmId( const QString &algorithmId )
 {
   mAlgorithmId = algorithmId;
-  mAlgorithm.reset( QgsApplication::processingRegistry()->createAlgorithmById( mAlgorithmId ) );
+  mAlgorithm.reset( QgsApplication::processingRegistry()->createAlgorithmById( mAlgorithmId, mConfiguration ) );
 }
 
 ///@endcond

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -208,10 +208,6 @@ void QgsProcessingModelChildAlgorithm::setAlgorithmId( const QString &algorithmI
 {
   mAlgorithmId = algorithmId;
   mAlgorithm.reset( QgsApplication::processingRegistry()->createAlgorithmById( mAlgorithmId ) );
-  if ( mAlgorithm )
-  {
-    mAlgorithm->init( QVariantMap() );
-  }
 }
 
 ///@endcond

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
@@ -88,6 +88,30 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     void setAlgorithmId( const QString &algorithmId );
 
     /**
+     * Returns the child algorithm's configuration map.
+     *
+     * This map specifies configuration settings which are passed
+     * to the algorithm, allowing it to dynamically adjust its initialized parameters
+     * and outputs according to this configuration. This allows child algorithms in the model
+     * to adjust their behavior at run time according to some user configuration.
+     *
+     * \see setConfiguration()
+     */
+    QVariantMap configuration() const;
+
+    /**
+     * Sets the child algorithm's \a configuration map.
+     *
+     * This map specifies configuration settings which are passed
+     * to the algorithm, allowing it to dynamically adjust its initialized parameters
+     * and outputs according to this configuration. This allows child algorithms in the model
+     * to adjust their behavior at run time according to some user configuration.
+     *
+     * \see configuration()
+     */
+    void setConfiguration( const QVariantMap &configuration );
+
+    /**
      * Returns the underlying child algorithm, or a nullptr
      * if a matching algorithm is not available.
      * \see algorithmId()
@@ -236,6 +260,8 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
 
     QString mAlgorithmId;
     std::unique_ptr< QgsProcessingAlgorithm > mAlgorithm;
+
+    QVariantMap mConfiguration;
 
     //! A map of parameter sources. Keys are algorithm parameter names.
     QMap< QString, QgsProcessingModelChildParameterSources > mParams;

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
@@ -23,6 +23,7 @@
 #include "qgsprocessingmodelcomponent.h"
 #include "qgsprocessingmodelchildparametersource.h"
 #include "qgsprocessingmodeloutput.h"
+#include <memory>
 
 class QgsProcessingModelAlgorithm;
 class QgsProcessingAlgorithm;
@@ -43,6 +44,9 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
      * should be set to a QgsProcessingAlgorithm algorithm ID.
      */
     QgsProcessingModelChildAlgorithm( const QString &algorithmId = QString() );
+
+    QgsProcessingModelChildAlgorithm( const QgsProcessingModelChildAlgorithm &other );
+    QgsProcessingModelChildAlgorithm &operator=( const QgsProcessingModelChildAlgorithm &other );
 
     /**
      * Returns the child algorithm's unique ID string, used the identify
@@ -81,7 +85,7 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
      * \see algorithm()
      * \see algorithmId()
      */
-    void setAlgorithmId( const QString &algorithmId ) { mAlgorithmId = algorithmId; }
+    void setAlgorithmId( const QString &algorithmId );
 
     /**
      * Returns the underlying child algorithm, or a nullptr
@@ -231,6 +235,7 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     QString mId;
 
     QString mAlgorithmId;
+    std::unique_ptr< QgsProcessingAlgorithm > mAlgorithm;
 
     //! A map of parameter sources. Keys are algorithm parameter names.
     QMap< QString, QgsProcessingModelChildParameterSources > mParams;
@@ -247,6 +252,7 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     bool mParametersCollapsed = true;
     //! Whether list of outputs should be collapsed in the graphical modeller
     bool mOutputsCollapsed = true;
+
 };
 
 ///@endcond

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -69,9 +69,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsTransformAlgorithm() );
 }
 
-
-
-QgsCentroidAlgorithm::QgsCentroidAlgorithm()
+void QgsCentroidAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Centroids" ), QgsProcessing::TypeVectorPoint ) );
@@ -140,7 +138,7 @@ QVariantMap QgsCentroidAlgorithm::processAlgorithm( const QVariantMap &parameter
 // QgsBufferAlgorithm
 //
 
-QgsBufferAlgorithm::QgsBufferAlgorithm()
+void QgsBufferAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "DISTANCE" ), QObject::tr( "Distance" ), QgsProcessingParameterNumber::Double, 10 ) );
@@ -254,7 +252,7 @@ QVariantMap QgsBufferAlgorithm::processAlgorithm( const QVariantMap &parameters,
 }
 
 
-QgsDissolveAlgorithm::QgsDissolveAlgorithm()
+void QgsDissolveAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterField( QStringLiteral( "FIELD" ), QObject::tr( "Unique ID fields" ), QVariant(),
@@ -412,7 +410,7 @@ QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameter
   return outputs;
 }
 
-QgsClipAlgorithm::QgsClipAlgorithm()
+void QgsClipAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Clip layer" ), QList< int >() << QgsProcessing::TypeVectorPolygon ) );
@@ -568,7 +566,7 @@ QVariantMap QgsClipAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
 }
 
 
-QgsTransformAlgorithm::QgsTransformAlgorithm()
+void QgsTransformAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "TARGET_CRS" ), QObject::tr( "Target CRS" ), QStringLiteral( "EPSG:4326" ) ) );
@@ -632,7 +630,7 @@ QVariantMap QgsTransformAlgorithm::processAlgorithm( const QVariantMap &paramete
 }
 
 
-QgsSubdivideAlgorithm::QgsSubdivideAlgorithm()
+void QgsSubdivideAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsProcessingParameterNumber::Integer,
@@ -707,8 +705,7 @@ QVariantMap QgsSubdivideAlgorithm::processAlgorithm( const QVariantMap &paramete
 }
 
 
-
-QgsMultipartToSinglepartAlgorithm::QgsMultipartToSinglepartAlgorithm()
+void QgsMultipartToSinglepartAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
 
@@ -791,7 +788,7 @@ QVariantMap QgsMultipartToSinglepartAlgorithm::processAlgorithm( const QVariantM
 }
 
 
-QgsExtractByExpressionAlgorithm::QgsExtractByExpressionAlgorithm()
+void QgsExtractByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterExpression( QStringLiteral( "EXPRESSION" ), QObject::tr( "Expression" ), QVariant(), QStringLiteral( "INPUT" ) ) );
@@ -909,7 +906,7 @@ QVariantMap QgsExtractByExpressionAlgorithm::processAlgorithm( const QVariantMap
 }
 
 
-QgsExtractByAttributeAlgorithm::QgsExtractByAttributeAlgorithm()
+void QgsExtractByAttributeAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterField( QStringLiteral( "FIELD" ), QObject::tr( "Selection attribute" ), QVariant(), QStringLiteral( "INPUT" ) ) );

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -84,7 +84,7 @@ QString QgsCentroidAlgorithm::shortHelpString() const
                       "The attributes associated to each point in the output layer are the same ones associated to the original features." );
 }
 
-QgsCentroidAlgorithm *QgsCentroidAlgorithm::create() const
+QgsCentroidAlgorithm *QgsCentroidAlgorithm::createInstance() const
 {
   return new QgsCentroidAlgorithm();
 }
@@ -164,7 +164,7 @@ QString QgsBufferAlgorithm::shortHelpString() const
                       "The mitre limit parameter is only applicable for mitre join styles, and controls the maximum distance from the offset curve to use when creating a mitred join." );
 }
 
-QgsBufferAlgorithm *QgsBufferAlgorithm::create() const
+QgsBufferAlgorithm *QgsBufferAlgorithm::createInstance() const
 {
   return new QgsBufferAlgorithm();
 }
@@ -273,7 +273,7 @@ QString QgsDissolveAlgorithm::shortHelpString() const
                       "In case the input is a polygon layer, common boundaries of adjacent polygons being dissolved will get erased." );
 }
 
-QgsDissolveAlgorithm *QgsDissolveAlgorithm::create() const
+QgsDissolveAlgorithm *QgsDissolveAlgorithm::createInstance() const
 {
   return new QgsDissolveAlgorithm();
 }
@@ -430,7 +430,7 @@ QString QgsClipAlgorithm::shortHelpString() const
                       "be manually updated." );
 }
 
-QgsClipAlgorithm *QgsClipAlgorithm::create() const
+QgsClipAlgorithm *QgsClipAlgorithm::createInstance() const
 {
   return new QgsClipAlgorithm();
 }
@@ -583,7 +583,7 @@ QString QgsTransformAlgorithm::shortHelpString() const
                       "Attributes are not modified by this algorithm." );
 }
 
-QgsTransformAlgorithm *QgsTransformAlgorithm::create() const
+QgsTransformAlgorithm *QgsTransformAlgorithm::createInstance() const
 {
   return new QgsTransformAlgorithm();
 }
@@ -652,7 +652,7 @@ QString QgsSubdivideAlgorithm::shortHelpString() const
                       "Curved geometries will be segmentized before subdivision." );
 }
 
-QgsSubdivideAlgorithm *QgsSubdivideAlgorithm::create() const
+QgsSubdivideAlgorithm *QgsSubdivideAlgorithm::createInstance() const
 {
   return new QgsSubdivideAlgorithm();
 }
@@ -723,7 +723,7 @@ QString QgsMultipartToSinglepartAlgorithm::shortHelpString() const
                       "contain, and the same attributes are used for each of them." );
 }
 
-QgsMultipartToSinglepartAlgorithm *QgsMultipartToSinglepartAlgorithm::create() const
+QgsMultipartToSinglepartAlgorithm *QgsMultipartToSinglepartAlgorithm::createInstance() const
 {
   return new QgsMultipartToSinglepartAlgorithm();
 }
@@ -810,7 +810,7 @@ QString QgsExtractByExpressionAlgorithm::shortHelpString() const
                       "For more information about expressions see the <a href =\"{qgisdocs}/user_manual/working_with_vector/expression.html\">user manual</a>" );
 }
 
-QgsExtractByExpressionAlgorithm *QgsExtractByExpressionAlgorithm::create() const
+QgsExtractByExpressionAlgorithm *QgsExtractByExpressionAlgorithm::createInstance() const
 {
   return new QgsExtractByExpressionAlgorithm();
 }
@@ -941,7 +941,7 @@ QString QgsExtractByAttributeAlgorithm::shortHelpString() const
                       "of an attribute from the input layer." );
 }
 
-QgsExtractByAttributeAlgorithm *QgsExtractByAttributeAlgorithm::create() const
+QgsExtractByAttributeAlgorithm *QgsExtractByAttributeAlgorithm::createInstance() const
 {
   return new QgsExtractByAttributeAlgorithm();
 }

--- a/src/core/processing/qgsnativealgorithms.h
+++ b/src/core/processing/qgsnativealgorithms.h
@@ -60,7 +60,7 @@ class QgsCentroidAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "centroid,center,average,point,middle" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector geometry tools" ); }
     QString shortHelpString() const override;
-    QgsCentroidAlgorithm *create() const override SIP_FACTORY;
+    QgsCentroidAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -84,7 +84,7 @@ class QgsTransformAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "transform,reproject,crs,srs,warp" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector general tools" ); }
     QString shortHelpString() const override;
-    QgsTransformAlgorithm *create() const override SIP_FACTORY;
+    QgsTransformAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -108,7 +108,7 @@ class QgsBufferAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "buffer,grow" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector geometry tools" ); }
     QString shortHelpString() const override;
-    QgsBufferAlgorithm *create() const override SIP_FACTORY;
+    QgsBufferAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -132,7 +132,7 @@ class QgsDissolveAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "dissolve,union,combine,collect" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector geometry tools" ); }
     QString shortHelpString() const override;
-    QgsDissolveAlgorithm *create() const override SIP_FACTORY;
+    QgsDissolveAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -171,7 +171,7 @@ class QgsExtractByAttributeAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "extract,filter,attribute,value,contains,null,field" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector selection tools" ); }
     QString shortHelpString() const override;
-    QgsExtractByAttributeAlgorithm *create() const override SIP_FACTORY;
+    QgsExtractByAttributeAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -195,7 +195,7 @@ class QgsExtractByExpressionAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "extract,filter,expression,field" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector selection tools" ); }
     QString shortHelpString() const override;
-    QgsExtractByExpressionAlgorithm *create() const override SIP_FACTORY;
+    QgsExtractByExpressionAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -219,7 +219,7 @@ class QgsClipAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "clip,intersect,intersection,mask" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector overlay tools" ); }
     QString shortHelpString() const override;
-    QgsClipAlgorithm *create() const override SIP_FACTORY;
+    QgsClipAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -244,7 +244,7 @@ class QgsSubdivideAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "subdivide,segmentize,split,tesselate" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector geometry tools" ); }
     QString shortHelpString() const override;
-    QgsSubdivideAlgorithm *create() const override SIP_FACTORY;
+    QgsSubdivideAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 
@@ -268,7 +268,7 @@ class QgsMultipartToSinglepartAlgorithm : public QgsProcessingAlgorithm
     virtual QStringList tags() const override { return QObject::tr( "multi,single,multiple,split,dump" ).split( ',' ); }
     QString group() const override { return QObject::tr( "Vector geometry tools" ); }
     QString shortHelpString() const override;
-    QgsMultipartToSinglepartAlgorithm *create() const override SIP_FACTORY;
+    QgsMultipartToSinglepartAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 

--- a/src/core/processing/qgsnativealgorithms.h
+++ b/src/core/processing/qgsnativealgorithms.h
@@ -53,8 +53,8 @@ class QgsCentroidAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsCentroidAlgorithm();
-
+    QgsCentroidAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "centroids" ); }
     QString displayName() const override { return QObject::tr( "Centroids" ); }
     virtual QStringList tags() const override { return QObject::tr( "centroid,center,average,point,middle" ).split( ',' ); }
@@ -77,8 +77,8 @@ class QgsTransformAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsTransformAlgorithm();
-
+    QgsTransformAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "reprojectlayer" ); }
     QString displayName() const override { return QObject::tr( "Reproject layer" ); }
     virtual QStringList tags() const override { return QObject::tr( "transform,reproject,crs,srs,warp" ).split( ',' ); }
@@ -101,7 +101,8 @@ class QgsBufferAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsBufferAlgorithm();
+    QgsBufferAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
 
     QString name() const override { return QStringLiteral( "buffer" ); }
     QString displayName() const override { return QObject::tr( "Buffer" ); }
@@ -125,8 +126,8 @@ class QgsDissolveAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsDissolveAlgorithm();
-
+    QgsDissolveAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "dissolve" ); }
     QString displayName() const override { return QObject::tr( "Dissolve" ); }
     virtual QStringList tags() const override { return QObject::tr( "dissolve,union,combine,collect" ).split( ',' ); }
@@ -164,8 +165,8 @@ class QgsExtractByAttributeAlgorithm : public QgsProcessingAlgorithm
       DoesNotContain,
     };
 
-    QgsExtractByAttributeAlgorithm();
-
+    QgsExtractByAttributeAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "extractbyattribute" ); }
     QString displayName() const override { return QObject::tr( "Extract by attribute" ); }
     virtual QStringList tags() const override { return QObject::tr( "extract,filter,attribute,value,contains,null,field" ).split( ',' ); }
@@ -188,8 +189,8 @@ class QgsExtractByExpressionAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsExtractByExpressionAlgorithm();
-
+    QgsExtractByExpressionAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "extractbyexpression" ); }
     QString displayName() const override { return QObject::tr( "Extract by expression" ); }
     virtual QStringList tags() const override { return QObject::tr( "extract,filter,expression,field" ).split( ',' ); }
@@ -212,8 +213,8 @@ class QgsClipAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsClipAlgorithm();
-
+    QgsClipAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "clip" ); }
     QString displayName() const override { return QObject::tr( "Clip" ); }
     virtual QStringList tags() const override { return QObject::tr( "clip,intersect,intersection,mask" ).split( ',' ); }
@@ -237,8 +238,8 @@ class QgsSubdivideAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsSubdivideAlgorithm();
-
+    QgsSubdivideAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "subdivide" ); }
     QString displayName() const override { return QObject::tr( "Subdivide" ); }
     virtual QStringList tags() const override { return QObject::tr( "subdivide,segmentize,split,tesselate" ).split( ',' ); }
@@ -261,8 +262,8 @@ class QgsMultipartToSinglepartAlgorithm : public QgsProcessingAlgorithm
 
   public:
 
-    QgsMultipartToSinglepartAlgorithm();
-
+    QgsMultipartToSinglepartAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override { return QStringLiteral( "multiparttosingleparts" ); }
     QString displayName() const override { return QObject::tr( "Multipart to singleparts" ); }
     virtual QStringList tags() const override { return QObject::tr( "multi,single,multiple,split,dump" ).split( ',' ); }

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -33,6 +33,13 @@ QgsProcessingAlgorithm::~QgsProcessingAlgorithm()
   qDeleteAll( mOutputs );
 }
 
+QgsProcessingAlgorithm *QgsProcessingAlgorithm::create() const
+{
+  std::unique_ptr< QgsProcessingAlgorithm > creation( createInstance() );
+  creation->setProvider( provider() );
+  return creation.release();
+}
+
 QString QgsProcessingAlgorithm::id() const
 {
   if ( mProvider )

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -33,11 +33,11 @@ QgsProcessingAlgorithm::~QgsProcessingAlgorithm()
   qDeleteAll( mOutputs );
 }
 
-QgsProcessingAlgorithm *QgsProcessingAlgorithm::create() const
+QgsProcessingAlgorithm *QgsProcessingAlgorithm::create( const QVariantMap &configuration ) const
 {
   std::unique_ptr< QgsProcessingAlgorithm > creation( createInstance() );
   creation->setProvider( provider() );
-  creation->initAlgorithm();
+  creation->initAlgorithm( configuration );
   return creation.release();
 }
 

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -37,6 +37,7 @@ QgsProcessingAlgorithm *QgsProcessingAlgorithm::create() const
 {
   std::unique_ptr< QgsProcessingAlgorithm > creation( createInstance() );
   creation->setProvider( provider() );
+  creation->initAlgorithm();
   return creation.release();
 }
 

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -322,7 +322,15 @@ class CORE_EXPORT QgsProcessingAlgorithm
      *
      * This method should return a 'pristine' instance of the algorithm class.
      */
-    virtual QgsProcessingAlgorithm *createInstance() const = 0 SIP_FACTORY;
+    virtual QgsProcessingAlgorithm *createInstance() const = 0;
+#ifdef SIP_RUN
+    SIP_VIRTUAL_CATCHER_CODE
+    PyObject *resObj = sipCallMethod( 0, sipMethod, "" );
+    sipIsErr = !resObj || sipParseResult( 0, sipMethod, resObj, "H2", sipType_QgsProcessingAlgorithm, &sipRes ) < 0;
+    if ( !sipIsErr )
+      sipTransferTo( resObj, Py_None );
+    SIP_END
+#endif
 
     /**
      * Adds a parameter \a definition to the algorithm. Ownership of the definition is transferred to the algorithm.

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -33,6 +33,13 @@ class QgsFeatureSink;
 class QgsProcessingFeedback;
 
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+#include <qgsprocessingmodelalgorithm.h>
+% End
+#endif
+
+
 /**
  * \class QgsProcessingAlgorithm
  * \ingroup core
@@ -41,6 +48,16 @@ class QgsProcessingFeedback;
  */
 class CORE_EXPORT QgsProcessingAlgorithm
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast< QgsProcessingModelAlgorithm * >( sipCpp ) != NULL )
+      sipType = sipType_QgsProcessingModelAlgorithm;
+    else
+      sipType = sipType_QgsProcessingAlgorithm;
+    SIP_END
+#endif
+
   public:
 
     //! Flags indicating how and when an algorithm operates and should be exposed to users

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -62,10 +62,9 @@ class CORE_EXPORT QgsProcessingAlgorithm
 
     virtual ~QgsProcessingAlgorithm();
 
-
-    //! Algorithms cannot be copied - clone() should be used instead
+    //! Algorithms cannot be copied - create() should be used instead
     QgsProcessingAlgorithm( const QgsProcessingAlgorithm &other ) = delete;
-    //! Algorithms cannot be copied- clone() should be used instead
+    //! Algorithms cannot be copied- create() should be used instead
     QgsProcessingAlgorithm &operator=( const QgsProcessingAlgorithm &other ) = delete;
 
     /**

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -57,6 +57,10 @@ class CORE_EXPORT QgsProcessingAlgorithm
 
     /**
      * Constructor for QgsProcessingAlgorithm.
+     *
+     * initAlgorithm() should be called after creating an algorithm to ensure it can correctly configure
+     * its parameterDefinitions() and outputDefinitions(). Alternatively, calling create() will return
+     * a pre-initialized copy of the algorithm.
      */
     QgsProcessingAlgorithm() = default;
 
@@ -69,6 +73,11 @@ class CORE_EXPORT QgsProcessingAlgorithm
 
     /**
      * Creates a copy of the algorithm, ready for execution.
+     *
+     * This method returns a new, preinitialized copy of the algorithm, ready for
+     * executing.
+     *
+     * \see initAlgorithm()
      */
     QgsProcessingAlgorithm *create() const SIP_FACTORY;
 
@@ -333,9 +342,33 @@ class CORE_EXPORT QgsProcessingAlgorithm
 #endif
 
     /**
+     * Initializes the algorithm using the specified \a configuration.
+     *
+     * This should be called directly after creating algorithms and before retrieving
+     * any parameterDefinitions() or outputDefinitions().
+     *
+     * Subclasses should use their implementations to add all required input parameter and output
+     * definitions (which can be dynamically adjusted according to \a configuration).
+     *
+     * Dynamic configuration can be used by algorithms which alter their behavior
+     * when used inside processing models. For instance, a "feature router" type
+     * algorithm which sends input features to one of any number of outputs sinks
+     * based on some preconfigured filter parameters can use the init method to
+     * create these outputs based on the specified \a configuration.
+     *
+     * \see addParameter()
+     * \see addOutput()
+     */
+    virtual void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) = 0;
+
+    /**
      * Adds a parameter \a definition to the algorithm. Ownership of the definition is transferred to the algorithm.
      * Returns true if parameter could be successfully added, or false if the parameter could not be added (e.g.
      * as a result of a duplicate name).
+     *
+     * This should usually be called from a subclass' initAlgorithm() implementation.
+     *
+     * \see initAlgorithm()
      * \see addOutput()
      */
     bool addParameter( QgsProcessingParameterDefinition *parameterDefinition SIP_TRANSFER );
@@ -350,7 +383,11 @@ class CORE_EXPORT QgsProcessingAlgorithm
      * Adds an output \a definition to the algorithm. Ownership of the definition is transferred to the algorithm.
      * Returns true if the output could be successfully added, or false if the output could not be added (e.g.
      * as a result of a duplicate name).
+     *
+     * This should usually be called from a subclass' initAlgorithm() implementation.
+     *
      * \see addParameter()
+     * \see initAlgorithm()
      */
     bool addOutput( QgsProcessingOutputDefinition *outputDefinition SIP_TRANSFER );
 

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
     /**
      * Creates a copy of the algorithm, ready for execution.
      */
-    virtual QgsProcessingAlgorithm *create() const = 0 SIP_FACTORY;
+    QgsProcessingAlgorithm *create() const SIP_FACTORY;
 
     /**
      * Returns the algorithm name, used for identifying the algorithm. This string
@@ -316,6 +316,13 @@ class CORE_EXPORT QgsProcessingAlgorithm
     void setProvider( QgsProcessingProvider *provider );
 
   protected:
+
+    /**
+     * Creates a new instance of the algorithm class.
+     *
+     * This method should return a 'pristine' instance of the algorithm class.
+     */
+    virtual QgsProcessingAlgorithm *createInstance() const = 0 SIP_FACTORY;
 
     /**
      * Adds a parameter \a definition to the algorithm. Ownership of the definition is transferred to the algorithm.

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -77,9 +77,15 @@ class CORE_EXPORT QgsProcessingAlgorithm
      * This method returns a new, preinitialized copy of the algorithm, ready for
      * executing.
      *
+     * The \a configuration argument allows passing of a map of configuration settings
+     * to the algorithm, allowing it to dynamically adjust its initialized parameters
+     * and outputs according to this configuration. This is generally used only for
+     * algorithms in a model, allowing them to adjust their behavior at run time
+     * according to some user configuration.
+     *
      * \see initAlgorithm()
      */
-    QgsProcessingAlgorithm *create() const SIP_FACTORY;
+    QgsProcessingAlgorithm *create( const QVariantMap &configuration = QVariantMap() ) const SIP_FACTORY;
 
     /**
      * Returns the algorithm name, used for identifying the algorithm. This string

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -98,3 +98,14 @@ const QgsProcessingAlgorithm *QgsProcessingRegistry::algorithmById( const QStrin
   return nullptr;
 }
 
+QgsProcessingAlgorithm *QgsProcessingRegistry::createAlgorithmById( const QString &id ) const
+{
+  const QgsProcessingAlgorithm *alg = algorithmById( id );
+  if ( !alg )
+    return nullptr;
+
+  std::unique_ptr< QgsProcessingAlgorithm > creation( alg->create() );
+  creation->setProvider( alg->provider() );
+  return creation.release();
+}
+

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -105,7 +105,6 @@ QgsProcessingAlgorithm *QgsProcessingRegistry::createAlgorithmById( const QStrin
     return nullptr;
 
   std::unique_ptr< QgsProcessingAlgorithm > creation( alg->create() );
-  creation->setProvider( alg->provider() );
   return creation.release();
 }
 

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -98,13 +98,13 @@ const QgsProcessingAlgorithm *QgsProcessingRegistry::algorithmById( const QStrin
   return nullptr;
 }
 
-QgsProcessingAlgorithm *QgsProcessingRegistry::createAlgorithmById( const QString &id ) const
+QgsProcessingAlgorithm *QgsProcessingRegistry::createAlgorithmById( const QString &id, const QVariantMap &configuration ) const
 {
   const QgsProcessingAlgorithm *alg = algorithmById( id );
   if ( !alg )
     return nullptr;
 
-  std::unique_ptr< QgsProcessingAlgorithm > creation( alg->create() );
+  std::unique_ptr< QgsProcessingAlgorithm > creation( alg->create( configuration ) );
   return creation.release();
 }
 

--- a/src/core/processing/qgsprocessingregistry.h
+++ b/src/core/processing/qgsprocessingregistry.h
@@ -102,11 +102,18 @@ class CORE_EXPORT QgsProcessingRegistry : public QObject
 
     /**
      * Creates a new instance of an algorithm by its ID. If no matching algorithm is found, a nullptr
-     * is returned. Callers take responsibility for deleting the returned object.`
+     * is returned. Callers take responsibility for deleting the returned object.
+     *
+     * The \a configuration argument allows passing of a map of configuration settings
+     * to the algorithm, allowing it to dynamically adjust its initialized parameters
+     * and outputs according to this configuration. This is generally used only for
+     * algorithms in a model, allowing them to adjust their behavior at run time
+     * according to some user configuration.
+     *
      * \see algorithms()
      * \see algorithmById()
      */
-    QgsProcessingAlgorithm *createAlgorithmById( const QString &id ) const SIP_FACTORY;
+    QgsProcessingAlgorithm *createAlgorithmById( const QString &id, const QVariantMap &configuration = QVariantMap() ) const SIP_FACTORY;
 
   signals:
 

--- a/src/core/processing/qgsprocessingregistry.h
+++ b/src/core/processing/qgsprocessingregistry.h
@@ -96,8 +96,17 @@ class CORE_EXPORT QgsProcessingRegistry : public QObject
      * Finds an algorithm by its ID. If no matching algorithm is found, a nullptr
      * is returned.
      * \see algorithms()
+     * \see createAlgorithmById()
      */
     const QgsProcessingAlgorithm *algorithmById( const QString &id ) const;
+
+    /**
+     * Creates a new instance of an algorithm by its ID. If no matching algorithm is found, a nullptr
+     * is returned. Callers take responsibility for deleting the returned object.`
+     * \see algorithms()
+     * \see algorithmById()
+     */
+    QgsProcessingAlgorithm *createAlgorithmById( const QString &id ) const SIP_FACTORY;
 
   signals:
 

--- a/src/core/qgis_sip.h
+++ b/src/core/qgis_sip.h
@@ -179,5 +179,9 @@
  */
 #define SIP_ABSTRACT
 
+/*
+ * Virtual catcher code
+ */
+#define SIP_VIRTUAL_CATCHER_CODE(code)
 
 #endif // QGIS_SIP_H

--- a/tests/src/core/testqgsprocessing.cpp
+++ b/tests/src/core/testqgsprocessing.cpp
@@ -827,6 +827,17 @@ void TestQgsProcessing::algorithm()
   QVERIFY( !r.algorithmById( "p1:alg3" ) );
   QVERIFY( !r.algorithmById( "px:alg1" ) );
 
+  // createAlgorithmById
+  QVERIFY( !r.createAlgorithmById( "p1:alg3" ) );
+  std::unique_ptr< QgsProcessingAlgorithm > creation( r.createAlgorithmById( "p1:alg1" ) );
+  QVERIFY( creation.get() );
+  QCOMPARE( creation->provider()->id(), QStringLiteral( "p1" ) );
+  QCOMPARE( creation->id(), QStringLiteral( "p1:alg1" ) );
+  creation.reset( r.createAlgorithmById( "p1:alg2" ) );
+  QVERIFY( creation.get() );
+  QCOMPARE( creation->provider()->id(), QStringLiteral( "p1" ) );
+  QCOMPARE( creation->id(), QStringLiteral( "p1:alg2" ) );
+
   //test that loading a provider triggers an algorithm refresh
   DummyProvider *p2 = new DummyProvider( "p2" );
   QVERIFY( p2->algorithms().isEmpty() );

--- a/tests/src/core/testqgsprocessing.cpp
+++ b/tests/src/core/testqgsprocessing.cpp
@@ -40,6 +40,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
 
     DummyAlgorithm( const QString &name ) : mName( name ) { mFlags = QgsProcessingAlgorithm::flags(); }
 
+    void initAlgorithm( const QVariantMap & = QVariantMap() ) override {}
     QString name() const override { return mName; }
     QString displayName() const override { return mName; }
     QVariantMap processAlgorithm( const QVariantMap &, QgsProcessingContext &, QgsProcessingFeedback * ) override { return QVariantMap(); }

--- a/tests/src/core/testqgsprocessing.cpp
+++ b/tests/src/core/testqgsprocessing.cpp
@@ -4284,6 +4284,11 @@ void TestQgsProcessing::modelerAlgorithm()
   child.setAlgorithmId( QStringLiteral( "native:centroids" ) );
   QVERIFY( child.algorithm() );
   QCOMPARE( child.algorithm()->id(), QStringLiteral( "native:centroids" ) );
+  QVariantMap myConfig;
+  myConfig.insert( QStringLiteral( "some_key" ), 11 );
+  child.setConfiguration( myConfig );
+  QCOMPARE( child.configuration(), myConfig );
+
   child.setDescription( QStringLiteral( "desc" ) );
   QCOMPARE( child.description(), QStringLiteral( "desc" ) );
   QVERIFY( child.isActive() );
@@ -4593,6 +4598,7 @@ void TestQgsProcessing::modelerAlgorithm()
   QgsProcessingModelChildAlgorithm alg5c1;
   alg5c1.setChildId( "cx1" );
   alg5c1.setAlgorithmId( "buffer" );
+  alg5c1.setConfiguration( myConfig );
   alg5c1.addParameterSources( "x", QgsProcessingModelChildParameterSources() << QgsProcessingModelChildParameterSource::fromModelParameter( "p1" ) );
   alg5c1.addParameterSources( "y", QgsProcessingModelChildParameterSources() << QgsProcessingModelChildParameterSource::fromChildOutput( "cx2", "out3" ) );
   alg5c1.addParameterSources( "z", QgsProcessingModelChildParameterSources() << QgsProcessingModelChildParameterSource::fromStaticValue( 5 ) );
@@ -4639,6 +4645,7 @@ void TestQgsProcessing::modelerAlgorithm()
   QgsProcessingModelChildAlgorithm alg6c1 = alg6.childAlgorithm( "cx1" );
   QCOMPARE( alg6c1.childId(), QStringLiteral( "cx1" ) );
   QCOMPARE( alg6c1.algorithmId(), QStringLiteral( "buffer" ) );
+  QCOMPARE( alg6c1.configuration(), myConfig );
   QVERIFY( alg6c1.isActive() );
   QVERIFY( alg6c1.outputsCollapsed() );
   QVERIFY( alg6c1.parametersCollapsed() );

--- a/tests/src/core/testqgsprocessing.cpp
+++ b/tests/src/core/testqgsprocessing.cpp
@@ -45,7 +45,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
     QVariantMap processAlgorithm( const QVariantMap &, QgsProcessingContext &, QgsProcessingFeedback * ) override { return QVariantMap(); }
 
     virtual Flags flags() const override { return mFlags; }
-    DummyAlgorithm *create() const override { return new DummyAlgorithm( name() ); }
+    DummyAlgorithm *createInstance() const override { return new DummyAlgorithm( name() ); }
 
     QString mName;
 
@@ -334,6 +334,7 @@ class TestQgsProcessing: public QObject
     void modelAcceptableValues();
     void tempUtils();
     void convertCompatible();
+    void create();
 
   private:
 
@@ -5124,6 +5125,17 @@ void TestQgsProcessing::convertCompatible()
   QVERIFY( out != layer->source() );
   QVERIFY( out.endsWith( ".shp" ) );
   QVERIFY( out.startsWith( QgsProcessingUtils::tempFolder() ) );
+}
+
+void TestQgsProcessing::create()
+{
+  DummyAlgorithm alg( QStringLiteral( "test" ) );
+  DummyProvider p( QStringLiteral( "test_provider" ) );
+  alg.setProvider( &p );
+
+  std::unique_ptr< QgsProcessingAlgorithm > newInstance( alg.create() );
+  QVERIFY( newInstance.get() );
+  QCOMPARE( newInstance->provider(), &p );
 }
 
 QGSTEST_MAIN( TestQgsProcessing )


### PR DESCRIPTION
This implements some minor refactoring to the QgsProcessingAlgorithm API - looks like a lot of changes, but they aren't that intrusive.

These changes are designed to allow the API to handle some future use cases:

- algorithms can be subclassed and have subclasses add additional parameters/outputs to the algorithm. With the previous approach of declaring parameters/outputs in the constructor, it's not possible to call virtual methods to add additional parameters/ outputs (since you can't call virtual methods from a constructor). Accordingly the algorithm declaration of parameters/outputs was moved to a new virtual initAlgorithm() method.

- initAlgorithm takes a variant map argument, allowing an algorithm to dynamically adjust its declared parameters and outputs according to this configuration map. This potentially allows model algorithms which
can be configured to have variable numbers of parameters and outputs at run time. E.g. a "router" algorithm which directs features to one of any number of output sinks depending on some
user configured criteria. (ping @m-kuhn)

There's nothing user-visible with these changes, it's just making sure we won't be restricted when the 3.0 API freezes.