### PR TITLE
Avoid 'flashy' status bar progress widget when map renders are fast

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2067,6 +2067,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsStatusBar *mStatusBar = nullptr;
 
+    QTime mLastRenderTime;
+    double mLastRenderTimeSeconds = 0;
+    QTimer mRenderProgressBarTimer;
+    QMetaObject::Connection mRenderProgressBarTimerConnection;
+
     friend class TestQgisAppPython;
 };
 


### PR DESCRIPTION
If previous canvas render took less than 0.5 seconds, delay the appearance of the 'render in progress' status bar widget by a short amount - this avoids the status bar rapidly appearing and then disappearing for very fast renders.

(especially of use when doing fancy presentations where QGIS is used as a game engine ;) )
