### PR TITLE
[FEATURE] Constraints are resolved for joined fields

### DIFF
--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -127,6 +127,18 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
 .. versionadded:: 2.16
 %End
 
+    void updateConstraint( const QgsVectorLayer *layer, int index, const QgsFeature &feature, QgsFieldConstraints::ConstraintOrigin constraintOrigin = QgsFieldConstraints::ConstraintOriginNotSet );
+%Docstring
+ Update constraint on a feature coming from a specific layer.
+ \param layer The vector layer where the feature is defined
+ \param index The index of the field to check
+ \param feature The feature to use to evaluate the constraint
+ \param constraintOrigin Optional origin for constraints to check. This
+ can be used to limit the constraints tested to only provider or layer
+ based constraints.
+.. versionadded:: 3.0
+%End
+
     bool isValidConstraint() const;
 %Docstring
  Get the current constraint status.

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -416,10 +416,11 @@ QgsFeature QgsVectorLayerJoinBuffer::joinedFeatureOf( const QgsVectorLayerJoinIn
 
   if ( info->joinLayer() )
   {
+    joinedFeature.setFields( info->joinLayer()->fields() );
+
+    QString joinFieldName = info->joinFieldName();
     const QVariant targetValue = feature.attribute( info->targetFieldName() );
-    QString fieldRef = QgsExpression::quotedColumnRef( info->joinFieldName() );
-    QString quotedVal = QgsExpression::quotedValue( targetValue.toString() );
-    const QString filter = QStringLiteral( "%1 = %2" ).arg( fieldRef, quotedVal );
+    QString filter = QgsExpression::createFieldEqualityExpression( joinFieldName, targetValue );
 
     QgsFeatureRequest request;
     request.setFilterExpression( filter );

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -18,6 +18,8 @@
 #include "qgsvectordataprovider.h"
 #include "qgsfields.h"
 #include "qgsvectorlayerutils.h"
+#include "qgsvectorlayerjoinbuffer.h"
+#include "qgsvectorlayerjoininfo.h"
 
 #include <QTableView>
 
@@ -119,8 +121,13 @@ void QgsEditorWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult cons
 
 void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft, QgsFieldConstraints::ConstraintOrigin constraintOrigin )
 {
+  updateConstraint( layer(), mFieldIdx, ft, constraintOrigin );
+}
+
+void QgsEditorWidgetWrapper::updateConstraint( const QgsVectorLayer *layer, int index, const QgsFeature &ft, QgsFieldConstraints::ConstraintOrigin constraintOrigin )
+{
   bool toEmit( false );
-  QgsField field = layer()->fields().at( mFieldIdx );
+  QgsField field = layer->fields().at( index );
 
   QString expression = field.constraints().constraintExpression();
   QStringList expressions, descriptions;
@@ -161,10 +168,10 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft, QgsFieldCon
   }
 
   QStringList errors;
-  bool hardConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer(), ft, mFieldIdx, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
+  bool hardConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
 
   QStringList softErrors;
-  bool softConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer(), ft, mFieldIdx, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
+  bool softConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
   errors << softErrors;
 
   mValidConstraint = hardConstraintsOk && softConstraintsOk;

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -126,53 +126,71 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft, QgsFieldCon
 
 void QgsEditorWidgetWrapper::updateConstraint( const QgsVectorLayer *layer, int index, const QgsFeature &ft, QgsFieldConstraints::ConstraintOrigin constraintOrigin )
 {
-  bool toEmit( false );
-  QgsField field = layer->fields().at( index );
-
-  QString expression = field.constraints().constraintExpression();
-  QStringList expressions, descriptions;
-
-  if ( ! expression.isEmpty() )
-  {
-    expressions << expression;
-    descriptions << field.constraints().constraintDescription();
-    toEmit = true;
-  }
-
-  if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintNotNull )
-  {
-    descriptions << tr( "Not NULL" );
-    if ( !expression.isEmpty() )
-    {
-      expressions << field.name() + QStringLiteral( " IS NOT NULL" );
-    }
-    else
-    {
-      expressions << QStringLiteral( "IS NOT NULL" );
-    }
-    toEmit = true;
-  }
-
-  if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
-  {
-    descriptions << tr( "Unique" );
-    if ( !expression.isEmpty() )
-    {
-      expressions << field.name() + QStringLiteral( " IS UNIQUE" );
-    }
-    else
-    {
-      expressions << QStringLiteral( "IS UNIQUE" );
-    }
-    toEmit = true;
-  }
-
   QStringList errors;
-  bool hardConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
-
   QStringList softErrors;
-  bool softConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
-  errors << softErrors;
+  QStringList expressions;
+  QStringList descriptions;
+  bool toEmit( false );
+  bool hardConstraintsOk( true );
+  bool softConstraintsOk( true );
+
+  QgsField field = layer->fields().at( index );
+  QString expression = field.constraints().constraintExpression();
+
+  if ( ft.isValid() )
+  {
+    if ( ! expression.isEmpty() )
+    {
+      expressions << expression;
+      descriptions << field.constraints().constraintDescription();
+      toEmit = true;
+    }
+
+    if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintNotNull )
+    {
+      descriptions << tr( "Not NULL" );
+      if ( !expression.isEmpty() )
+      {
+        expressions << field.name() + QStringLiteral( " IS NOT NULL" );
+      }
+      else
+      {
+        expressions << QStringLiteral( "IS NOT NULL" );
+      }
+      toEmit = true;
+    }
+
+    if ( field.constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
+    {
+      descriptions << tr( "Unique" );
+      if ( !expression.isEmpty() )
+      {
+        expressions << field.name() + QStringLiteral( " IS UNIQUE" );
+      }
+      else
+      {
+        expressions << QStringLiteral( "IS UNIQUE" );
+      }
+      toEmit = true;
+    }
+
+    hardConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
+
+    softConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
+    errors << softErrors;
+  }
+  else // invalid feature
+  {
+    if ( ! expression.isEmpty() )
+    {
+      hardConstraintsOk = true;
+      softConstraintsOk = false;
+
+      errors << "Invalid feature";
+
+      toEmit = true;
+    }
+  }
 
   mValidConstraint = hardConstraintsOk && softConstraintsOk;
   mIsBlockingCommit = !hardConstraintsOk;

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -139,6 +139,18 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     void updateConstraint( const QgsFeature &featureContext, QgsFieldConstraints::ConstraintOrigin constraintOrigin = QgsFieldConstraints::ConstraintOriginNotSet );
 
     /**
+     * Update constraint on a feature coming from a specific layer.
+     * \param layer The vector layer where the feature is defined
+     * \param index The index of the field to check
+     * \param feature The feature to use to evaluate the constraint
+     * \param constraintOrigin Optional origin for constraints to check. This
+     * can be used to limit the constraints tested to only provider or layer
+     * based constraints.
+     * \since QGIS 3.0
+     */
+    void updateConstraint( const QgsVectorLayer *layer, int index, const QgsFeature &feature, QgsFieldConstraints::ConstraintOrigin constraintOrigin = QgsFieldConstraints::ConstraintOriginNotSet );
+
+    /**
      * Get the current constraint status.
      * \returns true if the constraint is valid or if there's no constraint,
      * false otherwise

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -318,6 +318,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     //! constraints management
     void updateAllConstraints();
     void updateConstraints( QgsEditorWidgetWrapper *w );
+    void updateConstraint( const QgsFeature &ft, QgsEditorWidgetWrapper *eww );
     bool currentFormFeature( QgsFeature &feature );
     bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions );
     QList<QgsEditorWidgetWrapper *> constraintDependencies( QgsEditorWidgetWrapper *w );
@@ -340,6 +341,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QList<QgsAttributeFormInterface *> mInterfaces;
     QMap< int, QgsAttributeFormEditorWidget * > mFormEditorWidgets;
     QgsExpressionContext mExpressionContext;
+    QMap<const QgsVectorLayerJoinInfo *, QgsFeature> mJoinedFeatures;
 
     struct ContainerInformation
     {


### PR DESCRIPTION
## Description

When the option *Dynamic form* is activated in the join configuration, constraints for joined fields are properly updated in the form during the creation/modification of a feature in the target layer.

In the next screenshot, we're modifying the *id* field in the target layer which is used for joining. Constraints on joined fields (like *p1_x* or *p2_y*) are resolved on the fly:

![c0](https://user-images.githubusercontent.com/9266424/28356593-8e2ed8d2-6c60-11e7-8f3a-72c080cdc0c0.png)

Moreover, if a constraint is defined on a joined field and the corresponding joined feature does not exist, then the constraint is *soft* failing with the next warning : *Invalid feature*.

In the next screenshot, we're creating a new feature in the target layer with *id = 3*. In this case we know that:
- a feature yet exists in the layer *p2* with a join id equals to 3 and the constraint is valid for *p2_y*
- there's no feature in the layer *p1* with a join id equals to 3 so the constraint cannot be properly resolved

![c1](https://user-images.githubusercontent.com/9266424/28356964-bb469a70-6c61-11e7-9869-8ca2aafedc6c.png)

Some tests have been added to validate the behavior.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
