### PR TITLE
[processing] fix non-normal blending composition for the rasterzie alg

### DIFF
--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -57,6 +57,7 @@ __revision__ = '$Format:%H$'
 
 
 class RasterizeAlgorithm(QgisAlgorithm):
+
     """Processing algorithm renders map canvas to a raster file.
     It's possible to choose the following parameters:
         - Map theme to render
@@ -195,6 +196,7 @@ class RasterizeAlgorithm(QgisAlgorithm):
 
 
 class TileSet():
+
     """
     A set of tiles
     """
@@ -236,11 +238,11 @@ class TileSet():
         self.dataset.SetGeoTransform(
             [extent.xMinimum(), mupp, 0, extent.yMaximum(), 0, -mupp])
 
-        self.image = QImage(QSize(tile_size, tile_size), QImage.Format_RGB32)
+        self.image = QImage(QSize(tile_size, tile_size), QImage.Format_ARGB32)
 
         self.settings = QgsMapSettings()
         self.settings.setOutputDpi(self.image.logicalDpiX())
-        self.settings.setOutputImageFormat(QImage.Format_RGB32)
+        self.settings.setOutputImageFormat(QImage.Format_ARGB32)
         self.settings.setDestinationCrs(crs)
         self.settings.setOutputSize(self.image.size())
         self.settings.setFlag(QgsMapSettings.Antialiasing, True)


### PR DESCRIPTION
## Description
Set the rasterize algorithm's QImage format to Format_ARGB32 so it can properly render layers with a non-normal blending mode.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
