### PR TITLE
From Clipboard Cut&Paste fix when attached special field values. Fixes #16870

### DIFF
--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -190,8 +190,17 @@ QgsFeatureList QgsClipboard::stringToFeatureList( const QString &string, const Q
 
   Q_FOREACH ( const QString &row, values )
   {
-    // Assume that it's just WKT for now.
-    QgsGeometry geometry = QgsGeometry::fromWkt( row );
+    // Assume that it's just WKT for now. because GeoJSON is managed by
+    // previous QgsOgrUtils::stringToFeatureList call
+    // Get the first value of a \t separated list. WKT clipboard pasted
+    // feature has first element the WKT geom.
+    // This split is to fix te following issue: https://issues.qgis.org/issues/16870
+    // Value separators are set in generateClipboardText
+    QStringList fieldValues = row.split( '\t' );
+    if ( fieldValues.isEmpty() )
+      continue;
+
+    QgsGeometry geometry = QgsGeometry::fromWkt( fieldValues[0] );
     if ( geometry.isNull() )
       continue;
 


### PR DESCRIPTION
## Description
In some cases when features are attached from clipboard as \t separated string, the import failed due the fact that the fromWkt geometry contructor is build on WKT * dumped fields. In some case when some dumped field has values inside parenthesis "(some value") the fromWkt parser return a ZM geometry.
This patch strips the leading field values leaving only WKT to the parser. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
