### PR TITLE
Close unmatched xml tag

### DIFF
--- a/resources/qgis-resource-metadata.xml
+++ b/resources/qgis-resource-metadata.xml
@@ -11,7 +11,7 @@
         <keyword>kw2</keyword>
     </keywords>
     <fees>None</fees>
-    <constraints type="access">None<constraints>
+    <constraints type="access">None</constraints>
     <rights>Copyright foo 2017</rights>
     <encoding>utf-8</encoding>
     <crs>EPSG:4326</crs>


### PR DESCRIPTION
The xml example file for the QGIS internal schema has an unmatched xml tag <constraints>, which causes the xml to be invalid.