### PR TITLE
Force use of QgsUnitTypes::RenderMillimeters in QgsSymbol::bigSymbolP…

### DIFF
--- a/src/core/symbology-ng/qgssymbol.cpp
+++ b/src/core/symbology-ng/qgssymbol.cpp
@@ -449,6 +449,10 @@ void QgsSymbol::drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext
 {
   QgsRenderContext context = customContext ? *customContext : QgsRenderContext::fromQPainter( painter );
   context.setForceVectorOutput( true );
+  // TODO: replace this hack with something better
+  QgsUnitTypes::RenderUnit save_outputUnit = outputUnit();
+  // Preview and Icons should not use MapUnits and others that cannot (often) be seen.
+  setOutputUnit( QgsUnitTypes::RenderMillimeters );
   QgsSymbolRenderContext symbolContext( context, outputUnit(), mOpacity, false, mRenderHints, nullptr, QgsFields(), mapUnitScale() );
 
   Q_FOREACH ( QgsSymbolLayer *layer, mLayers )
@@ -474,6 +478,8 @@ void QgsSymbol::drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext
     else
       layer->drawPreviewIcon( symbolContext, size );
   }
+  // Restore original value
+  setOutputUnit( save_outputUnit );
 }
 
 void QgsSymbol::exportImage( const QString &path, const QString &format, QSize size )

--- a/src/core/symbology-ng/qgssymbol.cpp
+++ b/src/core/symbology-ng/qgssymbol.cpp
@@ -527,6 +527,10 @@ QImage QgsSymbol::bigSymbolPreviewImage( QgsExpressionContext *expressionContext
   }
 
   QgsRenderContext context = QgsRenderContext::fromQPainter( &p );
+  // TODO: replace this hack with something better
+  QgsUnitTypes::RenderUnit save_outputUnit = outputUnit();
+  // Preview and Icons should not use MapUnits and others that cannot (often) be seen.
+  setOutputUnit( QgsUnitTypes::RenderMillimeters );
   if ( expressionContext )
     context.setExpressionContext( *expressionContext );
 
@@ -550,6 +554,8 @@ QImage QgsSymbol::bigSymbolPreviewImage( QgsExpressionContext *expressionContext
   }
 
   stopRender( context );
+  // Restore original value
+  setOutputUnit( save_outputUnit );
   return preview;
 }
 

--- a/src/core/symbology-ng/qgssymbollayer.cpp
+++ b/src/core/symbology-ng/qgssymbollayer.cpp
@@ -412,6 +412,10 @@ void QgsMarkerSymbolLayer::startRender( QgsSymbolRenderContext &context )
 
 void QgsMarkerSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext &context, QSize size )
 {
+  QgsUnitTypes::RenderUnit save_outputUnit = outputUnit();
+  // Preview and Icons should not use MapUnits and others that cannot (often) be seen.
+  // Using RenderUnit from SymbolLayerItem,with QgsUnitTypes::RenderMillimeters, through QgsSymbolLayerUtils::symbolLayerPreviewIcon.
+  setOutputUnit( context.outputUnit() );
   startRender( context );
   QgsPaintEffect *effect = paintEffect();
   if ( effect && effect->enabled() )
@@ -424,6 +428,8 @@ void QgsMarkerSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext &context, QSi
     renderPoint( QPointF( size.width() / 2, size.height() / 2 ), context );
   }
   stopRender( context );
+  // Restore original value
+  setOutputUnit( save_outputUnit );
 }
 
 void QgsMarkerSymbolLayer::markerOffset( QgsSymbolRenderContext &context, double &offsetX, double &offsetY ) const


### PR DESCRIPTION
…QgsSymbol::bigSymbolPreviewImage.

## Description
QgsSymbol::bigSymbolPreviewImage does not render properly when OuputUnit is not set to RenderMillimeters

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ x] Commit messages are descriptive and explain the rationale for changes
- [ x] Commits which fix bugs include `fixes #16866` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

See https://issues.qgis.org/issues/16866 for detailed description.

The QgsUnitTypes::RenderUnit of the Layer is being used instead of QgsUnitTypes::RenderMillimeters.
The QgsDistanceArea being used is not based on the Layer being used.

Thus when this runs, MapUnits are assumed to be in Degrees, RenderMetersInMapUnits (a value given in Meters) is transformed into degrees. So for the given 5.1 Meters: 0.00000458141 is bing used - which cannot be seen.
This seems to also to effect Icons being shown for the 'Simple marker' and in the Layer Panel.

![updatepreview all original](https://user-images.githubusercontent.com/4899405/28238880-ec8bf942-695d-11e7-92c5-fc045faa02ed.png)

This solution is a bit of a Hack, for reasons given in issue 16866.
I can also not determine if there are any side effects.

My assumption is that since this function uses a fixed size for the image (100x100) that this is not the case.

