### PR TITLE
Fixes value relation widget to keep scrollbar activated, fixes #16654

### DIFF
--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -104,7 +104,6 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
 %End
 
     virtual void setEnabled( bool enabled );
-
 %Docstring
  Is used to enable or disable the edit functionality of the managed widget.
  By default this will enable or disable the whole widget

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -122,7 +122,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      *
      * \param enabled  Enable or Disable?
      */
-    void setEnabled( bool enabled ) override;
+    virtual void setEnabled( bool enabled ) override;
 
     /** Sets the widget to display in an indeterminate "mixed value" state.
      * \since QGIS 2.16

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -33,6 +33,7 @@ QgsValueRelationWidgetWrapper::QgsValueRelationWidgetWrapper( QgsVectorLayer *vl
   , mListWidget( nullptr )
   , mLineEdit( nullptr )
   , mLayer( nullptr )
+  , mUpdating( false )
 {
 }
 
@@ -197,4 +198,27 @@ void QgsValueRelationWidgetWrapper::showIndeterminateState()
   {
     whileBlocking( mLineEdit )->clear();
   }
+}
+
+void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
+{
+  if ( mUpdating )
+    return;
+
+  if ( mListWidget )
+  {
+    mUpdating = true;
+    for ( int i = 0; i < mListWidget->count(); ++i )
+    {
+      QListWidgetItem *item = mListWidget->item( i );
+
+      if ( enabled )
+        item->setFlags( item->flags() | Qt::ItemIsEnabled );
+      else
+        item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
+    }
+    mUpdating = false;
+  }
+  else
+    QgsEditorWidgetWrapper::setEnabled( enabled );
 }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -80,6 +80,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     bool mUpdating;
 
     friend class QgsValueRelationWidgetFactory;
+    friend class TestQgsValueRelationWidgetWrapper;
 };
 
 #endif // QGSVALUERELATIONWIDGETWRAPPER_H

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -59,6 +59,8 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
     void showIndeterminateState() override;
 
+    void setEnabled( bool enabled ) override;
+
   protected:
     QWidget *createWidget( QWidget *parent ) override;
     void initWidget( QWidget *editor ) override;
@@ -74,6 +76,8 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
     QgsValueRelationFieldFormatter::ValueRelationCache mCache;
     QgsVectorLayer *mLayer = nullptr;
+
+    bool mUpdating;
 
     friend class QgsValueRelationWidgetFactory;
 };

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -22,6 +22,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/symbology-ng
+  ${CMAKE_SOURCE_DIR}/src/core/fieldformatter
   ${CMAKE_SOURCE_DIR}/src/test
   ${CMAKE_SOURCE_DIR}/src/native
 
@@ -134,3 +135,4 @@ ADD_QGIS_TEST(listwidgettest testqgslistwidget.cpp)
 ADD_QGIS_TEST(filedownloader testqgsfiledownloader.cpp)
 ADD_QGIS_TEST(composergui testqgscomposergui.cpp)
 ADD_QGIS_TEST(layoutview testqgslayoutview.cpp)
+ADD_QGIS_TEST(valuerelationwidgetwrapper testqgsvaluerelationwidgetwrapper.cpp)

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -1,0 +1,110 @@
+/***************************************************************************
+    testqgsvaluerelationwidgetwrapper.cpp
+     --------------------------------------
+    Date                 : 21 07 2017
+    Copyright            : (C) 2017 Paul Blottiere
+    Email                : paul dot blottiere at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+#include <QScrollBar>
+
+#include <editorwidgets/core/qgseditorwidgetregistry.h>
+#include <qgsapplication.h>
+#include <qgsproject.h>
+#include <qgsvectorlayer.h>
+#include "qgseditorwidgetwrapper.h"
+#include <editorwidgets/qgsvaluerelationwidgetwrapper.h>
+#include "qgsgui.h"
+
+class TestQgsValueRelationWidgetWrapper : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsValueRelationWidgetWrapper() {}
+
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void testScrollBarUnlocked();
+};
+
+void TestQgsValueRelationWidgetWrapper::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsGui::editorWidgetRegistry()->initEditors();
+}
+
+void TestQgsValueRelationWidgetWrapper::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsValueRelationWidgetWrapper::init()
+{
+}
+
+void TestQgsValueRelationWidgetWrapper::cleanup()
+{
+}
+
+void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
+{
+  // create a vector layer
+  QgsVectorLayer vl1( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=fk|:int" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+  QgsProject::instance()->addMapLayer( &vl1, false, false );
+
+  // build a value relation widget wrapper
+  QListWidget lw;
+  QWidget editor;
+  QgsValueRelationWidgetWrapper w( &vl1, 0, &editor, nullptr );
+  w.setEnabled( true );
+  w.initWidget( &lw );
+
+  // add an item virtually
+  QListWidgetItem item;
+  item.setText( "MyText" );
+  w.mListWidget->addItem( &item );
+  QCOMPARE( w.mListWidget->item( 0 )->text(), QString( "MyText" ) );
+
+  // when the widget wrapper is enabled, the container should be enabled
+  // as well as items
+  w.setEnabled( true );
+
+  QCOMPARE( w.widget()->isEnabled(), true );
+
+  bool itemEnabled = w.mListWidget->item( 0 )->flags() & Qt::ItemIsEnabled;
+  QCOMPARE( itemEnabled, true );
+
+  // when the widget wrapper is disabled, the container should still be enabled
+  // to keep the scrollbar available but items should be disabled to avoid
+  // edition
+  w.setEnabled( false );
+
+  itemEnabled = w.mListWidget->item( 0 )->flags() & Qt::ItemIsEnabled;
+  QCOMPARE( itemEnabled, false );
+
+  QCOMPARE( w.widget()->isEnabled(), true );
+
+  // recheck after re-enabled
+  w.setEnabled( true );
+
+  QCOMPARE( w.widget()->isEnabled(), true );
+  itemEnabled = w.mListWidget->item( 0 )->flags() & Qt::ItemIsEnabled;
+  QCOMPARE( itemEnabled, true );
+}
+
+QGSTEST_MAIN( TestQgsValueRelationWidgetWrapper )
+#include "testqgsvaluerelationwidgetwrapper.moc"


### PR DESCRIPTION
## Description

This PR fixes an issue regarding the value relation widget : https://issues.qgis.org/issues/16654

The scroll bar is now enabled even in read-only mode (but items remain disabled).

Some tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
