### PR TITLE
Reorganize buttons to set map extent

### DIFF
--- a/src/ui/qgsextentgroupboxwidget.ui
+++ b/src/ui/qgsextentgroupboxwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>380</width>
-    <height>202</height>
+    <width>679</width>
+    <height>163</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -77,7 +77,7 @@
    <item>
     <widget class="QWidget" name="widget_2" native="true">
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="4">
+      <item row="0" column="6">
        <widget class="QPushButton" name="mCurrentExtentButton">
         <property name="minimumSize">
          <size>
@@ -103,7 +103,7 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="3">
+      <item row="0" column="5">
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -116,7 +116,7 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="5">
+      <item row="0" column="10">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -129,20 +129,7 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="mOriginalExtentButton">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Current layer extent</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
+      <item row="0" column="3">
        <widget class="QPushButton" name="mButtonCalcFromLayer">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -155,7 +142,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="4">
+      <item row="0" column="11">
        <widget class="QPushButton" name="mButtonDrawOnCanvas">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -165,6 +152,19 @@
         </property>
         <property name="text">
          <string>Draw on canvas</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QPushButton" name="mOriginalExtentButton">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Current layer extent</string>
         </property>
        </widget>
       </item>
@@ -178,7 +178,10 @@
   <tabstop>mXMinLineEdit</tabstop>
   <tabstop>mXMaxLineEdit</tabstop>
   <tabstop>mYMinLineEdit</tabstop>
+  <tabstop>mOriginalExtentButton</tabstop>
+  <tabstop>mButtonCalcFromLayer</tabstop>
   <tabstop>mCurrentExtentButton</tabstop>
+  <tabstop>mButtonDrawOnCanvas</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
There's likely no situation where the four buttons are activated simultaneously... Better have three on a line than the current heterogeneous UI.

![image](https://user-images.githubusercontent.com/7983394/29644181-704314b6-8874-11e7-850d-455e9c1d47ab.png)

![image](https://user-images.githubusercontent.com/7983394/29644237-d98eaeb2-8874-11e7-9737-199eeafa3bfc.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
