### PR TITLE
[feature][needs-docs] Adds delete layer context action to ogr and geopackage items

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -361,7 +361,7 @@ QgsGeoPackageRasterLayerItem::QgsGeoPackageRasterLayerItem( QgsDataItem *parent,
 QList<QAction *> QgsGeoPackageVectorLayerItem::actions()
 {
   QList<QAction *> lst = QgsGeoPackageAbstractLayerItem::actions();
-  QAction *actionDeleteLayer = new QAction( tr( "Delete %1" ).arg( mName ), this );
+  QAction *actionDeleteLayer = new QAction( tr( "Delete layer '%1'..." ).arg( mName ), this );
   connect( actionDeleteLayer, &QAction::triggered, this, &QgsGeoPackageVectorLayerItem::deleteLayer );
   lst.append( actionDeleteLayer );
   return lst;
@@ -371,7 +371,7 @@ QList<QAction *> QgsGeoPackageVectorLayerItem::actions()
 void QgsGeoPackageVectorLayerItem::deleteLayer()
 {
   if ( QMessageBox::question( nullptr, QObject::tr( "Delete Layer" ),
-                              QObject::tr( "Are you sure you want to delete %1?" ).arg( mName ),
+                              QObject::tr( "Are you sure you want to delete layer '%1'?" ).arg( mName ),
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -371,7 +371,7 @@ QList<QAction *> QgsGeoPackageVectorLayerItem::actions()
 void QgsGeoPackageVectorLayerItem::deleteLayer()
 {
   if ( QMessageBox::question( nullptr, QObject::tr( "Delete Layer" ),
-                              QObject::tr( "Are you sure you want to delete layer '%1'?" ).arg( mName ),
+                              QObject::tr( "Are you sure you want to delete layer '%1' from GeoPackage?" ).arg( mName ),
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -49,7 +49,11 @@ class QgsGeoPackageVectorLayerItem : public QgsGeoPackageAbstractLayerItem
     Q_OBJECT
   public:
     QgsGeoPackageVectorLayerItem( QgsDataItem *parent, QString name, QString path, QString uri, LayerType layerType );
-
+#ifdef HAVE_GUI
+    QList<QAction *> actions() override;
+  public slots:
+    void deleteLayer();
+#endif
 };
 
 

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -134,7 +134,7 @@ void QgsOgrLayerItem::deleteLayer()
   QString confirmMessage;
   if ( mIsSubLayer )
   {
-    confirmMessage = QObject::tr( "Are you sure you want to delete layer '%1'?" ).arg( mName );
+    confirmMessage = QObject::tr( "Are you sure you want to delete layer '%1' from datasource?" ).arg( mName );
   }
   else
   {

--- a/src/providers/ogr/qgsogrdataitems.h
+++ b/src/providers/ogr/qgsogrdataitems.h
@@ -29,6 +29,12 @@ class QgsOgrLayerItem : public QgsLayerItem
     bool setCrs( const QgsCoordinateReferenceSystem &crs ) override;
 
     QString layerName() const override;
+
+#ifdef HAVE_GUI
+    QList<QAction *> actions() override;
+  public slots:
+    void deleteLayer();
+#endif
 };
 
 

--- a/src/providers/ogr/qgsogrdataitems.h
+++ b/src/providers/ogr/qgsogrdataitems.h
@@ -24,7 +24,7 @@ class QgsOgrLayerItem : public QgsLayerItem
 {
     Q_OBJECT
   public:
-    QgsOgrLayerItem( QgsDataItem *parent, QString name, QString path, QString uri, LayerType layerType );
+    QgsOgrLayerItem( QgsDataItem *parent, QString name, QString path, QString uri, LayerType layerType, bool isSubLayer = false );
 
     bool setCrs( const QgsCoordinateReferenceSystem &crs ) override;
 
@@ -35,6 +35,8 @@ class QgsOgrLayerItem : public QgsLayerItem
   public slots:
     void deleteLayer();
 #endif
+  private:
+    bool mIsSubLayer;
 };
 
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -4332,41 +4332,41 @@ QGISEXTERN bool deleteLayer( const QString &uri, QString &errCause )
     switch ( error )
     {
       case OGRERR_NOT_ENOUGH_DATA:
-        errCause = QStringLiteral( "Not enough data to deserialize" );
+        errCause = QObject::tr( "Not enough data to deserialize" );
         break;
       case OGRERR_NOT_ENOUGH_MEMORY:
-        errCause = QStringLiteral( "Not enough memory" );
+        errCause = QObject::tr( "Not enough memory" );
         break;
       case OGRERR_UNSUPPORTED_GEOMETRY_TYPE:
-        errCause = QStringLiteral( "Unsupported geometry type" );
+        errCause = QObject::tr( "Unsupported geometry type" );
         break;
       case OGRERR_UNSUPPORTED_OPERATION:
-        errCause = QStringLiteral( "Unsupported operation" );
+        errCause = QObject::tr( "Unsupported operation" );
         break;
       case OGRERR_CORRUPT_DATA:
-        errCause = QStringLiteral( "Corrupt data" );
+        errCause = QObject::tr( "Corrupt data" );
         break;
       case OGRERR_FAILURE:
-        errCause = QStringLiteral( "Failure" );
+        errCause = QObject::tr( "Failure" );
         break;
       case OGRERR_UNSUPPORTED_SRS:
-        errCause = QStringLiteral( "Unsupported SRS" );
+        errCause = QObject::tr( "Unsupported SRS" );
         break;
       case OGRERR_INVALID_HANDLE:
-        errCause = QStringLiteral( "Invalid handle" );
+        errCause = QObject::tr( "Invalid handle" );
         break;
       case OGRERR_NON_EXISTING_FEATURE:
-        errCause = QStringLiteral( "Non existing feature" );
+        errCause = QObject::tr( "Non existing feature" );
         break;
       default:
       case OGRERR_NONE:
-        errCause = QStringLiteral( "Success" );
+        errCause = QObject::tr( "Success" );
         break;
     }
-    errCause = QStringLiteral( "OGR result code: %s" ).arg( errCause );
+    errCause = QObject::tr( "GDAL result code: %s" ).arg( errCause );
     return error == OGRERR_NONE;
   }
   // This should never happen:
-  errCause = QStringLiteral( "Layer not found: %s" ).arg( uri );
+  errCause = QObject::tr( "Layer not found: %s" ).arg( uri );
   return false;
 }


### PR DESCRIPTION
~~TODO: decide what to do if the layer to be deleted was
added to the canvas: block the deletion?~~

~~Current implementation just ignores the fact with
no apparent serious consequences beside that
obviously the layer is not drawn anymore.~~

I opted for a warning and abort deletion (a confirmation dialog would also be a viable solution), but what I want to avoid is accidental data loss: if the layer is currently in the project it is unlikely that the user really wants to delete it permanently.

This is what happens in this case:

![immagine](https://user-images.githubusercontent.com/142164/29364252-21b737c8-8293-11e7-868a-255060f40fd7.png)


