### PR TITLE
Unified layer dialog raster mods

### DIFF
--- a/python/gui/qgsabstractdatasourcewidget.sip
+++ b/python/gui/qgsabstractdatasourcewidget.sip
@@ -82,6 +82,14 @@ Emitted when a raster layer has been selected for addition
 Emitted when a vector layer has been selected for addition
 %End
 
+    void addVectorLayers( const QStringList &layerQStringList, const QString &enc, const QString &dataSourceType );
+%Docstring
+ Emitted when one or more OGR supported layers are selected for addition
+ \param layerQStringList list of layers protocol URIs
+ \param enc encoding
+ \param dataSourceType string (can be "file" or "database")
+%End
+
     void progress( int, int );
 %Docstring
 Emitted when a progress dialog is shown by the provider dialog

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -294,7 +294,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsuserprofile.h"
 
 #include "qgssublayersdialog.h"
-#include "ogr/qgsopenvectorlayerdialog.h"
 #include "ogr/qgsvectorlayersaveasdialog.h"
 
 #include "qgsosmdownloaddialog.h"

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -179,10 +179,8 @@ SET(QGIS_GUI_SRCS
   locator/qgslocatorfilter.cpp
   locator/qgslocatorwidget.cpp
 
-  ogr/qgsopenvectorlayerdialog.cpp
   ogr/qgsogrhelperfunctions.cpp
   ogr/qgsnewogrconnection.cpp
-  ogr/qgsopenvectorlayerdialog.cpp
   ogr/qgsvectorlayersaveasdialog.cpp
 
   qgisinterface.cpp
@@ -508,7 +506,6 @@ SET(QGIS_GUI_MOC_HDRS
   qgsdatasourcemanagerdialog.h
   qgsabstractdatasourcewidget.h
 
-  ogr/qgsopenvectorlayerdialog.h
   ogr/qgsnewogrconnection.h
   ogr/qgsvectorlayersaveasdialog.h
 
@@ -718,7 +715,6 @@ SET(QGIS_GUI_HDRS
   qgsdatasourcemanagerdialog.h
   qgsabstractdatasourcewidget.h
 
-  ogr/qgsopenvectorlayerdialog.h
   ogr/qgsogrhelperfunctions.h
   ogr/qgsnewogrconnection.h
   ogr/qgsvectorlayersaveasdialog.h
@@ -816,7 +812,6 @@ SET(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssqlcomposerdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgssublayersdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgstablewidgetuibase.h
-  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsopenvectorlayerdialogbase.h
 )
 
 IF(ENABLE_MODELTEST)

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -86,6 +86,13 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     //! Emitted when a vector layer has been selected for addition
     void addVectorLayer( const QString &uri, const QString &layerName );
 
+    /** Emitted when one or more OGR supported layers are selected for addition
+     * \param layerQStringList list of layers protocol URIs
+     * \param enc encoding
+     * \param dataSourceType string (can be "file" or "database")
+     */
+    void addVectorLayers( const QStringList &layerQStringList, const QString &enc, const QString &dataSourceType );
+
     //! Emitted when a progress dialog is shown by the provider dialog
     void progress( int, int );
 

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -87,11 +87,11 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     void addVectorLayer( const QString &uri, const QString &layerName );
 
     /** Emitted when one or more OGR supported layers are selected for addition
-     * \param layerQStringList list of layers protocol URIs
-     * \param enc encoding
+     * \param layerList list of layers protocol URIs
+     * \param encoding encoding
      * \param dataSourceType string (can be "file" or "database")
      */
-    void addVectorLayers( const QStringList &layerQStringList, const QString &enc, const QString &dataSourceType );
+    void addVectorLayers( const QStringList &layerList, const QString &encoding, const QString &dataSourceType );
 
     //! Emitted when a progress dialog is shown by the provider dialog
     void progress( int, int );

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -76,12 +76,7 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QWidget *parent, QgsMapC
   // Add data provider dialogs
   QWidget *dlg = nullptr;
 
-  dlg = providerDialog( QStringLiteral( "delimitedtext" ), tr( "Delimited Text" ), QStringLiteral( "/mActionAddDelimitedTextLayer.svg" ) );
-
-  if ( dlg )
-  {
-    connect( dlg, SIGNAL( addVectorLayer( QString, QString, QString ) ), this, SLOT( vectorLayerAdded( QString, QString, QString ) ) );
-  }
+  addVectorProviderDialog( QStringLiteral( "delimitedtext" ), tr( "Delimited Text" ), QStringLiteral( "/mActionAddDelimitedTextLayer.svg" ) );
 
 #ifdef HAVE_POSTGRESQL
   addDbProviderDialog( QStringLiteral( "postgres" ), tr( "PostgreSQL" ), QStringLiteral( "/mActionAddPostgisLayer.svg" ) );
@@ -97,11 +92,13 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QWidget *parent, QgsMapC
   addDbProviderDialog( QStringLiteral( "oracle" ), tr( "Oracle" ), QStringLiteral( "/mActionAddOracleLayer.svg" ) );
 #endif
 
-  dlg = providerDialog( QStringLiteral( "virtual" ), tr( "Virtual Layer" ), QStringLiteral( "/mActionAddVirtualLayer.svg" ) );
+  dlg = addVectorProviderDialog( QStringLiteral( "virtual" ), tr( "Virtual Layer" ), QStringLiteral( "/mActionAddVirtualLayer.svg" ) );
 
+  // Apparently this is the only provider using replaceVectorLayer, we should
+  // move this in to the base abstract class when it is used by at least one
+  // additional provider.
   if ( dlg )
   {
-    connect( dlg, SIGNAL( addVectorLayer( QString, QString, QString ) ), this, SLOT( vectorLayerAdded( QString, QString, QString ) ) );
     connect( dlg, SIGNAL( replaceVectorLayer( QString, QString, QString, QString ) ), this, SIGNAL( replaceSelectedVectorLayer( QString, QString, QString, QString ) ) );
   }
 
@@ -197,7 +194,7 @@ QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::providerDialog( const Q
   }
 }
 
-void QgsDataSourceManagerDialog::addDbProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
+QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::addDbProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
 {
   QgsAbstractDataSourceWidget *dlg = providerDialog( providerKey, providerName, icon, title );
   if ( dlg )
@@ -211,9 +208,10 @@ void QgsDataSourceManagerDialog::addDbProviderDialog( const QString providerKey,
     connect( dlg, SIGNAL( connectionsChanged() ), this, SIGNAL( connectionsChanged() ) );
     connect( this, SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
   }
+  return dlg;
 }
 
-void QgsDataSourceManagerDialog::addRasterProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
+QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::addRasterProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
 {
   QgsAbstractDataSourceWidget *dlg = providerDialog( providerKey, providerName, icon, title );
   if ( dlg )
@@ -223,9 +221,10 @@ void QgsDataSourceManagerDialog::addRasterProviderDialog( const QString provider
     connect( dlg, SIGNAL( connectionsChanged() ), this, SIGNAL( connectionsChanged() ) );
     connect( this,  SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
   }
+  return dlg;
 }
 
-void QgsDataSourceManagerDialog::addVectorProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
+QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::addVectorProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
 {
   QgsAbstractDataSourceWidget *dlg = providerDialog( providerKey, providerName, icon, title );
   if ( dlg )
@@ -234,6 +233,7 @@ void QgsDataSourceManagerDialog::addVectorProviderDialog( const QString provider
     { this->vectorLayerAdded( vectorLayerPath, baseName, providerKey ); } );
     connect( this,  SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
   }
+  return dlg;
 }
 
 void QgsDataSourceManagerDialog::showEvent( QShowEvent *e )

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -116,9 +116,9 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
   private:
     // Return the dialog from the provider
     QgsAbstractDataSourceWidget *providerDialog( const QString providerKey, const QString providerName, const QString icon, QString title = QString() );
-    void addDbProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
-    void addRasterProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
-    void addVectorProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
+    QgsAbstractDataSourceWidget *addDbProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
+    QgsAbstractDataSourceWidget *addRasterProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
+    QgsAbstractDataSourceWidget *addVectorProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
     Ui::QgsDataSourceManagerDialog *ui;
     QgsBrowserDockWidget *mBrowserWidget = nullptr;
     int mPreviousRow;

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -193,7 +193,7 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
 
   // add the layer to the map
-  emit addVectorLayer( QString::fromAscii( url.toEncoded() ), txtLayerName->text(), QStringLiteral( "delimitedtext" ) );
+  emit addVectorLayer( QString::fromAscii( url.toEncoded() ), txtLayerName->text() );
   if ( widgetMode() == QgsProviderRegistry::WidgetMode::None )
   {
     accept();

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -72,9 +72,6 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     void updateFieldsAndEnable();
     void enableAccept();
     bool validate();
-
-  signals:
-    void addVectorLayer( const QString &, const QString &, const QString & );
 };
 
 #endif // QGSDELIMITEDTEXTSOURCESELECT_H

--- a/src/providers/gdal/CMakeLists.txt
+++ b/src/providers/gdal/CMakeLists.txt
@@ -2,10 +2,12 @@ SET(GDAL_SRCS
   qgsgdalproviderbase.cpp
   qgsgdalprovider.cpp
   qgsgdaldataitems.cpp
+  qgsgdalsourceselect.cpp
 )
 SET(GDAL_MOC_HDRS
   qgsgdalprovider.h
   qgsgdaldataitems.h
+  qgsgdalsourceselect.h
 )
 
 INCLUDE_DIRECTORIES (

--- a/src/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/providers/gdal/qgsgdalsourceselect.cpp
@@ -1,0 +1,48 @@
+/***************************************************************************
+                          qgsgdalsourceselect.h
+                             -------------------
+    begin                : August 05 2017
+    copyright            : (C) 2017 by Alessandro Pasotti
+    email                : apasotti at boundlessgeo dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgdalsourceselect.h"
+#include "qgsproviderregistry.h"
+
+QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ):
+  QgsAbstractDataSourceWidget( parent, fl, widgetMode )
+{
+  setupUi( this );
+  setupButtons( buttonBox );
+  mQgsFileWidget->setFilter( QgsProviderRegistry::instance()->fileRasterFilters() );
+  connect( mQgsFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
+  {
+    mRasterPath = path;
+    emit enableButtons( ! mRasterPath.isEmpty() );
+  } );
+}
+
+QgsGdalSourceSelect::~QgsGdalSourceSelect()
+{
+
+}
+
+void QgsGdalSourceSelect::addButtonClicked()
+{
+  QFileInfo baseName( mRasterPath );
+  emit addRasterLayer( mRasterPath, baseName.baseName(), QStringLiteral( "gdal" ) );
+}
+
+QGISEXTERN QgsGdalSourceSelect *selectWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
+{
+  return new QgsGdalSourceSelect( parent, fl, widgetMode );
+}

--- a/src/providers/gdal/qgsgdalsourceselect.h
+++ b/src/providers/gdal/qgsgdalsourceselect.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+                          qgsgdalsourceselect.h
+                             -------------------
+    begin                : August 05 2017
+    copyright            : (C) 2017 by Alessandro Pasotti
+    email                : apasotti at boundlessgeo dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGGDALSOURCESELECT_H
+#define QGGDALSOURCESELECT_H
+
+#include "ui_qgsgdalsourceselectbase.h"
+#include "qgsabstractdatasourcewidget.h"
+
+
+/** \class QgsGdalSourceSelect
+ * \brief Dialog to select GDAL supported rasters
+ */
+class QgsGdalSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsGdalSourceSelectBase
+{
+    Q_OBJECT
+
+  public:
+    //! Constructor
+    QgsGdalSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
+
+    ~QgsGdalSourceSelect();
+
+  public slots:
+    //! Determines the tables the user selected and closes the dialog
+    void addButtonClicked() override;
+
+  private:
+
+    QString mRasterPath;
+
+};
+
+#endif // QGGDALSOURCESELECT_H

--- a/src/providers/ogr/CMakeLists.txt
+++ b/src/providers/ogr/CMakeLists.txt
@@ -5,9 +5,15 @@ SET (OGR_SRCS
     qgsogrfeatureiterator.cpp
     qgsogrconnpool.cpp
     qgsogrexpressioncompiler.cpp
+    qgsogrsourceselect.cpp
 )
 
-SET(OGR_MOC_HDRS qgsogrprovider.h qgsogrdataitems.h qgsogrconnpool.h)
+SET(OGR_MOC_HDRS
+    qgsogrprovider.h
+    qgsogrdataitems.h
+    qgsogrconnpool.h
+    qgsogrsourceselect.h
+)
 
 ########################################################
 # Build
@@ -20,9 +26,11 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/symbology-ng
   ${CMAKE_SOURCE_DIR}/src/core/expression
+  ${CMAKE_SOURCE_DIR}/src/gui
 
   ${CMAKE_BINARY_DIR}/src/core
   ${CMAKE_BINARY_DIR}/src/gui
+  ${CMAKE_BINARY_DIR}/src/ui
 )
 INCLUDE_DIRECTORIES(SYSTEM
   ${GDAL_INCLUDE_DIR}
@@ -35,6 +43,14 @@ ADD_LIBRARY(ogrprovider MODULE ${OGR_SRCS} ${OGR_MOC_SRCS})
 TARGET_LINK_LIBRARIES(ogrprovider
   qgis_core
 )
+
+
+IF (WITH_GUI)
+  TARGET_LINK_LIBRARIES (ogrprovider
+    qgis_gui
+  )
+ENDIF ()
+
 IF (MSVC)
   #needed for linking to gdal which needs odbc
   SET(TARGET_LINK_LIBRARIES ${TARGET_LINK_LIBRARIE} odbc32 odbccp32)

--- a/src/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/providers/ogr/qgsogrsourceselect.cpp
@@ -1,0 +1,485 @@
+/***************************************************************************
+                          qgsogrsourceselect.cpp
+ Dialog to select the type and source for ogr vectors, supports
+ file, database, directory and protocol sources.
+                             -------------------
+    ---------------------
+    begin                : Aug 05, 2017
+    copyright            : (C) 2017 by Alessandro Pasotti
+    email                : apasotti at itopen dot it
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QTextCodec>
+
+#include "qgslogger.h"
+#include "qgsogrsourceselect.h"
+#include "qgsvectordataprovider.h"
+#include "qgssettings.h"
+#include "qgsproviderregistry.h"
+#include "ogr/qgsnewogrconnection.h"
+#include "ogr/qgsogrhelperfunctions.h"
+#include "qgscontexthelp.h"
+#include "qgsapplication.h"
+
+QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
+  : QgsAbstractDataSourceWidget( parent, fl, widgetMode )
+{
+  setupUi( this );
+  setupButtons( buttonBox );
+
+  if ( mWidgetMode != QgsProviderRegistry::WidgetMode::None )
+  {
+    this->layout()->setSizeConstraint( QLayout::SetNoConstraint );
+  }
+
+  cmbDatabaseTypes->blockSignals( true );
+  cmbConnections->blockSignals( true );
+  radioSrcFile->setChecked( true );
+  mDataSourceType = QStringLiteral( "file" );
+
+  //set encoding
+  cmbEncodings->addItems( QgsVectorDataProvider::availableEncodings() );
+
+  QgsSettings settings;
+  QString enc = settings.value( QStringLiteral( "UI/encoding" ), "System" ).toString();
+
+  restoreGeometry( settings.value( QStringLiteral( "Windows/OpenVectorLayer/geometry" ) ).toByteArray() );
+
+  // The specified decoding is added if not existing already, and then set current.
+  // This should select it.
+  int encindex = cmbEncodings->findText( enc );
+  if ( encindex < 0 )
+  {
+    cmbEncodings->insertItem( 0, enc );
+    encindex = 0;
+  }
+  cmbEncodings->setCurrentIndex( encindex );
+
+  //add database drivers
+  mVectorFileFilter = QgsProviderRegistry::instance()->fileVectorFilters();
+  QgsDebugMsg( "Database drivers :" + QgsProviderRegistry::instance()->databaseDrivers() );
+  QStringList dbDrivers = QgsProviderRegistry::instance()->databaseDrivers().split( ';' );
+
+  for ( int i = 0; i < dbDrivers.count(); i++ )
+  {
+    QString dbDriver = dbDrivers.at( i );
+    if ( ( !dbDriver.isEmpty() ) && ( !dbDriver.isNull() ) )
+      cmbDatabaseTypes->addItem( dbDriver.split( ',' ).at( 0 ) );
+  }
+
+  //add directory drivers
+  QStringList dirDrivers = QgsProviderRegistry::instance()->directoryDrivers().split( ';' );
+  for ( int i = 0; i < dirDrivers.count(); i++ )
+  {
+    QString dirDriver = dirDrivers.at( i );
+    if ( ( !dirDriver.isEmpty() ) && ( !dirDriver.isNull() ) )
+      cmbDirectoryTypes->addItem( dirDriver.split( ',' ).at( 0 ) );
+  }
+
+  //add protocol drivers
+  QStringList proDrivers = QgsProviderRegistry::instance()->protocolDrivers().split( ';' );
+  for ( int i = 0; i < proDrivers.count(); i++ )
+  {
+    QString proDriver = proDrivers.at( i );
+    if ( ( !proDriver.isEmpty() ) && ( !proDriver.isNull() ) )
+      cmbProtocolTypes->addItem( proDriver.split( ',' ).at( 0 ) );
+  }
+  cmbDatabaseTypes->blockSignals( false );
+  cmbConnections->blockSignals( false );
+}
+
+QgsOgrSourceSelect::~QgsOgrSourceSelect()
+{
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "Windows/OpenVectorLayer/geometry" ), saveGeometry() );
+}
+
+QStringList QgsOgrSourceSelect::openFile()
+{
+  QStringList selectedFiles;
+  QgsDebugMsg( "Vector file filters: " + mVectorFileFilter );
+  QString enc = encoding();
+  QString title = tr( "Open an OGR Supported Vector Layer" );
+  QgsGuiUtils::openFilesRememberingFilter( QStringLiteral( "lastVectorFileFilter" ), mVectorFileFilter, selectedFiles, enc, title );
+
+  return selectedFiles;
+}
+
+QString QgsOgrSourceSelect::openDirectory()
+{
+  QgsSettings settings;
+
+  bool haveLastUsedDir = settings.contains( QStringLiteral( "/UI/LastUsedDirectory" ) );
+  QString lastUsedDir = settings.value( QStringLiteral( "UI/LastUsedDirectory" ), QDir::homePath() ).toString();
+  if ( !haveLastUsedDir )
+    lastUsedDir = QLatin1String( "" );
+
+  QString path = QFileDialog::getExistingDirectory( this,
+                 tr( "Open Directory" ), lastUsedDir,
+                 QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks );
+
+  settings.setValue( QStringLiteral( "UI/LastUsedDirectory" ), path );
+  //process path if it is grass
+  if ( cmbDirectoryTypes->currentText() == QLatin1String( "Grass Vector" ) )
+  {
+#ifdef Q_OS_WIN
+    //replace backslashes with forward slashes
+    path.replace( '\\', '/' );
+#endif
+    path = path + "/head";
+  }
+  return path;
+}
+
+QStringList QgsOgrSourceSelect::dataSources()
+{
+  return mDataSources;
+}
+
+QString QgsOgrSourceSelect::encoding()
+{
+  return cmbEncodings->currentText();
+}
+
+QString QgsOgrSourceSelect::dataSourceType()
+{
+  return mDataSourceType;
+}
+
+void QgsOgrSourceSelect::addNewConnection()
+{
+  QgsNewOgrConnection *nc = new QgsNewOgrConnection( this );
+  nc->exec();
+  delete nc;
+
+  populateConnectionList();
+}
+
+void QgsOgrSourceSelect::editConnection()
+{
+  QgsNewOgrConnection *nc = new QgsNewOgrConnection( this, cmbDatabaseTypes->currentText(), cmbConnections->currentText() );
+  nc->exec();
+  delete nc;
+
+  populateConnectionList();
+}
+
+void QgsOgrSourceSelect::deleteConnection()
+{
+  QgsSettings settings;
+  QString key = '/' + cmbDatabaseTypes->currentText() + "/connections/" + cmbConnections->currentText();
+  QString msg = tr( "Are you sure you want to remove the %1 connection and all associated settings?" )
+                .arg( cmbConnections->currentText() );
+  QMessageBox::StandardButton result = QMessageBox::information( this, tr( "Confirm Delete" ), msg, QMessageBox::Ok | QMessageBox::Cancel );
+  if ( result == QMessageBox::Ok )
+  {
+    settings.remove( key + "/host" );
+    settings.remove( key + "/database" );
+    settings.remove( key + "/username" );
+    settings.remove( key + "/password" );
+    settings.remove( key + "/port" );
+    settings.remove( key + "/save" );
+    settings.remove( key );
+    cmbConnections->removeItem( cmbConnections->currentIndex() );  // populateConnectionList();
+    setConnectionListPosition();
+  }
+}
+
+void QgsOgrSourceSelect::populateConnectionList()
+{
+  QgsSettings settings;
+  settings.beginGroup( '/' + cmbDatabaseTypes->currentText() + "/connections" );
+  QStringList keys = settings.childGroups();
+  QStringList::Iterator it = keys.begin();
+  cmbConnections->clear();
+  while ( it != keys.end() )
+  {
+    cmbConnections->addItem( *it );
+    ++it;
+  }
+  settings.endGroup();
+  setConnectionListPosition();
+}
+
+void QgsOgrSourceSelect::setConnectionListPosition()
+{
+  QgsSettings settings;
+  // If possible, set the item currently displayed database
+
+  QString toSelect = settings.value( '/' + cmbDatabaseTypes->currentText() + "/connections/selected" ).toString();
+  // Does toSelect exist in cmbConnections?
+  bool set = false;
+  for ( int i = 0; i < cmbConnections->count(); ++i )
+    if ( cmbConnections->itemText( i ) == toSelect )
+    {
+      cmbConnections->setCurrentIndex( i );
+      set = true;
+      break;
+    }
+  // If we couldn't find the stored item, but there are some,
+  // default to the last item (this makes some sense when deleting
+  // items as it allows the user to repeatidly click on delete to
+  // remove a whole lot of items).
+  if ( !set && cmbConnections->count() > 0 )
+  {
+    // If toSelect is null, then the selected connection wasn't found
+    // by QgsSettings, which probably means that this is the first time
+    // the user has used qgis with database connections, so default to
+    // the first in the list of connetions. Otherwise default to the last.
+    if ( toSelect.isNull() )
+      cmbConnections->setCurrentIndex( 0 );
+    else
+      cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
+  }
+}
+
+void QgsOgrSourceSelect::setConnectionTypeListPosition()
+{
+  QgsSettings settings;
+
+  QString toSelect = settings.value( QStringLiteral( "ogr/connections/selectedtype" ) ).toString();
+  for ( int i = 0; i < cmbDatabaseTypes->count(); ++i )
+    if ( cmbDatabaseTypes->itemText( i ) == toSelect )
+    {
+      cmbDatabaseTypes->setCurrentIndex( i );
+      break;
+    }
+}
+
+void QgsOgrSourceSelect::setSelectedConnectionType()
+{
+  QgsSettings settings;
+  QString baseKey = QStringLiteral( "/ogr/connections/" );
+  settings.setValue( baseKey + "selectedtype", cmbDatabaseTypes->currentText() );
+  QgsDebugMsg( "Setting selected type to" + cmbDatabaseTypes->currentText() );
+}
+
+void QgsOgrSourceSelect::setSelectedConnection()
+{
+  QgsSettings settings;
+  settings.setValue( '/' + cmbDatabaseTypes->currentText() + "/connections/selected", cmbConnections->currentText() );
+  QgsDebugMsg( "Setting selected connection to " + cmbConnections->currentText() );
+}
+
+
+void QgsOgrSourceSelect::on_buttonSelectSrc_clicked()
+{
+  if ( radioSrcFile->isChecked() )
+  {
+    QStringList selected = openFile();
+    if ( !selected.isEmpty() )
+    {
+      inputSrcDataset->setText( selected.join( QStringLiteral( ";" ) ) );
+      addButton()->setFocus();
+      emit enableButtons( true );
+    }
+  }
+  else if ( radioSrcDirectory->isChecked() )
+  {
+    inputSrcDataset->setText( openDirectory() );
+  }
+  else if ( !radioSrcDatabase->isChecked() )
+  {
+    Q_ASSERT( !"SHOULD NEVER GET HERE" );
+  }
+}
+
+void QgsOgrSourceSelect::addButtonClicked()
+{
+  QgsSettings settings;
+  mDataSources.clear();
+
+  if ( radioSrcDatabase->isChecked() )
+  {
+    if ( !settings.contains( '/' + cmbDatabaseTypes->currentText()
+                             + "/connections/" + cmbConnections->currentText()
+                             + "/host" ) )
+    {
+      QMessageBox::information( this,
+                                tr( "Add vector layer" ),
+                                tr( "No database selected." ) );
+      return;
+    }
+
+    QString baseKey = '/' + cmbDatabaseTypes->currentText() + "/connections/";
+    baseKey += cmbConnections->currentText();
+    QString host = settings.value( baseKey + "/host" ).toString();
+    QString database = settings.value( baseKey + "/database" ).toString();
+    QString port = settings.value( baseKey + "/port" ).toString();
+    QString user = settings.value( baseKey + "/username" ).toString();
+    QString pass = settings.value( baseKey + "/password" ).toString();
+
+    bool makeConnection = false;
+    if ( pass.isEmpty() )
+    {
+      if ( cmbDatabaseTypes->currentText() == QLatin1String( "MSSQL" ) )
+        makeConnection = true;
+      else
+        pass = QInputDialog::getText( this,
+                                      tr( "Password for " ) + user,
+                                      tr( "Please enter your password:" ),
+                                      QLineEdit::Password, QString(),
+                                      &makeConnection );
+    }
+
+    if ( makeConnection || !pass.isEmpty() )
+    {
+      mDataSources << createDatabaseURI(
+                     cmbDatabaseTypes->currentText(),
+                     host,
+                     database,
+                     port,
+                     user,
+                     pass
+                   );
+    }
+  }
+  else if ( radioSrcProtocol->isChecked() )
+  {
+    if ( protocolURI->text().isEmpty() )
+    {
+      QMessageBox::information( this,
+                                tr( "Add vector layer" ),
+                                tr( "No protocol URI entered." ) );
+      return;
+    }
+
+    mDataSources << createProtocolURI( cmbProtocolTypes->currentText(), protocolURI->text() );
+  }
+  else if ( radioSrcFile->isChecked() )
+  {
+    if ( inputSrcDataset->text().isEmpty() )
+    {
+      QMessageBox::information( this,
+                                tr( "Add vector layer" ),
+                                tr( "No layers selected." ) );
+      return;
+    }
+
+    mDataSources << inputSrcDataset->text().split( ';' );
+  }
+  else if ( radioSrcDirectory->isChecked() )
+  {
+    if ( inputSrcDataset->text().isEmpty() )
+    {
+      QMessageBox::information( this,
+                                tr( "Add vector layer" ),
+                                tr( "No directory selected." ) );
+      return;
+    }
+
+    mDataSources << inputSrcDataset->text();
+  }
+
+  // Save the used encoding
+  settings.setValue( QStringLiteral( "UI/encoding" ), encoding() );
+
+  if ( ! mDataSources.isEmpty() )
+  {
+    emit addVectorLayers( mDataSources, encoding(), dataSourceType() );
+  }
+}
+
+//********************auto connected slots *****************/
+
+void QgsOgrSourceSelect::on_radioSrcFile_toggled( bool checked )
+{
+  if ( checked )
+  {
+    labelDirectoryType->hide();
+    cmbDirectoryTypes->hide();
+    fileGroupBox->show();
+    dbGroupBox->hide();
+    protocolGroupBox->hide();
+    mDataSourceType = QStringLiteral( "file" );
+  }
+}
+
+void QgsOgrSourceSelect::on_radioSrcDirectory_toggled( bool checked )
+{
+  if ( checked )
+  {
+    labelDirectoryType->show();
+    cmbDirectoryTypes->show();
+    fileGroupBox->show();
+    dbGroupBox->hide();
+    protocolGroupBox->hide();
+    mDataSourceType = QStringLiteral( "directory" );
+  }
+}
+
+void QgsOgrSourceSelect::on_radioSrcDatabase_toggled( bool checked )
+{
+  if ( checked )
+  {
+    layout()->blockSignals( true );
+    fileGroupBox->hide();
+    protocolGroupBox->hide();
+    dbGroupBox->show();
+    layout()->blockSignals( false );
+    setConnectionTypeListPosition();
+    populateConnectionList();
+    setConnectionListPosition();
+    mDataSourceType = QStringLiteral( "database" );
+  }
+}
+
+void QgsOgrSourceSelect::on_radioSrcProtocol_toggled( bool checked )
+{
+  if ( checked )
+  {
+    fileGroupBox->hide();
+    dbGroupBox->hide();
+    protocolGroupBox->show();
+    mDataSourceType = QStringLiteral( "protocol" );
+  }
+}
+
+// Slot for adding a new connection
+void QgsOgrSourceSelect::on_btnNew_clicked()
+{
+  addNewConnection();
+}
+// Slot for deleting an existing connection
+void QgsOgrSourceSelect::on_btnDelete_clicked()
+{
+  deleteConnection();
+}
+
+
+// Slot for editing a connection
+void QgsOgrSourceSelect::on_btnEdit_clicked()
+{
+  editConnection();
+}
+
+void QgsOgrSourceSelect::on_cmbDatabaseTypes_currentIndexChanged( const QString &text )
+{
+  Q_UNUSED( text );
+  populateConnectionList();
+  setSelectedConnectionType();
+}
+
+void QgsOgrSourceSelect::on_cmbConnections_currentIndexChanged( const QString &text )
+{
+  Q_UNUSED( text );
+  setSelectedConnection();
+}
+//********************end auto connected slots *****************/
+
+
+QGISEXTERN QgsOgrSourceSelect *selectWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
+{
+  return new QgsOgrSourceSelect( parent, fl, widgetMode );
+}

--- a/src/providers/ogr/qgsogrsourceselect.h
+++ b/src/providers/ogr/qgsogrsourceselect.h
@@ -1,12 +1,20 @@
 /***************************************************************************
-                          qgsopenvectorlayerdialog.h
+                          qgsogrsourceselect.h
  Dialog to select the type and source for ogr vectors, supports
  file, database, directory and protocol sources.
                              -------------------
+    ---------------------
+    Adapted to source select:
+
+    date                 : Aug 5, 2017
+    copyright            : (C) 2017 by Alessandro Pasotti
+    email                : apasotti at itopen dot it
+
+    Original work done by:
     begin                : Mon Jan 2 2009
     copyright            : (C) 2009 by Godofredo Contreras Nava
     email                : frdcn at hotmail.com
- ***************************************************************************/
+  ***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -16,10 +24,10 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QGSOPENVECTORLAYERDIALOG_H
-#define QGSOPENVECTORLAYERDIALOG_H
+#ifndef QGSOGRSOURCESELECT_H
+#define QGSOGRSOURCESELECT_H
 
-#include <ui_qgsopenvectorlayerdialogbase.h>
+#include <ui_qgsogrsourceselectbase.h>
 #include <QDialog>
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
@@ -33,13 +41,13 @@
  *  file, database, directory and protocol sources.
  *  \note not available in Python bindings
  */
-class GUI_EXPORT QgsOpenVectorLayerDialog : public QgsAbstractDataSourceWidget, private Ui::QgsOpenVectorLayerDialogBase
+class GUI_EXPORT QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOgrSourceSelectBase
 {
     Q_OBJECT
 
   public:
-    QgsOpenVectorLayerDialog( QWidget *parent = nullptr, Qt::WindowFlags fl = 0, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
-    ~QgsOpenVectorLayerDialog();
+    QgsOgrSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = 0, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
+    ~QgsOgrSourceSelect();
     //! Opens a dialog to select a file datasource*/
     QStringList openFile();
     //! Opens a dialog to select a directory datasource*/
@@ -94,7 +102,6 @@ class GUI_EXPORT QgsOpenVectorLayerDialog : public QgsAbstractDataSourceWidget, 
     void on_cmbDatabaseTypes_currentIndexChanged( const QString &text );
     void on_cmbConnections_currentIndexChanged( const QString &text );
     void on_buttonBox_helpRequested() { QgsHelp::openHelp( QStringLiteral( "working_with_vector/supported_data.html#loading-a-layer-from-a-file" ) ); }
-
 };
 
-#endif // QGSOPENVECTORDIALOG_H
+#endif // QGSOGRSOURCESELECT_H

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -376,7 +376,7 @@ void QgsVirtualLayerSourceSelect::addButtonClicked()
   }
   else
   {
-    emit addVectorLayer( def.toString(), layerName, QStringLiteral( "virtual" ) );
+    emit addVectorLayer( def.toString(), layerName );
   }
   if ( widgetMode() == QgsProviderRegistry::WidgetMode::None )
   {

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -54,8 +54,6 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     void updateLayersList();
 
   signals:
-    //! Source, name, provider
-    void addVectorLayer( QString, QString, QString );
     //! Old_id, source, name, provider
     void replaceVectorLayer( QString, QString, QString, QString );
 

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsGdalSourceSelectBase</class>
+ <widget class="QDialog" name="QgsGdalSourceSelectBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>355</width>
+    <height>229</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add Layer(s) from a Server</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff>.</normaloff>.</iconset>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QgsFileWidget" name="mQgsFileWidget"/>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Path to a raster data source</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsGdalSourceSelectBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>518</x>
+     <y>510</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>551</x>
+     <y>370</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgsogrsourceselectbase.ui
+++ b/src/ui/qgsogrsourceselectbase.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QgsOpenVectorLayerDialogBase</class>
- <widget class="QDialog" name="QgsOpenVectorLayerDialogBase">
+ <class>QgsOgrSourceSelectBase</class>
+ <widget class="QDialog" name="QgsOgrSourceSelectBase">
   <property name="windowModality">
    <enum>Qt::WindowModal</enum>
   </property>
@@ -320,7 +320,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>QgsOpenVectorLayerDialogBase</receiver>
+   <receiver>QgsOgrSourceSelectDialogBase</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -336,7 +336,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>QgsOpenVectorLayerDialogBase</receiver>
+   <receiver>QgsOgrSourceSelectDialogBase</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">


### PR DESCRIPTION
## Description

This PR adds the two missing source select provider dialogs to OGR and GDAL and move some more functionality to the base abstract class.

**All providers now use the base abstract class and share the same loginc for buttons and signals/slot connections**

The OpenVectorFile dialog has now been moved from gui/ogr into the ogr provider directory where it belongs.

# New raster widget for the unified dialog

![unified-dialog-raster](https://user-images.githubusercontent.com/142164/28996287-9464e9e4-79fd-11e7-803e-6472147af80a.png)
