### PR TITLE
Make crssync quiet by default

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -166,9 +166,9 @@ void QgsApplication::init( QString profileFolder )
     ABISYM( mRunningFromBuildDir ) = true;
     ABISYM( mBuildSourcePath ) = f.readLine().trimmed();
     ABISYM( mBuildOutputPath ) = f.readLine().trimmed();
-    qDebug( "Running from build directory!" );
-    qDebug( "- source directory: %s", ABISYM( mBuildSourcePath ).toUtf8().data() );
-    qDebug( "- output directory of the build: %s", ABISYM( mBuildOutputPath ).toUtf8().data() );
+    QgsDebugMsgLevel( QStringLiteral( "Running from build directory!" ), 4 );
+    QgsDebugMsgLevel( QStringLiteral( "- source directory: %1" ).arg( ABISYM( mBuildSourcePath ).toUtf8().data() ), 4 );
+    QgsDebugMsgLevel( QStringLiteral( "- output directory of the build: %1" ).arg( ABISYM( mBuildOutputPath ).toUtf8().data() ), 4 );
 #ifdef _MSC_VER
     ABISYM( mCfgIntDir ) = prefixPath.split( '/', QString::SkipEmptyParts ).last();
     qDebug( "- cfg: %s", ABISYM( mCfgIntDir ).toUtf8().data() );

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1715,7 +1715,7 @@ QString QgsCoordinateReferenceSystem::quotedValue( QString value )
 // adapted from gdal/ogr/ogr_srs_dict.cpp
 bool QgsCoordinateReferenceSystem::loadWkts( QHash<int, QString> &wkts, const char *filename )
 {
-  qDebug( "Loading %s", filename );
+  QgsDebugMsgLevel( QStringLiteral( "Loading %1" ).arg( filename ), 4 );
   const char *pszFilename = CPLFindFile( "gdal", filename );
   if ( !pszFilename )
     return false;
@@ -1826,7 +1826,7 @@ bool QgsCoordinateReferenceSystem::loadIds( QHash<int, QString> &wkts )
 
     f.close();
 
-    qDebug( "Loaded %d/%d from %s", n, l, filename.toUtf8().constData() );
+    QgsDebugMsgLevel( QStringLiteral( "Loaded %1/%2 from %3" ).arg( QString::number( n ), QString::number( l ), filename.toUtf8().constData() ), 4 );
   }
 
   OSRDestroySpatialReference( crs );
@@ -1841,7 +1841,7 @@ int QgsCoordinateReferenceSystem::syncDatabase()
 
   int inserted = 0, updated = 0, deleted = 0, errors = 0;
 
-  qDebug( "Load srs db from: %s", QgsApplication::srsDatabaseFilePath().toLocal8Bit().constData() );
+  QgsDebugMsgLevel( QStringLiteral( "Load srs db from: %1" ).arg( QgsApplication::srsDatabaseFilePath().toLocal8Bit().constData() ), 4 );
 
   sqlite3 *database = nullptr;
   if ( sqlite3_open( dbFilePath.toUtf8().constData(), &database ) != SQLITE_OK )
@@ -1874,7 +1874,7 @@ int QgsCoordinateReferenceSystem::syncDatabase()
   loadIds( wkts );
   loadWkts( wkts, "epsg.wkt" );
 
-  qDebug( "%d WKTs loaded", wkts.count() );
+  QgsDebugMsgLevel( QStringLiteral( "%1 WKTs loaded" ).arg( wkts.count() ), 4 );
 
   for ( QHash<int, QString>::const_iterator it = wkts.constBegin(); it != wkts.constEnd(); ++it )
   {
@@ -2114,7 +2114,7 @@ int QgsCoordinateReferenceSystem::syncDatabase()
 
   sqlite3_close( database );
 
-  qWarning( "CRS update (inserted:%d updated:%d deleted:%d errors:%d)", inserted, updated, deleted, errors );
+  QgsDebugMsgLevel( QStringLiteral( "CRS update (inserted:%1 updated:%2 deleted:%3 errors:%4)" ).arg( QString::number( inserted ), QString::number( updated ), QString::number( deleted ), QString::number( errors ) ), 4 );
 
   if ( errors > 0 )
     return -errors;

--- a/src/crssync/main.cpp
+++ b/src/crssync/main.cpp
@@ -40,6 +40,16 @@ int main( int argc, char **argv )
 {
   QCoreApplication app( argc, argv );
 
+  const QStringList args = QCoreApplication::arguments();
+
+  bool verbose = false;
+
+  for ( const QString &arg : args )
+  {
+    if ( arg == QLatin1String( "--verbose" ) )
+      verbose = true;
+  }
+
   QgsApplication::init();
 
   if ( !QgsApplication::isRunningFromBuildDir() )
@@ -48,7 +58,8 @@ int main( int argc, char **argv )
     QgsApplication::setPrefixPath( prefixPath ? prefixPath : CMAKE_INSTALL_PREFIX, TRUE );
   }
 
-  std::cout << "Synchronizing CRS database with GDAL/PROJ definitions." << std::endl;
+  if ( verbose )
+    std::cout << "Synchronizing CRS database with GDAL/PROJ definitions." << std::endl;
 
   CPLPushErrorHandler( showError );
 
@@ -56,11 +67,11 @@ int main( int argc, char **argv )
 
   CPLPopErrorHandler();
 
-  if ( res == 0 )
+  if ( res == 0 && verbose )
   {
     std::cout << "No CRS updates were necessary." << std::endl;
   }
-  else if ( res > 0 )
+  else if ( res > 0 && verbose )
   {
     std::cout << res << " CRSs updated." << std::endl;
   }


### PR DESCRIPTION
We only need it to show up in the build log if something has gone wrong.
By default we will just happily assume that it's doing a great job in
all conscience.