### PR TITLE
Add a pure virtual clone method to processing parameter definitions

### DIFF
--- a/python/core/processing/qgsprocessingparameters.sip
+++ b/python/core/processing/qgsprocessingparameters.sip
@@ -213,6 +213,12 @@ class QgsProcessingParameterDefinition
 
     virtual ~QgsProcessingParameterDefinition();
 
+    virtual QgsProcessingParameterDefinition *clone() const = 0 /Factory/;
+%Docstring
+ Creates a clone of the parameter definition.
+ :rtype: QgsProcessingParameterDefinition
+%End
+
     virtual QString type() const = 0;
 %Docstring
  Unique parameter type name.
@@ -620,6 +626,8 @@ class QgsProcessingParameterBoolean : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
 
@@ -656,6 +664,8 @@ class QgsProcessingParameterCrs : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -693,6 +703,8 @@ class QgsProcessingParameterMapLayer : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -730,6 +742,8 @@ class QgsProcessingParameterExtent : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -768,6 +782,8 @@ class QgsProcessingParameterPoint : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -809,6 +825,8 @@ class QgsProcessingParameterFile : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -879,6 +897,8 @@ class QgsProcessingParameterMatrix : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -967,6 +987,8 @@ class QgsProcessingParameterMultipleLayers : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1050,6 +1072,8 @@ class QgsProcessingParameterNumber : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1133,6 +1157,8 @@ class QgsProcessingParameterRange : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1188,6 +1214,8 @@ class QgsProcessingParameterRasterLayer : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1227,6 +1255,8 @@ class QgsProcessingParameterEnum : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1298,6 +1328,8 @@ class QgsProcessingParameterString : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
 
@@ -1354,6 +1386,8 @@ class QgsProcessingParameterExpression : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
 
@@ -1413,6 +1447,8 @@ class QgsProcessingParameterVectorLayer : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1479,6 +1515,8 @@ class QgsProcessingParameterField : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1565,6 +1603,8 @@ class QgsProcessingParameterFeatureSource : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1704,6 +1744,8 @@ class QgsProcessingParameterFeatureSink : QgsProcessingDestinationParameter
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1781,6 +1823,8 @@ class QgsProcessingParameterVectorDestination : QgsProcessingDestinationParamete
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1852,6 +1896,8 @@ class QgsProcessingParameterRasterDestination : QgsProcessingDestinationParamete
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1895,6 +1941,8 @@ class QgsProcessingParameterFileDestination : QgsProcessingDestinationParameter
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1958,6 +2006,8 @@ class QgsProcessingParameterFolderDestination : QgsProcessingDestinationParamete
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 
@@ -1998,6 +2048,8 @@ class QgsProcessingParameterBand : QgsProcessingParameterDefinition
  Returns the type name for the parameter class.
  :rtype: str
 %End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
     virtual QString type() const;
     virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
 

--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -63,6 +63,10 @@ class buildvrt(GdalAlgorithm):
             def __init__(self, name, description):
                 super().__init__(name, description)
 
+            def clone(self):
+                copy = ParameterVrtDestination(self.name(), self.description())
+                return copy
+
             def type(self):
                 return 'vrt_destination'
 

--- a/python/plugins/processing/algs/qgis/Aggregate.py
+++ b/python/plugins/processing/algs/qgis/Aggregate.py
@@ -78,6 +78,10 @@ class Aggregate(QgisAlgorithm):
                 super().__init__(name, description)
                 self._parentLayerParameter = parentLayerParameterName
 
+            def clone(self):
+                copy = ParameterAggregates(self.name(), self.description(), self._parentLayerParameter)
+                return copy
+
             def type(self):
                 return 'aggregates'
 

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -26,18 +26,12 @@ __copyright__ = '(C) 2014, Arnaud Morvan'
 __revision__ = '$Format:%H$'
 
 from qgis.core import (
-    QgsApplication,
     QgsDistanceArea,
     QgsExpression,
-    QgsFeature,
-    QgsFeatureSink,
     QgsField,
     QgsFields,
     QgsProcessingException,
-    QgsProcessingParameterDefinition,
-    QgsProcessingUtils,
-    QgsProject,
-)
+    QgsProcessingParameterDefinition)
 
 from processing.algs.qgis.QgisAlgorithm import QgisFeatureBasedAlgorithm
 
@@ -58,6 +52,10 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
             def __init__(self, name, description, parentLayerParameterName='INPUT'):
                 super().__init__(name, description)
                 self._parentLayerParameter = parentLayerParameterName
+
+            def clone(self):
+                copy = ParameterFieldsMapping(self.name(), self.description(), self._parentLayerParameter)
+                return copy
 
             def type(self):
                 return 'fields_mapping'

--- a/python/plugins/processing/algs/qgis/Heatmap.py
+++ b/python/plugins/processing/algs/qgis/Heatmap.py
@@ -116,6 +116,10 @@ class Heatmap(QgisAlgorithm):
                 self.radius_param = radius_param
                 self.radius_field_param = radius_field_param
 
+            def clone(self):
+                copy = ParameterHeatmapPixelSize(self.name(), self.description(), self.parent_layer, self.radius_param, self.radius_field_param, self.minimum(), self.maximum(), self.defaultValue((), self.flags() & QgsProcessingParameterDefinition.FlagOptional))
+                return copy
+
         pixel_size_param = ParameterHeatmapPixelSize(self.PIXEL_SIZE,
                                                      self.tr('Output raster size'),
                                                      parent_layer=self.INPUT,

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -975,6 +975,11 @@ QgsProcessingParameterBoolean::QgsProcessingParameterBoolean( const QString &nam
   : QgsProcessingParameterDefinition( name, description, defaultValue, optional )
 {}
 
+QgsProcessingParameterDefinition *QgsProcessingParameterBoolean::clone() const
+{
+  return new QgsProcessingParameterBoolean( *this );
+}
+
 QString QgsProcessingParameterBoolean::valueAsPythonString( const QVariant &val, QgsProcessingContext & ) const
 {
   if ( val.canConvert<QgsProperty>() )
@@ -1001,6 +1006,11 @@ QgsProcessingParameterCrs::QgsProcessingParameterCrs( const QString &name, const
   : QgsProcessingParameterDefinition( name, description, defaultValue, optional )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterCrs::clone() const
+{
+  return new QgsProcessingParameterCrs( *this );
 }
 
 bool QgsProcessingParameterCrs::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -1042,6 +1052,11 @@ QgsProcessingParameterMapLayer::QgsProcessingParameterMapLayer( const QString &n
   : QgsProcessingParameterDefinition( name, description, defaultValue, optional )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterMapLayer::clone() const
+{
+  return new QgsProcessingParameterMapLayer( *this );
 }
 
 bool QgsProcessingParameterMapLayer::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context ) const
@@ -1095,6 +1110,11 @@ QgsProcessingParameterExtent::QgsProcessingParameterExtent( const QString &name,
   : QgsProcessingParameterDefinition( name, description, defaultValue, optional )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterExtent::clone() const
+{
+  return new QgsProcessingParameterExtent( *this );
 }
 
 bool QgsProcessingParameterExtent::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context ) const
@@ -1163,6 +1183,11 @@ QgsProcessingParameterPoint::QgsProcessingParameterPoint( const QString &name, c
 
 }
 
+QgsProcessingParameterDefinition *QgsProcessingParameterPoint::clone() const
+{
+  return new QgsProcessingParameterPoint( *this );
+}
+
 bool QgsProcessingParameterPoint::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
 {
   if ( !input.isValid() )
@@ -1203,6 +1228,11 @@ QgsProcessingParameterFile::QgsProcessingParameterFile( const QString &name, con
   , mExtension( extension )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterFile::clone() const
+{
+  return new QgsProcessingParameterFile( *this );
 }
 
 bool QgsProcessingParameterFile::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -1273,6 +1303,11 @@ QgsProcessingParameterMatrix::QgsProcessingParameterMatrix( const QString &name,
   , mFixedNumberRows( fixedNumberRows )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterMatrix::clone() const
+{
+  return new QgsProcessingParameterMatrix( *this );
 }
 
 bool QgsProcessingParameterMatrix::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -1388,6 +1423,11 @@ QgsProcessingParameterMultipleLayers::QgsProcessingParameterMultipleLayers( cons
   , mLayerType( layerType )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterMultipleLayers::clone() const
+{
+  return new QgsProcessingParameterMultipleLayers( *this );
 }
 
 bool QgsProcessingParameterMultipleLayers::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context ) const
@@ -1583,6 +1623,11 @@ QgsProcessingParameterNumber::QgsProcessingParameterNumber( const QString &name,
 
 }
 
+QgsProcessingParameterDefinition *QgsProcessingParameterNumber::clone() const
+{
+  return new QgsProcessingParameterNumber( *this );
+}
+
 bool QgsProcessingParameterNumber::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
 {
   if ( !input.isValid() )
@@ -1671,6 +1716,11 @@ QgsProcessingParameterRange::QgsProcessingParameterRange( const QString &name, c
   , mDataType( type )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterRange::clone() const
+{
+  return new QgsProcessingParameterRange( *this );
 }
 
 bool QgsProcessingParameterRange::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -1765,6 +1815,11 @@ QgsProcessingParameterRasterLayer::QgsProcessingParameterRasterLayer( const QStr
 
 }
 
+QgsProcessingParameterDefinition *QgsProcessingParameterRasterLayer::clone() const
+{
+  return new QgsProcessingParameterRasterLayer( *this );
+}
+
 bool QgsProcessingParameterRasterLayer::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context ) const
 {
   if ( !input.isValid() )
@@ -1816,6 +1871,11 @@ QgsProcessingParameterEnum::QgsProcessingParameterEnum( const QString &name, con
   , mAllowMultiple( allowMultiple )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterEnum::clone() const
+{
+  return new QgsProcessingParameterEnum( *this );
 }
 
 bool QgsProcessingParameterEnum::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -1982,6 +2042,11 @@ QgsProcessingParameterString::QgsProcessingParameterString( const QString &name,
 
 }
 
+QgsProcessingParameterDefinition *QgsProcessingParameterString::clone() const
+{
+  return new QgsProcessingParameterString( *this );
+}
+
 QString QgsProcessingParameterString::valueAsPythonString( const QVariant &value, QgsProcessingContext & ) const
 {
   if ( value.canConvert<QgsProperty>() )
@@ -2059,6 +2124,11 @@ QgsProcessingParameterExpression::QgsProcessingParameterExpression( const QStrin
 
 }
 
+QgsProcessingParameterDefinition *QgsProcessingParameterExpression::clone() const
+{
+  return new QgsProcessingParameterExpression( *this );
+}
+
 QString QgsProcessingParameterExpression::valueAsPythonString( const QVariant &value, QgsProcessingContext & ) const
 {
   if ( value.canConvert<QgsProperty>() )
@@ -2111,6 +2181,11 @@ QgsProcessingParameterVectorLayer::QgsProcessingParameterVectorLayer( const QStr
   , mDataTypes( types )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterVectorLayer::clone() const
+{
+  return new QgsProcessingParameterVectorLayer( *this );
 }
 
 bool QgsProcessingParameterVectorLayer::checkValueIsAcceptable( const QVariant &var, QgsProcessingContext *context ) const
@@ -2199,6 +2274,11 @@ QgsProcessingParameterField::QgsProcessingParameterField( const QString &name, c
   , mAllowMultiple( allowMultiple )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterField::clone() const
+{
+  return new QgsProcessingParameterField( *this );
 }
 
 bool QgsProcessingParameterField::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -2402,6 +2482,11 @@ QgsProcessingParameterFeatureSource::QgsProcessingParameterFeatureSource( const 
 
 }
 
+QgsProcessingParameterDefinition *QgsProcessingParameterFeatureSource::clone() const
+{
+  return new QgsProcessingParameterFeatureSource( *this );
+}
+
 bool QgsProcessingParameterFeatureSource::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context ) const
 {
   QVariant var = input;
@@ -2577,6 +2662,11 @@ QgsProcessingParameterFeatureSink::QgsProcessingParameterFeatureSink( const QStr
   , mDataType( type )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterFeatureSink::clone() const
+{
+  return new QgsProcessingParameterFeatureSink( *this );
 }
 
 bool QgsProcessingParameterFeatureSink::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -2760,6 +2850,11 @@ QgsProcessingParameterRasterDestination::QgsProcessingParameterRasterDestination
   : QgsProcessingDestinationParameter( name, description, defaultValue, optional )
 {}
 
+QgsProcessingParameterDefinition *QgsProcessingParameterRasterDestination::clone() const
+{
+  return new QgsProcessingParameterRasterDestination( *this );
+}
+
 bool QgsProcessingParameterRasterDestination::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
 {
   QVariant var = input;
@@ -2829,6 +2924,11 @@ QgsProcessingParameterFileDestination::QgsProcessingParameterFileDestination( co
   , mFileFilter( fileFilter.isEmpty() ? QObject::tr( "All files (*.*)" ) : fileFilter )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterFileDestination::clone() const
+{
+  return new QgsProcessingParameterFileDestination( *this );
 }
 
 bool QgsProcessingParameterFileDestination::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -2933,6 +3033,11 @@ QgsProcessingParameterFolderDestination::QgsProcessingParameterFolderDestination
   : QgsProcessingDestinationParameter( name, description, defaultValue, optional )
 {}
 
+QgsProcessingParameterDefinition *QgsProcessingParameterFolderDestination::clone() const
+{
+  return new QgsProcessingParameterFolderDestination( *this );
+}
+
 bool QgsProcessingParameterFolderDestination::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
 {
   QVariant var = input;
@@ -3010,6 +3115,11 @@ QgsProcessingParameterVectorDestination::QgsProcessingParameterVectorDestination
   , mDataType( type )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterVectorDestination::clone() const
+{
+  return new QgsProcessingParameterVectorDestination( *this );
 }
 
 bool QgsProcessingParameterVectorDestination::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
@@ -3177,6 +3287,11 @@ QgsProcessingParameterBand::QgsProcessingParameterBand( const QString &name, con
   , mParentLayerParameterName( parentLayerParameterName )
 {
 
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterBand::clone() const
+{
+  return new QgsProcessingParameterBand( *this );
 }
 
 bool QgsProcessingParameterBand::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -258,6 +258,11 @@ class CORE_EXPORT QgsProcessingParameterDefinition
     virtual ~QgsProcessingParameterDefinition() = default;
 
     /**
+     * Creates a clone of the parameter definition.
+     */
+    virtual QgsProcessingParameterDefinition *clone() const = 0 SIP_FACTORY;
+
+    /**
      * Unique parameter type name.
      */
     virtual QString type() const = 0;
@@ -640,6 +645,7 @@ class CORE_EXPORT QgsProcessingParameterBoolean : public QgsProcessingParameterD
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "boolean" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
     QString asScriptCode() const override;
@@ -670,6 +676,7 @@ class CORE_EXPORT QgsProcessingParameterCrs : public QgsProcessingParameterDefin
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "crs" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -701,6 +708,7 @@ class CORE_EXPORT QgsProcessingParameterMapLayer : public QgsProcessingParameter
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "layer" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -732,6 +740,7 @@ class CORE_EXPORT QgsProcessingParameterExtent : public QgsProcessingParameterDe
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "extent" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -764,6 +773,7 @@ class CORE_EXPORT QgsProcessingParameterPoint : public QgsProcessingParameterDef
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "point" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
 
@@ -801,6 +811,7 @@ class CORE_EXPORT QgsProcessingParameterFile : public QgsProcessingParameterDefi
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "file" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString asScriptCode() const override;
@@ -865,6 +876,7 @@ class CORE_EXPORT QgsProcessingParameterMatrix : public QgsProcessingParameterDe
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "matrix" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -948,6 +960,7 @@ class CORE_EXPORT QgsProcessingParameterMultipleLayers : public QgsProcessingPar
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "multilayer" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1026,6 +1039,7 @@ class CORE_EXPORT QgsProcessingParameterNumber : public QgsProcessingParameterDe
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "number" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1103,6 +1117,7 @@ class CORE_EXPORT QgsProcessingParameterRange : public QgsProcessingParameterDef
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "range" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1152,6 +1167,7 @@ class CORE_EXPORT QgsProcessingParameterRasterLayer : public QgsProcessingParame
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "raster" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1185,6 +1201,7 @@ class CORE_EXPORT QgsProcessingParameterEnum : public QgsProcessingParameterDefi
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "enum" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1250,6 +1267,7 @@ class CORE_EXPORT QgsProcessingParameterString : public QgsProcessingParameterDe
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "string" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
     QString asScriptCode() const override;
@@ -1301,6 +1319,7 @@ class CORE_EXPORT QgsProcessingParameterExpression : public QgsProcessingParamet
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "expression" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
     QStringList dependsOnOtherParameters() const override;
@@ -1355,6 +1374,7 @@ class CORE_EXPORT QgsProcessingParameterVectorLayer : public QgsProcessingParame
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "vector" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1418,6 +1438,7 @@ class CORE_EXPORT QgsProcessingParameterField : public QgsProcessingParameterDef
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "field" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1497,6 +1518,7 @@ class CORE_EXPORT QgsProcessingParameterFeatureSource : public QgsProcessingPara
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "source" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1626,6 +1648,7 @@ class CORE_EXPORT QgsProcessingParameterFeatureSink : public QgsProcessingDestin
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "sink" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1690,6 +1713,7 @@ class CORE_EXPORT QgsProcessingParameterVectorDestination : public QgsProcessing
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "vectorDestination" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1751,6 +1775,7 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "rasterDestination" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1786,6 +1811,7 @@ class CORE_EXPORT QgsProcessingParameterFileDestination : public QgsProcessingDe
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "fileDestination" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
@@ -1841,6 +1867,7 @@ class CORE_EXPORT QgsProcessingParameterFolderDestination : public QgsProcessing
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "folderDestination" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QgsProcessingOutputDefinition *toOutputDefinition() const override SIP_FACTORY;
@@ -1874,6 +1901,7 @@ class CORE_EXPORT QgsProcessingParameterBand : public QgsProcessingParameterDefi
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return QStringLiteral( "band" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
     QString type() const override { return typeName(); }
     bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;


### PR DESCRIPTION
And use it when we need to clone parameters (instead of more fragile conversion to and from variants)

This fixes model loading which use algorithms which create python subclasses of parameter definitions
