### PR TITLE
Small advanced digitizing cleanup

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -460,6 +460,7 @@ QgsAdvancedDigitizingDockWidget        {#qgis_api_break_3_0_QgsAdvancedDigitizin
 -------------------------------
 
 - canvasReleaseEvent takes now QgsAdvancedDigitizingDockWidget::CaptureMode as second argument.
+- snappingMode() was removed. Advanced digitizing now always uses project's snapping configuration.
 
 
 QgsApplication        {#qgis_api_break_3_0_QgsApplication}
@@ -1548,6 +1549,13 @@ QgsMapLayerLegend        {#qgis_api_break_3_0_QgsMapLayerLegend}
 -----------------
 
 - defaultPluginLegend() was removed. Plugin layers have to provide their legend implementation.
+
+
+QgsMapMouseEvent        {#qgis_api_break_3_0_QgsMapMouseEvent}
+----------------
+
+- SnappingMode enum was removed.
+- snapPoint() and snapSegment() do not take SnappingMode argument anymore. Snapping is done according to project's snapping configuration.
 
 
 QgsMapOverviewCanvas        {#qgis_api_break_3_0_QgsMapOverviewCanvas}

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -227,13 +227,6 @@ class QgsAdvancedDigitizingDockWidget : QgsDockWidget
  Clear any cached previous clicks and helper lines
 %End
 
-    QgsMapMouseEvent::SnappingMode snappingMode();
-%Docstring
- The snapping mode
- :return: Snapping mode
- :rtype: QgsMapMouseEvent.SnappingMode
-%End
-
     virtual void keyPressEvent( QKeyEvent *e );
 
 

--- a/python/gui/qgsmapmouseevent.sip
+++ b/python/gui/qgsmapmouseevent.sip
@@ -31,13 +31,6 @@ class QgsMapMouseEvent : QMouseEvent
 %End
   public:
 
-    enum SnappingMode
-    {
-      NoSnapping,
-      SnapProjectConfig,
-      SnapAllLayers,
-    };
-
     QgsMapMouseEvent( QgsMapCanvas *mapCanvas, QMouseEvent *event );
 %Docstring
  Creates a new QgsMapMouseEvent. Should only be required to be called from the QgsMapCanvas.
@@ -59,7 +52,7 @@ class QgsMapMouseEvent : QMouseEvent
  \param modifiers Keyboard modifiers
 %End
 
-    QgsPointXY snapPoint( SnappingMode snappingMode );
+    QgsPointXY snapPoint();
 %Docstring
  snapPoint will snap the points using the map canvas snapping utils configuration
 .. note::
@@ -68,12 +61,11 @@ class QgsMapMouseEvent : QMouseEvent
  :rtype: QgsPointXY
 %End
 
-    QList<QgsPointXY> snapSegment( SnappingMode snappingMode, bool *snapped = 0, bool allLayers = false ) const;
+    QList<QgsPointXY> snapSegment( bool *snapped = 0, bool allLayers = false ) const;
 %Docstring
  Returns the first snapped segment. If the cached snapped match is a segment, it will simply return it.
  Otherwise it will try to snap a segment according to the event's snapping mode. In this case the cache
  will not be overwritten.
- \param snappingMode Specify if the default project settings or all layers should be used for snapping
  \param snapped if given, determines if a segment has been snapped
  \param allLayers if true, override snapping mode
  :rtype: list of QgsPointXY

--- a/python/gui/qgsmaptooladvanceddigitizing.sip
+++ b/python/gui/qgsmaptooladvanceddigitizing.sip
@@ -123,7 +123,6 @@ Catch the mouse move event, filters it, transforms it to map coordinates and sen
 %End
 
 
-
 };
 
 /************************************************************************

--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -182,7 +182,7 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent *e )
   {
     if ( mCurrentMoveAction == QgsMapCanvasAnnotationItem::MoveMapPosition )
     {
-      QgsPointXY mapPos = transformCanvasToAnnotation( e->snapPoint( QgsMapMouseEvent::SnapProjectConfig ), annotation );
+      QgsPointXY mapPos = transformCanvasToAnnotation( e->snapPoint(), annotation );
       annotation->setMapPosition( mapPos );
       annotation->setRelativePosition( QPointF( e->posF().x() / mCanvas->width(),
                                        e->posF().y() / mCanvas->height() ) );

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -81,7 +81,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   if ( !mRubberBand )
   {
     // ideally we would snap preferably on the moved feature
-    e->snapPoint( QgsMapMouseEvent::SnapProjectConfig );
+    e->snapPoint();
 
     //find first geometry under mouse cursor and store iterator to it
     QgsPointXY layerCoords = toLayerCoordinates( vlayer, e->mapPoint() );
@@ -159,7 +159,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       mRubberBand = nullptr;
       return;
     }
-    e->snapPoint( QgsMapMouseEvent::SnapProjectConfig );
+    e->snapPoint();
 
     QgsPointXY startPointLayerCoords = toLayerCoordinates( ( QgsMapLayer * )vlayer, mStartPointMapCoords );
     QgsPointXY stopPointLayerCoords = toLayerCoordinates( ( QgsMapLayer * )vlayer, e->mapPoint() );

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -256,12 +256,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     void clear();
 
-    /**
-     * The snapping mode
-     * \returns Snapping mode
-     */
-    QgsMapMouseEvent::SnappingMode snappingMode() { return mSnappingMode; }
-
     void keyPressEvent( QKeyEvent *e ) override;
 
     //! determines if CAD tools are enabled or if map tools behaves "nomally"
@@ -455,7 +449,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     //! is CAD currently enabled for current map tool
     bool mCadEnabled;
     bool mConstructionMode;
-    QgsMapMouseEvent::SnappingMode mSnappingMode;
 
     // constraints
     std::unique_ptr< CadConstraint > mAngleConstraint;
@@ -478,7 +471,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     // UI
     QAction *mEnableAction = nullptr;
     QMap< QAction *, int > mCommonAngleActions; // map the common angle actions with their angle values
-    QMap< QAction *, QgsMapMouseEvent::SnappingMode > mSnappingActions; // map the snapping mode actions with their values
 
   private:
 #ifdef SIP_RUN

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -29,7 +29,7 @@ struct EdgesOnlyFilter : public QgsPointLocator::MatchFilter
 
 QgsMapMouseEvent::QgsMapMouseEvent( QgsMapCanvas *mapCanvas, QMouseEvent *event )
   : QMouseEvent( event->type(), event->pos(), event->button(), event->buttons(), event->modifiers() )
-  , mSnappingMode( NoSnapping )
+  , mHasCachedSnapResult( false )
   , mOriginalMapPoint( mapCanvas ? mapCanvas->mapSettings().mapToPixel().toMapCoordinates( event->pos() ) : QgsPointXY() )
   , mMapPoint( mOriginalMapPoint )
   , mPixelPoint( event->pos() )
@@ -39,7 +39,7 @@ QgsMapMouseEvent::QgsMapMouseEvent( QgsMapCanvas *mapCanvas, QMouseEvent *event 
 
 QgsMapMouseEvent::QgsMapMouseEvent( QgsMapCanvas *mapCanvas, QEvent::Type type, QPoint pos, Qt::MouseButton button, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers )
   : QMouseEvent( type, pos, button, buttons, modifiers )
-  , mSnappingMode( NoSnapping )
+  , mHasCachedSnapResult( false )
   , mOriginalMapPoint( mapCanvas ? mapCanvas->mapSettings().mapToPixel().toMapCoordinates( pos ) : QgsPointXY() )
   , mMapPoint( mOriginalMapPoint )
   , mPixelPoint( pos )
@@ -47,39 +47,16 @@ QgsMapMouseEvent::QgsMapMouseEvent( QgsMapCanvas *mapCanvas, QEvent::Type type, 
 {
 }
 
-QgsPointXY QgsMapMouseEvent::snapPoint( SnappingMode snappingMode )
+QgsPointXY QgsMapMouseEvent::snapPoint()
 {
   // Use cached result
-  if ( mSnappingMode == snappingMode )
+  if ( mHasCachedSnapResult )
     return mMapPoint;
 
-  mSnappingMode = snappingMode;
-
-  if ( snappingMode == NoSnapping )
-  {
-    mMapPoint = mOriginalMapPoint;
-    mPixelPoint = pos();
-    return mMapPoint;
-  }
+  mHasCachedSnapResult = true;
 
   QgsSnappingUtils *snappingUtils = mMapCanvas->snappingUtils();
-  if ( snappingMode == SnapAllLayers )
-  {
-    QgsSnappingConfig canvasConfig = snappingUtils->config();
-    QgsSnappingConfig localConfig = snappingUtils->config();
-
-    localConfig.setMode( QgsSnappingConfig::AllLayers );
-    localConfig.setType( QgsSnappingConfig::VertexAndSegment );
-    snappingUtils->setConfig( localConfig );
-
-    mSnapMatch = snappingUtils->snapToMap( mMapPoint );
-
-    snappingUtils->setConfig( canvasConfig );
-  }
-  else
-  {
-    mSnapMatch = snappingUtils->snapToMap( mMapPoint );
-  }
+  mSnapMatch = snappingUtils->snapToMap( mMapPoint );
 
   if ( mSnapMatch.isValid() )
   {
@@ -95,28 +72,27 @@ QgsPointXY QgsMapMouseEvent::snapPoint( SnappingMode snappingMode )
   return mMapPoint;
 }
 
-QList<QgsPointXY> QgsMapMouseEvent::snapSegment( SnappingMode snappingMode, bool *snapped, bool allLayers ) const
+QList<QgsPointXY> QgsMapMouseEvent::snapSegment( bool *snapped, bool allLayers ) const
 {
   QList<QgsPointXY> segment;
   QgsPointXY pt1, pt2;
 
   // If there's a cached snapping result we use it
-  if ( snappingMode == mSnappingMode && mSnapMatch.hasEdge() )
+  if ( mHasCachedSnapResult && mSnapMatch.hasEdge() )
   {
     mSnapMatch.edgePoints( pt1, pt2 );
     segment << pt1 << pt2;
   }
-
-  else if ( snappingMode != NoSnapping )
+  else
   {
     QgsPointLocator::Match match;
-    if ( snappingMode == SnapProjectConfig && !allLayers )
+    if ( !allLayers )
     {
       // run snapToMap with only segments
       EdgesOnlyFilter filter;
       match = mMapCanvas->snappingUtils()->snapToMap( mOriginalMapPoint, &filter );
     }
-    else if ( snappingMode == SnapAllLayers || allLayers )
+    else
     {
       // run snapToMap with only edges on all layers
       QgsSnappingUtils *snappingUtils = mMapCanvas->snappingUtils();

--- a/src/gui/qgsmapmouseevent.h
+++ b/src/gui/qgsmapmouseevent.h
@@ -45,13 +45,6 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
 
   public:
 
-    enum SnappingMode
-    {
-      NoSnapping,
-      SnapProjectConfig,  //!< Snap according to the configuration set in the snapping settings
-      SnapAllLayers,      //!< Snap to all rendered layers (tolerance and type from defaultSettings())
-    };
-
     /**
      * Creates a new QgsMapMouseEvent. Should only be required to be called from the QgsMapCanvas.
      *
@@ -77,17 +70,16 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
      * \brief snapPoint will snap the points using the map canvas snapping utils configuration
      * \note if snapping did not succeeded, the map point will be reset to its original position
      */
-    QgsPointXY snapPoint( SnappingMode snappingMode );
+    QgsPointXY snapPoint();
 
     /**
      * Returns the first snapped segment. If the cached snapped match is a segment, it will simply return it.
      * Otherwise it will try to snap a segment according to the event's snapping mode. In this case the cache
      * will not be overwritten.
-     * \param snappingMode Specify if the default project settings or all layers should be used for snapping
      * \param snapped if given, determines if a segment has been snapped
      * \param allLayers if true, override snapping mode
      */
-    QList<QgsPointXY> snapSegment( SnappingMode snappingMode, bool *snapped = nullptr, bool allLayers = false ) const;
+    QList<QgsPointXY> snapSegment( bool *snapped = nullptr, bool allLayers = false ) const;
 
     /**
      * Returns true if there is a snapped point cached.
@@ -144,7 +136,8 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
 
     QPoint mapToPixelCoordinates( const QgsPointXY &point );
 
-    SnappingMode mSnappingMode;
+    //! Whether snapPoint() was already called
+    bool mHasCachedSnapResult;
 
     //! Unsnapped point in map coordinates.
     QgsPointXY mOriginalMapPoint;

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -86,5 +86,5 @@ void QgsMapToolAdvancedDigitizing::cadPointChanged( const QgsPointXY &point )
 void QgsMapToolAdvancedDigitizing::snap( QgsMapMouseEvent *e )
 {
   if ( !mCadDockWidget->cadEnabled() )
-    e->snapPoint( QgsMapMouseEvent::SnapProjectConfig );
+    e->snapPoint();
 }

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -21,10 +21,6 @@
 QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolEdit( canvas )
   , mCaptureMode( CapturePoint )
-  , mSnapOnPress( false )
-  , mSnapOnRelease( false )
-  , mSnapOnMove( false )
-  , mSnapOnDoubleClick( false )
   , mCadDockWidget( cadDockWidget )
 {
 }

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -124,11 +124,6 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     //! The capture mode in which this tool operates
     CaptureMode mCaptureMode;
 
-    bool mSnapOnPress;       //!< Snap on press
-    bool mSnapOnRelease;     //!< Snap on release
-    bool mSnapOnMove;        //!< Snap on move
-    bool mSnapOnDoubleClick; //!< Snap on double-click
-
   private slots:
 
     /**

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -50,12 +50,6 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
 {
   mCaptureMode = mode;
 
-  // enable the snapping on mouse move / release
-  mSnapOnMove = true;
-  mSnapOnRelease = true;
-  mSnapOnDoubleClick = false;
-  mSnapOnPress = false;
-
   mCaptureModeFromLayer = mode == CaptureNone;
   mCapturing = false;
 


### PR DESCRIPTION
Always use snapping configuration from the project in advanced digitizing dock.
    
It was slightly confusing to have another override for snapping while it is possible to configure "no snapping" or "all layers" snapping mode in project anyway. And with the nice snapping toolbar it can be also done very quickly.

Also removes some unused class members from QgsMapToolAdvancedDigitizing