### PR TITLE
Geopackage: moved delete to abstract item and implemented raster deletion

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -514,7 +514,7 @@ void QgsGeoPackageAbstractLayerItem::deleteLayer()
     }
     else
     {
-      QMessageBox::information( nullptr, tr( "Delete Layer" ), tr( "Layer deleted successfully." ) );
+      QMessageBox::information( nullptr, tr( "Delete Layer" ), tr( "Layer <b>%1</b> deleted successfully." ).arg( mName ) );
       if ( mParent )
         mParent->refresh();
     }
@@ -577,19 +577,24 @@ bool QgsGeoPackageRasterLayerItem::executeDeleteLayer( QString &errCause )
       else
       {
         // Remove table
-        QString sql;
         char *errmsg = NULL;
-        sql = QStringLiteral( "DROP table %1;"
-                              "DELETE FROM gpkg_contents WHERE table_name = '%1';"
-                              "DELETE FROM gpkg_tile_matrix WHERE table_name = '%1';"
-                              "DELETE FROM gpkg_tile_matrix_set WHERE table_name = '%1';" ).arg( layerName );
+        char *sql = sqlite3_mprintf(
+                      "DROP table %w;"
+                      "DELETE FROM gpkg_contents WHERE table_name = '%q';"
+                      "DELETE FROM gpkg_tile_matrix WHERE table_name = '%q';"
+                      "DELETE FROM gpkg_tile_matrix_set WHERE table_name = '%q';",
+                      layerName.toUtf8().constData(),
+                      layerName.toUtf8().constData(),
+                      layerName.toUtf8().constData(),
+                      layerName.toUtf8().constData() );
         status = sqlite3_exec(
                    handle,                              /* An open database */
-                   sql.toUtf8().constData(),            /* SQL to be evaluated */
+                   sql,                                 /* SQL to be evaluated */
                    NULL,                                /* Callback function */
                    NULL,                                /* 1st argument to callback */
                    &errmsg                              /* Error msg written here */
                  );
+        sqlite3_free( sql );
         if ( status == SQLITE_OK )
         {
           result = true;

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -595,6 +595,24 @@ bool QgsGeoPackageRasterLayerItem::executeDeleteLayer( QString &errCause )
                    &errmsg                              /* Error msg written here */
                  );
         sqlite3_free( sql );
+        // Remove from optional tables, may silently fail
+        for ( const auto tableName : QStringList()
+              << QStringLiteral( "gpkg_extensions" )
+              << QStringLiteral( "gpkg_metadata" )
+              << QStringLiteral( "gpkg_metadata_reference" ) )
+        {
+          char *sql = sqlite3_mprintf( "DELETE FROM table %w WHERE table_name = '%q",
+                                       tableName.toUtf8().constData(),
+                                       layerName.toUtf8().constData() );
+          status = sqlite3_exec(
+                     handle,                              /* An open database */
+                     sql,                                 /* SQL to be evaluated */
+                     NULL,                                /* Callback function */
+                     NULL,                                /* 1st argument to callback */
+                     NULL                                 /* Error msg written here */
+                   );
+          sqlite3_free( sql );
+        }
         if ( status == SQLITE_OK )
         {
           result = true;

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -598,7 +598,6 @@ bool QgsGeoPackageRasterLayerItem::executeDeleteLayer( QString &errCause )
         // Remove from optional tables, may silently fail
         for ( const auto tableName : QStringList()
               << QStringLiteral( "gpkg_extensions" )
-              << QStringLiteral( "gpkg_metadata" )
               << QStringLiteral( "gpkg_metadata_reference" ) )
         {
           char *sql = sqlite3_mprintf( "DELETE FROM table %w WHERE table_name = '%q",

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -623,7 +623,7 @@ bool QgsGeoPackageRasterLayerItem::executeDeleteLayer( QString &errCause )
           sqlite3_free( errmsg );
         }
       }
-      sqlite3_close_v2( handle );
+      sqlite3_close( handle );
     }
   }
   else

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -76,7 +76,7 @@ class QgsGeoPackageConnectionItem : public QgsDataCollectionItem
 #ifdef HAVE_GUI
     virtual bool acceptDrop() override { return true; }
     virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
-    QList<QAction *> actions();
+    QList<QAction *> actions() override;
 #endif
 
     //! Return the layer type from \a geometryType
@@ -106,7 +106,7 @@ class QgsGeoPackageRootItem : public QgsDataCollectionItem
 
 #ifdef HAVE_GUI
     virtual QWidget *paramWidget() override;
-    QList<QAction *> actions();
+    QList<QAction *> actions() override;
 
   public slots:
     void newConnection();

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -29,8 +29,14 @@ class QgsGeoPackageAbstractLayerItem : public QgsLayerItem
   protected:
     QgsGeoPackageAbstractLayerItem( QgsDataItem *parent, QString name, QString path, QString uri, LayerType layerType, QString providerKey );
 
+    /** Subclasses need to implement this function with
+     * the real deletion implementation
+     */
+    virtual bool executeDeleteLayer( QString &errCause );
 #ifdef HAVE_GUI
-    QList<QAction *> actions() override;
+    QList<QAction *> actions();
+  public slots:
+    virtual void deleteLayer();
 #endif
 };
 
@@ -38,28 +44,29 @@ class QgsGeoPackageAbstractLayerItem : public QgsLayerItem
 class QgsGeoPackageRasterLayerItem : public QgsGeoPackageAbstractLayerItem
 {
     Q_OBJECT
+
   public:
     QgsGeoPackageRasterLayerItem( QgsDataItem *parent, QString name, QString path, QString uri );
-
+  protected:
+    virtual bool executeDeleteLayer( QString &errCause ) override;
 };
 
 
 class QgsGeoPackageVectorLayerItem : public QgsGeoPackageAbstractLayerItem
 {
     Q_OBJECT
+
   public:
     QgsGeoPackageVectorLayerItem( QgsDataItem *parent, QString name, QString path, QString uri, LayerType layerType );
-#ifdef HAVE_GUI
-    QList<QAction *> actions() override;
-  public slots:
-    void deleteLayer();
-#endif
+  protected:
+    virtual bool executeDeleteLayer( QString &errCause ) override;
 };
 
 
 class QgsGeoPackageConnectionItem : public QgsDataCollectionItem
 {
     Q_OBJECT
+
   public:
     QgsGeoPackageConnectionItem( QgsDataItem *parent, QString name, QString path );
 
@@ -67,11 +74,10 @@ class QgsGeoPackageConnectionItem : public QgsDataCollectionItem
     virtual bool equal( const QgsDataItem *other ) override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
-#endif
-
     virtual bool acceptDrop() override { return true; }
     virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
+    QList<QAction *> actions();
+#endif
 
     //! Return the layer type from \a geometryType
     static QgsLayerItem::LayerType layerTypeFromDb( const QString &geometryType );
@@ -91,6 +97,7 @@ class QgsGeoPackageConnectionItem : public QgsDataCollectionItem
 class QgsGeoPackageRootItem : public QgsDataCollectionItem
 {
     Q_OBJECT
+
   public:
     QgsGeoPackageRootItem( QgsDataItem *parent, QString name, QString path );
     ~QgsGeoPackageRootItem();
@@ -98,12 +105,10 @@ class QgsGeoPackageRootItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
     virtual QWidget *paramWidget() override;
-#endif
+    QList<QAction *> actions();
 
   public slots:
-#ifdef HAVE_GUI
     void newConnection();
     void connectionsChanged();
     void createDatabase();
@@ -120,9 +125,7 @@ class QgsGeoPackageDataItemProvider : public QgsDataItemProvider
 {
   public:
     virtual QString name() override { return QStringLiteral( "GPKG" ); }
-
     virtual int capabilities() override { return QgsDataProvider::Database; }
-
     virtual QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
 };
 


### PR DESCRIPTION
This PR implements raster deletion in gpkg from the browser.

There is also a bugfix that prevented single raster layers to be shown in my previous implementation.

There is still some TODO:

- [x]  try to delete entries from the optional tables: gpkg_extensions, gpkg_metadata / gpkg_metadata_reference, ignoring the errors.
- [x] address security issue as mentioned by Even
