### PR TITLE
Use pointers and not references to QgsAbstractGeometry

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1252,6 +1252,13 @@ QgsGeometryAnalyzer        {#qgis_api_break_3_0_QgsGeometryAnalyzer}
 - locateBetweenMeasures() and locateAlongMeasure() now take geometry references, not pointers, and return
 a QgsGeometry value rather than a pointer.
 
+QgsGeometryEngine        {#qgis_api_break_3_0_QgsGeometryEngine}
+-----------------
+
+- `QgsAbstractGeometry&` parameters have been changed to `QgsAbstractGeometry*` (Affects C++ only)
+- `centroid()` returns the point instead of working on a parameter. The return value is a `nullptr` when `false` has been returned in the past.
+- `pointOnSurface()` returns the point instead of working on a parameter. The return value is a `nullptr` when `false` has been returned in the past.
+
 
 QgsGeometrySimplifier        {#qgis_api_break_3_0_QgsGeometrySimplifier}
 ---------------------

--- a/python/core/geometry/qgsgeometryengine.sip
+++ b/python/core/geometry/qgsgeometryengine.sip
@@ -85,16 +85,28 @@ class QgsGeometryEngine
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
-    virtual bool centroid( QgsPoint &pt, QString *errorMsg = 0 ) const = 0;
+
+    virtual QgsPoint *centroid( QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
- :rtype: bool
+ Calculates the centroid of this.
+ May return a `None`.
+
+.. versionadded:: 3.0
+ :rtype: QgsPoint
 %End
-    virtual bool pointOnSurface( QgsPoint &pt, QString *errorMsg = 0 ) const = 0;
+
+    virtual QgsPoint *pointOnSurface( QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
- :rtype: bool
+ Calculate a point that is guaranteed to be on the surface of this.
+ May return a `None`.
+
+.. versionadded:: 3.0
+ :rtype: QgsPoint
 %End
+
     virtual QgsAbstractGeometry *convexHull( QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
+ Calculate the convex hull of this.
  :rtype: QgsAbstractGeometry
 %End
 

--- a/python/core/geometry/qgsgeometryengine.sip
+++ b/python/core/geometry/qgsgeometryengine.sip
@@ -26,15 +26,15 @@ class QgsGeometryEngine
     virtual void geometryChanged() = 0;
     virtual void prepareGeometry() = 0;
 
-    virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
-    virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
-    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
@@ -42,7 +42,7 @@ class QgsGeometryEngine
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
-    virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
@@ -78,40 +78,40 @@ class QgsGeometryEngine
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
-    virtual double distance( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: float
 %End
-    virtual bool intersects( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End
-    virtual bool touches( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End
-    virtual bool crosses( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End
-    virtual bool within( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End
-    virtual bool overlaps( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End
-    virtual bool contains( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End
-    virtual bool disjoint( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End
 
-    virtual QString relate( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  Returns the Dimensional Extended 9 Intersection Model (DE-9IM) representation of the
  relationship between the geometries.
@@ -122,7 +122,7 @@ class QgsGeometryEngine
  :rtype: str
 %End
 
-    virtual bool relatePattern( const QgsAbstractGeometry &geom, const QString &pattern, QString *errorMsg = 0 ) const = 0;
+    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = 0 ) const = 0;
 %Docstring
  Tests whether two geometries are related by a specified Dimensional Extended 9 Intersection Model (DE-9IM)
  pattern.
@@ -146,7 +146,7 @@ class QgsGeometryEngine
 %Docstring
  :rtype: bool
 %End
-    virtual bool isEqual( const QgsAbstractGeometry &geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
  :rtype: bool
 %End

--- a/python/core/geometry/qgsgeometryengine.sip
+++ b/python/core/geometry/qgsgeometryengine.sip
@@ -28,22 +28,41 @@ class QgsGeometryEngine
 
     virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
+ Calculate the intersection of this and ``geom``.
+
+.. versionadded:: 3.0
  :rtype: QgsAbstractGeometry
 %End
+
     virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
+ Calculate the difference of this and ``geom``.
+
+.. versionadded:: 3.0
  :rtype: QgsAbstractGeometry
 %End
+
     virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
+ Calculate the combination of this and ``geom``.
+
+.. versionadded:: 3.0
  :rtype: QgsAbstractGeometry
 %End
-    virtual QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry * > &, QString *errorMsg = 0 ) const = 0 /Factory/;
+
+    virtual QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry * > &geometries, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
+ Calculate the combination of this and ``geometries``.
+
+.. versionadded:: 3.0
  :rtype: QgsAbstractGeometry
 %End
+
     virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
+ Calculate the symmetric difference of this and ``geom``.
+
+.. versionadded:: 3.0
  :rtype: QgsAbstractGeometry
 %End
     virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = 0 ) const = 0 /Factory/;
@@ -78,36 +97,68 @@ class QgsGeometryEngine
 %Docstring
  :rtype: QgsAbstractGeometry
 %End
+
     virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Calculates the distance between this and ``geom``.
+
+.. versionadded:: 3.0
  :rtype: float
 %End
+
     virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if ``geom`` intersects this.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
+
     virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if ``geom`` touches this.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
+
     virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if ``geom`` crosses this.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
+
     virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if ``geom`` is within this.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
+
     virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if ``geom`` overlaps this.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
+
     virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if ``geom`` contains this.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
+
     virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if ``geom`` is disjoint from this.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
 
@@ -146,8 +197,13 @@ class QgsGeometryEngine
 %Docstring
  :rtype: bool
 %End
+
     virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
+ Checks if this is equal to ``geom``.
+ If both are Null geometries, `false` is returned.
+
+.. versionadded:: 3.0
  :rtype: bool
 %End
     virtual bool isEmpty( QString *errorMsg ) const = 0;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2373,14 +2373,14 @@ static QVariant fcnRelate( const QVariantList &values, const QgsExpressionContex
   if ( values.length() == 2 )
   {
     //two geometry arguments, return relation
-    QString result = engine->relate( *sGeom.geometry() );
+    QString result = engine->relate( sGeom.geometry() );
     return QVariant::fromValue( result );
   }
   else
   {
     //three arguments, test pattern
     QString pattern = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
-    bool result = engine->relatePattern( *sGeom.geometry(), pattern );
+    bool result = engine->relatePattern( sGeom.geometry(), pattern );
     return QVariant::fromValue( result );
   }
 }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -845,7 +845,7 @@ int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other )
 
   QgsGeos geos( d->geometry );
 
-  QgsAbstractGeometry *diffGeom = geos.intersection( *other.geometry() );
+  QgsAbstractGeometry *diffGeom = geos.intersection( other.geometry() );
   if ( !diffGeom )
   {
     return 1;
@@ -867,7 +867,7 @@ QgsGeometry QgsGeometry::makeDifference( const QgsGeometry &other ) const
 
   QgsGeos geos( d->geometry );
 
-  QgsAbstractGeometry *diffGeom = geos.intersection( *other.geometry() );
+  QgsAbstractGeometry *diffGeom = geos.intersection( other.geometry() );
   if ( !diffGeom )
   {
     return QgsGeometry();
@@ -965,7 +965,7 @@ bool QgsGeometry::intersects( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.intersects( *geometry.d->geometry );
+  return geos.intersects( geometry.d->geometry );
 }
 
 bool QgsGeometry::contains( const QgsPointXY *p ) const
@@ -977,7 +977,7 @@ bool QgsGeometry::contains( const QgsPointXY *p ) const
 
   QgsPoint pt( p->x(), p->y() );
   QgsGeos geos( d->geometry );
-  return geos.contains( pt );
+  return geos.contains( &pt );
 }
 
 bool QgsGeometry::contains( const QgsGeometry &geometry ) const
@@ -988,7 +988,7 @@ bool QgsGeometry::contains( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.contains( *( geometry.d->geometry ) );
+  return geos.contains( geometry.d->geometry );
 }
 
 bool QgsGeometry::disjoint( const QgsGeometry &geometry ) const
@@ -999,7 +999,7 @@ bool QgsGeometry::disjoint( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.disjoint( *( geometry.d->geometry ) );
+  return geos.disjoint( geometry.d->geometry );
 }
 
 bool QgsGeometry::equals( const QgsGeometry &geometry ) const
@@ -1010,7 +1010,7 @@ bool QgsGeometry::equals( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.isEqual( *( geometry.d->geometry ) );
+  return geos.isEqual( geometry.d->geometry );
 }
 
 bool QgsGeometry::touches( const QgsGeometry &geometry ) const
@@ -1021,7 +1021,7 @@ bool QgsGeometry::touches( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.touches( *( geometry.d->geometry ) );
+  return geos.touches( geometry.d->geometry );
 }
 
 bool QgsGeometry::overlaps( const QgsGeometry &geometry ) const
@@ -1032,7 +1032,7 @@ bool QgsGeometry::overlaps( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.overlaps( *( geometry.d->geometry ) );
+  return geos.overlaps( geometry.d->geometry );
 }
 
 bool QgsGeometry::within( const QgsGeometry &geometry ) const
@@ -1043,7 +1043,7 @@ bool QgsGeometry::within( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.within( *( geometry.d->geometry ) );
+  return geos.within( geometry.d->geometry );
 }
 
 bool QgsGeometry::crosses( const QgsGeometry &geometry ) const
@@ -1054,7 +1054,7 @@ bool QgsGeometry::crosses( const QgsGeometry &geometry ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.crosses( *( geometry.d->geometry ) );
+  return geos.crosses( geometry.d->geometry );
 }
 
 QString QgsGeometry::exportToWkt( int precision ) const
@@ -1394,7 +1394,7 @@ double QgsGeometry::distance( const QgsGeometry &geom ) const
   }
 
   QgsGeos g( d->geometry );
-  return g.distance( *( geom.d->geometry ) );
+  return g.distance( geom.d->geometry );
 }
 
 QgsGeometry QgsGeometry::buffer( double distance, int segments ) const
@@ -1405,12 +1405,8 @@ QgsGeometry QgsGeometry::buffer( double distance, int segments ) const
   }
 
   QgsGeos g( d->geometry );
-  QgsAbstractGeometry *geom = g.buffer( distance, segments );
-  if ( !geom )
-  {
-    return QgsGeometry();
-  }
-  return QgsGeometry( geom );
+  std::unique_ptr<QgsAbstractGeometry> geom( g.buffer( distance, segments ) );
+  return QgsGeometry( geom.release() );
 }
 
 QgsGeometry QgsGeometry::buffer( double distance, int segments, EndCapStyle endCapStyle, JoinStyle joinStyle, double miterLimit ) const
@@ -1797,7 +1793,7 @@ QgsGeometry QgsGeometry::intersection( const QgsGeometry &geometry ) const
   QgsGeos geos( d->geometry );
 
   QString error;
-  QgsAbstractGeometry *resultGeom = geos.intersection( *( geometry.d->geometry ), &error );
+  QgsAbstractGeometry *resultGeom = geos.intersection( geometry.d->geometry, &error );
 
   if ( !resultGeom )
   {
@@ -1819,7 +1815,7 @@ QgsGeometry QgsGeometry::combine( const QgsGeometry &geometry ) const
   QgsGeos geos( d->geometry );
   QString error;
 
-  QgsAbstractGeometry *resultGeom = geos.combine( *( geometry.d->geometry ), &error );
+  QgsAbstractGeometry *resultGeom = geos.combine( geometry.d->geometry, &error );
   if ( !resultGeom )
   {
     QgsGeometry geom;
@@ -1856,7 +1852,7 @@ QgsGeometry QgsGeometry::difference( const QgsGeometry &geometry ) const
   QgsGeos geos( d->geometry );
 
   QString error;
-  QgsAbstractGeometry *resultGeom = geos.difference( *( geometry.d->geometry ), &error );
+  QgsAbstractGeometry *resultGeom = geos.difference( geometry.d->geometry, &error );
   if ( !resultGeom )
   {
     QgsGeometry geom;
@@ -1877,7 +1873,7 @@ QgsGeometry QgsGeometry::symDifference( const QgsGeometry &geometry ) const
 
   QString error;
 
-  QgsAbstractGeometry *resultGeom = geos.symDifference( *( geometry.d->geometry ), &error );
+  QgsAbstractGeometry *resultGeom = geos.symDifference( geometry.d->geometry, &error );
   if ( !resultGeom )
   {
     QgsGeometry geom;
@@ -2051,7 +2047,7 @@ bool QgsGeometry::isGeosEqual( const QgsGeometry &g ) const
   }
 
   QgsGeos geos( d->geometry );
-  return geos.isEqual( *( g.d->geometry ) );
+  return geos.isEqual( g.d->geometry );
 }
 
 QgsGeometry QgsGeometry::unaryUnion( const QList<QgsGeometry> &geometries )

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1581,16 +1581,8 @@ QgsGeometry QgsGeometry::centroid() const
   }
 
   QgsGeos geos( d->geometry );
-  std::unique_ptr<QgsPoint> centroid( new QgsPoint() );
-  QString error;
-  bool ok = geos.centroid( *centroid.get(), &error );
-  if ( !ok )
-  {
-    QgsGeometry geom;
-    geom.d->error = error;
-    return geom;
-  }
-  return QgsGeometry( centroid.release() );
+
+  return QgsGeometry( geos.centroid( &d->error ) );
 }
 
 QgsGeometry QgsGeometry::pointOnSurface() const
@@ -1601,17 +1593,8 @@ QgsGeometry QgsGeometry::pointOnSurface() const
   }
 
   QgsGeos geos( d->geometry );
-  std::unique_ptr<QgsPoint>pt( new QgsPoint() );
 
-  QString error;
-  bool ok = geos.pointOnSurface( *pt.get(), &error );
-  if ( !ok )
-  {
-    QgsGeometry geom;
-    geom.d->error = error;
-    return geom;
-  }
-  return QgsGeometry( pt.release() );
+  return QgsGeometry( geos.pointOnSurface( &d->error ) );
 }
 
 QgsGeometry QgsGeometry::poleOfInaccessibility( double precision, double *distanceToBoundary ) const

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -70,16 +70,16 @@ int QgsGeometryEditUtils::addRing( QgsAbstractGeometry *geom, QgsCurve *ring )
   ringGeom->prepareGeometry();
 
   //for each polygon, test if inside outer ring and no intersection with other interior ring
-  QList< QgsCurvePolygon * >::iterator polyIter = polygonList.begin();
-  for ( ; polyIter != polygonList.end(); ++polyIter )
+  QList< QgsCurvePolygon * >::const_iterator polyIter = polygonList.constBegin();
+  for ( ; polyIter != polygonList.constEnd(); ++polyIter )
   {
-    if ( ringGeom->within( **polyIter ) )
+    if ( ringGeom->within( *polyIter ) )
     {
       //check if disjoint with other interior rings
       int nInnerRings = ( *polyIter )->numInteriorRings();
       for ( int i = 0; i < nInnerRings; ++i )
       {
-        if ( !ringGeom->disjoint( *( *polyIter )->interiorRing( i ) ) )
+        if ( !ringGeom->disjoint( ( *polyIter )->interiorRing( i ) ) )
         {
           delete ring;
           return 4;
@@ -284,7 +284,7 @@ QgsAbstractGeometry *QgsGeometryEditUtils::avoidIntersections( const QgsAbstract
     return nullptr;
   }
 
-  QgsAbstractGeometry *diffGeom = geomEngine->difference( *combinedGeometries );
+  QgsAbstractGeometry *diffGeom = geomEngine->difference( combinedGeometries );
 
   delete combinedGeometries;
   return diffGeom;

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -36,10 +36,39 @@ class CORE_EXPORT QgsGeometryEngine
     virtual void geometryChanged() = 0;
     virtual void prepareGeometry() = 0;
 
+    /**
+     * Calculate the intersection of this and \a geom.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Calculate the difference of this and \a geom.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Calculate the combination of this and \a geom.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry * > &, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Calculate the combination of this and \a geometries.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
+    virtual QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry * > &geometries, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Calculate the symmetric difference of this and \a geom.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *buffer( double distance, int segments, int endCapStyle, int joinStyle, double miterLimit, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
@@ -49,13 +78,61 @@ class CORE_EXPORT QgsGeometryEngine
     virtual bool centroid( QgsPoint &pt, QString *errorMsg = nullptr ) const = 0;
     virtual bool pointOnSurface( QgsPoint &pt, QString *errorMsg = nullptr ) const = 0;
     virtual QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Calculates the distance between this and \a geom.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if \a geom intersects this.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if \a geom touches this.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if \a geom crosses this.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if \a geom is within this.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if \a geom overlaps this.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if \a geom contains this.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if \a geom is disjoint from this.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
 
     /** Returns the Dimensional Extended 9 Intersection Model (DE-9IM) representation of the
@@ -80,6 +157,13 @@ class CORE_EXPORT QgsGeometryEngine
     virtual double area( QString *errorMsg = nullptr ) const = 0;
     virtual double length( QString *errorMsg = nullptr ) const = 0;
     virtual bool isValid( QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if this is equal to \a geom.
+     * If both are Null geometries, `false` is returned.
+     *
+     * \since QGIS 3.0 \a geom is a pointer
+     */
     virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
     virtual bool isEmpty( QString *errorMsg ) const = 0;
 

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -75,8 +75,26 @@ class CORE_EXPORT QgsGeometryEngine
     virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *envelope( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual bool centroid( QgsPoint &pt, QString *errorMsg = nullptr ) const = 0;
-    virtual bool pointOnSurface( QgsPoint &pt, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Calculates the centroid of this.
+     * May return a `nullptr`.
+     *
+     * \since QGIS 3.0 the centroid is returned
+     */
+    virtual QgsPoint *centroid( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Calculate a point that is guaranteed to be on the surface of this.
+     * May return a `nullptr`.
+     *
+     * \since QGIS 3.0 the centroid is returned
+     */
+    virtual QgsPoint *pointOnSurface( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Calculate the convex hull of this.
+     */
     virtual QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
 
     /**

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -36,11 +36,11 @@ class CORE_EXPORT QgsGeometryEngine
     virtual void geometryChanged() = 0;
     virtual void prepareGeometry() = 0;
 
-    virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry * > &, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *buffer( double distance, int segments, int endCapStyle, int joinStyle, double miterLimit, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
     virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
@@ -49,14 +49,14 @@ class CORE_EXPORT QgsGeometryEngine
     virtual bool centroid( QgsPoint &pt, QString *errorMsg = nullptr ) const = 0;
     virtual bool pointOnSurface( QgsPoint &pt, QString *errorMsg = nullptr ) const = 0;
     virtual QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual double distance( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
-    virtual bool intersects( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
-    virtual bool touches( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
-    virtual bool crosses( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
-    virtual bool within( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
-    virtual bool overlaps( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
-    virtual bool contains( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
-    virtual bool disjoint( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
+    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
 
     /** Returns the Dimensional Extended 9 Intersection Model (DE-9IM) representation of the
      * relationship between the geometries.
@@ -65,7 +65,7 @@ class CORE_EXPORT QgsGeometryEngine
      * \returns DE-9IM string for relationship, or an empty string if an error occurred
      * \since QGIS 2.12
      */
-    virtual QString relate( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
+    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
 
     /** Tests whether two geometries are related by a specified Dimensional Extended 9 Intersection Model (DE-9IM)
      * pattern.
@@ -75,12 +75,12 @@ class CORE_EXPORT QgsGeometryEngine
      * \returns true if geometry relationship matches with pattern
      * \since QGIS 2.14
      */
-    virtual bool relatePattern( const QgsAbstractGeometry &geom, const QString &pattern, QString *errorMsg = nullptr ) const = 0;
+    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = nullptr ) const = 0;
 
     virtual double area( QString *errorMsg = nullptr ) const = 0;
     virtual double length( QString *errorMsg = nullptr ) const = 0;
     virtual bool isValid( QString *errorMsg = nullptr ) const = 0;
-    virtual bool isEqual( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
     virtual bool isEmpty( QString *errorMsg ) const = 0;
 
     /** Determines whether the geometry is simple (according to OGC definition).

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -179,12 +179,12 @@ void QgsGeos::cacheGeos() const
   mGeos = asGeos( mGeometry, mPrecision );
 }
 
-QgsAbstractGeometry *QgsGeos::intersection( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::intersection( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return overlay( geom, INTERSECTION, errorMsg );
 }
 
-QgsAbstractGeometry *QgsGeos::difference( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::difference( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return overlay( geom, DIFFERENCE, errorMsg );
 }
@@ -329,7 +329,7 @@ QgsAbstractGeometry *QgsGeos::subdivide( int maxNodes, QString *errorMsg ) const
   return parts.release();
 }
 
-QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return overlay( geom, UNION, errorMsg );
 }
@@ -358,12 +358,12 @@ QgsAbstractGeometry *QgsGeos::combine( const QList<QgsAbstractGeometry *> &geomL
   return result;
 }
 
-QgsAbstractGeometry *QgsGeos::symDifference( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::symDifference( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return overlay( geom, SYMDIFFERENCE, errorMsg );
 }
 
-double QgsGeos::distance( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   double distance = -1.0;
   if ( !mGeos )
@@ -371,7 +371,7 @@ double QgsGeos::distance( const QgsAbstractGeometry &geom, QString *errorMsg ) c
     return distance;
   }
 
-  GEOSGeometry *otherGeosGeom = asGeos( &geom, mPrecision );
+  GEOSGeometry *otherGeosGeom = asGeos( geom, mPrecision );
   if ( !otherGeosGeom )
   {
     return distance;
@@ -388,49 +388,49 @@ double QgsGeos::distance( const QgsAbstractGeometry &geom, QString *errorMsg ) c
   return distance;
 }
 
-bool QgsGeos::intersects( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::intersects( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, INTERSECTS, errorMsg );
 }
 
-bool QgsGeos::touches( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::touches( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, TOUCHES, errorMsg );
 }
 
-bool QgsGeos::crosses( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::crosses( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, CROSSES, errorMsg );
 }
 
-bool QgsGeos::within( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::within( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, WITHIN, errorMsg );
 }
 
-bool QgsGeos::overlaps( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::overlaps( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, OVERLAPS, errorMsg );
 }
 
-bool QgsGeos::contains( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::contains( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, CONTAINS, errorMsg );
 }
 
-bool QgsGeos::disjoint( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::disjoint( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, DISJOINT, errorMsg );
 }
 
-QString QgsGeos::relate( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   if ( !mGeos )
   {
     return QString();
   }
 
-  GEOSGeomScopedPtr geosGeom( asGeos( &geom, mPrecision ) );
+  GEOSGeomScopedPtr geosGeom( asGeos( geom, mPrecision ) );
   if ( !geosGeom )
   {
     return QString();
@@ -457,14 +457,14 @@ QString QgsGeos::relate( const QgsAbstractGeometry &geom, QString *errorMsg ) co
   return result;
 }
 
-bool QgsGeos::relatePattern( const QgsAbstractGeometry &geom, const QString &pattern, QString *errorMsg ) const
+bool QgsGeos::relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg ) const
 {
-  if ( !mGeos )
+  if ( !mGeos || !geom )
   {
     return false;
   }
 
-  GEOSGeomScopedPtr geosGeom( asGeos( &geom, mPrecision ) );
+  GEOSGeomScopedPtr geosGeom( asGeos( geom, mPrecision ) );
   if ( !geosGeom )
   {
     return false;
@@ -1217,6 +1217,9 @@ QgsPoint QgsGeos::coordSeqPoint( const GEOSCoordSequence *cs, int i, bool hasZ, 
 
 GEOSGeometry *QgsGeos::asGeos( const QgsAbstractGeometry *geom, double precision )
 {
+  if ( !geom )
+    return nullptr;
+
   int coordDims = 2;
   if ( geom->is3D() )
   {
@@ -1254,7 +1257,9 @@ GEOSGeometry *QgsGeos::asGeos( const QgsAbstractGeometry *geom, double precision
       }
     }
 
+
     const QgsGeometryCollection *c = qgsgeometry_cast<const QgsGeometryCollection *>( geom );
+
     if ( !c )
       return nullptr;
 
@@ -1290,14 +1295,14 @@ GEOSGeometry *QgsGeos::asGeos( const QgsAbstractGeometry *geom, double precision
   return nullptr;
 }
 
-QgsAbstractGeometry *QgsGeos::overlay( const QgsAbstractGeometry &geom, Overlay op, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg ) const
 {
-  if ( !mGeos )
+  if ( !mGeos || !geom )
   {
     return nullptr;
   }
 
-  GEOSGeomScopedPtr geosGeom( asGeos( &geom, mPrecision ) );
+  GEOSGeomScopedPtr geosGeom( asGeos( geom, mPrecision ) );
   if ( !geosGeom )
   {
     return nullptr;
@@ -1350,14 +1355,14 @@ QgsAbstractGeometry *QgsGeos::overlay( const QgsAbstractGeometry &geom, Overlay 
   }
 }
 
-bool QgsGeos::relation( const QgsAbstractGeometry &geom, Relation r, QString *errorMsg ) const
+bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *errorMsg ) const
 {
-  if ( !mGeos )
+  if ( !mGeos || !geom )
   {
     return false;
   }
 
-  GEOSGeomScopedPtr geosGeom( asGeos( &geom, mPrecision ) );
+  GEOSGeomScopedPtr geosGeom( asGeos( geom, mPrecision ) );
   if ( !geosGeom )
   {
     return false;
@@ -1605,16 +1610,16 @@ bool QgsGeos::isValid( QString *errorMsg ) const
   CATCH_GEOS_WITH_ERRMSG( false );
 }
 
-bool QgsGeos::isEqual( const QgsAbstractGeometry &geom, QString *errorMsg ) const
+bool QgsGeos::isEqual( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
-  if ( !mGeos )
+  if ( !mGeos || !geom )
   {
     return false;
   }
 
   try
   {
-    GEOSGeomScopedPtr geosGeom( asGeos( &geom, mPrecision ) );
+    GEOSGeomScopedPtr geosGeom( asGeos( geom, mPrecision ) );
     if ( !geosGeom )
     {
       return false;

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -1503,36 +1503,30 @@ QgsAbstractGeometry *QgsGeos::interpolate( double distance, QString *errorMsg ) 
   return fromGeos( geos.get() );
 }
 
-bool QgsGeos::centroid( QgsPoint &pt, QString *errorMsg ) const
+QgsPoint *QgsGeos::centroid( QString *errorMsg ) const
 {
   if ( !mGeos )
   {
-    return false;
+    return nullptr;
   }
 
   GEOSGeomScopedPtr geos;
+  double x;
+  double y;
+
   try
   {
     geos.reset( GEOSGetCentroid_r( geosinit.ctxt,  mGeos ) );
-  }
-  CATCH_GEOS_WITH_ERRMSG( false );
 
-  if ( !geos )
-  {
-    return false;
-  }
+    if ( !geos )
+      return nullptr;
 
-  try
-  {
-    double x, y;
     GEOSGeomGetX_r( geosinit.ctxt, geos.get(), &x );
     GEOSGeomGetY_r( geosinit.ctxt, geos.get(), &y );
-    pt.setX( x );
-    pt.setY( y );
   }
-  CATCH_GEOS_WITH_ERRMSG( false );
+  CATCH_GEOS_WITH_ERRMSG( nullptr );
 
-  return true;
+  return new QgsPoint( x, y );
 }
 
 QgsAbstractGeometry *QgsGeos::envelope( QString *errorMsg ) const
@@ -1550,12 +1544,15 @@ QgsAbstractGeometry *QgsGeos::envelope( QString *errorMsg ) const
   return fromGeos( geos.get() );
 }
 
-bool QgsGeos::pointOnSurface( QgsPoint &pt, QString *errorMsg ) const
+QgsPoint *QgsGeos::pointOnSurface( QString *errorMsg ) const
 {
   if ( !mGeos )
   {
-    return false;
+    return nullptr;
   }
+
+  double x;
+  double y;
 
   GEOSGeomScopedPtr geos;
   try
@@ -1564,19 +1561,15 @@ bool QgsGeos::pointOnSurface( QgsPoint &pt, QString *errorMsg ) const
 
     if ( !geos || GEOSisEmpty_r( geosinit.ctxt, geos.get() ) != 0 )
     {
-      return false;
+      return nullptr;
     }
 
-    double x, y;
     GEOSGeomGetX_r( geosinit.ctxt, geos.get(), &x );
     GEOSGeomGetY_r( geosinit.ctxt, geos.get(), &y );
-
-    pt.setX( x );
-    pt.setY( y );
   }
-  CATCH_GEOS_WITH_ERRMSG( false );
+  CATCH_GEOS_WITH_ERRMSG( nullptr );
 
-  return true;
+  return new QgsPoint( x, y );
 }
 
 QgsAbstractGeometry *QgsGeos::convexHull( QString *errorMsg ) const

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -46,8 +46,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     void geometryChanged() override;
     void prepareGeometry() override;
 
-    QgsAbstractGeometry *intersection( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    QgsAbstractGeometry *difference( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
 
     /**
      * Performs a fast, non-robust intersection between the geometry and
@@ -71,9 +71,9 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      */
     QgsAbstractGeometry *subdivide( int maxNodes, QString *errorMsg = nullptr ) const;
 
-    QgsAbstractGeometry *combine( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry *> &, QString *errorMsg = nullptr ) const override;
-    QgsAbstractGeometry *symDifference( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *buffer( double distance, int segments, int endCapStyle, int joinStyle, double miterLimit, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr ) const override;
@@ -82,20 +82,20 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     bool centroid( QgsPoint &pt, QString *errorMsg = nullptr ) const override;
     bool pointOnSurface( QgsPoint &pt, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr ) const override;
-    double distance( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool intersects( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool touches( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool crosses( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool within( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool overlaps( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool contains( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool disjoint( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    QString relate( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
-    bool relatePattern( const QgsAbstractGeometry &geom, const QString &pattern, QString *errorMsg = nullptr ) const override;
+    double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool within( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+    bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = nullptr ) const override;
     double area( QString *errorMsg = nullptr ) const override;
     double length( QString *errorMsg = nullptr ) const override;
     bool isValid( QString *errorMsg = nullptr ) const override;
-    bool isEqual( const QgsAbstractGeometry &geom, QString *errorMsg = nullptr ) const override;
+    bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     bool isEmpty( QString *errorMsg = nullptr ) const override;
     bool isSimple( QString *errorMsg = nullptr ) const override;
 
@@ -243,8 +243,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
 
     //geos util functions
     void cacheGeos() const;
-    QgsAbstractGeometry *overlay( const QgsAbstractGeometry &geom, Overlay op, QString *errorMsg = nullptr ) const;
-    bool relation( const QgsAbstractGeometry &geom, Relation r, QString *errorMsg = nullptr ) const;
+    QgsAbstractGeometry *overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg = nullptr ) const;
+    bool relation( const QgsAbstractGeometry *geom, Relation r, QString *errorMsg = nullptr ) const;
     static GEOSCoordSequence *createCoordinateSequence( const QgsCurve *curve, double precision, bool forceClose = false );
     static QgsLineString *sequenceToLinestring( const GEOSGeometry *geos, bool hasZ, bool hasM );
     static int numberOfGeometries( GEOSGeometry *g );

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -79,8 +79,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *envelope( QString *errorMsg = nullptr ) const override;
-    bool centroid( QgsPoint &pt, QString *errorMsg = nullptr ) const override;
-    bool pointOnSurface( QgsPoint &pt, QString *errorMsg = nullptr ) const override;
+    QgsPoint *centroid( QString *errorMsg = nullptr ) const override;
+    QgsPoint *pointOnSurface( QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr ) const override;
     double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -156,16 +156,13 @@ QgsRectangle QgsRectangle::buffer( double width )
 QgsRectangle QgsRectangle::intersect( const QgsRectangle *rect ) const
 {
   QgsRectangle intersection = QgsRectangle();
-  //If they don't actually intersect an empty QgsRectangle should be returned
-  if ( !rect || !intersects( *rect ) )
+  if ( rect && intersects( *rect ) )
   {
-    return intersection;
+    intersection.setXMinimum( mXmin > rect->xMinimum() ? mXmin : rect->xMinimum() );
+    intersection.setXMaximum( mXmax < rect->xMaximum() ? mXmax : rect->xMaximum() );
+    intersection.setYMinimum( mYmin > rect->yMinimum() ? mYmin : rect->yMinimum() );
+    intersection.setYMaximum( mYmax < rect->yMaximum() ? mYmax : rect->yMaximum() );
   }
-
-  intersection.setXMinimum( mXmin > rect->xMinimum() ? mXmin : rect->xMinimum() );
-  intersection.setXMaximum( mXmax < rect->xMaximum() ? mXmax : rect->xMaximum() );
-  intersection.setYMinimum( mYmin > rect->yMinimum() ? mYmin : rect->yMinimum() );
-  intersection.setYMaximum( mYmax < rect->yMaximum() ? mYmax : rect->yMaximum() );
   return intersection;
 }
 

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -484,11 +484,11 @@ QVariantMap QgsClipAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
       }
       testedFeatureIds.insert( inputFeature.id() );
 
-      if ( !engine->intersects( *inputFeature.geometry().geometry() ) )
+      if ( !engine->intersects( inputFeature.geometry().geometry() ) )
         continue;
 
       QgsGeometry newGeometry;
-      if ( !engine->contains( *inputFeature.geometry().geometry() ) )
+      if ( !engine->contains( inputFeature.geometry().geometry() ) )
       {
         QgsGeometry currentGeometry = inputFeature.geometry();
         newGeometry = combinedClipGeom.intersection( currentGeometry );

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -111,7 +111,7 @@ bool QgsMemoryFeatureIterator::nextFeatureUsingList( QgsFeature &feature )
     if ( !mFilterRect.isNull() && mRequest.flags() & QgsFeatureRequest::ExactIntersect )
     {
       // do exact check in case we're doing intersection
-      if ( mSource->mFeatures.value( *mFeatureIdListIterator ).hasGeometry() && mSelectRectEngine->intersects( *mSource->mFeatures.value( *mFeatureIdListIterator ).geometry().geometry() ) )
+      if ( mSource->mFeatures.value( *mFeatureIdListIterator ).hasGeometry() && mSelectRectEngine->intersects( mSource->mFeatures.value( *mFeatureIdListIterator ).geometry().geometry() ) )
         hasFeature = true;
     }
     else
@@ -166,7 +166,7 @@ bool QgsMemoryFeatureIterator::nextFeatureTraverseAll( QgsFeature &feature )
       if ( mRequest.flags() & QgsFeatureRequest::ExactIntersect )
       {
         // using exact test when checking for intersection
-        if ( mSelectIterator->hasGeometry() && mSelectRectEngine->intersects( *mSelectIterator->geometry().geometry() ) )
+        if ( mSelectIterator->hasGeometry() && mSelectRectEngine->intersects( mSelectIterator->geometry().geometry() ) )
           hasFeature = true;
       }
       else

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -155,7 +155,7 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
     // filter out elements outside of the polygon
     if ( f.geometry() && polygonEngine )
     {
-      if ( !polygonEngine->intersects( *f.geometry().geometry() ) )
+      if ( !polygonEngine->intersects( f.geometry().geometry() ) )
       {
         continue;
       }

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2646,7 +2646,7 @@ QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
       }
     }
 
-    if ( fet.hasGeometry() && filterRectEngine && !filterRectEngine->intersects( *fet.geometry().geometry() ) )
+    if ( fet.hasGeometry() && filterRectEngine && !filterRectEngine->intersects( fet.geometry().geometry() ) )
       continue;
 
     if ( attributes.size() < 1 && options.skipAttributeCreation )

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -453,7 +453,7 @@ void QgsSearchQueryBuilder::loadQuery()
   for ( ; attIt != attributes.constEnd(); ++attIt )
   {
     //test if attribute is there
-    if ( !mFieldMap.contains( *attIt ) )
+    if ( !mFieldMap.contains( attIt ) )
     {
       bool ok;
       QString replaceAttribute = QInputDialog::getItem( 0, tr( "Select attribute" ), tr( "There is no attribute '%1' in the current vector layer. Please select an existing attribute" ).arg( *attIt ),

--- a/src/plugins/geometry_checker/checks/qgsgeometryareacheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryareacheck.cpp
@@ -198,7 +198,7 @@ bool QgsGeometryAreaCheck::mergeWithNeighbor( QgsFeature &feature, int partIdx, 
   QgsGeometry mergeFeatureGeom = mergeFeature.geometry();
   QgsAbstractGeometry *mergeGeom = mergeFeatureGeom.geometry();
   QgsGeometryEngine *geomEngine = QgsGeometryCheckerUtils::createGeomEngine( QgsGeometryCheckerUtils::getGeomPart( mergeGeom, mergePartIdx ), QgsGeometryCheckPrecision::tolerance() );
-  QgsAbstractGeometry *combinedGeom = geomEngine->combine( *QgsGeometryCheckerUtils::getGeomPart( geom, partIdx ), &errMsg );
+  QgsAbstractGeometry *combinedGeom = geomEngine->combine( QgsGeometryCheckerUtils::getGeomPart( geom, partIdx ), &errMsg );
   delete geomEngine;
   if ( !combinedGeom || combinedGeom->isEmpty() )
   {

--- a/src/plugins/geometry_checker/checks/qgsgeometrycontainedcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrycontainedcheck.cpp
@@ -46,7 +46,7 @@ void QgsGeometryContainedCheck::collectErrors( QList<QgsGeometryCheckError *> &e
       }
 
       QString errMsg;
-      if ( geomEngine->within( *otherFeature.geometry().geometry(), &errMsg ) )
+      if ( geomEngine->within( otherFeature.geometry().geometry(), &errMsg ) )
       {
         errors.append( new QgsGeometryContainedCheckError( this, featureid, feature.geometry().geometry()->centroid(), otherid ) );
       }
@@ -76,7 +76,7 @@ void QgsGeometryContainedCheck::fixError( QgsGeometryCheckError *error, int meth
   QgsGeometry featureGeom = feature.geometry();
   QgsGeometryEngine *geomEngine = QgsGeometryCheckerUtils::createGeomEngine( featureGeom.geometry(), QgsGeometryCheckPrecision::tolerance() );
 
-  if ( !geomEngine->within( *otherFeature.geometry().geometry() ) )
+  if ( !geomEngine->within( otherFeature.geometry().geometry() ) )
   {
     delete geomEngine;
     error->setObsolete();

--- a/src/plugins/geometry_checker/checks/qgsgeometryduplicatecheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryduplicatecheck.cpp
@@ -48,7 +48,7 @@ void QgsGeometryDuplicateCheck::collectErrors( QList<QgsGeometryCheckError *> &e
         continue;
       }
       QString errMsg;
-      QgsAbstractGeometry *diffGeom = geomEngine->symDifference( *testFeature.geometry().geometry(), &errMsg );
+      QgsAbstractGeometry *diffGeom = geomEngine->symDifference( testFeature.geometry().geometry(), &errMsg );
       if ( diffGeom && diffGeom->area() < QgsGeometryCheckPrecision::tolerance() )
       {
         duplicates.append( id );
@@ -94,7 +94,7 @@ void QgsGeometryDuplicateCheck::fixError( QgsGeometryCheckError *error, int meth
       {
         continue;
       }
-      QgsAbstractGeometry *diffGeom = geomEngine->symDifference( *testFeature.geometry().geometry() );
+      QgsAbstractGeometry *diffGeom = geomEngine->symDifference( testFeature.geometry().geometry() );
       if ( diffGeom && diffGeom->area() < QgsGeometryCheckPrecision::tolerance() )
       {
         mFeaturePool->deleteFeature( testFeature );

--- a/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.cpp
@@ -74,7 +74,7 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
 
   // Compute difference between envelope and union to obtain gap polygons
   geomEngine = QgsGeometryCheckerUtils::createGeomEngine( envelope, QgsGeometryCheckPrecision::tolerance() );
-  QgsAbstractGeometry *diffGeom = geomEngine->difference( *unionGeom, &errMsg );
+  QgsAbstractGeometry *diffGeom = geomEngine->difference( unionGeom, &errMsg );
   delete geomEngine;
   if ( !diffGeom )
   {
@@ -198,7 +198,7 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( QgsGeometryGapCheckError *err, Chan
   QgsGeometry mergeFeatureGeom = mergeFeature.geometry();
   QgsAbstractGeometry *mergeGeom = mergeFeatureGeom.geometry();
   QgsGeometryEngine *geomEngine = QgsGeometryCheckerUtils::createGeomEngine( errGeometry, QgsGeometryCheckPrecision::tolerance() );
-  QgsAbstractGeometry *combinedGeom = geomEngine->combine( *QgsGeometryCheckerUtils::getGeomPart( mergeGeom, mergePartIdx ), &errMsg );
+  QgsAbstractGeometry *combinedGeom = geomEngine->combine( QgsGeometryCheckerUtils::getGeomPart( mergeGeom, mergePartIdx ), &errMsg );
   delete geomEngine;
   if ( !combinedGeom || combinedGeom->isEmpty() )
   {

--- a/src/plugins/geometry_checker/checks/qgsgeometryoverlapcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryoverlapcheck.cpp
@@ -48,9 +48,9 @@ void QgsGeometryOverlapCheck::collectErrors( QList<QgsGeometryCheckError *> &err
       }
 
       QString errMsg;
-      if ( geomEngine->overlaps( *otherFeature.geometry().geometry(), &errMsg ) )
+      if ( geomEngine->overlaps( otherFeature.geometry().geometry(), &errMsg ) )
       {
-        QgsAbstractGeometry *interGeom = geomEngine->intersection( *otherFeature.geometry().geometry() );
+        QgsAbstractGeometry *interGeom = geomEngine->intersection( otherFeature.geometry().geometry() );
         if ( interGeom && !interGeom->isEmpty() )
         {
           QgsGeometryCheckerUtils::filter1DTypes( interGeom );
@@ -92,13 +92,13 @@ void QgsGeometryOverlapCheck::fixError( QgsGeometryCheckError *error, int method
   QgsGeometryEngine *geomEngine = QgsGeometryCheckerUtils::createGeomEngine( geom, QgsGeometryCheckPrecision::tolerance() );
 
   // Check if error still applies
-  if ( !geomEngine->overlaps( *otherFeature.geometry().geometry() ) )
+  if ( !geomEngine->overlaps( otherFeature.geometry().geometry() ) )
   {
     delete geomEngine;
     error->setObsolete();
     return;
   }
-  QgsAbstractGeometry *interGeom = geomEngine->intersection( *otherFeature.geometry().geometry(), &errMsg );
+  QgsAbstractGeometry *interGeom = geomEngine->intersection( otherFeature.geometry().geometry(), &errMsg );
   delete geomEngine;
   if ( !interGeom )
   {
@@ -133,7 +133,7 @@ void QgsGeometryOverlapCheck::fixError( QgsGeometryCheckError *error, int method
   else if ( method == Subtract )
   {
     geomEngine = QgsGeometryCheckerUtils::createGeomEngine( geom, QgsGeometryCheckPrecision::reducedTolerance() );
-    QgsAbstractGeometry *diff1 = geomEngine->difference( *interPart, &errMsg );
+    QgsAbstractGeometry *diff1 = geomEngine->difference( interPart, &errMsg );
     delete geomEngine;
     if ( !diff1 || diff1->isEmpty() )
     {
@@ -146,7 +146,7 @@ void QgsGeometryOverlapCheck::fixError( QgsGeometryCheckError *error, int method
     }
     QgsGeometry otherFeatureGeom = otherFeature.geometry();
     QgsGeometryEngine *otherGeomEngine = QgsGeometryCheckerUtils::createGeomEngine( otherFeatureGeom.geometry(), QgsGeometryCheckPrecision::reducedTolerance() );
-    QgsAbstractGeometry *diff2 = otherGeomEngine->difference( *interPart, &errMsg );
+    QgsAbstractGeometry *diff2 = otherGeomEngine->difference( interPart, &errMsg );
     delete otherGeomEngine;
     if ( !diff2 || diff2->isEmpty() )
     {

--- a/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.cpp
@@ -211,9 +211,9 @@ void QgsGeometrySelfIntersectionCheck::fixError( QgsGeometryCheckError *error, i
         QgsGeometryEngine *geomEnginePoly2 = QgsGeometryCheckerUtils::createGeomEngine( poly2, QgsGeometryCheckPrecision::tolerance() );
         for ( int n = poly->numInteriorRings(), i = n - 1; i >= 0; --i )
         {
-          if ( !geomEnginePoly1->contains( *poly->interiorRing( i ) ) )
+          if ( !geomEnginePoly1->contains( poly->interiorRing( i ) ) )
           {
-            if ( geomEnginePoly2->contains( *poly->interiorRing( i ) ) )
+            if ( geomEnginePoly2->contains( poly->interiorRing( i ) ) )
             {
               poly2->addInteriorRing( static_cast<QgsCurve *>( poly->interiorRing( i )->clone() ) );
               // No point in adding ChangeAdded changes, since the entire poly2 is added anyways later on

--- a/src/plugins/spatialquery/qgsspatialquery.cpp
+++ b/src/plugins/spatialquery/qgsspatialquery.cpp
@@ -208,7 +208,7 @@ void QgsSpatialQuery::setSpatialIndexReference( QgsFeatureIds &qsetIndexInvalidR
 
 void QgsSpatialQuery::execQuery( QgsFeatureIds &qsetIndexResult, QgsFeatureIds &qsetIndexInvalidTarget, int relation )
 {
-  bool ( QgsGeometryEngine::* operation )( const QgsAbstractGeometry &, QString * ) const;
+  bool ( QgsGeometryEngine::* operation )( const QgsAbstractGeometry *, QString * ) const;
   switch ( relation )
   {
     case Disjoint:
@@ -245,7 +245,7 @@ void QgsSpatialQuery::execQuery( QgsFeatureIds &qsetIndexResult, QgsFeatureIds &
   coordinateTransform->setCoordinateTransform( mLayerTarget, mLayerReference );
 
   // Set function for populate result
-  void ( QgsSpatialQuery::* funcPopulateIndexResult )( QgsFeatureIds &, QgsFeatureId, const QgsGeometry &, bool ( QgsGeometryEngine::* )( const QgsAbstractGeometry &, QString * ) const );
+  void ( QgsSpatialQuery::* funcPopulateIndexResult )( QgsFeatureIds &, QgsFeatureId, const QgsGeometry &, bool ( QgsGeometryEngine::* )( const QgsAbstractGeometry *, QString * ) const );
   funcPopulateIndexResult = ( relation == Disjoint )
                             ? &QgsSpatialQuery::populateIndexResultDisjoint
                             : &QgsSpatialQuery::populateIndexResult;
@@ -273,7 +273,7 @@ void QgsSpatialQuery::execQuery( QgsFeatureIds &qsetIndexResult, QgsFeatureIds &
 
 void QgsSpatialQuery::populateIndexResult(
   QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, const QgsGeometry &geomTarget,
-  bool ( QgsGeometryEngine::* op )( const QgsAbstractGeometry &, QString * ) const )
+  bool ( QgsGeometryEngine::* op )( const QgsAbstractGeometry *, QString * ) const )
 {
   QgsFeatureIds listIdReference = mIndexReference.intersects( geomTarget.boundingBox() ).toSet();
   if ( listIdReference.isEmpty() )
@@ -293,7 +293,7 @@ void QgsSpatialQuery::populateIndexResult(
   {
     geomReference = featureReference.geometry();
 
-    if ( ( geomEngine->*op )( *geomReference.geometry(), 0 ) )
+    if ( ( geomEngine->*op )( geomReference.geometry(), 0 ) )
     {
       qsetIndexResult.insert( idTarget );
       break;
@@ -305,7 +305,7 @@ void QgsSpatialQuery::populateIndexResult(
 
 void QgsSpatialQuery::populateIndexResultDisjoint(
   QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, const QgsGeometry &geomTarget,
-  bool ( QgsGeometryEngine::* op )( const QgsAbstractGeometry &, QString * ) const )
+  bool ( QgsGeometryEngine::* op )( const QgsAbstractGeometry *, QString * ) const )
 {
   QgsFeatureIds listIdReference = mIndexReference.intersects( geomTarget.boundingBox() ).toSet();
   if ( listIdReference.isEmpty() )
@@ -326,7 +326,7 @@ void QgsSpatialQuery::populateIndexResultDisjoint(
   while ( listIt.nextFeature( featureReference ) )
   {
     geomReference = featureReference.geometry();
-    if ( ( geomEngine->*op )( *geomReference.geometry(), 0 ) )
+    if ( ( geomEngine->*op )( geomReference.geometry(), 0 ) )
     {
       addIndex = false;
       break;

--- a/src/plugins/spatialquery/qgsspatialquery.h
+++ b/src/plugins/spatialquery/qgsspatialquery.h
@@ -138,7 +138,7 @@ class QgsSpatialQuery
      * \param operation          Pointer to function of GEOS operation
      */
     void populateIndexResult( QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, const QgsGeometry &geomTarget,
-                              bool ( QgsGeometryEngine::* operation )( const QgsAbstractGeometry &, QString * ) const );
+                              bool ( QgsGeometryEngine::*operation )( const QgsAbstractGeometry *, QString * ) const );
 
     /**
      * \brief Populate index Result Disjoint
@@ -148,7 +148,7 @@ class QgsSpatialQuery
      * \param operation          Pointer to function of GEOS operation
      */
     void populateIndexResultDisjoint( QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, const QgsGeometry &geomTarget,
-                                      bool ( QgsGeometryEngine::*operation )( const QgsAbstractGeometry &, QString * ) const );
+                                      bool ( QgsGeometryEngine::*operation )( const QgsAbstractGeometry *, QString * ) const );
 
     MngProgressBar *mPb = nullptr;
     bool mUseReferenceSelection;


### PR DESCRIPTION
because using this more consistently throughout the codebase makes it
easier to maintain code.
We also do not want to call the copy constructor on them, using pointers
just makes this more obvious. Further, casting is also something
that's commonly done on pointers and not references.

And if you want a value or a reference, just use QgsGeometry, it's meant
to be handled like this.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
