### PR TITLE
Fixes relation reference widget by refreshing filter lists. Fixes #16400

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -280,6 +280,20 @@ void QgsRelationReferenceWidget::setForeignKey( const QVariant &value )
   }
   else
   {
+    QVariant nullValue = QgsApplication::nullRepresentation();
+
+    if ( mChainFilters && mFeature.isValid() && mFilterComboBoxes.count() >= mFilterFields.count() )
+    {
+      QgsFeature feature = mFeature;
+
+      for ( int i = 0; i < mFilterFields.size(); i++ )
+      {
+        QVariant v = feature.attribute( mFilterFields[i] );
+        QString f = v.isNull() ? nullValue.toString() : v.toString();
+        mFilterComboBoxes.at( i )->setCurrentIndex( mFilterComboBoxes.at( i )->findText( f ) );
+      }
+    }
+
     int i = mComboBox->findData( mFeature.id(), QgsAttributeTableModel::FeatureIdRole );
     if ( i == -1 && mAllowNull )
     {
@@ -971,12 +985,12 @@ void QgsRelationReferenceWidget::disableChainedComboBoxes( const QComboBox *scb 
       continue;
     }
 
+    cb->setCurrentIndex( 0 );
     if ( ccb->currentIndex() == 0 )
     {
-      cb->setCurrentIndex( 0 );
       cb->setEnabled( false );
     }
-    else
-      ccb = cb;
+
+    ccb = cb;
   }
 }

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -39,6 +39,12 @@ class TestQgsRelationReferenceWidget : public QObject
     void cleanup(); // will be called after every testfunction.
 
     void testChainFilter();
+    void testChainFilterRefreshed();
+
+  private:
+    std::unique_ptr<QgsVectorLayer> mLayer1;
+    std::unique_ptr<QgsVectorLayer> mLayer2;
+    std::unique_ptr<QgsRelation> mRelation;
 };
 
 void TestQgsRelationReferenceWidget::initTestCase()
@@ -55,6 +61,64 @@ void TestQgsRelationReferenceWidget::cleanupTestCase()
 
 void TestQgsRelationReferenceWidget::init()
 {
+  // create layer
+  mLayer1.reset( new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=fk:int" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) ) );
+  QgsProject::instance()->addMapLayer( mLayer1.get(), false, false );
+
+  mLayer2.reset( new QgsVectorLayer( QStringLiteral( "LineString?field=pk:int&field=material:string&field=diameter:int&field=raccord:string" ), QStringLiteral( "vl2" ), QStringLiteral( "memory" ) ) );
+  QgsProject::instance()->addMapLayer( mLayer2.get(), false, false );
+
+  // create relation
+  mRelation.reset( new QgsRelation() );
+  mRelation->setId( QStringLiteral( "vl1.vl2" ) );
+  mRelation->setName( QStringLiteral( "vl1.vl2" ) );
+  mRelation->setReferencingLayer( mLayer1->id() );
+  mRelation->setReferencedLayer( mLayer2->id() );
+  mRelation->addFieldPair( "fk", "pk" );
+  QVERIFY( mRelation->isValid() );
+  QgsProject::instance()->relationManager()->addRelation( *mRelation.get() );
+
+  // add features
+  QgsFeature ft0( mLayer1->fields() );
+  ft0.setAttribute( QStringLiteral( "pk" ), 0 );
+  ft0.setAttribute( QStringLiteral( "fk" ), 0 );
+  mLayer1->startEditing();
+  mLayer1->addFeature( ft0 );
+  mLayer1->commitChanges();
+
+  QgsFeature ft1( mLayer1->fields() );
+  ft1.setAttribute( QStringLiteral( "pk" ), 1 );
+  ft1.setAttribute( QStringLiteral( "fk" ), 1 );
+  mLayer1->startEditing();
+  mLayer1->addFeature( ft1 );
+  mLayer1->commitChanges();
+
+  QgsFeature ft2( mLayer2->fields() );
+  ft2.setAttribute( QStringLiteral( "pk" ), 10 );
+  ft2.setAttribute( QStringLiteral( "material" ), "iron" );
+  ft2.setAttribute( QStringLiteral( "diameter" ), 120 );
+  ft2.setAttribute( QStringLiteral( "raccord" ), "brides" );
+  mLayer2->startEditing();
+  mLayer2->addFeature( ft2 );
+  mLayer2->commitChanges();
+
+  QgsFeature ft3( mLayer2->fields() );
+  ft3.setAttribute( QStringLiteral( "pk" ), 11 );
+  ft3.setAttribute( QStringLiteral( "material" ), "iron" );
+  ft3.setAttribute( QStringLiteral( "diameter" ), 120 );
+  ft3.setAttribute( QStringLiteral( "raccord" ), "sleeve" );
+  mLayer2->startEditing();
+  mLayer2->addFeature( ft3 );
+  mLayer2->commitChanges();
+
+  QgsFeature ft4( mLayer2->fields() );
+  ft4.setAttribute( QStringLiteral( "pk" ), 12 );
+  ft4.setAttribute( QStringLiteral( "material" ), "steel" );
+  ft4.setAttribute( QStringLiteral( "diameter" ), 120 );
+  ft4.setAttribute( QStringLiteral( "raccord" ), "collar" );
+  mLayer2->startEditing();
+  mLayer2->addFeature( ft4 );
+  mLayer2->commitChanges();
 }
 
 void TestQgsRelationReferenceWidget::cleanup()
@@ -63,71 +127,13 @@ void TestQgsRelationReferenceWidget::cleanup()
 
 void TestQgsRelationReferenceWidget::testChainFilter()
 {
-  // create layers
-  QgsVectorLayer vl1( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=fk:int" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
-  QgsVectorLayer vl2( QStringLiteral( "LineString?field=pk:int&field=material:string&field=diameter:int&field=raccord:string" ), QStringLiteral( "vl2" ), QStringLiteral( "memory" ) );
-  QgsProject::instance()->addMapLayer( &vl1, false, false );
-  QgsProject::instance()->addMapLayer( &vl2, false, false );
-
-  // create a relation between them
-  QgsRelation relation;
-  relation.setId( QStringLiteral( "vl1.vl2" ) );
-  relation.setName( QStringLiteral( "vl1.vl2" ) );
-  relation.setReferencingLayer( vl1.id() );
-  relation.setReferencedLayer( vl2.id() );
-  relation.addFieldPair( "fk", "pk" );
-  QVERIFY( relation.isValid() );
-  QgsProject::instance()->relationManager()->addRelation( relation );
-
-  // add features
-  QgsFeature ft0( vl1.fields() );
-  ft0.setAttribute( QStringLiteral( "pk" ), 0 );
-  ft0.setAttribute( QStringLiteral( "fk" ), 0 );
-  vl1.startEditing();
-  vl1.addFeature( ft0 );
-  vl1.commitChanges();
-
-  QgsFeature ft1( vl1.fields() );
-  ft1.setAttribute( QStringLiteral( "pk" ), 1 );
-  ft1.setAttribute( QStringLiteral( "fk" ), 1 );
-  vl1.startEditing();
-  vl1.addFeature( ft1 );
-  vl1.commitChanges();
-
-  QgsFeature ft2( vl2.fields() );
-  ft2.setAttribute( QStringLiteral( "pk" ), 10 );
-  ft2.setAttribute( QStringLiteral( "material" ), "iron" );
-  ft2.setAttribute( QStringLiteral( "diameter" ), 120 );
-  ft2.setAttribute( QStringLiteral( "raccord" ), "brides" );
-  vl2.startEditing();
-  vl2.addFeature( ft2 );
-  vl2.commitChanges();
-
-  QgsFeature ft3( vl2.fields() );
-  ft3.setAttribute( QStringLiteral( "pk" ), 11 );
-  ft3.setAttribute( QStringLiteral( "material" ), "iron" );
-  ft3.setAttribute( QStringLiteral( "diameter" ), 120 );
-  ft3.setAttribute( QStringLiteral( "raccord" ), "sleeve" );
-  vl2.startEditing();
-  vl2.addFeature( ft3 );
-  vl2.commitChanges();
-
-  QgsFeature ft4( vl2.fields() );
-  ft4.setAttribute( QStringLiteral( "pk" ), 12 );
-  ft4.setAttribute( QStringLiteral( "material" ), "steel" );
-  ft4.setAttribute( QStringLiteral( "diameter" ), 120 );
-  ft4.setAttribute( QStringLiteral( "raccord" ), "collar" );
-  vl2.startEditing();
-  vl2.addFeature( ft4 );
-  vl2.commitChanges();
-
   // init a relation reference widget
   QStringList filterFields = { "material", "diameter", "raccord" };
 
   QgsRelationReferenceWidget w( new QWidget() );
   w.setChainFilters( true );
   w.setFilterFields( filterFields );
-  w.setRelation( relation, true );
+  w.setRelation( *mRelation, true );
   w.init();
 
   // check default status for comboboxes
@@ -179,6 +185,41 @@ void TestQgsRelationReferenceWidget::testChainFilter()
   // if there's no filter at all, all features' id should be proposed
   cbs[0]->setCurrentIndex( cbs[0]->findText( "material" ) );
   QCOMPARE( w.mComboBox->count(), 4 );
+}
+
+void TestQgsRelationReferenceWidget::testChainFilterRefreshed()
+{
+  // init a relation reference widget
+  QStringList filterFields = { "material", "diameter", "raccord" };
+
+  QgsRelationReferenceWidget w( new QWidget() );
+  w.setChainFilters( true );
+  w.setFilterFields( filterFields );
+  w.setRelation( *mRelation, true );
+  w.init();
+
+  // check default status for comboboxes
+  QList<QComboBox *> cbs = w.mFilterComboBoxes;
+  QCOMPARE( cbs.count(), 3 );
+  QCOMPARE( cbs[0]->currentText(), QString( "material" ) );
+  QCOMPARE( cbs[1]->currentText(), QString( "diameter" ) );
+  QCOMPARE( cbs[2]->currentText(), QString( "raccord" ) );
+
+  // update foreign key
+  w.setForeignKey( QVariant( 12 ) );
+  QCOMPARE( cbs[0]->currentText(), QString( "steel" ) );
+  QCOMPARE( cbs[1]->currentText(), QString( "120" ) );
+  QCOMPARE( cbs[2]->currentText(), QString( "collar" ) );
+
+  w.setForeignKey( QVariant( 10 ) );
+  QCOMPARE( cbs[0]->currentText(), QString( "iron" ) );
+  QCOMPARE( cbs[1]->currentText(), QString( "120" ) );
+  QCOMPARE( cbs[2]->currentText(), QString( "brides" ) );
+
+  w.setForeignKey( QVariant( 11 ) );
+  QCOMPARE( cbs[0]->currentText(), QString( "iron" ) );
+  QCOMPARE( cbs[1]->currentText(), QString( "120" ) );
+  QCOMPARE( cbs[2]->currentText(), QString( "sleeve" ) );
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
## Description

This PR fixes an issue regarding the relation reference widget : https://issues.qgis.org/issues/16400

Some tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
