### PR TITLE
Fixes relation reference widget when filters are reset

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -185,6 +185,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
   private:
     void highlightFeature( QgsFeature f = QgsFeature(), CanvasExtent canvasExtent = Fixed );
     void updateAttributeEditorFrame( const QgsFeature &feature );
+    void disableChainedComboBoxes( const QComboBox *cb );
 
     // initialized
     QgsAttributeEditorContext mEditorContext;

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -166,6 +166,19 @@ void TestQgsRelationReferenceWidget::testChainFilter()
       // "material" ==  'iron' AND "diameter" == '120' AND "raccord" = 'collar'
     }
   }
+
+  // set the filter for "raccord" and then reset filter for "diameter". As
+  // chain filter is activated, the filter on "raccord" field should be reset
+  cbs[2]->setCurrentIndex( cbs[2]->findText( "brides" ) );
+  cbs[1]->setCurrentIndex( cbs[1]->findText( "diameter" ) );
+
+  // combobox should propose NULL, 10 and 11 because the filter is now:
+  // "material" == 'iron'
+  QCOMPARE( w.mComboBox->count(), 3 );
+
+  // if there's no filter at all, all features' id should be proposed
+  cbs[0]->setCurrentIndex( cbs[0]->findText( "material" ) );
+  QCOMPARE( w.mComboBox->count(), 4 );
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
## Description

This PR is the follow up of https://github.com/qgis/QGIS/pull/4904.

When the *Chain filter* option is activated, items of combo boxes are correctly updated with values leading to actual features. 

However there's still an issue when previous filters are reset (in this case, items of combo boxes are not properly updated). This PR fixes this issue.

A simple test have been added to highlight the issue.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
