### PR TITLE
Non-blocking save as image/pdf dialogs

### DIFF
--- a/python/core/qgsmaprenderertask.sip
+++ b/python/core/qgsmaprenderertask.sip
@@ -31,7 +31,8 @@ class QgsMapRendererTask : QgsTask
 
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
-                        const QString &fileFormat = QString( "PNG" ) );
+                        const QString &fileFormat = QString( "PNG" ),
+                        const bool forceRaster = false );
 %Docstring
  Constructor for QgsMapRendererTask to render a map to an image file.
 %End

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -21,8 +21,9 @@
 #include "ui_qgsmapsavedialog.h"
 
 #include "qgisapp.h"
-#include "qgsrectangle.h"
 #include "qgsmapcanvas.h"
+#include "qgsmapdecoration.h"
+#include "qgsrectangle.h"
 
 #include <QDialog>
 #include <QSize>
@@ -45,7 +46,10 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
 
     /** Constructor for QgsMapSaveDialog
      */
-    QgsMapSaveDialog( QWidget *parent = nullptr, QgsMapCanvas *mapCanvas = nullptr, const QString &activeDecorations = QString(), DialogType type = Image );
+    QgsMapSaveDialog( QWidget *parent = nullptr, QgsMapCanvas *mapCanvas = nullptr,
+                      QList< QgsDecorationItem * > decorations = QList< QgsDecorationItem * >(),
+                      QList< QgsAnnotation *> annotations = QList< QgsAnnotation * >(),
+                      DialogType type = Image );
 
     //! returns extent rectangle
     QgsRectangle extent() const;
@@ -73,6 +77,8 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
 
   private:
 
+    void accepted();
+
     void updateDpi( int dpi );
     void updateOutputWidth( int width );
     void updateOutputHeight( int height );
@@ -82,6 +88,9 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
 
     DialogType mDialogType;
     QgsMapCanvas *mMapCanvas;
+    QList< QgsMapDecoration * > mDecorations;
+    QList< QgsAnnotation *> mAnnotations;
+
     QgsRectangle mExtent;
     int mDpi;
     QSize mSize;

--- a/src/core/qgsmaprenderertask.cpp
+++ b/src/core/qgsmaprenderertask.cpp
@@ -22,17 +22,19 @@
 
 #include <QFile>
 #include <QTextStream>
+#include <QPrinter>
 
-QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat )
+QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat, const bool forceRaster )
   : QgsTask( tr( "Saving as image" ) )
   , mMapSettings( ms )
   , mFileName( fileName )
   , mFileFormat( fileFormat )
+  , mForceRaster( forceRaster )
 {
 }
 
 QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, QPainter *p )
-  : QgsTask( tr( "Saving as image" ) )
+  : QgsTask( tr( "Rendering to painter" ) )
   , mMapSettings( ms )
   , mPainter( p )
 {
@@ -70,8 +72,27 @@ bool QgsMapRendererTask::run()
   QImage img;
   std::unique_ptr< QPainter > tempPainter;
   QPainter *destPainter = mPainter;
+  std::unique_ptr< QPrinter > printer;
 
-  if ( !mPainter )
+  if ( mFileFormat == QStringLiteral( "PDF" ) )
+  {
+    printer.reset( new QPrinter() );
+    printer->setOutputFileName( mFileName );
+    printer->setOutputFormat( QPrinter::PdfFormat );
+    printer->setOrientation( QPrinter::Portrait );
+    // paper size needs to be given in millimeters in order to be able to set a resolution to pass onto the map renderer
+    printer->setPaperSize( mMapSettings.outputSize()  * 25.4 / mMapSettings.outputDpi(), QPrinter::Millimeter );
+    printer->setPageMargins( 0, 0, 0, 0, QPrinter::Millimeter );
+    printer->setResolution( mMapSettings.outputDpi() );
+
+    if ( !mForceRaster )
+    {
+      tempPainter.reset( new QPainter( printer.get() ) );
+      destPainter = tempPainter.get();
+    }
+  }
+
+  if ( !destPainter )
   {
     // save rendered map to an image file
     img = QImage( mMapSettings.outputSize(), QImage::Format_ARGB32 );
@@ -149,27 +170,39 @@ bool QgsMapRendererTask::run()
   if ( !mFileName.isEmpty() )
   {
     destPainter->end();
-    bool success = img.save( mFileName, mFileFormat.toLocal8Bit().data() );
-    if ( !success )
+
+    if ( mForceRaster && mFileFormat == QStringLiteral( "PDF" ) )
     {
-      mError = ImageSaveFail;
-      return false;
+      QPainter pp;
+      pp.begin( printer.get() );
+      QRectF rect( 0, 0, img.width(), img.height() );
+      pp.drawImage( rect, img, rect );
+      pp.end();
     }
-
-    if ( mSaveWorldFile )
+    else if ( mFileFormat != QStringLiteral( "PDF" ) )
     {
-      QFileInfo info  = QFileInfo( mFileName );
-
-      // build the world file name
-      QString outputSuffix = info.suffix();
-      QString worldFileName = info.absolutePath() + '/' + info.baseName() + '.'
-                              + outputSuffix.at( 0 ) + outputSuffix.at( info.suffix().size() - 1 ) + 'w';
-      QFile worldFile( worldFileName );
-
-      if ( worldFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) //don't use QIODevice::Text
+      bool success = img.save( mFileName, mFileFormat.toLocal8Bit().data() );
+      if ( !success )
       {
-        QTextStream stream( &worldFile );
-        stream << QgsMapSettingsUtils::worldFileContent( mMapSettings );
+        mError = ImageSaveFail;
+        return false;
+      }
+
+      if ( mSaveWorldFile )
+      {
+        QFileInfo info  = QFileInfo( mFileName );
+
+        // build the world file name
+        QString outputSuffix = info.suffix();
+        QString worldFileName = info.absolutePath() + '/' + info.baseName() + '.'
+                                + outputSuffix.at( 0 ) + outputSuffix.at( info.suffix().size() - 1 ) + 'w';
+        QFile worldFile( worldFileName );
+
+        if ( worldFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) //don't use QIODevice::Text
+        {
+          QTextStream stream( &worldFile );
+          stream << QgsMapSettingsUtils::worldFileContent( mMapSettings );
+        }
       }
     }
   }

--- a/src/core/qgsmaprenderertask.h
+++ b/src/core/qgsmaprenderertask.h
@@ -55,7 +55,8 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
      */
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
-                        const QString &fileFormat = QString( "PNG" ) );
+                        const QString &fileFormat = QString( "PNG" ),
+                        const bool forceRaster = false );
 
     /**
      * Constructor for QgsMapRendererTask to render a map to a painter object.
@@ -108,6 +109,7 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
 
     QString mFileName;
     QString mFileFormat;
+    bool mForceRaster = false;
     bool mSaveWorldFile = false;
 
     QList< QgsAnnotation * > mAnnotations;


### PR DESCRIPTION
## Description
This PR is required to introduce a drawing extent on canvas feature to QGIS' Save as image / PDF function. Code has been moved around to allow for the creation of non-blocking save as image / PDF dialogs.

@nyalldawson , your review would be greatly appreciated

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
