### PR TITLE
New expressions: Minimal enclosing Circle and Oriented BBox

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -577,13 +577,6 @@ Returns true if WKB of the geometry is of WKBMulti* type
  :rtype: QgsGeometry
 %End
 
-    QgsGeometry orientedMinimumBoundingBox( ) const;
-%Docstring
- Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)
- rotated rectangle which fully encompasses the geometry.
-.. versionadded:: 3.0
- :rtype: QgsGeometry
-%End
 
     QgsGeometry minimalEnclosingCircle( QgsPointXY &center /Out/, double &radius /Out/, unsigned int segments = 36 ) const;
 %Docstring
@@ -595,13 +588,6 @@ Returns true if WKB of the geometry is of WKBMulti* type
  :rtype: QgsGeometry
 %End
 
-    QgsGeometry minimalEnclosingCircle( unsigned int segments = 36 ) const;
-%Docstring
- Returns the minimal enclosing circle for the geometry.
-.. seealso:: QgsEllipse.toPolygon()
-.. versionadded:: 3.0
- :rtype: QgsGeometry
-%End
 
     QgsGeometry orthogonalize( double tolerance = 1.0E-8, int maxIterations = 1000, double angleThreshold = 15.0 ) const;
 %Docstring

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -577,11 +577,27 @@ Returns true if WKB of the geometry is of WKBMulti* type
  :rtype: QgsGeometry
 %End
 
+    QgsGeometry orientedMinimumBoundingBox( ) const;
+%Docstring
+ Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)
+ rotated rectangle which fully encompasses the geometry.
+.. versionadded:: 3.0
+ :rtype: QgsGeometry
+%End
+
     QgsGeometry minimalEnclosingCircle( QgsPointXY &center /Out/, double &radius /Out/, unsigned int segments = 36 ) const;
 %Docstring
  Returns the minimal enclosing circle for the geometry.
  \param center Center of the minimal enclosing circle returneds
  \param radius Radius of the minimal enclosing circle returned
+.. seealso:: QgsEllipse.toPolygon()
+.. versionadded:: 3.0
+ :rtype: QgsGeometry
+%End
+
+    QgsGeometry minimalEnclosingCircle( unsigned int segments = 36 ) const;
+%Docstring
+ Returns the minimal enclosing circle for the geometry.
 .. seealso:: QgsEllipse.toPolygon()
 .. versionadded:: 3.0
  :rtype: QgsGeometry

--- a/resources/function_help/json/minimal_circle
+++ b/resources/function_help/json/minimal_circle
@@ -1,0 +1,10 @@
+{
+  "name": "minimal_circle",
+  "type": "function",
+  "description": "Returns the minimal enclosing circle of a geometry. It represents the minimum circle that encloses all geometries within the set.",
+  "arguments": [ {"arg":"geometry","description":"a geometry"},
+                 {"arg":"segment", "description": "optional argument for polygon segmentation. By default this value is 36"}],
+  "examples": [ { "expression":"geom_to_wkt( minimal_circle( geom_from_wkt( 'LINESTRING(0 5, 0 -5, 2 1)' ), 4 ) )", "returns":"Polygon ((0 5, 5 -0, -0 -5, -5 0, 0 5))"},
+  { "expression":"geom_to_wkt( minimal_circle( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ), 4 ) )", "returns":"Polygon ((3 4, 3 2, 1 2, 1 4, 3 4))"}
+  ]
+}

--- a/resources/function_help/json/oriented_bbox
+++ b/resources/function_help/json/oriented_bbox
@@ -1,0 +1,8 @@
+{
+  "name": "oriented_bbox",
+  "type": "function",
+  "description":"Returns a geometry which represents the minimal oriented bounding box of an input geometry.",
+  "arguments": [ {"arg":"geom","description":"a geometry"} ],
+  "examples": [ { "expression":"geom_to_wkt( oriented_bbox( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ) ) )", "returns":"Polygon ((1 4, 1 2, 3 2, 3 4, 1 4))"}]
+}
+

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2532,6 +2532,29 @@ static QVariant fcnConvexHull( const QVariantList &values, const QgsExpressionCo
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
+
+static QVariant fcnMinimalCircle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+{
+  QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  QgsPointXY center;
+  double radius;
+  unsigned int segments = 36;
+  if ( values.length() == 2 )
+    segments = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
+  QgsGeometry geom = fGeom.minimalEnclosingCircle( center, radius, segments );
+  QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
+  return result;
+}
+
+static QVariant fcnOrientedBBox( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+{
+  QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  double area, angle, width, height;
+  QgsGeometry geom = fGeom.orientedMinimumBoundingBox( area, angle, width, height );
+  QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
+  return result;
+}
+
 static QVariant fcnDifference( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
@@ -4135,6 +4158,13 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "bounds_height" ), 1, fcnBoundsHeight, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "is_closed" ), 1, fcnIsClosed, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "convex_hull" ), 1, fcnConvexHull, QStringLiteral( "GeometryGroup" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "convexHull" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "oriented_bbox" ), QgsExpressionFunction::ParameterList()
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ),
+                                            fcnOrientedBBox, QStringLiteral( "GeometryGroup" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "minimal_circle" ), QgsExpressionFunction::ParameterList()
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "segments" ), true, 36 ),
+                                            fcnMinimalCircle, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "difference" ), 2, fcnDifference, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "distance" ), 2, fcnDistance, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "hausdorff_distance" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry1" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "geometry2" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2533,15 +2533,14 @@ static QVariant fcnConvexHull( const QVariantList &values, const QgsExpressionCo
   return result;
 }
 
+
 static QVariant fcnMinimalCircle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
-  QgsPointXY center;
-  double radius;
   unsigned int segments = 36;
   if ( values.length() == 2 )
     segments = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
-  QgsGeometry geom = fGeom.minimalEnclosingCircle( center, radius, segments );
+  QgsGeometry geom = fGeom.minimalEnclosingCircle( segments );
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
@@ -2549,8 +2548,7 @@ static QVariant fcnMinimalCircle( const QVariantList &values, const QgsExpressio
 static QVariant fcnOrientedBBox( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
-  double area, angle, width, height;
-  QgsGeometry geom = fGeom.orientedMinimumBoundingBox( area, angle, width, height );
+  QgsGeometry geom = fGeom.orientedMinimumBoundingBox( );
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1009,6 +1009,12 @@ QgsGeometry QgsGeometry::orientedMinimumBoundingBox( double &area, double &angle
   return minBounds;
 }
 
+QgsGeometry QgsGeometry::orientedMinimumBoundingBox() const
+{
+  double area, angle, width, height;
+  return orientedMinimumBoundingBox( area, angle, width, height );
+}
+
 static QgsCircle __recMinimalEnclosingCircle( QgsMultiPoint points, QgsMultiPoint boundary )
 {
   auto l_boundary = boundary.length();
@@ -1081,6 +1087,14 @@ QgsGeometry QgsGeometry::minimalEnclosingCircle( QgsPointXY &center, double &rad
   QgsGeometry geom;
   geom.setGeometry( circ.toPolygon( segments ) );
   return geom;
+
+}
+
+QgsGeometry QgsGeometry::minimalEnclosingCircle( unsigned int segments ) const
+{
+  QgsPointXY center;
+  double radius;
+  return minimalEnclosingCircle( center, radius, segments );
 
 }
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -600,6 +600,13 @@ class CORE_EXPORT QgsGeometry
     QgsGeometry orientedMinimumBoundingBox( double &area SIP_OUT, double &angle SIP_OUT, double &width SIP_OUT, double &height SIP_OUT ) const;
 
     /**
+     * Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)
+     * rotated rectangle which fully encompasses the geometry.
+     * \since QGIS 3.0
+     */
+    QgsGeometry orientedMinimumBoundingBox( ) const;
+
+    /**
      * Returns the minimal enclosing circle for the geometry.
      * \param center Center of the minimal enclosing circle returneds
      * \param radius Radius of the minimal enclosing circle returned
@@ -607,6 +614,13 @@ class CORE_EXPORT QgsGeometry
      * \since QGIS 3.0
      */
     QgsGeometry minimalEnclosingCircle( QgsPointXY &center SIP_OUT, double &radius SIP_OUT, unsigned int segments = 36 ) const;
+
+    /**
+     * Returns the minimal enclosing circle for the geometry.
+     * \param segments Number of segments used to segment geometry. \see QgsEllipse::toPolygon()
+     * \since QGIS 3.0
+     */
+    QgsGeometry minimalEnclosingCircle( unsigned int segments = 36 ) const;
 
     /**
      * Attempts to orthogonalize a line or polygon geometry by shifting vertices to make the geometries

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -599,12 +599,15 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry orientedMinimumBoundingBox( double &area SIP_OUT, double &angle SIP_OUT, double &width SIP_OUT, double &height SIP_OUT ) const;
 
+#ifndef SIP_RUN
+
     /**
      * Returns the oriented minimum bounding box for the geometry, which is the smallest (by area)
      * rotated rectangle which fully encompasses the geometry.
      * \since QGIS 3.0
      */
     QgsGeometry orientedMinimumBoundingBox( ) const;
+#endif
 
     /**
      * Returns the minimal enclosing circle for the geometry.
@@ -615,12 +618,15 @@ class CORE_EXPORT QgsGeometry
      */
     QgsGeometry minimalEnclosingCircle( QgsPointXY &center SIP_OUT, double &radius SIP_OUT, unsigned int segments = 36 ) const;
 
+#ifndef SIP_RUN
+
     /**
      * Returns the minimal enclosing circle for the geometry.
      * \param segments Number of segments used to segment geometry. \see QgsEllipse::toPolygon()
      * \since QGIS 3.0
      */
     QgsGeometry minimalEnclosingCircle( unsigned int segments = 36 ) const;
+#endif
 
     /**
      * Attempts to orthogonalize a line or polygon geometry by shifting vertices to make the geometries

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2304,12 +2304,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "bounds" ) << "bounds( $geometry )" << geom << false << true << QgsGeometry::fromRect( geom.boundingBox() );
 
       geom = QgsGeometry::fromPolygon( polygon );
-      double bbox_area, bbox_angle, bbox_width, bbox_height;
-      QTest::newRow( "oriented_bbox" ) << "oriented_bbox( $geometry )" << geom << false << true << geom.orientedMinimumBoundingBox( bbox_area, bbox_angle, bbox_width, bbox_height );
+      QTest::newRow( "oriented_bbox" ) << "oriented_bbox( $geometry )" << geom << false << true << geom.orientedMinimumBoundingBox( );
       geom = QgsGeometry::fromPolygon( polygon );
-      QgsPointXY circ_center;
-      double circ_radius;
-      QTest::newRow( "minimal_circle" ) << "minimal_circle( $geometry )" << geom << false << true << geom.minimalEnclosingCircle( circ_center, circ_radius );
+      QTest::newRow( "minimal_circle" ) << "minimal_circle( $geometry )" << geom << false << true << geom.minimalEnclosingCircle( );
 
       geom = QgsGeometry::fromPolygon( polygon );
       QTest::newRow( "translate" ) << "translate( $geometry, 1, 2)" << geom << false << true << QgsGeometry::fromWkt( QStringLiteral( "POLYGON ((1 2,11 12,11 2,1 2))" ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2304,6 +2304,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "bounds" ) << "bounds( $geometry )" << geom << false << true << QgsGeometry::fromRect( geom.boundingBox() );
 
       geom = QgsGeometry::fromPolygon( polygon );
+      double bbox_area, bbox_angle, bbox_width, bbox_height;
+      QTest::newRow( "oriented_bbox" ) << "oriented_bbox( $geometry )" << geom << false << true << geom.orientedMinimumBoundingBox( bbox_area, bbox_angle, bbox_width, bbox_height );
+      geom = QgsGeometry::fromPolygon( polygon );
+      QgsPointXY circ_center;
+      double circ_radius;
+      QTest::newRow( "minimal_circle" ) << "minimal_circle( $geometry )" << geom << false << true << geom.minimalEnclosingCircle( circ_center, circ_radius );
+
+      geom = QgsGeometry::fromPolygon( polygon );
       QTest::newRow( "translate" ) << "translate( $geometry, 1, 2)" << geom << false << true << QgsGeometry::fromWkt( QStringLiteral( "POLYGON ((1 2,11 12,11 2,1 2))" ) );
       geom = QgsGeometry::fromPolyline( line );
       QTest::newRow( "translate" ) << "translate( $geometry, -1, 2)" << geom << false << true << QgsGeometry::fromWkt( QStringLiteral( "LINESTRING (-1 2, 9 12)" ) );


### PR DESCRIPTION
## Description
As proposed by [@nyalldawson](https://github.com/qgis/QGIS/pull/5106#issuecomment-326770705):

> One potential follow up to this work would be to expose this as a function in the expression engine. I can see it as useful for geometry generators.

It's done! I have also add an expression for the oriented bounding box algorithm.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
