### PR TITLE
Correctly create raster for heatmap output

### DIFF
--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -227,7 +227,7 @@ int QgsKernelDensityEstimation::radiusSizeInPixels( double radius ) const
 
 bool QgsKernelDensityEstimation::createEmptyLayer( GDALDriverH driver, const QgsRectangle &bounds, int rows, int columns ) const
 {
-  double geoTransform[6] = { bounds.xMinimum(), mPixelSize, 0, bounds.yMinimum(), 0, mPixelSize };
+  double geoTransform[6] = { bounds.xMinimum(), mPixelSize, 0, bounds.yMaximum(), 0, -mPixelSize };
   GDALDatasetH emptyDataset = GDALCreate( driver, mOutputFile.toUtf8(), columns, rows, 1, GDT_Float32, nullptr );
   if ( !emptyDataset )
     return false;


### PR DESCRIPTION
Incorrect creation of geo transform was leading to invalid raster outputs and many "creating warped vrt" log messages.

Credit for discovering this to @alexbruy !
