### PR TITLE
Remove redundant math constant defines

### DIFF
--- a/python/core/qgsdistancearea.sip
+++ b/python/core/qgsdistancearea.sip
@@ -179,7 +179,7 @@ Constructor
  :rtype: float
 %End
 
-    double measureLineProjected( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI / 2, QgsPointXY *projectedPoint /Out/ = 0 ) const;
+    double measureLineProjected( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI_2, QgsPointXY *projectedPoint /Out/ = 0 ) const;
 %Docstring
  Calculates the distance from one point with distance in meters and azimuth (direction)
  When the sourceCrs() is geographic, computeSpheroidProject() will be called
@@ -279,7 +279,7 @@ Constructor
  :rtype: float
 %End
 
-    QgsPointXY computeSpheroidProject( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI / 2 ) const;
+    QgsPointXY computeSpheroidProject( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI_2 ) const;
 %Docstring
  Given a location, an azimuth and a distance, computes the
  location of the projected point. Based on Vincenty's formula

--- a/python/core/symbology/qgssymbollayer.sip
+++ b/python/core/symbology/qgssymbollayer.sip
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsSymbolLayer
 {
 

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -20,10 +20,6 @@
 
 #define NO_DATA -9999
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 QgsKernelDensityEstimation::QgsKernelDensityEstimation( const QgsKernelDensityEstimation::Parameters &parameters, const QString &outputFile, const QString &outputFormat )
   : mSource( parameters.source )
   , mOutputFile( outputFile )

--- a/src/app/dwg/libdxfrw/drw_base.h
+++ b/src/app/dwg/libdxfrw/drw_base.h
@@ -38,12 +38,6 @@
 #  define DRW_POSIX
 #endif
 
-#ifndef M_PI
-#define M_PI   3.141592653589793238462643
-#endif
-#ifndef M_PI_2
-#define M_PI_2 1.57079632679489661923
-#endif
 #define M_PIx2 6.283185307179586 // 2*PI
 #define ARAD 57.29577951308232
 

--- a/src/app/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/qgsdecorationnortharrowdialog.cpp
@@ -152,8 +152,7 @@ void QgsDecorationNorthArrowDialog::drawNorthArrow()
     myQPainter.rotate( rotation );
     //work out how to shift the image so that it appears in the center of the canvas
     //(x cos a + y sin a - x, -x sin a + y cos a - y)
-    const double PI = 3.14159265358979323846;
-    double myRadiansDouble = ( PI / 180 ) * rotation;
+    double myRadiansDouble = ( M_PI / 180 ) * rotation;
     int xShift = static_cast<int>( (
                                      ( centerXDouble * std::cos( myRadiansDouble ) ) +
                                      ( centerYDouble * std::sin( myRadiansDouble ) )

--- a/src/app/qgsmaptoolrotatefeature.cpp
+++ b/src/app/qgsmaptoolrotatefeature.cpp
@@ -36,8 +36,6 @@
 #include <limits>
 #include <cmath>
 
-#define PI 3.14159265
-
 QgsAngleMagnetWidget::QgsAngleMagnetWidget( const QString &label, QWidget *parent )
   : QWidget( parent )
 {
@@ -152,7 +150,7 @@ void QgsMapToolRotateFeature::canvasMoveEvent( QgsMapMouseEvent *e )
   {
     const double XDistance = e->pos().x() - mStPoint.x();
     const double YDistance = e->pos().y() - mStPoint.y();
-    double rotation = std::atan2( YDistance, XDistance ) * ( 180 / PI );
+    double rotation = std::atan2( YDistance, XDistance ) * ( 180 / M_PI );
 
     if ( mRotationWidget )
     {
@@ -297,7 +295,7 @@ void QgsMapToolRotateFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
 
     double XDistance = mInitialPos.x() - mAnchorPoint->x();
     double YDistance = mInitialPos.y() - mAnchorPoint->y() ;
-    mRotationOffset = std::atan2( YDistance, XDistance ) * ( 180 / PI );
+    mRotationOffset = std::atan2( YDistance, XDistance ) * ( 180 / M_PI );
 
     createRotationWidget();
     if ( e->modifiers() & Qt::ShiftModifier )
@@ -349,7 +347,7 @@ void QgsMapToolRotateFeature::applyRotation( double rotation )
   }
 
   //calculations for affine transformation
-  double angle = -1 * mRotation * ( PI / 180 );
+  double angle = -1 * mRotation * ( M_PI / 180 );
   QgsPointXY anchorPoint = toLayerCoordinates( vlayer, mStartPointMapCoords );
   double a = std::cos( angle );
   double b = -1 * std::sin( angle );

--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -24,10 +24,6 @@ email                : jpalmer at linz dot govt dot nz
 #include <cmath>
 #include <QMouseEvent>
 
-#ifndef M_PI
-#define M_PI 3.1415926535897931159979634685
-#endif
-
 const int RADIUS_SEGMENTS = 40;
 
 QgsMapToolSelectRadius::QgsMapToolSelectRadius( QgsMapCanvas *canvas )

--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -388,18 +388,18 @@ double QgsComposerArrow::computeMarkerMargin() const
   {
     if ( mMarkerMode == DefaultMarker )
     {
-      margin = mPen.widthF() / std::sqrt( 2.0 ) + mArrowHeadWidth / 2.0;
+      margin = mPen.widthF() * M_SQRT1_2 + mArrowHeadWidth / 2.0;
     }
     else if ( mMarkerMode == NoMarker )
     {
-      margin = mPen.widthF() / std::sqrt( 2.0 );
+      margin = mPen.widthF() * M_SQRT1_2;
     }
     else if ( mMarkerMode == SVGMarker )
     {
       double startMarkerMargin = std::sqrt( 0.25 * ( mStartArrowHeadHeight * mStartArrowHeadHeight + mArrowHeadWidth * mArrowHeadWidth ) );
       double stopMarkerMargin = std::sqrt( 0.25 * ( mStopArrowHeadHeight * mStopArrowHeadHeight + mArrowHeadWidth * mArrowHeadWidth ) );
       double markerMargin = std::max( startMarkerMargin, stopMarkerMargin );
-      margin = std::max( mPen.widthF() / std::sqrt( 2.0 ), markerMargin );
+      margin = std::max( mPen.widthF() * M_SQRT1_2, markerMargin );
     }
   }
   return margin;

--- a/src/core/effects/qgsshadoweffect.cpp
+++ b/src/core/effects/qgsshadoweffect.cpp
@@ -56,8 +56,8 @@ void QgsShadowEffect::draw( QgsRenderContext &context )
   double offsetDist = context.convertToPainterUnits( mOffsetDist, mOffsetUnit, mOffsetMapUnitScale );
 
   double   angleRad = mOffsetAngle * M_PI / 180; // to radians
-  QPointF transPt( -offsetDist * std::cos( angleRad + M_PI / 2 ),
-                   -offsetDist * std::sin( angleRad + M_PI / 2 ) );
+  QPointF transPt( -offsetDist * std::cos( angleRad + M_PI_2 ),
+                   -offsetDist * std::sin( angleRad + M_PI_2 ) );
 
   //transparency, scale
   QgsImageOperation::multiplyOpacity( colorisedIm, mOpacity );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2645,9 +2645,9 @@ static QVariant fcnAzimuth( const QVariantList &values, const QgsExpressionConte
   if ( pt1->y() == pt2->y() )
   {
     if ( pt1->x() < pt2->x() )
-      return M_PI / 2;
+      return M_PI_2;
     else if ( pt1->x() > pt2->x() )
-      return M_PI + ( M_PI / 2 );
+      return M_PI + ( M_PI_2 );
     else
       return 0;
   }
@@ -2661,7 +2661,7 @@ static QVariant fcnAzimuth( const QVariantList &values, const QgsExpressionConte
     else /* ( pt1->y() > pt2->y() )  - equality case handled above */
     {
       return std::atan( std::fabs( pt1->y() - pt2->y() ) / std::fabs( pt1->x() - pt2->x() ) )
-             + ( M_PI / 2 );
+             + ( M_PI_2 );
     }
   }
 
@@ -2675,7 +2675,7 @@ static QVariant fcnAzimuth( const QVariantList &values, const QgsExpressionConte
     else /* ( pt1->y() < pt2->y() )  - equality case handled above */
     {
       return std::atan( std::fabs( pt1->y() - pt2->y() ) / std::fabs( pt1->x() - pt2->x() ) )
-             + ( M_PI + ( M_PI / 2 ) );
+             + ( M_PI + ( M_PI_2 ) );
     }
   }
 }
@@ -3791,7 +3791,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "degrees" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "radians" ) ), fcnDegrees, QStringLiteral( "Math" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "azimuth" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "point_a" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "point_b" ) ), fcnAzimuth, QStringList() << QStringLiteral( "Math" ) << QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "inclination" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "point_a" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "point_b" ) ), fcnInclination, QStringList() << QStringLiteral( "Math" ) << QStringLiteral( "GeometryGroup" ) )
-        << new QgsStaticExpressionFunction( QStringLiteral( "project" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "point" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "distance" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "azimuth" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "elevation" ), true, M_PI / 2 ), fcnProject, QStringLiteral( "GeometryGroup" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "project" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "point" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "distance" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "azimuth" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "elevation" ), true, M_PI_2 ), fcnProject, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "abs" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnAbs, QStringLiteral( "Math" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "cos" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "angle" ) ), fcnCos, QStringLiteral( "Math" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "sin" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "angle" ) ), fcnSin, QStringLiteral( "Math" ) )

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -772,7 +772,7 @@ void QgsCircularString::sumUpArea( double &sum ) const
     bool circlePointLeftOfLine = QgsGeometryUtils::leftOfLine( p2.x(), p2.y(), p1.x(), p1.y(), p3.x(), p3.y() ) < 0;
     bool centerPointLeftOfLine = QgsGeometryUtils::leftOfLine( centerX, centerY, p1.x(), p1.y(), p3.x(), p3.y() ) < 0;
 
-    double cov = 0.5 - d * std::sqrt( r2 - d * d ) / ( M_PI * r2 ) - 1 / M_PI * std::asin( d / radius );
+    double cov = 0.5 - d * std::sqrt( r2 - d * d ) / ( M_PI * r2 ) - M_1_PI * std::asin( d / radius );
     double circleChordArea = 0;
     if ( circlePointLeftOfLine == centerPointLeftOfLine )
     {

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1093,7 +1093,7 @@ QgsLineString QgsGeometryUtils::perpendicularSegment( const QgsPoint &p, const Q
 double QgsGeometryUtils::lineAngle( double x1, double y1, double x2, double y2 )
 {
   double at = std::atan2( y2 - y1, x2 - x1 );
-  double a = -at + M_PI / 2.0;
+  double a = -at + M_PI_2;
   return normalizedAngle( a );
 }
 
@@ -1107,7 +1107,7 @@ double QgsGeometryUtils::angleBetweenThreePoints( double x1, double y1, double x
 double QgsGeometryUtils::linePerpendicularAngle( double x1, double y1, double x2, double y2 )
 {
   double a = lineAngle( x1, y1, x2, y2 );
-  a += ( M_PI / 2.0 );
+  a += M_PI_2;
   return normalizedAngle( a );
 }
 

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -373,7 +373,7 @@ QgsVector calcMotion( const QgsPoint &a, const QgsPoint &b, const QgsPoint &c,
 
   // wonderful nasty hack which has survived through JOSM -> id -> QGIS
   // to deal with almost-straight segments (angle is closer to 180 than to 90/270).
-  if ( dotProduct < -0.707106781186547 )
+  if ( dotProduct < -M_SQRT1_2 )
     dotProduct += 1.0;
 
   QgsVector new_v = p + q;

--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -386,9 +386,9 @@ QVector<double> QgsTriangle::angles() const
   double a2 = std::fmod( QgsGeometryUtils::angleBetweenThreePoints( ax, ay, bx, by, cx, cy ), M_PI );
   double a3 = std::fmod( QgsGeometryUtils::angleBetweenThreePoints( bx, by, cx, cy, ax, ay ), M_PI );
 
-  angles.append( ( a1 > M_PI / 2 ? a1 - M_PI / 2 : a1 ) );
-  angles.append( ( a2 > M_PI / 2 ? a2 - M_PI / 2 : a2 ) );
-  angles.append( ( a3 > M_PI / 2 ? a3 - M_PI / 2 : a3 ) );
+  angles.append( ( a1 > M_PI_2 ? a1 - M_PI_2 : a1 ) );
+  angles.append( ( a2 > M_PI_2 ? a2 - M_PI_2 : a2 ) );
+  angles.append( ( a3 > M_PI_2 ? a3 - M_PI_2 : a3 ) );
 
   return angles;
 }
@@ -419,7 +419,7 @@ bool QgsTriangle::isRight( double angleTolerance ) const
   QVector<double>::iterator ita = a.begin();
   while ( ita != a.end() )
   {
-    if ( qgsDoubleNear( *ita, M_PI / 2.0, angleTolerance ) )
+    if ( qgsDoubleNear( *ita, M_PI_2, angleTolerance ) )
       return true;
     ita++;
   }

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -443,7 +443,7 @@ int FeaturePart::createCandidatesAroundPoint( double x, double y, QList< LabelPo
   double candidateAngleIncrement = 2 * M_PI / numberCandidates; /* angle bw 2 pos */
 
   /* various angles */
-  double a90  = M_PI / 2;
+  double a90  = M_PI_2;
   double a180 = M_PI;
   double a270 = a180 + a90;
   double a360 = 2 * M_PI;
@@ -470,7 +470,7 @@ int FeaturePart::createCandidatesAroundPoint( double x, double y, QList< LabelPo
 
   int i;
   double angleToCandidate;
-  for ( i = 0, angleToCandidate = M_PI / 4; i < numberCandidates; i++, angleToCandidate += candidateAngleIncrement )
+  for ( i = 0, angleToCandidate = M_PI_4; i < numberCandidates; i++, angleToCandidate += candidateAngleIncrement )
   {
     double labelX = x;
     double labelY = y;
@@ -763,12 +763,12 @@ int FeaturePart::createCandidatesAlongLineNearStraightSegments( QList<LabelPosit
       else
         angle = std::atan2( candidateEndY - candidateStartY, candidateEndX - candidateStartX );
 
-      beta = angle + M_PI / 2;
+      beta = angle + M_PI_2;
 
       if ( mLF->layer()->arrangement() == QgsPalLayerSettings::Line )
       {
         // find out whether the line direction for this candidate is from right to left
-        bool isRightToLeft = ( angle > M_PI / 2 || angle <= -M_PI / 2 );
+        bool isRightToLeft = ( angle > M_PI_2 || angle <= -M_PI_2 );
         // meaning of above/below may be reversed if using map orientation and the line has right-to-left direction
         bool reversed = ( ( flags & FLAG_MAP_ORIENTATION ) ? isRightToLeft : false );
         bool aboveLine = ( !reversed && ( flags & FLAG_ABOVE_LINE ) ) || ( reversed && ( flags & FLAG_BELOW_LINE ) );
@@ -908,12 +908,12 @@ int FeaturePart::createCandidatesAlongLineNearMidpoint( QList<LabelPosition *> &
     else
       angle = std::atan2( candidateEndY - candidateStartY, candidateEndX - candidateStartX );
 
-    beta = angle + M_PI / 2;
+    beta = angle + M_PI_2;
 
     if ( mLF->layer()->arrangement() == QgsPalLayerSettings::Line )
     {
       // find out whether the line direction for this candidate is from right to left
-      bool isRightToLeft = ( angle > M_PI / 2 || angle <= -M_PI / 2 );
+      bool isRightToLeft = ( angle > M_PI_2 || angle <= -M_PI_2 );
       // meaning of above/below may be reversed if using map orientation and the line has right-to-left direction
       bool reversed = ( ( flags & FLAG_MAP_ORIENTATION ) ? isRightToLeft : false );
       bool aboveLine = ( !reversed && ( flags & FLAG_ABOVE_LINE ) ) || ( reversed && ( flags & FLAG_BELOW_LINE ) );
@@ -1125,7 +1125,7 @@ LabelPosition *FeaturePart::curvedPlacementAtOffset( PointSet *path_positions, d
     while ( render_angle >= 2 * M_PI ) render_angle -= 2 * M_PI;
     while ( render_angle < 0 ) render_angle += 2 * M_PI;
 
-    if ( render_angle > M_PI / 2 && render_angle < 1.5 * M_PI )
+    if ( render_angle > M_PI_2 && render_angle < 1.5 * M_PI )
       slp->incrementUpsideDownCharCount();
   }
   // END FOR
@@ -1136,7 +1136,7 @@ LabelPosition *FeaturePart::curvedPlacementAtOffset( PointSet *path_positions, d
 static LabelPosition *_createCurvedCandidate( LabelPosition *lp, double angle, double dist )
 {
   LabelPosition *newLp = new LabelPosition( *lp );
-  newLp->offsetPosition( dist * std::cos( angle + M_PI / 2 ), dist * std::sin( angle + M_PI / 2 ) );
+  newLp->offsetPosition( dist * std::cos( angle + M_PI_2 ), dist * std::sin( angle + M_PI_2 ) );
   return newLp;
 }
 
@@ -1424,18 +1424,18 @@ int FeaturePart::createCandidatesForPolygon( QList< LabelPosition *> &lPos, Poin
         }
         else if ( box->length > 1.5 * labelWidth && box->width > 1.5 * labelWidth )
         {
-          if ( box->alpha <= M_PI / 4 )
+          if ( box->alpha <= M_PI_4 )
           {
             alpha = box->alpha;
           }
           else
           {
-            alpha = box->alpha - M_PI / 2;
+            alpha = box->alpha - M_PI_2;
           }
         }
         else if ( box->length > box->width )
         {
-          alpha = box->alpha - M_PI / 2;
+          alpha = box->alpha - M_PI_2;
         }
         else
         {
@@ -1464,8 +1464,8 @@ int FeaturePart::createCandidatesForPolygon( QList< LabelPosition *> &lPos, Poin
           for ( py = py0; py <= box->length; py += dy )
           {
 
-            rx = std::cos( box->alpha ) * px + std::cos( box->alpha - M_PI / 2 ) * py;
-            ry = std::sin( box->alpha ) * px + std::sin( box->alpha - M_PI / 2 ) * py;
+            rx = std::cos( box->alpha ) * px + std::cos( box->alpha - M_PI_2 ) * py;
+            ry = std::sin( box->alpha ) * px + std::sin( box->alpha - M_PI_2 ) * py;
 
             rx += box->x[0];
             ry += box->y[0];

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -44,10 +44,6 @@
 #include <cmath>
 #include <cfloat>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 using namespace pal;
 
 FeaturePart::FeaturePart( QgsLabelFeature *feat, const GEOSGeometry *geom )

--- a/src/core/pal/geomfunction.cpp
+++ b/src/core/pal/geomfunction.cpp
@@ -329,7 +329,7 @@ bool GeomFunction::containsCandidate( const GEOSPreparedGeometry *geom, double x
   GEOSCoordSeq_setY_r( geosctxt, coord, 0, y );
   if ( !qgsDoubleNear( alpha, 0.0 ) )
   {
-    double beta = alpha + ( M_PI / 2 );
+    double beta = alpha + M_PI_2;
     double dx1 = std::cos( alpha ) * width;
     double dy1 = std::sin( alpha ) * width;
     double dx2 = std::cos( beta ) * height;

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -38,10 +38,6 @@
 #include <cmath>
 #include <cfloat>
 
-#ifndef M_PI
-#define M_PI 3.1415926535897931159979634685
-#endif
-
 using namespace pal;
 
 LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, double alpha, double cost, FeaturePart *feature, bool isReversed, Quadrant quadrant )

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -70,7 +70,7 @@ LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, 
   while ( this->alpha < 0 )
     this->alpha += 2 * M_PI;
 
-  double beta = this->alpha + ( M_PI / 2 );
+  double beta = this->alpha + M_PI_2;
 
   double dx1, dx2, dy1, dy2;
 
@@ -94,7 +94,7 @@ LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, 
 
   // upside down ? (curved labels are always correct)
   if ( !feature->layer()->isCurved() &&
-       this->alpha > M_PI / 2 && this->alpha <= 3 * M_PI / 2 )
+       this->alpha > M_PI_2 && this->alpha <= 3 * M_PI_2 )
   {
     if ( feature->showUprightLabels() )
     {

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -656,7 +656,7 @@ CHullBox *PointSet::compute_chull_bbox()
     for ( i = 0; i < 16; i += 4 )
     {
 
-      alpha_seg = ( ( i / 4 > 0 ? ( i / 4 ) - 1 : 3 ) ) * M_PI / 2 + alpha;
+      alpha_seg = ( ( i / 4 > 0 ? ( i / 4 ) - 1 : 3 ) ) * M_PI_2 + alpha;
 
       best_cp = DBL_MAX;
       for ( j = 0; j < nbPoints; j++ )

--- a/src/core/pal/util.cpp
+++ b/src/core/pal/util.cpp
@@ -37,18 +37,6 @@
 #include "qgslogger.h"
 #include <cfloat>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-#ifndef M_PI_2
-#define M_PI_2 1.57079632679489661923
-#endif
-
-#ifndef M_SQRT2
-#define M_SQRT2 1.41421356237309504880
-#endif
-
 void pal::Util::sort( void **items, int N, bool ( *greater )( void *l, void *r ) )
 {
 

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -662,7 +662,7 @@ void QgsDistanceArea::computeAreaInit()
   m_QbarC =                     - ( 3.0 / 25.0 ) * e4 - ( 12.0 / 35.0 ) * e6;
   m_QbarD = ( 4.0 / 49.0 ) * e6;
 
-  m_Qp = getQ( M_PI / 2 );
+  m_Qp = getQ( M_PI_2 );
   m_E  = 4 * M_PI * m_Qp * m_AE;
   if ( m_E < 0.0 )
     m_E = -m_E;

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -34,11 +34,6 @@
 #include "qgsunittypes.h"
 #include "qgsexception.h"
 
-// MSVC compiler doesn't have defined M_PI in math.h
-#ifndef M_PI
-#define M_PI          3.14159265358979323846
-#endif
-
 #define DEG2RAD(x)    ((x)*M_PI/180)
 #define RAD2DEG(r) (180.0 * (r) / M_PI)
 #define POW2(x) ((x)*(x))

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -193,7 +193,7 @@ class CORE_EXPORT QgsDistanceArea
      * \see sourceCrs()
      * \see computeSpheroidProject()
      */
-    double measureLineProjected( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI / 2, QgsPointXY *projectedPoint SIP_OUT = nullptr ) const;
+    double measureLineProjected( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI_2, QgsPointXY *projectedPoint SIP_OUT = nullptr ) const;
 
     /**
      * Returns the units of distance for length calculations made by this object.
@@ -286,7 +286,7 @@ class CORE_EXPORT QgsDistanceArea
      * \param azimuth - azimuth in radians, clockwise from North
      * \return p2 - location of projected point as longitude/latitude.
      */
-    QgsPointXY computeSpheroidProject( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI / 2 ) const;
+    QgsPointXY computeSpheroidProject( const QgsPointXY &p1, double distance = 1, double azimuth = M_PI_2 ) const;
 
   private:
 

--- a/src/core/qgstextrenderer.cpp
+++ b/src/core/qgstextrenderer.cpp
@@ -2198,8 +2198,8 @@ void QgsTextRenderer::drawBackground( QgsRenderContext &context, QgsTextRenderer
       else if ( background.type() == QgsTextBackgroundSettings::ShapeEllipse )
       {
         // start with label bound by ellipse
-        h = h / std::sqrt( 2.0 ) * 2;
-        w = w / std::sqrt( 2.0 ) * 2;
+        h = h * M_SQRT1_2 * 2;
+        w = w * M_SQRT1_2 * 2;
       }
 
       double bufferWidth = context.convertToPainterUnits( background.size().width(), background.sizeUnit(),
@@ -2388,8 +2388,8 @@ void QgsTextRenderer::drawShadow( QgsRenderContext &context, const QgsTextRender
     angleRad -= ( component.rotation * M_PI / 180 + component.rotationOffset * M_PI / 180 );
   }
 
-  QPointF transPt( -offsetDist * std::cos( angleRad + M_PI / 2 ),
-                   -offsetDist * std::sin( angleRad + M_PI / 2 ) );
+  QPointF transPt( -offsetDist * std::cos( angleRad + M_PI_2 ),
+                   -offsetDist * std::sin( angleRad + M_PI_2 ) );
 
   p->save();
   p->setRenderHint( QPainter::SmoothPixmapTransform );

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -672,7 +672,7 @@ class MyLine
     // return angle in radians
     double angle()
     {
-      double a = ( mVertical ? M_PI / 2 : std::atan( mT ) );
+      double a = ( mVertical ? M_PI_2 : std::atan( mT ) );
 
       if ( !mIncreasing )
         a += M_PI;

--- a/src/core/symbology/qgspointclusterrenderer.cpp
+++ b/src/core/symbology/qgspointclusterrenderer.cpp
@@ -24,10 +24,6 @@
 #include "qgsproperty.h"
 #include <cmath>
 
-#ifndef M_SQRT2
-#define M_SQRT2 1.41421356237309504880
-#endif
-
 QgsPointClusterRenderer::QgsPointClusterRenderer()
   : QgsPointDistanceRenderer( QStringLiteral( "pointCluster" ) )
 {

--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -25,10 +25,6 @@
 #include <QPainter>
 #include <cmath>
 
-#ifndef M_SQRT2
-#define M_SQRT2 1.41421356237309504880
-#endif
-
 QgsPointDisplacementRenderer::QgsPointDisplacementRenderer( const QString &labelAttributeName )
   : QgsPointDistanceRenderer( QStringLiteral( "pointDisplacement" ), labelAttributeName )
   , mPlacement( Ring )

--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -27,10 +27,6 @@
 
 #include <cmath>
 
-#ifndef M_SQRT2
-#define M_SQRT2 1.41421356237309504880
-#endif
-
 QgsPointDistanceRenderer::QgsPointDistanceRenderer( const QString &rendererName, const QString &labelAttributeName )
   : QgsFeatureRenderer( rendererName )
   , mLabelAttributeName( labelAttributeName )

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -15,11 +15,6 @@
 #ifndef QGSSYMBOLLAYER_H
 #define QGSSYMBOLLAYER_H
 
-// MSVC compiler doesn't have defined M_PI in math.h
-#ifndef M_PI
-#define M_PI          3.14159265358979323846
-#endif
-
 #define DEG2RAD(x)    ((x)*M_PI/180)
 #define DEFAULT_SCALE_METHOD              QgsSymbol::ScaleDiameter
 

--- a/src/plugins/georeferencer/qgsleastsquares.cpp
+++ b/src/plugins/georeferencer/qgsleastsquares.cpp
@@ -201,7 +201,7 @@ void normalizeCoordinates( const QVector<QgsPointXY> &coords, QVector<QgsPointXY
   }
   meanDist *= 1.0 / coords.size();
 
-  double OOD = meanDist / std::sqrt( 2.0 );
+  double OOD = meanDist * M_SQRT1_2;
   double D   = 1.0 / OOD;
   normalizedCoords.resize( coords.size() );
   for ( int i = 0; i < coords.size(); i++ )

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -1321,7 +1321,7 @@ void QgsWmsProjectParser::addLayers( QDomDocument &doc,
         if ( version == QLatin1String( "1.1.1" ) )
         {
           double OGC_PX_M = 0.00028; // OGC reference pixel size in meter, also used by qgis
-          double SCALE_TO_SCALEHINT = OGC_PX_M * std::sqrt( 2.0 );
+          double SCALE_TO_SCALEHINT = OGC_PX_M * M_SQRT2;
 
           QDomElement scaleHintElem = doc.createElement( QStringLiteral( "ScaleHint" ) );
           scaleHintElem.setAttribute( QStringLiteral( "min" ), QString::number( currentLayer->maximumScale() * SCALE_TO_SCALEHINT ) );

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1001,7 +1001,7 @@ namespace QgsWms
             if ( version == QLatin1String( "1.1.1" ) )
             {
               double OGC_PX_M = 0.00028; // OGC reference pixel size in meter, also used by qgis
-              double SCALE_TO_SCALEHINT = OGC_PX_M * std::sqrt( 2.0 );
+              double SCALE_TO_SCALEHINT = OGC_PX_M * M_SQRT2;
 
               QDomElement scaleHintElem = doc.createElement( QStringLiteral( "ScaleHint" ) );
               scaleHintElem.setAttribute( QStringLiteral( "min" ), QString::number( l->maximumScale() * SCALE_TO_SCALEHINT ) );


### PR DESCRIPTION
Since we use _USE_MATH_DEFINES for windows builds, these are not required.