### PR TITLE
changes to QgsDateTimeEdit to support the minimal Date supported by Q…

### DIFF
--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -30,6 +30,18 @@ Determines if the widget allows setting null date/time.
  :rtype: bool
 %End
 
+    void setMinimumEditDateTime();
+%Docstring
+ Set the lowest Date that can be displayed with the Qt.ISODate format
+  - uses QDateTimeEdit.setMinimumDateTime (since Qt 4.4)
+ \note
+  - QDate and QDateTime does not support minus years for the Qt.ISODate format
+  -> returns empty (toString) or invalid (fromString) values
+  - QDateTimeEdit.setMinimumDateTime does not support dates < '0100-01-01'
+  -> it is not for us to wonder why [defined in qdatetimeparser_p.h]
+.. versionadded:: 3.0
+%End
+
     void setDateTime( const QDateTime &dateTime );
 %Docstring
  setDateTime set the date time in the widget and handles null date times.

--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -30,18 +30,6 @@ Determines if the widget allows setting null date/time.
  :rtype: bool
 %End
 
-    void setMinimumEditDateTime();
-%Docstring
- Set the lowest Date that can be displayed with the Qt.ISODate format
-  - uses QDateTimeEdit.setMinimumDateTime (since Qt 4.4)
- \note
-  - QDate and QDateTime does not support minus years for the Qt.ISODate format
-  -> returns empty (toString) or invalid (fromString) values
-  - QDateTimeEdit.setMinimumDateTime does not support dates < '0100-01-01'
-  -> it is not for us to wonder why [defined in qdatetimeparser_p.h]
-.. versionadded:: 3.0
-%End
-
     void setDateTime( const QDateTime &dateTime );
 %Docstring
  setDateTime set the date time in the widget and handles null date times.

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -52,6 +52,7 @@ QgsDateTimeEdit::QgsDateTimeEdit( QWidget *parent )
 
   // init with current time so mIsNull is properly initialized
   QDateTimeEdit::setDateTime( QDateTime::currentDateTime() );
+  setMinimumEditDateTime();
 }
 
 void QgsDateTimeEdit::setAllowNull( bool allowNull )

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -38,6 +38,20 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     void setAllowNull( bool allowNull );
     bool allowNull() const {return mAllowNull;}
 
+    /** Set the lowest Date that can be displayed with the Qt::ISODate format
+     *  - uses QDateTimeEdit::setMinimumDateTime (since Qt 4.4)
+     * \note
+     *  - QDate and QDateTime does not support minus years for the Qt::ISODate format
+     *  -> returns empty (toString) or invalid (fromString) values
+     *  - QDateTimeEdit::setMinimumDateTime does not support dates < '0100-01-01'
+     *  -> it is not for us to wonder why [defined in qdatetimeparser_p.h]
+    * \since QGIS 3.0
+    */
+    void setMinimumEditDateTime()
+    {
+      setMinimumDateTime( QDateTime::fromString( "0100-01-01", Qt::ISODate ) );
+    }
+
     /**
      * \brief setDateTime set the date time in the widget and handles null date times.
      * \note since QDateTimeEdit::setDateTime() is not virtual, setDateTime must be called for QgsDateTimeEdit.

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -38,20 +38,6 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     void setAllowNull( bool allowNull );
     bool allowNull() const {return mAllowNull;}
 
-    /** Set the lowest Date that can be displayed with the Qt::ISODate format
-     *  - uses QDateTimeEdit::setMinimumDateTime (since Qt 4.4)
-     * \note
-     *  - QDate and QDateTime does not support minus years for the Qt::ISODate format
-     *  -> returns empty (toString) or invalid (fromString) values
-     *  - QDateTimeEdit::setMinimumDateTime does not support dates < '0100-01-01'
-     *  -> it is not for us to wonder why [defined in qdatetimeparser_p.h]
-    * \since QGIS 3.0
-    */
-    void setMinimumEditDateTime()
-    {
-      setMinimumDateTime( QDateTime::fromString( "0100-01-01", Qt::ISODate ) );
-    }
-
     /**
      * \brief setDateTime set the date time in the widget and handles null date times.
      * \note since QDateTimeEdit::setDateTime() is not virtual, setDateTime must be called for QgsDateTimeEdit.
@@ -95,6 +81,21 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
 
     QLineEdit *mNullLabel = nullptr;
     QToolButton *mClearButton = nullptr;
+
+    /** Set the lowest Date that can be displayed with the Qt::ISODate format
+     *  - uses QDateTimeEdit::setMinimumDateTime (since Qt 4.4)
+     * \note
+     *  - QDate and QDateTime does not support minus years for the Qt::ISODate format
+     *  -> returns empty (toString) or invalid (fromString) values
+     *  - QDateTimeEdit::setMinimumDateTime does not support dates < '0100-01-01'
+     *  -> it is not for us to wonder why [defined in qdatetimeparser_p.h]
+    * \since QGIS 3.0
+    * \note not available in Python bindings
+    */
+    void setMinimumEditDateTime()
+    {
+      setMinimumDateTime( QDateTime::fromString( "0100-01-01", Qt::ISODate ) );
+    }
 
 };
 


### PR DESCRIPTION
…Changes to QgsDateTimeEdit

## Description
Changes to QgsDateTimeEdit to support the minimal Date supported by QDateTimeEdit (0100-01-01)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

The default setting for QDateTimeEdit for the MinimalDate is '1752-09-14', based on the Act of Parliament of 1751 (Calendar Act) - which is a disaster for any Historical Database for any event before 1752-09-14.

The MinimalDate supported by QDateTimeEdit is: '0100-01-01' (as defined in  qdatetimeparser_p.h)
* both for the functions setMinimumDateTime and setMinimumDate
   * even though the QT-Documention implies at any valid QDateTime can be used with setMinimumDateTime

Both function have existed since QT 4.4, so this could be backported to the QGIS 2.

Since QgsDateTimeEdit is derived from QDateTimeEdit, this pull request adds a function that
* sets a date that both QDateTimeEdit supports and can be formatted as Qt::ISODate
   * and is called during the construction of QgsDateTimeEdit (called setMinimumEditDateTime())

This value can be reset to the default value ('1752-09-14') by calling 
* QDateTimeEdit::clearMinimumDateTime().

No changes are needed in QgsDateTimeEditWrapper, since mQgsDateTimeEdit has already been set and mQDateTimeEdit is casted from mQgsDateTimeEdit during QgsDateTimeEditWrapper::initWidget.

For Providers that properly supports DATE/DATETIME fields, the default settings of QDateTimeEdit causes damage to the original Data:

When editing starts any Date less than '1752-09-14' reverts to '1752-09-14'.
![qgsdatetimeedit 01](https://user-images.githubusercontent.com/4899405/28103329-744ce4b2-66d5-11e7-8015-4941e915dc0b.png)

With this solution only Dates less that '0100-01-01' will revert to '0100-01-01':

![qgsdatetimeedit 02](https://user-images.githubusercontent.com/4899405/28103411-de34994c-66d5-11e7-9914-0ca9e0b059e3.png)

When new geometries are created and the default value in the Database is '0001-01-01' (undetermined begin), '0100-01-01' will be set, otherwise (for QDateTimeEdit) a valid QDateTime object is accepted (in this sample '3000-01-01' (undetermined begin)).

![qgsdatetimeedit 03](https://user-images.githubusercontent.com/4899405/28103507-5c0bd218-66d6-11e7-9e90-b2fc5659bc2e.png)

So for a Roman Street-Database, this cannot be seen as a final solution.

