### PR TITLE
Fixes relation reference widget by refreshing filter lists. Fixes #16400 (backport)

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -276,6 +276,20 @@ void QgsRelationReferenceWidget::setForeignKey( const QVariant& value )
   }
   else
   {
+    QString nullValue = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+
+    if ( mChainFilters && mFeature.isValid() && mFilterComboBoxes.count() >= mFilterFields.count() )
+    {
+      QgsFeature feature = mFeature;
+
+      for ( int i = 0; i < mFilterFields.size(); i++ )
+      {
+        QVariant v = feature.attribute( mFilterFields[i] );
+        QString f = v.isNull() ? nullValue : v.toString();
+        mFilterComboBoxes.at( i )->setCurrentIndex( mFilterComboBoxes.at( i )->findText( f ) );
+      }
+    }
+
     int i = mComboBox->findData( mFeature.id(), QgsAttributeTableModel::FeatureIdRole );
     if ( i == -1 && mAllowNull )
     {
@@ -951,12 +965,12 @@ void QgsRelationReferenceWidget::disableChainedComboBoxes( const QComboBox *scb 
       continue;
     }
 
+    cb->setCurrentIndex( 0 );
     if ( ccb->currentIndex() == 0 )
     {
-      cb->setCurrentIndex( 0 );
       cb->setEnabled( false );
     }
-    else
-      ccb = cb;
+
+    ccb = cb;
   }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue regarding the relation reference widget : https://issues.qgis.org/issues/16400

Some tests have been added.

It's a backport of https://github.com/qgis/QGIS/pull/5043

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
