### PR TITLE
Remove python future compatibility layer

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -18,9 +18,6 @@ email                : lrssvtml (at) gmail (dot) com
  ***************************************************************************/
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
-from __future__ import print_function
-from builtins import str
-from builtins import range
 from qgis.PyQt.QtCore import Qt, QObject, QEvent, QCoreApplication, QFileInfo, QSize
 from qgis.PyQt.QtGui import QFont, QFontMetrics, QColor, QKeySequence, QCursor, QFontDatabase
 from qgis.PyQt.QtWidgets import QShortcut, QMenu, QApplication, QWidget, QGridLayout, QSpacerItem, QSizePolicy, QFileDialog, QTabWidget, QTreeWidgetItem, QFrame, QLabel, QToolButton, QMessageBox

--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -1,8 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
-from builtins import map
-from builtins import str
-from builtins import range
 # -*- coding: utf-8 -*-
 ###############################################################################
 #

--- a/python/plugins/MetaSearch/pavement.py
+++ b/python/plugins/MetaSearch/pavement.py
@@ -1,6 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 # -*- coding: utf-8 -*-
 ###############################################################################
 #

--- a/python/plugins/MetaSearch/util.py
+++ b/python/plugins/MetaSearch/util.py
@@ -1,6 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
-from builtins import object
 # -*- coding: utf-8 -*-
 ###############################################################################
 #

--- a/python/plugins/db_manager/db_manager.py
+++ b/python/plugins/db_manager/db_manager.py
@@ -21,8 +21,6 @@ The content of this file is based on
  *                                                                         *
  ***************************************************************************/
 """
-from __future__ import absolute_import
-from builtins import range
 
 import functools
 

--- a/python/plugins/db_manager/db_plugins/vlayers/connector.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/connector.py
@@ -18,8 +18,6 @@ email                : hugo dot mercier at oslandia dot com
  *                                                                         *
  ***************************************************************************/
 """
-from __future__ import print_function
-from builtins import object
 
 from qgis.PyQt.QtCore import QUrl, QTemporaryFile
 

--- a/python/plugins/processing/algs/examplescripts/scripts/examplescript.py
+++ b/python/plugins/processing/algs/examplescripts/scripts/examplescript.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 ##text=string
 # fix_print_with_import
 

--- a/python/plugins/processing/algs/grass7/ext/i.py
+++ b/python/plugins/processing/algs/grass7/ext/i.py
@@ -16,10 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'April 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_albedo.py
+++ b/python/plugins/processing/algs/grass7/ext/i_albedo.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_aster_toar.py
+++ b/python/plugins/processing/algs/grass7/ext/i_aster_toar.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_cca.py
+++ b/python/plugins/processing/algs/grass7/ext/i_cca.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_cluster.py
+++ b/python/plugins/processing/algs/grass7/ext/i_cluster.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_colors_enhance.py
+++ b/python/plugins/processing/algs/grass7/ext/i_colors_enhance.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_evapo_mh.py
+++ b/python/plugins/processing/algs/grass7/ext/i_evapo_mh.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_gensig.py
+++ b/python/plugins/processing/algs/grass7/ext/i_gensig.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_gensigset.py
+++ b/python/plugins/processing/algs/grass7/ext/i_gensigset.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_group.py
+++ b/python/plugins/processing/algs/grass7/ext/i_group.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_landsat_acca.py
+++ b/python/plugins/processing/algs/grass7/ext/i_landsat_acca.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_landsat_toar.py
+++ b/python/plugins/processing/algs/grass7/ext/i_landsat_toar.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_maxlik.py
+++ b/python/plugins/processing/algs/grass7/ext/i_maxlik.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_oif.py
+++ b/python/plugins/processing/algs/grass7/ext/i_oif.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_pansharpen.py
+++ b/python/plugins/processing/algs/grass7/ext/i_pansharpen.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_pca.py
+++ b/python/plugins/processing/algs/grass7/ext/i_pca.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_rectify.py
+++ b/python/plugins/processing/algs/grass7/ext/i_rectify.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'April 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_segment.py
+++ b/python/plugins/processing/algs/grass7/ext/i_segment.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_smap.py
+++ b/python/plugins/processing/algs/grass7/ext/i_smap.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_tasscap.py
+++ b/python/plugins/processing/algs/grass7/ext/i_tasscap.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'March 2016'

--- a/python/plugins/processing/algs/grass7/ext/i_topo_corr.py
+++ b/python/plugins/processing/algs/grass7/ext/i_topo_corr.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'April 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_cwed.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_cwed.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_cwed_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_cwed_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_dominance.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_dominance.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_dominance_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_dominance_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_edgedensity.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_edgedensity.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_edgedensity_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_edgedensity_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_mpa.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_mpa.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_mpa_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_mpa_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_mps.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_mps.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_mps_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_mps_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_padcv.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_padcv.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_padcv_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_padcv_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_padrange.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_padrange.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_padrange_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_padrange_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_padsd.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_padsd.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_padsd_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_padsd_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_patchdensity.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_patchdensity.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_patchdensity_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_patchdensity_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_patchnum.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_patchnum.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_patchnum_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_patchnum_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_pielou.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_pielou.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_pielou_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_pielou_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_renyi.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_renyi.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_renyi_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_renyi_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_richness.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_richness.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_richness_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_richness_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_shannon.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_shannon.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_shannon_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_shannon_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_shape.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_shape.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_shape_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_shape_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_simpson.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_simpson.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_li_simpson_ascii.py
+++ b/python/plugins/processing/algs/grass7/ext/r_li_simpson_ascii.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_mapcalc.py
+++ b/python/plugins/processing/algs/grass7/ext/r_mapcalc.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_mask_rast.py
+++ b/python/plugins/processing/algs/grass7/ext/r_mask_rast.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_mask_vect.py
+++ b/python/plugins/processing/algs/grass7/ext/r_mask_vect.py
@@ -16,7 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_rgb.py
+++ b/python/plugins/processing/algs/grass7/ext/r_rgb.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/ext/r_tile.py
+++ b/python/plugins/processing/algs/grass7/ext/r_tile.py
@@ -16,8 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from future import standard_library
-standard_library.install_aliases()
 
 __author__ = 'Médéric Ribreux'
 __date__ = 'February 2016'

--- a/python/plugins/processing/algs/grass7/nviz7.py
+++ b/python/plugins/processing/algs/grass7/nviz7.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import str
-from builtins import range
 
 __author__ = 'Arnaud Morvan'
 __date__ = 'October 2014'

--- a/python/plugins/processing/algs/qgis/voronoi.py
+++ b/python/plugins/processing/algs/qgis/voronoi.py
@@ -897,6 +897,7 @@ if __name__ == "__main__":
     sl = SiteList(pts)
     voronoi(sl, c)
 
+
 def cmp(a, b):
     """Compare the two objects x and y and return an integer according to the
     outcome. The return value is negative if x < y, zero if x == y and strictly

--- a/python/plugins/processing/algs/qgis/voronoi.py
+++ b/python/plugins/processing/algs/qgis/voronoi.py
@@ -896,3 +896,12 @@ if __name__ == "__main__":
 
     sl = SiteList(pts)
     voronoi(sl, c)
+
+def cmp(a, b):
+    """Compare the two objects x and y and return an integer according to the
+    outcome. The return value is negative if x < y, zero if x == y and strictly
+    positive if x > y.
+
+    In python 2 cmp() was a built in function but in python 3 is gone.
+    """
+    return (a > b) - (a < b)

--- a/python/plugins/processing/algs/qgis/voronoi.py
+++ b/python/plugins/processing/algs/qgis/voronoi.py
@@ -16,12 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import next
-from past.builtins import cmp
-from builtins import str
-from builtins import range
-from builtins import object
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'

--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -16,10 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
 
 
 __author__ = 'Victor Olaya'

--- a/python/plugins/processing/algs/saga/SagaDescriptionCreator.py
+++ b/python/plugins/processing/algs/saga/SagaDescriptionCreator.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import str
-from builtins import object
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'

--- a/python/plugins/processing/algs/saga/SplitRGBBands.py
+++ b/python/plugins/processing/algs/saga/SplitRGBBands.py
@@ -16,8 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from future import standard_library
-standard_library.install_aliases()
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'

--- a/python/plugins/processing/algs/saga/versioncheck.py
+++ b/python/plugins/processing/algs/saga/versioncheck.py
@@ -16,8 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import str
 
 __author__ = 'Victor Olaya'
 __date__ = 'December 2014'

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import str
-from builtins import object
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'

--- a/python/plugins/processing/gui/BatchOutputSelectionPanel.py
+++ b/python/plugins/processing/gui/BatchOutputSelectionPanel.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import str
-from builtins import range
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'

--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -16,10 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import zip
-from builtins import str
-from builtins import object
 
 __author__ = 'Matthias Kuhn'
 __date__ = 'January 2016'

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -16,10 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 
 __author__ = 'Victor Olaya'
 __date__ = 'April 2013'

--- a/python/plugins/processing/tools/postgis.py
+++ b/python/plugins/processing/tools/postgis.py
@@ -16,11 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import map
-from builtins import str
-from builtins import range
-from builtins import object
 
 __author__ = 'Martin Dobias'
 __date__ = 'November 2012'

--- a/python/plugins/processing/tools/vector.py
+++ b/python/plugins/processing/tools/vector.py
@@ -16,13 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
-from builtins import object
-
 
 __author__ = 'Victor Olaya'
 __date__ = 'February 2013'

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -22,10 +22,6 @@
  *                                                                         *
  ***************************************************************************/
 """
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
 
 from qgis.PyQt.QtCore import (pyqtSignal, QObject, QCoreApplication, QFile,
                               QDir, QDirIterator, QDate, QUrl, QFileInfo,

--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -16,10 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import print_function
-from builtins import zip
-from builtins import map
-from builtins import str
 
 __author__ = 'Matthias Kuhn'
 __date__ = 'January 2016'

--- a/python/utils.py
+++ b/python/utils.py
@@ -16,10 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 
 __author__ = 'Martin Dobias'
 __date__ = 'November 2009'

--- a/tests/src/python/qgis_wrapped_server.py
+++ b/tests/src/python/qgis_wrapped_server.py
@@ -34,9 +34,6 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
-from future import standard_library
-standard_library.install_aliases()
-
 __author__ = 'Alessandro Pasotti'
 __date__ = '05/15/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'

--- a/tests/src/python/test_qgis_local_server.py
+++ b/tests/src/python/test_qgis_local_server.py
@@ -13,8 +13,6 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
-from future import standard_library
-standard_library.install_aliases()
 __author__ = 'Larry Shaffer'
 __date__ = '2014/02/16'
 __copyright__ = 'Copyright 2014, The QGIS Project'

--- a/tests/src/python/test_qgsfiledownloader.py
+++ b/tests/src/python/test_qgsfiledownloader.py
@@ -18,8 +18,6 @@ from qgis.PyQt.QtCore import QEventLoop, QUrl
 from qgis.gui import (QgsFileDownloader,)
 from qgis.testing import start_app, unittest
 
-standard_library.install_aliases()
-
 __author__ = 'Alessandro Pasotti'
 __date__ = '08/11/2016'
 __copyright__ = 'Copyright 2016, The QGIS Project'

--- a/tests/src/python/test_qgsfiledownloader.py
+++ b/tests/src/python/test_qgsfiledownloader.py
@@ -10,8 +10,7 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
-from __future__ import print_function
-from future import standard_library
+
 import os
 import tempfile
 from functools import partial

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -11,9 +11,7 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
-from future import standard_library
 import collections
-standard_library.install_aliases()
 
 __author__ = 'Larry Shaffer'
 __date__ = '07/09/2013'

--- a/tests/src/python/test_qgssettings.py
+++ b/tests/src/python/test_qgssettings.py
@@ -9,8 +9,7 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
-from __future__ import print_function
-from future import standard_library
+
 import os
 import tempfile
 from qgis.core import (QgsSettings,)

--- a/tests/src/python/test_qgssettings.py
+++ b/tests/src/python/test_qgssettings.py
@@ -16,8 +16,6 @@ from qgis.core import (QgsSettings,)
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtCore import QSettings
 
-standard_library.install_aliases()
-
 __author__ = 'Alessandro Pasotti'
 __date__ = '02/02/2017'
 __copyright__ = 'Copyright 2017, The QGIS Project'


### PR DESCRIPTION
## Description
Removed python future compatibility. Python 2 compatibility is no more needed with QGIS 3.
_The future is now!_
