### PR TITLE
[FEATURE] Make field to calculate statistics on optional in Statistics by category in Processing…

### DIFF
--- a/python/plugins/processing/algs/qgis/StatisticsByCategories.py
+++ b/python/plugins/processing/algs/qgis/StatisticsByCategories.py
@@ -62,7 +62,8 @@ class StatisticsByCategories(QgisAlgorithm):
                                                       parentLayerParameterName=self.INPUT, type=QgsProcessingParameterField.Numeric))
         self.addParameter(QgsProcessingParameterField(self.CATEGORIES_FIELD_NAME,
                                                       self.tr('Field with categories'),
-                                                      parentLayerParameterName=self.INPUT, type=QgsProcessingParameterField.Any))
+                                                      parentLayerParameterName=self.INPUT, type=QgsProcessingParameterField.Any,
+                                                      optional=TRUE))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Statistics by category')))
 
@@ -90,7 +91,10 @@ class StatisticsByCategories(QgisAlgorithm):
             feedback.setProgress(int(current * total))
             attrs = feat.attributes()
             try:
-                value = float(attrs[value_field_index])
+                if value_field_index > 0:
+                    value = float(attrs[value_field_index])
+                else:
+                    value = 0
                 cat = attrs[category_field_index]
                 if cat not in values:
                     values[cat] = []


### PR DESCRIPTION
## Description
Make *Field to calculate statistics on* optional in *Statistics by categories*.
*Field to calculate statistics on* has been made optional and values set to 0.
This results in a table with 0 or NAN values in all the statistics columns except for *count*.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
