### PR TITLE
[bugfix] Fixes relation widget reference when filter value contains a quote #16399 (backport)

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -1008,6 +1008,15 @@ class QgsExpression
      */
     static QString formatPreviewString( const QVariant& value );
 
+    /** Create an expression allowing to evaluate if a field is equal to a
+     *  value. The value may be null.
+     * @param fieldName the name of the field
+     * @param value the value of the field
+     * @returns the expression to evaluate field equality
+     * @since QGIS 2.18
+     */
+    static QString createFieldEqualityExpression( const QString &fieldName, const QVariant &value );
+
   protected:
     void initGeomCalculator();
 };

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -5324,6 +5324,18 @@ QVariant QgsExpression::StaticFunction::func( const QVariantList &values, const 
   Q_NOWARN_DEPRECATED_POP
 }
 
+QString QgsExpression::createFieldEqualityExpression( const QString &fieldName, const QVariant &value )
+{
+  QString expr;
+
+  if ( value.isNull() )
+    expr = QString( "%1 IS NULL" ).arg( quotedColumnRef( fieldName ) );
+  else
+    expr = QString( "%1 = %2" ).arg( quotedColumnRef( fieldName ), quotedValue( value ) );
+
+  return expr;
+}
+
 const QgsExpression::Node* QgsExpression::rootNode() const
 {
   return d->mRootNode;

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -1488,6 +1488,15 @@ class CORE_EXPORT QgsExpression
      */
     static QString formatPreviewString( const QVariant& value );
 
+    /** Create an expression allowing to evaluate if a field is equal to a
+     *  value. The value may be null.
+     * @param fieldName the name of the field
+     * @param value the value of the field
+     * @returns the expression to evaluate field equality
+     * @since QGIS 2.18
+     */
+    static QString createFieldEqualityExpression( const QString &fieldName, const QVariant &value );
+
   protected:
     void initGeomCalculator();
 

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -167,19 +167,8 @@ QString QgsRelation::getRelatedFeaturesFilter( const QgsFeature& feature ) const
 
   Q_FOREACH ( const QgsRelation::FieldPair& fieldPair, mFieldPairs )
   {
-    int referencingIdx = referencingLayer()->fields().indexFromName( fieldPair.referencingField() );
-    QgsField referencingField = referencingLayer()->fields().at( referencingIdx );
-
-    if ( referencingField.type() == QVariant::String )
-    {
-      // Use quotes
-      conditions << QString( "\"%1\" = '%2'" ).arg( fieldPair.referencingField(), feature.attribute( fieldPair.referencedField() ).toString() );
-    }
-    else
-    {
-      // No quotes
-      conditions << QString( "\"%1\" = %2" ).arg( fieldPair.referencingField(), feature.attribute( fieldPair.referencedField() ).toString() );
-    }
+    QVariant val( feature.attribute( fieldPair.referencedField() ) );
+    conditions << QgsExpression::createFieldEqualityExpression( fieldPair.referencingField(), val );
   }
 
   return conditions.join( " AND " );
@@ -191,21 +180,8 @@ QgsFeatureRequest QgsRelation::getReferencedFeatureRequest( const QgsAttributes&
 
   Q_FOREACH ( const QgsRelation::FieldPair& fieldPair, mFieldPairs )
   {
-    int referencedIdx = referencedLayer()->fields().indexFromName( fieldPair.referencedField() );
     int referencingIdx = referencingLayer()->fields().indexFromName( fieldPair.referencingField() );
-
-    QgsField referencedField = referencedLayer()->fields().at( referencedIdx );
-
-    if ( referencedField.type() == QVariant::String )
-    {
-      // Use quotes
-      conditions << QString( "\"%1\" = '%2'" ).arg( fieldPair.referencedField(), attributes.at( referencingIdx ).toString() );
-    }
-    else
-    {
-      // No quotes
-      conditions << QString( "\"%1\" = %2" ).arg( fieldPair.referencedField(), attributes.at( referencingIdx ).toString() );
-    }
+    conditions << QgsExpression::createFieldEqualityExpression( fieldPair.referencedField(), attributes.at( referencingIdx ) );
   }
 
   QgsFeatureRequest myRequest;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -846,14 +846,7 @@ void QgsRelationReferenceWidget::filterChanged()
       }
       else
       {
-        if ( mReferencedLayer->fields().field( fieldName ).type() == QVariant::String )
-        {
-          filters << QString( "\"%1\" = '%2'" ).arg( fieldName, cb->currentText() );
-        }
-        else
-        {
-          filters << QString( "\"%1\" = %2" ).arg( fieldName, cb->currentText() );
-        }
+        filters << QgsExpression::createFieldEqualityExpression( fieldName, cb->currentText() );
       }
       attrs << mReferencedLayer->fieldNameIndex( fieldName );
     }

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -195,5 +195,39 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         e.setExpression('1')
         self.assertTrue(e.isValid())
 
+    def testCreateFieldEqualityExpression(self):
+        e = QgsExpression()
+
+        # test when value is null
+        field = "myfield"
+        value = None
+        res = '"myfield" IS NULL'
+        self.assertEqual(e.createFieldEqualityExpression(field, value), res)
+
+        # test when value is null and field name has a quote
+        field = "my'field"
+        value = None
+        res = '"my\'field" IS NULL'
+        self.assertEqual(e.createFieldEqualityExpression(field, value), res)
+
+        # test when field name has a quote and value is an int
+        field = "my'field"
+        value = 5
+        res = '"my\'field" = 5'
+        self.assertEqual(e.createFieldEqualityExpression(field, value), res)
+
+        # test when field name has a quote and value is a string
+        field = "my'field"
+        value = '5'
+        res = '"my\'field" = \'5\''
+        self.assertEqual(e.createFieldEqualityExpression(field, value), res)
+
+        # test when field name has a quote and value is a boolean
+        field = "my'field"
+        value = True
+        res = '"my\'field" = TRUE'
+        self.assertEqual(e.createFieldEqualityExpression(field, value), res)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

( @nyalldawson this PR is a backport of https://github.com/qgis/QGIS/pull/4810)

This PR fixes the relation widget reference when filter value contains a quote (see https://issues.qgis.org/issues/16399).

Moreover, a unit test has been added to highlight the issue and there are other fixes about filtering safety.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
