### PR TITLE
Fix relation widget crash when editing features after opening form with relation widget

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6329,7 +6329,7 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer* vlayer, bool symbologyOpt
 
 void QgisApp::checkForDeprecatedLabelsInProject()
 {
-  bool ok;
+  bool ok = false;
   QgsProject::instance()->readBoolEntry( "DeprecatedLabels", "/Enabled", false, &ok );
   if ( ok ) // project already flagged (regardless of project property value)
   {

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -609,7 +609,8 @@ void QgsSnappingUtils::readConfigFromProject()
   setSnapOnIntersections( QgsProject::instance()->readNumEntry( "Digitizing", "/IntersectionSnapping", 0 ) );
 
   //read snapping settings from project
-  bool snappingDefinedInProject, ok;
+  bool snappingDefinedInProject = false;
+  bool ok = false;
   QStringList layerIdList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingList", QStringList(), &snappingDefinedInProject );
   QStringList enabledList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingEnabledList", QStringList(), &ok );
   QStringList toleranceList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceList", QStringList(), &ok );

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -22,6 +22,7 @@
 QgsVectorLayerCache::QgsVectorLayerCache( QgsVectorLayer* layer, int cacheSize, QObject* parent )
     : QObject( parent )
     , mLayer( layer )
+    , mCacheGeometry( true )
     , mFullCache( false )
 {
   mCache.setMaxCost( cacheSize );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -521,7 +521,7 @@ void QgsRelationReferenceWidget::init()
       attributes << mReferencedLayer->fieldNameIndex( attr );
 
     layerCache->setCacheSubsetOfAttributes( attributes );
-    mMasterModel = new QgsAttributeTableModel( layerCache );
+    mMasterModel = new QgsAttributeTableModel( layerCache, this );
     mMasterModel->setRequest( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( requestedAttrs.toList(), mReferencedLayer->fields() ) );
     mFilterModel = new QgsAttributeTableFilterModel( mCanvas, mMasterModel, mMasterModel );
     mFeatureListModel = new QgsFeatureListModel( mFilterModel, this );


### PR DESCRIPTION
Also a significant leak/performance killer - the attribute model for the relation reference widget is not correctly parented, so is never deleted when the relation widget itself is deleted.
