### PR TITLE
Off-line editing does not work with WFS-T layers having …

### DIFF
--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -115,6 +115,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void applyGeometryChanges( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );
     void updateFidLookup( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );
     void copySymbology( QgsVectorLayer *sourceLayer, QgsVectorLayer *targetLayer );
+    QString wkbTypeAsString( const QgsWkbTypes::Type wkbType );
 
     /**
      * Updates all relations that reference or are referenced by the source layer to the targetLayer.


### PR DESCRIPTION
…mixed simple and multi geoms

Fixes #17019 

Needs backporting

BTW this is  just a patch for an issue with the WFS provider that reports the "wrong" `wkbType` for the layer.
This is due to the fact that the test layer that unveiled the bug has both POLYGON (the first feature is of this type) and MULTIPOLYGON and that in this test scenario QGIS Server `DescribeFeatureType`  does not return any detail about the geometry type, in this case the provider uses a different approach and deduces the wkbType from a `DescribeFeatureType` of the first feature.

@rouault would it be possible to choose a more robust approach in this case? At least the wkbType could be corretted after the first feature iteration, when we can get the geometry type of all the features in the dataset, always better than live with  wrong wkbType for the whole life of the layer: I suspect that this may cause other bugs.
