### PR TITLE
always set a default name in the qgis project to avoid discrepancies with GetCapabilities

### DIFF
--- a/src/app/qgsmaplayerstyleguiutils.cpp
+++ b/src/app/qgsmaplayerstyleguiutils.cpp
@@ -65,8 +65,6 @@ QList<QAction *> QgsMapLayerStyleGuiUtils::actionsUseStyle( QgsMapLayer *layer, 
   Q_FOREACH ( QString name, mgr->styles() )
   {
     bool active = name == mgr->currentStyle();
-    if ( name.isEmpty() )
-      name = defaultStyleName();
     QAction *actionUse = new QAction( name, parent );
     connect( actionUse, &QAction::triggered, this, &QgsMapLayerStyleGuiUtils::useStyle );
     actionUse->setCheckable( true );
@@ -89,12 +87,6 @@ void QgsMapLayerStyleGuiUtils::addStyleManagerActions( QMenu *m, QgsMapLayer *la
   Q_FOREACH ( QAction *a, actionsUseStyle( layer, m ) )
     m->addAction( a );
 }
-
-QString QgsMapLayerStyleGuiUtils::defaultStyleName()
-{
-  return tr( "(default)" );
-}
-
 
 void QgsMapLayerStyleGuiUtils::addStyle()
 {
@@ -133,8 +125,6 @@ void QgsMapLayerStyleGuiUtils::useStyle()
   if ( !layer )
     return;
   QString name = a->text();
-  if ( name == defaultStyleName() )
-    name.clear();
 
   bool res = layer->styleManager()->setCurrentStyle( name );
   if ( !res )

--- a/src/app/qgsmaplayerstyleguiutils.h
+++ b/src/app/qgsmaplayerstyleguiutils.h
@@ -38,9 +38,6 @@ class QgsMapLayerStyleGuiUtils : public QObject
     //! Add actions for the given map layer to the menu
     void addStyleManagerActions( QMenu *m, QgsMapLayer *layer );
 
-  private:
-    QString defaultStyleName();
-
   private slots:
     void addStyle();
     void useStyle();

--- a/src/core/qgsmaplayerstylemanager.cpp
+++ b/src/core/qgsmaplayerstylemanager.cpp
@@ -28,21 +28,37 @@ QgsMapLayerStyleManager::QgsMapLayerStyleManager( QgsMapLayer *layer )
   reset();
 }
 
+QString QgsMapLayerStyleManager::defaultStyleName() const
+{
+  return tr( "default" );
+}
+
+
 void QgsMapLayerStyleManager::reset()
 {
-  mStyles.insert( QString(), QgsMapLayerStyle() ); // insert entry for the default current style
-  mCurrentStyle.clear();
+  mStyles.insert( defaultStyleName(), QgsMapLayerStyle() ); // insert entry for the default current style
+  mCurrentStyle = defaultStyleName();
 }
 
 void QgsMapLayerStyleManager::readXml( const QDomElement &mgrElement )
 {
   mCurrentStyle = mgrElement.attribute( QStringLiteral( "current" ) );
+  if ( mCurrentStyle.isEmpty() )
+  {
+    // For old project made with QGIS 2, we migrate to "default".
+    mCurrentStyle = defaultStyleName();
+  }
 
   mStyles.clear();
   QDomElement ch = mgrElement.firstChildElement( QStringLiteral( "map-layer-style" ) );
   while ( !ch.isNull() )
   {
     QString name = ch.attribute( QStringLiteral( "name" ) );
+    if ( name.isEmpty() )
+    {
+      // For old project made with QGIS 2, we migrate to "default".
+      name = defaultStyleName();
+    }
     QgsMapLayerStyle style;
     style.readXml( ch );
     mStyles.insert( name, style );

--- a/src/core/qgsmaplayerstylemanager.h
+++ b/src/core/qgsmaplayerstylemanager.h
@@ -161,6 +161,7 @@ class CORE_EXPORT QgsMapLayerStyleManager : public QObject
     QMap<QString, QgsMapLayerStyle> mStyles;
     QString mCurrentStyle;
     QgsMapLayerStyle *mOverriddenOriginalStyle = nullptr;
+    QString defaultStyleName() const;
 };
 
 #endif // QGSMAPLAYERSTYLEMANAGER_H

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -81,10 +81,6 @@ QgsMapLayerStyleManagerWidget::QgsMapLayerStyleManagerWidget( QgsMapLayer *layer
   Q_FOREACH ( const QString name, mLayer->styleManager()->styles() )
   {
     QString stylename = name;
-
-    if ( stylename.isEmpty() )
-      stylename = QStringLiteral( "(default)" );
-
     QStandardItem *item = new QStandardItem( stylename );
     mModel->appendRow( item );
   }
@@ -99,9 +95,6 @@ void QgsMapLayerStyleManagerWidget::styleClicked( const QModelIndex &index )
     return;
 
   QString name = index.data().toString();
-  if ( name == QLatin1String( "(default)" ) )
-    name = QLatin1String( "" );
-
   mLayer->styleManager()->setCurrentStyle( name );
 }
 

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1122,9 +1122,6 @@ namespace QgsWms
       hrefString.append( href.hasQuery() ? "&" : "?" );
       Q_FOREACH ( QString styleName, currentLayer->styleManager()->styles() )
       {
-        if ( styleName.isEmpty() )
-          styleName = EMPTY_STYLE_NAME;
-
         QDomElement styleElem = doc.createElement( QStringLiteral( "Style" ) );
         QDomElement styleNameElem = doc.createElement( QStringLiteral( "Name" ) );
         QDomText styleNameText = doc.createTextNode( styleName );

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -439,9 +439,6 @@ namespace QgsWms
     {
       Q_FOREACH ( QString styleName, currentLayer->styleManager()->styles() )
       {
-        if ( styleName.isEmpty() )
-          styleName = EMPTY_STYLE_NAME;
-
         QDomElement styleListElem = doc.createElement( QStringLiteral( "StyleList" ) );
         //only one default style in project file mode
         QDomElement styleElem = doc.createElement( QStringLiteral( "Style" ) );

--- a/src/server/services/wms/qgswmsgetstyles.cpp
+++ b/src/server/services/wms/qgswmsgetstyles.cpp
@@ -175,8 +175,6 @@ namespace QgsWms
             Q_FOREACH ( QString styleName, vlayer->styleManager()->styles() )
             {
               vlayer->styleManager()->setCurrentStyle( styleName );
-              if ( styleName.isEmpty() )
-                styleName = EMPTY_STYLE_NAME;
               QDomElement styleElem = vlayer->renderer()->writeSld( myDocument, styleName );
               namedLayerNode.appendChild( styleElem );
             }

--- a/src/server/services/wms/qgswmsutils.h
+++ b/src/server/services/wms/qgswmsutils.h
@@ -37,10 +37,6 @@ class QgsRectangle;
 //! WMS implementation
 namespace QgsWms
 {
-  // style name to use for the unnamed style of layers (must not be empty name in WMS)
-  // this implies that a layer style called "default" will not be usable in WMS server
-  const QString EMPTY_STYLE_NAME = QStringLiteral( "default" );
-
   //! Supported image output format
   enum ImageOutputFormat
   {

--- a/tests/src/core/testqgsmaplayerstylemanager.cpp
+++ b/tests/src/core/testqgsmaplayerstylemanager.cpp
@@ -74,7 +74,7 @@ void TestQgsMapLayerStyleManager::testDefault()
   QVERIFY( mgr );
 
   QCOMPARE( mgr->styles().count(), 1 );
-  QCOMPARE( mgr->style( QString() ).isValid(), true );
+  QCOMPARE( mgr->style( QStringLiteral( "default" ) ).isValid(), true );
 }
 
 void TestQgsMapLayerStyleManager::testStyle()
@@ -147,12 +147,12 @@ void TestQgsMapLayerStyleManager::testReadWrite()
   sm1.readXml( mgrElem );
 
   QCOMPARE( sm1.styles().count(), 2 );
-  QCOMPARE( sm1.style( QString() ).isValid(), true );
+  QCOMPARE( sm1.style( QStringLiteral( "default" ) ).isValid(), true );
   QCOMPARE( sm1.style( "blue" ).isValid(), true );
   QCOMPARE( sm1.currentStyle(), QString( "blue" ) );
 
   // now use the default style - the symbol should get red color
-  sm1.setCurrentStyle( QString() );
+  sm1.setCurrentStyle( QStringLiteral( "default" ) );
 
   QgsSingleSymbolRenderer *r2 = dynamic_cast<QgsSingleSymbolRenderer *>( mVL->renderer() );
   QVERIFY( r2 );
@@ -187,7 +187,7 @@ void TestQgsMapLayerStyleManager::testSwitchingStyles()
 
   _setVLColor( mVL, Qt::green );
 
-  mVL->styleManager()->setCurrentStyle( QString() );
+  mVL->styleManager()->setCurrentStyle( QStringLiteral( "default" ) );
   QCOMPARE( _getVLColor( mVL ), QColor( Qt::red ) );
 
   mVL->styleManager()->setCurrentStyle( QStringLiteral( "s1" ) );
@@ -195,7 +195,7 @@ void TestQgsMapLayerStyleManager::testSwitchingStyles()
 
   _setVLColor( mVL, Qt::blue );
 
-  mVL->styleManager()->setCurrentStyle( QString() );
+  mVL->styleManager()->setCurrentStyle( QStringLiteral( "default" ) );
   QCOMPARE( _getVLColor( mVL ), QColor( Qt::red ) );
 
   mVL->styleManager()->setCurrentStyle( QStringLiteral( "s1" ) );


### PR DESCRIPTION
## Description

always set a default name in the qgis project to avoid discrepancies with GetCapabilities


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit