### PR TITLE
[needs-docs] Relation Reference Widget: Add option to show/hide Open Form Button

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -44,6 +44,7 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
   connect( mCbxAllowNull, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mCbxOrderByValue, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mCbxShowForm, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
+  connect( mCbxShowOpenFormButton, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mCbxMapIdentification, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mCbxReadOnly, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mComboRelation, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
@@ -59,6 +60,7 @@ void QgsRelationReferenceConfigDlg::setConfig( const QVariantMap &config )
   mCbxAllowNull->setChecked( config.value( QStringLiteral( "AllowNULL" ), false ).toBool() );
   mCbxOrderByValue->setChecked( config.value( QStringLiteral( "OrderByValue" ), false ).toBool() );
   mCbxShowForm->setChecked( config.value( QStringLiteral( "ShowForm" ), false ).toBool() );
+  mCbxShowOpenFormButton->setChecked( config.value( QStringLiteral( "ShowOpenFormButton" ), true ).toBool() );
 
   if ( config.contains( QStringLiteral( "Relation" ) ) )
   {
@@ -121,6 +123,7 @@ QVariantMap QgsRelationReferenceConfigDlg::config()
   myConfig.insert( QStringLiteral( "AllowNULL" ), mCbxAllowNull->isChecked() );
   myConfig.insert( QStringLiteral( "OrderByValue" ), mCbxOrderByValue->isChecked() );
   myConfig.insert( QStringLiteral( "ShowForm" ), mCbxShowForm->isChecked() );
+  myConfig.insert( QStringLiteral( "ShowOpenFormButton" ), mCbxShowOpenFormButton->isChecked() );
   myConfig.insert( QStringLiteral( "MapIdentification" ), mCbxMapIdentification->isEnabled() && mCbxMapIdentification->isChecked() );
   myConfig.insert( QStringLiteral( "ReadOnly" ), mCbxReadOnly->isChecked() );
   myConfig.insert( QStringLiteral( "Relation" ), mComboRelation->currentData() );

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -50,11 +50,13 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   bool mapIdent = config( QStringLiteral( "MapIdentification" ), false ).toBool();
   bool readOnlyWidget = config( QStringLiteral( "ReadOnly" ), false ).toBool();
   bool orderByValue = config( QStringLiteral( "OrderByValue" ), false ).toBool();
+  bool showOpenFormButton = config( QStringLiteral( "ShowOpenFormButton" ), true ).toBool();
 
   mWidget->setEmbedForm( showForm );
   mWidget->setReadOnlySelector( readOnlyWidget );
   mWidget->setAllowMapIdentification( mapIdent );
   mWidget->setOrderByValue( orderByValue );
+  mWidget->setOpenFormButtonVisible( showOpenFormButton );
   if ( config( QStringLiteral( "FilterFields" ), QVariant() ).isValid() )
   {
     mWidget->setFilterFields( config( QStringLiteral( "FilterFields" ) ).toStringList() );

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -21,6 +21,13 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxShowOpenFormButton">
+     <property name="text">
+      <string>Show open form button</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="mComboRelation"/>
    </item>
@@ -31,7 +38,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxReadOnly">
      <property name="text">
       <string>Use a read-only line edit instead of a combobox</string>
@@ -59,7 +66,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxMapIdentification">
      <property name="text">
       <string>On map identification (for geometric layers only)</string>
@@ -73,7 +80,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mFilterGroupBox">
      <property name="title">
       <string>Filters</string>
@@ -152,7 +159,7 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxAllowAddFeatures">
      <property name="text">
       <string>Allow adding new features</string>
@@ -181,6 +188,7 @@
   <tabstop>mCbxAllowNull</tabstop>
   <tabstop>mCbxOrderByValue</tabstop>
   <tabstop>mCbxShowForm</tabstop>
+  <tabstop>mCbxShowOpenFormButton</tabstop>
   <tabstop>mCbxMapIdentification</tabstop>
   <tabstop>mCbxReadOnly</tabstop>
   <tabstop>mCbxAllowAddFeatures</tabstop>


### PR DESCRIPTION
The option was already available in the API ([`QgsRelationReferenceWidget->setOpenFormButtonVisible`](http://qgis.org/api/classQgsRelationReferenceWidget.html#ac6b4d84830a642a977787aa9de0dff1b)), but couldn't be used from `QgsEditorWidgetSetup` nor from the config dialog. For the former, a `ShowOpenFormButton` key is added, whereas for the latter, a new check box is available (checked by default).

![open_form_button_config_dialog](https://user-images.githubusercontent.com/652785/28750551-6a2d9be2-74b4-11e7-91ef-90f053481675.png)

Being able to hide the Open Form Button is helpful when configuring lookup tables, where a single combo box should be shown in the edit form with no additional buttons.

![open_form_button_visible](https://user-images.githubusercontent.com/652785/28750553-6a392ea8-74b4-11e7-9647-16ed1b2fec1a.png)

![open_form_button_invisible](https://user-images.githubusercontent.com/652785/28750552-6a31a93a-74b4-11e7-9576-0be99e93fd10.png)

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit