### PR TITLE
[backport on 2.14] enable custom help in python expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
         - BUILD=qt4
         - QT_VERSION=4
 #        - LLVM_VERSION=3.8
+      dist: precise
       sudo: false
       cache:
         apt: true

--- a/python/core/__init__.py
+++ b/python/core/__init__.py
@@ -83,7 +83,7 @@ def register_function(function, arg_count, group, usesgeometry=False, referenced
 
     helptemplate = string.Template("""<h3>$name function</h3><br>$doc""")
     name = kwargs.get('name', function.__name__)
-    helptext = function.__doc__ or ''
+    helptext = kwargs.get('help_text') or function.__doc__ or ''
     helptext = helptext.strip()
     expandargs = False
 
@@ -137,6 +137,7 @@ def qgsfunction(args='auto', group='custom', **kwargs):
     def wrapper(func):
         return register_function(func, args, group, **kwargs)
     return wrapper
+
 
 try:
     # Add a __nonzero__ method onto QPyNullVariant so we can check for null values easier.

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -41,6 +41,18 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
     def sqrt(values, feature, parent):
         pass
 
+    @qgsfunction(1, 'testing', register=False)
+    def help_with_docstring(values, feature, parent):
+        """The help comes from the python docstring."""
+        pass
+
+    help_text = 'The help comes from a variable.'
+
+    @qgsfunction(1, 'testing', register=False, help_text=help_text)
+    def help_with_variable(values, feature, parent):
+        """This docstring is not used for the help."""
+        pass
+
     @qgsfunction(1, 'testing', register=False, usesgeometry=True)
     def geomtest(values, feature, parent):
         pass
@@ -65,6 +77,17 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         function = self.autocount
         args = function.params()
         self.assertEqual(args, 3)
+
+    def testHelp(self):
+        QgsExpression.registerFunction(self.help_with_variable)
+        html = ('<h3>help_with_variable function</h3><br>'
+                'The help comes from a variable.')
+        self.assertEqual(self.help_with_variable.helptext(), html)
+
+        QgsExpression.registerFunction(self.help_with_docstring)
+        html = ('<h3>help_with_docstring function</h3><br>'
+                'The help comes from the python docstring.')
+        self.assertEqual(self.help_with_docstring.helptext(), html)
 
     def testAutoArgsAreExpanded(self):
         function = self.expandargs
@@ -185,6 +208,7 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
             exp = QgsExpression(e)
             result = exp.evaluate()
             self.assertEqual(exp_res, result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Backport from https://github.com/qgis/QGIS/pull/5059

Thanks if it can be backported to 2.14 too.
Ping @m-kuhn 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit