### PR TITLE
[processing] Simplify output creation

### DIFF
--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -392,13 +392,20 @@ class QgsProcessingAlgorithm
 .. seealso:: addOutput()
 %End
 
-    bool addParameter( QgsProcessingParameterDefinition *parameterDefinition /Transfer/ );
+    bool addParameter( QgsProcessingParameterDefinition *parameterDefinition /Transfer/, bool createOutput = true );
 %Docstring
  Adds a parameter ``definition`` to the algorithm. Ownership of the definition is transferred to the algorithm.
  Returns true if parameter could be successfully added, or false if the parameter could not be added (e.g.
  as a result of a duplicate name).
 
  This should usually be called from a subclass' initAlgorithm() implementation.
+
+ If the ``createOutput`` argument is true, then a corresponding output definition will also be created
+ (and added to the algorithm) where appropriate. E.g. when adding a QgsProcessingParameterVectorDestination
+ and ``createOutput`` is true, then a QgsProcessingOutputVectorLayer output will be created and
+ added to the algorithm. There is no need to call addOutput() to manually add a corresponding output
+ for this vector. If ``createOutput`` is false then this automatic output creation will not
+ occur.
 
 .. seealso:: initAlgorithm()
 .. seealso:: addOutput()
@@ -418,6 +425,9 @@ class QgsProcessingAlgorithm
  as a result of a duplicate name).
 
  This should usually be called from a subclass' initAlgorithm() implementation.
+
+ Note that in some cases output creation can be automatically performed when calling addParameter().
+ See the notes in addParameter() for a description of when this occurs.
 
 .. seealso:: addParameter()
 .. seealso:: initAlgorithm()

--- a/python/plugins/processing/algs/qgis/AddTableField.py
+++ b/python/plugins/processing/algs/qgis/AddTableField.py
@@ -27,16 +27,12 @@ __revision__ = '$Format:%H$'
 
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (QgsField,
-                       QgsFeature,
                        QgsFeatureSink,
-                       QgsApplication,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterString,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterEnum,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -73,7 +69,6 @@ class AddTableField(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.FIELD_PRECISION,
                                                        self.tr('Field precision'), QgsProcessingParameterNumber.Integer, 0, False, 0, 10))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT_LAYER, self.tr('Added')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT_LAYER, self.tr('Added')))
 
     def name(self):
         return 'addfieldtoattributestable'

--- a/python/plugins/processing/algs/qgis/Aspect.py
+++ b/python/plugins/processing/algs/qgis/Aspect.py
@@ -32,13 +32,8 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.analysis import QgsAspectFilter
 from qgis.core import (QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterRasterDestination,
-                       QgsProcessingOutputRasterLayer,
-                       QgsFeatureSink)
+                       QgsProcessingParameterRasterDestination)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
-from processing.core.parameters import ParameterRaster
-from processing.core.parameters import ParameterNumber
-from processing.core.outputs import OutputRaster
 from processing.tools import raster
 from processing.tools.dataobjects import exportRasterLayer
 

--- a/python/plugins/processing/algs/qgis/Aspect.py
+++ b/python/plugins/processing/algs/qgis/Aspect.py
@@ -67,7 +67,6 @@ class Aspect(QgisAlgorithm):
                                                        self.tr('Z factor'), QgsProcessingParameterNumber.Double,
                                                        1, False, 1, 999999.99))
         self.addParameter(QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr('Aspect')))
-        self.addOutput(QgsProcessingOutputRasterLayer(self.OUTPUT, self.tr('Aspect')))
 
     def name(self):
         return 'aspect'

--- a/python/plugins/processing/algs/qgis/AutoincrementalField.py
+++ b/python/plugins/processing/algs/qgis/AutoincrementalField.py
@@ -27,13 +27,9 @@ __revision__ = '$Format:%H$'
 
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (QgsField,
-                       QgsFeature,
                        QgsFeatureSink,
-                       QgsApplication,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -50,7 +46,6 @@ class AutoincrementalField(QgisAlgorithm):
                                                               self.tr('Input layer')))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Incremented')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Incremented')))
 
     def group(self):
         return self.tr('Vector table tools')

--- a/python/plugins/processing/algs/qgis/BasicStatistics.py
+++ b/python/plugins/processing/algs/qgis/BasicStatistics.py
@@ -32,11 +32,9 @@ from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsStatisticalSummary,
-                       QgsFeatureSink,
                        QgsStringStatisticalSummary,
                        QgsDateTimeStatisticalSummary,
                        QgsFeatureRequest,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFileDestination,

--- a/python/plugins/processing/algs/qgis/Boundary.py
+++ b/python/plugins/processing/algs/qgis/Boundary.py
@@ -31,19 +31,13 @@ from qgis.core import (QgsGeometry,
                        QgsWkbTypes,
                        QgsFeatureSink,
                        QgsProcessing,
-                       QgsProcessingUtils,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 
 from qgis.PyQt.QtGui import QIcon
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
-from processing.core.parameters import ParameterVector
-from processing.core.outputs import OutputVector
-from processing.tools import dataobjects
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
@@ -59,7 +53,6 @@ class Boundary(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER, self.tr('Input layer'), [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT_LAYER, self.tr('Boundary')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT_LAYER, self.tr("Boundaries")))
 
     def icon(self):
         return QIcon(os.path.join(pluginPath, 'images', 'ftools', 'convex_hull.png'))

--- a/python/plugins/processing/algs/qgis/BoundingBox.py
+++ b/python/plugins/processing/algs/qgis/BoundingBox.py
@@ -31,20 +31,14 @@ from qgis.core import (QgsGeometry,
                        QgsWkbTypes,
                        QgsFeatureSink,
                        QgsProcessing,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingParameterDefinition)
+                       QgsProcessingParameterFeatureSink)
 
 
 from qgis.PyQt.QtGui import QIcon
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
-from processing.core.parameters import ParameterVector
-from processing.core.outputs import OutputVector
-from processing.tools import dataobjects
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
@@ -66,7 +60,6 @@ class BoundingBox(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT_LAYER, self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT_LAYER, self.tr('Bounds'), QgsProcessing.TypeVectorPolygon))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT_LAYER, self.tr("Bounds")))
 
     def name(self):
         return 'boundingboxes'

--- a/python/plugins/processing/algs/qgis/CheckValidity.py
+++ b/python/plugins/processing/algs/qgis/CheckValidity.py
@@ -37,15 +37,12 @@ from qgis.core import (QgsSettings,
                        QgsFeatureRequest,
                        QgsFeatureSink,
                        QgsWkbTypes,
-                       QgsProcessingUtils,
                        QgsFields,
                        QgsProcessing,
                        QgsProcessingFeatureSource,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingOutputNumber
                        )
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
@@ -85,15 +82,12 @@ class CheckValidity(QgisAlgorithm):
                                                      self.tr('Method'), self.methods))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.VALID_OUTPUT, self.tr('Valid output'), QgsProcessing.TypeVectorAny, '', True))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.VALID_OUTPUT, self.tr('Valid output')))
         self.addOutput(QgsProcessingOutputNumber(self.VALID_COUNT, self.tr('Count of valid features')))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.INVALID_OUTPUT, self.tr('Invalid output'), QgsProcessing.TypeVectorAny, '', True))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.INVALID_OUTPUT, self.tr('Invalid output')))
         self.addOutput(QgsProcessingOutputNumber(self.INVALID_COUNT, self.tr('Count of invalid features')))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.ERROR_OUTPUT, self.tr('Error output'), QgsProcessing.TypeVectorAny, '', True))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.ERROR_OUTPUT, self.tr('Error output')))
         self.addOutput(QgsProcessingOutputNumber(self.ERROR_COUNT, self.tr('Count of errors')))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/ConcaveHull.py
+++ b/python/plugins/processing/algs/qgis/ConcaveHull.py
@@ -26,9 +26,7 @@ __copyright__ = '(C) 2014, Piotr Pociask'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsFeatureRequest,
-                       QgsFeature,
-                       QgsGeometry,
+from qgis.core import (QgsFeature,
                        QgsFeatureSink,
                        QgsWkbTypes,
                        QgsProcessing,

--- a/python/plugins/processing/algs/qgis/ConcaveHull.py
+++ b/python/plugins/processing/algs/qgis/ConcaveHull.py
@@ -31,16 +31,11 @@ from qgis.core import (QgsFeatureRequest,
                        QgsGeometry,
                        QgsFeatureSink,
                        QgsWkbTypes,
-                       QgsApplication,
                        QgsProcessing,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterVectorLayer,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterBoolean,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
 import processing
@@ -73,7 +68,6 @@ class ConcaveHull(QgisAlgorithm):
                                                         self.tr('Split multipart geometry into singleparts geometries'), defaultValue=False))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Concave hull'), type=QgsProcessing.TypeVectorPolygon))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Concave hull"), type=QgsProcessing.TypeVectorPolygon))
 
     def name(self):
         return 'concavehull'

--- a/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
+++ b/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
@@ -29,7 +29,6 @@ from qgis.core import (QgsVectorDataProvider,
                        QgsFields,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterField,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingOutputVectorLayer)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm

--- a/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
+++ b/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
@@ -27,7 +27,6 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsVectorDataProvider,
                        QgsFields,
-                       QgsApplication,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterField,
                        QgsProcessingParameterDefinition,

--- a/python/plugins/processing/algs/qgis/Delaunay.py
+++ b/python/plugins/processing/algs/qgis/Delaunay.py
@@ -40,7 +40,7 @@ from qgis.core import (QgsField,
                        QgsWkbTypes,
                        QgsProcessing,
                        QgsFields,
-                       QgsProcessingParameterFeatureSource
+                       QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm

--- a/python/plugins/processing/algs/qgis/Delaunay.py
+++ b/python/plugins/processing/algs/qgis/Delaunay.py
@@ -39,12 +39,9 @@ from qgis.core import (QgsField,
                        QgsPointXY,
                        QgsWkbTypes,
                        QgsProcessing,
-                       QgsProcessingUtils,
                        QgsFields,
-                       QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterDefinition,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSource
+                       QgsProcessingParameterFeatureSink)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
@@ -71,7 +68,6 @@ class Delaunay(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorPoint]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Delaunay triangulation'), type=QgsProcessing.TypeVectorPolygon))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Delaunay triangulation"), type=QgsProcessing.TypeVectorPolygon))
 
     def name(self):
         return 'delaunaytriangulation'

--- a/python/plugins/processing/algs/qgis/DeleteColumn.py
+++ b/python/plugins/processing/algs/qgis/DeleteColumn.py
@@ -25,13 +25,10 @@ __copyright__ = '(C) 2010, Michael Minn'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsApplication,
-                       QgsFeatureSink,
-                       QgsProcessingUtils,
+from qgis.core import (QgsFeatureSink,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink,
-                       QgsProcessingParameterField,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterField)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -57,7 +54,6 @@ class DeleteColumn(QgisAlgorithm):
                                                       None, self.INPUT, QgsProcessingParameterField.Any, True))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Output layer')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Output layer")))
 
     def name(self):
         return 'deletecolumn'

--- a/python/plugins/processing/algs/qgis/DeleteHoles.py
+++ b/python/plugins/processing/algs/qgis/DeleteHoles.py
@@ -24,15 +24,11 @@ __copyright__ = '(C) 2015, Etienne Trimaille'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsApplication,
-                       QgsFeatureSink,
+from qgis.core import (QgsFeatureSink,
                        QgsProcessing,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingParameterDefinition)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -53,7 +49,6 @@ class DeleteHoles(QgisAlgorithm):
                                                        0, True, 0.0, 10000000.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Cleaned'), QgsProcessing.TypeVectorPolygon))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Cleaned'), QgsProcessing.TypeVectorPolygon))
 
     def tags(self):
         return self.tr('remove,delete,drop,holes,rings,fill').split(',')

--- a/python/plugins/processing/algs/qgis/DensifyGeometries.py
+++ b/python/plugins/processing/algs/qgis/DensifyGeometries.py
@@ -28,15 +28,11 @@ __revision__ = '$Format:%H$'
 
 import os
 
-from qgis.core import (QgsWkbTypes,
-                       QgsFeatureSink,
-                       QgsApplication,
+from qgis.core import (QgsFeatureSink,
                        QgsProcessing,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingParameterDefinition)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -63,7 +59,6 @@ class DensifyGeometries(QgisAlgorithm):
                                                        1, False, 1, 10000000))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Densified')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Densified')))
 
     def name(self):
         return 'densifygeometries'

--- a/python/plugins/processing/algs/qgis/DensifyGeometriesInterval.py
+++ b/python/plugins/processing/algs/qgis/DensifyGeometriesInterval.py
@@ -27,17 +27,11 @@ __copyright__ = '(C) 2012, Anita Graser'
 
 __revision__ = '$Format:%H$'
 
-from math import sqrt
-
-from qgis.core import (QgsWkbTypes,
-                       QgsApplication,
-                       QgsFeatureSink,
+from qgis.core import (QgsFeatureSink,
                        QgsProcessing,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingParameterDefinition)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -61,7 +55,6 @@ class DensifyGeometriesInterval(QgisAlgorithm):
                                                        1, False, 0, 10000000))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Densified')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Densified')))
 
     def name(self):
         return 'densifygeometriesgivenaninterval'

--- a/python/plugins/processing/algs/qgis/Difference.py
+++ b/python/plugins/processing/algs/qgis/Difference.py
@@ -33,13 +33,9 @@ from qgis.core import (QgsFeature,
                        QgsFeatureSink,
                        QgsGeometry,
                        QgsFeatureRequest,
-                       NULL,
                        QgsWkbTypes,
-                       QgsMessageLog,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
+                       QgsProcessingParameterFeatureSink
                        QgsSpatialIndex)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -68,7 +64,6 @@ class Difference(QgisAlgorithm):
                                                               self.tr('Difference layer')))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Difference')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Difference')))
 
     def name(self):
         return 'difference'

--- a/python/plugins/processing/algs/qgis/Difference.py
+++ b/python/plugins/processing/algs/qgis/Difference.py
@@ -35,7 +35,7 @@ from qgis.core import (QgsFeature,
                        QgsFeatureRequest,
                        QgsWkbTypes,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink
+                       QgsProcessingParameterFeatureSink,
                        QgsSpatialIndex)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 

--- a/python/plugins/processing/algs/qgis/DropGeometry.py
+++ b/python/plugins/processing/algs/qgis/DropGeometry.py
@@ -29,12 +29,9 @@ from qgis.core import (QgsFeatureRequest,
                        QgsWkbTypes,
                        QgsFeatureSink,
                        QgsCoordinateReferenceSystem,
-                       QgsApplication,
                        QgsProcessing,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -55,7 +52,6 @@ class DropGeometry(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorPoint, QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Dropped geometry')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Dropped geometry")))
 
     def name(self):
         return 'dropgeometries'

--- a/python/plugins/processing/algs/qgis/ExtentFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ExtentFromLayer.py
@@ -37,19 +37,12 @@ from qgis.core import (QgsField,
                        QgsFeature,
                        QgsWkbTypes,
                        QgsProcessing,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
                        QgsProcessingParameterBoolean,
-                       QgsProcessingParameterDefinition,
                        QgsFields)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
-from processing.core.parameters import ParameterVector
-from processing.core.parameters import ParameterBoolean
-from processing.core.outputs import OutputVector
-from processing.tools import dataobjects
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
@@ -78,8 +71,7 @@ class ExtentFromLayer(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterBoolean(self.BY_FEATURE,
                                                         self.tr('Calculate extent for each feature separately'), False))
 
-        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extent')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Extent"), QgsProcessing.TypeVectorPolygon))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extent'), type=QgsProcessing.TypeVectorPolygon))
 
     def name(self):
         return 'polygonfromlayerextent'

--- a/python/plugins/processing/algs/qgis/FixGeometry.py
+++ b/python/plugins/processing/algs/qgis/FixGeometry.py
@@ -31,10 +31,8 @@ from qgis.core import (QgsWkbTypes,
                        QgsProcessingFeatureSource,
                        QgsGeometry,
                        QgsProcessing,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -56,7 +54,6 @@ class FixGeometry(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Fixed geometries')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Fixed geometries")))
 
     def name(self):
         return 'fixgeometries'

--- a/python/plugins/processing/algs/qgis/GridPolygon.py
+++ b/python/plugins/processing/algs/qgis/GridPolygon.py
@@ -30,9 +30,7 @@ import math
 
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtCore import QVariant
-from qgis.core import (QgsRectangle,
-                       QgsCoordinateReferenceSystem,
-                       QgsField,
+from qgis.core import (QgsField,
                        QgsFeatureSink,
                        QgsFeature,
                        QgsGeometry,
@@ -44,13 +42,10 @@ from qgis.core import (QgsRectangle,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterCrs,
                        QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingParameterDefinition,
                        QgsFields)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
-from processing.tools import dataobjects
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
@@ -102,8 +97,7 @@ class GridPolygon(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterCrs(self.CRS, 'Grid CRS', 'ProjectCrs'))
 
-        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Grid')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Grid'), QgsProcessing.TypeVectorPolygon))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Grid'), type=QgsProcessing.TypeVectorPolygon))
 
     def name(self):
         return 'creategridpolygon'

--- a/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
@@ -27,9 +27,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsVectorLayerExporter,
                        QgsSettings,
-                       QgsApplication,
                        QgsFeatureSink,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterString,
                        QgsProcessingParameterField,

--- a/python/plugins/processing/algs/qgis/Merge.py
+++ b/python/plugins/processing/algs/qgis/Merge.py
@@ -34,18 +34,12 @@ from qgis.core import (QgsFields,
                        QgsFeatureRequest,
                        QgsFeatureSink,
                        QgsProcessing,
-                       QgsProcessingUtils,
                        QgsProcessingParameterMultipleLayers,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
                        QgsMapLayer)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
-from processing.core.parameters import ParameterMultipleInput
-from processing.core.outputs import OutputVector
-from processing.tools import dataobjects
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
@@ -69,7 +63,6 @@ class Merge(QgisAlgorithm):
                                                                QgsProcessing.TypeVectorAny))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Merged')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Merged')))
 
     def name(self):
         return 'mergevectorlayers'

--- a/python/plugins/processing/algs/qgis/PointsLayerFromTable.py
+++ b/python/plugins/processing/algs/qgis/PointsLayerFromTable.py
@@ -31,11 +31,9 @@ from qgis.core import (QgsApplication,
                        QgsFeatureRequest,
                        QgsGeometry,
                        QgsProcessing,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterCrs,
-                       QgsProcessingOutputVectorLayer,
                        QgsProcessingParameterField)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -80,7 +78,6 @@ class PointsLayerFromTable(QgisAlgorithm):
                                                     self.tr('Target CRS'), defaultValue='EPSG:4326'))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Points from table'), type=QgsProcessing.TypeVectorPoint))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Points from table'), type=QgsProcessing.TypeVectorPoint))
 
     def name(self):
         return 'createpointslayerfromtable'

--- a/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
@@ -26,8 +26,7 @@ __copyright__ = '(C) 2012, Victor Olaya, Carterix Geomatics'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsApplication,
-                       QgsProcessingParameterString)
+from qgis.core import (QgsProcessingParameterString)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
 from processing.tools import postgis

--- a/python/plugins/processing/algs/qgis/RandomExtract.py
+++ b/python/plugins/processing/algs/qgis/RandomExtract.py
@@ -32,8 +32,7 @@ from qgis.core import (QgsFeatureSink,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
 
@@ -66,7 +65,6 @@ class RandomExtract(QgisAlgorithm):
                                                        10, False, 0.0, 999999999999.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extracted (random)')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Extracted (random)')))
 
     def name(self):
         return 'randomextract'

--- a/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
@@ -28,15 +28,12 @@ __revision__ = '$Format:%H$'
 
 import random
 
-from qgis.core import (QgsApplication,
-                       QgsFeatureSink,
-                       QgsProcessingUtils,
+from qgis.core import (QgsFeatureSink,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterField,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 from collections import defaultdict
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
@@ -74,7 +71,6 @@ class RandomExtractWithinSubsets(QgisAlgorithm):
                                                        10, False, 0.0, 999999999999.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extracted (random stratified)')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Extracted (random stratified)')))
 
     def name(self):
         return 'randomextractwithinsubsets'

--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -32,16 +32,19 @@ from math import sqrt
 
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtCore import QVariant
-from qgis.core import (QgsRectangle, QgsFields, QgsFeatureSink, QgsField, QgsFeature, QgsWkbTypes,
-                       QgsGeometry, QgsPointXY, QgsCoordinateReferenceSystem,
+from qgis.core import (QgsFields,
+                       QgsFeatureSink,
+                       QgsField,
+                       QgsFeature,
+                       QgsWkbTypes,
+                       QgsGeometry,
+                       QgsPointXY,
                        QgsProcessing,
                        QgsProcessingParameterExtent,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterCrs,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingParameterDefinition,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -82,7 +85,6 @@ class RegularPoints(QgisAlgorithm):
                                                     self.tr('Output layer CRS'), 'ProjectCrs'))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Regular points'), QgsProcessing.TypeVectorPoint))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Regular points'), QgsProcessing.TypeVectorPoint))
 
     def name(self):
         return 'regularpoints'

--- a/python/plugins/processing/algs/qgis/SaveSelectedFeatures.py
+++ b/python/plugins/processing/algs/qgis/SaveSelectedFeatures.py
@@ -27,8 +27,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsFeatureSink,
                        QgsProcessingParameterVectorLayer,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterFeatureSink)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 
@@ -46,7 +45,6 @@ class SaveSelectedFeatures(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT, self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Selection')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Selection")))
 
     def name(self):
         return 'saveselectedfeatures'

--- a/python/plugins/processing/algs/qgis/SelectByAttribute.py
+++ b/python/plugins/processing/algs/qgis/SelectByAttribute.py
@@ -25,10 +25,8 @@ __copyright__ = '(C) 2010, Michael Minn'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsApplication)
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (QgsExpression,
-                       QgsProcessingUtils,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterField,
                        QgsProcessingParameterEnum,

--- a/python/plugins/processing/algs/qgis/SimplifyGeometries.py
+++ b/python/plugins/processing/algs/qgis/SimplifyGeometries.py
@@ -32,12 +32,10 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.core import (QgsMapToPixelSimplifier,
                        QgsMessageLog,
                        QgsFeatureSink,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterEnum,
-                       QgsProcessingParameterNumber,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterNumber)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import dataobjects
@@ -76,7 +74,6 @@ class SimplifyGeometries(QgisAlgorithm):
                                                        self.tr('Tolerance'), minValue=0.0, maxValue=10000000.0, defaultValue=1.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Simplified')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Simplified')))
 
     def name(self):
         return 'simplifygeometries'

--- a/python/plugins/processing/algs/qgis/SimplifyGeometries.py
+++ b/python/plugins/processing/algs/qgis/SimplifyGeometries.py
@@ -32,13 +32,13 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.core import (QgsMapToPixelSimplifier,
                        QgsMessageLog,
                        QgsFeatureSink,
+                       QgsProcessing,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterNumber)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
-from processing.tools import dataobjects
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
@@ -62,7 +62,7 @@ class SimplifyGeometries(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer'),
-                                                              [dataobjects.TYPE_VECTOR_POLYGON, dataobjects.TYPE_VECTOR_LINE]))
+                                                              [QgsProcessing.TypeVectorPolygon, QgsProcessing.TypeVectorLine]))
         self.methods = [self.tr('Distance (Douglas-Peucker)'),
                         'Snap to grid',
                         'Area (Visvalingam)']

--- a/python/plugins/processing/algs/qgis/Smooth.py
+++ b/python/plugins/processing/algs/qgis/Smooth.py
@@ -25,13 +25,10 @@ __copyright__ = '(C) 2015, Nyall Dawson'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsApplication,
-                       QgsFeatureSink,
-                       QgsProcessingUtils,
+from qgis.core import (QgsFeatureSink,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink,
-                       QgsProcessingParameterNumber,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterNumber)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
@@ -66,7 +63,6 @@ class Smooth(QgisAlgorithm):
                                                        defaultValue=180.0, minValue=0.0, maxValue=180.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Smoothed')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Smoothed')))
 
     def name(self):
         return 'smoothgeometry'

--- a/python/plugins/processing/algs/qgis/Smooth.py
+++ b/python/plugins/processing/algs/qgis/Smooth.py
@@ -26,13 +26,13 @@ __copyright__ = '(C) 2015, Nyall Dawson'
 __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsFeatureSink,
+                       QgsProcessing,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterNumber)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
-from processing.tools import dataobjects
 
 
 class Smooth(QgisAlgorithm):
@@ -51,7 +51,7 @@ class Smooth(QgisAlgorithm):
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
-                                                              self.tr('Input layer'), [dataobjects.TYPE_VECTOR_POLYGON, dataobjects.TYPE_VECTOR_LINE]))
+                                                              self.tr('Input layer'), [QgsProcessing.TypeVectorPolygon, QgsProcessing.TypeVectorLine]))
         self.addParameter(QgsProcessingParameterNumber(self.ITERATIONS,
                                                        self.tr('Iterations'),
                                                        defaultValue=1, minValue=1, maxValue=10))

--- a/python/plugins/processing/algs/qgis/SnapGeometries.py
+++ b/python/plugins/processing/algs/qgis/SnapGeometries.py
@@ -29,12 +29,10 @@ from qgis.analysis import (QgsGeometrySnapper,
                            QgsInternalGeometrySnapper)
 from qgis.core import (QgsFeatureSink,
                        QgsProcessing,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterEnum,
-                       QgsProcessingOutputVectorLayer)
+                       QgsProcessingParameterEnum)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -74,7 +72,6 @@ class SnapGeometriesToLayer(QgisAlgorithm):
             options=self.modes, defaultValue=0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Snapped geometry')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Snapped geometry")))
 
     def name(self):
         return 'snapgeometries'

--- a/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
@@ -27,7 +27,6 @@ __copyright__ = '(C) 2016, Mathieu Pellerin'
 __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsDataSourceUri,
-                       QgsApplication,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterString)
 

--- a/python/plugins/processing/algs/qgis/SymmetricalDifference.py
+++ b/python/plugins/processing/algs/qgis/SymmetricalDifference.py
@@ -37,7 +37,7 @@ from qgis.core import (QgsFeature,
                        QgsWkbTypes,
                        QgsMessageLog,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink
+                       QgsProcessingParameterFeatureSink,
                        QgsSpatialIndex)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector

--- a/python/plugins/processing/algs/qgis/SymmetricalDifference.py
+++ b/python/plugins/processing/algs/qgis/SymmetricalDifference.py
@@ -36,10 +36,8 @@ from qgis.core import (QgsFeature,
                        NULL,
                        QgsWkbTypes,
                        QgsMessageLog,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
+                       QgsProcessingParameterFeatureSink
                        QgsSpatialIndex)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector
@@ -69,7 +67,6 @@ class SymmetricalDifference(QgisAlgorithm):
                                                               self.tr('Difference layer')))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Symmetrical difference')))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Symmetrical difference')))
 
     def name(self):
         return 'symmetricaldifference'

--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -37,11 +37,8 @@ from qgis.core import (QgsFeatureRequest,
                        QgsPointXY,
                        QgsWkbTypes,
                        QgsProcessing,
-                       QgsProcessingUtils,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSink,
-                       QgsProcessingOutputVectorLayer,
                        QgsProcessingParameterNumber)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
@@ -73,7 +70,6 @@ class VoronoiPolygons(QgisAlgorithm):
                                                        minValue=0.0, maxValue=9999999999, defaultValue=0.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Voronoi polygons'), type=QgsProcessing.TypeVectorPolygon))
-        self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr("Voronoi polygons"), type=QgsProcessing.TypeVectorPolygon))
 
     def name(self):
         return 'voronoipolygons'

--- a/python/plugins/processing/algs/qgis/ZonalStatistics.py
+++ b/python/plugins/processing/algs/qgis/ZonalStatistics.py
@@ -31,10 +31,7 @@ from collections import OrderedDict
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.analysis import QgsZonalStatistics
-from qgis.core import (QgsFeatureSink,
-                       QgsProcessing,
-                       QgsProcessingUtils,
-                       QgsProcessingParameterDefinition,
+from qgis.core import (QgsProcessing,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterString,

--- a/python/plugins/processing/algs/qgis/scripts/Frequency_analysis.py
+++ b/python/plugins/processing/algs/qgis/scripts/Frequency_analysis.py
@@ -6,8 +6,6 @@
 ##Fields=field multiple Input
 ##Frequency=sink table
 
-#outputs
-##Frequency=output outputVector
 
 from processing.tools.vector import TableWriter
 from collections import defaultdict

--- a/python/plugins/processing/algs/qgis/scripts/Keep_n_biggest_parts.py
+++ b/python/plugins/processing/algs/qgis/scripts/Keep_n_biggest_parts.py
@@ -7,9 +7,6 @@ from builtins import range
 ##To_keep=number 1
 ##Biggest parts=sink polygon
 
-#outputs
-
-##Biggest parts=output outputVector
 
 from qgis.core import QgsGeometry, QgsWkbTypes, QgsProcessingUtils
 from operator import itemgetter

--- a/python/plugins/processing/algs/qgis/scripts/Number_of_unique_values_in_classes.py
+++ b/python/plugins/processing/algs/qgis/scripts/Number_of_unique_values_in_classes.py
@@ -8,8 +8,6 @@
 ##value_field=field input
 ##N_unique_values=sink
 
-#outputs
-##N_unique_values=output outputVector
 
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import QgsFeature, QgsField, QgsProcessingUtils

--- a/python/plugins/processing/tests/testdata/scripts/centroids.py
+++ b/python/plugins/processing/tests/testdata/scripts/centroids.py
@@ -6,10 +6,6 @@
 ##INPUT_LAYER=source
 ##OUTPUT_LAYER=sink point
 
-#outputs
-
-##OUTPUT_LAYER=output outputVector
-
 from qgis.core import QgsWkbTypes, QgsProcessingUtils
 
 fields = INPUT_LAYER.fields()

--- a/python/plugins/processing/tests/testdata/scripts/selectbyattribute.py
+++ b/python/plugins/processing/tests/testdata/scripts/selectbyattribute.py
@@ -6,10 +6,6 @@
 ##INPUT_LAYER=vector
 ##OUTPUT_LAYER=vectorDestination
 
-#outputs
-
-##OUTPUT_LAYER=output outputVector
-
 import processing
 
 result = processing.run("qgis:selectbyattribute",

--- a/python/plugins/processing/tests/testdata/scripts/selectbyexpression.py
+++ b/python/plugins/processing/tests/testdata/scripts/selectbyexpression.py
@@ -6,10 +6,6 @@
 ##INPUT_LAYER=vector
 ##OUTPUT_LAYER=vectorDestination
 
-#outputs
-
-##OUTPUT_LAYER=output outputVector
-
 
 import processing
 

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -73,7 +73,6 @@ void QgsCentroidAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Centroids" ), QgsProcessing::TypeVectorPoint ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Centroids" ), QgsProcessing::TypeVectorPoint ) );
 }
 
 QString QgsCentroidAlgorithm::shortHelpString() const
@@ -150,7 +149,6 @@ void QgsBufferAlgorithm::initAlgorithm( const QVariantMap & )
 
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "DISSOLVE" ), QObject::tr( "Dissolve result" ), false ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Buffered" ), QgsProcessing::TypeVectorPolygon ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Buffered" ), QgsProcessing::TypeVectorPoint ) );
 }
 
 QString QgsBufferAlgorithm::shortHelpString() const
@@ -259,7 +257,6 @@ void QgsDissolveAlgorithm::initAlgorithm( const QVariantMap & )
                 QStringLiteral( "INPUT" ), QgsProcessingParameterField::Any, true, true ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Dissolved" ) ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Dissolved" ) ) );
 }
 
 QString QgsDissolveAlgorithm::shortHelpString() const
@@ -416,7 +413,6 @@ void QgsClipAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Clip layer" ), QList< int >() << QgsProcessing::TypeVectorPolygon ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Clipped" ) ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Clipped" ) ) );
 }
 
 QString QgsClipAlgorithm::shortHelpString() const
@@ -571,7 +567,6 @@ void QgsTransformAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "TARGET_CRS" ), QObject::tr( "Target CRS" ), QStringLiteral( "EPSG:4326" ) ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Reprojected" ) ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Reprojected" ) ) );
 }
 
 QString QgsTransformAlgorithm::shortHelpString() const
@@ -637,7 +632,6 @@ void QgsSubdivideAlgorithm::initAlgorithm( const QVariantMap & )
                 256, false, 8, 100000 ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Subdivided" ) ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Subdivided" ) ) );
 }
 
 QString QgsSubdivideAlgorithm::shortHelpString() const
@@ -710,7 +704,6 @@ void QgsMultipartToSinglepartAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Single parts" ) ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "Single parts" ) ) );
 }
 
 QString QgsMultipartToSinglepartAlgorithm::shortHelpString() const
@@ -794,10 +787,8 @@ void QgsExtractByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExpression( QStringLiteral( "EXPRESSION" ), QObject::tr( "Expression" ), QVariant(), QStringLiteral( "INPUT" ) ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Matching features" ) ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ),  QObject::tr( "Matching (expression)" ) ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "FAIL_OUTPUT" ),  QObject::tr( "Non-matching" ),
                 QgsProcessing::TypeVectorAny, QVariant(), true ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "FAIL_OUTPUT" ),  QObject::tr( "Non-matching (expression)" ) ) );
 }
 
 QString QgsExtractByExpressionAlgorithm::shortHelpString() const
@@ -925,10 +916,8 @@ void QgsExtractByAttributeAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterString( QStringLiteral( "VALUE" ), QObject::tr( "Value" ), QVariant(), false, true ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Extracted (attribute)" ) ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT" ),  QObject::tr( "Matching (attribute)" ) ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "FAIL_OUTPUT" ),  QObject::tr( "Extracted (non-matching)" ),
                 QgsProcessing::TypeVectorAny, QVariant(), true ) );
-  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "FAIL_OUTPUT" ),  QObject::tr( "Non-matching (attribute)" ) ) );
 }
 
 QString QgsExtractByAttributeAlgorithm::shortHelpString() const

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -226,7 +226,7 @@ QString QgsProcessingAlgorithm::asPythonCommand( const QVariantMap &parameters, 
   return s;
 }
 
-bool QgsProcessingAlgorithm::addParameter( QgsProcessingParameterDefinition *definition )
+bool QgsProcessingAlgorithm::addParameter( QgsProcessingParameterDefinition *definition, bool createOutput )
 {
   if ( !definition )
     return false;
@@ -242,7 +242,11 @@ bool QgsProcessingAlgorithm::addParameter( QgsProcessingParameterDefinition *def
   }
 
   mParameters << definition;
-  return true;
+
+  if ( createOutput )
+    return createAutoOutputForParameter( definition );
+  else
+    return true;
 }
 
 void QgsProcessingAlgorithm::removeParameter( const QString &name )
@@ -579,6 +583,28 @@ QList<double> QgsProcessingAlgorithm::parameterAsRange( const QVariantMap &param
 QStringList QgsProcessingAlgorithm::parameterAsFields( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const
 {
   return QgsProcessingParameters::parameterAsFields( parameterDefinition( name ), parameters, context );
+}
+
+bool QgsProcessingAlgorithm::createAutoOutputForParameter( QgsProcessingParameterDefinition *parameter )
+{
+  if ( !parameter->isDestination() )
+    return true; // nothing created, but nothing went wrong - so return true
+
+  QgsProcessingDestinationParameter *dest = static_cast< QgsProcessingDestinationParameter * >( parameter );
+  QgsProcessingOutputDefinition *output( dest->toOutputDefinition() );
+  if ( !output )
+    return true; // nothing created - but nothing went wrong - so return true
+
+  if ( !addOutput( output ) )
+  {
+    // couldn't add output - probably a duplicate name
+    delete output;
+    return false;
+  }
+  else
+  {
+    return true;
+  }
 }
 
 

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -391,10 +391,17 @@ class CORE_EXPORT QgsProcessingAlgorithm
      *
      * This should usually be called from a subclass' initAlgorithm() implementation.
      *
+     * If the \a createOutput argument is true, then a corresponding output definition will also be created
+     * (and added to the algorithm) where appropriate. E.g. when adding a QgsProcessingParameterVectorDestination
+     * and \a createOutput is true, then a QgsProcessingOutputVectorLayer output will be created and
+     * added to the algorithm. There is no need to call addOutput() to manually add a corresponding output
+     * for this vector. If \a createOutput is false then this automatic output creation will not
+     * occur.
+     *
      * \see initAlgorithm()
      * \see addOutput()
      */
-    bool addParameter( QgsProcessingParameterDefinition *parameterDefinition SIP_TRANSFER );
+    bool addParameter( QgsProcessingParameterDefinition *parameterDefinition SIP_TRANSFER, bool createOutput = true );
 
     /**
      * Removes the parameter with matching \a name from the algorithm, and deletes any existing
@@ -408,6 +415,9 @@ class CORE_EXPORT QgsProcessingAlgorithm
      * as a result of a duplicate name).
      *
      * This should usually be called from a subclass' initAlgorithm() implementation.
+     *
+     * Note that in some cases output creation can be automatically performed when calling addParameter().
+     * See the notes in addParameter() for a description of when this occurs.
      *
      * \see addParameter()
      * \see initAlgorithm()
@@ -672,7 +682,8 @@ class CORE_EXPORT QgsProcessingAlgorithm
     bool mHasPostProcessed = false;
     std::unique_ptr< QgsProcessingContext > mLocalContext;
 
-    // friend class to access setProvider() - we do not want this public!
+    bool createAutoOutputForParameter( QgsProcessingParameterDefinition *parameter );
+
     friend class QgsProcessingProvider;
     friend class TestQgsProcessing;
     friend class QgsProcessingModelAlgorithm;

--- a/tests/src/core/testqgsprocessing.cpp
+++ b/tests/src/core/testqgsprocessing.cpp
@@ -101,10 +101,10 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       //destination styleparameters
       QVERIFY( destinationParameterDefinitions().isEmpty() );
       QgsProcessingParameterFeatureSink *p5 = new QgsProcessingParameterFeatureSink( "p5" );
-      QVERIFY( addParameter( p5 ) );
+      QVERIFY( addParameter( p5, false ) );
       QCOMPARE( destinationParameterDefinitions(), QgsProcessingParameterDefinitions() << p5 );
       QgsProcessingParameterFeatureSink *p6 = new QgsProcessingParameterFeatureSink( "p6" );
-      QVERIFY( addParameter( p6 ) );
+      QVERIFY( addParameter( p6, false ) );
       QCOMPARE( destinationParameterDefinitions(), QgsProcessingParameterDefinitions() << p5 << p6 );
 
       // remove parameter
@@ -113,6 +113,21 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       QCOMPARE( destinationParameterDefinitions(), QgsProcessingParameterDefinitions() << p5 );
       removeParameter( "p5" );
       QVERIFY( destinationParameterDefinitions().isEmpty() );
+
+      // try with auto output creation
+      QgsProcessingParameterVectorDestination *p7 = new QgsProcessingParameterVectorDestination( "p7", "my output" );
+      QVERIFY( addParameter( p7 ) );
+      QCOMPARE( destinationParameterDefinitions(), QgsProcessingParameterDefinitions() << p7 );
+      QVERIFY( outputDefinition( "p7" ) );
+      QCOMPARE( outputDefinition( "p7" )->name(), QStringLiteral( "p7" ) );
+      QCOMPARE( outputDefinition( "p7" )->type(), QStringLiteral( "outputVector" ) );
+      QCOMPARE( outputDefinition( "p7" )->description(), QStringLiteral( "my output" ) );
+
+      // duplicate output name
+      QVERIFY( addOutput( new QgsProcessingOutputVectorLayer( "p8" ) ) );
+      QgsProcessingParameterVectorDestination *p8 = new QgsProcessingParameterVectorDestination( "p8" );
+      // this should fail - it would result in a duplicate output name
+      QVERIFY( !addParameter( p8 ) );
     }
 
     void runOutputChecks()


### PR DESCRIPTION
QgsProcessingAlgorithm::addParameter() has a new createOuput argument (true by default).

If the createOutput argument is true, then a corresponding output definition will also be created (and added to the algorithm) where appropriate. E.g. when adding a QgsProcessingParameterVectorDestination and createOutput is true, then a QgsProcessingOutputVectorLayer output will be created and added to the algorithm. There is no need to call addOutput() to manually add a corresponding output for this
vector. If createOutput is false then this automatic output creation will not occur.

This should simplify declaration of outputs for algorithms as it avoids the need to manually declare these corresponding outputs.