### PR TITLE
Open raster layer UI improvements

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1905,7 +1905,7 @@ void QgisApp::createActions()
   connect( mActionEmbedLayers, &QAction::triggered, this, &QgisApp::embedLayers );
   connect( mActionAddLayerDefinition, &QAction::triggered, this, &QgisApp::addLayerDefinition );
   connect( mActionAddOgrLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "ogr" ) ); } );
-  connect( mActionAddRasterLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "raster" ) ); } );
+  connect( mActionAddRasterLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "gdal" ) ); } );
   connect( mActionAddPgLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "postgres" ) ); } );
   connect( mActionAddSpatiaLiteLayer, &QAction::triggered, [ = ] { dataSourceManager( QStringLiteral( "spatialite" ) ); } );
   connect( mActionAddMssqlLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "mssql" ) ); } );

--- a/src/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/providers/gdal/qgsgdalsourceselect.cpp
@@ -23,9 +23,10 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
 {
   setupUi( this );
   setupButtons( buttonBox );
-  mQgsFileWidget->setFilter( QgsProviderRegistry::instance()->fileRasterFilters() );
-  mQgsFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
-  connect( mQgsFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
+  mFileWidget->setDialogTitle( tr( "Open GDAL Supported Raster Dataset(s)" ) );
+  mFileWidget->setFilter( QgsProviderRegistry::instance()->fileRasterFilters() );
+  mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {
     mRasterPath = path;
     emit enableButtons( ! mRasterPath.isEmpty() );

--- a/src/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/providers/ogr/qgsogrsourceselect.cpp
@@ -97,49 +97,22 @@ QgsOgrSourceSelect::QgsOgrSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   }
   cmbDatabaseTypes->blockSignals( false );
   cmbConnections->blockSignals( false );
+
+  mFileWidget->setDialogTitle( tr( "Open OGR Supported Vector Dataset(s)" ) );
+  mFileWidget->setFilter( mVectorFileFilter );
+  mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
+
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
+  {
+    mVectorPath = path;
+    emit enableButtons( ! mVectorPath.isEmpty() );
+  } );
 }
 
 QgsOgrSourceSelect::~QgsOgrSourceSelect()
 {
   QgsSettings settings;
   settings.setValue( QStringLiteral( "Windows/OpenVectorLayer/geometry" ), saveGeometry() );
-}
-
-QStringList QgsOgrSourceSelect::openFile()
-{
-  QStringList selectedFiles;
-  QgsDebugMsg( "Vector file filters: " + mVectorFileFilter );
-  QString enc = encoding();
-  QString title = tr( "Open an OGR Supported Vector Layer" );
-  QgsGuiUtils::openFilesRememberingFilter( QStringLiteral( "lastVectorFileFilter" ), mVectorFileFilter, selectedFiles, enc, title );
-
-  return selectedFiles;
-}
-
-QString QgsOgrSourceSelect::openDirectory()
-{
-  QgsSettings settings;
-
-  bool haveLastUsedDir = settings.contains( QStringLiteral( "/UI/LastUsedDirectory" ) );
-  QString lastUsedDir = settings.value( QStringLiteral( "UI/LastUsedDirectory" ), QDir::homePath() ).toString();
-  if ( !haveLastUsedDir )
-    lastUsedDir = QLatin1String( "" );
-
-  QString path = QFileDialog::getExistingDirectory( this,
-                 tr( "Open Directory" ), lastUsedDir,
-                 QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks );
-
-  settings.setValue( QStringLiteral( "UI/LastUsedDirectory" ), path );
-  //process path if it is grass
-  if ( cmbDirectoryTypes->currentText() == QLatin1String( "Grass Vector" ) )
-  {
-#ifdef Q_OS_WIN
-    //replace backslashes with forward slashes
-    path.replace( '\\', '/' );
-#endif
-    path = path + "/head";
-  }
-  return path;
 }
 
 QStringList QgsOgrSourceSelect::dataSources()
@@ -272,29 +245,6 @@ void QgsOgrSourceSelect::setSelectedConnection()
   QgsDebugMsg( "Setting selected connection to " + cmbConnections->currentText() );
 }
 
-
-void QgsOgrSourceSelect::on_buttonSelectSrc_clicked()
-{
-  if ( radioSrcFile->isChecked() )
-  {
-    QStringList selected = openFile();
-    if ( !selected.isEmpty() )
-    {
-      inputSrcDataset->setText( selected.join( QStringLiteral( ";" ) ) );
-      addButton()->setFocus();
-      emit enableButtons( true );
-    }
-  }
-  else if ( radioSrcDirectory->isChecked() )
-  {
-    inputSrcDataset->setText( openDirectory() );
-  }
-  else if ( !radioSrcDatabase->isChecked() )
-  {
-    Q_ASSERT( !"SHOULD NEVER GET HERE" );
-  }
-}
-
 void QgsOgrSourceSelect::addButtonClicked()
 {
   QgsSettings settings;
@@ -359,7 +309,7 @@ void QgsOgrSourceSelect::addButtonClicked()
   }
   else if ( radioSrcFile->isChecked() )
   {
-    if ( inputSrcDataset->text().isEmpty() )
+    if ( mVectorPath.isEmpty() )
     {
       QMessageBox::information( this,
                                 tr( "Add vector layer" ),
@@ -367,11 +317,11 @@ void QgsOgrSourceSelect::addButtonClicked()
       return;
     }
 
-    mDataSources << inputSrcDataset->text().split( ';' );
+    mDataSources << QgsFileWidget::splitFilePaths( mVectorPath );
   }
   else if ( radioSrcDirectory->isChecked() )
   {
-    if ( inputSrcDataset->text().isEmpty() )
+    if ( mVectorPath.isEmpty() )
     {
       QMessageBox::information( this,
                                 tr( "Add vector layer" ),
@@ -379,7 +329,17 @@ void QgsOgrSourceSelect::addButtonClicked()
       return;
     }
 
-    mDataSources << inputSrcDataset->text();
+    //process path if it is grass
+    if ( cmbDirectoryTypes->currentText() == QLatin1String( "Grass Vector" ) )
+    {
+#ifdef Q_OS_WIN
+      //replace backslashes with forward slashes
+      mVectorPath.replace( '\\', '/' );
+#endif
+      mVectorPath = mVectorPath + "/head";
+    }
+
+    mDataSources << mVectorPath;
   }
 
   // Save the used encoding
@@ -402,6 +362,12 @@ void QgsOgrSourceSelect::on_radioSrcFile_toggled( bool checked )
     fileGroupBox->show();
     dbGroupBox->hide();
     protocolGroupBox->hide();
+
+    mFileWidget->setDialogTitle( tr( "Open an OGR Supported Vector Layer" ) );
+    mFileWidget->setFilter( mVectorFileFilter );
+    mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
+    mFileWidget->setFilePath( QString() );
+
     mDataSourceType = QStringLiteral( "file" );
   }
 }
@@ -415,6 +381,11 @@ void QgsOgrSourceSelect::on_radioSrcDirectory_toggled( bool checked )
     fileGroupBox->show();
     dbGroupBox->hide();
     protocolGroupBox->hide();
+
+    mFileWidget->setDialogTitle( tr( "Open Directory" ) );
+    mFileWidget->setStorageMode( QgsFileWidget::GetDirectory );
+    mFileWidget->setFilePath( QString() );
+
     mDataSourceType = QStringLiteral( "directory" );
   }
 }

--- a/src/providers/ogr/qgsogrsourceselect.h
+++ b/src/providers/ogr/qgsogrsourceselect.h
@@ -91,7 +91,6 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     //! Sets the selected connection
     void setSelectedConnection();
 
-    void on_buttonSelectSrc_clicked();
     void on_radioSrcFile_toggled( bool checked );
     void on_radioSrcDirectory_toggled( bool checked );
     void on_radioSrcDatabase_toggled( bool checked );
@@ -102,6 +101,11 @@ class QgsOgrSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsOg
     void on_cmbDatabaseTypes_currentIndexChanged( const QString &text );
     void on_cmbConnections_currentIndexChanged( const QString &text );
     void showHelp();
+
+  private:
+
+    QString mVectorPath;
+
 };
 
 #endif // QGSOGRSOURCESELECT_H

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -39,12 +39,12 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Dataset</string>
+         <string>Raster Dataset(s)</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QgsFileWidget" name="mQgsFileWidget"/>
+       <widget class="QgsFileWidget" name="mFileWidget"/>
       </item>
      </layout>
     </widget>

--- a/src/ui/qgsgdalsourceselectbase.ui
+++ b/src/ui/qgsgdalsourceselectbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Add Layer(s) from a Server</string>
+   <string>Add Raster Layer(s)</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -24,17 +24,32 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="srcGroupBox_1">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
+     <property name="title">
+      <string>Source</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Dataset</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsFileWidget" name="mQgsFileWidget"/>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QgsFileWidget" name="mQgsFileWidget"/>
-   </item>
-   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -47,10 +62,10 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Path to a raster data source</string>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsogrsourceselectbase.ui
+++ b/src/ui/qgsogrsourceselectbase.ui
@@ -103,35 +103,28 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2" colspan="2">
-       <widget class="QComboBox" name="cmbDirectoryTypes"/>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cmbDirectoryTypes">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0">
        <widget class="QLabel" name="labelSrcDataset">
         <property name="text">
-         <string>Dataset</string>
+         <string>Vector Dataset(s)</string>
         </property>
         <property name="buddy">
-         <cstring>inputSrcDataset</cstring>
+         <cstring>mFileWidget</cstring>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QLineEdit" name="inputSrcDataset">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QToolButton" name="buttonSelectSrc">
-        <property name="text">
-         <string>…</string>
-        </property>
-       </widget>
+      <item row="1" column="1">
+       <widget class="QgsFileWidget" name="mFileWidget"/>
       </item>
      </layout>
     </widget>
@@ -297,6 +290,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>radioSrcFile</tabstop>
   <tabstop>radioSrcDirectory</tabstop>
@@ -306,8 +306,7 @@
   <tabstop>cmbProtocolTypes</tabstop>
   <tabstop>protocolURI</tabstop>
   <tabstop>cmbDirectoryTypes</tabstop>
-  <tabstop>inputSrcDataset</tabstop>
-  <tabstop>buttonSelectSrc</tabstop>
+  <tabstop>mFileWidget</tabstop>
   <tabstop>cmbDatabaseTypes</tabstop>
   <tabstop>cmbConnections</tabstop>
   <tabstop>btnNew</tabstop>

--- a/src/ui/qgsogrsourceselectbase.ui
+++ b/src/ui/qgsogrsourceselectbase.ui
@@ -127,9 +127,9 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QPushButton" name="buttonSelectSrc">
+       <widget class="QToolButton" name="buttonSelectSrc">
         <property name="text">
-         <string>Browse</string>
+         <string>…</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Description
This PR fixes a problem whereas clicking on "open raster layer" toolbar button fails to focus the data source manager to the raster tab. It also harmonizes the open raster & open vector UIs:
![screenshot from 2017-08-25 10-53-16](https://user-images.githubusercontent.com/1728657/29699080-28df608c-8984-11e7-9c44-576fb69e4719.png)

@elpaso , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
