### PR TITLE
add category in QgsLayerMetadata using keywords

### DIFF
--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -492,7 +492,7 @@ class QgsLayerMetadata
  CRS which is actually used to display and manipulate the layer within QGIS.
  This may be the case when a layer has an incorrect CRS within its metadata
  and a user has manually overridden the layer's CRS within QGIS.
-.. seealso:: setCrs()
+.. seealso:: crs()
 %End
 
     KeywordMap keywords() const;
@@ -535,6 +535,15 @@ class QgsLayerMetadata
 .. seealso:: setKeywords()
 %End
 
+    bool removeKeywords( const QString &vocabulary );
+%Docstring
+ Remove a vocabulary from the list.
+
+.. seealso:: setKeywords()
+.. seealso:: addKeywords()
+ :rtype: bool
+%End
+
     QStringList keywordVocabularies() const;
 %Docstring
  Returns a list of keyword vocabularies contained in the metadata.
@@ -557,6 +566,23 @@ class QgsLayerMetadata
 
 .. seealso:: keywordVocabularies()
  :rtype: list of str
+%End
+
+    QStringList categories() const;
+%Docstring
+ Returns categories of the resource.
+ Categories are stored using a special vocabulary 'gmd:topicCategory' in keywords.
+
+.. seealso:: keywords()
+ :rtype: list of str
+%End
+
+    void setCategories( const QStringList &categories );
+%Docstring
+ Sets categories of the resource.
+ Categories are stored using a special vocabulary 'gmd:topicCategory' in keywords.
+
+.. seealso:: keywords()
 %End
 
     QgsLayerMetadata::ContactList contacts() const;

--- a/resources/qgis-resource-metadata.xml
+++ b/resources/qgis-resource-metadata.xml
@@ -6,6 +6,9 @@
     <type>dataset</type>
     <title>roads</title>
     <abstract>my roads</abstract>
+    <keywords vocabulary="gmd:topicCategory">
+        <keyword>natural</keyword>
+    </keywords>
     <keywords vocabulary="GEMET">
         <keyword>kw1</keyword>
         <keyword>kw2</keyword>

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -158,6 +158,11 @@ void QgsLayerMetadata::addKeywords( const QString &vocabulary, const QStringList
   mKeywords.insert( vocabulary, keywords );
 }
 
+bool QgsLayerMetadata::removeKeywords( const QString &vocabulary )
+{
+  return mKeywords.remove( vocabulary );
+}
+
 QStringList QgsLayerMetadata::keywordVocabularies() const
 {
   return mKeywords.keys();
@@ -166,6 +171,23 @@ QStringList QgsLayerMetadata::keywordVocabularies() const
 QStringList QgsLayerMetadata::keywords( const QString &vocabulary ) const
 {
   return mKeywords.value( vocabulary );
+}
+
+QStringList QgsLayerMetadata::categories() const
+{
+  if ( mKeywords.contains( "gmd:topicCategory" ) )
+  {
+    return mKeywords.value( "gmd:topicCategory" );
+  }
+  else
+  {
+    return QStringList();
+  }
+}
+
+void QgsLayerMetadata::setCategories( const QStringList &category )
+{
+  mKeywords.insert( "gmd:topicCategory", category );
 }
 
 QList<QgsLayerMetadata::Contact> QgsLayerMetadata::contacts() const

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -545,7 +545,7 @@ class CORE_EXPORT QgsLayerMetadata
      * CRS which is actually used to display and manipulate the layer within QGIS.
      * This may be the case when a layer has an incorrect CRS within its metadata
      * and a user has manually overridden the layer's CRS within QGIS.
-     * \see setCrs()
+     * \see crs()
      */
     void setCrs( const QgsCoordinateReferenceSystem &crs );
 
@@ -589,6 +589,14 @@ class CORE_EXPORT QgsLayerMetadata
     void addKeywords( const QString &vocabulary, const QStringList &keywords );
 
     /**
+     * Remove a vocabulary from the list.
+     *
+     * \see setKeywords()
+     * \see addKeywords()
+     */
+    bool removeKeywords( const QString &vocabulary );
+
+    /**
      * Returns a list of keyword vocabularies contained in the metadata.
      *
      * The vocabulary string is a reference (URI/URL preferred) to a codelist or vocabulary
@@ -609,6 +617,22 @@ class CORE_EXPORT QgsLayerMetadata
      * \see keywordVocabularies()
      */
     QStringList keywords( const QString &vocabulary ) const;
+
+    /**
+     * Returns categories of the resource.
+     * Categories are stored using a special vocabulary 'gmd:topicCategory' in keywords.
+     *
+     * \see keywords()
+     */
+    QStringList categories() const;
+
+    /**
+     * Sets categories of the resource.
+     * Categories are stored using a special vocabulary 'gmd:topicCategory' in keywords.
+     *
+     * \see keywords()
+     */
+    void setCategories( const QStringList &categories );
 
     /**
      * Returns a list of contact persons or entities associated with the resource.

--- a/tests/src/python/test_qgslayermetadata.py
+++ b/tests/src/python/test_qgslayermetadata.py
@@ -48,6 +48,9 @@ class TestQgsLayerMetadata(unittest.TestCase):
         m.setTitle('title')
         self.assertEqual(m.title(), 'title')
 
+        m.setCategories(['category'])
+        self.assertEqual(m.categories(), ['category'])
+
         m.setAbstract('abstract')
         self.assertEqual(m.abstract(), 'abstract')
 
@@ -101,6 +104,11 @@ class TestQgsLayerMetadata(unittest.TestCase):
 
     def testKeywords(self):
         m = QgsLayerMetadata()
+
+        m.setKeywords({'gmd:topicCategory': ['natural']})
+        self.assertEqual(m.keywords(), {'gmd:topicCategory': ['natural']})
+        self.assertEqual(m.categories(), ['natural'])
+        self.assertTrue(m.removeKeywords('gmd:topicCategory'))
 
         m.setKeywords({'vocab a': ['keyword a', 'other a'],
                        'vocab b': ['keyword b', 'other b']})


### PR DESCRIPTION
## Description

According to the discussion on gitter: https://gitter.im/qgis/metadata?at=5956798bbf7e6af22c8e0b81
@tomkralidis proposed to use the keyword with a special vocabulary to store the category.

CMIIW, but we allow only one category, right?
If yes, I should fix also to have only one keyword in this special vocabulary when we use the `setKeywords` or `addKeywords` methods.

Ping @tomkralidis @kalxas @nyalldawson 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit