### PR TITLE
Return enum instead of int from QgsGeometry operations

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -44,6 +44,23 @@ class QgsGeometry
 #include "qgsgeometry.h"
 %End
   public:
+
+    enum OperationResult
+    {
+      Success,
+      NothingHappened,
+      InvalidBaseGeometry,
+      InvalidInput,
+      GeometryEngineError,
+      AddPartSelectedGeometryNotFound,
+      AddPartNotMultiGeometry,
+      AddRingNotClosed,
+      AddRingNotValid,
+      AddRingCrossesExistingRings,
+      AddRingNotInExistingFeature,
+      SplitCannotSplitPoint,
+    };
+
     QgsGeometry();
 %Docstring
 Constructor
@@ -380,63 +397,58 @@ Returns true if WKB of the geometry is of WKBMulti* type
  :rtype: float
 %End
 
-    int addRing( const QList<QgsPointXY> &ring );
+    OperationResult addRing( const QList<QgsPointXY> &ring );
 %Docstring
  Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
-:return: 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*
- :rtype: int
+ \param ring The ring to be added
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int addRing( QgsCurve *ring /Transfer/ );
+    OperationResult addRing( QgsCurve *ring /Transfer/ );
 %Docstring
  Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
-:return: 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*
- :rtype: int
+ \param ring The ring to be added
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int addPart( const QList<QgsPointXY> &points, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::UnknownGeometry ) /PyName=addPoints/;
+    OperationResult addPart( const QList<QgsPointXY> &points, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::UnknownGeometry ) /PyName=addPoints/;
 %Docstring
  Adds a new part to a the geometry.
  \param points points describing part to add
  \param geomType default geometry type to create if no existing geometry
- :return: 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
- not disjoint with existing polygons of the feature
- :rtype: int
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int addPart( const QgsPointSequence &points, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::UnknownGeometry ) /PyName=addPointsV2/;
+    OperationResult addPart( const QgsPointSequence &points, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::UnknownGeometry ) /PyName=addPointsV2/;
 %Docstring
  Adds a new part to a the geometry.
  \param points points describing part to add
  \param geomType default geometry type to create if no existing geometry
- :return: 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
- not disjoint with existing polygons of the feature
- :rtype: int
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int addPart( QgsAbstractGeometry *part /Transfer/, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::UnknownGeometry );
+    OperationResult addPart( QgsAbstractGeometry *part /Transfer/, QgsWkbTypes::GeometryType geomType = QgsWkbTypes::UnknownGeometry );
 %Docstring
  Adds a new part to this geometry.
  \param part part to add (ownership is transferred)
  \param geomType default geometry type to create if no existing geometry
- :return: 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
- not disjoint with existing polygons of the feature
- :rtype: int
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
 
-    int addPart( const QgsGeometry &newPart ) /PyName=addPartGeometry/;
+    OperationResult addPart( const QgsGeometry &newPart ) /PyName=addPartGeometry/;
 %Docstring
  Adds a new island polygon to a multipolygon feature
-:return: 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-not disjoint with existing polygons of the feature
+ :return: OperationResult a result code: success or reason of failure
 .. note::
 
-   available in Python bindings as addPartGeometry
-.. versionadded:: 2.2
- :rtype: int
+   available in python bindings as addPartGeometry
+ :rtype: OperationResult
 %End
 
     QgsGeometry removeInteriorRings( double minimumAllowedArea = -1 ) const;
@@ -448,52 +460,52 @@ not disjoint with existing polygons of the feature
  :rtype: QgsGeometry
 %End
 
-    int translate( double dx, double dy );
+    OperationResult translate( double dx, double dy );
 %Docstring
  Translate this geometry by dx, dy
-:return: 0 in case of success*
- :rtype: int
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int transform( const QgsCoordinateTransform &ct );
+    OperationResult transform( const QgsCoordinateTransform &ct );
 %Docstring
  Transform this geometry as described by CoordinateTransform ct
-:return: 0 in case of success*
- :rtype: int
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int transform( const QTransform &ct );
+    OperationResult transform( const QTransform &ct );
 %Docstring
  Transform this geometry as described by QTransform ct
-.. versionadded:: 2.8
-:return: 0 in case of success*
- :rtype: int
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int rotate( double rotation, const QgsPointXY &center );
+    OperationResult rotate( double rotation, const QgsPointXY &center );
 %Docstring
  Rotate this geometry around the Z axis
-.. versionadded:: 2.8
-\param rotation clockwise rotation in degrees
-\param center rotation center
-:return: 0 in case of success*
- :rtype: int
+ \param rotation clockwise rotation in degrees
+ \param center rotation center
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int splitGeometry( const QList<QgsPointXY> &splitLine,
-                       QList<QgsGeometry> &newGeometries /Out/,
-                       bool topological,
-                       QList<QgsPointXY> &topologyTestPoints /Out/ );
+    OperationResult splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeometry> &newGeometries, bool topological, QList<QgsPointXY> &topologyTestPoints );
 %Docstring
- :rtype: int
+ Splits this geometry according to a given line.
+ \param splitLine the line that splits the geometry
+ \param[out] newGeometries list of new geometries that have been created with the split
+ \param topological true if topological editing is enabled
+ \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
-    int reshapeGeometry( const QgsLineString &reshapeLineString );
+    OperationResult reshapeGeometry( const QgsLineString &reshapeLineString );
 %Docstring
  Replaces a part of this geometry with another line
- :return: 0 in case of success
-.. versionadded:: 1.3
- :rtype: int
+ :return: OperationResult a result code: success or reason of failure
+ :rtype: OperationResult
 %End
 
 

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -312,50 +312,50 @@ Returns true if WKB of the geometry is of WKBMulti* type
     bool moveVertex( double x, double y, int atVertex );
 %Docstring
  Moves the vertex at the given position number
-  and item (first number is index 0)
-  to the given coordinates.
-  Returns false if atVertex does not correspond to a valid vertex
-  on this geometry
+ and item (first number is index 0)
+ to the given coordinates.
+ Returns false if atVertex does not correspond to a valid vertex
+ on this geometry
  :rtype: bool
 %End
 
     bool moveVertex( const QgsPoint &p, int atVertex );
 %Docstring
  Moves the vertex at the given position number
-  and item (first number is index 0)
-  to the given coordinates.
-  Returns false if atVertex does not correspond to a valid vertex
-  on this geometry
+ and item (first number is index 0)
+ to the given coordinates.
+ Returns false if atVertex does not correspond to a valid vertex
+ on this geometry
  :rtype: bool
 %End
 
     bool deleteVertex( int atVertex );
 %Docstring
  Deletes the vertex at the given position number and item
-  (first number is index 0)
-  Returns false if atVertex does not correspond to a valid vertex
-  on this geometry (including if this geometry is a Point),
-  or if the number of remaining vertices in the linestring
-  would be less than two.
-  It is up to the caller to distinguish between
-  these error conditions.  (Or maybe we add another method to this
-  object to help make the distinction?)
+ (first number is index 0)
+ :return: false if atVertex does not correspond to a valid vertex
+ on this geometry (including if this geometry is a Point),
+ or if the number of remaining vertices in the linestring
+ would be less than two.
+ It is up to the caller to distinguish between
+ these error conditions.  (Or maybe we add another method to this
+ object to help make the distinction?)
  :rtype: bool
 %End
 
     QgsPoint vertexAt( int atVertex ) const;
 %Docstring
-  Returns coordinates of a vertex.
-  \param atVertex index of the vertex
-  :return: Coordinates of the vertex or QgsPoint(0,0) on error
+ Returns coordinates of a vertex.
+ \param atVertex index of the vertex
+ :return: Coordinates of the vertex or QgsPoint(0,0) on error
  :rtype: QgsPoint
 %End
 
     double sqrDistToVertexAt( QgsPointXY &point /In/, int atVertex ) const;
 %Docstring
-  Returns the squared Cartesian distance between the given point
-  to the given vertex index (vertex at the given position number,
-  ring and item (first number is index 0))
+ Returns the squared Cartesian distance between the given point
+ to the given vertex index (vertex at the given position number,
+ ring and item (first number is index 0))
  :rtype: float
 %End
 
@@ -462,21 +462,21 @@ Returns true if WKB of the geometry is of WKBMulti* type
 
     OperationResult translate( double dx, double dy );
 %Docstring
- Translate this geometry by dx, dy
+ Translates this geometry by dx, dy
  :return: OperationResult a result code: success or reason of failure
  :rtype: OperationResult
 %End
 
     OperationResult transform( const QgsCoordinateTransform &ct );
 %Docstring
- Transform this geometry as described by CoordinateTransform ct
+ Transforms this geometry as described by CoordinateTransform ct
  :return: OperationResult a result code: success or reason of failure
  :rtype: OperationResult
 %End
 
     OperationResult transform( const QTransform &ct );
 %Docstring
- Transform this geometry as described by QTransform ct
+ Transforms this geometry as described by QTransform ct
  :return: OperationResult a result code: success or reason of failure
  :rtype: OperationResult
 %End
@@ -549,32 +549,32 @@ Returns true if WKB of the geometry is of WKBMulti* type
 
     bool intersects( const QgsRectangle &r ) const;
 %Docstring
-Test for intersection with a rectangle (uses GEOS)
+Tests for intersection with a rectangle (uses GEOS)
  :rtype: bool
 %End
 
     bool intersects( const QgsGeometry &geometry ) const;
 %Docstring
-Test for intersection with a geometry (uses GEOS)
+Tests for intersection with a geometry (uses GEOS)
  :rtype: bool
 %End
 
     bool contains( const QgsPointXY *p ) const;
 %Docstring
-Test for containment of a point (uses GEOS)
+Tests for containment of a point (uses GEOS)
  :rtype: bool
 %End
 
     bool contains( const QgsGeometry &geometry ) const;
 %Docstring
- Test for if geometry is contained in another (uses GEOS)
+ Tests for if geometry is contained in another (uses GEOS)
 .. versionadded:: 1.5
  :rtype: bool
 %End
 
     bool disjoint( const QgsGeometry &geometry ) const;
 %Docstring
- Test for if geometry is disjoint of another (uses GEOS)
+ Tests for if geometry is disjoint of another (uses GEOS)
 .. versionadded:: 1.5
  :rtype: bool
 %End
@@ -637,7 +637,7 @@ Test for containment of a point (uses GEOS)
     QgsGeometry buffer( double distance, int segments ) const;
 %Docstring
  Returns a buffer region around this geometry having the given width and with a specified number
-of segments used to approximate curves *
+ of segments used to approximate curves
  :rtype: QgsGeometry
 %End
 
@@ -839,7 +839,7 @@ Returns a simplified version of this geometry using a specified tolerance value
 
     QgsGeometry interpolate( double distance ) const;
 %Docstring
- Return interpolated point on line at distance.
+ Returns interpolated point on line at distance.
 
  If the input is a NULL geometry, the output will also be a NULL geometry.
 
@@ -968,14 +968,14 @@ Returns an extruded version of this geometry.
 .. note::
 
    precision parameter added in QGIS 2.4
-  :return: true in case of success and false else
+ :return: true in case of success and false else
  :rtype: str
 %End
 
     QString exportToGeoJSON( int precision = 17 ) const;
 %Docstring
  Exports the geometry to GeoJSON
-  :return: a QString representing the geometry as GeoJSON
+ :return: a QString representing the geometry as GeoJSON
 .. versionadded:: 1.8
 .. note::
 
@@ -999,43 +999,43 @@ Returns an extruded version of this geometry.
 
     QgsPointXY asPoint() const;
 %Docstring
- Return contents of the geometry as a point
+ Returns contents of the geometry as a point
  if wkbType is WKBPoint, otherwise returns [0,0]
  :rtype: QgsPointXY
 %End
 
     QgsPolyline asPolyline() const;
 %Docstring
- Return contents of the geometry as a polyline
+ Returns contents of the geometry as a polyline
  if wkbType is WKBLineString, otherwise an empty list
  :rtype: QgsPolyline
 %End
 
     QgsPolygon asPolygon() const;
 %Docstring
- Return contents of the geometry as a polygon
+ Returns contents of the geometry as a polygon
  if wkbType is WKBPolygon, otherwise an empty list
  :rtype: QgsPolygon
 %End
 
     QgsMultiPoint asMultiPoint() const;
 %Docstring
- Return contents of the geometry as a multi point
-if wkbType is WKBMultiPoint, otherwise an empty list *
+ Returns contents of the geometry as a multi point
+ if wkbType is WKBMultiPoint, otherwise an empty list
  :rtype: QgsMultiPoint
 %End
 
     QgsMultiPolyline asMultiPolyline() const;
 %Docstring
- Return contents of the geometry as a multi linestring
-if wkbType is WKBMultiLineString, otherwise an empty list *
+ Returns contents of the geometry as a multi linestring
+ if wkbType is WKBMultiLineString, otherwise an empty list
  :rtype: QgsMultiPolyline
 %End
 
     QgsMultiPolygon asMultiPolygon() const;
 %Docstring
- Return contents of the geometry as a multi polygon
-if wkbType is WKBMultiPolygon, otherwise an empty list *
+ Returns contents of the geometry as a multi polygon
+ if wkbType is WKBMultiPolygon, otherwise an empty list
  :rtype: QgsMultiPolygon
 %End
 
@@ -1048,7 +1048,7 @@ if wkbType is WKBMultiPolygon, otherwise an empty list *
 
     QPointF asQPointF() const;
 %Docstring
- Return contents of the geometry as a QPointF if wkbType is WKBPoint,
+ Returns contents of the geometry as a QPointF if wkbType is WKBPoint,
  otherwise returns a null QPointF.
 .. versionadded:: 2.7
  :rtype: QPointF
@@ -1056,7 +1056,7 @@ if wkbType is WKBMultiPolygon, otherwise an empty list *
 
     QPolygonF asQPolygonF() const;
 %Docstring
- Return contents of the geometry as a QPolygonF. If geometry is a linestring,
+ Returns contents of the geometry as a QPolygonF. If geometry is a linestring,
  then the result will be an open QPolygonF. If the geometry is a polygon,
  then the result will be a closed QPolygonF of the geometry's exterior ring.
 .. versionadded:: 2.7
@@ -1065,17 +1065,17 @@ if wkbType is WKBMultiPolygon, otherwise an empty list *
 
     bool deleteRing( int ringNum, int partNum = 0 );
 %Docstring
- Delete a ring in polygon or multipolygon.
-Ring 0 is outer ring and can't be deleted.
-:return: true on success
+ Deletes a ring in polygon or multipolygon.
+ Ring 0 is outer ring and can't be deleted.
+ :return: true on success
 .. versionadded:: 1.2
  :rtype: bool
 %End
 
     bool deletePart( int partNum );
 %Docstring
- Delete part identified by the part number
-:return: true on success
+ Deletes part identified by the part number
+ :return: true on success
 .. versionadded:: 1.2
  :rtype: bool
 %End
@@ -1107,12 +1107,12 @@ Ring 0 is outer ring and can't be deleted.
 
 %Docstring
  Modifies geometry to avoid intersections with the layers specified in project properties
-  :return: 0 in case of success,
-          1 if geometry is not of polygon type,
-          2 if avoid intersection would change the geometry type,
-          3 other error during intersection removal
-  \param avoidIntersectionsLayers list of layers to check for intersections
-  \param ignoreFeatures possibility to give a list of features where intersections should be ignored (not available in Python bindings)
+ :return: 0 in case of success,
+         1 if geometry is not of polygon type,
+         2 if avoid intersection would change the geometry type,
+         3 other error during intersection removal
+ \param avoidIntersectionsLayers list of layers to check for intersections
+ \param ignoreFeatures possibility to give a list of features where intersections should be ignored (not available in Python bindings)
 .. versionadded:: 1.5
  :rtype: int
 %End
@@ -1172,7 +1172,7 @@ Ring 0 is outer ring and can't be deleted.
 
     void validateGeometry( QList<QgsGeometry::Error> &errors /Out/, ValidationMethod method = ValidatorQgisInternal );
 %Docstring
- Validate geometry and produce a list of geometry errors.
+ Validates geometry and produces a list of geometry errors.
  The ``method`` argument dictates which validator to utilize.
 .. versionadded:: 1.5
 .. note::

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -490,7 +490,7 @@ Returns true if WKB of the geometry is of WKBMulti* type
  :rtype: OperationResult
 %End
 
-    OperationResult splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeometry> &newGeometries, bool topological, QList<QgsPointXY> &topologyTestPoints );
+    OperationResult splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeometry> &newGeometries /Out/, bool topological, QList<QgsPointXY> &topologyTestPoints /Out/ );
 %Docstring
  Splits this geometry according to a given line.
  \param splitLine the line that splits the geometry

--- a/python/core/geometry/qgsgeometryengine.sip
+++ b/python/core/geometry/qgsgeometryengine.sip
@@ -21,6 +21,19 @@ class QgsGeometryEngine
 #include "qgsgeometryengine.h"
 %End
   public:
+
+    enum EngineOperationResult
+    {
+      Success,
+      NothingHappened,
+      MethodNotImplemented,
+      EngineError,
+      NodedGeometryError,
+      InvalidBaseGeometry,
+      InvalidInput,
+      SplitCannotSplitPoint,
+    };
+
     virtual ~QgsGeometryEngine();
 
     virtual void geometryChanged() = 0;
@@ -230,12 +243,12 @@ class QgsGeometryEngine
  :rtype: bool
 %End
 
-    virtual int splitGeometry( const QgsLineString &splitLine,
-                               QList<QgsAbstractGeometry *> &newGeometries,
-                               bool topological,
-                               QgsPointSequence &topologyTestPoints, QString *errorMsg = 0 ) const;
+    virtual QgsGeometryEngine::EngineOperationResult splitGeometry( const QgsLineString &splitLine,
+        QList<QgsAbstractGeometry *> &newGeometries,
+        bool topological,
+        QgsPointSequence &topologyTestPoints, QString *errorMsg = 0 ) const;
 %Docstring
- :rtype: int
+ :rtype: QgsGeometryEngine.EngineOperationResult
 %End
 
     virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, int joinStyle, double miterLimit, QString *errorMsg = 0 ) const = 0 /Factory/;

--- a/python/core/qgsvectorlayereditutils.sip
+++ b/python/core/qgsvectorlayereditutils.sip
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsVectorLayerEditUtils
 {
 
@@ -66,22 +65,22 @@ class QgsVectorLayerEditUtils
     QgsGeometry::OperationResult addRing( const QList<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 );
 %Docstring
  Adds a ring to polygon/multipolygon features
- @param ring ring to add
- @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+ \param ring ring to add
+ \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
  all intersecting features are tested and the ring is added to the first valid feature.
- @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
- @return OperationResult result code: success or reason of failure
+ \param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+ :return: OperationResult result code: success or reason of failure
  :rtype: QgsGeometry.OperationResult
 %End
 
     QgsGeometry::OperationResult addRing( QgsCurve *ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /PyName=addCurvedRing/;
 %Docstring
  Adds a ring to polygon/multipolygon features
- @param ring ring to add
- @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+ \param ring ring to add
+ \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
  all intersecting features are tested and the ring is added to the first valid feature.
- @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
- @return OperationResult result code: success or reason of failure
+ \param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+ :return: OperationResult result code: success or reason of failure
 .. note::
 
    available in python bindings as addCurvedRing
@@ -91,14 +90,25 @@ class QgsVectorLayerEditUtils
     QgsGeometry::OperationResult addPart( const QList<QgsPointXY> &ring, QgsFeatureId featureId );
 %Docstring
  Adds a new part polygon to a multipart feature
- @returns QgsGeometry.OperationResult a result code: success or reason of failure
+ :return:
+ - QgsGeometry.Success
+ - QgsGeometry.AddPartSelectedGeometryNotFound
+ - QgsGeometry.AddPartNotMultiGeometry
+ - QgsGeometry.InvalidBaseGeometry
+ - QgsGeometry.InvalidInput
  :rtype: QgsGeometry.OperationResult
 %End
 
     QgsGeometry::OperationResult addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
 %Docstring
  Adds a new part polygon to a multipart feature
- @returns QgsGeometry.OperationResult a result code: success or reason of failure
+
+ :return:
+ - QgsGeometry.Success
+ - QgsGeometry.AddPartSelectedGeometryNotFound
+ - QgsGeometry.AddPartNotMultiGeometry
+ - QgsGeometry.InvalidBaseGeometry
+ - QgsGeometry.InvalidInput
 .. note::
 
    available in python bindings as addPartV2
@@ -107,6 +117,18 @@ class QgsVectorLayerEditUtils
 
     QgsGeometry::OperationResult addPart( QgsCurve *ring, QgsFeatureId featureId ) /PyName=addCurvedPart/;
 %Docstring
+ Add a new part polygon to a multipart feature
+
+ :return:
+ - QgsGeometry.Success
+ - QgsGeometry.AddPartSelectedGeometryNotFound
+ - QgsGeometry.AddPartNotMultiGeometry
+ - QgsGeometry.InvalidBaseGeometry
+ - QgsGeometry.InvalidInput
+
+.. note::
+
+   available in python bindings as addCurvedPart
  :rtype: QgsGeometry.OperationResult
 %End
 
@@ -122,11 +144,28 @@ class QgsVectorLayerEditUtils
 
     QgsGeometry::OperationResult splitParts( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 %Docstring
+ Split parts cut by the given line
+ \param splitLine line that splits the layer feature parts
+ \param topologicalEditing true if topological editing is enabled
+ :return:
+  - QgsGeometry.InvalidBaseGeometry
+  - QgsGeometry.Success
+  - QgsGeometry.InvalidInput
+  - QgsGeometry.NothingHappened if a selection is present but no feature has been split
+  - QgsGeometry.InvalidBaseGeometry
+  - QgsGeometry.GeometryEngineError
+  - QgsGeometry.SplitCannotSplitPoint
  :rtype: QgsGeometry.OperationResult
 %End
 
     QgsGeometry::OperationResult splitFeatures( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 %Docstring
+ Splits features cut by the given line
+ \param splitLine line that splits the layer features
+ \param topologicalEditing true if topological editing is enabled
+ :return:
+  0 in case of success,
+  4 if there is a selection but no feature split
  :rtype: QgsGeometry.OperationResult
 %End
 

--- a/python/core/qgsvectorlayereditutils.sip
+++ b/python/core/qgsvectorlayereditutils.sip
@@ -21,32 +21,32 @@ class QgsVectorLayerEditUtils
     bool insertVertex( double x, double y, QgsFeatureId atFeatureId, int beforeVertex );
 %Docstring
  Insert a new vertex before the given vertex number,
-  in the given ring, item (first number is index 0), and feature
-  Not meaningful for Point geometries
+ in the given ring, item (first number is index 0), and feature
+ Not meaningful for Point geometries
  :rtype: bool
 %End
 
     bool insertVertex( const QgsPoint &point, QgsFeatureId atFeatureId, int beforeVertex );
 %Docstring
- Insert a new vertex before the given vertex number,
-  in the given ring, item (first number is index 0), and feature
-  Not meaningful for Point geometries
+ Inserts a new vertex before the given vertex number,
+ in the given ring, item (first number is index 0), and feature
+ Not meaningful for Point geometries
  :rtype: bool
 %End
 
     bool moveVertex( double x, double y, QgsFeatureId atFeatureId, int atVertex );
 %Docstring
  Moves the vertex at the given position number,
-  ring and item (first number is index 0), and feature
-  to the given coordinates
+ ring and item (first number is index 0), and feature
+ to the given coordinates
  :rtype: bool
 %End
 
     bool moveVertex( const QgsPoint &p, QgsFeatureId atFeatureId, int atVertex ) /PyName=moveVertexV2/;
 %Docstring
  Moves the vertex at the given position number,
-  ring and item (first number is index 0), and feature
-  to the given coordinates
+ ring and item (first number is index 0), and feature
+ to the given coordinates
 .. note::
 
    available in Python bindings as moveVertexV2
@@ -117,7 +117,7 @@ class QgsVectorLayerEditUtils
 
     QgsGeometry::OperationResult addPart( QgsCurve *ring, QgsFeatureId featureId ) /PyName=addCurvedPart/;
 %Docstring
- Add a new part polygon to a multipart feature
+ Adds a new part polygon to a multipart feature
 
  :return:
  - QgsGeometry.Success
@@ -144,7 +144,7 @@ class QgsVectorLayerEditUtils
 
     QgsGeometry::OperationResult splitParts( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 %Docstring
- Split parts cut by the given line
+ Splits parts cut by the given line
  \param splitLine line that splits the layer feature parts
  \param topologicalEditing true if topological editing is enabled
  :return:

--- a/python/core/qgsvectorlayereditutils.sip
+++ b/python/core/qgsvectorlayereditutils.sip
@@ -63,29 +63,51 @@ class QgsVectorLayerEditUtils
  :rtype: QgsVectorLayer.EditResult
 %End
 
-    int addRing( const QList<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 );
+    QgsGeometry::OperationResult addRing( const QList<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 );
 %Docstring
- :rtype: int
+ Adds a ring to polygon/multipolygon features
+ @param ring ring to add
+ @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+ all intersecting features are tested and the ring is added to the first valid feature.
+ @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+ @return OperationResult result code: success or reason of failure
+ :rtype: QgsGeometry.OperationResult
 %End
 
-    int addRing( QgsCurve *ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /PyName=addCurvedRing/;
+    QgsGeometry::OperationResult addRing( QgsCurve *ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /PyName=addCurvedRing/;
 %Docstring
- :rtype: int
+ Adds a ring to polygon/multipolygon features
+ @param ring ring to add
+ @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+ all intersecting features are tested and the ring is added to the first valid feature.
+ @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+ @return OperationResult result code: success or reason of failure
+.. note::
+
+   available in python bindings as addCurvedRing
+ :rtype: QgsGeometry.OperationResult
 %End
 
-    int addPart( const QList<QgsPointXY> &ring, QgsFeatureId featureId );
+    QgsGeometry::OperationResult addPart( const QList<QgsPointXY> &ring, QgsFeatureId featureId );
 %Docstring
- :rtype: int
+ Adds a new part polygon to a multipart feature
+ @returns QgsGeometry.OperationResult a result code: success or reason of failure
+ :rtype: QgsGeometry.OperationResult
 %End
 
-    int addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
+    QgsGeometry::OperationResult addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
 %Docstring
- :rtype: int
+ Adds a new part polygon to a multipart feature
+ @returns QgsGeometry.OperationResult a result code: success or reason of failure
+.. note::
+
+   available in python bindings as addPartV2
+ :rtype: QgsGeometry.OperationResult
 %End
 
-    int addPart( QgsCurve *ring, QgsFeatureId featureId ) /PyName=addCurvedPart/;
+    QgsGeometry::OperationResult addPart( QgsCurve *ring, QgsFeatureId featureId ) /PyName=addCurvedPart/;
 %Docstring
- :rtype: int
+ :rtype: QgsGeometry.OperationResult
 %End
 
     int translateFeature( QgsFeatureId featureId, double dx, double dy );
@@ -98,14 +120,14 @@ class QgsVectorLayerEditUtils
  :rtype: int
 %End
 
-    int splitParts( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
+    QgsGeometry::OperationResult splitParts( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 %Docstring
- :rtype: int
+ :rtype: QgsGeometry.OperationResult
 %End
 
-    int splitFeatures( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
+    QgsGeometry::OperationResult splitFeatures( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 %Docstring
- :rtype: int
+ :rtype: QgsGeometry.OperationResult
 %End
 
     int addTopologicalPoints( const QgsGeometry &geom );
@@ -127,15 +149,6 @@ class QgsVectorLayerEditUtils
  editing.
  \param p position of the vertex
  :return: 0 in case of success
- :rtype: int
-%End
-
-  protected:
-
-    int boundingBoxFromPointList( const QList<QgsPointXY> &list, double &xmin, double &ymin, double &xmax, double &ymax ) const;
-%Docstring
- Little helper function that gives bounding box from a list of points.
-:return: 0 in case of success *
  :rtype: int
 %End
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -626,7 +626,7 @@ double QgsGeometry::closestSegmentWithContext(
   return sqrDist;
 }
 
-int QgsGeometry::addRing( const QList<QgsPointXY> &ring )
+QgsGeometry::OperationResult QgsGeometry::addRing( const QList<QgsPointXY> &ring )
 {
   detach( true );
 
@@ -634,12 +634,12 @@ int QgsGeometry::addRing( const QList<QgsPointXY> &ring )
   return addRing( ringLine );
 }
 
-int QgsGeometry::addRing( QgsCurve *ring )
+QgsGeometry::OperationResult QgsGeometry::addRing( QgsCurve *ring )
 {
   if ( !d->geometry )
   {
     delete ring;
-    return 1;
+    return InvalidInput;
   }
 
   detach( true );
@@ -647,14 +647,14 @@ int QgsGeometry::addRing( QgsCurve *ring )
   return QgsGeometryEditUtils::addRing( d->geometry, ring );
 }
 
-int QgsGeometry::addPart( const QList<QgsPointXY> &points, QgsWkbTypes::GeometryType geomType )
+QgsGeometry::OperationResult QgsGeometry::addPart( const QList<QgsPointXY> &points, QgsWkbTypes::GeometryType geomType )
 {
   QgsPointSequence l;
   convertPointList( points, l );
   return addPart( l, geomType );
 }
 
-int QgsGeometry::addPart( const QgsPointSequence &points, QgsWkbTypes::GeometryType geomType )
+QgsGeometry::OperationResult QgsGeometry::addPart( const QgsPointSequence &points, QgsWkbTypes::GeometryType geomType )
 {
   QgsAbstractGeometry *partGeom = nullptr;
   if ( points.size() == 1 )
@@ -670,7 +670,7 @@ int QgsGeometry::addPart( const QgsPointSequence &points, QgsWkbTypes::GeometryT
   return addPart( partGeom, geomType );
 }
 
-int QgsGeometry::addPart( QgsAbstractGeometry *part, QgsWkbTypes::GeometryType geomType )
+QgsGeometry::OperationResult QgsGeometry::addPart( QgsAbstractGeometry *part, QgsWkbTypes::GeometryType geomType )
 {
   if ( !d->geometry )
   {
@@ -687,7 +687,7 @@ int QgsGeometry::addPart( QgsAbstractGeometry *part, QgsWkbTypes::GeometryType g
         d->geometry = new QgsMultiPolygonV2();
         break;
       default:
-        return 1;
+        return QgsGeometry::AddPartNotMultiGeometry;
     }
   }
   else
@@ -699,11 +699,15 @@ int QgsGeometry::addPart( QgsAbstractGeometry *part, QgsWkbTypes::GeometryType g
   return QgsGeometryEditUtils::addPart( d->geometry, part );
 }
 
-int QgsGeometry::addPart( const QgsGeometry &newPart )
+QgsGeometry::OperationResult QgsGeometry::addPart( const QgsGeometry &newPart )
 {
-  if ( !d->geometry || !newPart.d || !newPart.d->geometry )
+  if ( !d->geometry )
   {
-    return 1;
+    return QgsGeometry::InvalidBaseGeometry;
+  }
+  if ( !newPart.d || !newPart.d->geometry )
+  {
+    return QgsGeometry::AddPartNotMultiGeometry;
   }
 
   return addPart( newPart.d->geometry->clone() );
@@ -744,11 +748,15 @@ QgsGeometry QgsGeometry::removeInteriorRings( double minimumRingArea ) const
   }
 }
 
-int QgsGeometry::addPart( GEOSGeometry *newPart )
+QgsGeometry::OperationResult QgsGeometry::addPart( GEOSGeometry *newPart )
 {
-  if ( !d->geometry || !newPart )
+  if ( !d->geometry )
   {
-    return 1;
+    return QgsGeometry::InvalidBaseGeometry;
+  }
+  if ( !newPart )
+  {
+    return QgsGeometry::AddPartNotMultiGeometry;
   }
 
   detach( true );
@@ -757,24 +765,24 @@ int QgsGeometry::addPart( GEOSGeometry *newPart )
   return QgsGeometryEditUtils::addPart( d->geometry, geom );
 }
 
-int QgsGeometry::translate( double dx, double dy )
+QgsGeometry::OperationResult QgsGeometry::translate( double dx, double dy )
 {
   if ( !d->geometry )
   {
-    return 1;
+    return QgsGeometry::InvalidBaseGeometry;
   }
 
   detach( true );
 
   d->geometry->transform( QTransform::fromTranslate( dx, dy ) );
-  return 0;
+  return QgsGeometry::Success;
 }
 
-int QgsGeometry::rotate( double rotation, const QgsPointXY &center )
+QgsGeometry::OperationResult QgsGeometry::rotate( double rotation, const QgsPointXY &center )
 {
   if ( !d->geometry )
   {
-    return 1;
+    return QgsGeometry::InvalidBaseGeometry;
   }
 
   detach( true );
@@ -783,14 +791,14 @@ int QgsGeometry::rotate( double rotation, const QgsPointXY &center )
   t.rotate( -rotation );
   t.translate( -center.x(), -center.y() );
   d->geometry->transform( t );
-  return 0;
+  return QgsGeometry::Success;
 }
 
-int QgsGeometry::splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeometry> &newGeometries, bool topological, QList<QgsPointXY> &topologyTestPoints )
+QgsGeometry::OperationResult QgsGeometry::splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeometry> &newGeometries, bool topological, QList<QgsPointXY> &topologyTestPoints )
 {
   if ( !d->geometry )
   {
-    return 0;
+    return InvalidBaseGeometry;
   }
 
   QList<QgsAbstractGeometry *> newGeoms;
@@ -798,9 +806,9 @@ int QgsGeometry::splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeo
   QgsPointSequence tp;
 
   QgsGeos geos( d->geometry );
-  int result = geos.splitGeometry( splitLineString, newGeoms, topological, tp );
+  QgsGeometryEngine::EngineOperationResult result = geos.splitGeometry( splitLineString, newGeoms, topological, tp );
 
-  if ( result == 0 )
+  if ( result == QgsGeometryEngine::Success )
   {
     detach( false );
     d->geometry = newGeoms.at( 0 );
@@ -813,27 +821,69 @@ int QgsGeometry::splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeo
   }
 
   convertPointList( tp, topologyTestPoints );
-  return result;
+
+  switch ( result )
+  {
+    case QgsGeometryEngine::Success:
+      return QgsGeometry::Success;
+    case QgsGeometryEngine::MethodNotImplemented:
+    case QgsGeometryEngine::EngineError:
+    case QgsGeometryEngine::NodedGeometryError:
+      return QgsGeometry::GeometryEngineError;
+    case QgsGeometryEngine::InvalidBaseGeometry:
+      return QgsGeometry::InvalidBaseGeometry;
+    case QgsGeometryEngine::InvalidInput:
+      return QgsGeometry::InvalidInput;
+    case QgsGeometryEngine::SplitCannotSplitPoint:
+      return QgsGeometry::SplitCannotSplitPoint;
+    case QgsGeometryEngine::NothingHappened:
+      return QgsGeometry::NothingHappened;
+      //default: do not implement default to handle properly all cases
+  }
+
+  // this should never be reached
+  Q_ASSERT( false );
+  return QgsGeometry::NothingHappened;
 }
 
-int QgsGeometry::reshapeGeometry( const QgsLineString &reshapeLineString )
+QgsGeometry::OperationResult QgsGeometry::reshapeGeometry( const QgsLineString &reshapeLineString )
 {
   if ( !d->geometry )
   {
-    return 0;
+    return InvalidBaseGeometry;
   }
 
   QgsGeos geos( d->geometry );
-  int errorCode = 0;
+  QgsGeometryEngine::EngineOperationResult errorCode = QgsGeometryEngine::Success;
   QgsAbstractGeometry *geom = geos.reshapeGeometry( reshapeLineString, &errorCode );
-  if ( errorCode == 0 && geom )
+  if ( errorCode == QgsGeometryEngine::Success && geom )
   {
     detach( false );
     delete d->geometry;
     d->geometry = geom;
-    return 0;
+    return Success;
   }
-  return errorCode;
+
+  switch ( errorCode )
+  {
+    case QgsGeometryEngine::Success:
+      return Success;
+    case QgsGeometryEngine::MethodNotImplemented:
+    case QgsGeometryEngine::EngineError:
+    case QgsGeometryEngine::NodedGeometryError:
+      return GeometryEngineError;
+    case QgsGeometryEngine::InvalidBaseGeometry:
+      return InvalidBaseGeometry;
+    case QgsGeometryEngine::InvalidInput:
+      return InvalidInput;
+    case QgsGeometryEngine::SplitCannotSplitPoint: // should not happen
+      return GeometryEngineError;
+    case QgsGeometryEngine::NothingHappened:
+      return NothingHappened;
+  }
+
+  // should not be reached
+  return GeometryEngineError;
 }
 
 int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other )
@@ -2091,28 +2141,28 @@ bool QgsGeometry::requiresConversionToStraightSegments() const
   return d->geometry->hasCurvedSegments();
 }
 
-int QgsGeometry::transform( const QgsCoordinateTransform &ct )
+QgsGeometry::OperationResult QgsGeometry::transform( const QgsCoordinateTransform &ct )
 {
   if ( !d->geometry )
   {
-    return 1;
+    return QgsGeometry::InvalidBaseGeometry;
   }
 
   detach();
   d->geometry->transform( ct );
-  return 0;
+  return QgsGeometry::Success;
 }
 
-int QgsGeometry::transform( const QTransform &ct )
+QgsGeometry::OperationResult QgsGeometry::transform( const QTransform &ct )
 {
   if ( !d->geometry )
   {
-    return 1;
+    return QgsGeometry::InvalidBaseGeometry;
   }
 
   detach();
   d->geometry->transform( ct );
-  return 0;
+  return QgsGeometry::Success;
 }
 
 void QgsGeometry::mapToPixel( const QgsMapToPixel &mtp )

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -705,7 +705,7 @@ QgsGeometry::OperationResult QgsGeometry::addPart( const QgsGeometry &newPart )
   {
     return QgsGeometry::InvalidBaseGeometry;
   }
-  if ( !newPart.d || !newPart.d->geometry )
+  if ( !newPart || !newPart.d->geometry )
   {
     return QgsGeometry::AddPartNotMultiGeometry;
   }

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -126,12 +126,14 @@ class CORE_EXPORT QgsGeometry
     //! Copy constructor will prompt a deep copy of the object
     QgsGeometry( const QgsGeometry & );
 
-    /** Assignments will prompt a deep copy of the object
+    /**
+     * Creates a deep copy of the object
      * \note not available in Python bindings
      */
     QgsGeometry &operator=( QgsGeometry const &rhs ) SIP_SKIP;
 
-    /** Creates a geometry from an abstract geometry object. Ownership of
+    /**
+     * Creates a geometry from an abstract geometry object. Ownership of
      * geom is transferred.
      * \since QGIS 2.10
      */
@@ -140,19 +142,22 @@ class CORE_EXPORT QgsGeometry
 
     ~QgsGeometry();
 
-    /** Returns the underlying geometry store.
+    /**
+     * Returns the underlying geometry store.
     * \since QGIS 2.10
     * \see setGeometry
     */
     QgsAbstractGeometry *geometry() const;
 
-    /** Sets the underlying geometry store. Ownership of geometry is transferred.
+    /**
+     * Sets the underlying geometry store. Ownership of geometry is transferred.
      * \since QGIS 2.10
      * \see geometry
      */
     void setGeometry( QgsAbstractGeometry *geometry SIP_TRANSFER );
 
-    /** Returns true if the geometry is null (ie, contains no underlying geometry
+    /**
+     * Returns true if the geometry is null (ie, contains no underlying geometry
      * accessible via geometry() ).
      * \see geometry
      * \since QGIS 2.10
@@ -187,9 +192,9 @@ class CORE_EXPORT QgsGeometry
     void fromGeos( GEOSGeometry *geos ) SIP_SKIP;
 
     /**
-      Set the geometry, feeding in the buffer containing OGC Well-Known Binary and the buffer's length.
-      This class will take ownership of the buffer.
-      \note not available in Python bindings
+     * Set the geometry, feeding in the buffer containing OGC Well-Known Binary and the buffer's length.
+     * This class will take ownership of the buffer.
+     * \note not available in Python bindings
      */
     void fromWkb( unsigned char *wkb, int length ) SIP_SKIP;
 
@@ -228,12 +233,12 @@ class CORE_EXPORT QgsGeometry
     bool isMultipart() const;
 
     /** Compares the geometry with another geometry using GEOS
-      \since QGIS 1.5
+     * \since QGIS 1.5
      */
     bool isGeosEqual( const QgsGeometry & ) const;
 
     /** Checks validity of the geometry using GEOS
-      \since QGIS 1.5
+     * \since QGIS 1.5
      */
     bool isGeosValid() const;
 
@@ -246,13 +251,15 @@ class CORE_EXPORT QgsGeometry
      */
     bool isSimple() const;
 
-    /** Returns the area of the geometry using GEOS
-      \since QGIS 1.5
+    /**
+     * Returns the area of the geometry using GEOS
+     * \since QGIS 1.5
      */
     double area() const;
 
-    /** Returns the length of geometry using GEOS
-      \since QGIS 1.5
+    /**
+     * Returns the length of geometry using GEOS
+     * \since QGIS 1.5
      */
     double length() const;
 
@@ -336,55 +343,60 @@ class CORE_EXPORT QgsGeometry
      */
     bool insertVertex( const QgsPoint &point, int beforeVertex );
 
-    /** Moves the vertex at the given position number
-     *  and item (first number is index 0)
-     *  to the given coordinates.
-     *  Returns false if atVertex does not correspond to a valid vertex
-     *  on this geometry
+    /**
+     * Moves the vertex at the given position number
+     * and item (first number is index 0)
+     * to the given coordinates.
+     * Returns false if atVertex does not correspond to a valid vertex
+     * on this geometry
      */
     bool moveVertex( double x, double y, int atVertex );
 
-    /** Moves the vertex at the given position number
-     *  and item (first number is index 0)
-     *  to the given coordinates.
-     *  Returns false if atVertex does not correspond to a valid vertex
-     *  on this geometry
+    /**
+     * Moves the vertex at the given position number
+     * and item (first number is index 0)
+     * to the given coordinates.
+     * Returns false if atVertex does not correspond to a valid vertex
+     * on this geometry
      */
     bool moveVertex( const QgsPoint &p, int atVertex );
 
-    /** Deletes the vertex at the given position number and item
-     *  (first number is index 0)
-     *  Returns false if atVertex does not correspond to a valid vertex
-     *  on this geometry (including if this geometry is a Point),
-     *  or if the number of remaining vertices in the linestring
-     *  would be less than two.
-     *  It is up to the caller to distinguish between
-     *  these error conditions.  (Or maybe we add another method to this
-     *  object to help make the distinction?)
+    /**
+     * Deletes the vertex at the given position number and item
+     * (first number is index 0)
+     * \returns false if atVertex does not correspond to a valid vertex
+     * on this geometry (including if this geometry is a Point),
+     * or if the number of remaining vertices in the linestring
+     * would be less than two.
+     * It is up to the caller to distinguish between
+     * these error conditions.  (Or maybe we add another method to this
+     * object to help make the distinction?)
      */
     bool deleteVertex( int atVertex );
 
     /**
-     *  Returns coordinates of a vertex.
-     *  \param atVertex index of the vertex
-     *  \returns Coordinates of the vertex or QgsPoint(0,0) on error
+     * Returns coordinates of a vertex.
+     * \param atVertex index of the vertex
+     * \returns Coordinates of the vertex or QgsPoint(0,0) on error
      */
     QgsPoint vertexAt( int atVertex ) const;
 
     /**
-     *  Returns the squared Cartesian distance between the given point
-     *  to the given vertex index (vertex at the given position number,
-     *  ring and item (first number is index 0))
+     * Returns the squared Cartesian distance between the given point
+     * to the given vertex index (vertex at the given position number,
+     * ring and item (first number is index 0))
      */
     double sqrDistToVertexAt( QgsPointXY &point SIP_IN, int atVertex ) const;
 
-    /** Returns the nearest point on this geometry to another geometry.
+    /**
+     * Returns the nearest point on this geometry to another geometry.
      * \since QGIS 2.14
      * \see shortestLine()
      */
     QgsGeometry nearestPoint( const QgsGeometry &other ) const;
 
-    /** Returns the shortest line joining this geometry to another geometry.
+    /**
+     * Returns the shortest line joining this geometry to another geometry.
      * \since QGIS 2.14
      * \see nearestPoint()
      */
@@ -476,19 +488,19 @@ class CORE_EXPORT QgsGeometry
     QgsGeometry removeInteriorRings( double minimumAllowedArea = -1 ) const;
 
     /**
-     * Translate this geometry by dx, dy
+     * Translates this geometry by dx, dy
      * \returns OperationResult a result code: success or reason of failure
      */
     OperationResult translate( double dx, double dy );
 
     /**
-     * Transform this geometry as described by CoordinateTransform ct
+     * Transforms this geometry as described by CoordinateTransform ct
      * \returns OperationResult a result code: success or reason of failure
      */
     OperationResult transform( const QgsCoordinateTransform &ct );
 
     /**
-     * Transform this geometry as described by QTransform ct
+     * Transforms this geometry as described by QTransform ct
      * \returns OperationResult a result code: success or reason of failure
      */
     OperationResult transform( const QTransform &ct );
@@ -558,41 +570,48 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry orthogonalize( double tolerance = 1.0E-8, int maxIterations = 1000, double angleThreshold = 15.0 ) const;
 
-    //! Test for intersection with a rectangle (uses GEOS)
+    //! Tests for intersection with a rectangle (uses GEOS)
     bool intersects( const QgsRectangle &r ) const;
 
-    //! Test for intersection with a geometry (uses GEOS)
+    //! Tests for intersection with a geometry (uses GEOS)
     bool intersects( const QgsGeometry &geometry ) const;
 
-    //! Test for containment of a point (uses GEOS)
+    //! Tests for containment of a point (uses GEOS)
     bool contains( const QgsPointXY *p ) const;
 
-    /** Test for if geometry is contained in another (uses GEOS)
-     *  \since QGIS 1.5 */
+    /** Tests for if geometry is contained in another (uses GEOS)
+     *  \since QGIS 1.5
+     */
     bool contains( const QgsGeometry &geometry ) const;
 
-    /** Test for if geometry is disjoint of another (uses GEOS)
-     *  \since QGIS 1.5 */
+    /** Tests for if geometry is disjoint of another (uses GEOS)
+     *  \since QGIS 1.5
+     */
     bool disjoint( const QgsGeometry &geometry ) const;
 
     /** Test for if geometry equals another (uses GEOS)
-     *  \since QGIS 1.5 */
+     *  \since QGIS 1.5
+     */
     bool equals( const QgsGeometry &geometry ) const;
 
     /** Test for if geometry touch another (uses GEOS)
-     *  \since QGIS 1.5 */
+     *  \since QGIS 1.5
+     */
     bool touches( const QgsGeometry &geometry ) const;
 
     /** Test for if geometry overlaps another (uses GEOS)
-     *  \since QGIS 1.5 */
+     *  \since QGIS 1.5
+     */
     bool overlaps( const QgsGeometry &geometry ) const;
 
     /** Test for if geometry is within another (uses GEOS)
-     *  \since QGIS 1.5 */
+     *  \since QGIS 1.5
+     */
     bool within( const QgsGeometry &geometry ) const;
 
     /** Test for if geometry crosses another (uses GEOS)
-     *  \since QGIS 1.5 */
+     *  \since QGIS 1.5
+     */
     bool crosses( const QgsGeometry &geometry ) const;
 
     //! Side of line to buffer
@@ -618,11 +637,14 @@ class CORE_EXPORT QgsGeometry
       JoinStyleBevel, //!< Use beveled joins
     };
 
-    /** Returns a buffer region around this geometry having the given width and with a specified number
-        of segments used to approximate curves */
+    /**
+     * Returns a buffer region around this geometry having the given width and with a specified number
+     * of segments used to approximate curves
+     */
     QgsGeometry buffer( double distance, int segments ) const;
 
-    /** Returns a buffer region around the geometry, with additional style options.
+    /**
+     * Returns a buffer region around the geometry, with additional style options.
      * \param distance    buffer distance
      * \param segments    for round joins, number of segments to approximate quarter-circle
      * \param endCapStyle end cap style
@@ -632,7 +654,8 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry buffer( double distance, int segments, EndCapStyle endCapStyle, JoinStyle joinStyle, double miterLimit ) const;
 
-    /** Returns an offset line at a given distance and side from an input line.
+    /**
+     * Returns an offset line at a given distance and side from an input line.
      * \param distance    buffer distance
      * \param segments    for round joins, number of segments to approximate quarter-circle
      * \param joinStyle   join style for corners in geometry
@@ -799,7 +822,7 @@ class CORE_EXPORT QgsGeometry
     QgsGeometry subdivide( int maxNodes = 256 ) const;
 
     /**
-     * Return interpolated point on line at distance.
+     * Returns interpolated point on line at distance.
      *
      * If the input is a NULL geometry, the output will also be a NULL geometry.
      *
@@ -811,7 +834,8 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry interpolate( double distance ) const;
 
-    /** Returns a distance representing the location along this linestring of the closest point
+    /**
+     * Returns a distance representing the location along this linestring of the closest point
      * on this linestring geometry to the specified point. Ie, the returned value indicates
      * how far along this linestring you need to traverse to get to the closest location
      * where this linestring comes to the specified point.
@@ -823,7 +847,8 @@ class CORE_EXPORT QgsGeometry
      */
     double lineLocatePoint( const QgsGeometry &point ) const;
 
-    /** Returns the angle parallel to the linestring or polygon boundary at the specified distance
+    /**
+     * Returns the angle parallel to the linestring or polygon boundary at the specified distance
      * along the geometry. Angles are in radians, clockwise from north.
      * If the distance coincides precisely at a node then the average angle from the segment either side
      * of the node is returned.
@@ -903,21 +928,24 @@ class CORE_EXPORT QgsGeometry
      */
     QByteArray exportToWkb() const;
 
-    /** Exports the geometry to WKT
-     *  \note precision parameter added in QGIS 2.4
-     *  \returns true in case of success and false else
+    /**
+     * Exports the geometry to WKT
+     * \note precision parameter added in QGIS 2.4
+     * \returns true in case of success and false else
      */
     QString exportToWkt( int precision = 17 ) const;
 
-    /** Exports the geometry to GeoJSON
-     *  \returns a QString representing the geometry as GeoJSON
-     *  \since QGIS 1.8
-     *  \note Available in Python bindings since QGIS 1.9
-     *  \note precision parameter added in QGIS 2.4
+    /**
+     * Exports the geometry to GeoJSON
+     * \returns a QString representing the geometry as GeoJSON
+     * \since QGIS 1.8
+     * \note Available in Python bindings since QGIS 1.9
+     * \note precision parameter added in QGIS 2.4
      */
     QString exportToGeoJSON( int precision = 17 ) const;
 
-    /** Try to convert the geometry to the requested type
+    /**
+     * Try to convert the geometry to the requested type
      * \param destType the geometry type to be converted to
      * \param destMultipart determines if the output geometry will be multipart or not
      * \returns the converted geometry or nullptr if the conversion fails.
@@ -927,59 +955,76 @@ class CORE_EXPORT QgsGeometry
 
     /* Accessor functions for getting geometry data */
 
-    /** Return contents of the geometry as a point
+    /**
+     * Returns contents of the geometry as a point
      * if wkbType is WKBPoint, otherwise returns [0,0]
      */
     QgsPointXY asPoint() const;
 
-    /** Return contents of the geometry as a polyline
+    /**
+     * Returns contents of the geometry as a polyline
      * if wkbType is WKBLineString, otherwise an empty list
      */
     QgsPolyline asPolyline() const;
 
-    /** Return contents of the geometry as a polygon
+    /**
+     * Returns contents of the geometry as a polygon
      * if wkbType is WKBPolygon, otherwise an empty list
      */
     QgsPolygon asPolygon() const;
 
-    /** Return contents of the geometry as a multi point
-        if wkbType is WKBMultiPoint, otherwise an empty list */
+    /**
+     * Returns contents of the geometry as a multi point
+     * if wkbType is WKBMultiPoint, otherwise an empty list
+     */
     QgsMultiPoint asMultiPoint() const;
 
-    /** Return contents of the geometry as a multi linestring
-        if wkbType is WKBMultiLineString, otherwise an empty list */
+    /**
+     * Returns contents of the geometry as a multi linestring
+     * if wkbType is WKBMultiLineString, otherwise an empty list
+     */
     QgsMultiPolyline asMultiPolyline() const;
 
-    /** Return contents of the geometry as a multi polygon
-        if wkbType is WKBMultiPolygon, otherwise an empty list */
+    /**
+     * Returns contents of the geometry as a multi polygon
+     * if wkbType is WKBMultiPolygon, otherwise an empty list
+     */
     QgsMultiPolygon asMultiPolygon() const;
 
-    /** Return contents of the geometry as a list of geometries
-     \since QGIS 1.1 */
+    /**
+     * Return contents of the geometry as a list of geometries
+     * \since QGIS 1.1
+     */
     QList<QgsGeometry> asGeometryCollection() const;
 
-    /** Return contents of the geometry as a QPointF if wkbType is WKBPoint,
+    /**
+     * Returns contents of the geometry as a QPointF if wkbType is WKBPoint,
      * otherwise returns a null QPointF.
      * \since QGIS 2.7
      */
     QPointF asQPointF() const;
 
-    /** Return contents of the geometry as a QPolygonF. If geometry is a linestring,
+    /**
+     * Returns contents of the geometry as a QPolygonF. If geometry is a linestring,
      * then the result will be an open QPolygonF. If the geometry is a polygon,
      * then the result will be a closed QPolygonF of the geometry's exterior ring.
      * \since QGIS 2.7
      */
     QPolygonF asQPolygonF() const;
 
-    /** Delete a ring in polygon or multipolygon.
-      Ring 0 is outer ring and can't be deleted.
-      \returns true on success
-      \since QGIS 1.2 */
+    /**
+     * Deletes a ring in polygon or multipolygon.
+     * Ring 0 is outer ring and can't be deleted.
+     * \returns true on success
+     * \since QGIS 1.2
+     */
     bool deleteRing( int ringNum, int partNum = 0 );
 
-    /** Delete part identified by the part number
-      \returns true on success
-      \since QGIS 1.2 */
+    /**
+     * Deletes part identified by the part number
+     * \returns true on success
+     * \since QGIS 1.2
+     */
     bool deletePart( int partNum );
 
     /**
@@ -1003,14 +1048,15 @@ class CORE_EXPORT QgsGeometry
      */
     bool convertToSingleType();
 
-    /** Modifies geometry to avoid intersections with the layers specified in project properties
-     *  \returns 0 in case of success,
-     *          1 if geometry is not of polygon type,
-     *          2 if avoid intersection would change the geometry type,
-     *          3 other error during intersection removal
-     *  \param avoidIntersectionsLayers list of layers to check for intersections
-     *  \param ignoreFeatures possibility to give a list of features where intersections should be ignored (not available in Python bindings)
-     *  \since QGIS 1.5
+    /**
+     * Modifies geometry to avoid intersections with the layers specified in project properties
+     * \returns 0 in case of success,
+     *         1 if geometry is not of polygon type,
+     *         2 if avoid intersection would change the geometry type,
+     *         3 other error during intersection removal
+     * \param avoidIntersectionsLayers list of layers to check for intersections
+     * \param ignoreFeatures possibility to give a list of features where intersections should be ignored (not available in Python bindings)
+     * \since QGIS 1.5
      */
     int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
                             const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures SIP_PYARGREMOVE = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) );
@@ -1072,7 +1118,8 @@ class CORE_EXPORT QgsGeometry
       ValidatorGeos, //!< Use GEOS validation methods
     };
 
-    /** Validate geometry and produce a list of geometry errors.
+    /**
+     * Validates geometry and produces a list of geometry errors.
      * The \a method argument dictates which validator to utilize.
      * \since QGIS 1.5
      * \note Available in Python bindings since QGIS 1.6
@@ -1095,32 +1142,37 @@ class CORE_EXPORT QgsGeometry
      */
     static QgsGeometry polygonize( const QList< QgsGeometry> &geometries );
 
-    /** Converts the geometry to straight line segments, if it is a curved geometry type.
+    /**
+     * Converts the geometry to straight line segments, if it is a curved geometry type.
      * \since QGIS 2.10
      * \see requiresConversionToStraightSegments
      */
     void convertToStraightSegment();
 
-    /** Returns true if the geometry is a curved geometry type which requires conversion to
+    /**
+     * Returns true if the geometry is a curved geometry type which requires conversion to
      * display as straight line segments.
      * \since QGIS 2.10
      * \see convertToStraightSegment
      */
     bool requiresConversionToStraightSegments() const;
 
-    /** Transforms the geometry from map units to pixels in place.
+    /**
+     * Transforms the geometry from map units to pixels in place.
      * \param mtp map to pixel transform
      * \since QGIS 2.10
      */
     void mapToPixel( const QgsMapToPixel &mtp );
 
-    /** Draws the geometry onto a QPainter
+    /**
+     * Draws the geometry onto a QPainter
      * \param p destination QPainter
      * \since QGIS 2.10
      */
     void draw( QPainter &p ) const;
 
-    /** Calculates the vertex ID from a vertex number
+    /**
+     * Calculates the vertex ID from a vertex number
      * \param nr vertex number
      * \param id reference to QgsVertexId for storing result
      * \returns true if vertex was found
@@ -1129,7 +1181,8 @@ class CORE_EXPORT QgsGeometry
      */
     bool vertexIdFromVertexNr( int nr, QgsVertexId &id SIP_OUT ) const;
 
-    /** Returns the vertex number corresponding to a vertex idd
+    /**
+     * Returns the vertex number corresponding to a vertex idd
      * \param i vertex id
      * \returns vertex number
      * \since QGIS 2.10
@@ -1145,19 +1198,22 @@ class CORE_EXPORT QgsGeometry
      */
     QString error() const;
 
-    /** Return GEOS context handle
+    /**
+     * Return GEOS context handle
      * \since QGIS 2.6
      * \note not available in Python
      */
     static GEOSContextHandle_t getGEOSHandler() SIP_SKIP;
 
-    /** Construct geometry from a QPointF
+    /**
+     * Construct geometry from a QPointF
      * \param point source QPointF
      * \since QGIS 2.7
      */
     static QgsGeometry fromQPointF( QPointF point );
 
-    /** Construct geometry from a QPolygonF. If the polygon is closed than
+    /**
+     * Construct geometry from a QPolygonF. If the polygon is closed than
      * the resultant geometry will be a polygon, if it is open than the
      * geometry will be a polyline.
      * \param polygon source QPolygonF
@@ -1165,14 +1221,16 @@ class CORE_EXPORT QgsGeometry
      */
     static QgsGeometry fromQPolygonF( const QPolygonF &polygon );
 
-    /** Creates a QgsPolyline from a QPolygonF.
+    /**
+     * Creates a QgsPolyline from a QPolygonF.
      * \param polygon source polygon
      * \returns QgsPolyline
      * \see createPolygonFromQPolygonF
      */
     static QgsPolyline createPolylineFromQPolygonF( const QPolygonF &polygon ) SIP_FACTORY;
 
-    /** Creates a QgsPolygon from a QPolygonF.
+    /**
+     * Creates a QgsPolygon from a QPolygonF.
      * \param polygon source polygon
      * \returns QgsPolygon
      * \see createPolylineFromQPolygonF
@@ -1192,7 +1250,8 @@ class CORE_EXPORT QgsGeometry
     static bool compare( const QgsPolyline &p1, const QgsPolyline &p2,
                          double epsilon = 4 * std::numeric_limits<double>::epsilon() );
 
-    /** Compares two polygons for equality within a specified tolerance.
+    /**
+     * Compares two polygons for equality within a specified tolerance.
      * \param p1 first polygon
      * \param p2 second polygon
      * \param epsilon maximum difference for coordinates between the polygons
@@ -1203,7 +1262,8 @@ class CORE_EXPORT QgsGeometry
     static bool compare( const QgsPolygon &p1, const QgsPolygon &p2,
                          double epsilon = 4 * std::numeric_limits<double>::epsilon() );
 
-    /** Compares two multipolygons for equality within a specified tolerance.
+    /**
+     * Compares two multipolygons for equality within a specified tolerance.
      * \param p1 first multipolygon
      * \param p2 second multipolygon
      * \param epsilon maximum difference for coordinates between the multipolygons
@@ -1216,7 +1276,8 @@ class CORE_EXPORT QgsGeometry
                          double epsilon = 4 * std::numeric_limits<double>::epsilon() );
 #else
 
-    /** Compares two geometry objects for equality within a specified tolerance.
+    /**
+     * Compares two geometry objects for equality within a specified tolerance.
      * The objects can be of type QgsPolyline, QgsPolygon or QgsMultiPolygon.
      * The 2 types should match.
      * \param p1 first geometry object
@@ -1332,7 +1393,8 @@ class CORE_EXPORT QgsGeometry
     % End
 #endif
 
-    /** Smooths a geometry by rounding off corners using the Chaikin algorithm. This operation
+    /**
+     * Smooths a geometry by rounding off corners using the Chaikin algorithm. This operation
      * roughly doubles the number of vertices in a geometry.
      * \param iterations number of smoothing iterations to run. More iterations results
      * in a smoother geometry
@@ -1346,17 +1408,20 @@ class CORE_EXPORT QgsGeometry
     QgsGeometry smooth( const unsigned int iterations = 1, const double offset = 0.25,
                         double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
-    /** Creates and returns a new geometry engine
+    /**
+     * Creates and returns a new geometry engine
      */
     static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry ) SIP_FACTORY;
 
-    /** Upgrades a point list from QgsPointXY to QgsPointV2
+    /**
+     * Upgrades a point list from QgsPointXY to QgsPointV2
      * \param input list of QgsPointXY objects to be upgraded
      * \param output destination for list of points converted to QgsPointV2
      */
     static void convertPointList( const QList<QgsPointXY> &input, QgsPointSequence &output );
 
-    /** Downgrades a point list from QgsPoint to QgsPoint
+    /**
+     * Downgrades a point list from QgsPoint to QgsPoint
      * \param input list of QgsPoint objects to be downgraded
      * \param output destination for list of points converted to QgsPoint
      */
@@ -1368,7 +1433,8 @@ class CORE_EXPORT QgsGeometry
       return QVariant::fromValue( *this );
     }
 
-    /** Returns true if the geometry is non empty (ie, isNull() returns false),
+    /**
+     * Returns true if the geometry is non empty (ie, isNull() returns false),
      * or false if it is an empty, uninitialized geometry (ie, isNull() returns true).
      * \since QGIS 3.0
      */

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -104,7 +104,7 @@ class CORE_EXPORT QgsGeometry
     enum OperationResult
     {
       Success = 0, //!< Operation succeeded
-      NothingHappened, //!< Nothing happened, without any error
+      NothingHappened = 1000, //!< Nothing happened, without any error
       InvalidBaseGeometry, //!< The base geometry on which the operation is done is invalid or empty
       InvalidInput, //!< The input geometry (ring, part, split line, etc.) has not the correct geometry type
       GeometryEngineError, //!< Geometry engine misses a method implemented or an error occured in the geometry engine

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -107,7 +107,7 @@ class CORE_EXPORT QgsGeometry
       NothingHappened = 1000, //!< Nothing happened, without any error
       InvalidBaseGeometry, //!< The base geometry on which the operation is done is invalid or empty
       InvalidInput, //!< The input geometry (ring, part, split line, etc.) has not the correct geometry type
-      GeometryEngineError, //!< Geometry engine misses a method implemented or an error occured in the geometry engine
+      GeometryEngineError, //!< Geometry engine misses a method implemented or an error occurred in the geometry engine
       /* Add part issues */
       AddPartSelectedGeometryNotFound, //!< The selected geometry cannot be found
       AddPartNotMultiGeometry, //!< The source geometry is not multi

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -509,7 +509,7 @@ class CORE_EXPORT QgsGeometry
      * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
      * \returns OperationResult a result code: success or reason of failure
      */
-    OperationResult splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeometry> &newGeometries, bool topological, QList<QgsPointXY> &topologyTestPoints );
+    OperationResult splitGeometry( const QList<QgsPointXY> &splitLine, QList<QgsGeometry> &newGeometries SIP_OUT, bool topological, QList<QgsPointXY> &topologyTestPoints SIP_OUT );
 
     /**
      * Replaces a part of this geometry with another line

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -99,7 +99,7 @@ class CORE_EXPORT QgsGeometry
 
     /**
      * Success or failure of a geometry operation.
-     * This gived details about cause of failure.
+     * This gives details about cause of failure.
      */
     enum OperationResult
     {

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -120,9 +120,7 @@ QgsGeometry::OperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry 
   if ( QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::MultiSurface
        || QgsWkbTypes::flatType( geom->wkbType() ) == QgsWkbTypes::MultiPolygon )
   {
-    std::unique_ptr<QgsCurve> curve( qgsgeometry_cast<QgsCurve *>( part.get() ) );
-    if ( curve )
-      part.release();
+    QgsCurve *curve = qgsgeometry_cast<QgsCurve *>( part.get() );
 
     if ( curve && curve->isClosed() && curve->numPoints() >= 4 )
     {
@@ -135,7 +133,10 @@ QgsGeometry::OperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry 
       {
         poly.reset( new QgsCurvePolygon() );
       }
-      poly->setExteriorRing( curve.release() );
+      // Ownership is still with part, curve points to the same object and is transferred
+      // to poly here.
+      part.release();
+      poly->setExteriorRing( curve );
       added = geomCollection->addGeometry( poly.release() );
     }
     else if ( QgsWkbTypes::flatType( part->wkbType() ) == QgsWkbTypes::Polygon )

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -24,6 +24,7 @@ class QgsVectorLayer;
 #define SIP_NO_FILE
 
 #include "qgsfeature.h"
+#include "qgsgeometry.h"
 #include <QMap>
 
 /** \ingroup core
@@ -36,19 +37,24 @@ class QgsGeometryEditUtils
 {
   public:
 
-    /** Adds interior ring (taking ownership).
-    \returns 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-    3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
-    static int addRing( QgsAbstractGeometry *geom, QgsCurve *ring );
+    /**
+     * Add an interior \a ring to a \a geometry.
+     * Ownership of the \a ring is transferred.
+     * \returns 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
+     * 3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring
+     */
+    static QgsGeometry::OperationResult addRing( QgsAbstractGeometry *geometry, QgsCurve *ring SIP_TRANSFER );
 
-    /** Adds part to multi type geometry (taking ownership)
-    \returns 0 in case of success, 1 if not a multigeometry, 2 if part is not a valid geometry, 3 if new polygon ring
-    not disjoint with existing polygons of the feature*/
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
-    static int addPart( QgsAbstractGeometry *geom, QgsAbstractGeometry *part );
+    /**
+     * Add a \a part to multi type \a geometry.
+     * Ownership of the \a part is transferred.
+     * \returns 0 in case of success, 1 if not a multigeometry, 2 if part is not a valid geometry, 3 if new polygon ring
+     * not disjoint with existing polygons of the feature
+     */
+    static QgsGeometry::OperationResult addPart( QgsAbstractGeometry *geometry, QgsAbstractGeometry *part SIP_TRANSFER );
 
-    /** Deletes a ring from a geometry.
+    /**
+     * Deletes a ring from a geometry.
      * \returns true if delete was successful
      */
     static bool deleteRing( QgsAbstractGeometry *geom, int ringNum, int partNum = 0 );

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -18,6 +18,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 #include "qgis_core.h"
 #include "qgslinestring.h"
+#include "qgsgeometry.h"
 
 #include <QList>
 
@@ -31,6 +32,24 @@ class QgsAbstractGeometry;
 class CORE_EXPORT QgsGeometryEngine
 {
   public:
+
+    /**
+     * Success or failure of a geometry operation.
+     * This gived details about cause of failure.
+     */
+    enum EngineOperationResult
+    {
+      Success = 0, //!< Operation succeeded
+      NothingHappened, //!< Nothing happened, without any error
+      MethodNotImplemented, //!< Method not implemented in geometry engine
+      EngineError, //!< Error occured in the geometry engine
+      NodedGeometryError, //!< Error occured while creating a noded geometry
+      InvalidBaseGeometry, //!< The geometry on which the operation occurs is not valid
+      InvalidInput, //!< The input is not valid
+      /* split */
+      SplitCannotSplitPoint, //!< Points cannot be split
+    };
+
     virtual ~QgsGeometryEngine() = default;
 
     virtual void geometryChanged() = 0;
@@ -190,17 +209,17 @@ class CORE_EXPORT QgsGeometryEngine
      */
     virtual bool isSimple( QString *errorMsg = nullptr ) const = 0;
 
-    virtual int splitGeometry( const QgsLineString &splitLine,
-                               QList<QgsAbstractGeometry *> &newGeometries,
-                               bool topological,
-                               QgsPointSequence &topologyTestPoints, QString *errorMsg = nullptr ) const
+    virtual QgsGeometryEngine::EngineOperationResult splitGeometry( const QgsLineString &splitLine,
+        QList<QgsAbstractGeometry *> &newGeometries,
+        bool topological,
+        QgsPointSequence &topologyTestPoints, QString *errorMsg = nullptr ) const
     {
       Q_UNUSED( splitLine );
       Q_UNUSED( newGeometries );
       Q_UNUSED( topological );
       Q_UNUSED( topologyTestPoints );
       Q_UNUSED( errorMsg );
-      return 2;
+      return MethodNotImplemented;
     }
 
     virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, int joinStyle, double miterLimit, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -40,7 +40,7 @@ class CORE_EXPORT QgsGeometryEngine
     enum EngineOperationResult
     {
       Success = 0, //!< Operation succeeded
-      NothingHappened, //!< Nothing happened, without any error
+      NothingHappened = 1000, //!< Nothing happened, without any error
       MethodNotImplemented, //!< Method not implemented in geometry engine
       EngineError, //!< Error occured in the geometry engine
       NodedGeometryError, //!< Error occured while creating a noded geometry

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -35,15 +35,15 @@ class CORE_EXPORT QgsGeometryEngine
 
     /**
      * Success or failure of a geometry operation.
-     * This gived details about cause of failure.
+     * This gives details about cause of failure.
      */
     enum EngineOperationResult
     {
       Success = 0, //!< Operation succeeded
       NothingHappened = 1000, //!< Nothing happened, without any error
       MethodNotImplemented, //!< Method not implemented in geometry engine
-      EngineError, //!< Error occured in the geometry engine
-      NodedGeometryError, //!< Error occured while creating a noded geometry
+      EngineError, //!< Error occurred in the geometry engine
+      NodedGeometryError, //!< Error occurred while creating a noded geometry
       InvalidBaseGeometry, //!< The geometry on which the operation occurs is not valid
       InvalidInput, //!< The input is not valid
       /* split */

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -20,6 +20,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 #include "qgis_core.h"
 #include "qgsgeometryengine.h"
+#include "qgsgeometry.h"
 #include <geos_c.h>
 
 class QgsLineString;
@@ -106,11 +107,11 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
     \param[out] errorMsg error messages emitted, if any
     \returns 0 in case of success, 1 if geometry has not been split, error else*/
-    int splitGeometry( const QgsLineString &splitLine,
-                       QList<QgsAbstractGeometry *> &newGeometries,
-                       bool topological,
-                       QgsPointSequence &topologyTestPoints,
-                       QString *errorMsg = nullptr ) const override;
+    EngineOperationResult splitGeometry( const QgsLineString &splitLine,
+                                         QList<QgsAbstractGeometry *> &newGeometries,
+                                         bool topological,
+                                         QgsPointSequence &topologyTestPoints,
+                                         QString *errorMsg = nullptr ) const override;
 
     QgsAbstractGeometry *offsetCurve( double distance, int segments, int joinStyle, double miterLimit, QString *errorMsg = nullptr ) const override;
 
@@ -131,8 +132,14 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
                                             int joinStyle, double miterLimit,
                                             QString *errorMsg = nullptr ) const;
 
-
-    QgsAbstractGeometry *reshapeGeometry( const QgsLineString &reshapeWithLine, int *errorCode, QString *errorMsg = nullptr ) const;
+    /**
+     * Reshapes the geometry using a line
+     * @param reshapeWithLine the line used to reshape lines or polygons
+     * @param errorCode if specified, provides result of operation (success or reason of failure)
+     * @param errorMsg if specified, provides more details about failure
+     * @return the reshaped geometry
+     */
+    QgsAbstractGeometry *reshapeGeometry( const QgsLineString &reshapeWithLine, EngineOperationResult *errorCode, QString *errorMsg = nullptr ) const;
 
     /** Merges any connected lines in a LineString/MultiLineString geometry and
      * converts them to single line strings.
@@ -261,10 +268,10 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     static GEOSGeometry *createGeosPolygon( const QgsAbstractGeometry *poly, double precision );
 
     //utils for geometry split
-    int topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPointSequence &testPoints, QString *errorMsg = nullptr ) const;
+    bool topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPointSequence &testPoints, QString *errorMsg = nullptr ) const;
     GEOSGeometry *linePointDifference( GEOSGeometry *GEOSsplitPoint ) const;
-    int splitLinearGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const;
-    int splitPolygonGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const;
+    EngineOperationResult splitLinearGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const;
+    EngineOperationResult splitPolygonGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const;
 
     //utils for reshape
     static GEOSGeometry *reshapeLine( const GEOSGeometry *line, const GEOSGeometry *reshapeLineGeos, double precision );

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -443,7 +443,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitParts( const QList<Qg
     fit = mLayer->getFeatures( QgsFeatureRequest().setFilterRect( bBox ).setFlags( QgsFeatureRequest::ExactIntersect ) );
   }
 
-  int addPartRet = 0;
+  QgsGeometry::OperationResult addPartRet = QgsGeometry::Success;
 
   QgsFeature feat;
   while ( fit.nextFeature( feat ) )
@@ -472,25 +472,6 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitParts( const QList<Qg
       {
         mLayer->editBuffer()->changeGeometry( feat.id(), featureGeom );
       }
-      else
-      {
-        // Test addPartRet
-        switch ( addPartRet )
-        {
-          case 1:
-            QgsDebugMsg( "Not a multipolygon" );
-            break;
-
-          case 2:
-            QgsDebugMsg( "Not a valid geometry" );
-            break;
-
-          case 3:
-            QgsDebugMsg( "New polygon ring" );
-            break;
-        }
-      }
-      mLayer->editBuffer()->changeGeometry( feat.id(), featureGeom );
 
       if ( topologicalEditing )
       {
@@ -502,13 +483,13 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitParts( const QList<Qg
       }
       ++numberOfSplitParts;
     }
-    else if ( splitFunctionReturn > 1 ) //1 means no split but also no error
+    else if ( splitFunctionReturn != QgsGeometry::Success && splitFunctionReturn != QgsGeometry::NothingHappened )
     {
       returnCode = splitFunctionReturn;
     }
   }
 
-  if ( numberOfSplitParts == 0 && mLayer->selectedFeatureCount() > 0  && returnCode == 0 )
+  if ( numberOfSplitParts == 0 && mLayer->selectedFeatureCount() > 0  && returnCode == QgsGeometry::Success )
   {
     //There is a selection but no feature has been split.
     //Maybe user forgot that only the selected features are split

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -277,7 +277,6 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QList
   if ( !mLayer->isSpatial() )
     return QgsGeometry::InvalidBaseGeometry;
 
-  QgsFeatureList newFeatures; //store all the newly created features
   double xMin, yMin, xMax, yMax;
   QgsRectangle bBox; //bounding box of the split line
   QgsGeometry::OperationResult returnCode = QgsGeometry::Success;
@@ -293,7 +292,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QList
   }
   else //else consider all the feature that intersect the bounding box of the split line
   {
-    if ( boundingBoxFromPointList( splitLine, xMin, yMin, xMax, yMax ) == 0 )
+    if ( boundingBoxFromPointList( splitLine, xMin, yMin, xMax, yMax ) )
     {
       bBox.setXMinimum( xMin );
       bBox.setYMinimum( yMin );
@@ -402,7 +401,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitParts( const QList<Qg
   }
   else //else consider all the feature that intersect the bounding box of the split line
   {
-    if ( boundingBoxFromPointList( splitLine, xMin, yMin, xMax, yMax ) == 0 )
+    if ( boundingBoxFromPointList( splitLine, xMin, yMin, xMax, yMax ) )
     {
       bBox.setXMinimum( xMin );
       bBox.setYMinimum( yMin );

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -32,39 +32,45 @@ class CORE_EXPORT QgsVectorLayerEditUtils
   public:
     QgsVectorLayerEditUtils( QgsVectorLayer *layer );
 
-    /** Insert a new vertex before the given vertex number,
-     *  in the given ring, item (first number is index 0), and feature
-     *  Not meaningful for Point geometries
+    /**
+     * Insert a new vertex before the given vertex number,
+     * in the given ring, item (first number is index 0), and feature
+     * Not meaningful for Point geometries
      */
     bool insertVertex( double x, double y, QgsFeatureId atFeatureId, int beforeVertex );
 
-    /** Insert a new vertex before the given vertex number,
-     *  in the given ring, item (first number is index 0), and feature
-     *  Not meaningful for Point geometries
+    /**
+     * Inserts a new vertex before the given vertex number,
+     * in the given ring, item (first number is index 0), and feature
+     * Not meaningful for Point geometries
      */
     bool insertVertex( const QgsPoint &point, QgsFeatureId atFeatureId, int beforeVertex );
 
-    /** Moves the vertex at the given position number,
-     *  ring and item (first number is index 0), and feature
-     *  to the given coordinates
+    /**
+     * Moves the vertex at the given position number,
+     * ring and item (first number is index 0), and feature
+     * to the given coordinates
      */
     bool moveVertex( double x, double y, QgsFeatureId atFeatureId, int atVertex );
 
-    /** Moves the vertex at the given position number,
-     *  ring and item (first number is index 0), and feature
-     *  to the given coordinates
-     *  \note available in Python bindings as moveVertexV2
+    /**
+     * Moves the vertex at the given position number,
+     * ring and item (first number is index 0), and feature
+     * to the given coordinates
+     * \note available in Python bindings as moveVertexV2
      */
     bool moveVertex( const QgsPoint &p, QgsFeatureId atFeatureId, int atVertex ) SIP_PYNAME( moveVertexV2 );
 
-    /** Deletes a vertex from a feature.
+    /**
+     * Deletes a vertex from a feature.
      * \param featureId ID of feature to remove vertex from
      * \param vertex index of vertex to delete
      * \since QGIS 2.14
      */
     QgsVectorLayer::EditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
-    /** Adds a ring to polygon/multipolygon features
+    /**
+     * Adds a ring to polygon/multipolygon features
      * \param ring ring to add
      * \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
@@ -109,7 +115,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     QgsGeometry::OperationResult addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
 
     /**
-     * Add a new part polygon to a multipart feature
+     * Adds a new part polygon to a multipart feature
      *
      * \return
      * - QgsGeometry::Success
@@ -132,7 +138,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     int translateFeature( QgsFeatureId featureId, double dx, double dy );
 
     /**
-     * Split parts cut by the given line
+     * Splits parts cut by the given line
      * \param splitLine line that splits the layer feature parts
      * \param topologicalEditing true if topological editing is enabled
      * \return
@@ -156,14 +162,16 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      */
     QgsGeometry::OperationResult splitFeatures( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 
-    /** Adds topological points for every vertex of the geometry.
+    /**
+     * Adds topological points for every vertex of the geometry.
      * \param geom the geometry where each vertex is added to segments of other features
      * \note geom is not going to be modified by the function
      * \returns 0 in case of success
      */
     int addTopologicalPoints( const QgsGeometry &geom );
 
-    /** Adds a vertex to segments which intersect point p but don't
+    /**
+     * Adds a vertex to segments which intersect point p but don't
      * already have a vertex there. If a feature already has a vertex at position p,
      * no additional vertex is inserted. This method is useful for topological
      * editing.

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -19,9 +19,8 @@
 #include "qgis_core.h"
 #include "qgis.h"
 #include "qgsfeature.h"
-
-#include "qgsvectorlayer.h"
 #include "qgsgeometry.h"
+#include "qgsvectorlayer.h"
 
 class QgsCurve;
 
@@ -66,68 +65,40 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     QgsVectorLayer::EditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /** Adds a ring to polygon/multipolygon features
-     * \param ring ring to add
-     * \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+     * @param ring ring to add
+     * @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
-     * \param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
-     * \returns
-     *   0 in case of success,
-     *   1 problem with feature type,
-     *   2 ring not closed,
-     *   3 ring not valid,
-     *   4 ring crosses existing rings,
-     *   5 no feature found where ring can be inserted
+     * @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+     * @return OperationResult result code: success or reason of failure
      */
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addRing( const QList<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = nullptr );
+    QgsGeometry::OperationResult addRing( const QList<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = nullptr );
 
-    /** Adds a ring to polygon/multipolygon features
-     * \param ring ring to add
-     * \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+    /**
+     * Adds a ring to polygon/multipolygon features
+     * @param ring ring to add
+     * @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
-     * \param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
-     * \returns
-     *  0 in case of success,
-     *  1 problem with feature type,
-     *  2 ring not closed,
-     *  3 ring not valid,
-     *  4 ring crosses existing rings,
-     *  5 no feature found where ring can be inserted
-     * \note available in Python bindings as addCurvedRing
+     * @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+     * @return OperationResult result code: success or reason of failure
+     * @note available in python bindings as addCurvedRing
      */
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addRing( QgsCurve *ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = nullptr ) SIP_PYNAME( addCurvedRing );
+    QgsGeometry::OperationResult addRing( QgsCurve *ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = nullptr ) SIP_PYNAME( addCurvedRing );
 
-    /** Adds a new part polygon to a multipart feature
-     * \returns
-     *  0 in case of success,
-     *  1 if selected feature is not multipart,
-     *  2 if ring is not a valid geometry,
-     *  3 if new polygon ring not disjoint with existing rings,
-     *  4 if no feature was selected,
-     *  5 if several features are selected,
-     *  6 if selected geometry not found
+    /**
+     * Adds a new part polygon to a multipart feature
+     * @returns QgsGeometry::OperationResult a result code: success or reason of failure
      */
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addPart( const QList<QgsPointXY> &ring, QgsFeatureId featureId );
+    QgsGeometry::OperationResult addPart( const QList<QgsPointXY> &ring, QgsFeatureId featureId );
 
-    /** Adds a new part polygon to a multipart feature
-     * \returns
-     *  0 in case of success,
-     *  1 if selected feature is not multipart,
-     *  2 if ring is not a valid geometry,
-     *  3 if new polygon ring not disjoint with existing rings,
-     *  4 if no feature was selected,
-     *  5 if several features are selected,
-     *  6 if selected geometry not found
-     * \note available in Python bindings as addPartV2
+    /**
+     * Adds a new part polygon to a multipart feature
+     * @returns QgsGeometry::OperationResult a result code: success or reason of failure
+     * @note available in python bindings as addPartV2
      */
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
+    QgsGeometry::OperationResult addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
 
-    //! \note available in Python bindings as addCurvedPart
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addPart( QgsCurve *ring, QgsFeatureId featureId ) SIP_PYNAME( addCurvedPart );
+    // @note available in python bindings as addCurvedPart
+    QgsGeometry::OperationResult addPart( QgsCurve *ring, QgsFeatureId featureId ) SIP_PYNAME( addCurvedPart );
 
     /** Translates feature by dx, dy
      * \param featureId id of the feature to translate
@@ -145,7 +116,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      *   4 if there is a selection but no feature split
      */
     // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int splitParts( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
+    QgsGeometry::OperationResult splitParts( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 
     /** Splits features cut by the given line
      *  \param splitLine line that splits the layer features
@@ -155,7 +126,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      *   4 if there is a selection but no feature split
      */
     // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int splitFeatures( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
+    QgsGeometry::OperationResult splitFeatures( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 
     /** Adds topological points for every vertex of the geometry.
      * \param geom the geometry where each vertex is added to segments of other features
@@ -173,15 +144,15 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      */
     int addTopologicalPoints( const QgsPointXY &p );
 
-  protected:
-
-    /** Little helper function that gives bounding box from a list of points.
-    \returns 0 in case of success */
-    int boundingBoxFromPointList( const QList<QgsPointXY> &list, double &xmin, double &ymin, double &xmax, double &ymax ) const;
-
   private:
 
-    QgsVectorLayer *L = nullptr;
+    /**
+     * Little helper function that gives bounding box from a list of points.
+     * \returns True in case of success
+     */
+    bool boundingBoxFromPointList( const QList<QgsPointXY> &list, double &xmin, double &ymin, double &xmax, double &ymax ) const;
+
+    QgsVectorLayer *mLayer = nullptr;
 };
 
 #endif // QGSVECTORLAYEREDITUTILS_H

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -65,67 +65,95 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     QgsVectorLayer::EditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /** Adds a ring to polygon/multipolygon features
-     * @param ring ring to add
-     * @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+     * \param ring ring to add
+     * \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
-     * @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
-     * @return OperationResult result code: success or reason of failure
+     * \param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+     * \return OperationResult result code: success or reason of failure
      */
     QgsGeometry::OperationResult addRing( const QList<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = nullptr );
 
     /**
      * Adds a ring to polygon/multipolygon features
-     * @param ring ring to add
-     * @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
+     * \param ring ring to add
+     * \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
-     * @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
-     * @return OperationResult result code: success or reason of failure
-     * @note available in python bindings as addCurvedRing
+     * \param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
+     * \return OperationResult result code: success or reason of failure
+     * \note available in python bindings as addCurvedRing
      */
     QgsGeometry::OperationResult addRing( QgsCurve *ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = nullptr ) SIP_PYNAME( addCurvedRing );
 
     /**
      * Adds a new part polygon to a multipart feature
-     * @returns QgsGeometry::OperationResult a result code: success or reason of failure
+     * \return
+     * - QgsGeometry::Success
+     * - QgsGeometry::AddPartSelectedGeometryNotFound
+     * - QgsGeometry::AddPartNotMultiGeometry
+     * - QgsGeometry::InvalidBaseGeometry
+     * - QgsGeometry::InvalidInput
      */
     QgsGeometry::OperationResult addPart( const QList<QgsPointXY> &ring, QgsFeatureId featureId );
 
     /**
      * Adds a new part polygon to a multipart feature
-     * @returns QgsGeometry::OperationResult a result code: success or reason of failure
-     * @note available in python bindings as addPartV2
+     *
+     * \return
+     * - QgsGeometry::Success
+     * - QgsGeometry::AddPartSelectedGeometryNotFound
+     * - QgsGeometry::AddPartNotMultiGeometry
+     * - QgsGeometry::InvalidBaseGeometry
+     * - QgsGeometry::InvalidInput
+     * \note available in python bindings as addPartV2
      */
     QgsGeometry::OperationResult addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
 
-    // @note available in python bindings as addCurvedPart
+    /**
+     * Add a new part polygon to a multipart feature
+     *
+     * \return
+     * - QgsGeometry::Success
+     * - QgsGeometry::AddPartSelectedGeometryNotFound
+     * - QgsGeometry::AddPartNotMultiGeometry
+     * - QgsGeometry::InvalidBaseGeometry
+     * - QgsGeometry::InvalidInput
+     *
+     * \note available in python bindings as addCurvedPart
+     */
     QgsGeometry::OperationResult addPart( QgsCurve *ring, QgsFeatureId featureId ) SIP_PYNAME( addCurvedPart );
 
-    /** Translates feature by dx, dy
+    /**
+     * Translates feature by dx, dy
      * \param featureId id of the feature to translate
      * \param dx translation of x-coordinate
      * \param dy translation of y-coordinate
-     * \returns 0 in case of success
+     * \return 0 in case of success
      */
     int translateFeature( QgsFeatureId featureId, double dx, double dy );
 
-    /** Splits parts cut by the given line
-     *  \param splitLine line that splits the layer feature parts
-     *  \param topologicalEditing true if topological editing is enabled
-     *  \returns
-     *   0 in case of success,
-     *   4 if there is a selection but no feature split
+    /**
+     * Split parts cut by the given line
+     * \param splitLine line that splits the layer feature parts
+     * \param topologicalEditing true if topological editing is enabled
+     * \return
+     *  - QgsGeometry::InvalidBaseGeometry
+     *  - QgsGeometry::Success
+     *  - QgsGeometry::InvalidInput
+     *  - QgsGeometry::NothingHappened if a selection is present but no feature has been split
+     *  - QgsGeometry::InvalidBaseGeometry
+     *  - QgsGeometry::GeometryEngineError
+     *  - QgsGeometry::SplitCannotSplitPoint
      */
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
     QgsGeometry::OperationResult splitParts( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 
-    /** Splits features cut by the given line
-     *  \param splitLine line that splits the layer features
-     *  \param topologicalEditing true if topological editing is enabled
-     *  \returns
-     *   0 in case of success,
-     *   4 if there is a selection but no feature split
+    /**
+     * Splits features cut by the given line
+     * \param splitLine line that splits the layer features
+     * \param topologicalEditing true if topological editing is enabled
+     * \return
+     *  0 in case of success,
+     *  4 if there is a selection but no feature split
      */
-    // TODO QGIS 3.0 returns an enum instead of a magic constant
     QgsGeometry::OperationResult splitFeatures( const QList<QgsPointXY> &splitLine, bool topologicalEditing = false );
 
     /** Adds topological points for every vertex of the geometry.

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1423,14 +1423,14 @@ class TestQgsGeometry(unittest.TestCase):
         ]
 
         polyline = QgsGeometry.fromPolyline(points[0])
-        self.assertEqual(polyline.addPoints(points[1][0:1]), 2, "addPoints with one point line unexpectedly succeeded.")
-        self.assertEqual(polyline.addPoints(points[1][0:2]), 0, "addPoints with two point line failed.")
+        self.assertEqual(polyline.addPoints(points[1][0:1]), QgsGeometry.InvalidInput, "addPoints with one point line unexpectedly succeeded.")
+        self.assertEqual(polyline.addPoints(points[1][0:2]), QgsGeometry.Success, "addPoints with two point line failed.")
         expwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0), (3 0, 3 1))"
         wkt = polyline.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
         polyline = QgsGeometry.fromPolyline(points[0])
-        self.assertEqual(polyline.addPoints(points[1]), 0, "addPoints with %d point line failed." % len(points[1]))
+        self.assertEqual(polyline.addPoints(points[1]), QgsGeometry.Success, "addPoints with %d point line failed." % len(points[1]))
         expwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0), (3 0, 3 1, 5 1, 5 0, 6 0))"
         wkt = polyline.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
@@ -1439,7 +1439,7 @@ class TestQgsGeometry(unittest.TestCase):
         polyline = QgsGeometry.fromPolyline(points[0])
         polyline.geometry().addZValue(4.0)
         points2 = [QgsPoint(p[0], p[1], 3.0, wkbType=QgsWkbTypes.PointZ) for p in points[1]]
-        self.assertEqual(polyline.addPointsV2(points2), 0)
+        self.assertEqual(polyline.addPointsV2(points2), QgsGeometry.Success)
         expwkt = "MultiLineStringZ ((0 0 4, 1 0 4, 1 1 4, 2 1 4, 2 0 4),(3 0 3, 3 1 3, 5 1 3, 5 0 3, 6 0 3))"
         wkt = polyline.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
@@ -1456,12 +1456,12 @@ class TestQgsGeometry(unittest.TestCase):
 
         polygon = QgsGeometry.fromPolygon(points[0])
 
-        self.assertEqual(polygon.addPoints(points[1][0][0:1]), 2, "addPoints with one point ring unexpectedly succeeded.")
-        self.assertEqual(polygon.addPoints(points[1][0][0:2]), 2, "addPoints with two point ring unexpectedly succeeded.")
-        self.assertEqual(polygon.addPoints(points[1][0][0:3]), 2, "addPoints with unclosed three point ring unexpectedly succeeded.")
-        self.assertEqual(polygon.addPoints([QgsPointXY(4, 0), QgsPointXY(5, 0), QgsPointXY(4, 0)]), 2, "addPoints with 'closed' three point ring unexpectedly succeeded.")
+        self.assertEqual(polygon.addPoints(points[1][0][0:1]), QgsGeometry.InvalidInput, "addPoints with one point ring unexpectedly succeeded.")
+        self.assertEqual(polygon.addPoints(points[1][0][0:2]), QgsGeometry.InvalidInput, "addPoints with two point ring unexpectedly succeeded.")
+        self.assertEqual(polygon.addPoints(points[1][0][0:3]), QgsGeometry.InvalidInput, "addPoints with unclosed three point ring unexpectedly succeeded.")
+        self.assertEqual(polygon.addPoints([QgsPointXY(4, 0), QgsPointXY(5, 0), QgsPointXY(4, 0)]), QgsGeometry.InvalidInput, "addPoints with 'closed' three point ring unexpectedly succeeded.")
 
-        self.assertEqual(polygon.addPoints(points[1][0]), 0, "addPoints failed")
+        self.assertEqual(polygon.addPoints(points[1][0]), QgsGeometry.Success, "addPoints failed")
         expwkt = "MultiPolygon (((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0)),((4 0, 5 0, 5 2, 3 2, 3 1, 4 1, 4 0)))"
         wkt = polygon.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
@@ -1469,13 +1469,13 @@ class TestQgsGeometry(unittest.TestCase):
         mp = QgsGeometry.fromMultiPolygon(points[:1])
         p = QgsGeometry.fromPolygon(points[1])
 
-        self.assertEqual(mp.addPartGeometry(p), 0)
+        self.assertEqual(mp.addPartGeometry(p), QgsGeometry.Success)
         wkt = mp.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
         mp = QgsGeometry.fromMultiPolygon(points[:1])
         mp2 = QgsGeometry.fromMultiPolygon(points[1:])
-        self.assertEqual(mp.addPartGeometry(mp2), 0)
+        self.assertEqual(mp.addPartGeometry(mp2), QgsGeometry.Success)
         wkt = mp.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
@@ -1483,7 +1483,7 @@ class TestQgsGeometry(unittest.TestCase):
         polygon = QgsGeometry.fromPolygon(points[0])
         polygon.geometry().addZValue(4.0)
         points2 = [QgsPoint(pi[0], pi[1], 3.0, wkbType=QgsWkbTypes.PointZ) for pi in points[1][0]]
-        self.assertEqual(polygon.addPointsV2(points2), 0)
+        self.assertEqual(polygon.addPointsV2(points2), QgsGeometry.Success)
         expwkt = "MultiPolygonZ (((0 0 4, 1 0 4, 1 1 4, 2 1 4, 2 2 4, 0 2 4, 0 0 4)),((4 0 3, 5 0 3, 5 2 3, 3 2 3, 3 1 3, 4 1 3, 4 0 3)))"
         wkt = polygon.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
@@ -1492,38 +1492,38 @@ class TestQgsGeometry(unittest.TestCase):
         empty = QgsGeometry()
         # if not default type specified, addPart should fail
         result = empty.addPoints([QgsPointXY(4, 0)])
-        assert result != 0, 'Got return code {}'.format(result)
+        assert result != QgsGeometry.Success, 'Got return code {}'.format(result)
         result = empty.addPoints([QgsPointXY(4, 0)], QgsWkbTypes.PointGeometry)
-        self.assertEqual(result, 0, 'Got return code {}'.format(result))
+        self.assertEqual(result, QgsGeometry.Success, 'Got return code {}'.format(result))
         wkt = empty.exportToWkt()
         expwkt = 'MultiPoint ((4 0))'
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
         result = empty.addPoints([QgsPointXY(5, 1)])
-        self.assertEqual(result, 0, 'Got return code {}'.format(result))
+        self.assertEqual(result, QgsGeometry.Success, 'Got return code {}'.format(result))
         wkt = empty.exportToWkt()
         expwkt = 'MultiPoint ((4 0),(5 1))'
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
         # next try with lines
         empty = QgsGeometry()
         result = empty.addPoints(points[0][0], QgsWkbTypes.LineGeometry)
-        self.assertEqual(result, 0, 'Got return code {}'.format(result))
+        self.assertEqual(result, QgsGeometry.Success, 'Got return code {}'.format(result))
         wkt = empty.exportToWkt()
         expwkt = 'MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0))'
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
         result = empty.addPoints(points[1][0])
-        self.assertEqual(result, 0, 'Got return code {}'.format(result))
+        self.assertEqual(result, QgsGeometry.Success, 'Got return code {}'.format(result))
         wkt = empty.exportToWkt()
         expwkt = 'MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0),(4 0, 5 0, 5 2, 3 2, 3 1, 4 1, 4 0))'
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
         # finally try with polygons
         empty = QgsGeometry()
         result = empty.addPoints(points[0][0], QgsWkbTypes.PolygonGeometry)
-        self.assertEqual(result, 0, 'Got return code {}'.format(result))
+        self.assertEqual(result, QgsGeometry.Success, 'Got return code {}'.format(result))
         wkt = empty.exportToWkt()
         expwkt = 'MultiPolygon (((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0)))'
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
         result = empty.addPoints(points[1][0])
-        self.assertEqual(result, 0, 'Got return code {}'.format(result))
+        self.assertEqual(result, QgsGeometry.Success, 'Got return code {}'.format(result))
         wkt = empty.exportToWkt()
         expwkt = 'MultiPolygon (((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0)),((4 0, 5 0, 5 2, 3 2, 3 1, 4 1, 4 0)))'
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)


### PR DESCRIPTION
QGIS 2 was using magic numbers for return values of geometry operations which is not very verbose and the compiler can't guarantee type safety. No fun.

It's a rebased version of #3429 . Some additional adjustments have been made.