### PR TITLE
fix display of the checkbox about opening sublayers in a group

### DIFF
--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -79,13 +79,9 @@ QgsSublayersDialog::QgsSublayersDialog( ProviderType providerType, const QString
   restoreGeometry( settings.value( "/Windows/" + mName + "SubLayers/geometry" ).toByteArray() );
 
   // Checkbox about adding sublayers to a group
-  if ( mShowAddToGroupCheckbox )
-  {
-    mCheckboxAddToGroup = new QCheckBox( tr( "Add layers to a group" ) );
-    bool addToGroup = settings.value( QStringLiteral( "/qgis/openSublayersInGroup" ), false ).toBool();
-    mCheckboxAddToGroup->setChecked( addToGroup );
-    buttonBox->addButton( mCheckboxAddToGroup, QDialogButtonBox::ActionRole );
-  }
+  mCheckboxAddToGroup = new QCheckBox( tr( "Add layers to a group" ), this );
+  buttonBox->addButton( mCheckboxAddToGroup, QDialogButtonBox::ActionRole );
+  mCheckboxAddToGroup->setVisible( false );
 }
 
 QgsSublayersDialog::~QgsSublayersDialog()
@@ -201,11 +197,20 @@ int QgsSublayersDialog::exec()
     cursor = QCursor( * QApplication::overrideCursor() );
     QApplication::restoreOverrideCursor();
   }
+
+  // Checkbox about adding sublayers to a group
+  if ( mShowAddToGroupCheckbox )
+  {
+    mCheckboxAddToGroup->setVisible( true );
+    bool addToGroup = settings.value( QStringLiteral( "/qgis/openSublayersInGroup" ), false ).toBool();
+    mCheckboxAddToGroup->setChecked( addToGroup );
+  }
+
   int ret = QDialog::exec();
   if ( overrideCursor )
     QApplication::setOverrideCursor( cursor );
 
-  if ( mCheckboxAddToGroup )
+  if ( mShowAddToGroupCheckbox )
     settings.setValue( QStringLiteral( "/qgis/openSublayersInGroup" ), mCheckboxAddToGroup->isChecked() );
   return ret;
 }


### PR DESCRIPTION
## Description

The display of the checkbox 'open layers in a group' was set in the constructor of the dialog. But in the constructor, the property was always false. I had to move the checkbox display in the `exec` function.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
