### PR TITLE
Geopackage fix mixed geometry layers and attributes

### DIFF
--- a/python/gui/qgsnewgeopackagelayerdialog.sip
+++ b/python/gui/qgsnewgeopackagelayerdialog.sip
@@ -31,6 +31,19 @@ Constructor
 .. versionadded:: 3.0
 %End
 
+    QString databasePath() const;
+%Docstring
+ Returns the database path
+.. versionadded:: 3.0
+ :rtype: str
+%End
+
+    void setDatabasePath( const QString &path );
+%Docstring
+ Sets the the database ``path``
+.. versionadded:: 3.0
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/qgsnewgeopackagelayerdialog.h
+++ b/src/gui/qgsnewgeopackagelayerdialog.h
@@ -41,6 +41,18 @@ class GUI_EXPORT QgsNewGeoPackageLayerDialog: public QDialog, private Ui::QgsNew
      */
     void setCrs( const QgsCoordinateReferenceSystem &crs );
 
+    /**
+     * Returns the database path
+     * \since QGIS 3.0
+     */
+    QString databasePath() const { return mDatabaseEdit->text(); }
+
+    /**
+     * Sets the the database \a path
+     * \since QGIS 3.0
+     */
+    void setDatabasePath( const QString &path ) { mDatabaseEdit->setText( path ); }
+
   private slots:
     void on_mAddAttributeButton_clicked();
     void on_mRemoveAttributeButton_clicked();

--- a/src/providers/ogr/qgsgeopackageconnection.cpp
+++ b/src/providers/ogr/qgsgeopackageconnection.cpp
@@ -47,7 +47,7 @@ QgsDataSourceUri QgsGeoPackageConnection::uri()
   return uri;
 }
 
-void QgsGeoPackageConnection::setPath( QString &path )
+void QgsGeoPackageConnection::setPath( const QString &path )
 {
   mPath = path;
 }

--- a/src/providers/ogr/qgsgeopackageconnection.h
+++ b/src/providers/ogr/qgsgeopackageconnection.h
@@ -47,11 +47,11 @@ class QgsGeoPackageConnection : public QObject
     //! \see QgsDataSourceUri
     QgsDataSourceUri uri();
     //! Return the path
-    QString path( ) { return mPath; }
+    QString path( ) const { return mPath; }
     //! Returns the connection name
-    QString name() { return mConnName; }
+    QString name() const { return mConnName; }
     //! Set the \a path fo the connection
-    void setPath( QString &path );
+    void setPath( const QString &path );
     //! Store the connection data in the settings
     void save();
     const static QString SETTINGS_PREFIX;

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -76,7 +76,7 @@ class QgsGeoPackageConnectionItem : public QgsDataCollectionItem
 #ifdef HAVE_GUI
     void editConnection();
     void deleteConnection();
-
+    void addTable();
 #endif
 
   protected:
@@ -102,8 +102,11 @@ class QgsGeoPackageRootItem : public QgsDataCollectionItem
 #ifdef HAVE_GUI
     void newConnection();
     void connectionsChanged();
-#endif
     void createDatabase();
+#endif
+
+  private:
+    bool storeConnection( const QString &path );
 
 };
 


### PR DESCRIPTION
Forgot to mention: also implements action to add a layer to existing gpkg.

In addition to geometry filtered layers for each geometry
type in a mixed-geometry type layer adds a table
layer with all attributes.

Tehre is no perfetc solution here, if the layer is created
with a filter on geometrytype, the attributes are not shown
(this is probably a pre-existing bug), if the layer is added
as is, only the first geometry type is drawn.

With this implementation at least all data (attributes and
geometries) are accessible in some way.

Note that geopackage layers added by DB Manager do not show
all geometries of a mixed type layer.
