### PR TITLE
Add null handling to value map edit widget (fixes #15215)

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -39,6 +39,7 @@ QgsValueMapConfigDlg::QgsValueMapConfigDlg( QgsVectorLayer* vl, int fieldIdx, QW
 QgsEditorWidgetConfig QgsValueMapConfigDlg::config()
 {
   QgsEditorWidgetConfig cfg;
+  QSettings settings;
 
   //store data to map
   for ( int i = 0; i < tableWidget->rowCount() - 1; i++ )
@@ -50,7 +51,7 @@ QgsEditorWidgetConfig QgsValueMapConfigDlg::config()
       continue;
 
     QString ks = ki->text();
-    if (( ks == QString( "NULL" ) ) && !( ki->flags() & Qt::ItemIsEditable ) )
+    if (( ks == settings.value( "qgis/nullValue", "NULL" ).toString() ) && !( ki->flags() & Qt::ItemIsEditable ) )
       ks = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}";
 
     if ( !vi || vi->text().isNull() )
@@ -146,6 +147,7 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
 
 void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString description )
 {
+  QSettings settings;
   QTableWidgetItem* valueCell;
   QTableWidgetItem* descriptionCell = new QTableWidgetItem( description );
   tableWidget->insertRow( row );
@@ -153,7 +155,7 @@ void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString d
   {
     QFont cellFont;
     cellFont.setItalic( true );
-    valueCell = new QTableWidgetItem( "NULL" );
+    valueCell = new QTableWidgetItem( settings.value( "qgis/nullValue", "NULL" ).toString() );
     valueCell->setFont( cellFont );
     valueCell->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled );
     descriptionCell->setFont( cellFont );

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -52,7 +52,7 @@ QgsEditorWidgetConfig QgsValueMapConfigDlg::config()
 
     QString ks = ki->text();
     if (( ks == settings.value( "qgis/nullValue", "NULL" ).toString() ) && !( ki->flags() & Qt::ItemIsEditable ) )
-      ks = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}";
+      ks = VALUEMAP_NULL_TEXT;
 
     if ( !vi || vi->text().isNull() )
     {
@@ -132,7 +132,7 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
 
   if ( insertNull )
   {
-    setRow( row, "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}", "<NULL>" );
+    setRow( row, VALUEMAP_NULL_TEXT, "<NULL>" );
     ++row;
   }
 
@@ -151,7 +151,7 @@ void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString d
   QTableWidgetItem* valueCell;
   QTableWidgetItem* descriptionCell = new QTableWidgetItem( description );
   tableWidget->insertRow( row );
-  if ( value == QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" ) )
+  if ( value == QString( VALUEMAP_NULL_TEXT ) )
   {
     QFont cellFont;
     cellFont.setItalic( true );
@@ -170,7 +170,7 @@ void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString d
 
 void QgsValueMapConfigDlg::addNullButtonPushed()
 {
-  setRow( tableWidget->rowCount() - 1, "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}", "<NULL>" );
+  setRow( tableWidget->rowCount() - 1, VALUEMAP_NULL_TEXT, "<NULL>" );
 }
 
 void QgsValueMapConfigDlg::loadFromLayerButtonPushed()
@@ -243,7 +243,7 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
     }
 
     if ( key == settings.value( "qgis/nullValue", "NULL" ).toString() )
-      key = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+      key = QString( VALUEMAP_NULL_TEXT );
 
     map[ key ] = val;
   }

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsattributetypeloaddialog.h"
 
-#include <QSettings>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QTextStream>
@@ -29,6 +28,7 @@ QgsValueMapConfigDlg::QgsValueMapConfigDlg( QgsVectorLayer* vl, int fieldIdx, QW
 
   tableWidget->insertRow( 0 );
 
+  connect( addNullButton, SIGNAL( clicked() ), this, SLOT( addNullButtonPushed() ) );
   connect( removeSelectedButton, SIGNAL( clicked() ), this, SLOT( removeSelectedButtonPushed() ) );
   connect( loadFromLayerButton, SIGNAL( clicked() ), this, SLOT( loadFromLayerButtonPushed() ) );
   connect( loadFromCSVButton, SIGNAL( clicked() ), this, SLOT( loadFromCSVButtonPushed() ) );
@@ -48,13 +48,17 @@ QgsEditorWidgetConfig QgsValueMapConfigDlg::config()
     if ( !ki )
       continue;
 
+    QString ks = ki->text();
+    if (( ks == QString( "NULL" ) ) && !( ki->flags() & Qt::ItemIsEditable ) )
+      ks = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}";
+
     if ( !vi || vi->text().isNull() )
     {
-      cfg.insert( ki->text(), ki->text() );
+      cfg.insert( ks, ks );
     }
     else
     {
-      cfg.insert( vi->text(), ki->text() );
+      cfg.insert( vi->text(), ks );
     }
   }
 
@@ -72,16 +76,10 @@ void QgsValueMapConfigDlg::setConfig( const QgsEditorWidgetConfig& config )
   int row = 0;
   for ( QgsEditorWidgetConfig::ConstIterator mit = config.begin(); mit != config.end(); mit++, row++ )
   {
-    tableWidget->insertRow( row );
     if ( mit.value().isNull() )
-    {
-      tableWidget->setItem( row, 0, new QTableWidgetItem( mit.key() ) );
-    }
+      setRow( row, mit.key(), QString( "" ) );
     else
-    {
-      tableWidget->setItem( row, 0, new QTableWidgetItem( mit.value().toString() ) );
-      tableWidget->setItem( row, 1, new QTableWidgetItem( mit.key() ) );
-    }
+      setRow( row, mit.value().toString(), mit.key() );
   }
 }
 
@@ -132,25 +130,44 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
 
   if ( insertNull )
   {
-    QSettings settings;
-    tableWidget->setItem( row, 0, new QTableWidgetItem( settings.value( "qgis/nullValue", "NULL" ).toString() ) );
-    tableWidget->setItem( row, 1, new QTableWidgetItem( "<NULL>" ) );
+    setRow( row, "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}", "<NULL>" );
     ++row;
   }
 
   for ( QMap<QString, QVariant>::const_iterator mit = map.begin(); mit != map.end(); ++mit, ++row )
   {
-    tableWidget->insertRow( row );
     if ( mit.value().isNull() )
-    {
-      tableWidget->setItem( row, 0, new QTableWidgetItem( mit.key() ) );
-    }
+      setRow( row, mit.key(), QString( "" ) );
     else
-    {
-      tableWidget->setItem( row, 0, new QTableWidgetItem( mit.key() ) );
-      tableWidget->setItem( row, 1, new QTableWidgetItem( mit.value().toString() ) );
-    }
+      setRow( row, mit.key(), mit.value().toString() );
   }
+}
+
+void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString description )
+{
+  QTableWidgetItem* valueCell;
+  QTableWidgetItem* descriptionCell = new QTableWidgetItem( description );
+  tableWidget->insertRow( row );
+  if ( value == QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" ) )
+  {
+    QFont cellFont;
+    cellFont.setItalic( true );
+    valueCell = new QTableWidgetItem( "NULL" );
+    valueCell->setFont( cellFont );
+    valueCell->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled );
+    descriptionCell->setFont( cellFont );
+  }
+  else
+  {
+    valueCell = new QTableWidgetItem( value );
+  }
+  tableWidget->setItem( row, 0, valueCell );
+  tableWidget->setItem( row, 1, descriptionCell );
+}
+
+void QgsValueMapConfigDlg::addNullButtonPushed()
+{
+  setRow( tableWidget->rowCount() - 1, "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}", "<NULL>" );
 }
 
 void QgsValueMapConfigDlg::loadFromLayerButtonPushed()

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsattributetypeloaddialog.h"
 
+#include <QSettings>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QTextStream>
@@ -77,7 +78,7 @@ void QgsValueMapConfigDlg::setConfig( const QgsEditorWidgetConfig& config )
   for ( QgsEditorWidgetConfig::ConstIterator mit = config.begin(); mit != config.end(); mit++, row++ )
   {
     if ( mit.value().isNull() )
-      setRow( row, mit.key(), QString( "" ) );
+      setRow( row, mit.key(), QString() );
     else
       setRow( row, mit.value().toString(), mit.key() );
   }
@@ -137,7 +138,7 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
   for ( QMap<QString, QVariant>::const_iterator mit = map.begin(); mit != map.end(); ++mit, ++row )
   {
     if ( mit.value().isNull() )
-      setRow( row, mit.key(), QString( "" ) );
+      setRow( row, mit.key(), QString() );
     else
       setRow( row, mit.key(), mit.value().toString() );
   }
@@ -181,6 +182,8 @@ void QgsValueMapConfigDlg::loadFromLayerButtonPushed()
 
 void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
 {
+  QSettings settings;
+
   QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Select a file" ), QDir::homePath() );
   if ( fileName.isNull() )
     return;
@@ -236,6 +239,9 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
     {
       val = val.mid( 1, val.length() - 2 );
     }
+
+    if ( key == settings.value( "qgis/nullValue", "NULL" ).toString() )
+      key = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
 
     map[ key ] = val;
   }

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -20,6 +20,8 @@
 
 #include "qgseditorconfigwidget.h"
 
+#define VALUEMAP_NULL_TEXT "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"
+
 /** \ingroup gui
  * \class QgsValueMapConfigDlg
  * \note not available in Python bindings

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -36,8 +36,12 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
 
     void updateMap( const QMap<QString, QVariant> &map, bool insertNull );
 
+  private:
+    void setRow( int row, const QString value, const QString description );
+
   private slots:
     void vCellChanged( int row, int column );
+    void addNullButtonPushed();
     void removeSelectedButtonPushed();
     void loadFromLayerButtonPushed();
     void loadFromCSVButtonPushed();

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -96,12 +96,6 @@ QString QgsValueMapSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper
 
   QString currentKey = mComboBox->itemData( mComboBox->currentIndex() ).toString();
 
-  if ( currentKey == QString( VALUEMAP_NULL_TEXT ) )
-    if ( flags & EqualTo )
-      return fieldName + " IS NULL";
-  if ( flags & NotEqualTo )
-    return fieldName + " IS NOT NULL";
-
   switch ( fldType )
   {
     case QVariant::Int:
@@ -152,7 +146,8 @@ void QgsValueMapSearchWidgetWrapper::initWidget( QWidget* editor )
 
     while ( it != cfg.constEnd() )
     {
-      mComboBox->addItem( it.key(), it.value() );
+      if ( it.value() != QString( VALUEMAP_NULL_TEXT ) )
+        mComboBox->addItem( it.key(), it.value() );
       ++it;
     }
     connect( mComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( comboBoxIndexChanged( int ) ) );

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsvaluemapsearchwidgetwrapper.h"
 #include "qgstexteditconfigdlg.h"
+#include "qgsvaluemapconfigdlg.h"
 
 #include "qgsfield.h"
 #include "qgsfieldvalidator.h"
@@ -94,6 +95,12 @@ QString QgsValueMapSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper
     return fieldName + " IS NOT NULL";
 
   QString currentKey = mComboBox->itemData( mComboBox->currentIndex() ).toString();
+
+  if ( currentKey == QString( VALUEMAP_NULL_TEXT ) )
+    if ( flags & EqualTo )
+      return fieldName + " IS NULL";
+  if ( flags & NotEqualTo )
+    return fieldName + " IS NOT NULL";
 
   switch ( fldType )
   {

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -91,7 +91,7 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
   if ( value.isNull() )
   {
     valueInternalText = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
-    valueDisplayText = QString( "NULL" );
+    valueDisplayText = settings.value( "qgis/nullValue", "NULL" ).toString();
   }
   else
   {

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -88,9 +88,10 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
 
   QString valueInternalText;
   QString valueDisplayText;
+  QSettings settings;
   if ( value.isNull() )
   {
-    valueInternalText = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+    valueInternalText = QString( VALUEMAP_NULL_TEXT );
     valueDisplayText = settings.value( "qgis/nullValue", "NULL" ).toString();
   }
   else

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -86,13 +86,20 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
 {
   Q_UNUSED( cache )
 
-  QString v;
+  QString valueInternalText;
+  QString valueDisplayText;
   if ( value.isNull() )
-    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+  {
+    valueInternalText = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+    valueDisplayText = QString( "NULL" );
+  }
   else
-    v = value.toString();
+  {
+    valueInternalText = value.toString();
+    valueDisplayText = value.toString();
+  }
 
-  return config.key( v, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( value ) ) ).toString() );
+  return config.key( valueInternalText, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( valueDisplayText ) ) ).toString() );
 }
 
 QVariant QgsValueMapWidgetFactory::sortValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -20,6 +20,8 @@
 #include "qgsdefaultsearchwidgetwrapper.h"
 #include "qgsvaluemapconfigdlg.h"
 
+#include <QSettings>
+
 QgsValueMapWidgetFactory::QgsValueMapWidgetFactory( const QString& name )
     : QgsEditorWidgetFactory( name )
 {
@@ -82,11 +84,15 @@ void QgsValueMapWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config,
 
 QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const
 {
-  Q_UNUSED( vl )
-  Q_UNUSED( fieldIdx )
   Q_UNUSED( cache )
 
-  return config.key( value, QVariant( QString( "(%1)" ).arg( value.toString() ) ).toString() );
+  QString v;
+  if ( value.isNull() )
+    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+  else
+    v = value.toString();
+
+  return config.key( v, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( value ) ) ).toString() );
 }
 
 QVariant QgsValueMapWidgetFactory::sortValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -90,17 +90,11 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
   QString valueDisplayText;
   QSettings settings;
   if ( value.isNull() )
-  {
     valueInternalText = QString( VALUEMAP_NULL_TEXT );
-    valueDisplayText = settings.value( "qgis/nullValue", "NULL" ).toString();
-  }
   else
-  {
     valueInternalText = value.toString();
-    valueDisplayText = value.toString();
-  }
 
-  return config.key( valueInternalText, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( valueDisplayText ) ) ).toString() );
+  return config.key( valueInternalText, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( value ) ) ).toString() );
 }
 
 QVariant QgsValueMapWidgetFactory::sortValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsvaluemapwidgetwrapper.h"
 
+#include <QSettings>
+
 QgsValueMapWidgetWrapper::QgsValueMapWidgetWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent )
     : QgsEditorWidgetWrapper( vl, fieldIdx, editor, parent )
     , mComboBox( nullptr )
@@ -24,10 +26,13 @@ QgsValueMapWidgetWrapper::QgsValueMapWidgetWrapper( QgsVectorLayer* vl, int fiel
 
 QVariant QgsValueMapWidgetWrapper::value() const
 {
-  QVariant v;
+  QString v;
 
   if ( mComboBox )
-    v = mComboBox->itemData( mComboBox->currentIndex() );
+    v = mComboBox->itemData( mComboBox->currentIndex() ).toString();
+
+  if ( v == QSettings().value( "qgis/nullValue", "NULL" ).toString() )
+    return QVariant( field().type() );
 
   return v;
 }
@@ -70,6 +75,12 @@ bool QgsValueMapWidgetWrapper::valid() const
 
 void QgsValueMapWidgetWrapper::setValue( const QVariant& value )
 {
+  QString v;
+  if ( value.isNull() )
+    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+  else
+    v = value.toString();
+
   if ( mComboBox )
-    mComboBox->setCurrentIndex( mComboBox->findData( value ) );
+    mComboBox->setCurrentIndex( mComboBox->findData( v ) );
 }

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -31,7 +31,7 @@ QVariant QgsValueMapWidgetWrapper::value() const
   if ( mComboBox )
     v = mComboBox->itemData( mComboBox->currentIndex() );
 
-  if ( v == QSettings().value( "qgis/nullValue", "NULL" ).toString() )
+  if ( v == QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" ) )
     v = QVariant( field().type() );
 
   return v;
@@ -77,7 +77,7 @@ void QgsValueMapWidgetWrapper::setValue( const QVariant& value )
 {
   QString v;
   if ( value.isNull() )
-    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+    v = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
   else
     v = value.toString();
 

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -26,13 +26,13 @@ QgsValueMapWidgetWrapper::QgsValueMapWidgetWrapper( QgsVectorLayer* vl, int fiel
 
 QVariant QgsValueMapWidgetWrapper::value() const
 {
-  QString v;
+  QVariant v;
 
   if ( mComboBox )
-    v = mComboBox->itemData( mComboBox->currentIndex() ).toString();
+    v = mComboBox->itemData( mComboBox->currentIndex() );
 
   if ( v == QSettings().value( "qgis/nullValue", "NULL" ).toString() )
-    return QVariant( field().type() );
+    v = QVariant( field().type() );
 
   return v;
 }

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsvaluemapwidgetwrapper.h"
+#include "qgsvaluemapconfigdlg.h"
 
 #include <QSettings>
 
@@ -31,7 +32,7 @@ QVariant QgsValueMapWidgetWrapper::value() const
   if ( mComboBox )
     v = mComboBox->itemData( mComboBox->currentIndex() );
 
-  if ( v == QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" ) )
+  if ( v == QString( VALUEMAP_NULL_TEXT ) )
     v = QVariant( field().type() );
 
   return v;
@@ -77,7 +78,7 @@ void QgsValueMapWidgetWrapper::setValue( const QVariant& value )
 {
   QString v;
   if ( value.isNull() )
-    v = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+    v = QString( VALUEMAP_NULL_TEXT );
   else
     v = value.toString();
 

--- a/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
@@ -14,7 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="3">
+   <item row="0" column="0" colspan="5">
     <widget class="QLabel" name="valueMapLabel">
      <property name="text">
       <string>Combo box with predefined items. Value is stored in the attribute, description is shown in the combo box.</string>
@@ -31,14 +31,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="loadFromCSVButton">
-     <property name="text">
-      <string>Load Data from CSV File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
+   <item row="1" column="4">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -51,7 +44,7 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0" colspan="3">
+   <item row="2" column="0" colspan="5">
     <widget class="QTableWidget" name="tableWidget">
      <column>
       <property name="text">
@@ -65,14 +58,7 @@
      </column>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QPushButton" name="removeSelectedButton">
-     <property name="text">
-      <string>Remove Selected</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
+   <item row="3" column="3" colspan="2">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -84,6 +70,27 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="addNullButton">
+     <property name="text">
+      <string>Add &quot;NULL&quot; value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="removeSelectedButton">
+     <property name="text">
+      <string>Remove Selected</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="loadFromCSVButton">
+     <property name="text">
+      <string>Load Data from CSV File</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -27,6 +27,8 @@ start_app()
 
 class TestQgsTextEditWidget(unittest.TestCase):
 
+    VALUEMAP_NULL_TEXT = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"
+
     @classmethod
     def setUpClass(cls):
         QgsEditorWidgetRegistry.initEditors()
@@ -92,6 +94,55 @@ class TestQgsTextEditWidget(unittest.TestCase):
         self.assertEqual(w.value(), 'this_is_a_')
 
         QgsMapLayerRegistry.instance().removeAllMapLayers()
+
+    def test_ValueMap_representValue(self):
+        layer = QgsVectorLayer("none?field=number1:integer&field=number2:double&field=text1:string&field=number3:integer&field=number4:double&field=text2:string",
+                               "layer", "memory")
+        assert layer.isValid()
+        QgsMapLayerRegistry.instance().addMapLayer(layer)
+        f = QgsFeature()
+        f.setAttributes([2, 2.5, 'NULL', None, None, None])
+        assert layer.dataProvider().addFeatures([f])
+        reg = QgsEditorWidgetRegistry.instance()
+        factory = reg.factory("ValueMap")
+        self.assertIsNotNone(factory)
+
+        # Tests with different value types occuring in the value map
+        config = {'two': '2', 'twoandhalf': '2.5', 'NULL text': 'NULL',
+                  'nothing': self.VALUEMAP_NULL_TEXT}
+        self.assertEqual(factory.representValue(layer, 0, config, None, 2), 'two')
+        self.assertEqual(factory.representValue(layer, 1, config, None, 2.5), 'twoandhalf')
+        self.assertEqual(factory.representValue(layer, 2, config, None, 'NULL'), 'NULL text')
+        # Tests with null values of different types, if value map contains null
+        self.assertEqual(factory.representValue(layer, 3, config, None, None), 'nothing')
+        self.assertEqual(factory.representValue(layer, 4, config, None, None), 'nothing')
+        self.assertEqual(factory.representValue(layer, 5, config, None, None), 'nothing')
+        # Tests with fallback display for different value types
+        config = {}
+        self.assertEqual(factory.representValue(layer, 0, config, None, 2), '(2)')
+        self.assertEqual(factory.representValue(layer, 1, config, None, 2.5), '(2.50000)')
+        self.assertEqual(factory.representValue(layer, 2, config, None, 'NULL'), '(NULL)')
+        # Tests with fallback display for null in different types of fields
+        self.assertEqual(factory.representValue(layer, 3, config, None, None), '(NULL)')
+        self.assertEqual(factory.representValue(layer, 4, config, None, None), '(NULL)')
+        self.assertEqual(factory.representValue(layer, 5, config, None, None), '(NULL)')
+
+        QgsMapLayerRegistry.instance().removeAllMapLayers()
+
+    def test_ValueMap_set_get(self):
+        layer = QgsVectorLayer("none?field=number:integer", "layer", "memory")
+        assert layer.isValid()
+        QgsMapLayerRegistry.instance().addMapLayer(layer)
+        reg = QgsEditorWidgetRegistry.instance()
+        configWdg = reg.createConfigWidget('ValueMap', layer, 0, None)
+
+        config = {'two': '2', 'twoandhalf': '2.5', 'NULL text': 'NULL',
+                  'nothing': self.VALUEMAP_NULL_TEXT}
+
+        # Set a configuration containing values and NULL and check if it
+        # is returned intact.
+        configWdg.setConfig(config)
+        self.assertEqual(configWdg.config(), config)
 
     def test_ValueRelation_representValue(self):
 


### PR DESCRIPTION
## Description
I submitted this before (PR #3274 and #3289) but somehow it only ended up in master, not in 2.18. As requested in the bug report (redmine #15215), here another PR against 2.18.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
