### PR TITLE
Show toplevel wms group in browser

### DIFF
--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -94,37 +94,15 @@ QVector<QgsDataItem *> QgsWMSConnectionItem::createChildren()
     QgsWmsCapabilitiesProperty capabilitiesProperty = caps.capabilitiesProperty();
     const QgsWmsCapabilityProperty &capabilityProperty = capabilitiesProperty.capability;
 
-    // If we have several top-level layers, or if we just have one single top-level layer,
-    // then use those top-level layers directly
-    if ( capabilityProperty.layers.size() > 1 ||
-         ( capabilityProperty.layers.size() == 1 && capabilityProperty.layers[0].layer.size() == 0 ) )
+    Q_FOREACH ( const QgsWmsLayerProperty &layerProperty, capabilityProperty.layers )
     {
-      Q_FOREACH ( const QgsWmsLayerProperty &layerProperty, capabilityProperty.layers )
-      {
-        // Attention, the name may be empty
-        QgsDebugMsg( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title );
-        QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
+      // Attention, the name may be empty
+      QgsDebugMsg( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title );
+      QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
 
-        QgsWMSLayerItem *layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, uri, layerProperty );
+      QgsWMSLayerItem *layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, uri, layerProperty );
 
-        children << layer;
-      }
-    }
-    // Otherwise if we have just one single top-level layers with children, then
-    // skip this top-level layer and iterate directly on its children
-    // Note (E. Rouault): this was the historical behavior before fixing #13762
-    else if ( capabilityProperty.layers.size() == 1 )
-    {
-      Q_FOREACH ( const QgsWmsLayerProperty &layerProperty, capabilityProperty.layers[0].layer )
-      {
-        // Attention, the name may be empty
-        QgsDebugMsg( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title );
-        QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
-
-        QgsWMSLayerItem *layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, uri, layerProperty );
-
-        children << layer;
-      }
+      children << layer;
     }
   }
 


### PR DESCRIPTION
In the browser, the toplevel group for wms 1.3 is not added. Therefore, it is not possible to drag the toplevel into the map (it has to be done with the 'Add wms' dialog instead), see also https://lists.osgeo.org/pipermail/qgis-developer/2017-July/049452.html

This PR code removes the logic to filter out the wms 1.3 toplevel group.