### PR TITLE
Remove what's this button

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2287,14 +2287,6 @@ void QgisApp::createMenus()
   mWebMenu = new QMenu( tr( "&Web" ), menuBar() );
   mWebMenu->setObjectName( QStringLiteral( "mWebMenu" ) );
 
-
-  // Help menu
-  // add What's this button to it
-  QAction *before = mActionHelpAPI;
-  QAction *actionWhatsThis = QWhatsThis::createAction( this );
-  actionWhatsThis->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionWhatsThis.svg" ) ) );
-  mHelpMenu->insertAction( before, actionWhatsThis );
-
   createProfileMenu();
 }
 


### PR DESCRIPTION
This removes the "what's this" menu entry in the About menu.

I just tried it on a couple of items (toolbar buttons etc) and I didn't manage to actually hit anything with information.
Tooltips are a much better (less clicks) way to provide hints about what UI elements are here for.