### PR TITLE
Harmonize the warning message when saving DB password

### DIFF
--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -87,7 +87,7 @@ void QgsDb2NewConnection::accept()
   if ( !hasAuthConfigID && chkStorePassword->isChecked() &&
        QMessageBox::question( this,
                               tr( "Saving passwords" ),
-                              tr( "WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory on Unix-like systems, or in your user profile on Windows. If you do not want this to happen, please press the Cancel button.\n" ),
+                              tr( "WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory (Unix-like systems) or user profile (Windows). If you want to avoid this, please uncheck the option.\n" ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return;

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -93,7 +93,7 @@ void QgsOracleNewConnection::accept()
   if ( chkStorePassword->isChecked() &&
        QMessageBox::question( this,
                               tr( "Saving passwords" ),
-                              tr( "WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory on Unix-like systems, or in your user profile on Windows. If you do not want this to happen, please press the Cancel button.\n" ),
+                              tr( "WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory (Unix-like systems) or user profile (Windows). If you want to avoid this, please uncheck the option.\n" ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return;

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -122,7 +122,7 @@ void QgsPgNewConnection::accept()
   if ( !hasAuthConfigID && chkStorePassword->isChecked() &&
        QMessageBox::question( this,
                               tr( "Saving passwords" ),
-                              trUtf8( "WARNING: You have opted to save your password. It will be stored in unsecured plain text in your project files and in your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't save a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
+                              trUtf8( "WARNING: You have opted to save your password. It will be stored in unsecured plain text in your project files and in your home directory (Unix-like systems) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't save a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return;

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -184,9 +184,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>HEADS UP: You have opted to save your password. It will be stored in plain text in your project files and in your home directory on Unix-like systems, or in your user profile on Windows
-
-Untick save if you don't wish to be the case.</string>
+            <string>WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory (Unix-like systems) or user profile (Windows). If you want to avoid this, please uncheck the option.</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>


### PR DESCRIPTION
This PR harmonizes the warning message displayed when saving database password in clear text, leading to almost one sentence to translate. Also, it's more about unchecking the "save" box (refs https://github.com/qgis/qgis3_UIX_discussion/issues/19#issuecomment-266994315) than closing the message box.
A cleaner fix could even be a unique function that handles this message and call it from the different dialogs. Actually, the cleanest and best message imho is the one provided in the PostgreSQL case because:
- it states that saving the password in clear text in unsecure
- and it provides instructions to deal with this situation
![image](https://user-images.githubusercontent.com/7983394/29643353-df3bf6fe-886e-11e7-9eaf-f6c399de5827.png)

But it requires some preliminary work on dialog standardization (eg, use the authentication widget).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
