### PR TITLE
[Server] WMS GetFeatureInfo refactoring

### DIFF
--- a/python/server/qgsserverprojectutils.sip
+++ b/python/server/qgsserverprojectutils.sip
@@ -145,6 +145,62 @@ namespace QgsServerProjectUtils
  :rtype: bool
 %End
 
+  bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
+%Docstring
+ Returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
+ \param project the QGIS project
+ :return: if the geometry is displayed as Well Known Text in GetFeatureInfo request.
+ :rtype: bool
+%End
+
+  bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
+%Docstring
+ Returns if the geometry has to be segmentize in GetFeatureInfo request.
+ \param project the QGIS project
+ :return: if the geometry has to be segmentize in GetFeatureInfo request.
+ :rtype: bool
+%End
+
+  int wmsFeatureInfoPrecision( const QgsProject &project );
+%Docstring
+ Returns the geometry precision for GetFeatureInfo request.
+ \param project the QGIS project
+ :return: the geometry precision for GetFeatureInfo request.
+ :rtype: int
+%End
+
+  QString wmsFeatureInfoDocumentElement( const QgsProject &project );
+%Docstring
+ Returns the document element name for XML GetFeatureInfo request.
+ \param project the QGIS project
+ :return: the document element name for XML GetFeatureInfo request.
+ :rtype: str
+%End
+
+  QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
+%Docstring
+ Returns the document element namespace for XML GetFeatureInfo request.
+ \param project the QGIS project
+ :return: the document element namespace for XML GetFeatureInfo request.
+ :rtype: str
+%End
+
+  QString wmsFeatureInfoSchema( const QgsProject &project );
+%Docstring
+ Returns the schema URL for XML GetFeatureInfo request.
+ \param project the QGIS project
+ :return: the schema URL for XML GetFeatureInfo request.
+ :rtype: str
+%End
+
+  QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
+%Docstring
+ Returns the mapping between layer name and wms layer name for GetFeatureInfo request.
+ \param project the QGIS project
+ :return: the mapping between layer name and wms layer name for GetFeatureInfo request.
+ :rtype: QHash<str, QString>
+%End
+
   bool wmsInspireActivate( const QgsProject &project );
 %Docstring
  Returns if Inspire is activated.

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -117,6 +117,77 @@ bool QgsServerProjectUtils::wmsInfoFormatSia2045( const QgsProject &project )
   return false;
 }
 
+bool QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( const QgsProject &project )
+{
+  QString wktGeom = project.readEntry( QStringLiteral( "WMSAddWktGeometry" ), QStringLiteral( "/" ), "" );
+
+  if ( wktGeom.compare( QLatin1String( "enabled" ), Qt::CaseInsensitive ) == 0
+       || wktGeom.compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return true;
+  }
+  return false;
+}
+
+bool QgsServerProjectUtils::wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project )
+{
+  QString segmGeom = project.readEntry( QStringLiteral( "WMSSegmentizeFeatureInfoGeometry" ), QStringLiteral( "/" ), "" );
+
+  if ( segmGeom.compare( QLatin1String( "enabled" ), Qt::CaseInsensitive ) == 0
+       || segmGeom.compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return true;
+  }
+  return false;
+}
+
+int QgsServerProjectUtils::wmsFeatureInfoPrecision( const QgsProject &project )
+{
+  return project.readNumEntry( QStringLiteral( "WMSPrecision" ), QStringLiteral( "/" ), 6 );
+}
+
+QString QgsServerProjectUtils::wmsFeatureInfoDocumentElement( const QgsProject &project )
+{
+  return project.readEntry( QStringLiteral( "WMSFeatureInfoDocumentElement" ), QStringLiteral( "/" ), "" );
+}
+
+QString QgsServerProjectUtils::wmsFeatureInfoDocumentElementNs( const QgsProject &project )
+{
+  return project.readEntry( QStringLiteral( "WMSFeatureInfoDocumentElementNS" ), QStringLiteral( "/" ), "" );
+}
+
+QString QgsServerProjectUtils::wmsFeatureInfoSchema( const QgsProject &project )
+{
+  return project.readEntry( QStringLiteral( "WMSFeatureInfoSchema" ), QStringLiteral( "/" ), "" );
+}
+
+QHash<QString, QString> QgsServerProjectUtils::wmsFeatureInfoLayerAliasMap( const QgsProject &project )
+{
+  QHash<QString, QString> aliasMap;
+
+  //WMSFeatureInfoAliasLayers
+  QStringList aliasLayerStringList = project.readListEntry( QStringLiteral( "WMSFeatureInfoAliasLayers" ), QStringLiteral( "/value" ), QStringList() );
+  if ( aliasLayerStringList.isEmpty() )
+  {
+    return aliasMap;
+  }
+
+  //WMSFeatureInfoLayerAliases
+  QStringList layerAliasStringList = project.readListEntry( QStringLiteral( "WMSFeatureInfoLayerAliases" ), QStringLiteral( "/value" ), QStringList() );
+  if ( layerAliasStringList.isEmpty() )
+  {
+    return aliasMap;
+  }
+
+  int nMapEntries = qMin( aliasLayerStringList.size(), layerAliasStringList.size() );
+  for ( int i = 0; i < nMapEntries; ++i )
+  {
+    aliasMap.insert( aliasLayerStringList.at( i ), layerAliasStringList.at( i ) );
+  }
+
+  return aliasMap;
+}
+
 bool QgsServerProjectUtils::wmsInspireActivate( const QgsProject &project )
 {
   return project.readBoolEntry( QStringLiteral( "WMSInspire" ), QStringLiteral( "/activated" ) );

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -132,6 +132,48 @@ namespace QgsServerProjectUtils
     */
   SERVER_EXPORT bool wmsInfoFormatSia2045( const QgsProject &project );
 
+  /** Returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
+    * \param project the QGIS project
+    * \returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
+    */
+  SERVER_EXPORT bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
+
+  /** Returns if the geometry has to be segmentize in GetFeatureInfo request.
+    * \param project the QGIS project
+    * \returns if the geometry has to be segmentize in GetFeatureInfo request.
+    */
+  SERVER_EXPORT bool wmsFeatureInfoSegmentizeWktGeometry( const QgsProject &project );
+
+  /** Returns the geometry precision for GetFeatureInfo request.
+    * \param project the QGIS project
+    * \returns the geometry precision for GetFeatureInfo request.
+    */
+  SERVER_EXPORT int wmsFeatureInfoPrecision( const QgsProject &project );
+
+  /** Returns the document element name for XML GetFeatureInfo request.
+    * \param project the QGIS project
+    * \returns the document element name for XML GetFeatureInfo request.
+    */
+  SERVER_EXPORT QString wmsFeatureInfoDocumentElement( const QgsProject &project );
+
+  /** Returns the document element namespace for XML GetFeatureInfo request.
+    * \param project the QGIS project
+    * \returns the document element namespace for XML GetFeatureInfo request.
+    */
+  SERVER_EXPORT QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
+
+  /** Returns the schema URL for XML GetFeatureInfo request.
+    * \param project the QGIS project
+    * \returns the schema URL for XML GetFeatureInfo request.
+    */
+  SERVER_EXPORT QString wmsFeatureInfoSchema( const QgsProject &project );
+
+  /** Returns the mapping between layer name and wms layer name for GetFeatureInfo request.
+    * \param project the QGIS project
+    * \returns the mapping between layer name and wms layer name for GetFeatureInfo request.
+    */
+  SERVER_EXPORT QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
+
   /** Returns if Inspire is activated.
     * \param project the QGIS project
     * \returns if Inspire is activated.

--- a/src/server/services/wms/qgswmsgetfeatureinfo.cpp
+++ b/src/server/services/wms/qgswmsgetfeatureinfo.cpp
@@ -25,136 +25,6 @@
 namespace QgsWms
 {
 
-  void writeInfoResponse( QDomDocument &infoDoc, QgsServerResponse &response, const QString &infoFormat )
-  {
-    QByteArray ba;
-    QgsMessageLog::logMessage( "Info format is:" + infoFormat );
-
-    if ( infoFormat == QLatin1String( "text/xml" ) || infoFormat.startsWith( QLatin1String( "application/vnd.ogc.gml" ) ) )
-    {
-      ba = infoDoc.toByteArray();
-    }
-    else if ( infoFormat == QLatin1String( "text/plain" ) || infoFormat == QLatin1String( "text/html" ) )
-    {
-      //create string
-      QString featureInfoString;
-
-      if ( infoFormat == QLatin1String( "text/plain" ) )
-      {
-        featureInfoString.append( "GetFeatureInfo results\n" );
-        featureInfoString.append( "\n" );
-      }
-      else if ( infoFormat == QLatin1String( "text/html" ) )
-      {
-        featureInfoString.append( "<HEAD>\n" );
-        featureInfoString.append( "<TITLE> GetFeatureInfo results </TITLE>\n" );
-        featureInfoString.append( "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">\n" );
-        featureInfoString.append( "</HEAD>\n" );
-        featureInfoString.append( "<BODY>\n" );
-      }
-
-      QDomNodeList layerList = infoDoc.elementsByTagName( QStringLiteral( "Layer" ) );
-
-      //layer loop
-      for ( int i = 0; i < layerList.size(); ++i )
-      {
-        QDomElement layerElem = layerList.at( i ).toElement();
-        if ( infoFormat == QLatin1String( "text/plain" ) )
-        {
-          featureInfoString.append( "Layer '" + layerElem.attribute( QStringLiteral( "name" ) ) + "'\n" );
-        }
-        else if ( infoFormat == QLatin1String( "text/html" ) )
-        {
-          featureInfoString.append( "<TABLE border=1 width=100%>\n" );
-          featureInfoString.append( "<TR><TH width=25%>Layer</TH><TD>" + layerElem.attribute( QStringLiteral( "name" ) ) + "</TD></TR>\n" );
-          featureInfoString.append( "</BR>" );
-        }
-
-        //feature loop (for vector layers)
-        QDomNodeList featureNodeList = layerElem.elementsByTagName( QStringLiteral( "Feature" ) );
-        QDomElement currentFeatureElement;
-
-        if ( featureNodeList.isEmpty() ) //raster layer?
-        {
-          QDomNodeList attributeNodeList = layerElem.elementsByTagName( QStringLiteral( "Attribute" ) );
-          for ( int j = 0; j < attributeNodeList.size(); ++j )
-          {
-            QDomElement attributeElement = attributeNodeList.at( j ).toElement();
-            if ( infoFormat == QLatin1String( "text/plain" ) )
-            {
-              featureInfoString.append( attributeElement.attribute( QStringLiteral( "name" ) ) + " = '" +
-                                        attributeElement.attribute( QStringLiteral( "value" ) ) + "'\n" );
-            }
-            else if ( infoFormat == QLatin1String( "text/html" ) )
-            {
-              featureInfoString.append( "<TR><TH>" + attributeElement.attribute( QStringLiteral( "name" ) ) + "</TH><TD>" +
-                                        attributeElement.attribute( QStringLiteral( "value" ) ) + "</TD></TR>\n" );
-            }
-          }
-        }
-        else //vector layer
-        {
-          for ( int j = 0; j < featureNodeList.size(); ++j )
-          {
-            QDomElement featureElement = featureNodeList.at( j ).toElement();
-            if ( infoFormat == QLatin1String( "text/plain" ) )
-            {
-              featureInfoString.append( "Feature " + featureElement.attribute( QStringLiteral( "id" ) ) + "\n" );
-            }
-            else if ( infoFormat == QLatin1String( "text/html" ) )
-            {
-              featureInfoString.append( "<TABLE border=1 width=100%>\n" );
-              featureInfoString.append( "<TR><TH>Feature</TH><TD>" + featureElement.attribute( QStringLiteral( "id" ) ) + "</TD></TR>\n" );
-            }
-            //attribute loop
-            QDomNodeList attributeNodeList = featureElement.elementsByTagName( QStringLiteral( "Attribute" ) );
-            for ( int k = 0; k < attributeNodeList.size(); ++k )
-            {
-              QDomElement attributeElement = attributeNodeList.at( k ).toElement();
-              if ( infoFormat == QLatin1String( "text/plain" ) )
-              {
-                featureInfoString.append( attributeElement.attribute( QStringLiteral( "name" ) ) + " = '" +
-                                          attributeElement.attribute( QStringLiteral( "value" ) ) + "'\n" );
-              }
-              else if ( infoFormat == QLatin1String( "text/html" ) )
-              {
-                featureInfoString.append( "<TR><TH>" + attributeElement.attribute( QStringLiteral( "name" ) ) + "</TH><TD>" + attributeElement.attribute( QStringLiteral( "value" ) ) + "</TD></TR>\n" );
-              }
-            }
-
-            if ( infoFormat == QLatin1String( "text/html" ) )
-            {
-              featureInfoString.append( "</TABLE>\n</BR>\n" );
-            }
-          }
-        }
-        if ( infoFormat == QLatin1String( "text/plain" ) )
-        {
-          featureInfoString.append( "\n" );
-        }
-        else if ( infoFormat == QLatin1String( "text/html" ) )
-        {
-          featureInfoString.append( "</TABLE>\n<BR></BR>\n" );
-
-        }
-      }
-      if ( infoFormat == QLatin1String( "text/html" ) )
-      {
-        featureInfoString.append( "</BODY>\n" );
-      }
-      ba = featureInfoString.toUtf8();
-    }
-    else //unsupported format, set exception
-    {
-      throw QgsServiceException( QStringLiteral( "InvalidFormat" ),
-                                 QString( "Feature info format '%1' is not supported. Possibilities are 'text/plain', 'text/html' or 'text/xml'." ).arg( infoFormat ) );
-    }
-
-    response.setHeader( QStringLiteral( "Content-Type" ), infoFormat + QStringLiteral( "; charset=utf-8" ) );
-    response.write( ba );
-  }
-
-
   void writeGetFeatureInfo( QgsServerInterface *serverIface, const QgsProject *project,
                             const QString &version, const QgsServerRequest &request,
                             QgsServerResponse &response )
@@ -163,9 +33,11 @@ namespace QgsWms
     QgsServerRequest::Parameters params = request.parameters();
     QgsRenderer renderer( serverIface, project, params, getConfigParser( serverIface ) );
 
-    QDomDocument doc = renderer.getFeatureInfo( version );
-    QString outputFormat = params.value( QStringLiteral( "INFO_FORMAT" ), QStringLiteral( "text/plain" ) );
-    writeInfoResponse( doc,  response, outputFormat );
+    std::unique_ptr<QByteArray> result( renderer.getFeatureInfo( version ) );
+    QString infoFormat = params.value( QStringLiteral( "INFO_FORMAT" ), QStringLiteral( "text/plain" ) );
+
+    response.setHeader( QStringLiteral( "Content-Type" ), infoFormat + QStringLiteral( "; charset=utf-8" ) );
+    response.write( *result );
   }
 
 

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -404,7 +404,6 @@ namespace QgsWms
   {
     mRequestParameters = parameters;
 
-    log( "load WMS Request parameters:" );
     const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
     foreach ( QString key, parameters.keys() )
     {
@@ -415,7 +414,6 @@ namespace QgsWms
         if ( value.canConvert( mParameters[name].mType ) )
         {
           mParameters[name].mValue = value;
-          log( " - " + key + " : " + parameters[key] );
         }
         else
         {
@@ -716,10 +714,10 @@ namespace QgsWms
   {
     QString fStr = infoFormatAsString();
 
-    if ( fStr.isEmpty() )
-      return Format::NONE;
-
     Format f = Format::TEXT;
+    if ( fStr.isEmpty() )
+      return f;
+
     if ( fStr.startsWith( QLatin1String( "text/xml" ), Qt::CaseInsensitive ) )
       f = Format::XML;
     else if ( fStr.startsWith( QLatin1String( "text/html" ), Qt::CaseInsensitive ) )
@@ -728,6 +726,18 @@ namespace QgsWms
       f = Format::GML;
 
     return f;
+  }
+
+  int QgsWmsParameters::infoFormatVersion() const
+  {
+    if ( infoFormat() != Format::GML )
+      return -1;
+
+    QString fStr = infoFormatAsString();
+    if ( fStr.startsWith( QLatin1String( "application/vnd.ogc.gml/3" ), Qt::CaseInsensitive ) )
+      return 3;
+    else
+      return 2;
   }
 
   QString QgsWmsParameters::i() const

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -191,6 +191,41 @@ namespace QgsWms
                               };
     save( pFormat );
 
+    const Parameter pInfoFormat = { ParameterName::INFO_FORMAT,
+                                    QVariant::String,
+                                    QVariant( "" ),
+                                    QVariant()
+                                  };
+    save( pInfoFormat );
+
+    const Parameter pI = { ParameterName::I,
+                           QVariant::Int,
+                           QVariant( -1 ),
+                           QVariant()
+                         };
+    save( pI );
+
+    const Parameter pJ = { ParameterName::J,
+                           QVariant::Int,
+                           QVariant( -1 ),
+                           QVariant()
+                         };
+    save( pJ );
+
+    const Parameter pX = { ParameterName::X,
+                           QVariant::Int,
+                           QVariant( -1 ),
+                           QVariant()
+                         };
+    save( pX );
+
+    const Parameter pY = { ParameterName::Y,
+                           QVariant::Int,
+                           QVariant( -1 ),
+                           QVariant()
+                         };
+    save( pY );
+
     const Parameter pRule = { ParameterName::RULE,
                               QVariant::String,
                               QVariant( "" ),
@@ -253,6 +288,20 @@ namespace QgsWms
                                 QVariant()
                               };
     save( pLayers );
+
+    const Parameter pQueryLayers = { ParameterName::QUERY_LAYERS,
+                                     QVariant::String,
+                                     QVariant( "" ),
+                                     QVariant()
+                                   };
+    save( pQueryLayers );
+
+    const Parameter pFeatureCount = { ParameterName::FEATURE_COUNT,
+                                      QVariant::Int,
+                                      QVariant( 1 ),
+                                      QVariant()
+                                    };
+    save( pFeatureCount );
 
     const Parameter pLayerTitle = { ParameterName::LAYERTITLE,
                                     QVariant::Bool,
@@ -324,12 +373,26 @@ namespace QgsWms
                               };
     save( pFilter );
 
+    const Parameter pFilterGeom = { ParameterName::FILTER_GEOM,
+                                    QVariant::String,
+                                    QVariant( "" ),
+                                    QVariant()
+                                  };
+    save( pFilterGeom );
+
     const Parameter pSelection = { ParameterName::SELECTION,
                                    QVariant::String,
                                    QVariant( "" ),
                                    QVariant()
                                  };
     save( pSelection );
+
+    const Parameter pWmsPrecision = { ParameterName::WMS_PRECISION,
+                                      QVariant::Int,
+                                      QVariant( -1 ),
+                                      QVariant()
+                                    };
+    save( pWmsPrecision );
   }
 
   QgsWmsParameters::QgsWmsParameters( const QgsServerRequest::Parameters &parameters )
@@ -341,6 +404,7 @@ namespace QgsWms
   {
     mRequestParameters = parameters;
 
+    log( "load WMS Request parameters:" );
     const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
     foreach ( QString key, parameters.keys() )
     {
@@ -351,6 +415,7 @@ namespace QgsWms
         if ( value.canConvert( mParameters[name].mType ) )
         {
           mParameters[name].mValue = value;
+          log( " - " + key + " : " + parameters[key] );
         }
         else
         {
@@ -628,15 +693,81 @@ namespace QgsWms
 
   QgsWmsParameters::Format QgsWmsParameters::format() const
   {
-    Format f = Format::PNG;
     QString fStr = formatAsString();
 
+    if ( fStr.isEmpty() )
+      return Format::NONE;
+
+    Format f = Format::PNG;
     if ( fStr.compare( QLatin1String( "jpg" ), Qt::CaseInsensitive ) == 0
          || fStr.compare( QLatin1String( "jpeg" ), Qt::CaseInsensitive ) == 0
          || fStr.compare( QLatin1String( "image/jpeg" ), Qt::CaseInsensitive ) == 0 )
       f = Format::JPG;
 
     return f;
+  }
+
+  QString QgsWmsParameters::infoFormatAsString() const
+  {
+    return value( ParameterName::INFO_FORMAT ).toString();
+  }
+
+  QgsWmsParameters::Format QgsWmsParameters::infoFormat() const
+  {
+    QString fStr = infoFormatAsString();
+
+    if ( fStr.isEmpty() )
+      return Format::NONE;
+
+    Format f = Format::TEXT;
+    if ( fStr.startsWith( QLatin1String( "text/xml" ), Qt::CaseInsensitive ) )
+      f = Format::XML;
+    else if ( fStr.startsWith( QLatin1String( "text/html" ), Qt::CaseInsensitive ) )
+      f = Format::HTML;
+    else if ( fStr.startsWith( QLatin1String( "application/vnd.ogc.gml" ), Qt::CaseInsensitive ) )
+      f = Format::GML;
+
+    return f;
+  }
+
+  QString QgsWmsParameters::i() const
+  {
+    return value( ParameterName::I ).toString();
+  }
+
+  QString QgsWmsParameters::j() const
+  {
+    return value( ParameterName::J ).toString();
+  }
+
+  int QgsWmsParameters::iAsInt() const
+  {
+    return toInt( ParameterName::I );
+  }
+
+  int QgsWmsParameters::jAsInt() const
+  {
+    return toInt( ParameterName::J );
+  }
+
+  QString QgsWmsParameters::x() const
+  {
+    return value( ParameterName::X ).toString();
+  }
+
+  QString QgsWmsParameters::y() const
+  {
+    return value( ParameterName::Y ).toString();
+  }
+
+  int QgsWmsParameters::xAsInt() const
+  {
+    return toInt( ParameterName::X );
+  }
+
+  int QgsWmsParameters::yAsInt() const
+  {
+    return toInt( ParameterName::Y );
   }
 
   QString QgsWmsParameters::rule() const
@@ -672,6 +803,16 @@ namespace QgsWms
   bool QgsWmsParameters::showFeatureCountAsBool() const
   {
     return toBool( ParameterName::SHOWFEATURECOUNT );
+  }
+
+  QString QgsWmsParameters::featureCount() const
+  {
+    return value( ParameterName::FEATURE_COUNT ).toString();
+  }
+
+  int QgsWmsParameters::featureCountAsInt() const
+  {
+    return toInt( ParameterName::FEATURE_COUNT );
   }
 
   QString QgsWmsParameters::boxSpace() const
@@ -960,6 +1101,16 @@ namespace QgsWms
     return toFloatList( highlightLabelBufferSize(), ParameterName::HIGHLIGHT_LABELBUFFERSIZE );
   }
 
+  QString QgsWmsParameters::wmsPrecision() const
+  {
+    return value( ParameterName::WMS_PRECISION ).toString();
+  }
+
+  int QgsWmsParameters::wmsPrecisionAsInt() const
+  {
+    return toInt( ParameterName::WMS_PRECISION );
+  }
+
   QString QgsWmsParameters::sld() const
   {
     return value( ParameterName::SLD ).toString();
@@ -968,6 +1119,11 @@ namespace QgsWms
   QStringList QgsWmsParameters::filters() const
   {
     return toStringList( ParameterName::FILTER, ';' );
+  }
+
+  QString QgsWmsParameters::filterGeom() const
+  {
+    return value( ParameterName::FILTER_GEOM ).toString();
   }
 
   QStringList QgsWmsParameters::selections() const
@@ -990,6 +1146,11 @@ namespace QgsWms
     QStringList layer = toStringList( ParameterName::LAYER );
     QStringList layers = toStringList( ParameterName::LAYERS );
     return layer << layers;
+  }
+
+  QStringList QgsWmsParameters::queryLayersNickname() const
+  {
+    return toStringList( ParameterName::QUERY_LAYERS );
   }
 
   QStringList QgsWmsParameters::allStyles() const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -86,6 +86,8 @@ namespace QgsWms
         LAYERS,
         LAYERSPACE,
         LAYERTITLESPACE,
+        QUERY_LAYERS,
+        FEATURE_COUNT,
         SHOWFEATURECOUNT,
         STYLE,
         STYLES,
@@ -95,7 +97,13 @@ namespace QgsWms
         OPACITIES,
         SLD,
         FILTER,
+        FILTER_GEOM,
         FORMAT,
+        INFO_FORMAT,
+        I,
+        J,
+        X,
+        Y,
         RULE,
         RULELABEL,
         SCALE,
@@ -108,7 +116,8 @@ namespace QgsWms
         HIGHLIGHT_LABELWEIGHT,
         HIGHLIGHT_LABELCOLOR,
         HIGHLIGHT_LABELBUFFERCOLOR,
-        HIGHLIGHT_LABELBUFFERSIZE
+        HIGHLIGHT_LABELBUFFERSIZE,
+        WMS_PRECISION
       };
       Q_ENUM( ParameterName )
 
@@ -116,7 +125,11 @@ namespace QgsWms
       {
         NONE,
         JPG,
-        PNG
+        PNG,
+        TEXT,
+        XML,
+        HTML,
+        GML
       };
 
       struct Parameter
@@ -203,6 +216,11 @@ namespace QgsWms
        */
       QStringList filters() const;
 
+      /** Returns the filter geometry found in FILTER_GEOM parameter.
+       * \returns the filter geometry as Well Known Text.
+       */
+      QString filterGeom() const;
+
       /** Returns the list of opacities found in OPACITIES parameter.
        * \returns the list of opacities in string
        */
@@ -220,6 +238,11 @@ namespace QgsWms
        * \returns nickname of layers
        */
       QStringList allLayersNickname() const;
+
+      /** Returns nickname of layers found in QUERY_LAYERS parameter.
+       * \returns nickname of layers
+       */
+      QStringList queryLayersNickname() const;
 
       /** Returns styles found in STYLE and STYLES parameters.
        * \returns name of styles
@@ -241,6 +264,69 @@ namespace QgsWms
        * \returns format
        */
       Format format() const;
+
+      /** Returns INFO_FORMAT parameter as a string.
+       * \returns INFO_FORMAT parameter as string
+       */
+      QString infoFormatAsString() const;
+
+      /** Returns infoFormat. If the INFO_FORMAT parameter is not used, then the
+       *  default value is text/plain.
+       * \returns infoFormat
+       */
+      Format infoFormat() const;
+
+      /** Returns I parameter or an empty string if not defined.
+       * \returns i parameter
+       */
+      QString i() const;
+
+      /** Returns I parameter as an int or its default value if not
+       *  defined. An exception is raised if I is defined and cannot be
+       *  converted.
+       * \returns i parameter
+       * \throws QgsBadRequestException
+       */
+      int iAsInt() const;
+
+      /** Returns J parameter or an empty string if not defined.
+       * \returns j parameter
+       */
+      QString j() const;
+
+      /** Returns J parameter as an int or its default value if not
+       *  defined. An exception is raised if J is defined and cannot be
+       *  converted.
+       * \returns j parameter
+       * \throws QgsBadRequestException
+       */
+      int jAsInt() const;
+
+      /** Returns X parameter or an empty string if not defined.
+       * \returns x parameter
+       */
+      QString x() const;
+
+      /** Returns X parameter as an int or its default value if not
+       *  defined. An exception is raised if X is defined and cannot be
+       *  converted.
+       * \returns x parameter
+       * \throws QgsBadRequestException
+       */
+      int xAsInt() const;
+
+      /** Returns Y parameter or an empty string if not defined.
+       * \returns y parameter
+       */
+      QString y() const;
+
+      /** Returns Y parameter as an int or its default value if not
+       *  defined. An exception is raised if Y is defined and cannot be
+       *  converted.
+       * \returns j parameter
+       * \throws QgsBadRequestException
+       */
+      int yAsInt() const;
 
       /** Returns RULE parameter or an empty string if none is defined
        * \returns RULE parameter or an empty string if none is defined
@@ -270,6 +356,18 @@ namespace QgsWms
        * \throws QgsBadRequestException
        */
       bool showFeatureCountAsBool() const;
+
+      /** Returns FEATURE_COUNT parameter or an empty string if none is defined
+       * \returns FEATURE_COUNT parameter or an empty string if none is defined
+       */
+      QString featureCount() const;
+
+      /** Returns FEATURE_COUNT as an integer. An exception is raised if an invalid
+       *  parameter is found.
+       * \returns FeatureCount
+       * \throws QgsBadRequestException
+       */
+      int featureCountAsInt() const;
 
       /** Returns SCALE parameter or an empty string if none is defined
        * \returns SCALE parameter or an empty string if none is defined
@@ -594,6 +692,19 @@ namespace QgsWms
        * \throws QgsBadRequestException
        */
       QList<QColor> highlightLabelBufferColorAsColor() const;
+
+      /** Returns WMS_PRECISION parameter or an empty string if not defined.
+       * \returns wms precision parameter
+       */
+      QString wmsPrecision() const;
+
+      /** Returns WMS_PRECISION parameter as an int or its default value if not
+       *  defined. An exception is raised if WMS_PRECISION is defined and cannot be
+       *  converted.
+       * \returns wms precision parameter
+       * \throws QgsBadRequestException
+       */
+      int wmsPrecisionAsInt() const;
 
     private:
       QString name( ParameterName name ) const;

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -276,6 +276,12 @@ namespace QgsWms
        */
       Format infoFormat() const;
 
+      /** Returns the infoFormat version for GML. If the INFO_FORMAT is not GML,
+       *  then the default value is -1.
+       * \returns infoFormat version
+       */
+      int infoFormatVersion() const;
+
       /** Returns I parameter or an empty string if not defined.
        * \returns i parameter
        */

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -116,7 +116,7 @@ namespace QgsWms
       /** Creates an xml document that describes the result of the getFeatureInfo request.
        * May throw an exception
        */
-      QDomDocument getFeatureInfo( const QString &version = "1.3.0" );
+      QByteArray *getFeatureInfo( const QString &version = "1.3.0" );
 
     private:
 
@@ -139,6 +139,9 @@ namespace QgsWms
 
       // Remove unwanted layers (restricted, not visible, etc)
       void removeUnwantedLayers( QList<QgsMapLayer *> &layers, double scaleDenominator = -1 ) const;
+
+      // Remove non identifiable layers (restricted, not visible, etc)
+      void removeNonIdentifiableLayers( QList<QgsMapLayer *> &layers ) const;
 
       // Rendering step for layers
       QPainter *layersRendering( const QgsMapSettings &mapSettings, QImage &image, HitTest *hitTest = nullptr ) const;
@@ -211,6 +214,9 @@ namespace QgsWms
        */
       void initializeSLDParser( QStringList &layersList, QStringList &stylesList );
 
+      QDomDocument featureInfoDocument( QList<QgsMapLayer *> &layers, const QgsMapSettings &mapSettings,
+                                        const QImage *outputImage, const QString &version ) const;
+
       /** Appends feature info xml for the layer to the layer element of the feature info dom document
       \param featureBBox the bounding box of the selected features in output CRS
       \returns true in case of success*/
@@ -222,7 +228,6 @@ namespace QgsWms
                                        const QgsMapSettings &mapSettings,
                                        QgsRenderContext &renderContext,
                                        const QString &version,
-                                       const QString &infoFormat,
                                        QgsRectangle *featureBBox = nullptr,
                                        QgsGeometry *filterGeom = nullptr ) const;
       //! Appends feature info xml for the layer to the layer element of the dom document
@@ -231,8 +236,7 @@ namespace QgsWms
                                        const QgsPointXY *infoPoint,
                                        QDomDocument &infoDocument,
                                        QDomElement &layerElement,
-                                       const QString &version,
-                                       const QString &infoFormat ) const;
+                                       const QString &version ) const;
 
       /** Creates a layer set and returns a stringlist with layer ids that can be passed to a renderer. Usually used in conjunction with readLayersAndStyles
          \param scaleDenominator Filter out layer if scale based visibility does not match (or use -1 if no scale restriction)*/
@@ -291,7 +295,13 @@ namespace QgsWms
       bool checkMaximumWidthHeight() const;
 
       //! Converts a feature info xml document to SIA2045 norm
-      void convertFeatureInfoToSIA2045( QDomDocument &doc );
+      void convertFeatureInfoToSia2045( QDomDocument &doc ) const;
+
+      //! Converts a feature info xml document to HTML
+      QByteArray convertFeatureInfoToHtml( const QDomDocument &doc ) const;
+
+      //! Converts a feature info xml document to Text
+      QByteArray convertFeatureInfoToText( const QDomDocument &doc ) const;
 
       QDomElement createFeatureGML(
         QgsFeature *feat,

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -334,7 +334,7 @@ namespace QgsWms
       int getImageQuality() const;
 
       //! Return precision to use for GetFeatureInfo request
-      int getWMSPrecision( int defaultValue ) const;
+      int getWMSPrecision() const;
 
   };
 

--- a/tests/src/python/test_qgsserver_accesscontrol.py
+++ b/tests/src/python/test_qgsserver_accesscontrol.py
@@ -454,6 +454,33 @@ class TestQgsServerAccessControl(unittest.TestCase):
             "No color in result of GetFeatureInfo\n%s" % response)
 
         response, headers = self._get_restricted(query_string)
+        self.assertEqual(
+            headers.get("Content-Type"), "text/xml; charset=utf-8",
+            "Content type for GetFeatureInfo is wrong: %s" % headers.get("Content-Type"))
+        self.assertTrue(
+            str(response).find('<ServiceException code="Security">') != -1,
+            "Not allowed do a GetFeatureInfo on Country"
+        )
+
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetFeatureInfo",
+            "LAYERS": "Hello",
+            "QUERY_LAYERS": "Hello",
+            "STYLES": "",
+            "FORMAT": "image/png",
+            "BBOX": "-16817707,-6318936.5,5696513,16195283.5",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "SRS": "EPSG:3857",
+            "FEATURE_COUNT": "10",
+            "INFO_FORMAT": "application/vnd.ogc.gml",
+            "X": "56",
+            "Y": "144"
+        }.items())])
+        response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
             "No result in GetFeatureInfo\n%s" % response)
@@ -1053,6 +1080,33 @@ class TestQgsServerAccessControl(unittest.TestCase):
             str(response).find("<qgs:pk>1</qgs:pk>") != -1,
             "No good result in GetFeatureInfo Hello/1\n%s" % response)
 
+        response, headers = self._get_restricted(query_string)
+        self.assertEqual(
+            headers.get("Content-Type"), "text/xml; charset=utf-8",
+            "Content type for GetFeatureInfo is wrong: %s" % headers.get("Content-Type"))
+        self.assertTrue(
+            str(response).find('<ServiceException code="Security">') != -1,
+            "Not allowed do a GetFeatureInfo on Country"
+        )
+
+        query_string = "&".join(["%s=%s" % i for i in list({
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetFeatureInfo",
+            "LAYERS": "Hello_SubsetString",
+            "QUERY_LAYERS": "Hello_SubsetString",
+            "STYLES": "",
+            "FORMAT": "image/png",
+            "BBOX": "-16817707,-6318936.5,5696513,16195283.5",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "SRS": "EPSG:3857",
+            "FEATURE_COUNT": "10",
+            "INFO_FORMAT": "application/vnd.ogc.gml",
+            "X": "56",
+            "Y": "144",
+            "MAP": urllib.parse.quote(self.projectPath)
+        }.items())])
         response, headers = self._get_restricted(query_string)
         self.assertTrue(
             str(response).find("<qgs:pk>") != -1,

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -69,7 +69,16 @@ class TestQgsServerWMS(QgsServerTestBase):
         for request in ('GetCapabilities', 'GetProjectSettings', 'GetContext'):
             self.wms_request_compare(request)
 
-        # Test getfeatureinfo response
+        # Test getfeatureinfo response xml (default info_format)
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=text%2Fxml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
+                                 'wms_getfeatureinfo-text-xml')
+
+        # Test getfeatureinfo response html
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fhtml&transparent=true&' +
@@ -78,10 +87,10 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
                                  'wms_getfeatureinfo-text-html')
 
-        # Test getfeatureinfo default info_format
+        # Test getfeatureinfo response text
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
-                                 'transparent=true&' +
+                                 'info_format=text%2Fplain&transparent=true&' +
                                  'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -69,7 +69,7 @@ class TestQgsServerWMS(QgsServerTestBase):
         for request in ('GetCapabilities', 'GetProjectSettings', 'GetContext'):
             self.wms_request_compare(request)
 
-        # Test getfeatureinfo response xml (default info_format)
+        # Test getfeatureinfo response xml
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fxml&transparent=true&' +
@@ -87,10 +87,10 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
                                  'wms_getfeatureinfo-text-html')
 
-        # Test getfeatureinfo response text
+        # Test getfeatureinfo default info_format
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
-                                 'info_format=text%2Fplain&transparent=true&' +
+                                 'transparent=true&' +
                                  'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
@@ -1,0 +1,14 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<GetFeatureInfoResponse>
+ <Layer name="testlayer èé">
+  <Feature id="2">
+   <Attribute value="3" name="id"/>
+   <Attribute value="three" name="name"/>
+   <Attribute value="three èé↓" name="utf8nameè"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
+   <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>


### PR DESCRIPTION
Removing QgsWMSProjectParser from GetFeatureInfo
https://github.com/qgis/qgis3.0_api/issues/57

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
