### PR TITLE
Filling the help infrastructure

### DIFF
--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -64,6 +64,7 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
   : QDialog( parent, f )
 {
   setupUi( this );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDwgImportDialog::showHelp );
 
   QgsSettings s;
   leDatabase->setText( s.value( "/DwgImport/lastDatabase", "" ).toString() );
@@ -477,4 +478,9 @@ void QgsDwgImportDialog::on_buttonBox_accepted()
 
     dwgGroup->setExpanded( false );
   }
+}
+
+void QgsDwgImportDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#importing-a-dxf-or-dwg-file" ) );
 }

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -19,6 +19,7 @@
 #define QGSDWGIMPORTDIALOG_H
 
 #include "ui_qgsdwgimportbase.h"
+#include "qgshelp.h"
 
 class QgsVectorLayer;
 class QgsLayerTreeGroup;
@@ -40,6 +41,7 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
     void on_pbDeselectAll_clicked();
     void on_leDatabase_textChanged( const QString &text );
     void on_leLayerGroup_textChanged( const QString &text );
+    void showHelp();
 
   private:
     QgsVectorLayer *layer( QgsLayerTreeGroup *layerGroup, QString layer, QString table );

--- a/src/app/qgsalignrasterdialog.cpp
+++ b/src/app/qgsalignrasterdialog.cpp
@@ -108,6 +108,7 @@ QgsAlignRasterDialog::QgsAlignRasterDialog( QWidget *parent )
   // TODO: auto-detect reference layer
 
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsAlignRasterDialog::runAlign );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsAlignRasterDialog::showHelp );
 
   populateLayersView();
 
@@ -119,6 +120,12 @@ QgsAlignRasterDialog::QgsAlignRasterDialog( QWidget *parent )
 QgsAlignRasterDialog::~QgsAlignRasterDialog()
 {
   delete mAlign;
+}
+
+
+void QgsAlignRasterDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "working_with_raster/raster_analysis.html#raster-alignment" ) );
 }
 
 

--- a/src/app/qgsalignrasterdialog.h
+++ b/src/app/qgsalignrasterdialog.h
@@ -17,6 +17,7 @@
 
 #include <QDialog>
 #include "qgsalignraster.h"
+#include "qgshelp.h"
 #include "ui_qgsalignrasterdialog.h"
 
 class QgsAlignRaster;
@@ -49,6 +50,7 @@ class QgsAlignRasterDialog : public QDialog, private Ui::QgsAlignRasterDialog
     void updateCustomGridOffset();
 
     void updateParametersFromReferenceLayer();
+    void showHelp();
 
   protected:
     void populateLayersView();

--- a/src/app/qgsattributeactionpropertiesdialog.cpp
+++ b/src/app/qgsattributeactionpropertiesdialog.cpp
@@ -212,5 +212,12 @@ void QgsAttributeActionPropertiesDialog::init( const QSet<QString> &actionScopes
   connect( mActionText, &QsciScintilla::textChanged, this, &QgsAttributeActionPropertiesDialog::updateButtons );
   connect( mChooseIconButton, &QAbstractButton::clicked, this, &QgsAttributeActionPropertiesDialog::chooseIcon );
 
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsAttributeActionPropertiesDialog::showHelp );
+
   updateButtons();
+}
+
+void QgsAttributeActionPropertiesDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "working_with_vector/vector_properties.html#actions-properties" ) );
 }

--- a/src/app/qgsattributeactionpropertiesdialog.h
+++ b/src/app/qgsattributeactionpropertiesdialog.h
@@ -19,6 +19,7 @@
 #include "ui_qgsattributeactionpropertiesdialogbase.h"
 
 #include "qgsaction.h"
+#include "qgshelp.h"
 
 #include <QDialog>
 
@@ -52,6 +53,7 @@ class QgsAttributeActionPropertiesDialog: public QDialog, private Ui::QgsAttribu
     void insertExpressionOrField();
     void chooseIcon();
     void updateButtons();
+    void showHelp();
 
   private:
     void init( const QSet<QString> &actionScopes );

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -93,6 +93,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   restoreGeometry( settings.value( QStringLiteral( "Windows/QgsAttributeTypeDialog/geometry" ) ).toByteArray() );
 
   constraintExpressionWidget->setLayer( vl );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsAttributeTypeDialog::showHelp );
 }
 
 QgsAttributeTypeDialog::~QgsAttributeTypeDialog()
@@ -370,4 +371,9 @@ void QgsAttributeTypeDialog::defaultExpressionChanged()
   QString previewText = fieldFormatter->representValue( mLayer, mFieldIdx, editorWidgetConfig(), QVariant(), val );
 
   mDefaultPreviewLabel->setText( "<i>" + previewText + "</i>" );
+}
+
+void QgsAttributeTypeDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "working_with_vector/vector_properties.html#configure-the-field-behavior" ) );
 }

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -22,6 +22,7 @@
 #include "qgseditorconfigwidget.h"
 #include "qgsfeature.h"
 #include "qgsvectordataprovider.h"
+#include "qgshelp.h"
 #include "qgis_app.h"
 
 class QDialog;
@@ -174,6 +175,8 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
     void on_selectionListWidget_currentRowChanged( int index );
 
     void defaultExpressionChanged();
+
+    void showHelp();
 
   private:
     QgsVectorLayer *mLayer = nullptr;

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -62,6 +62,7 @@ QgsCustomizationDialog::QgsCustomizationDialog( QWidget * parent, QSettings * se
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::apply );
   connect( buttonBox->button( QDialogButtonBox::Cancel ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::cancel );
   connect( buttonBox->button( QDialogButtonBox::Reset ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::reset );
+  connect( buttonBox->button( QDialogButtonBox::Help ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::showHelp );
 
 }
 
@@ -482,6 +483,12 @@ bool QgsCustomizationDialog::catchOn()
 {
   return actionCatch->isChecked();
 }
+
+void QgsCustomizationDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#customization" ) );
+}
+
 
 void QgsCustomization::addTreeItemActions( QTreeWidgetItem *parentItem, const QList<QAction *> &actions )
 {

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -18,6 +18,7 @@
 #define QGSCUSTOMIZATION_H
 
 #include "ui_qgscustomizationdialogbase.h"
+#include "qgshelp.h"
 
 #include <QDialog>
 #include <QDomNode>
@@ -76,6 +77,8 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
     void apply();
 
     void cancel();
+
+    void showHelp();
 
     // Reset values from settings
     void reset();

--- a/src/app/qgsdecorationlayoutextentdialog.cpp
+++ b/src/app/qgsdecorationlayoutextentdialog.cpp
@@ -43,7 +43,6 @@ QgsDecorationLayoutExtentDialog::QgsDecorationLayoutExtentDialog( QgsDecorationL
   updateGuiElements();
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsDecorationLayoutExtentDialog::apply );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDecorationLayoutExtentDialog::showHelp );
-// Pas écrit pareil ci-dessus
 
   mSymbolButton->setMapCanvas( QgisApp::instance()->mapCanvas() );
 }

--- a/src/app/qgsdecorationlayoutextentdialog.cpp
+++ b/src/app/qgsdecorationlayoutextentdialog.cpp
@@ -42,6 +42,8 @@ QgsDecorationLayoutExtentDialog::QgsDecorationLayoutExtentDialog( QgsDecorationL
 
   updateGuiElements();
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsDecorationLayoutExtentDialog::apply );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDecorationLayoutExtentDialog::showHelp );
+// Pas écrit pareil ci-dessus
 
   mSymbolButton->setMapCanvas( QgisApp::instance()->mapCanvas() );
 }
@@ -83,4 +85,9 @@ void QgsDecorationLayoutExtentDialog::apply()
 void QgsDecorationLayoutExtentDialog::on_buttonBox_rejected()
 {
   reject();
+}
+
+void QgsDecorationLayoutExtentDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#decorations" ) ); //to be precised
 }

--- a/src/app/qgsdecorationlayoutextentdialog.cpp
+++ b/src/app/qgsdecorationlayoutextentdialog.cpp
@@ -88,5 +88,5 @@ void QgsDecorationLayoutExtentDialog::on_buttonBox_rejected()
 
 void QgsDecorationLayoutExtentDialog::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#decorations" ) ); //to be precised
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#decorations" ) );
 }

--- a/src/app/qgsdecorationlayoutextentdialog.h
+++ b/src/app/qgsdecorationlayoutextentdialog.h
@@ -21,6 +21,7 @@
 #include <QDialog>
 #include "qgis_app.h"
 #include "qgstextrenderer.h"
+#include "qgshelp.h"
 #include <memory>
 
 class QgsDecorationLayoutExtent;
@@ -38,6 +39,7 @@ class APP_EXPORT QgsDecorationLayoutExtentDialog : public QDialog, private Ui::Q
     void apply();
     void on_buttonBox_accepted();
     void on_buttonBox_rejected();
+    void showHelp();
 
 
   private:

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -444,6 +444,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   connect( this, &QDialog::accepted, this, &QgsDxfExportDialog::saveSettings );
   connect( mSelectAllButton, &QAbstractButton::clicked, this, &QgsDxfExportDialog::selectAll );
   connect( mDeselectAllButton, &QAbstractButton::clicked, this, &QgsDxfExportDialog::deSelectAll );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDxfExportDialog::showHelp );
 
   mFileLineEdit->setFocus();
 
@@ -646,4 +647,8 @@ QgsCoordinateReferenceSystem QgsDxfExportDialog::crs() const
 QString QgsDxfExportDialog::mapTheme() const
 {
   return mVisibilityPresets->currentText();
+}
+void QgsDxfExportDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#create-dxf-files" ) );
 }

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -21,6 +21,7 @@
 #include "ui_qgsdxfexportdialogbase.h"
 #include "qgslayertreemodel.h"
 #include "qgsdxfexport.h"
+#include "qgshelp.h"
 
 #include <QList>
 #include <QPair>
@@ -102,6 +103,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     void saveSettings();
     void on_mVisibilityPresets_currentIndexChanged( int index );
     void on_mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs );
+    void showHelp();
 
   private:
     void cleanGroup( QgsLayerTreeNode *node );

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -463,6 +463,5 @@ void QgsMapSaveDialog::accepted()
 
 void QgsMapSaveDialog::showHelp()
 {
-  // description needs to be written and i'm not sure of the place yet
-  QgsHelp::openHelp( QStringLiteral( "introduction/getting_started.html#output" ) ); //to be precised
+  QgsHelp::openHelp( QStringLiteral( "introduction/getting_started.html#output" ) );
 }

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -119,6 +119,7 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, QL
   }
 
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsMapSaveDialog::accepted );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsMapSaveDialog::showHelp );
 }
 
 void QgsMapSaveDialog::updateDpi( int dpi )
@@ -458,4 +459,10 @@ void QgsMapSaveDialog::accepted()
       QgsApplication::taskManager()->addTask( mapRendererTask );
     }
   }
+}
+
+void QgsMapSaveDialog::showHelp()
+{
+  // description needs to be written and i'm not sure of the place yet
+  QgsHelp::openHelp( QStringLiteral( "introduction/getting_started.html#output" ) ); //to be precised
 }

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -24,6 +24,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsmapdecoration.h"
 #include "qgsrectangle.h"
+#include "qgshelp.h"
 
 #include <QDialog>
 #include <QSize>
@@ -97,6 +98,9 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
     int mDpi;
     QSize mSize;
 
+  private slots:
+
+    void showHelp();
 };
 
 #endif // QGSMAPSAVEDIALOG_H

--- a/src/app/qgsprojectlayergroupdialog.cpp
+++ b/src/app/qgsprojectlayergroupdialog.cpp
@@ -47,6 +47,7 @@ QgsProjectLayerGroupDialog::QgsProjectLayerGroupDialog( QWidget *parent, const Q
   }
 
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsProjectLayerGroupDialog::showHelp );
 }
 
 QgsProjectLayerGroupDialog::~QgsProjectLayerGroupDialog()
@@ -232,4 +233,10 @@ void QgsProjectLayerGroupDialog::on_mButtonBox_accepted()
     s.setValue( QStringLiteral( "/qgis/last_embedded_project_path" ), fi.absolutePath() );
   }
   accept();
+}
+
+void QgsProjectLayerGroupDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#nesting-projects" ) );
+
 }

--- a/src/app/qgsprojectlayergroupdialog.h
+++ b/src/app/qgsprojectlayergroupdialog.h
@@ -17,6 +17,7 @@
 
 #include "QDialog"
 #include "ui_qgsprojectlayergroupdialogbase.h"
+#include "qgshelp.h"
 #include "qgis_app.h"
 
 class QDomElement;
@@ -44,6 +45,7 @@ class APP_EXPORT QgsProjectLayerGroupDialog: public QDialog, private Ui::QgsProj
     void on_mProjectFileLineEdit_editingFinished();
     void onTreeViewSelectionChanged();
     void on_mButtonBox_accepted();
+    void showHelp();
 
   private:
     void changeProjectFile();

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -30,6 +30,7 @@
 QgsRasterCalcDialog::QgsRasterCalcDialog( QWidget *parent, Qt::WindowFlags f ): QDialog( parent, f )
 {
   setupUi( this );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsRasterCalcDialog::showHelp );
 
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/RasterCalc/geometry" ) ).toByteArray() );
@@ -222,6 +223,11 @@ void QgsRasterCalcDialog::on_mButtonBox_accepted()
   QgsSettings s;
   s.setValue( QStringLiteral( "/RasterCalculator/lastOutputFormat" ), QVariant( mOutputFormatComboBox->currentText() ) );
   s.setValue( QStringLiteral( "/RasterCalculator/lastOutputDir" ), QVariant( QFileInfo( mOutputLayerLineEdit->text() ).absolutePath() ) );
+}
+
+void QgsRasterCalcDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "working_with_raster/raster_analysis.html#raster-calculator" ) );
 }
 
 void QgsRasterCalcDialog::on_mOutputLayerPushButton_clicked()

--- a/src/app/qgsrastercalcdialog.h
+++ b/src/app/qgsrastercalcdialog.h
@@ -20,6 +20,7 @@
 
 #include "ui_qgsrastercalcdialogbase.h"
 #include "qgsrastercalculator.h"
+#include "qgshelp.h"
 #include "qgis_app.h"
 
 //! A dialog to enter a raster calculation expression
@@ -54,6 +55,7 @@ class APP_EXPORT QgsRasterCalcDialog: public QDialog, private Ui::QgsRasterCalcD
     void on_mOutputLayerLineEdit_textChanged( const QString &text );
     //! Enables OK button if calculator expression is valid and output file path exists
     void setAcceptButtonState();
+    void showHelp();
 
     //calculator buttons
     void on_mPlusPushButton_clicked();

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -41,6 +41,7 @@ QgsConfigureShortcutsDialog::QgsConfigureShortcutsDialog( QWidget *parent, QgsSh
   if ( !mManager )
     mManager = QgsGui::shortcutsManager();
 
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsConfigureShortcutsDialog::showHelp ); // Vérifier nommage des boutons
   connect( btnChangeShortcut, &QAbstractButton::clicked, this, &QgsConfigureShortcutsDialog::changeShortcut );
   connect( btnResetShortcut, &QAbstractButton::clicked, this, &QgsConfigureShortcutsDialog::resetShortcut );
   connect( btnSetNoShortcut, &QAbstractButton::clicked, this, &QgsConfigureShortcutsDialog::setNoShortcut );
@@ -490,4 +491,9 @@ void QgsConfigureShortcutsDialog::on_mLeFilter_textChanged( const QString &text 
       item->setHidden( false );
     }
   }
+}
+
+void QgsConfigureShortcutsDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#keyboard-shortcuts" ) );
 }

--- a/src/gui/qgsconfigureshortcutsdialog.h
+++ b/src/gui/qgsconfigureshortcutsdialog.h
@@ -20,6 +20,7 @@
 #include "qgis.h"
 
 #include "ui_qgsconfigureshortcutsdialog.h"
+#include "qgshelp.h"
 #include "qgis_gui.h"
 
 class QShortcut;
@@ -59,6 +60,9 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
     void on_mLeFilter_textChanged( const QString &text );
 
     void actionChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous );
+
+    //! Open the associated help
+    void showHelp();
 
   private:
 

--- a/src/ui/qgsalignrasterdialog.ui
+++ b/src/ui/qgsalignrasterdialog.ui
@@ -208,7 +208,7 @@
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
@@ -218,15 +218,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsExtentGroupBox</class>
-   <extends>QGroupBox</extends>
+   <extends>QgsCollapsibleGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsattributeactionpropertiesdialogbase.ui
+++ b/src/ui/qgsattributeactionpropertiesdialogbase.ui
@@ -67,7 +67,7 @@
    <item row="6" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -136,7 +136,7 @@
       <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QgsFieldExpressionWidget" name="mFieldExpression">
+         <widget class="QgsFieldExpressionWidget" name="mFieldExpression" native="true">
           <property name="focusPolicy">
            <enum>Qt::TabFocus</enum>
           </property>

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -104,16 +104,6 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <layout class="QGridLayout" name="gridLayout_4">
      <item row="0" column="0">
@@ -188,6 +178,16 @@
        <widget class="QStackedWidget" name="stackedWidget"/>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgsconfigureshortcutsdialog.ui
+++ b/src/ui/qgsconfigureshortcutsdialog.ui
@@ -109,7 +109,7 @@
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Close</set>
+        <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
        </property>
       </widget>
      </item>

--- a/src/ui/qgscustomizationdialogbase.ui
+++ b/src/ui/qgscustomizationdialogbase.ui
@@ -56,7 +56,7 @@
        <enum>Qt::Horizontal</enum>
       </property>
       <property name="standardButtons">
-       <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
+       <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
       </property>
      </widget>
     </item>

--- a/src/ui/qgsdecorationlayoutextentdialog.ui
+++ b/src/ui/qgsdecorationlayoutextentdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>293</width>
-    <height>143</height>
+    <width>377</width>
+    <height>148</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,28 +32,21 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="mCheckBoxLabelExtents">
+      <item row="1" column="1">
+       <widget class="QgsFontButton" name="mButtonFontStyle">
         <property name="enabled">
          <bool>true</bool>
         </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
-         <string>Label extents</string>
+         <string>Font</string>
         </property>
        </widget>
-      </item>
-      <item row="2" column="1">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="mLineSymbolLabel">
@@ -68,32 +61,13 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsFontButton" name="mButtonFontStyle">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="mCheckBoxLabelExtents">
         <property name="enabled">
          <bool>true</bool>
         </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="text">
-         <string>Font</string>
+         <string>Label extents</string>
         </property>
        </widget>
       </item>
@@ -119,6 +93,19 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
@@ -128,7 +115,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>497</width>
-    <height>366</height>
+    <height>415</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -72,11 +72,11 @@
     </widget>
    </item>
    <item row="2" column="1" colspan="2">
-    <widget class="QgsScaleWidget" name="mScaleWidget">
+    <widget class="QgsScaleWidget" name="mScaleWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
      </property>
-     <property name="showCurrentScaleButton">
+     <property name="showCurrentScaleButton" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -131,7 +131,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -167,7 +167,7 @@
     </widget>
    </item>
    <item row="5" column="1" colspan="2">
-    <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+    <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
      </property>
@@ -177,15 +177,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsLayerTreeView</class>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>225</height>
+    <height>318</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,17 +25,17 @@
      </item>
      <item row="8" column="0" colspan="2">
       <widget class="QCheckBox" name="mSaveAsRaster">
-       <property name="text">
-        <string>Rasterize map</string>
+       <property name="visible">
+        <bool>false</bool>
        </property>
        <property name="toolTip">
         <string>Advanced effects such as blend modes or vector layer transparency cannot be exported as vectors.
 Rasterizing the map is recommended when such effects are used.</string>
        </property>
-       <property name="checked">
-        <bool>false</bool>
+       <property name="text">
+        <string>Rasterize map</string>
        </property>
-       <property name="visible">
+       <property name="checked">
         <bool>false</bool>
        </property>
       </widget>
@@ -50,7 +50,7 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="0" colspan="2">>
+     <item row="6" column="0" colspan="2">
       <widget class="QCheckBox" name="mDrawAnnotations">
        <property name="text">
         <string>Draw annotations</string>
@@ -133,9 +133,6 @@ Rasterizing the map is recommended when such effects are used.</string>
          </property>
          <item>
           <widget class="QgsRatioLockButton" name="mLockAspectRatio">
-           <property name="leftMargin">
-            <number>13</number>
-           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -144,6 +141,9 @@ Rasterizing the map is recommended when such effects are used.</string>
            </property>
            <property name="toolTip">
             <string>Lock aspect ratio (including while drawing extent onto canvas)</string>
+           </property>
+           <property name="leftMargin" stdset="0">
+            <number>13</number>
            </property>
           </widget>
          </item>
@@ -204,8 +204,7 @@ Rasterizing the map is recommended when such effects are used.</string>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QgsScaleWidget" name="mScaleWidget">
-      </widget>
+      <widget class="QgsScaleWidget" name="mScaleWidget" native="true"/>
      </item>
      <item row="0" column="0" colspan="2">
       <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
@@ -235,7 +234,7 @@ Rasterizing the map is recommended when such effects are used.</string>
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>
@@ -249,6 +248,16 @@ Rasterizing the map is recommended when such effects are used.</string>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsExtentGroupBox</class>
    <extends>QgsCollapsibleGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
@@ -259,16 +268,6 @@ Rasterizing the map is recommended when such effects are used.</string>
    <extends>QToolButton</extends>
    <header>qgsratiolockbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsprojectlayergroupdialogbase.ui
+++ b/src/ui/qgsprojectlayergroupdialogbase.ui
@@ -41,7 +41,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -504,7 +504,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This PR adds help button to some of the dialogs that missed it (ref https://github.com/qgis/qgis3_UIX_discussion/issues/33) and connects it to the online user manual. General implementation follows this structure (_hope that's correct_ - local build is fine):
- `.h` file: add `#include "qgshelp.h"` and the private slot `void showHelp();`
- `.cpp` file: connect the help button in the dialog initialisation and add the the showHelp function definition.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
