### PR TITLE
Fix in attributetable - problem and crash - Backport to 2.18

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -197,7 +197,7 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
       if ( newColumnMapping.size() == mColumnMapping.size() - removedColumnCount )
       {
         //the amount of removed column in the model need to be equal removedColumnCount
-        beginRemoveColumns( QModelIndex(), firstRemovedColumn, firstRemovedColumn+removedColumnCount-1 );
+        beginRemoveColumns( QModelIndex(), firstRemovedColumn, firstRemovedColumn + removedColumnCount - 1 );
         mColumnMapping = newColumnMapping;
         endRemoveColumns();
       }

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -196,7 +196,8 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
     {
       if ( newColumnMapping.size() == mColumnMapping.size() - removedColumnCount )
       {
-        beginRemoveColumns( QModelIndex(), firstRemovedColumn, firstRemovedColumn );
+        //the amount of removed column in the model need to be equal removedColumnCount
+        beginRemoveColumns( QModelIndex(), firstRemovedColumn, firstRemovedColumn+removedColumnCount-1 );
         mColumnMapping = newColumnMapping;
         endRemoveColumns();
       }

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -803,10 +803,10 @@ void QgsDualView::setFeatureSelectionManager( QgsIFeatureSelectionManager* featu
 
 void QgsDualView::setAttributeTableConfig( const QgsAttributeTableConfig& config )
 {
+  mConfig = config;
   mLayer->setAttributeTableConfig( config );
   mFilterModel->setAttributeTableConfig( config );
   mTableView->setAttributeTableConfig( config );
-  mConfig = config;
 }
 
 void QgsDualView::setSortExpression( const QString& sortExpression, Qt::SortOrder sortOrder )


### PR DESCRIPTION
## Description
Issue: https://issues.qgis.org/issues/16746 Problem when setting the columns to visible again, when field has other size.And when setting more than one to inactive, it crashed.

This is backport of #4875
--