### PR TITLE
[server][bugfix] Fixes OGC test on legendurl styles

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -362,7 +362,7 @@ namespace QgsWms
                                QVariant( "" ),
                                QVariant()
                              };
-    save( pLayers );
+    save( pStyle );
 
     const Parameter pStyles = { ParameterName::STYLES,
                                 QVariant::String,

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -702,7 +702,7 @@ class TestQgsServerWMS(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetMap_StyleDefault")
 
-        # custom style
+        # custom style with STYLES parameter
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),
             "SERVICE": "WMS",
@@ -710,6 +710,24 @@ class TestQgsServerWMS(QgsServerTestBase):
             "REQUEST": "GetMap",
             "LAYERS": "Country_Labels",
             "STYLES": "custom",
+            "FORMAT": "image/png",
+            "BBOX": "-16817707,-4710778,5696513,14587125",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "CRS": "EPSG:3857"
+        }.items())])
+
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetMap_StyleCustom")
+
+        # custom style with STYLE parameter
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetMap",
+            "LAYERS": "Country_Labels",
+            "STYLE": "custom",
             "FORMAT": "image/png",
             "BBOX": "-16817707,-4710778,5696513,14587125",
             "HEIGHT": "500",


### PR DESCRIPTION
## Description

This PR fixes the OGC test on styles for LegendURL which is currently failing : http://37.187.164.233/ogc/08_18_2017_14_56_00_wms_1_3_0.html#74d73148-36de-44b9-9570-cd3a7693cb94/d1e17339_1/d1e17414_1/d1e1366_1/d1e1500_1

A unit test has been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
