### PR TITLE
Fix QSocketNotifier error on startup

### DIFF
--- a/python/core/qgsuserprofilemanager.sip
+++ b/python/core/qgsuserprofilemanager.sip
@@ -196,7 +196,7 @@ class QgsUserProfileManager : QObject
  Emitted when the list of profiles is changed.
 
  This signal will only be emitted when isNewProfileNotificationEnabled() is true.
- By default By default new profile notification is disabled.
+ By default new profile notification is disabled.
 
 .. seealso:: isNewProfileNotificationEnabled()
 .. seealso:: setNewProfileNotificationEnabled()

--- a/python/core/qgsuserprofilemanager.sip
+++ b/python/core/qgsuserprofilemanager.sip
@@ -72,6 +72,28 @@ class QgsUserProfileManager : QObject
  :rtype: str
 %End
 
+    void setNewProfileNotificationEnabled( bool enabled );
+%Docstring
+ Sets whether the manager should watch for the creation of new user profiles and emit
+ the profilesChanged() signal when this occurs. By default new profile notification
+ is disabled.
+
+ Before calling this, ensure that the correct root location has been set via
+ calling setRootLocation().
+
+.. seealso:: isNewProfileNotificationEnabled()
+%End
+
+    bool isNewProfileNotificationEnabled() const;
+%Docstring
+ Returns whether the manager is watching for the creation of new user profiles and emitting
+ the profilesChanged() signal when this occurs. By default new profile notification
+ is disabled.
+
+.. seealso:: setNewProfileNotificationEnabled()
+ :rtype: bool
+%End
+
     bool rootLocationIsSet() const;
 %Docstring
  Check if the root location has been set for the manager.
@@ -169,9 +191,15 @@ class QgsUserProfileManager : QObject
 
   signals:
 
-    void profilesChanged( );
+    void profilesChanged();
 %Docstring
  Emitted when the list of profiles is changed.
+
+ This signal will only be emitted when isNewProfileNotificationEnabled() is true.
+ By default By default new profile notification is disabled.
+
+.. seealso:: isNewProfileNotificationEnabled()
+.. seealso:: setNewProfileNotificationEnabled()
 %End
 
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -655,6 +655,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mUserProfileManager = new QgsUserProfileManager( QString(), this );
   mUserProfileManager->setRootLocation( rootProfileLocation );
   mUserProfileManager->setActiveUserProfile( activeProfile );
+  mUserProfileManager->setNewProfileNotificationEnabled( true );
   connect( mUserProfileManager, &QgsUserProfileManager::profilesChanged, this, &QgisApp::refreshProfileMenu );
   endProfile();
 

--- a/src/core/qgsuserprofilemanager.h
+++ b/src/core/qgsuserprofilemanager.h
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsUserProfileManager : public QObject
      * Emitted when the list of profiles is changed.
      *
      * This signal will only be emitted when isNewProfileNotificationEnabled() is true.
-     * By default By default new profile notification is disabled.
+     * By default new profile notification is disabled.
      *
      * \see isNewProfileNotificationEnabled()
      * \see setNewProfileNotificationEnabled()

--- a/src/core/qgsuserprofilemanager.h
+++ b/src/core/qgsuserprofilemanager.h
@@ -82,6 +82,27 @@ class CORE_EXPORT QgsUserProfileManager : public QObject
     QString rootLocation() { return mRootProfilePath; }
 
     /**
+     * Sets whether the manager should watch for the creation of new user profiles and emit
+     * the profilesChanged() signal when this occurs. By default new profile notification
+     * is disabled.
+     *
+     * Before calling this, ensure that the correct root location has been set via
+     * calling setRootLocation().
+     *
+     * \see isNewProfileNotificationEnabled()
+     */
+    void setNewProfileNotificationEnabled( bool enabled );
+
+    /**
+     * Returns whether the manager is watching for the creation of new user profiles and emitting
+     * the profilesChanged() signal when this occurs. By default new profile notification
+     * is disabled.
+     *
+     * \see setNewProfileNotificationEnabled()
+     */
+    bool isNewProfileNotificationEnabled() const;
+
+    /**
      * Check if the root location has been set for the manager.
      * \return True if the root location has been set.
      */
@@ -168,11 +189,18 @@ class CORE_EXPORT QgsUserProfileManager : public QObject
 
     /**
      * Emitted when the list of profiles is changed.
+     *
+     * This signal will only be emitted when isNewProfileNotificationEnabled() is true.
+     * By default By default new profile notification is disabled.
+     *
+     * \see isNewProfileNotificationEnabled()
+     * \see setNewProfileNotificationEnabled()
      */
-    void profilesChanged( );
+    void profilesChanged();
 
   private:
 
+    bool mWatchProfiles = false;
     std::unique_ptr<QFileSystemWatcher> mWatcher;
 
     QString mRootProfilePath;


### PR DESCRIPTION
And avoid unnecessary creation of unused QFileSystemWatchers