### PR TITLE
Fix broken qgscolorramp button

### DIFF
--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -337,7 +337,7 @@ void QgsColorRampButton::loadColorRamp()
   QAction *selectedItem = qobject_cast<QAction *>( sender() );
   if ( selectedItem )
   {
-    QString name = selectedItem->text();
+    QString name = selectedItem->iconText();
     setColorRampName( name );
     setColorRampFromName( name );
   }


### PR DESCRIPTION
For a misterious reason ( the docs are not completely clear )
calling text() on the ramp QAction returned all string prefixed
with '&' causing the whole button to miss the changed ramp.

By calling iconText() instead we get the right name for
the ramp.
