### PR TITLE
[FEATURE] Draw extent onto canvas in save as image/PDF dialog

### DIFF
--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -137,6 +137,7 @@
 %Include qgsmaptoolcapture.sip
 %Include qgsmaptooledit.sip
 %Include qgsmaptoolemitpoint.sip
+%Include qgsmaptoolextent.sip
 %Include qgsmaptoolidentify.sip
 %Include qgsmaptoolidentifyfeature.sip
 %Include qgsmaptoolpan.sip

--- a/python/gui/qgsextentgroupbox.sip
+++ b/python/gui/qgsextentgroupbox.sip
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsExtentGroupBox : QgsCollapsibleGroupBox
 {
 %Docstring
@@ -34,6 +36,7 @@ class QgsExtentGroupBox : QgsCollapsibleGroupBox
       CurrentExtent,
       UserExtent,
       ProjectLayerExtent,
+      DrawOnCanvas,
     };
 
     explicit QgsExtentGroupBox( QWidget *parent /TransferThis/ = 0 );
@@ -124,6 +127,13 @@ class QgsExtentGroupBox : QgsCollapsibleGroupBox
  :rtype: str
 %End
 
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+ Sets the map canvas to enable dragging of extent on a canvas.
+ \param canvas the map canvas
+.. versionadded:: 3.0
+%End
+
   public slots:
 
     void setOutputExtentFromOriginal();
@@ -144,6 +154,12 @@ class QgsExtentGroupBox : QgsCollapsibleGroupBox
     void setOutputExtentFromLayer( const QgsMapLayer *layer );
 %Docstring
  Sets the output extent to match a ``layer``'s extent (may be transformed to output CRS).
+.. versionadded:: 3.0
+%End
+
+    void setOutputExtentFromDrawOnCanvas();
+%Docstring
+ Sets the output extent by dragging on the canvas.
 .. versionadded:: 3.0
 %End
 

--- a/python/gui/qgsmaptoolextent.sip
+++ b/python/gui/qgsmaptoolextent.sip
@@ -1,0 +1,75 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsmaptoolextent.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsMapToolExtent : QgsMapTool
+{
+%Docstring
+ A map tool that emits an extent from a rectangle drawn onto the map canvas.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsmaptoolextent.h"
+%End
+  public:
+
+    QgsMapToolExtent( QgsMapCanvas *canvas );
+%Docstring
+constructor
+%End
+
+    virtual Flags flags() const;
+    virtual void canvasMoveEvent( QgsMapMouseEvent *e );
+    virtual void canvasPressEvent( QgsMapMouseEvent *e );
+    virtual void canvasReleaseEvent( QgsMapMouseEvent *e );
+    virtual void activate();
+    virtual void deactivate();
+
+    void setRatio( QSize ratio );
+%Docstring
+ Sets a fixed aspect ratio to be used when dragging extent onto the canvas.
+ To unset a fixed aspect ratio, set the width and height to zero.
+ \param ratio aspect ratio's width and height
+ *
+%End
+
+    QSize ratio() const;
+%Docstring
+ Returns the current fixed aspect ratio to be used when dragging extent onto the canvas.
+ If the aspect ratio isn't fixed, the width and height will be set to zero.
+ *
+ :rtype: QSize
+%End
+
+    QgsRectangle extent() const;
+%Docstring
+ Returns the current extent drawn onto the canvas.
+ :rtype: QgsRectangle
+%End
+
+  signals:
+
+    void extentChanged( const QgsRectangle &extent );
+%Docstring
+signal emitted on extent change
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsmaptoolextent.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -59,6 +59,7 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, QL
   mExtentGroupBox->setOutputCrs( ms.destinationCrs() );
   mExtentGroupBox->setCurrentExtent( mExtent, ms.destinationCrs() );
   mExtentGroupBox->setOutputExtentFromCurrent();
+  mExtentGroupBox->setMapCanvas( mapCanvas );
 
   mScaleWidget->setScale( ms.scale() );
   mScaleWidget->setMapCanvas( mMapCanvas );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -283,6 +283,7 @@ SET(QGIS_GUI_SRCS
   qgsmaptoolcapture.cpp
   qgsmaptooledit.cpp
   qgsmaptoolemitpoint.cpp
+  qgsmaptoolextent.cpp
   qgsmaptoolidentify.cpp
   qgsmaptoolidentifyfeature.cpp
   qgsmaptoolpan.cpp
@@ -437,6 +438,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsmaptoolcapture.h
   qgsmaptooledit.h
   qgsmaptoolemitpoint.h
+  qgsmaptoolextent.h
   qgsmaptoolidentify.h
   qgsmaptoolidentifyfeature.h
   qgsmaptoolpan.h

--- a/src/gui/qgsextentgroupbox.cpp
+++ b/src/gui/qgsextentgroupbox.cpp
@@ -12,13 +12,17 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #include "qgsextentgroupbox.h"
 
+#include "qgslogger.h"
 #include "qgscoordinatetransform.h"
 #include "qgsrasterblock.h"
+#include "qgsmapcanvas.h"
 #include "qgsmaplayermodel.h"
 #include "qgsexception.h"
 #include "qgsproject.h"
+
 #include <QMenu>
 #include <QAction>
 
@@ -40,12 +44,14 @@ QgsExtentGroupBox::QgsExtentGroupBox( QWidget *parent )
   mYMaxLineEdit->setValidator( new QDoubleValidator( this ) );
 
   mOriginalExtentButton->setVisible( false );
+  mButtonDrawOnCanvas->setVisible( false );
 
   connect( mCurrentExtentButton, &QAbstractButton::clicked, this, &QgsExtentGroupBox::setOutputExtentFromCurrent );
   connect( mOriginalExtentButton, &QAbstractButton::clicked, this, &QgsExtentGroupBox::setOutputExtentFromOriginal );
+  connect( mButtonDrawOnCanvas, &QAbstractButton::clicked, this, &QgsExtentGroupBox::setOutputExtentFromDrawOnCanvas );
+
   connect( this, &QGroupBox::clicked, this, &QgsExtentGroupBox::groupBoxClicked );
 }
-
 
 void QgsExtentGroupBox::setOriginalExtent( const QgsRectangle &originalExtent, const QgsCoordinateReferenceSystem &originalCrs )
 {
@@ -81,6 +87,11 @@ void QgsExtentGroupBox::setOutputCrs( const QgsCoordinateReferenceSystem &output
       case ProjectLayerExtent:
         mOutputCrs = outputCrs;
         setOutputExtentFromLayer( mExtentLayer.data() );
+        break;
+
+      case DrawOnCanvas:
+        mOutputCrs = outputCrs;
+        extentDrawn( outputExtent() );
         break;
 
       case UserExtent:
@@ -167,6 +178,9 @@ void QgsExtentGroupBox::updateTitle()
     case ProjectLayerExtent:
       msg = mExtentLayerName;
       break;
+    case DrawOnCanvas:
+      msg = tr( "drawn on canvas" );
+      break;
   }
   if ( isCheckable() && !isChecked() )
     msg = tr( "none" );
@@ -213,7 +227,17 @@ void QgsExtentGroupBox::setExtentToLayerExtent( const QString &layerId )
 
 void QgsExtentGroupBox::setOutputExtentFromCurrent()
 {
-  setOutputExtent( mCurrentExtent, mCurrentCrs, CurrentExtent );
+  if ( mCanvas )
+  {
+    // Use unrotated visible extent to insure output size and scale matches canvas
+    QgsMapSettings ms = mCanvas->mapSettings();
+    ms.setRotation( 0 );
+    setOutputExtent( ms.visibleExtent(), ms.destinationCrs(), CurrentExtent );
+  }
+  else
+  {
+    setOutputExtent( mCurrentExtent, mCurrentCrs, CurrentExtent );
+  }
 }
 
 
@@ -236,6 +260,34 @@ void QgsExtentGroupBox::setOutputExtentFromLayer( const QgsMapLayer *layer )
   mExtentLayerName = layer->name();
 
   setOutputExtent( layer->extent(), layer->crs(), ProjectLayerExtent );
+}
+
+void QgsExtentGroupBox::setOutputExtentFromDrawOnCanvas()
+{
+  if ( mCanvas )
+  {
+    mMapToolPrevious = mCanvas->mapTool();
+    if ( !mMapToolExtent )
+    {
+      mMapToolExtent.reset( new QgsMapToolExtent( mCanvas ) );
+      connect( mMapToolExtent.get(), &QgsMapToolExtent::extentChanged, this, &QgsExtentGroupBox::extentDrawn );
+      connect( mMapToolExtent.get(), &QgsMapTool::deactivated, this, [ = ]
+      {
+        window()->setVisible( true );
+        mMapToolPrevious = nullptr;
+      } );
+    }
+    mCanvas->setMapTool( mMapToolExtent.get() );
+    window()->setVisible( false );
+  }
+}
+
+void QgsExtentGroupBox::extentDrawn( const QgsRectangle &extent )
+{
+  setOutputExtent( extent, mCanvas->mapSettings().destinationCrs(), DrawOnCanvas );
+  mCanvas->setMapTool( mMapToolPrevious );
+  window()->setVisible( true );
+  mMapToolPrevious = nullptr;
 }
 
 void QgsExtentGroupBox::groupBoxClicked()
@@ -268,4 +320,17 @@ void QgsExtentGroupBox::setTitleBase( const QString &title )
 QString QgsExtentGroupBox::titleBase() const
 {
   return mTitleBase;
+}
+
+void QgsExtentGroupBox::setMapCanvas( QgsMapCanvas *canvas )
+{
+  if ( canvas )
+  {
+    mCanvas = canvas;
+    mButtonDrawOnCanvas->setVisible( true );
+  }
+  else
+  {
+    mButtonDrawOnCanvas->setVisible( false );
+  }
 }

--- a/src/gui/qgsextentgroupbox.h
+++ b/src/gui/qgsextentgroupbox.h
@@ -12,10 +12,13 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #ifndef QGSEXTENTGROUPBOX_H
 #define QGSEXTENTGROUPBOX_H
 
 #include "qgscollapsiblegroupbox.h"
+#include "qgsmaptool.h"
+#include "qgsmaptoolextent.h"
 #include "qgis.h"
 
 #include "ui_qgsextentgroupboxwidget.h"
@@ -23,6 +26,8 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrectangle.h"
 #include "qgis_gui.h"
+
+#include <memory>
 
 class QgsCoordinateReferenceSystem;
 class QgsMapLayerModel;
@@ -52,6 +57,7 @@ class GUI_EXPORT QgsExtentGroupBox : public QgsCollapsibleGroupBox, private Ui::
       CurrentExtent,   //!< Map canvas extent
       UserExtent,      //!< Extent manually entered/modified by the user
       ProjectLayerExtent, //!< Extent taken from a layer within the project
+      DrawOnCanvas, //!< Extent taken from a rectangled drawn onto the map canvas
     };
 
     /**
@@ -135,6 +141,13 @@ class GUI_EXPORT QgsExtentGroupBox : public QgsCollapsibleGroupBox, private Ui::
      */
     QString titleBase() const;
 
+    /**
+     * Sets the map canvas to enable dragging of extent on a canvas.
+     * \param canvas the map canvas
+     * \since QGIS 3.0
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
   public slots:
 
     /**
@@ -158,6 +171,12 @@ class GUI_EXPORT QgsExtentGroupBox : public QgsCollapsibleGroupBox, private Ui::
      */
     void setOutputExtentFromLayer( const QgsMapLayer *layer );
 
+    /**
+     * Sets the output extent by dragging on the canvas.
+     * \since QGIS 3.0
+     */
+    void setOutputExtentFromDrawOnCanvas();
+
   signals:
 
     /**
@@ -174,6 +193,8 @@ class GUI_EXPORT QgsExtentGroupBox : public QgsCollapsibleGroupBox, private Ui::
 
     void groupBoxClicked();
     void layerMenuAboutToShow();
+
+    void extentDrawn( const QgsRectangle &extent );
 
   private:
     void setOutputExtent( const QgsRectangle &r, const QgsCoordinateReferenceSystem &srcCrs, QgsExtentGroupBox::ExtentState state );
@@ -198,6 +219,10 @@ class GUI_EXPORT QgsExtentGroupBox : public QgsCollapsibleGroupBox, private Ui::
     QList< QAction * > mMenuActions;
     QPointer< const QgsMapLayer > mExtentLayer;
     QString mExtentLayerName;
+
+    std::unique_ptr< QgsMapToolExtent > mMapToolExtent;
+    QPointer< QgsMapTool > mMapToolPrevious = nullptr;
+    QgsMapCanvas *mCanvas = nullptr;
 
     void setExtentToLayerExtent( const QString &layerId );
 

--- a/src/gui/qgsmaptoolextent.cpp
+++ b/src/gui/qgsmaptoolextent.cpp
@@ -1,0 +1,125 @@
+/***************************************************************************
+    qgsmaptoolextent.h  -  map tool that emits an extent
+    ---------------------
+    begin                : July 2017
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolextent.h"
+#include "qgsmapcanvas.h"
+#include "qgswkbtypes.h"
+
+#include <QMouseEvent>
+
+
+QgsMapToolExtent::QgsMapToolExtent( QgsMapCanvas *canvas )
+  : QgsMapTool( canvas )
+{
+  mRubberBand.reset( new QgsRubberBand( canvas, QgsWkbTypes::PolygonGeometry ) );
+}
+
+void QgsMapToolExtent::activate()
+{
+  QgsMapTool::activate();
+}
+
+void QgsMapToolExtent::deactivate()
+{
+  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
+
+  QgsMapTool::deactivate();
+}
+
+void QgsMapToolExtent::canvasMoveEvent( QgsMapMouseEvent *e )
+{
+  if ( !mDraw )
+    return;
+
+
+  QgsPointXY p = toMapCoordinates( e->pos() );
+  if ( mRatio.width() > 0 && mRatio.height() > 0 )
+  {
+    double width = qAbs( p.x() - mStartPoint.x() );
+    double height = width * ( mRatio.width() / mRatio.height() );
+    if ( p.y() - mStartPoint.y() < 0 )
+      height *= -1;
+    p.setY( mStartPoint.y() + height );
+  }
+
+  mEndPoint = toMapCoordinates( e->pos() );
+  calculateEndPoint( mEndPoint );
+  drawExtent();
+}
+
+void QgsMapToolExtent::canvasPressEvent( QgsMapMouseEvent *e )
+{
+  mStartPoint = toMapCoordinates( e->pos() );
+  mEndPoint = mStartPoint;
+  drawExtent();
+
+  mDraw = true;
+}
+
+void QgsMapToolExtent::canvasReleaseEvent( QgsMapMouseEvent *e )
+{
+  if ( !mDraw )
+    return;
+
+  mEndPoint = toMapCoordinates( e->pos() );
+  calculateEndPoint( mEndPoint );
+  drawExtent();
+
+  emit extentChanged( extent() );
+
+  mDraw = false;
+}
+
+QgsRectangle QgsMapToolExtent::extent() const
+{
+  if ( mStartPoint.x() != mEndPoint.x() && mStartPoint.y() != mEndPoint.y() )
+  {
+    return QgsRectangle( mStartPoint, mEndPoint );
+  }
+  else
+  {
+    return QgsRectangle();
+  }
+}
+
+void QgsMapToolExtent::calculateEndPoint( QgsPointXY &point )
+{
+  if ( mRatio.width() > 0 && mRatio.height() > 0 )
+  {
+    double width = qAbs( point.x() - mStartPoint.x() );
+    double height = width * mRatio.height() / mRatio.width();
+    if ( point.y() - mStartPoint.y() < 0 )
+      height *= -1;
+    point.setY( mStartPoint.y() + height );
+  }
+}
+
+void QgsMapToolExtent::drawExtent()
+{
+  if ( qgsDoubleNear( mStartPoint.x(), mEndPoint.x() ) && qgsDoubleNear( mStartPoint.y(), mEndPoint.y() ) )
+    return;
+
+  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
+
+  QgsRectangle rect( mStartPoint, mEndPoint );
+
+  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
+  mRubberBand->addPoint( QgsPointXY( rect.xMinimum(), rect.yMinimum() ), false );
+  mRubberBand->addPoint( QgsPointXY( rect.xMaximum(), rect.yMinimum() ), false );
+  mRubberBand->addPoint( QgsPointXY( rect.xMaximum(), rect.yMaximum() ), false );
+  mRubberBand->addPoint( QgsPointXY( rect.xMinimum(), rect.yMaximum() ), true );
+
+  mRubberBand->show();
+}

--- a/src/gui/qgsmaptoolextent.h
+++ b/src/gui/qgsmaptoolextent.h
@@ -1,0 +1,86 @@
+/***************************************************************************
+    qgsmaptoolextent.h  -  map tool that emits an extent
+    ---------------------
+    begin                : July 2017
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLEXTENT_H
+#define QGSMAPTOOLEXTENT_H
+
+#include "qgsmaptool.h"
+#include "qgspointxy.h"
+#include "qgsrubberband.h"
+#include "qgis_gui.h"
+
+#include <memory>
+
+class QgsMapCanvas;
+
+
+/** \ingroup gui
+ * A map tool that emits an extent from a rectangle drawn onto the map canvas.
+ * \since QGIS 3.0
+ */
+class GUI_EXPORT QgsMapToolExtent : public QgsMapTool
+{
+    Q_OBJECT
+
+  public:
+
+    //! constructor
+    QgsMapToolExtent( QgsMapCanvas *canvas );
+
+    virtual Flags flags() const override { return QgsMapTool::AllowZoomRect; }
+    virtual void canvasMoveEvent( QgsMapMouseEvent *e ) override;
+    virtual void canvasPressEvent( QgsMapMouseEvent *e ) override;
+    virtual void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    virtual void activate() override;
+    virtual void deactivate() override;
+
+    /** Sets a fixed aspect ratio to be used when dragging extent onto the canvas.
+     * To unset a fixed aspect ratio, set the width and height to zero.
+     * \param ratio aspect ratio's width and height
+     * */
+    void setRatio( QSize ratio ) { mRatio = ratio; }
+
+    /** Returns the current fixed aspect ratio to be used when dragging extent onto the canvas.
+     * If the aspect ratio isn't fixed, the width and height will be set to zero.
+     * */
+    QSize ratio() const { return mRatio; }
+
+    /** Returns the current extent drawn onto the canvas.
+     */
+    QgsRectangle extent() const;
+
+  signals:
+
+    //! signal emitted on extent change
+    void extentChanged( const QgsRectangle &extent );
+
+  private:
+
+    void calculateEndPoint( QgsPointXY &point );
+
+    void drawExtent();
+
+    std::unique_ptr< QgsRubberBand > mRubberBand;
+
+    QgsPointXY mStartPoint;
+    QgsPointXY mEndPoint;
+
+    bool mDraw = false;
+
+    QSize mRatio;
+
+};
+
+#endif

--- a/src/ui/qgsextentgroupboxwidget.ui
+++ b/src/ui/qgsextentgroupboxwidget.ui
@@ -155,6 +155,19 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="4">
+       <widget class="QPushButton" name="mButtonDrawOnCanvas">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Draw on canvas</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
## Description
~~This is a WIP, keen to get this part of the code reviewed.~~ The PR adds a QgsMapToolExtent class, which QgsExtentGroupBox uses to offer users the possibility to drag a rectangle onto his/her canvas to define an extent. The feature is used in the Save as image/PDF dialog.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
