### PR TITLE
[processing] Correctly delete processing dialogs

### DIFF
--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -90,7 +90,7 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
             dlg.exec_()
             # have to manually delete the dialog - otherwise it's owned by the
             # iface mainWindow and never deleted
-            del dlg
+            dlg.deleteLater()
             if canvas.mapTool() != prevMapTool:
                 try:
                     canvas.mapTool().reset()

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -252,7 +252,7 @@ class ProcessingToolbox(BASE, WIDGET):
                 dlg.exec_()
                 # have to manually delete the dialog - otherwise it's owned by the
                 # iface mainWindow and never deleted
-                del dlg
+                dlg.deleteLater()
 
     def executeAlgorithm(self):
         item = self.algorithmTree.currentItem()
@@ -293,7 +293,7 @@ class ProcessingToolbox(BASE, WIDGET):
                         self.addRecentAlgorithms(True)
                 # have to manually delete the dialog - otherwise it's owned by the
                 # iface mainWindow and never deleted
-                del dlg
+                dlg.deleteLater()
             else:
                 feedback = MessageBarProgress()
                 context = dataobjects.createContext(feedback)

--- a/python/plugins/processing/gui/ScriptEditorDialog.py
+++ b/python/plugins/processing/gui/ScriptEditorDialog.py
@@ -280,7 +280,7 @@ class ScriptEditorDialog(BASE, WIDGET):
 
         # have to manually delete the dialog - otherwise it's owned by the
         # iface mainWindow and never deleted
-        del dlg
+        dlg.deleteLater()
 
         if canvas.mapTool() != prevMapTool:
             try:

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -293,7 +293,7 @@ class ModelerDialog(BASE, WIDGET):
         dlg.exec_()
         # have to manually delete the dialog - otherwise it's owned by the
         # iface mainWindow and never deleted
-        del dlg
+        dlg.deleteLater()
 
     def save(self):
         self.saveModel(False)


### PR DESCRIPTION
## Description
`del dlg` do not delete the QT dialog, only the python variable.

Relate with 5c844a5cfb22de57c89eb85300f8d6b96ffbadb3

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
