### PR TITLE
[composer] Allow finer setting of scalebar height and widths

### DIFF
--- a/src/app/composer/qgscomposerscalebarwidget.cpp
+++ b/src/app/composer/qgscomposerscalebarwidget.cpp
@@ -219,7 +219,7 @@ void QgsComposerScaleBarWidget::on_mNumberOfSegmentsSpinBox_valueChanged( int i 
   mComposerScaleBar->endCommand();
 }
 
-void QgsComposerScaleBarWidget::on_mHeightSpinBox_valueChanged( int i )
+void QgsComposerScaleBarWidget::on_mHeightSpinBox_valueChanged( double d )
 {
   if ( !mComposerScaleBar )
   {
@@ -227,7 +227,7 @@ void QgsComposerScaleBarWidget::on_mHeightSpinBox_valueChanged( int i )
   }
   mComposerScaleBar->beginCommand( tr( "Scalebar height changed" ), QgsComposerMergeCommand::ScaleBarHeight );
   disconnectUpdateSignal();
-  mComposerScaleBar->setHeight( i );
+  mComposerScaleBar->setHeight( d );
   mComposerScaleBar->update();
   connectUpdateSignal();
   mComposerScaleBar->endCommand();
@@ -647,7 +647,7 @@ void QgsComposerScaleBarWidget::composerMapChanged( QgsComposerItem* item )
   mComposerScaleBar->endCommand();
 }
 
-void QgsComposerScaleBarWidget::on_mMinWidthSpinBox_valueChanged( int )
+void QgsComposerScaleBarWidget::on_mMinWidthSpinBox_valueChanged( double )
 {
   if ( !mComposerScaleBar )
   {
@@ -662,7 +662,7 @@ void QgsComposerScaleBarWidget::on_mMinWidthSpinBox_valueChanged( int )
   mComposerScaleBar->endCommand();
 }
 
-void QgsComposerScaleBarWidget::on_mMaxWidthSpinBox_valueChanged( int )
+void QgsComposerScaleBarWidget::on_mMaxWidthSpinBox_valueChanged( double )
 {
   if ( !mComposerScaleBar )
   {

--- a/src/app/composer/qgscomposerscalebarwidget.h
+++ b/src/app/composer/qgscomposerscalebarwidget.h
@@ -35,7 +35,7 @@ class QgsComposerScaleBarWidget: public QgsComposerItemBaseWidget, private Ui::Q
 
   public slots:
 
-    void on_mHeightSpinBox_valueChanged( int i );
+    void on_mHeightSpinBox_valueChanged( double d );
     void on_mLineWidthSpinBox_valueChanged( double d );
     void on_mSegmentSizeSpinBox_valueChanged( double d );
     void on_mSegmentsLeftSpinBox_valueChanged( int i );
@@ -54,8 +54,8 @@ class QgsComposerScaleBarWidget: public QgsComposerItemBaseWidget, private Ui::Q
     void on_mUnitsComboBox_currentIndexChanged( int index );
     void on_mLineJoinStyleCombo_currentIndexChanged( int index );
     void on_mLineCapStyleCombo_currentIndexChanged( int index );
-    void on_mMinWidthSpinBox_valueChanged( int i );
-    void on_mMaxWidthSpinBox_valueChanged( int i );
+    void on_mMinWidthSpinBox_valueChanged( double d );
+    void on_mMaxWidthSpinBox_valueChanged( double d );
 
   private slots:
     void setGuiElements();

--- a/src/core/composer/qgscomposerscalebar.cpp
+++ b/src/core/composer/qgscomposerscalebar.cpp
@@ -757,8 +757,8 @@ bool QgsComposerScaleBar::readXML( const QDomElement& itemElem, const QDomDocume
   mNumSegmentsLeft = itemElem.attribute( "numSegmentsLeft", "0" ).toInt();
   mNumUnitsPerSegment = itemElem.attribute( "numUnitsPerSegment", "1.0" ).toDouble();
   mSegmentSizeMode = static_cast<SegmentSizeMode>( itemElem.attribute( "segmentSizeMode", "0" ).toInt() );
-  mMinBarWidth = itemElem.attribute( "minBarWidth", "50" ).toInt();
-  mMaxBarWidth = itemElem.attribute( "maxBarWidth", "150" ).toInt();
+  mMinBarWidth = itemElem.attribute( "minBarWidth", "50" ).toDouble();
+  mMaxBarWidth = itemElem.attribute( "maxBarWidth", "150" ).toDouble();
   mSegmentMillimeters = itemElem.attribute( "segmentMillimeters", "0.0" ).toDouble();
   mNumMapUnitsPerScaleBarUnit = itemElem.attribute( "numMapUnitsPerScaleBarUnit", "1.0" ).toDouble();
   mPen.setWidthF( itemElem.attribute( "outlineWidth", "0.3" ).toDouble() );

--- a/src/ui/composer/qgscomposerscalebarwidgetbase.ui
+++ b/src/ui/composer/qgscomposerscalebarwidgetbase.ui
@@ -262,7 +262,7 @@
            </widget>
           </item>
           <item row="4" column="2">
-           <widget class="QgsSpinBox" name="mMaxWidthSpinBox">
+           <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -288,7 +288,7 @@
            </widget>
           </item>
           <item row="3" column="2">
-           <widget class="QgsSpinBox" name="mMinWidthSpinBox">
+           <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -304,7 +304,7 @@
            </widget>
           </item>
           <item row="5" column="2">
-           <widget class="QgsSpinBox" name="mHeightSpinBox">
+           <widget class="QgsDoubleSpinBox" name="mHeightSpinBox">
             <property name="suffix">
              <string> mm</string>
             </property>


### PR DESCRIPTION
While the settings are stored as double, they were being rounded off in the UI to the nearest mm

(backport of 7ca0b3d)
