### PR TITLE
[processing] improve rasterize dialog UI, add help

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -473,6 +473,17 @@ qgis:rasterlayerhistogram: >
 qgis:rasterlayerstatistics: >
   This algorithm computes basic statistics from the values in a given band of the raster layer.
 
+qgis:rasterize: >
+  This algorithm rasterizes map canvas content.
+
+  A map theme can be selected to render a predetermined set of layers with a defined style for each layer.
+
+  Alternatively, a single layer can be selected if not map theme is set.
+
+  If neither map theme nor the layer is set, the current map content will be rendered.
+
+  The minimum extent entered will internally be extended to be a multiple of the tile size.
+
 qgis:refactorfields: >
   This algorithm allows editing the structure of the attributes table of a vector layer. Fields can be modified in their type and name, using a fields mapping.
 

--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -84,31 +84,10 @@ class RasterizeAlgorithm(QgisAlgorithm):
         with some other properties.
         """
         # The parameters
-        map_theme_param = QgsProcessingParameterString(
-            self.MAP_THEME,
-            description=self.tr(
-                'Map theme to render.'),
-            defaultValue=None, optional=True)
-
-        map_theme_param.setMetadata(
-            {'widget_wrapper': {
-                'class':
-                    'processing.gui.wrappers_map_theme.MapThemeWrapper'}})
-        self.addParameter(map_theme_param)
-
-        self.addParameter(
-            QgsProcessingParameterMapLayer(
-                self.LAYER,
-                description=self.tr(
-                    'Layer to render. Will only be used if the map theme '
-                    'is not set. '
-                    'If both, map theme and layer are not '
-                    'set, the current map content will be rendered.'),
-                optional=True))
         self.addParameter(
             QgsProcessingParameterExtent(self.EXTENT, description=self.tr(
-                'The minimum extent to render. Will internally be extended to '
-                'be a multiple of the tile sizes.')))
+                'Minimum extent to render')))
+
         self.addParameter(
             QgsProcessingParameterNumber(
                 self.TILE_SIZE,
@@ -125,6 +104,25 @@ class RasterizeAlgorithm(QgisAlgorithm):
             type=QgsProcessingParameterNumber.Double
         ))
 
+        map_theme_param = QgsProcessingParameterString(
+            self.MAP_THEME,
+            description=self.tr(
+                'Map theme to render'),
+            defaultValue=None, optional=True)
+
+        map_theme_param.setMetadata(
+            {'widget_wrapper': {
+                'class':
+                    'processing.gui.wrappers_map_theme.MapThemeWrapper'}})
+        self.addParameter(map_theme_param)
+
+        self.addParameter(
+            QgsProcessingParameterMapLayer(
+                self.LAYER,
+                description=self.tr(
+                    'Single layer to render'),
+                optional=True))
+
         # We add a raster layer as output
         self.addParameter(QgsProcessingParameterRasterDestination(
             self.OUTPUT,
@@ -133,7 +131,7 @@ class RasterizeAlgorithm(QgisAlgorithm):
 
     def name(self):
         # Unique (non-user visible) name of algorithm
-        return 'Rasterize'
+        return 'rasterize'
 
     def displayName(self):
         # The name that the user will see in the toolbox


### PR DESCRIPTION
## Description
The rasterize algorithm's dialog suffered from "extreme wideness" due to long parameter strings. I've moved some of the content into the newly-added help section.

I've also moved the optional parameters below the non-optional ones, feels much more logical and intuitive that way.

Before (left) vs. after (right):
![screenshot from 2017-08-11 12-56-02](https://user-images.githubusercontent.com/1728657/29202725-0fbbedd6-7e95-11e7-825d-280ef13b0639.png)
_Notice the dialog content being cropped due to wide string, ending up hiding parameters' right-most control buttons_

@m-kuhn , @marioba , are you guys OK with this? 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
