### PR TITLE
Unified layer dialog mods

### DIFF
--- a/python/gui/qgsabstractdatasourcewidget.sip
+++ b/python/gui/qgsabstractdatasourcewidget.sip
@@ -46,6 +46,18 @@ Destructor
  The default implementation does nothing
 %End
 
+    virtual void addClicked();
+%Docstring
+ Triggered when the add button is clicked, the add layer signal is emitted
+ Concrete classes should implement the right behavior depending on the layer
+ being added.
+%End
+
+    virtual void okClicked();
+%Docstring
+ Triggered when the dialog is accepted, call addClicked() and emit the accepted() signal
+%End
+
   signals:
 
     void connectionsChanged();
@@ -79,6 +91,12 @@ Emitted when a progress dialog is shown by the provider dialog
 Emitted when a progress dialog is shown by the provider dialog
 %End
 
+    void enableButtons( bool enable );
+%Docstring
+Emitted when the ok/add buttons should be enabled/disabled
+%End
+
+
   protected:
 
     QgsAbstractDataSourceWidget( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
@@ -94,8 +112,19 @@ Return the widget mode
 
     const QgsMapCanvas *mapCanvas() const;
 %Docstring
- Return the map canvas (can be null)
+Return the map canvas (can be null)
  :rtype: QgsMapCanvas
+%End
+
+    void setupButtons( QDialogButtonBox *buttonBox );
+%Docstring
+Connect the ok and apply/add buttons to the slots
+%End
+
+    const QPushButton *addButton( );
+%Docstring
+Return the add Button
+ :rtype: QPushButton
 %End
 
 };

--- a/python/gui/qgsabstractdatasourcewidget.sip
+++ b/python/gui/qgsabstractdatasourcewidget.sip
@@ -46,16 +46,17 @@ Destructor
  The default implementation does nothing
 %End
 
-    virtual void addClicked();
+    virtual void addButtonClicked();
 %Docstring
  Triggered when the add button is clicked, the add layer signal is emitted
  Concrete classes should implement the right behavior depending on the layer
  being added.
 %End
 
-    virtual void okClicked();
+    virtual void okButtonClicked();
 %Docstring
- Triggered when the dialog is accepted, call addClicked() and emit the accepted() signal
+ Triggered when the dialog is accepted, call addButtonClicked() and
+ emit the accepted() signal
 %End
 
   signals:
@@ -121,7 +122,7 @@ Return the map canvas (can be null)
 Connect the ok and apply/add buttons to the slots
 %End
 
-    const QPushButton *addButton( );
+    QPushButton *addButton( ) const;
 %Docstring
 Return the add Button
  :rtype: QPushButton

--- a/python/gui/qgsowssourceselect.sip
+++ b/python/gui/qgsowssourceselect.sip
@@ -75,11 +75,6 @@ Loads connections from the file
  Once connected, available layers are displayed.
 %End
 
-    virtual void addClicked();
-%Docstring
-Determines the layers the user selected
-%End
-
     void searchFinished();
 
     void on_mChangeCRSButton_clicked();
@@ -211,7 +206,6 @@ Add a few example servers to the list.
 Returns a textual description for the authority id
  :rtype: str
 %End
-
 
 
 

--- a/src/gui/ogr/qgsopenvectorlayerdialog.cpp
+++ b/src/gui/ogr/qgsopenvectorlayerdialog.cpp
@@ -32,22 +32,10 @@
 #include "qgsapplication.h"
 
 QgsOpenVectorLayerDialog::QgsOpenVectorLayerDialog( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
-  : QDialog( parent, fl ),
-    mWidgetMode( widgetMode ),
-    mAddButton( nullptr )
+  : QgsAbstractDataSourceWidget( parent, fl, widgetMode )
 {
   setupUi( this );
-
-  if ( mWidgetMode != QgsProviderRegistry::WidgetMode::None )
-  {
-    this->layout()->setSizeConstraint( QLayout::SetNoConstraint );
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Cancel ) );
-  }
-
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  // TODO: enable/disable according to valid selection
-  mAddButton->setEnabled( true );
-  buttonBox->addButton( mAddButton, QDialogButtonBox::AcceptRole );
+  setupButtons( buttonBox );
 
   cmbDatabaseTypes->blockSignals( true );
   cmbConnections->blockSignals( true );
@@ -287,7 +275,7 @@ void QgsOpenVectorLayerDialog::on_buttonSelectSrc_clicked()
     if ( !selected.isEmpty() )
     {
       inputSrcDataset->setText( selected.join( QStringLiteral( ";" ) ) );
-      mAddButton->setFocus();
+      addButton()->setFocus();
     }
   }
   else if ( radioSrcDirectory->isChecked() )
@@ -302,8 +290,7 @@ void QgsOpenVectorLayerDialog::on_buttonSelectSrc_clicked()
 
 
 
-//********************auto connected slots *****************/
-void QgsOpenVectorLayerDialog::accept()
+void QgsOpenVectorLayerDialog::addButtonClicked()
 {
   QgsSettings settings;
   QgsDebugMsg( "dialog button accepted" );
@@ -395,15 +382,14 @@ void QgsOpenVectorLayerDialog::accept()
   // Save the used encoding
   settings.setValue( QStringLiteral( "UI/encoding" ), encoding() );
 
-  if ( mWidgetMode == QgsProviderRegistry::WidgetMode::None )
-  {
-    QDialog::accept();
-  }
-  else if ( ! mDataSources.isEmpty() )
+  if ( ! mDataSources.isEmpty() )
   {
     emit addVectorLayers( mDataSources, encoding(), dataSourceType() );
   }
 }
+
+
+//********************auto connected slots *****************/
 
 void QgsOpenVectorLayerDialog::on_radioSrcFile_toggled( bool checked )
 {

--- a/src/gui/ogr/qgsopenvectorlayerdialog.h
+++ b/src/gui/ogr/qgsopenvectorlayerdialog.h
@@ -23,6 +23,7 @@
 #include <QDialog>
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
+#include "qgsabstractdatasourcewidget.h"
 #include "qgis_gui.h"
 
 #define SIP_NO_FILE
@@ -32,7 +33,7 @@
  *  file, database, directory and protocol sources.
  *  \note not available in Python bindings
  */
-class GUI_EXPORT QgsOpenVectorLayerDialog : public QDialog, private Ui::QgsOpenVectorLayerDialogBase
+class GUI_EXPORT QgsOpenVectorLayerDialog : public QgsAbstractDataSourceWidget, private Ui::QgsOpenVectorLayerDialogBase
 {
     Q_OBJECT
 
@@ -60,8 +61,9 @@ class GUI_EXPORT QgsOpenVectorLayerDialog : public QDialog, private Ui::QgsOpenV
     QString mDataSourceType;
     //! Embedded dialog (do not call parent's accept) and emit signals
     QgsProviderRegistry::WidgetMode mWidgetMode = QgsProviderRegistry::WidgetMode::None;
-    //! Add layer button
-    QPushButton *mAddButton = nullptr;
+
+  public slots:
+    void addButtonClicked() override;
 
   private slots:
     //! Opens the create connection dialog to build a new connection
@@ -80,8 +82,6 @@ class GUI_EXPORT QgsOpenVectorLayerDialog : public QDialog, private Ui::QgsOpenV
     void setSelectedConnectionType();
     //! Sets the selected connection
     void setSelectedConnection();
-
-    void accept() override;
 
     void on_buttonSelectSrc_clicked();
     void on_radioSrcFile_toggled( bool checked );

--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -17,12 +17,12 @@
  ***************************************************************************/
 
 #include "qgsabstractdatasourcewidget.h"
+#include <QPushButton>
 
 QgsAbstractDataSourceWidget::QgsAbstractDataSourceWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ):
   QDialog( parent, fl ),
   mWidgetMode( widgetMode )
 {
-
 }
 
 QgsProviderRegistry::WidgetMode QgsAbstractDataSourceWidget::widgetMode() const
@@ -35,8 +35,40 @@ const QgsMapCanvas *QgsAbstractDataSourceWidget::mapCanvas() const
   return mMapCanvas;
 }
 
+void QgsAbstractDataSourceWidget::setupButtons( QDialogButtonBox *buttonBox )
+{
+
+  if ( mWidgetMode == QgsProviderRegistry::WidgetMode::None )
+  {
+    QPushButton *closeButton = new QPushButton( tr( "&Close" ) );
+    buttonBox->addButton( closeButton, QDialogButtonBox::ApplyRole );
+    connect( closeButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addClicked );
+  }
+
+  mAddButton = new QPushButton( tr( "&Add" ) );
+  mAddButton->setToolTip( tr( "Add selected layers to map" ) );
+  mAddButton->setEnabled( false );
+  buttonBox->addButton( mAddButton, QDialogButtonBox::ApplyRole );
+  connect( mAddButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addClicked );
+  connect( this, &QgsAbstractDataSourceWidget::enableButtons, mAddButton, &QPushButton::setEnabled );
+
+  QPushButton *okButton = new QPushButton( tr( "&Ok" ) );
+  okButton->setToolTip( tr( "Add selected layers to map and close this dialog" ) );
+  okButton->setEnabled( false );
+  buttonBox->addButton( okButton, QDialogButtonBox::AcceptRole );
+  connect( okButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::okClicked );
+  connect( this, &QgsAbstractDataSourceWidget::enableButtons, okButton, &QPushButton::setEnabled );
+
+}
+
 
 void QgsAbstractDataSourceWidget::setMapCanvas( const QgsMapCanvas *mapCanvas )
 {
   mMapCanvas = mapCanvas;
+}
+
+void QgsAbstractDataSourceWidget::okClicked()
+{
+  addClicked();
+  emit accepted();
 }

--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -42,21 +42,21 @@ void QgsAbstractDataSourceWidget::setupButtons( QDialogButtonBox *buttonBox )
   {
     QPushButton *closeButton = new QPushButton( tr( "&Close" ) );
     buttonBox->addButton( closeButton, QDialogButtonBox::ApplyRole );
-    connect( closeButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addClicked );
+    connect( closeButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addButtonClicked );
   }
 
   mAddButton = new QPushButton( tr( "&Add" ) );
   mAddButton->setToolTip( tr( "Add selected layers to map" ) );
   mAddButton->setEnabled( false );
   buttonBox->addButton( mAddButton, QDialogButtonBox::ApplyRole );
-  connect( mAddButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addClicked );
+  connect( mAddButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addButtonClicked );
   connect( this, &QgsAbstractDataSourceWidget::enableButtons, mAddButton, &QPushButton::setEnabled );
 
   QPushButton *okButton = new QPushButton( tr( "&Ok" ) );
   okButton->setToolTip( tr( "Add selected layers to map and close this dialog" ) );
   okButton->setEnabled( false );
   buttonBox->addButton( okButton, QDialogButtonBox::AcceptRole );
-  connect( okButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::okClicked );
+  connect( okButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::okButtonClicked );
   connect( this, &QgsAbstractDataSourceWidget::enableButtons, okButton, &QPushButton::setEnabled );
 
 }
@@ -67,8 +67,8 @@ void QgsAbstractDataSourceWidget::setMapCanvas( const QgsMapCanvas *mapCanvas )
   mMapCanvas = mapCanvas;
 }
 
-void QgsAbstractDataSourceWidget::okClicked()
+void QgsAbstractDataSourceWidget::okButtonClicked()
 {
-  addClicked();
+  addButtonClicked();
   emit accepted();
 }

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -63,11 +63,12 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      * Concrete classes should implement the right behavior depending on the layer
      * being added.
      */
-    virtual void addClicked() { }
+    virtual void addButtonClicked() { }
 
-    /** Triggered when the dialog is accepted, call addClicked() and emit the accepted() signal
+    /** Triggered when the dialog is accepted, call addButtonClicked() and
+     * emit the accepted() signal
      */
-    virtual void okClicked();
+    virtual void okButtonClicked();
 
   signals:
 
@@ -110,7 +111,7 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     void setupButtons( QDialogButtonBox *buttonBox );
 
     //! Return the add Button
-    const QPushButton *addButton( ) { return mAddButton; }
+    QPushButton *addButton( ) const { return mAddButton; }
 
   private:
     QPushButton *mAddButton  = nullptr;

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -26,6 +26,7 @@
 #include "qgsproviderregistry.h"
 #include "qgsguiutils.h"
 #include <QDialog>
+#include <QDialogButtonBox>
 
 class QgsMapCanvas;
 
@@ -58,6 +59,16 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      */
     virtual void refresh() {}
 
+    /** Triggered when the add button is clicked, the add layer signal is emitted
+     * Concrete classes should implement the right behavior depending on the layer
+     * being added.
+     */
+    virtual void addClicked() { }
+
+    /** Triggered when the dialog is accepted, call addClicked() and emit the accepted() signal
+     */
+    virtual void okClicked();
+
   signals:
 
     /** Emitted when the provider's connections have changed
@@ -80,6 +91,10 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     //! Emitted when a progress dialog is shown by the provider dialog
     void progressMessage( QString message );
 
+    //! Emitted when the ok/add buttons should be enabled/disabled
+    void enableButtons( bool enable );
+
+
   protected:
 
     //! Constructor
@@ -88,12 +103,17 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     //! Return the widget mode
     QgsProviderRegistry::WidgetMode widgetMode() const;
 
-    /** Return the map canvas (can be null)
-     */
+    //! Return the map canvas (can be null)
     const QgsMapCanvas *mapCanvas() const;
 
-  private:
+    //! Connect the ok and apply/add buttons to the slots
+    void setupButtons( QDialogButtonBox *buttonBox );
 
+    //! Return the add Button
+    const QPushButton *addButton( ) { return mAddButton; }
+
+  private:
+    QPushButton *mAddButton  = nullptr;
     QgsProviderRegistry::WidgetMode mWidgetMode;
     QgsMapCanvas const *mMapCanvas = nullptr;
 

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -192,6 +192,7 @@ QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::providerDialog( const Q
       dlg->setMapCanvas( mMapCanvas );
     }
     connect( dlg, &QgsAbstractDataSourceWidget::rejected, this, &QgsDataSourceManagerDialog::reject );
+    connect( dlg, &QgsAbstractDataSourceWidget::accepted, this, &QgsDataSourceManagerDialog::accept );
     return dlg;
   }
 }

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -209,7 +209,7 @@ void QgsDataSourceManagerDialog::addDbProviderDialog( const QString providerKey,
     connect( dlg, SIGNAL( progressMessage( QString ) ),
              this, SIGNAL( showStatusMessage( QString ) ) );
     connect( dlg, SIGNAL( connectionsChanged() ), this, SIGNAL( connectionsChanged() ) );
-    connect( this,  SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
+    connect( this, SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
   }
 }
 

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -60,19 +60,10 @@ QgsOWSSourceSelect::QgsOWSSourceSelect( const QString &service, QWidget *parent,
   , mCurrentTileset( nullptr )
 {
   setupUi( this );
-
-  if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
-  {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
-  }
+  setupButtons( buttonBox );
 
 
   setWindowTitle( tr( "Add Layer(s) from a %1 Server" ).arg( service ) );
-
-  mAddButton = buttonBox->button( QDialogButtonBox::Apply );
-  mAddButton->setText( tr( "&Add" ) );
-  mAddButton->setToolTip( tr( "Add selected layers to map" ) );
-  mAddButton->setEnabled( false );
 
   clearCrs();
 
@@ -90,7 +81,6 @@ QgsOWSSourceSelect::QgsOWSSourceSelect( const QString &service, QWidget *parent,
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::Manager )
   {
-    connect( mAddButton, &QAbstractButton::clicked, this, &QgsOWSSourceSelect::addClicked );
     //set the current project CRS if available
     QgsCoordinateReferenceSystem currentRefSys = QgsProject::instance()->crs();
     //convert CRS id to epsg
@@ -106,7 +96,6 @@ QgsOWSSourceSelect::QgsOWSSourceSelect( const QString &service, QWidget *parent,
     mTimeWidget->hide();
     mFormatWidget->hide();
     mCRSWidget->hide();
-    mAddButton->hide();
     mCacheWidget->hide();
   }
 
@@ -359,10 +348,6 @@ void QgsOWSSourceSelect::on_mConnectButton_clicked()
   populateLayerList();
 
   QApplication::restoreOverrideCursor();
-}
-
-void QgsOWSSourceSelect::addClicked()
-{
 }
 
 void QgsOWSSourceSelect::enableLayersForCrs( QTreeWidgetItem * )

--- a/src/gui/qgsowssourceselect.h
+++ b/src/gui/qgsowssourceselect.h
@@ -87,9 +87,6 @@ class GUI_EXPORT QgsOWSSourceSelect : public QgsAbstractDataSourceWidget, protec
      */
     void on_mConnectButton_clicked();
 
-    //! Determines the layers the user selected
-    virtual void addClicked();
-
     void searchFinished();
 
     //! Opens the Spatial Reference System dialog.
@@ -186,8 +183,6 @@ class GUI_EXPORT QgsOWSSourceSelect : public QgsAbstractDataSourceWidget, protec
 
     //! layer name derived from latest layer selection (updated as long it's not edited manually)
     QString mLastLayerName;
-
-    QPushButton *mAddButton = nullptr;
 
     QMap<QString, QString> mCrsNames;
 

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -27,13 +27,8 @@
 
 
 QgsAfsSourceSelect::QgsAfsSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
-  : QgsArcGisServiceSourceSelect( QStringLiteral( "ArcGisFeatureServer" ), QgsArcGisServiceSourceSelect::FeatureService, parent, fl )
+  : QgsArcGisServiceSourceSelect( QStringLiteral( "ArcGisFeatureServer" ), QgsArcGisServiceSourceSelect::FeatureService, parent, fl, widgetMode )
 {
-  if ( widgetMode == QgsProviderRegistry::WidgetMode::Embedded || widgetMode == QgsProviderRegistry::WidgetMode::Manager )
-  {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
-  }
-
   // import/export of connections not supported yet
   btnLoad->hide();
   btnSave->hide();

--- a/src/providers/arcgisrest/qgsamssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsamssourceselect.cpp
@@ -26,12 +26,8 @@
 
 
 QgsAmsSourceSelect::QgsAmsSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
-  : QgsArcGisServiceSourceSelect( QStringLiteral( "ArcGisMapServer" ), QgsArcGisServiceSourceSelect::MapService, parent, fl )
+  : QgsArcGisServiceSourceSelect( QStringLiteral( "ArcGisMapServer" ), QgsArcGisServiceSourceSelect::MapService, parent, fl, widgetMode )
 {
-  if ( widgetMode == QgsProviderRegistry::WidgetMode::Embedded || widgetMode == QgsProviderRegistry::WidgetMode::Manager )
-  {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
-  }
 
   // import/export of connections not supported yet
   btnLoad->hide();

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -57,7 +57,6 @@ QgsArcGisServiceSourceSelect::QgsArcGisServiceSourceSelect( const QString &servi
   mImageEncodingGroup( 0 )
 {
   setupUi( this );
-  // Creates and connects standard ok/apply buttons
   setupButtons( buttonBox );
   setWindowTitle( QStringLiteral( "Add %1 Layer from a Server" ).arg( mServiceName ) );
 
@@ -306,7 +305,7 @@ void QgsArcGisServiceSourceSelect::connectToServer()
   btnChangeSpatialRefSys->setEnabled( haveLayers );
 }
 
-void QgsArcGisServiceSourceSelect::addClicked()
+void QgsArcGisServiceSourceSelect::addButtonClicked()
 {
   if ( treeView->selectionModel()->selectedRows().isEmpty() )
   {

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -57,11 +57,9 @@ QgsArcGisServiceSourceSelect::QgsArcGisServiceSourceSelect( const QString &servi
   mImageEncodingGroup( 0 )
 {
   setupUi( this );
+  // Creates and connects standard ok/apply buttons
+  setupButtons( buttonBox );
   setWindowTitle( QStringLiteral( "Add %1 Layer from a Server" ).arg( mServiceName ) );
-
-  mAddButton = buttonBox->addButton( tr( "&Add" ), QDialogButtonBox::ActionRole );
-  mAddButton->setEnabled( false );
-  connect( mAddButton, &QAbstractButton::clicked, this, &QgsArcGisServiceSourceSelect::addButtonClicked );
 
   if ( mServiceType == FeatureService )
   {
@@ -300,7 +298,7 @@ void QgsArcGisServiceSourceSelect::connectToServer()
   }
 
   btnConnect->setEnabled( true );
-  mAddButton->setEnabled( haveLayers );
+  emit enableButtons( haveLayers );
   if ( mServiceType == FeatureService )
   {
     mBuildQueryButton->setEnabled( haveLayers );
@@ -308,7 +306,7 @@ void QgsArcGisServiceSourceSelect::connectToServer()
   btnChangeSpatialRefSys->setEnabled( haveLayers );
 }
 
-void QgsArcGisServiceSourceSelect::addButtonClicked()
+void QgsArcGisServiceSourceSelect::addClicked()
 {
   if ( treeView->selectionModel()->selectedRows().isEmpty() )
   {
@@ -439,7 +437,7 @@ void QgsArcGisServiceSourceSelect::treeWidgetCurrentRowChanged( const QModelInde
   {
     mBuildQueryButton->setEnabled( current.isValid() );
   }
-  mAddButton->setEnabled( current.isValid() );
+  emit enableButtons( current.isValid() );
 }
 
 void QgsArcGisServiceSourceSelect::buildQueryButtonClicked()

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.h
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.h
@@ -59,7 +59,6 @@ class QgsArcGisServiceSourceSelect : public QgsAbstractDataSourceWidget, protect
     QStandardItemModel *mModel = nullptr;
     QSortFilterProxyModel *mModelProxy = nullptr;
     QPushButton *mBuildQueryButton = nullptr;
-    QPushButton *mAddButton = nullptr;
     QButtonGroup *mImageEncodingGroup = nullptr;
     QgsRectangle mCanvasExtent;
     QgsCoordinateReferenceSystem mCanvasCrs;
@@ -105,7 +104,7 @@ class QgsArcGisServiceSourceSelect : public QgsAbstractDataSourceWidget, protect
     void addEntryToServerList();
     void deleteEntryOfServerList();
     void modifyEntryOfServerList();
-    void addButtonClicked();
+    void addClicked() override;
     void buildQueryButtonClicked();
     void changeCrs();
     void changeCrsFilter();

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.h
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.h
@@ -104,7 +104,7 @@ class QgsArcGisServiceSourceSelect : public QgsAbstractDataSourceWidget, protect
     void addEntryToServerList();
     void deleteEntryOfServerList();
     void modifyEntryOfServerList();
-    void addClicked() override;
+    void addButtonClicked() override;
     void buildQueryButtonClicked();
     void changeCrs();
     void changeCrsFilter();

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -312,7 +312,7 @@ void QgsDb2SourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex &in
   QgsSettings settings;
   if ( settings.value( QStringLiteral( "qgis/addDb2DC" ), false ).toBool() )
   {
-    addClicked();
+    addButtonClicked();
   }
   else
   {
@@ -427,7 +427,7 @@ void QgsDb2SourceSelect::populateConnectionList()
 }
 
 // Slot for performing action when the Add button is clicked
-void QgsDb2SourceSelect::addClicked()
+void QgsDb2SourceSelect::addButtonClicked()
 {
   QgsDebugMsg( QString( "mConnInfo:%1" ).arg( mConnInfo ) );
   mSelectedTables.clear();

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -122,17 +122,13 @@ QgsDb2SourceSelect::QgsDb2SourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   , mUseEstimatedMetadata( false )
 {
   setupUi( this );
-
+  setupButtons( buttonBox );
   setWindowTitle( tr( "Add Db2 Table(s)" ) );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
   {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
     mHoldDialogOpen->hide();
   }
-
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  mAddButton->setEnabled( false );
 
   mBuildQueryButton = new QPushButton( tr( "&Set Filter" ) );
   mBuildQueryButton->setToolTip( tr( "Set Filter" ) );
@@ -140,9 +136,6 @@ QgsDb2SourceSelect::QgsDb2SourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::Manager )
   {
-    buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
-    connect( mAddButton, &QAbstractButton::clicked, this, &QgsDb2SourceSelect::addTables );
-
     buttonBox->addButton( mBuildQueryButton, QDialogButtonBox::ActionRole );
     connect( mBuildQueryButton, &QAbstractButton::clicked, this, &QgsDb2SourceSelect::buildQuery );
   }
@@ -319,7 +312,7 @@ void QgsDb2SourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex &in
   QgsSettings settings;
   if ( settings.value( QStringLiteral( "qgis/addDb2DC" ), false ).toBool() )
   {
-    addTables();
+    addClicked();
   }
   else
   {
@@ -434,7 +427,7 @@ void QgsDb2SourceSelect::populateConnectionList()
 }
 
 // Slot for performing action when the Add button is clicked
-void QgsDb2SourceSelect::addTables()
+void QgsDb2SourceSelect::addClicked()
 {
   QgsDebugMsg( QString( "mConnInfo:%1" ).arg( mConnInfo ) );
   mSelectedTables.clear();
@@ -664,7 +657,7 @@ void QgsDb2SourceSelect::setSearchExpression( const QString &regexp )
 void QgsDb2SourceSelect::treeWidgetSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
   Q_UNUSED( deselected )
-  mAddButton->setEnabled( !selected.isEmpty() );
+  emit enableButtons( !selected.isEmpty() );
 }
 
 

--- a/src/providers/db2/qgsdb2sourceselect.h
+++ b/src/providers/db2/qgsdb2sourceselect.h
@@ -113,7 +113,7 @@ class QgsDb2SourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDb
 
   public slots:
     //! Determines the tables the user selected and closes the dialog
-    void addTables();
+    void addClicked() override;
     void buildQuery();
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
@@ -179,7 +179,6 @@ class QgsDb2SourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDb
     QgsDatabaseFilterProxyModel mProxyModel;
 
     QPushButton *mBuildQueryButton = nullptr;
-    QPushButton *mAddButton = nullptr;
 
     void finishList();
 };

--- a/src/providers/db2/qgsdb2sourceselect.h
+++ b/src/providers/db2/qgsdb2sourceselect.h
@@ -113,7 +113,7 @@ class QgsDb2SourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDb
 
   public slots:
     //! Determines the tables the user selected and closes the dialog
-    void addClicked() override;
+    void addButtonClicked() override;
     void buildQuery();
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -44,15 +44,10 @@ QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget *parent, Qt:
 {
 
   setupUi( this );
+  setupButtons( buttonBox );
 
   QgsSettings settings;
   restoreGeometry( settings.value( mPluginKey + "/geometry" ).toByteArray() );
-
-  if ( widgetMode() !=  QgsProviderRegistry::WidgetMode::None )
-  {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Cancel ) );
-    buttonBox->button( QDialogButtonBox::Ok )->setText( tr( "Add" ) );
-  }
 
   bgFileFormat = new QButtonGroup( this );
   bgFileFormat->addButton( delimiterCSV, swFileFormat->indexOf( swpCSVOptions ) );
@@ -114,7 +109,7 @@ void QgsDelimitedTextSourceSelect::on_btnBrowseForFile_clicked()
   getOpenFileName();
 }
 
-void QgsDelimitedTextSourceSelect::on_buttonBox_accepted()
+void QgsDelimitedTextSourceSelect::addClicked()
 {
   // The following conditions should not be hit! OK will not be enabled...
   if ( txtLayerName->text().isEmpty() )
@@ -205,10 +200,6 @@ void QgsDelimitedTextSourceSelect::on_buttonBox_accepted()
   }
 }
 
-void QgsDelimitedTextSourceSelect::on_buttonBox_rejected()
-{
-  reject();
-}
 
 QString QgsDelimitedTextSourceSelect::selectedChars()
 {
@@ -745,6 +736,5 @@ bool QgsDelimitedTextSourceSelect::validate()
 
 void QgsDelimitedTextSourceSelect::enableAccept()
 {
-  bool enabled = validate();
-  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
+  emit enableButtons( validate() );
 }

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -109,7 +109,7 @@ void QgsDelimitedTextSourceSelect::on_btnBrowseForFile_clicked()
   getOpenFileName();
 }
 
-void QgsDelimitedTextSourceSelect::addClicked()
+void QgsDelimitedTextSourceSelect::addButtonClicked()
 {
   // The following conditions should not be hit! OK will not be enabled...
   if ( txtLayerName->text().isEmpty() )

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -60,8 +60,6 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     QButtonGroup *bgGeomType = nullptr;
 
   private slots:
-    void on_buttonBox_accepted();
-    void on_buttonBox_rejected();
     void on_buttonBox_helpRequested()
     {
       QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#delimited-text-files" ) );
@@ -69,6 +67,7 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     void on_btnBrowseForFile_clicked();
 
   public slots:
+    void addClicked() override;
     void updateFileName();
     void updateFieldsAndEnable();
     void enableAccept();

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -67,7 +67,7 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     void on_btnBrowseForFile_clicked();
 
   public slots:
-    void addClicked() override;
+    void addButtonClicked() override;
     void updateFileName();
     void updateFieldsAndEnable();
     void enableAccept();

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -311,7 +311,7 @@ void QgsMssqlSourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex &
   QgsSettings settings;
   if ( settings.value( QStringLiteral( "qgis/addMSSQLDC" ), false ).toBool() )
   {
-    addClicked();
+    addButtonClicked();
   }
   else
   {
@@ -426,7 +426,7 @@ void QgsMssqlSourceSelect::populateConnectionList()
 }
 
 // Slot for performing action when the Add button is clicked
-void QgsMssqlSourceSelect::addClicked()
+void QgsMssqlSourceSelect::addButtonClicked()
 {
   QgsDebugMsg( QString( "mConnInfo:%1" ).arg( mConnInfo ) );
   mSelectedTables.clear();

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -124,10 +124,10 @@ QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl,
   , mUseEstimatedMetadata( false )
 {
   setupUi( this );
+  setupButtons( buttonBox );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
   {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
     mHoldDialogOpen->hide();
   }
   else
@@ -135,17 +135,12 @@ QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl,
     setWindowTitle( tr( "Add MSSQL Table(s)" ) );
   }
 
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  mAddButton->setEnabled( false );
-
   mBuildQueryButton = new QPushButton( tr( "&Set Filter" ) );
   mBuildQueryButton->setToolTip( tr( "Set Filter" ) );
   mBuildQueryButton->setDisabled( true );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::Manager )
   {
-    buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
-    connect( mAddButton, &QAbstractButton::clicked, this, &QgsMssqlSourceSelect::addTables );
 
     buttonBox->addButton( mBuildQueryButton, QDialogButtonBox::ActionRole );
     connect( mBuildQueryButton, &QAbstractButton::clicked, this, &QgsMssqlSourceSelect::buildQuery );
@@ -316,7 +311,7 @@ void QgsMssqlSourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex &
   QgsSettings settings;
   if ( settings.value( QStringLiteral( "qgis/addMSSQLDC" ), false ).toBool() )
   {
-    addTables();
+    addClicked();
   }
   else
   {
@@ -431,7 +426,7 @@ void QgsMssqlSourceSelect::populateConnectionList()
 }
 
 // Slot for performing action when the Add button is clicked
-void QgsMssqlSourceSelect::addTables()
+void QgsMssqlSourceSelect::addClicked()
 {
   QgsDebugMsg( QString( "mConnInfo:%1" ).arg( mConnInfo ) );
   mSelectedTables.clear();
@@ -745,5 +740,5 @@ void QgsMssqlSourceSelect::setSearchExpression( const QString &regexp )
 void QgsMssqlSourceSelect::treeWidgetSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
   Q_UNUSED( deselected )
-  mAddButton->setEnabled( !selected.isEmpty() );
+  emit enableButtons( !selected.isEmpty() );
 }

--- a/src/providers/mssql/qgsmssqlsourceselect.h
+++ b/src/providers/mssql/qgsmssqlsourceselect.h
@@ -87,7 +87,7 @@ class QgsMssqlSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qgs
     void refresh() override;
 
     //! Determines the tables the user selected and closes the dialog
-    void addTables();
+    void addClicked() override;
     void buildQuery();
 
     /** Connects to the database using the stored connection parameters.
@@ -152,7 +152,6 @@ class QgsMssqlSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qgs
     QgsDatabaseFilterProxyModel mProxyModel;
 
     QPushButton *mBuildQueryButton = nullptr;
-    QPushButton *mAddButton = nullptr;
 
     void finishList();
 };

--- a/src/providers/mssql/qgsmssqlsourceselect.h
+++ b/src/providers/mssql/qgsmssqlsourceselect.h
@@ -87,7 +87,7 @@ class QgsMssqlSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qgs
     void refresh() override;
 
     //! Determines the tables the user selected and closes the dialog
-    void addClicked() override;
+    void addButtonClicked() override;
     void buildQuery();
 
     /** Connects to the database using the stored connection parameters.

--- a/src/providers/ogr/CMakeLists.txt
+++ b/src/providers/ogr/CMakeLists.txt
@@ -1,5 +1,11 @@
 
-SET (OGR_SRCS qgsogrprovider.cpp qgsogrdataitems.cpp qgsogrfeatureiterator.cpp qgsogrconnpool.cpp qgsogrexpressioncompiler.cpp)
+SET (OGR_SRCS
+    qgsogrprovider.cpp
+    qgsogrdataitems.cpp
+    qgsogrfeatureiterator.cpp
+    qgsogrconnpool.cpp
+    qgsogrexpressioncompiler.cpp
+)
 
 SET(OGR_MOC_HDRS qgsogrprovider.h qgsogrdataitems.h qgsogrconnpool.h)
 

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -172,10 +172,10 @@ QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags f
   , mIsConnected( false )
 {
   setupUi( this );
+  setupButton( buttonBox );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
   {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
     mHoldDialogOpen->hide();
   }
   else
@@ -183,18 +183,12 @@ QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags f
     setWindowTitle( tr( "Add Oracle Table(s)" ) );
   }
 
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  mAddButton->setEnabled( false );
-
   mBuildQueryButton = new QPushButton( tr( "&Set Filter" ) );
   mBuildQueryButton->setToolTip( tr( "Set Filter" ) );
   mBuildQueryButton->setDisabled( true );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::Manager )
   {
-    buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
-    connect( mAddButton, &QAbstractButton::clicked, this, &QgsOracleSourceSelect::addTables );
-
     buttonBox->addButton( mBuildQueryButton, QDialogButtonBox::ActionRole );
     connect( mBuildQueryButton, &QAbstractButton::clicked, this, &QgsOracleSourceSelect::buildQuery );
   }
@@ -359,7 +353,7 @@ void QgsOracleSourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex 
   QgsSettings settings;
   if ( settings.value( QStringLiteral( "qgis/addOracleDC" ), false ).toBool() )
   {
-    addTables();
+    addClicked();
   }
   else
   {
@@ -470,7 +464,7 @@ void QgsOracleSourceSelect::populateConnectionList()
 }
 
 // Slot for performing action when the Add button is clicked
-void QgsOracleSourceSelect::addTables()
+void QgsOracleSourceSelect::addClicked()
 {
   mSelectedTables.clear();
 
@@ -674,5 +668,5 @@ void QgsOracleSourceSelect::loadTableFromCache()
 void QgsOracleSourceSelect::treeWidgetSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
   Q_UNUSED( deselected )
-  mAddButton->setEnabled( !selected.isEmpty() );
+  emit enableButtons( !selected.isEmpty() );
 }

--- a/src/providers/oracle/qgsoraclesourceselect.h
+++ b/src/providers/oracle/qgsoraclesourceselect.h
@@ -103,7 +103,7 @@ class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qg
 
   public slots:
     //! Determines the tables the user selected and closes the dialog
-    void addTables();
+    void addClicked() override;
     void buildQuery();
 
     /** Connects to the database using the stored connection parameters.

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -199,10 +199,10 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsPr
   , mUseEstimatedMetadata( false )
 {
   setupUi( this );
+  setupButtons( buttonBox );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
   {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
     mHoldDialogOpen->hide();
   }
   else
@@ -210,18 +210,12 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsPr
     setWindowTitle( tr( "Add PostGIS Table(s)" ) );
   }
 
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  mAddButton->setEnabled( false );
-
   mBuildQueryButton = new QPushButton( tr( "&Set Filter" ) );
   mBuildQueryButton->setToolTip( tr( "Set Filter" ) );
   mBuildQueryButton->setDisabled( true );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::Manager )
   {
-    buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
-    connect( mAddButton, &QAbstractButton::clicked, this, &QgsPgSourceSelect::addTables );
-
     buttonBox->addButton( mBuildQueryButton, QDialogButtonBox::ActionRole );
     connect( mBuildQueryButton, &QAbstractButton::clicked, this, &QgsPgSourceSelect::buildQuery );
   }
@@ -371,7 +365,7 @@ void QgsPgSourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex &ind
   QgsSettings settings;
   if ( settings.value( QStringLiteral( "qgis/addPostgisDC" ), false ).toBool() )
   {
-    addTables();
+    addClicked();
   }
   else
   {
@@ -485,7 +479,7 @@ void QgsPgSourceSelect::populateConnectionList()
 }
 
 // Slot for performing action when the Add button is clicked
-void QgsPgSourceSelect::addTables()
+void QgsPgSourceSelect::addClicked()
 {
   mSelectedTables.clear();
 
@@ -660,5 +654,5 @@ void QgsPgSourceSelect::treeWidgetSelectionChanged( const QItemSelection &select
 {
   Q_UNUSED( deselected )
   Q_UNUSED( selected )
-  mAddButton->setEnabled( !mTablesTreeView->selectionModel()->selection().isEmpty() );
+  emit enableButtons( !mTablesTreeView->selectionModel()->selection().isEmpty() );
 }

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -365,7 +365,7 @@ void QgsPgSourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex &ind
   QgsSettings settings;
   if ( settings.value( QStringLiteral( "qgis/addPostgisDC" ), false ).toBool() )
   {
-    addClicked();
+    addButtonClicked();
   }
   else
   {
@@ -479,7 +479,7 @@ void QgsPgSourceSelect::populateConnectionList()
 }
 
 // Slot for performing action when the Add button is clicked
-void QgsPgSourceSelect::addClicked()
+void QgsPgSourceSelect::addButtonClicked()
 {
   mSelectedTables.clear();
 

--- a/src/providers/postgres/qgspgsourceselect.h
+++ b/src/providers/postgres/qgspgsourceselect.h
@@ -86,7 +86,7 @@ class QgsPgSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbS
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
     //! Determines the tables the user selected and closes the dialog
-    void addClicked() override;
+    void addButtonClicked() override;
     void buildQuery();
 
     /** Connects to the database using the stored connection parameters.

--- a/src/providers/postgres/qgspgsourceselect.h
+++ b/src/providers/postgres/qgspgsourceselect.h
@@ -86,7 +86,7 @@ class QgsPgSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbS
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
     //! Determines the tables the user selected and closes the dialog
-    void addTables();
+    void addClicked() override;
     void buildQuery();
 
     /** Connects to the database using the stored connection parameters.
@@ -150,7 +150,6 @@ class QgsPgSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbS
     QgsDatabaseFilterProxyModel mProxyModel;
 
     QPushButton *mBuildQueryButton = nullptr;
-    QPushButton *mAddButton = nullptr;
 
     void finishList();
 };

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -364,7 +364,7 @@ void QgsSpatiaLiteSourceSelect::on_btnDelete_clicked()
   emit connectionsChanged();
 }
 
-void QgsSpatiaLiteSourceSelect::addClicked()
+void QgsSpatiaLiteSourceSelect::addButtonClicked()
 {
   m_selectedTables.clear();
 

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -44,6 +44,7 @@ QgsSpatiaLiteSourceSelect::QgsSpatiaLiteSourceSelect( QWidget *parent, Qt::Windo
   QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
 {
   setupUi( this );
+  setupButtons( buttonBox );
 
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/SpatiaLiteSourceSelect/geometry" ) ).toByteArray() );
@@ -58,9 +59,6 @@ QgsSpatiaLiteSourceSelect::QgsSpatiaLiteSourceSelect( QWidget *parent, Qt::Windo
   connect( mStatsButton, &QAbstractButton::clicked, this, &QgsSpatiaLiteSourceSelect::updateStatistics );
   mStatsButton->setEnabled( false );
 
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  connect( mAddButton, &QAbstractButton::clicked, this, &QgsSpatiaLiteSourceSelect::addClicked );
-  mAddButton->setEnabled( false );
 
   mBuildQueryButton = new QPushButton( tr( "&Set Filter" ) );
   connect( mBuildQueryButton, &QAbstractButton::clicked, this, &QgsSpatiaLiteSourceSelect::buildQuery );
@@ -68,11 +66,9 @@ QgsSpatiaLiteSourceSelect::QgsSpatiaLiteSourceSelect( QWidget *parent, Qt::Windo
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
   {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
     mHoldDialogOpen->hide();
   }
 
-  buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
   buttonBox->addButton( mBuildQueryButton, QDialogButtonBox::ActionRole );
   buttonBox->addButton( mStatsButton, QDialogButtonBox::ActionRole );
 
@@ -121,13 +117,6 @@ QgsSpatiaLiteSourceSelect::~QgsSpatiaLiteSourceSelect()
   settings.setValue( QStringLiteral( "Windows/SpatiaLiteSourceSelect/HoldDialogOpen" ), mHoldDialogOpen->isChecked() );
 }
 
-// Slot for performing action when the Add button is clicked
-void QgsSpatiaLiteSourceSelect::addClicked()
-{
-  addTables();
-}
-
-//! End Autoconnected SLOTS *
 
 // Remember which database is selected
 void QgsSpatiaLiteSourceSelect::on_cmbConnections_activated( int )
@@ -375,7 +364,7 @@ void QgsSpatiaLiteSourceSelect::on_btnDelete_clicked()
   emit connectionsChanged();
 }
 
-void QgsSpatiaLiteSourceSelect::addTables()
+void QgsSpatiaLiteSourceSelect::addClicked()
 {
   m_selectedTables.clear();
 
@@ -586,5 +575,5 @@ void QgsSpatiaLiteSourceSelect::setSearchExpression( const QString &regexp )
 void QgsSpatiaLiteSourceSelect::treeWidgetSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
   Q_UNUSED( deselected )
-  mAddButton->setEnabled( !selected.isEmpty() );
+  emit enableButtons( !selected.isEmpty() );
 }

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -57,8 +57,6 @@ class QgsSpatiaLiteSourceSelect: public QgsAbstractDataSourceWidget, private Ui:
     ~QgsSpatiaLiteSourceSelect();
     //! Populate the connection list combo box
     void populateConnectionList();
-    //! Determines the tables the user selected and closes the dialog
-    void addTables();
     //! String list containing the selected tables
     QStringList selectedTables();
     //! Connection info (DB-path)
@@ -76,7 +74,7 @@ class QgsSpatiaLiteSourceSelect: public QgsAbstractDataSourceWidget, private Ui:
      */
     void on_btnConnect_clicked();
     void buildQuery();
-    void addClicked();
+    void addClicked() override;
     void updateStatistics();
     //! Opens the create connection dialog to build a new connection
     void on_btnNew_clicked();
@@ -128,7 +126,6 @@ class QgsSpatiaLiteSourceSelect: public QgsAbstractDataSourceWidget, private Ui:
 
     QString layerURI( const QModelIndex &index );
     QPushButton *mBuildQueryButton = nullptr;
-    QPushButton *mAddButton = nullptr;
     QPushButton *mStatsButton = nullptr;
 };
 

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -74,7 +74,7 @@ class QgsSpatiaLiteSourceSelect: public QgsAbstractDataSourceWidget, private Ui:
      */
     void on_btnConnect_clicked();
     void buildQuery();
-    void addClicked() override;
+    void addButtonClicked() override;
     void updateStatistics();
     //! Opens the create connection dialog to build a new connection
     void on_btnNew_clicked();

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -344,7 +344,7 @@ void QgsVirtualLayerSourceSelect::onImportLayer()
   }
 }
 
-void QgsVirtualLayerSourceSelect::addClicked()
+void QgsVirtualLayerSourceSelect::addButtonClicked()
 {
   QString layerName = QStringLiteral( "virtual_layer" );
   QString id;

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -43,12 +43,7 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
   , mTreeView( nullptr )
 {
   setupUi( this );
-
-  if ( widgetMode != QgsProviderRegistry::WidgetMode::None )
-  {
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Cancel ) );
-    buttonBox->button( QDialogButtonBox::Ok )->setText( tr( "Add" ) );
-  }
+  setupButtons( buttonBox );
 
   connect( mTestButton, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::onTestQuery );
   connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::onBrowseCRS );
@@ -92,6 +87,9 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
     connect( mTreeView->model(), &QAbstractItemModel::rowsRemoved, this, &QgsVirtualLayerSourceSelect::updateLayersList );
     connect( mTreeView->model(), &QAbstractItemModel::dataChanged, this, &QgsVirtualLayerSourceSelect::updateLayersList );
   }
+  // There is no validation logic to enable/disable the buttons
+  // so they must be enabled by default
+  emit enableButtons( true );
 }
 
 void QgsVirtualLayerSourceSelect::refresh()
@@ -346,7 +344,7 @@ void QgsVirtualLayerSourceSelect::onImportLayer()
   }
 }
 
-void QgsVirtualLayerSourceSelect::on_buttonBox_accepted()
+void QgsVirtualLayerSourceSelect::addClicked()
 {
   QString layerName = QStringLiteral( "virtual_layer" );
   QString id;

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -41,7 +41,7 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
   public slots:
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
-    void addClicked() override;
+    void addButtonClicked() override;
 
   private slots:
     void onTestQuery();

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -41,9 +41,9 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
   public slots:
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
+    void addClicked() override;
 
   private slots:
-    void on_buttonBox_accepted();
     void onTestQuery();
     void onBrowseCRS();
     void onLayerComboChanged( int );

--- a/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
+++ b/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
@@ -343,7 +343,7 @@ In particular, saving a virtual layer with embedded layers to a QLR file can be 
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::NoButton</set>
        </property>
       </widget>
      </item>

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -113,7 +113,7 @@ QString QgsWCSSourceSelect::selectedIdentifier()
   return identifier;
 }
 
-void QgsWCSSourceSelect::addClicked()
+void QgsWCSSourceSelect::addButtonClicked()
 {
   QgsDataSourceUri uri = mUri;
 

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -152,6 +152,7 @@ void QgsWCSSourceSelect::addClicked()
   emit addRasterLayer( uri.encodedUri(), identifier, QStringLiteral( "wcs" ) );
 }
 
+
 void QgsWCSSourceSelect::on_mLayersTreeWidget_itemSelectionChanged()
 {
 
@@ -168,7 +169,7 @@ void QgsWCSSourceSelect::on_mLayersTreeWidget_itemSelectionChanged()
 
   updateButtons();
 
-  mAddButton->setEnabled( true );
+  emit enableButtons( true );
 }
 
 void QgsWCSSourceSelect::updateButtons()
@@ -186,7 +187,7 @@ void QgsWCSSourceSelect::updateButtons()
     }
   }
 
-  mAddButton->setEnabled( !mLayersTreeWidget->selectedItems().isEmpty() && !selectedCrs().isEmpty() && !selectedFormat().isEmpty() );
+  emit enableButtons( !mLayersTreeWidget->selectedItems().isEmpty() && !selectedCrs().isEmpty() && !selectedFormat().isEmpty() );
 }
 
 QList<QgsWCSSourceSelect::SupportedFormat> QgsWCSSourceSelect::providerFormats()

--- a/src/providers/wcs/qgswcssourceselect.h
+++ b/src/providers/wcs/qgswcssourceselect.h
@@ -71,7 +71,7 @@ class QgsWCSSourceSelect : public QgsOWSSourceSelect
 
     // QgsWcsCapabilities virtual methods
     void populateLayerList() override;
-    void addClicked() override;
+    void addButtonClicked() override;
     void on_mLayersTreeWidget_itemSelectionChanged() override;
     void enableLayersForCrs( QTreeWidgetItem *item ) override;
     void updateButtons() override;

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -54,25 +54,18 @@ QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   , mSQLComposerDialog( nullptr )
 {
   setupUi( this );
+  setupButtons( buttonBox );
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
   {
-    // For some obscure reason hiding does not work!
-    // buttonBox->button( QDialogButtonBox::Close )->hide();
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
     mHoldDialogOpen->hide();
   }
 
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  mAddButton->setEnabled( false );
 
   mBuildQueryButton = new QPushButton( tr( "&Build query" ) );
   mBuildQueryButton->setToolTip( tr( "Build query" ) );
   mBuildQueryButton->setDisabled( true );
 
-
-  buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
-  connect( mAddButton, &QAbstractButton::clicked, this, &QgsWFSSourceSelect::addLayer );
 
   buttonBox->addButton( mBuildQueryButton, QDialogButtonBox::ActionRole );
   connect( mBuildQueryButton, &QAbstractButton::clicked, this, &QgsWFSSourceSelect::buildQueryButtonClicked );
@@ -127,7 +120,6 @@ QgsWFSSourceSelect::~QgsWFSSourceSelect()
   delete mCapabilities;
   delete mModel;
   delete mModelProxy;
-  delete mAddButton;
   delete mBuildQueryButton;
 }
 
@@ -244,7 +236,7 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
     if ( !property( "hideDialogs" ).toBool() )
       box->open();
 
-    mAddButton->setEnabled( false );
+    emit enableButtons( false );
     return;
   }
 
@@ -291,7 +283,7 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
   else
   {
     QMessageBox::information( nullptr, tr( "No Layers" ), tr( "capabilities document contained no layers." ) );
-    mAddButton->setEnabled( false );
+    emit enableButtons( false );
     mBuildQueryButton->setEnabled( false );
   }
 }
@@ -368,7 +360,7 @@ void QgsWFSSourceSelect::connectToServer()
 }
 
 
-void QgsWFSSourceSelect::addLayer()
+void QgsWFSSourceSelect::addClicked()
 {
   //get selected entry in treeview
   QModelIndex currentIndex = treeView->selectionModel()->currentIndex();
@@ -768,7 +760,7 @@ void QgsWFSSourceSelect::treeWidgetCurrentRowChanged( const QModelIndex &current
   QgsDebugMsg( "treeWidget_currentRowChanged called" );
   changeCRSFilter();
   mBuildQueryButton->setEnabled( current.isValid() );
-  mAddButton->setEnabled( current.isValid() );
+  emit enableButtons( current.isValid() );
 }
 
 void QgsWFSSourceSelect::buildQueryButtonClicked()

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -360,7 +360,7 @@ void QgsWFSSourceSelect::connectToServer()
 }
 
 
-void QgsWFSSourceSelect::addClicked()
+void QgsWFSSourceSelect::addButtonClicked()
 {
   //get selected entry in treeview
   QModelIndex currentIndex = treeView->selectionModel()->currentIndex();

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -66,7 +66,6 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
     QStandardItemModel *mModel = nullptr;
     QSortFilterProxyModel *mModelProxy = nullptr;
     QPushButton *mBuildQueryButton = nullptr;
-    QPushButton *mAddButton = nullptr;
     QgsWfsCapabilities::Capabilities mCaps;
     QModelIndex mSQLIndex;
     QgsSQLComposerDialog *mSQLComposerDialog = nullptr;
@@ -82,13 +81,13 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
 
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
+    void addClicked() override;
 
   private slots:
     void addEntryToServerList();
     void modifyEntryOfServerList();
     void deleteEntryOfServerList();
     void connectToServer();
-    void addLayer();
     void buildQuery( const QModelIndex &index );
     void changeCRS();
     void changeCRSFilter();

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -81,7 +81,7 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
 
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
-    void addClicked() override;
+    void addButtonClicked() override;
 
   private slots:
     void addEntryToServerList();

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -61,16 +61,8 @@ QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 {
   setupUi( this );
 
-  if ( widgetMode() != QgsProviderRegistry::WidgetMode::None )
-  {
-    // For some obscure reason hiding does not work!
-    // buttonBox->button( QDialogButtonBox::Close )->hide();
-    buttonBox->removeButton( buttonBox->button( QDialogButtonBox::Close ) );
-  }
-
-  mAddButton = new QPushButton( tr( "&Add" ) );
-  mAddButton->setToolTip( tr( "Add selected layers to map" ) );
-  mAddButton->setEnabled( false );
+  // Creates and connects standard ok/apply buttons
+  setupButtons( buttonBox );
 
   mTileWidth->setValidator( new QIntValidator( 0, 9999, this ) );
   mTileHeight->setValidator( new QIntValidator( 0, 9999, this ) );
@@ -82,12 +74,6 @@ QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::Manager )
   {
-    buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
-    connect( mAddButton, &QAbstractButton::clicked, this, &QgsWMSSourceSelect::addClicked );
-
-    // TODO: do it without QgisApp
-    //mLayerUpButton->setIcon( QgisApp::getThemeIcon( "/mActionArrowUp.svg" ) );
-    //mLayerDownButton->setIcon( QgisApp::getThemeIcon( "/mActionArrowDown.svg" ) );
 
     QHBoxLayout *layout = new QHBoxLayout;
 
@@ -921,12 +907,12 @@ void QgsWMSSourceSelect::updateButtons()
       labelStatus->setText( tr( "Select layer(s)" ) );
     else
       labelStatus->setText( tr( "Select layer(s) or a tileset" ) );
-    mAddButton->setEnabled( false );
+    emit enableButtons( false );
   }
   else if ( !lstTilesets->selectedItems().isEmpty() && mLayerOrderTreeWidget->topLevelItemCount() > 0 )
   {
     labelStatus->setText( tr( "Select either layer(s) or a tileset" ) );
-    mAddButton->setEnabled( false );
+    emit enableButtons( false );
   }
   else
   {
@@ -938,34 +924,34 @@ void QgsWMSSourceSelect::updateButtons()
       if ( mCRSs.isEmpty() )
       {
         labelStatus->setText( tr( "No common CRS for selected layers." ) );
-        mAddButton->setEnabled( false );
+        emit enableButtons( false );
       }
       else if ( mCRS.isEmpty() )
       {
         labelStatus->setText( tr( "No CRS selected" ) );
-        mAddButton->setEnabled( false );
+        emit enableButtons( false );
       }
       else if ( mImageFormatGroup->checkedId() == -1 )
       {
         labelStatus->setText( tr( "No image encoding selected" ) );
-        mAddButton->setEnabled( false );
+        emit enableButtons( false );
       }
       else
       {
         labelStatus->setText( tr( "%n Layer(s) selected", "selected layer count", mLayerOrderTreeWidget->topLevelItemCount() ) );
-        mAddButton->setEnabled( true );
+        emit enableButtons( true );
       }
     }
     else
     {
       labelStatus->setText( tr( "Tileset selected" ) );
-      mAddButton->setEnabled( true );
+      emit enableButtons( true );
     }
   }
 
   if ( leLayerName->text().isEmpty() || leLayerName->text() == mLastLayerName )
   {
-    if ( mAddButton->isEnabled() )
+    if ( addButton()->isEnabled() )
     {
       if ( !lstTilesets->selectedItems().isEmpty() )
       {

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -471,7 +471,7 @@ void QgsWMSSourceSelect::on_btnConnect_clicked()
   populateLayerList( caps );
 }
 
-void QgsWMSSourceSelect::addClicked()
+void QgsWMSSourceSelect::addButtonClicked()
 {
   QStringList layers;
   QStringList styles;

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -75,7 +75,7 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
     void on_btnConnect_clicked();
 
     //! Determines the layers the user selected
-    void addClicked();
+    void addClicked() override;
 
     void searchFinished();
 
@@ -168,8 +168,6 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
 
     //! The widget that controls the image format radio buttons
     QButtonGroup *mImageFormatGroup = nullptr;
-
-    QPushButton *mAddButton = nullptr;
 
     QMap<QString, QString> mCrsNames;
 

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -75,7 +75,7 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
     void on_btnConnect_clicked();
 
     //! Determines the layers the user selected
-    void addClicked() override;
+    void addButtonClicked() override;
 
     void searchFinished();
 

--- a/src/ui/qgsarcgisservicesourceselectbase.ui
+++ b/src/ui/qgsarcgisservicesourceselectbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>592</width>
-    <height>439</height>
+    <height>440</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -246,7 +246,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsdbsourceselectbase.ui
+++ b/src/ui/qgsdbsourceselectbase.ui
@@ -250,7 +250,7 @@
    <item row="4" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -214,7 +214,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-229</y>
+        <y>0</y>
         <width>696</width>
         <height>742</height>
        </rect>
@@ -1340,7 +1340,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsopenvectorlayerdialogbase.ui
+++ b/src/ui/qgsopenvectorlayerdialogbase.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>450</width>
-    <height>529</height>
+    <height>575</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,13 +27,10 @@
     <normaloff>.</normaloff>.</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="sizeConstraint">
-    <enum>QLayout::SetFixedSize</enum>
-   </property>
    <item row="5" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsowssourceselectbase.ui
+++ b/src/ui/qgsowssourceselectbase.ui
@@ -27,7 +27,7 @@
    <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgswfssourceselectbase.ui
+++ b/src/ui/qgswfssourceselectbase.ui
@@ -53,11 +53,11 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QPushButton" name="btnConnect">
-          <property name="toolTip">
-           <string>Connect to selected service</string>
-          </property>
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Connect to selected service</string>
           </property>
           <property name="text">
            <string>C&amp;onnect</string>
@@ -76,11 +76,11 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnEdit">
-          <property name="toolTip">
-           <string>Edit selected service connection</string>
-          </property>
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Edit selected service connection</string>
           </property>
           <property name="text">
            <string>Edit</string>
@@ -89,11 +89,11 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnDelete">
-          <property name="toolTip">
-           <string>Remove connection to selected service</string>
-          </property>
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Remove connection to selected service</string>
           </property>
           <property name="text">
            <string>Remove</string>
@@ -177,7 +177,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>773</width>
-    <height>539</height>
+    <height>544</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,7 @@
    <item row="3" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Some more refactoring to bring the OGR vector source select dialog under the same class hierarchy of all the other provider source select dialogs and to add an Ok/Add (apply) button bar that looks and behaves the same in all dialogs.

The base class now also handles the basic Ok/Add (Apply) buttons with all their signals and slots.
All dialogs now have the same button bar at the bottom inherited from the abstract base.

![unified-dialog](https://user-images.githubusercontent.com/142164/28985469-fc1b47c2-7962-11e7-9315-098a70237000.png)

@jef-n would you please check the oracle part?
