### PR TITLE
use QGIS API instead of GDAL API to create heatmaps

### DIFF
--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -95,16 +95,14 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
   }
 
   int dataTypeSize = QgsRasterBlock::typeSize( Qgis::Float32 );
-  float *line = new float[ cols ];
-  memset( line, NO_DATA, dataTypeSize * cols );
+  std::vector<float> line( cols );
+  std::fill( line.begin(), line.end(), NO_DATA );
   QgsRasterBlock block( Qgis::Float32, cols, 1 );
-  block.setData( QByteArray::fromRawData( ( char * )line, dataTypeSize * cols ) );
+  block.setData( QByteArray::fromRawData( ( char * )&line[0], dataTypeSize * cols ) );
   for ( int i = 0; i < rows ; i++ )
   {
     mProvider->writeBlock( &block, 1, 0, i );
   }
-
-  delete [] line;
 
   mBufferSize = -1;
   if ( mRadiusField < 0 )

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -95,7 +95,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
   }
 
   int dataTypeSize = QgsRasterBlock::typeSize( Qgis::Float32 );
-  float *line = new float[ dataTypeSize * cols ];
+  float *line = new float[ cols ];
   for ( int i = 0; i < cols; i++ )
   {
     line[i] = NO_DATA;
@@ -180,7 +180,6 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
     // get the data
     QgsRasterBlock *block = mProvider->block( 1, extent, blockSize, blockSize );
     QByteArray blockData = block->data();
-    blockData.detach();
     float *dataBuffer = ( float * ) blockData.data();
 
     for ( int xp = 0; xp < blockSize; xp++ )
@@ -208,7 +207,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
       }
     }
 
-    block->setData( QByteArray::fromRawData( ( char * )dataBuffer, sizeof( float ) * blockSize * blockSize ) );
+    block->setData( blockData );
     if ( !mProvider->writeBlock( block, 1, xPosition, yPosition ) )
     {
       result = RasterIoError;

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -13,10 +13,13 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QByteArray>
+
 #include "qgskde.h"
 #include "qgsfeaturesource.h"
 #include "qgsfeatureiterator.h"
 #include "qgsgeometry.h"
+#include "qgsrasterfilewriter.h"
 
 #define NO_DATA -9999
 
@@ -32,8 +35,6 @@ QgsKernelDensityEstimation::QgsKernelDensityEstimation( const QgsKernelDensityEs
   , mDecay( parameters.decayRatio )
   , mOutputValues( parameters.outputValues )
   , mBufferSize( -1 )
-  , mDatasetH( nullptr )
-  , mRasterBandH( nullptr )
 {
   if ( !parameters.radiusField.isEmpty() )
     mRadiusField = mSource->fields().lookupField( parameters.radiusField );
@@ -68,14 +69,6 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::run()
 
 QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
 {
-  GDALAllRegister();
-
-  GDALDriverH driver = GDALGetDriverByName( mOutputFormat.toUtf8() );
-  if ( !driver )
-  {
-    return DriverError;
-  }
-
   if ( !mSource )
     return InvalidParameters;
 
@@ -86,16 +79,35 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
   int rows = std::max( std::ceil( mBounds.height() / mPixelSize ) + 1, 1.0 );
   int cols = std::max( std::ceil( mBounds.width() / mPixelSize ) + 1, 1.0 );
 
-  if ( !createEmptyLayer( driver, mBounds, rows, cols ) )
+  // create empty raster and fill it with nodata values
+  QgsRasterFileWriter writer( mOutputFile );
+  writer.setOutputProviderKey( QStringLiteral( "gdal" ) );
+  writer.setOutputFormat( mOutputFormat );
+  mProvider = writer.createOneBandRaster( Qgis::Float32, cols, rows, mBounds, mSource->sourceCrs() );
+  if ( !mProvider )
+  {
     return FileCreationError;
+  }
 
-  // open the raster in GA_Update mode
-  mDatasetH = GDALOpen( mOutputFile.toUtf8().constData(), GA_Update );
-  if ( !mDatasetH )
+  if ( !mProvider->setNoDataValue( 1, NO_DATA ) )
+  {
     return FileCreationError;
-  mRasterBandH = GDALGetRasterBand( mDatasetH, 1 );
-  if ( !mRasterBandH )
-    return FileCreationError;
+  }
+
+  int dataTypeSize = QgsRasterBlock::typeSize( Qgis::Float32 );
+  float *line = new float[ dataTypeSize * cols ];
+  for ( int i = 0; i < cols; i++ )
+  {
+    line[i] = NO_DATA;
+  }
+  QgsRasterBlock block( Qgis::Float32, cols, 1 );
+  block.setData( QByteArray::fromRawData( ( char * )line, dataTypeSize * cols ) );
+  for ( int i = 0; i < rows ; i++ )
+  {
+    mProvider->writeBlock( &block, 1, 0, i );
+  }
+
+  delete [] line;
 
   mBufferSize = -1;
   if ( mRadiusField < 0 )
@@ -162,13 +174,14 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
     unsigned int yPositionIO = ( ( mBounds.yMaximum() - ( *pointIt ).y() ) / mPixelSize ) - buffer;
 
 
+    // calculate buffer around pixel
+    QgsRectangle extent( ( *pointIt ).x() - radius, ( *pointIt ).y() - radius, ( *pointIt ).x() + radius, ( *pointIt ).y() + radius );
+
     // get the data
-    float *dataBuffer = ( float * ) CPLMalloc( sizeof( float ) * blockSize * blockSize );
-    if ( GDALRasterIO( mRasterBandH, GF_Read, xPosition, yPositionIO, blockSize, blockSize,
-                       dataBuffer, blockSize, blockSize, GDT_Float32, 0, 0 ) != CE_None )
-    {
-      result = RasterIoError;
-    }
+    QgsRasterBlock *block = mProvider->block( 1, extent, blockSize, blockSize );
+    QByteArray blockData = block->data();
+    blockData.detach();
+    float *dataBuffer = ( float * ) blockData.data();
 
     for ( int xp = 0; xp < blockSize; xp++ )
     {
@@ -194,12 +207,14 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
         dataBuffer[ pos ] += pixelValue;
       }
     }
-    if ( GDALRasterIO( mRasterBandH, GF_Write, xPosition, yPositionIO, blockSize, blockSize,
-                       dataBuffer, blockSize, blockSize, GDT_Float32, 0, 0 ) != CE_None )
+
+    block->setData( QByteArray::fromRawData( ( char * )dataBuffer, sizeof( float ) * blockSize * blockSize ) );
+    if ( !mProvider->writeBlock( block, 1, xPosition, yPosition ) )
     {
       result = RasterIoError;
     }
-    CPLFree( dataBuffer );
+
+    delete block;
   }
 
   return result;
@@ -207,9 +222,9 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
 
 QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::finalise()
 {
-  GDALClose( ( GDALDatasetH ) mDatasetH );
-  mDatasetH = nullptr;
-  mRasterBandH = nullptr;
+  mProvider->setEditable( false );
+  mProvider = nullptr;
+
   return Success;
 }
 
@@ -221,47 +236,6 @@ int QgsKernelDensityEstimation::radiusSizeInPixels( double radius ) const
     ++buffer;
   }
   return buffer;
-}
-
-bool QgsKernelDensityEstimation::createEmptyLayer( GDALDriverH driver, const QgsRectangle &bounds, int rows, int columns ) const
-{
-  double geoTransform[6] = { bounds.xMinimum(), mPixelSize, 0, bounds.yMaximum(), 0, -mPixelSize };
-  GDALDatasetH emptyDataset = GDALCreate( driver, mOutputFile.toUtf8(), columns, rows, 1, GDT_Float32, nullptr );
-  if ( !emptyDataset )
-    return false;
-
-  if ( GDALSetGeoTransform( emptyDataset, geoTransform ) != CE_None )
-    return false;
-
-  // Set the projection on the raster destination to match the input layer
-  if ( GDALSetProjection( emptyDataset, mSource->sourceCrs().toWkt().toLocal8Bit().data() ) != CE_None )
-    return false;
-
-  GDALRasterBandH poBand = GDALGetRasterBand( emptyDataset, 1 );
-  if ( !poBand )
-    return false;
-
-  if ( GDALSetRasterNoDataValue( poBand, NO_DATA ) != CE_None )
-    return false;
-
-  float *line = static_cast< float * >( CPLMalloc( sizeof( float ) * columns ) );
-  for ( int i = 0; i < columns; i++ )
-  {
-    line[i] = NO_DATA;
-  }
-  // Write the empty raster
-  for ( int i = 0; i < rows ; i++ )
-  {
-    if ( GDALRasterIO( poBand, GF_Write, 0, i, columns, 1, line, columns, 1, GDT_Float32, 0, 0 ) != CE_None )
-    {
-      return false;
-    }
-  }
-
-  CPLFree( line );
-  //close the dataset
-  GDALClose( emptyDataset );
-  return true;
 }
 
 double QgsKernelDensityEstimation::calculateKernelValue( const double distance, const double bandwidth, const QgsKernelDensityEstimation::KernelShape shape, const QgsKernelDensityEstimation::OutputValues outputType ) const
@@ -420,7 +394,3 @@ QgsRectangle QgsKernelDensityEstimation::calculateBounds() const
   bbox.setYMaximum( bbox.yMaximum() + radius );
   return bbox;
 }
-
-
-
-

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -203,7 +203,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
     }
 
     block->setData( blockData );
-    if ( !mProvider->writeBlock( block, 1, xPosition, yPosition ) )
+    if ( !mProvider->writeBlock( block, 1, xPosition, yPositionIO ) )
     {
       result = RasterIoError;
     }

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -96,10 +96,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
 
   int dataTypeSize = QgsRasterBlock::typeSize( Qgis::Float32 );
   float *line = new float[ cols ];
-  for ( int i = 0; i < cols; i++ )
-  {
-    line[i] = NO_DATA;
-  }
+  memset( line, NO_DATA, dataTypeSize * cols );
   QgsRasterBlock block( Qgis::Float32, cols, 1 );
   block.setData( QByteArray::fromRawData( ( char * )line, dataTypeSize * cols ) );
   for ( int i = 0; i < rows ; i++ )

--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -16,14 +16,11 @@
 #ifndef QGSKDE_H
 #define QGSKDE_H
 
-#include "qgsrectangle.h"
 #include <QString>
 
-// GDAL includes
-#include <gdal.h>
-#include <cpl_string.h>
-#include <cpl_conv.h>
 #include "qgis_analysis.h"
+#include "qgsrectangle.h"
+#include "qgsrasterdataprovider.h"
 
 class QgsFeatureSource;
 class QgsFeature;
@@ -162,11 +159,8 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
 
     int mBufferSize;
 
-    GDALDatasetH mDatasetH;
-    GDALRasterBandH mRasterBandH;
+    QgsRasterDataProvider *mProvider = nullptr;
 
-    //! Creates a new raster layer and initializes it to the no data value
-    bool createEmptyLayer( GDALDriverH driver, const QgsRectangle &bounds, int rows, int columns ) const;
     int radiusSizeInPixels( double radius ) const;
 };
 


### PR DESCRIPTION
## Description
Rough attempt to port heatmap code to QGIS raster API. Based on @wonder-sk excellent work on #4022.

Heatmaps, created by new code are almost the same as original, very small difference caused by rounding and slightly different approach to define pixel size in QGIS API, probably this can be addressed somehow. As Processing test for Heatmap algorithm passes, difference should be a really small.

@nyalldawson, @wonder-sk I would be grateful for your review and opinions about this.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
