### PR TITLE
Fix missing entries from composer map combo boxes (fixes #16924)

### DIFF
--- a/python/core/composer/qgscomposermodel.sip
+++ b/python/core/composer/qgscomposermodel.sip
@@ -283,7 +283,6 @@ class QgsComposerProxyModel: QSortFilterProxyModel
 
   protected:
     bool filterAcceptsRow( int source_row, const QModelIndex & source_parent ) const;
-    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const;
 
 };
 

--- a/src/core/composer/qgscomposermodel.cpp
+++ b/src/core/composer/qgscomposermodel.cpp
@@ -961,29 +961,16 @@ QgsComposerProxyModel::QgsComposerProxyModel( QgsComposition *composition, QObje
   // WARNING: the below code triggers a Qt bug (tested on Qt 4.8, can't reproduce on Qt5) whenever the QgsComposerModel source model
   // calls beginInsertRows - since it's non functional anyway it's now disabled
   // PLEASE verify that the Qt issue is fixed before reenabling
+
+  setDynamicSortFilter( true );
 #if 0
   // TODO doesn't seem to work correctly - not updated when item changes
-  setDynamicSortFilter( true );
   setSortLocaleAware( true );
   sort( QgsComposerModel::ItemId );
 #endif
 }
 
-bool QgsComposerProxyModel::lessThan( const QModelIndex &left, const QModelIndex &right ) const
-{
-  //sort by item id
-  const QgsComposerItem* item1 = itemFromSourceIndex( left );
-  const QgsComposerItem* item2 = itemFromSourceIndex( right );
-  if ( !item1 )
-    return false;
-
-  if ( !item2 )
-    return true;
-
-  return QString::localeAwareCompare( item1->displayName(), item2->displayName() ) < 0;
-}
-
-QgsComposerItem* QgsComposerProxyModel::itemFromSourceIndex( const QModelIndex &sourceIndex ) const
+QgsComposerItem *QgsComposerProxyModel::itemFromSourceIndex( const QModelIndex &sourceIndex ) const
 {
   if ( !mComposition )
     return nullptr;

--- a/src/core/composer/qgscomposermodel.h
+++ b/src/core/composer/qgscomposermodel.h
@@ -347,8 +347,7 @@ class CORE_EXPORT QgsComposerProxyModel: public QSortFilterProxyModel
     QgsComposerItem* itemFromSourceIndex( const QModelIndex& sourceIndex ) const;
 
   protected:
-    bool filterAcceptsRow( int source_row, const QModelIndex & source_parent ) const override;
-    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
+    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
   private:
     QgsComposition* mComposition;

--- a/src/gui/qgscomposeritemcombobox.cpp
+++ b/src/gui/qgscomposeritemcombobox.cpp
@@ -36,7 +36,6 @@ void QgsComposerItemComboBox::setComposition( QgsComposition *composition )
   connect( mProxyModel, SIGNAL( rowsRemoved( QModelIndex, int, int ) ), this, SLOT( rowsChanged() ) );
   setModel( mProxyModel );
   setModelColumn( QgsComposerModel::ItemId );
-  mProxyModel->sort( 0, Qt::AscendingOrder );
 }
 
 void QgsComposerItemComboBox::setItem( const QgsComposerItem* item )


### PR DESCRIPTION
Followup cb33c0d40 - avoid the crash the original fix was put in place to fix while still allowing new entries to show in the combo box
