### PR TITLE
[symbology] fix duplicate layers in symbol levels dialog

### DIFF
--- a/src/gui/symbology/qgssymbollevelsdialog.cpp
+++ b/src/gui/symbology/qgssymbollevelsdialog.cpp
@@ -30,7 +30,6 @@
 
 QgsSymbolLevelsDialog::QgsSymbolLevelsDialog( const QgsLegendSymbolList &list, bool usingSymbolLevels, QWidget *parent )
   : QDialog( parent )
-  , mList( list )
   , mForceOrderingEnabled( false )
 {
   setupUi( this );


### PR DESCRIPTION
## Description
This PR fixes a regression following commit a8999639c, whereas symbol layers are shown twice in the symbol levels dialog.

It fixes part of the issue filed here: https://issues.qgis.org/issues/16996 -- however, it still doesn't address the bigger issue, namely: symbol levels are broken, always set to 0!

@wonder-sk , I suspect the regression *might* be linked to your legend rework / cleanup. Could you have a look at this PR, as well as the bigger issue raised? Cheers.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
