### PR TITLE
Add {GP} to make the script use gsed in macos.

### DIFF
--- a/scripts/sipify_all.sh
+++ b/scripts/sipify_all.sh
@@ -31,11 +31,11 @@ modules=(core gui analysis server)
 for module in "${modules[@]}"; do
   while read -r sipfile; do
       echo "$sipfile"
-      header=$(sed -E 's/(.*)\.sip/src\/\1.h/' <<< $sipfile)
+      header=$(${GP}sed -E 's/(.*)\.sip/src\/\1.h/' <<< $sipfile)
       if [ ! -f $header ]; then
         echo "*** Missing header: $header for sipfile $sipfile"
       else
-        path=$(sed -r 's@/[^/]+$@@' <<< $sipfile)
+        path=$(${GP}sed -r 's@/[^/]+$@@' <<< $sipfile)
         mkdir -p python/$path
         ./scripts/sipify.pl $header > python/$sipfile
       fi


### PR DESCRIPTION
## Description
Fixing `scripts/sipify_all.sh` script that give error when run in MacOS like this:
```
sed: illegal option -- r
usage: sed script [-Ealn] [-i extension] [file ...]
       sed [-Ealn] [-i extension] [-e script] ... [-f script_file] ... [file …]
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit