### PR TITLE
Fix #16973: QGIS3.ini path is not properly calculated in Helpviewer

### DIFF
--- a/src/helpviewer/main.cpp
+++ b/src/helpviewer/main.cpp
@@ -17,23 +17,21 @@
  ***************************************************************************/
 #include <iostream>
 #include <QLocale>
-#include <QSettings>
 #include <QTranslator>
 #include <QLibraryInfo>
+#include <qgssettings.h>
 
 #include "qgshelpviewer.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
-#include "qgsconfig.h"
 
 int main( int argc, char **argv )
 {
-  QgsApplication a( argc, argv, true );
+  QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );
+  QCoreApplication::setOrganizationDomain( QgsApplication::QGIS_ORGANIZATION_DOMAIN );
+  QCoreApplication::setApplicationName( QgsApplication::QGIS_APPLICATION_NAME );
 
-  // Set up the QSettings environment must be done after qapp is created
-  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
-  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
-  QCoreApplication::setApplicationName( QStringLiteral( "QGIS3" ) );
+  QgsApplication a( argc, argv, true );
 
   QString myTranslationCode = QLatin1String( "" );
 
@@ -59,7 +57,7 @@ int main( int argc, char **argv )
   {
     myTranslationCode = QLocale::system().name();
 
-    QSettings settings;
+    QgsSettings settings;
     if ( settings.value( QStringLiteral( "locale/overrideFlag" ), false ).toBool() )
     {
       myTranslationCode = settings.value( QStringLiteral( "locale/userLocale" ), "en_US" ).toString();

--- a/src/helpviewer/qgshelpviewer.cpp
+++ b/src/helpviewer/qgshelpviewer.cpp
@@ -20,11 +20,10 @@
 
 #include <QString>
 #include <QApplication>
-#include <QSettings>
+#include <qgssettings.h>
 
 #include "qgshelpviewer.h"
 #include "qgsapplication.h"
-#include "qgslogger.h"
 
 QgsReaderThread::QgsReaderThread()
   : QThread()
@@ -111,12 +110,12 @@ void QgsHelpViewer::resizeEvent( QResizeEvent *event )
 
 void QgsHelpViewer::restorePosition()
 {
-  QSettings settings;
+  QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "HelpViewer/geometry" ) ).toByteArray() );
 }
 
 void QgsHelpViewer::saveWindowLocation()
 {
-  QSettings settings;
+  QgsSettings settings;
   settings.setValue( QStringLiteral( "HelpViewer/geometry" ), saveGeometry() );
 }


### PR DESCRIPTION
## Description
This PR does a minor fix to use the correct path of the default QGIS settings file, within the subprocess/application **helpviewer**. **Helpviewer** application stores the geometry of the help window in the settings file.

Since **helpviewer** is another QT application, we have to use the same settings to generate the correct settings path.

Before this PR, the path used by helpviewer is: (on Ubuntu)
`/home/jgr/.local/share/qgis_help/profiles/default/QGIS/QGIS3.ini`

The path should be:
`/home/jgr/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini`

**helpviewer** executable is `cmake-build-debug/output/lib/qgis/qgis_help` 

## Remarks
This PR fixes the issue in the short term. We should move forward to restructure the entire help/documentation system.

@DelazJ made a detailed report of the status of the help/documentation system in a [recent email](http://osgeo-org.1560.x6.nabble.com/Qgis-community-team-Let-s-bring-documentation-at-the-heart-of-QGIS-Desktop-td5329752.html). His message has links for related QEP.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
