### PR TITLE
Make layer rendering and resamplig groups collapsible

### DIFF
--- a/python/gui/qgscollapsiblegroupbox.sip
+++ b/python/gui/qgscollapsiblegroupbox.sip
@@ -188,8 +188,6 @@ Returns the name of the setting group in which the collapsed state will be saved
  :rtype: str
 %End
 
-  protected slots:
-
     void loadState();
 %Docstring
  Will load the collapsed and checked state

--- a/python/gui/raster/qgsrendererrasterpropertieswidget.sip
+++ b/python/gui/raster/qgsrendererrasterpropertieswidget.sip
@@ -47,7 +47,8 @@ class QgsRendererRasterPropertiesWidget : QgsMapLayerConfigWidget
 called when user changes renderer type
 %End
 
-    void apply();
+    virtual void apply();
+
 %Docstring
 Apply the changes from the dialog to the layer.
 %End

--- a/python/gui/raster/qgsrendererrasterpropertieswidget.sip
+++ b/python/gui/raster/qgsrendererrasterpropertieswidget.sip
@@ -58,6 +58,10 @@ Apply the changes from the dialog to the layer.
  \param layer The layer to use for the widget
 %End
 
+  protected:
+    virtual void hideEvent( QHideEvent *event );
+
+
 };
 
 /************************************************************************

--- a/python/gui/symbology/qgsrendererpropertiesdialog.sip
+++ b/python/gui/symbology/qgsrendererpropertiesdialog.sip
@@ -115,6 +115,9 @@ Apply and accept the changes for the dialog.
     virtual void keyPressEvent( QKeyEvent *event );
 
 
+    virtual void hideEvent( QHideEvent *event );
+
+
 
 
 

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -216,8 +216,6 @@ class GUI_EXPORT QgsCollapsibleGroupBox : public QgsCollapsibleGroupBoxBasic
     //! Returns the name of the setting group in which the collapsed state will be saved
     QString settingGroup() const { return mSettingGroup; }
 
-  protected slots:
-
     /**
      * Will load the collapsed and checked state
      *

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -62,6 +62,11 @@ QgsRendererRasterPropertiesWidget::QgsRendererRasterPropertiesWidget( QgsMapLaye
 
   setupUi( this );
 
+  gridLayout->setSpacing( 6 );
+  gridLayout->setContentsMargins( 0, 12, 0, 0 );
+  gridLayout_3->setSpacing( 6 );
+  gridLayout_3->setContentsMargins( 0, 12, 0, 0 );
+
   _initRendererWidgetFunctions();
 
   mZoomedInResamplingComboBox->insertItem( 0, tr( "Nearest neighbour" ) );

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -35,6 +35,8 @@
 
 #include "qgsmessagelog.h"
 
+#include <QHideEvent>
+
 static void _initRendererWidgetFunctions()
 {
   static bool sInitialized = false;
@@ -61,6 +63,9 @@ QgsRendererRasterPropertiesWidget::QgsRendererRasterPropertiesWidget( QgsMapLaye
     return;
 
   setupUi( this );
+
+  mColorRenderingBox->setSettingGroup( QStringLiteral( "colorRenderingGroupBox" ) );
+  mResamplingBox->setSettingGroup( QStringLiteral( "resamplingRenderingGroupBox" ) );
 
   gridLayout->setSpacing( 6 );
   gridLayout->setContentsMargins( 0, 12, 0, 0 );
@@ -431,4 +436,11 @@ void QgsRendererRasterPropertiesWidget::refreshAfterStyleChanged()
       }
     }
   }
+}
+
+void QgsRendererRasterPropertiesWidget::hideEvent( QHideEvent *e )
+{
+  mColorRenderingBox->saveState();
+  mResamplingBox->saveState();
+  QgsMapLayerConfigWidget::hideEvent( e );
 }

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.h
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.h
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsRendererRasterPropertiesWidget : public QgsMapLayerConfigWid
     void rendererChanged();
 
     //! Apply the changes from the dialog to the layer.
-    void apply();
+    void apply() override;
 
     /**
      * \brief Sync the widget to the given layer.

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.h
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.h
@@ -23,6 +23,7 @@
 #include "qgsmaplayerconfigwidget.h"
 #include "qgis_gui.h"
 
+class QHideEvent;
 
 class QgsRasterLayer;
 class QgsMapCanvas;
@@ -69,6 +70,10 @@ class GUI_EXPORT QgsRendererRasterPropertiesWidget : public QgsMapLayerConfigWid
      * \param layer The layer to use for the widget
      */
     void syncToLayer( QgsRasterLayer *layer );
+
+  protected:
+    // Reimplements dialog hide event so we can save groupboxes state
+    void hideEvent( QHideEvent *event ) override;
 
   private slots:
     //! Slot to reset all color rendering options to default

--- a/src/gui/symbology/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.cpp
@@ -37,6 +37,7 @@
 #include "qgsvectorlayer.h"
 
 #include <QKeyEvent>
+#include <QHideEvent>
 #include <QMessageBox>
 
 static bool _initRenderer( const QString &name, QgsRendererWidgetFunc f, const QString &iconName = QString() )
@@ -419,4 +420,10 @@ void QgsRendererPropertiesDialog::keyPressEvent( QKeyEvent *e )
   {
     QDialog::keyPressEvent( e );
   }
+}
+
+void QgsRendererPropertiesDialog::hideEvent( QHideEvent *e )
+{
+  mLayerRenderingGroupBox->saveState();
+  QDialog::hideEvent( e );
 }

--- a/src/gui/symbology/qgsrendererpropertiesdialog.h
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.h
@@ -26,6 +26,7 @@
 #include "qgis_gui.h"
 
 class QKeyEvent;
+class QHideEvent;
 
 class QgsVectorLayer;
 class QgsStyle;
@@ -136,6 +137,9 @@ class GUI_EXPORT QgsRendererPropertiesDialog : public QDialog, private Ui::QgsRe
 
     // Reimplements dialog keyPress event so we can ignore it
     void keyPressEvent( QKeyEvent *event ) override;
+
+    // Reimplements dialog hide event so we can save groupboxes state
+    void hideEvent( QHideEvent *event ) override;
 
     QgsVectorLayer *mLayer = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>386</width>
+    <width>387</width>
     <height>593</height>
    </rect>
   </property>
@@ -37,16 +37,7 @@
        </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item>
@@ -60,7 +51,7 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="5" column="0">
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -69,361 +60,13 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="leftMargin">
+      <property name="margin">
        <number>0</number>
       </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QGroupBox" name="mLayerRendering">
-        <property name="title">
-         <string>Layer rendering</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="0" colspan="2">
-          <widget class="QLabel" name="mBlendTypeLabel">
-           <property name="text">
-            <string>Blending mode</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2" colspan="3">
-          <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Brightness</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2" colspan="3">
-          <layout class="QHBoxLayout" name="horizontalLayout_11">
-           <item>
-            <widget class="QSlider" name="mSliderBrightness">
-             <property name="minimumSize">
-              <size>
-               <width>75</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="minimum">
-              <number>-255</number>
-             </property>
-             <property name="maximum">
-              <number>255</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="tickPosition">
-              <enum>QSlider::NoTicks</enum>
-             </property>
-             <property name="tickInterval">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="mBrightnessSpinBox">
-             <property name="minimum">
-              <number>-255</number>
-             </property>
-             <property name="maximum">
-              <number>255</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QLabel" name="labelSaturation">
-           <property name="text">
-            <string>Saturation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2" colspan="3">
-          <layout class="QHBoxLayout" name="horizontalLayout_10">
-           <item>
-            <widget class="QSlider" name="sliderSaturation">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>75</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="minimum">
-              <number>-100</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="spinBoxSaturation">
-             <property name="minimum">
-              <number>-100</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-             <property name="decimals" stdset="0">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="3" column="0" colspan="2">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Contrast</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2" colspan="3">
-          <layout class="QHBoxLayout" name="horizontalLayout_12">
-           <item>
-            <widget class="QSlider" name="mSliderContrast">
-             <property name="minimumSize">
-              <size>
-               <width>75</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="minimum">
-              <number>-100</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="singleStep">
-              <number>1</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="mContrastSpinBox">
-             <property name="minimum">
-              <number>-100</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QLabel" name="labelGrayscale">
-           <property name="text">
-            <string>Grayscale</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="2" colspan="3">
-          <widget class="QComboBox" name="comboGrayscale">
-           <item>
-            <property name="text">
-             <string>Off</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>By lightness</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>By luminosity</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>By average</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Hue</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="2" colspan="3">
-          <layout class="QFormLayout" name="formLayout_2">
-           <item row="0" column="0" colspan="2">
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
-             <item>
-              <widget class="QCheckBox" name="mColorizeCheck">
-               <property name="text">
-                <string>Colorize</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QgsColorButton" name="btnColorizeColor">
-               <property name="minimumSize">
-                <size>
-                 <width>100</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>100</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="labelColorizeStrength">
-             <property name="text">
-              <string>Strength</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_9">
-             <item>
-              <widget class="QSlider" name="sliderColorizeStrength">
-               <property name="maximum">
-                <number>100</number>
-               </property>
-               <property name="value">
-                <number>100</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="spinColorizeStrength">
-               <property name="suffix">
-                <string>%</string>
-               </property>
-               <property name="minimum">
-                <number>0</number>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-               <property name="value">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </item>
-         <item row="6" column="2" colspan="3">
-          <layout class="QHBoxLayout" name="horizontalLayout_13">
-           <item>
-            <widget class="QToolButton" name="mResetColorRenderingBtn">
-             <property name="toolTip">
-              <string>Reset all color rendering options to default</string>
-             </property>
-             <property name="text">
-              <string>Reset</string>
-             </property>
-             <property name="icon">
-              <iconset resource="../../images/images.qrc">
-               <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
-             </property>
-             <property name="toolButtonStyle">
-              <enum>Qt::ToolButtonTextBesideIcon</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="mResamplingBox">
-        <property name="title">
-         <string>Resampling</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout2">
-         <item row="0" column="0">
-          <widget class="QLabel" name="mZoomedInResamplingLabel">
-           <property name="text">
-            <string>Zoomed in</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="mZoomedOutResamplingLabel">
-           <property name="text">
-            <string>Zoomed out</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="mMaximumOversamplingLabel">
-           <property name="text">
-            <string>Oversampling</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QComboBox" name="mZoomedInResamplingComboBox"/>
-         </item>
-         <item row="1" column="2">
-          <widget class="QComboBox" name="mZoomedOutResamplingComboBox"/>
-         </item>
-         <item row="2" column="2">
-          <widget class="QDoubleSpinBox" name="mMaximumOversamplingSpinBox"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="10" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -436,12 +79,406 @@
      </property>
     </spacer>
    </item>
+   <item row="2" column="0">
+    <widget class="QgsCollapsibleGroupBox" name="mLayerRenderingBox">
+     <property name="title">
+      <string>Layer rendering</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>25</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="QSlider" name="mSliderBrightness">
+          <property name="minimumSize">
+           <size>
+            <width>75</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>-255</number>
+          </property>
+          <property name="maximum">
+           <number>255</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="tickPosition">
+           <enum>QSlider::NoTicks</enum>
+          </property>
+          <property name="tickInterval">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="mBrightnessSpinBox">
+          <property name="minimum">
+           <number>-255</number>
+          </property>
+          <property name="maximum">
+           <number>255</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mBlendTypeLabel">
+        <property name="text">
+         <string>Blending mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <widget class="QSlider" name="mSliderContrast">
+          <property name="minimumSize">
+           <size>
+            <width>75</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>-100</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="mContrastSpinBox">
+          <property name="minimum">
+           <number>-100</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="5" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QCheckBox" name="mColorizeCheck">
+          <property name="text">
+           <string>Colorize</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsColorButton" name="btnColorizeColor">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Brightness</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QSlider" name="sliderSaturation">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>75</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="minimum">
+           <number>-100</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBoxSaturation">
+          <property name="minimum">
+           <number>-100</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+          <property name="decimals" stdset="0">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelSaturation">
+        <property name="text">
+         <string>Saturation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="comboGrayscale">
+        <item>
+         <property name="text">
+          <string>Off</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>By lightness</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>By luminosity</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>By average</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Contrast</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelGrayscale">
+        <property name="text">
+         <string>Grayscale</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <layout class="QFormLayout" name="formLayout_2">
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelColorizeStrength">
+          <property name="text">
+           <string>Strength</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
+          <item>
+           <widget class="QSlider" name="sliderColorizeStrength">
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="spinColorizeStrength">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+      <item row="7" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_13">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mResetColorRenderingBtn">
+          <property name="toolTip">
+           <string>Reset all color rendering options to default</string>
+          </property>
+          <property name="text">
+           <string>Reset</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonTextBesideIcon</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Hue</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QgsCollapsibleGroupBox" name="mResamplingBox">
+     <property name="title">
+      <string>Resampling</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>12</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mZoomedInResamplingLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Zoomed in</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="mZoomedInResamplingComboBox"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="mZoomedOutResamplingComboBox"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mZoomedOutResamplingLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Zoomed out</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="mMaximumOversamplingLabel">
+        <property name="text">
+         <string>Oversampling</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QDoubleSpinBox" name="mMaximumOversamplingSpinBox"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
+   <extends>QPushButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
@@ -453,6 +490,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>cboRenderers</tabstop>
+  <tabstop>mLayerRenderingBox</tabstop>
   <tabstop>mBlendModeComboBox</tabstop>
   <tabstop>mSliderBrightness</tabstop>
   <tabstop>mBrightnessSpinBox</tabstop>
@@ -466,9 +504,10 @@
   <tabstop>sliderColorizeStrength</tabstop>
   <tabstop>spinColorizeStrength</tabstop>
   <tabstop>mResetColorRenderingBtn</tabstop>
+  <tabstop>mResamplingBox</tabstop>
+  <tabstop>mMaximumOversamplingSpinBox</tabstop>
   <tabstop>mZoomedInResamplingComboBox</tabstop>
   <tabstop>mZoomedOutResamplingComboBox</tabstop>
-  <tabstop>mMaximumOversamplingSpinBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -84,6 +84,9 @@
      <property name="title">
       <string>Layer rendering</string>
      </property>
+     <property name="saveCollapsedState" stdset="0">
+      <bool>true</bool>
+     </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <property name="leftMargin">
        <number>0</number>
@@ -408,6 +411,9 @@
     <widget class="QgsCollapsibleGroupBox" name="mResamplingBox">
      <property name="title">
       <string>Resampling</string>
+     </property>
+     <property name="saveCollapsedState" stdset="0">
+      <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -80,11 +80,11 @@
     </spacer>
    </item>
    <item row="2" column="0">
-    <widget class="QgsCollapsibleGroupBox" name="mLayerRenderingBox">
+    <widget class="QgsCollapsibleGroupBox" name="mColorRenderingBox">
      <property name="title">
-      <string>Layer rendering</string>
+      <string>Color rendering</string>
      </property>
-     <property name="saveCollapsedState" stdset="0">
+     <property name="saveCollapsedState">
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
@@ -412,7 +412,7 @@
      <property name="title">
       <string>Resampling</string>
      </property>
-     <property name="saveCollapsedState" stdset="0">
+     <property name="saveCollapsedState">
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
@@ -496,7 +496,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>cboRenderers</tabstop>
-  <tabstop>mLayerRenderingBox</tabstop>
+  <tabstop>mColorRenderingBox</tabstop>
   <tabstop>mBlendModeComboBox</tabstop>
   <tabstop>mSliderBrightness</tabstop>
   <tabstop>mBrightnessSpinBox</tabstop>

--- a/src/ui/qgsrendererv2propsdialogbase.ui
+++ b/src/ui/qgsrendererv2propsdialogbase.ui
@@ -105,7 +105,7 @@
             <bool>true</bool>
            </property>
            <property name="saveCollapsedState" stdset="0">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout">
             <property name="leftMargin">


### PR DESCRIPTION
## Description
The vector renderers base in the styling dock as "Layer rendering" as a collapsible group. The same goes for Raster renderer in properties. This is helpful to hide settings that are not used so often.

This PR adds collapsible groups to the raster renderer in the styling dock for "rendering" and "Resampling" groups.

Besides, It also renames the group "Layer rendering" to "Color rendering" to match the raster properties dialog. While in vector layer a similar group is called "Layer rendering", in rasters, transparency options are in a different tab, which also affects layer rendering.

Current state | Proposal

![image](https://user-images.githubusercontent.com/3607161/28597584-968d991a-7196-11e7-88a3-a726170e3102.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
