### PR TITLE
Reduce responsiveness impact by map canvas preview jobs

### DIFF
--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -750,6 +750,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     void projectThemesChanged();
 
+    void startPreviewJob( int number );
+
   private:
     /// this class is non-copyable
 
@@ -844,6 +846,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     QCursor mZoomCursor;
 
     QTimer mAutoRefreshTimer;
+
+    QTimer mPreviewTimer;
 
     QString mTheme;
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3950,6 +3950,8 @@ QgsCoordinateReferenceSystem QgsPostgresProvider::crs() const
   srs.createFromSrid( srid );
   if ( !srs.isValid() )
   {
+    static QMutex sMutex;
+    QMutexLocker locker( &sMutex );
     static QMap<int, QgsCoordinateReferenceSystem> sCrsCache;
     if ( sCrsCache.contains( srid ) )
       srs = sCrsCache.value( srid );


### PR DESCRIPTION
Starting 8 jobs in a loop on the main thread still can take some time (given that each job can have a larger number of layers).

This pull request starts each job separately in a quick succession but still with a small window in between for the event loop to process user input.

And it caches some database information that can lead to I/O during the setup of a layer source.

@mhugent @nyalldawson 
do you think this is a reasonable approach?