### PR TITLE
[FEATURE] Colourblind preview modes now work on OSX

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -326,16 +326,12 @@ QgsComposer::QgsComposer( QgsComposition *composition )
   QShortcut *ctrlEquals = new QShortcut( QKeySequence( QStringLiteral( "Ctrl+=" ) ), this );
   connect( ctrlEquals, &QShortcut::activated, mActionZoomIn, &QAction::trigger );
 
-#ifndef Q_OS_MAC
-  //disabled for OSX - see #10761
-  //also see http://qt-project.org/forums/viewthread/3630 QGraphicsEffects are not well supported on OSX
   QMenu *previewMenu = viewMenu->addMenu( QStringLiteral( "&Preview" ) );
   previewMenu->addAction( mActionPreviewModeOff );
   previewMenu->addAction( mActionPreviewModeGrayscale );
   previewMenu->addAction( mActionPreviewModeMono );
   previewMenu->addAction( mActionPreviewProtanope );
   previewMenu->addAction( mActionPreviewDeuteranope );
-#endif
 
   viewMenu->addSeparator();
   viewMenu->addAction( mActionZoomIn );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2245,14 +2245,6 @@ void QgisApp::createMenus()
     mSettingsMenu->insertSeparator( before );
   }
 
-
-#ifdef Q_OS_MAC
-  //disabled for OSX - see #10761
-  //also see http://qt-project.org/forums/viewthread/3630 QGraphicsEffects are not well supported on OSX
-  mMenuPreviewMode->menuAction()->setVisible( false );
-#endif
-
-
 #ifdef Q_OS_MAC
 
   // keep plugins from hijacking About and Preferences application menus

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -520,14 +520,13 @@ void QgsColorButton::prepareMenu()
   mMenu->addAction( pasteColorAction );
   connect( pasteColorAction, &QAction::triggered, this, &QgsColorButton::pasteColor );
 
-#ifndef Q_OS_MAC
   //disabled for OSX, as it is impossible to grab the mouse under OSX
   //see note for QWidget::grabMouse() re OSX Cocoa
   //http://qt-project.org/doc/qt-4.8/qwidget.html#grabMouse
   QAction *pickColorAction = new QAction( tr( "Pick color" ), this );
   mMenu->addAction( pickColorAction );
   connect( pickColorAction, &QAction::triggered, this, &QgsColorButton::activatePicker );
-#endif
+
   QAction *chooseColorAction = new QAction( tr( "Choose color..." ), this );
   mMenu->addAction( chooseColorAction );
   connect( chooseColorAction, &QAction::triggered, this, &QgsColorButton::showColorDialog );

--- a/src/gui/qgscompoundcolorwidget.cpp
+++ b/src/gui/qgscompoundcolorwidget.cpp
@@ -201,13 +201,6 @@ QgsCompoundColorWidget::QgsCompoundColorWidget( QWidget *parent, const QColor &c
   int currentTab = settings.value( QStringLiteral( "Windows/ColorDialog/activeTab" ), 0 ).toInt();
   mTabWidget->setCurrentIndex( currentTab );
 
-#ifdef Q_OS_MAC
-  //disable color picker tab for OSX, as it is impossible to grab the mouse under OSX
-  //see note for QWidget::grabMouse() re OSX Cocoa
-  //http://qt-project.org/doc/qt-4.8/qwidget.html#grabMouse
-  mTabWidget->removeTab( 3 );
-#endif
-
   //setup connections
   connect( mColorBox, &QgsColorWidget::colorChanged, this, &QgsCompoundColorWidget::setColor );
   connect( mColorWheel, &QgsColorWidget::colorChanged, this, &QgsCompoundColorWidget::setColor );


### PR DESCRIPTION
## Description

This change enables color blind modes on Mac OS. Tested against Qt 5.9



<img width="1093" alt="screen shot 2017-08-05 at 9 33 25 pm" src="https://user-images.githubusercontent.com/178003/28998438-3ff897ce-7a2b-11e7-999b-c46cab0d7f8e.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit