### PR TITLE
QgsGeometry: error reporting

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -716,6 +716,12 @@ Returns a simplified version of this geometry using a specified tolerance value
     QgsGeometry centroid() const;
 %Docstring
  Returns the center of mass of a geometry.
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
+
 .. note::
 
    for line based geometries, the center point of the line is returned,
@@ -730,6 +736,12 @@ Returns a simplified version of this geometry using a specified tolerance value
  Returns a point guaranteed to lie on the surface of a geometry. While the centroid()
  of a geometry may be located outside of the geometry itself (e.g., for concave shapes),
  the point on surface will always be inside the geometry.
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
+
 .. seealso:: centroid()
 .. seealso:: poleOfInaccessibility()
  :rtype: QgsGeometry
@@ -752,7 +764,12 @@ Returns a simplified version of this geometry using a specified tolerance value
 
     QgsGeometry convexHull() const;
 %Docstring
-Returns the smallest convex polygon that contains all the points in the geometry.
+ Returns the smallest convex polygon that contains all the points in the geometry.
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
  :rtype: QgsGeometry
 %End
 
@@ -799,14 +816,25 @@ Returns the smallest convex polygon that contains all the points in the geometry
 
  Curved geometries will be segmentized before subdivision.
 
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
+
 .. versionadded:: 3.0
  :rtype: QgsGeometry
 %End
 
     QgsGeometry interpolate( double distance ) const;
 %Docstring
- Return interpolated point on line at distance
-.. versionadded:: 1.9
+ Return interpolated point on line at distance.
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
+
+.. versionadded:: 2.0
 .. seealso:: lineLocatePoint()
  :rtype: QgsGeometry
 %End
@@ -841,7 +869,12 @@ Returns the smallest convex polygon that contains all the points in the geometry
 
     QgsGeometry intersection( const QgsGeometry &geometry ) const;
 %Docstring
-Returns a geometry representing the points shared by this geometry and other.
+ Returns a geometry representing the points shared by this geometry and other.
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
  :rtype: QgsGeometry
 %End
 
@@ -859,6 +892,12 @@ Returns a geometry representing the points shared by this geometry and other.
 %Docstring
  Returns a geometry representing all the points in this geometry and other (a
  union geometry operation).
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
+
 .. note::
 
    this operation is not called union since its a reserved word in C++.
@@ -878,13 +917,23 @@ Returns a geometry representing the points shared by this geometry and other.
 
     QgsGeometry difference( const QgsGeometry &geometry ) const;
 %Docstring
-Returns a geometry representing the points making up this geometry that do not make up other.
+ Returns a geometry representing the points making up this geometry that do not make up other.
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
  :rtype: QgsGeometry
 %End
 
     QgsGeometry symDifference( const QgsGeometry &geometry ) const;
 %Docstring
-Returns a geometry representing the points making up this geometry that do not make up other.
+ Returns a geometry representing the points making up this geometry that do not make up other.
+
+ If the input is a NULL geometry, the output will also be a NULL geometry.
+
+ If an error was encountered while creating the result, more information can be retrieved
+ by calling `error()` on the returned geometry.
  :rtype: QgsGeometry
 %End
 
@@ -1182,6 +1231,15 @@ Ring 0 is outer ring and can't be deleted.
 .. versionadded:: 2.10
 .. seealso:: vertexIdFromVertexNr
  :rtype: int
+%End
+
+    QString error() const;
+%Docstring
+ Returns an error string referring to an error that was produced
+ when this geometry was created.
+
+.. versionadded:: 3.0
+ :rtype: str
 %End
 
 

--- a/python/plugins/processing/algs/qgis/PointOnSurface.py
+++ b/python/plugins/processing/algs/qgis/PointOnSurface.py
@@ -83,7 +83,7 @@ class PointOnSurface(QgisAlgorithm):
             if input_geometry:
                 output_geometry = input_geometry.pointOnSurface()
                 if not output_geometry:
-                    raise QgsProcessingException(self.tr('Error calculating point on surface. Check the message log for GEOS errors.'))
+                    raise QgsProcessingException(self.tr('Error calculating point on surface: `{error_message}`'.format(error_message=output_geometry.error())))
 
                 output_feature.setGeometry(output_geometry)
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -672,6 +672,12 @@ class CORE_EXPORT QgsGeometry
 
     /**
      * Returns the center of mass of a geometry.
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     *
      * \note for line based geometries, the center point of the line is returned,
      * and for point based geometries, the point itself is returned
      * \see pointOnSurface()
@@ -683,6 +689,12 @@ class CORE_EXPORT QgsGeometry
      * Returns a point guaranteed to lie on the surface of a geometry. While the centroid()
      * of a geometry may be located outside of the geometry itself (e.g., for concave shapes),
      * the point on surface will always be inside the geometry.
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     *
      * \see centroid()
      * \see poleOfInaccessibility()
      */
@@ -702,7 +714,14 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry poleOfInaccessibility( double precision, double *distanceToBoundary SIP_OUT = nullptr ) const;
 
-    //! Returns the smallest convex polygon that contains all the points in the geometry.
+    /**
+     * Returns the smallest convex polygon that contains all the points in the geometry.
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     */
     QgsGeometry convexHull() const;
 
     /**
@@ -745,13 +764,24 @@ class CORE_EXPORT QgsGeometry
      *
      * Curved geometries will be segmentized before subdivision.
      *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     *
      * \since QGIS 3.0
      */
     QgsGeometry subdivide( int maxNodes = 256 ) const;
 
     /**
-     * Return interpolated point on line at distance
-     * \since QGIS 1.9
+     * Return interpolated point on line at distance.
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     *
+     * \since QGIS 2.0
      * \see lineLocatePoint()
      */
     QgsGeometry interpolate( double distance ) const;
@@ -778,7 +808,14 @@ class CORE_EXPORT QgsGeometry
      */
     double interpolateAngle( double distance ) const;
 
-    //! Returns a geometry representing the points shared by this geometry and other.
+    /**
+     * Returns a geometry representing the points shared by this geometry and other.
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     */
     QgsGeometry intersection( const QgsGeometry &geometry ) const;
 
     /**
@@ -790,13 +827,21 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry clipped( const QgsRectangle &rectangle );
 
-    /** Returns a geometry representing all the points in this geometry and other (a
+    /**
+     * Returns a geometry representing all the points in this geometry and other (a
      * union geometry operation).
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     *
      * \note this operation is not called union since its a reserved word in C++.
      */
     QgsGeometry combine( const QgsGeometry &geometry ) const;
 
-    /** Merges any connected lines in a LineString/MultiLineString geometry and
+    /**
+     * Merges any connected lines in a LineString/MultiLineString geometry and
      * converts them to single line strings.
      * \returns a LineString or MultiLineString geometry, with any connected lines
      * joined. An empty geometry will be returned if the input geometry was not a
@@ -805,10 +850,24 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry mergeLines() const;
 
-    //! Returns a geometry representing the points making up this geometry that do not make up other.
+    /**
+     * Returns a geometry representing the points making up this geometry that do not make up other.
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     */
     QgsGeometry difference( const QgsGeometry &geometry ) const;
 
-    //! Returns a geometry representing the points making up this geometry that do not make up other.
+    /**
+     * Returns a geometry representing the points making up this geometry that do not make up other.
+     *
+     * If the input is a NULL geometry, the output will also be a NULL geometry.
+     *
+     * If an error was encountered while creating the result, more information can be retrieved
+     * by calling `error()` on the returned geometry.
+     */
     QgsGeometry symDifference( const QgsGeometry &geometry ) const;
 
     //! Returns an extruded version of this geometry.
@@ -1046,6 +1105,14 @@ class CORE_EXPORT QgsGeometry
      * \see vertexIdFromVertexNr
      */
     int vertexNrFromVertexId( QgsVertexId i ) const;
+
+    /**
+     * Returns an error string referring to an error that was produced
+     * when this geometry was created.
+     *
+     * \since QGIS 3.0
+     */
+    QString error() const;
 
     /** Return GEOS context handle
      * \since QGIS 2.6


### PR DESCRIPTION
When methods are called that use GEOS to create new geometries, the
result geometries now contain information about what has gone wrong in
case of an error.

In practice, this means it's possible to give more detailed information
in place (and not only in the message log) when things like processing
algorithms fail.

```
>>> geom = QgsGeometry.fromWkt('POLYGON((0 4, 4 4, 2 2, 2 6))').pointOnSurface()
>>> geom.isNull()
True
>>> geom.error()
'TopologyException: Input geom 1 is invalid: Self-intersection at or near point 2 4 at 2 4'
```