### PR TITLE
Providers gui config

### DIFF
--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -405,3 +405,4 @@
 %Include symbology/qgsarrowsymbollayer.sip
 %Include composer/qgscomposerutils.sip
 %Include qgsuserprofile.sip
+

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -405,4 +405,3 @@
 %Include symbology/qgsarrowsymbollayer.sip
 %Include composer/qgscomposerutils.sip
 %Include qgsuserprofile.sip
-

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -297,3 +297,5 @@
 %Include locator/qgslocatorfilter.sip
 %Include locator/qgslocatorwidget.sip
 %Include qgsadvanceddigitizingcanvasitem.sip
+%Include qgssourceselectprovider.sip
+

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -21,6 +21,8 @@
 %Include qgsvertexmarker.sip
 %Include qgsfiledownloader.sip
 %Include qgsabstractdatasourcewidget.sip
+%Include qgssourceselectprovider.sip
+%Include qgssourceselectproviderregistry.sip
 %Include attributetable/qgsfeaturemodel.sip
 %Include auth/qgsauthauthoritieseditor.sip
 %Include auth/qgsauthcertificateinfo.sip
@@ -297,6 +299,3 @@
 %Include locator/qgslocatorfilter.sip
 %Include locator/qgslocatorwidget.sip
 %Include qgsadvanceddigitizingcanvasitem.sip
-%Include qgssourceselectprovider.sip
-%Include qgssourceselectproviderregistry.sip
-

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -298,4 +298,5 @@
 %Include locator/qgslocatorwidget.sip
 %Include qgsadvanceddigitizingcanvasitem.sip
 %Include qgssourceselectprovider.sip
+%Include qgssourceselectproviderregistry.sip
 

--- a/python/gui/qgsabstractdatasourcewidget.sip
+++ b/python/gui/qgsabstractdatasourcewidget.sip
@@ -95,8 +95,8 @@ Emitted when a vector layer has been selected for addition
  Emitted when a layer needs to be replaced
  \param oldId old layer ID
  \param source URI of the layer
- \params name of the layer
- \params provider key
+ \param name of the layer
+ \param provider key
 %End
 
 

--- a/python/gui/qgsabstractdatasourcewidget.sip
+++ b/python/gui/qgsabstractdatasourcewidget.sip
@@ -90,6 +90,16 @@ Emitted when a vector layer has been selected for addition
  \param dataSourceType string (can be "file" or "database")
 %End
 
+    void replaceVectorLayer( const QString &oldId, const QString &source, const QString &name, const QString &provider );
+%Docstring
+ Emitted when a layer needs to be replaced
+ \param oldId old layer ID
+ \param source URI of the layer
+ \params name of the layer
+ \params provider key
+%End
+
+
     void progress( int, int );
 %Docstring
 Emitted when a progress dialog is shown by the provider dialog

--- a/python/gui/qgsgui.sip
+++ b/python/gui/qgsgui.sip
@@ -38,6 +38,12 @@ class QgsGui
  :rtype: QgsEditorWidgetRegistry
 %End
 
+    static QgsSourceSelectProviderRegistry *sourceSelectProviderRegistry();
+%Docstring
+ Returns the global source select provider registry, used for managing all known source select widget factories.
+ :rtype: QgsSourceSelectProviderRegistry
+%End
+
     static QgsShortcutsManager *shortcutsManager();
 %Docstring
  Returns the global shortcuts manager, used for managing a QAction and QShortcut sequences.

--- a/python/gui/qgssourceselectprovider.sip
+++ b/python/gui/qgssourceselectprovider.sip
@@ -59,7 +59,7 @@ Text for the menu item entry, it will be visible to the user so make sure it's t
  :rtype: int
 %End
 
-    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = 0, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const = 0 /Factory/;
 %Docstring
  Create a new instance of QgsAbstractDataSourceWidget (or null).
  Caller takes responsibility of deleting created.

--- a/python/gui/qgssourceselectprovider.sip
+++ b/python/gui/qgssourceselectprovider.sip
@@ -12,7 +12,7 @@
 class QgsSourceSelectProvider
 {
 %Docstring
-.. seealso:: QgsDataSourceManagerDialog
+ This is the interface for those who want to add entries to the QgsDataSourceManagerDialog
 
 .. versionadded:: 3.0
 %End
@@ -45,10 +45,17 @@ Text for the menu item entry, it will be visible to the user so make sure it's t
  :rtype: str
 %End
 
-    virtual QIcon icon() const = 0 /Factory/;
+    virtual QString toolTip() const;
 %Docstring
- Creates a new instance of an QIcon for the menu item entry
- Caller takes responsibility of deleting created.
+ Text for the tooltip menu item entry, it will be visible to the user so make sure it's translatable
+
+ The default implementation returns an empty string.
+ :rtype: str
+%End
+
+    virtual QIcon icon() const = 0;
+%Docstring
+Creates a new instance of an QIcon for the menu item entry
  :rtype: QIcon
 %End
 

--- a/python/gui/qgssourceselectprovider.sip
+++ b/python/gui/qgssourceselectprovider.sip
@@ -1,0 +1,59 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssourceselectprovider.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsSourceSelectProvider
+{
+%Docstring
+.. seealso:: QgsDataSourceManagerDialog
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgssourceselectprovider.h"
+%End
+  public:
+    virtual ~QgsSourceSelectProvider();
+
+    virtual QString providerKey() const = 0;
+%Docstring
+Provider key
+ :rtype: str
+%End
+
+    virtual QString text() const = 0;
+%Docstring
+Text for the menu item entry
+ :rtype: str
+%End
+
+    virtual QIcon icon() const = 0 /Factory/;
+%Docstring
+Caller takes responsibility of deleting created.
+ :rtype: QIcon
+%End
+
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( ) = 0 /Factory/;
+%Docstring
+Caller takes responsibility of deleting created.
+ :rtype: QgsAbstractDataSourceWidget
+%End
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssourceselectprovider.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgssourceselectprovider.sip
+++ b/python/gui/qgssourceselectprovider.sip
@@ -25,25 +25,44 @@ class QgsSourceSelectProvider
 
     virtual QString providerKey() const = 0;
 %Docstring
-Provider key
+Data Provider key
+ :rtype: str
+%End
+
+    virtual QString name() const;
+%Docstring
+ Source select provider name, this is useful to retrieve
+ a particular source select in case the provider has more
+ than one, it should be unique among all providers.
+
+ The default implementation returns the providerKey()
  :rtype: str
 %End
 
     virtual QString text() const = 0;
 %Docstring
-Text for the menu item entry
+Text for the menu item entry, it will be visible to the user so make sure it's translatable
  :rtype: str
 %End
 
     virtual QIcon icon() const = 0 /Factory/;
 %Docstring
-Caller takes responsibility of deleting created.
+ Creates a new instance of an QIcon for the menu item entry
+ Caller takes responsibility of deleting created.
  :rtype: QIcon
 %End
 
-    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( ) = 0 /Factory/;
+    virtual int ordering( ) const;
 %Docstring
-Caller takes responsibility of deleting created.
+ Ordering: the source select provider registry will be able to sort
+ the source selects (ascending) using this integer value
+ :rtype: int
+%End
+
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = 0 ) const = 0 /Factory/;
+%Docstring
+ Create a new instance of QgsAbstractDataSourceWidget (or null).
+ Caller takes responsibility of deleting created.
  :rtype: QgsAbstractDataSourceWidget
 %End
 

--- a/python/gui/qgssourceselectproviderregistry.sip
+++ b/python/gui/qgssourceselectproviderregistry.sip
@@ -43,23 +43,24 @@ Get list of available providers
 
     void addProvider( QgsSourceSelectProvider *provider /Transfer/ );
 %Docstring
-Add a provider implementation. Takes ownership of the object.
+Add a ``provider`` implementation. Takes ownership of the object.
 %End
 
-    void removeProvider( QgsSourceSelectProvider *provider );
+    bool removeProvider( QgsSourceSelectProvider *provider /Transfer/ );
 %Docstring
-Remove provider implementation from the list (provider object is deleted)
+:return: true if the provider was actually removed and deleted
+ :rtype: bool
 %End
 
     QgsSourceSelectProvider *providerByName( const QString &name );
 %Docstring
-Return a provider by name or None if not found
+Return a provider by ``name`` or None if not found
  :rtype: QgsSourceSelectProvider
 %End
 
     QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey );
 %Docstring
-Return a (possibly empty) list of providers by data provider's key
+Return a (possibly empty) list of providers by data ``providerkey``
  :rtype: list of QgsSourceSelectProvider
 %End
 

--- a/python/gui/qgssourceselectproviderregistry.sip
+++ b/python/gui/qgssourceselectproviderregistry.sip
@@ -17,6 +17,12 @@ class QgsSourceSelectProviderRegistry
  QgsSourceSelectProviderRegistry is not usually directly created, but rather accessed through
  QgsGui.sourceSelectProviderRegistry().
 
+.. note::
+
+   This class access to QgsProviderRegistry instance to initialize, but QgsProviderRegistry is
+ typically initialized after QgsGui is constructed, for this reason a delayed initialization has been
+ implemented in the class.
+
 .. versionadded:: 3.0
 %End
 
@@ -29,7 +35,7 @@ class QgsSourceSelectProviderRegistry
     ~QgsSourceSelectProviderRegistry();
 
 
-    QList< QgsSourceSelectProvider *> providers() const;
+    QList< QgsSourceSelectProvider *> providers();
 %Docstring
 Get list of available providers
  :rtype: list of QgsSourceSelectProvider
@@ -45,13 +51,13 @@ Add a provider implementation. Takes ownership of the object.
 Remove provider implementation from the list (provider object is deleted)
 %End
 
-    QgsSourceSelectProvider *providerByName( const QString &name ) const;
+    QgsSourceSelectProvider *providerByName( const QString &name );
 %Docstring
 Return a provider by name or None if not found
  :rtype: QgsSourceSelectProvider
 %End
 
-    QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey ) const;
+    QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey );
 %Docstring
 Return a (possibly empty) list of providers by data provider's key
  :rtype: list of QgsSourceSelectProvider

--- a/python/gui/qgssourceselectproviderregistry.sip
+++ b/python/gui/qgssourceselectproviderregistry.sip
@@ -1,0 +1,68 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssourceselectproviderregistry.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsSourceSelectProviderRegistry
+{
+%Docstring
+ This class keeps a list of source select providers that may add items to the QgsDataSourceManagerDialog
+ When created, it automatically adds providers from data provider plugins (e.g. PostGIS, WMS, ...)
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgssourceselectproviderregistry.h"
+%End
+public:
+  QgsSourceSelectProviderRegistry();
+
+  ~QgsSourceSelectProviderRegistry();
+
+
+  QList< QgsSourceSelectProvider*> providers() const;
+%Docstring
+Get list of available providers
+ :rtype: list of QgsSourceSelectProvider
+%End
+
+  void addProvider( QgsSourceSelectProvider *provider /Transfer/ );
+%Docstring
+Add a provider implementation. Takes ownership of the object.
+%End
+
+  void removeProvider( QgsSourceSelectProvider *provider );
+%Docstring
+Remove provider implementation from the list (provider object is deleted)
+%End
+
+  QgsSourceSelectProvider *providerByName( const QString &name ) const;
+%Docstring
+Return a provider by name or None if not found
+ :rtype: QgsSourceSelectProvider
+%End
+
+  QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey ) const;
+%Docstring
+Return a (possibly empty) list of providers by data provider's key
+ :rtype: list of QgsSourceSelectProvider
+%End
+
+
+private:
+  QgsSourceSelectProviderRegistry( const QgsSourceSelectProviderRegistry &rh );
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssourceselectproviderregistry.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgssourceselectproviderregistry.sip
+++ b/python/gui/qgssourceselectproviderregistry.sip
@@ -20,43 +20,43 @@ class QgsSourceSelectProviderRegistry
 %TypeHeaderCode
 #include "qgssourceselectproviderregistry.h"
 %End
-public:
-  QgsSourceSelectProviderRegistry();
+  public:
+    QgsSourceSelectProviderRegistry();
 
-  ~QgsSourceSelectProviderRegistry();
+    ~QgsSourceSelectProviderRegistry();
 
 
-  QList< QgsSourceSelectProvider*> providers() const;
+    QList< QgsSourceSelectProvider *> providers() const;
 %Docstring
 Get list of available providers
  :rtype: list of QgsSourceSelectProvider
 %End
 
-  void addProvider( QgsSourceSelectProvider *provider /Transfer/ );
+    void addProvider( QgsSourceSelectProvider *provider /Transfer/ );
 %Docstring
 Add a provider implementation. Takes ownership of the object.
 %End
 
-  void removeProvider( QgsSourceSelectProvider *provider );
+    void removeProvider( QgsSourceSelectProvider *provider );
 %Docstring
 Remove provider implementation from the list (provider object is deleted)
 %End
 
-  QgsSourceSelectProvider *providerByName( const QString &name ) const;
+    QgsSourceSelectProvider *providerByName( const QString &name ) const;
 %Docstring
 Return a provider by name or None if not found
  :rtype: QgsSourceSelectProvider
 %End
 
-  QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey ) const;
+    QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey ) const;
 %Docstring
 Return a (possibly empty) list of providers by data provider's key
  :rtype: list of QgsSourceSelectProvider
 %End
 
 
-private:
-  QgsSourceSelectProviderRegistry( const QgsSourceSelectProviderRegistry &rh );
+  private:
+    QgsSourceSelectProviderRegistry( const QgsSourceSelectProviderRegistry &rh );
 };
 
 /************************************************************************

--- a/python/gui/qgssourceselectproviderregistry.sip
+++ b/python/gui/qgssourceselectproviderregistry.sip
@@ -14,6 +14,9 @@ class QgsSourceSelectProviderRegistry
  This class keeps a list of source select providers that may add items to the QgsDataSourceManagerDialog
  When created, it automatically adds providers from data provider plugins (e.g. PostGIS, WMS, ...)
 
+ QgsSourceSelectProviderRegistry is not usually directly created, but rather accessed through
+ QgsGui.sourceSelectProviderRegistry().
+
 .. versionadded:: 3.0
 %End
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -349,6 +349,7 @@ SET(QGIS_GUI_SRCS
   qgsfiledownloader.cpp
   qgsdatasourcemanagerdialog.cpp
   qgsabstractdatasourcewidget.cpp
+  qgssourceselectprovider.cpp
 )
 
 SET(QGIS_GUI_MOC_HDRS
@@ -711,6 +712,7 @@ SET(QGIS_GUI_HDRS
   qgsfiledownloader.h
   qgsdatasourcemanagerdialog.h
   qgsabstractdatasourcewidget.h
+  qgssourceselectprovider.h
 
   ogr/qgsogrhelperfunctions.h
   ogr/qgsnewogrconnection.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -350,6 +350,7 @@ SET(QGIS_GUI_SRCS
   qgsdatasourcemanagerdialog.cpp
   qgsabstractdatasourcewidget.cpp
   qgssourceselectprovider.cpp
+  qgssourceselectproviderregistry.cpp
 )
 
 SET(QGIS_GUI_MOC_HDRS
@@ -713,6 +714,7 @@ SET(QGIS_GUI_HDRS
   qgsdatasourcemanagerdialog.h
   qgsabstractdatasourcewidget.h
   qgssourceselectprovider.h
+  qgssourceselectproviderregistry.h
 
   ogr/qgsogrhelperfunctions.h
   ogr/qgsnewogrconnection.h

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -93,6 +93,15 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      */
     void addVectorLayers( const QStringList &layerList, const QString &encoding, const QString &dataSourceType );
 
+    /** Emitted when a layer needs to be replaced
+     * \param oldId old layer ID
+     * \param source URI of the layer
+     * \params name of the layer
+     * \params provider key
+     */
+    void replaceVectorLayer( const QString &oldId, const QString &source, const QString &name, const QString &provider );
+
+
     //! Emitted when a progress dialog is shown by the provider dialog
     void progress( int, int );
 

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -96,8 +96,8 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     /** Emitted when a layer needs to be replaced
      * \param oldId old layer ID
      * \param source URI of the layer
-     * \params name of the layer
-     * \params provider key
+     * \param name of the layer
+     * \param provider key
      */
     void replaceVectorLayer( const QString &oldId, const QString &source, const QString &name, const QString &provider );
 

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -56,47 +56,38 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QWidget *parent, QgsMapC
   connect( this, &QgsDataSourceManagerDialog::updateProjectHome, mBrowserWidget, &QgsBrowserDockWidget::updateProjectHome );
 
   // Add data provider dialogs
-  QWidget *dlg = nullptr;
 
-  addVectorProviderDialog( QStringLiteral( "ogr" ), tr( "Vector" ), QStringLiteral( "/mActionAddOgrLayer.svg" ) );
+  providerDialog( QStringLiteral( "ogr" ), tr( "Vector" ), QStringLiteral( "/mActionAddOgrLayer.svg" ) );
 
-  addRasterProviderDialog( QStringLiteral( "gdal" ), tr( "Raster" ), QStringLiteral( "/mActionAddRasterLayer.svg" ) );
+  providerDialog( QStringLiteral( "gdal" ), tr( "Raster" ), QStringLiteral( "/mActionAddRasterLayer.svg" ) );
 
-  addVectorProviderDialog( QStringLiteral( "delimitedtext" ), tr( "Delimited Text" ), QStringLiteral( "/mActionAddDelimitedTextLayer.svg" ) );
+  providerDialog( QStringLiteral( "delimitedtext" ), tr( "Delimited Text" ), QStringLiteral( "/mActionAddDelimitedTextLayer.svg" ) );
 
 #ifdef HAVE_POSTGRESQL
-  addDbProviderDialog( QStringLiteral( "postgres" ), tr( "PostgreSQL" ), QStringLiteral( "/mActionAddPostgisLayer.svg" ) );
+  providerDialog( QStringLiteral( "postgres" ), tr( "PostgreSQL" ), QStringLiteral( "/mActionAddPostgisLayer.svg" ) );
 #endif
 
-  addDbProviderDialog( QStringLiteral( "spatialite" ), tr( "SpatiaLite" ), QStringLiteral( "/mActionAddSpatiaLiteLayer.svg" ) );
+  providerDialog( QStringLiteral( "spatialite" ), tr( "SpatiaLite" ), QStringLiteral( "/mActionAddSpatiaLiteLayer.svg" ) );
 
-  addDbProviderDialog( QStringLiteral( "mssql" ), tr( "MSSQL" ), QStringLiteral( "/mActionAddMssqlLayer.svg" ) );
+  providerDialog( QStringLiteral( "mssql" ), tr( "MSSQL" ), QStringLiteral( "/mActionAddMssqlLayer.svg" ) );
 
-  addDbProviderDialog( QStringLiteral( "DB2" ), tr( "DB2" ), QStringLiteral( "/mActionAddDb2Layer.svg" ) );
+  providerDialog( QStringLiteral( "DB2" ), tr( "DB2" ), QStringLiteral( "/mActionAddDb2Layer.svg" ) );
 
 #ifdef HAVE_ORACLE
-  addDbProviderDialog( QStringLiteral( "oracle" ), tr( "Oracle" ), QStringLiteral( "/mActionAddOracleLayer.svg" ) );
+  providerDialog( QStringLiteral( "oracle" ), tr( "Oracle" ), QStringLiteral( "/mActionAddOracleLayer.svg" ) );
 #endif
 
-  dlg = addVectorProviderDialog( QStringLiteral( "virtual" ), tr( "Virtual Layer" ), QStringLiteral( "/mActionAddVirtualLayer.svg" ) );
+  providerDialog( QStringLiteral( "virtual" ), tr( "Virtual Layer" ), QStringLiteral( "/mActionAddVirtualLayer.svg" ) );
 
-  // Apparently this is the only provider using replaceVectorLayer, we should
-  // move this in to the base abstract class when it is used by at least one
-  // additional provider.
-  if ( dlg )
-  {
-    connect( dlg, SIGNAL( replaceVectorLayer( QString, QString, QString, QString ) ), this, SIGNAL( replaceSelectedVectorLayer( QString, QString, QString, QString ) ) );
-  }
+  providerDialog( QStringLiteral( "wms" ), tr( "WMS" ), QStringLiteral( "/mActionAddWmsLayer.svg" ) );
 
-  addRasterProviderDialog( QStringLiteral( "wms" ), tr( "WMS" ), QStringLiteral( "/mActionAddWmsLayer.svg" ) );
+  providerDialog( QStringLiteral( "wcs" ), tr( "WCS" ), QStringLiteral( "/mActionAddWcsLayer.svg" ) );
 
-  addRasterProviderDialog( QStringLiteral( "wcs" ), tr( "WCS" ), QStringLiteral( "/mActionAddWcsLayer.svg" ) );
+  providerDialog( QStringLiteral( "WFS" ), tr( "WFS" ), QStringLiteral( "/mActionAddWfsLayer.svg" ) );
 
-  addVectorProviderDialog( QStringLiteral( "WFS" ), tr( "WFS" ), QStringLiteral( "/mActionAddWfsLayer.svg" ) );
+  providerDialog( QStringLiteral( "arcgismapserver" ), tr( "ArcGIS Map Server" ), QStringLiteral( "/mActionAddAmsLayer.svg" ) );
 
-  addRasterProviderDialog( QStringLiteral( "arcgismapserver" ), tr( "ArcGIS Map Server" ), QStringLiteral( "/mActionAddAmsLayer.svg" ) );
-
-  addVectorProviderDialog( QStringLiteral( "arcgisfeatureserver" ), tr( "ArcGIS Feature Server" ), QStringLiteral( "/mActionAddAfsLayer.svg" ) );
+  providerDialog( QStringLiteral( "arcgisfeatureserver" ), tr( "ArcGIS Feature Server" ), QStringLiteral( "/mActionAddAfsLayer.svg" ) );
 
 }
 
@@ -171,51 +162,33 @@ QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::providerDialog( const Q
     }
     connect( dlg, &QgsAbstractDataSourceWidget::rejected, this, &QgsDataSourceManagerDialog::reject );
     connect( dlg, &QgsAbstractDataSourceWidget::accepted, this, &QgsDataSourceManagerDialog::accept );
+    makeConnections( dlg, providerKey );
     return dlg;
   }
 }
 
-QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::addDbProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
+void QgsDataSourceManagerDialog::makeConnections( QgsAbstractDataSourceWidget *dlg, const QString &providerKey )
 {
-  QgsAbstractDataSourceWidget *dlg = providerDialog( providerKey, providerName, icon, title );
-  if ( dlg )
-  {
-    connect( dlg, SIGNAL( addDatabaseLayers( QStringList const &, QString const & ) ),
-             this, SIGNAL( addDatabaseLayers( QStringList const &, QString const & ) ) );
-    connect( dlg, SIGNAL( progress( int, int ) ),
-             this, SIGNAL( showProgress( int, int ) ) );
-    connect( dlg, SIGNAL( progressMessage( QString ) ),
-             this, SIGNAL( showStatusMessage( QString ) ) );
-    connect( dlg, SIGNAL( connectionsChanged() ), this, SIGNAL( connectionsChanged() ) );
-    connect( this, SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
-  }
-  return dlg;
-}
+  // DB
+  connect( dlg, SIGNAL( addDatabaseLayers( QStringList const &, QString const & ) ),
+           this, SIGNAL( addDatabaseLayers( QStringList const &, QString const & ) ) );
+  connect( dlg, SIGNAL( progress( int, int ) ),
+           this, SIGNAL( showProgress( int, int ) ) );
+  connect( dlg, SIGNAL( progressMessage( QString ) ),
+           this, SIGNAL( showStatusMessage( QString ) ) );
+  // Vector
+  connect( dlg, &QgsAbstractDataSourceWidget::addVectorLayer, this, [ = ]( const QString & vectorLayerPath, const QString & baseName )
+  { this->vectorLayerAdded( vectorLayerPath, baseName, providerKey ); } );
+  connect( dlg, &QgsAbstractDataSourceWidget::addVectorLayers, this, &QgsDataSourceManagerDialog::vectorLayersAdded );  connect( dlg, SIGNAL( connectionsChanged() ), this, SIGNAL( connectionsChanged() ) );
+  // Raster
+  connect( dlg, SIGNAL( addRasterLayer( QString const &, QString const &, QString const & ) ),
+           this, SIGNAL( addRasterLayer( QString const &, QString const &, QString const & ) ) );
 
-QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::addRasterProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
-{
-  QgsAbstractDataSourceWidget *dlg = providerDialog( providerKey, providerName, icon, title );
-  if ( dlg )
-  {
-    connect( dlg, SIGNAL( addRasterLayer( QString const &, QString const &, QString const & ) ),
-             this, SIGNAL( addRasterLayer( QString const &, QString const &, QString const & ) ) );
-    connect( dlg, SIGNAL( connectionsChanged() ), this, SIGNAL( connectionsChanged() ) );
-    connect( this,  SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
-  }
-  return dlg;
-}
-
-QgsAbstractDataSourceWidget *QgsDataSourceManagerDialog::addVectorProviderDialog( const QString providerKey, const QString providerName, const QString icon, QString title )
-{
-  QgsAbstractDataSourceWidget *dlg = providerDialog( providerKey, providerName, icon, title );
-  if ( dlg )
-  {
-    connect( dlg, &QgsAbstractDataSourceWidget::addVectorLayer, this, [ = ]( const QString & vectorLayerPath, const QString & baseName )
-    { this->vectorLayerAdded( vectorLayerPath, baseName, providerKey ); } );
-    connect( dlg, &QgsAbstractDataSourceWidget::addVectorLayers, this, &QgsDataSourceManagerDialog::vectorLayersAdded );
-    connect( this,  SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
-  }
-  return dlg;
+  // Virtual
+  connect( dlg, SIGNAL( replaceVectorLayer( QString, QString, QString, QString ) ), this, SIGNAL( replaceSelectedVectorLayer( QString, QString, QString, QString ) ) );
+  // Common
+  connect( dlg, SIGNAL( connectionsChanged() ), this, SIGNAL( connectionsChanged() ) );
+  connect( this, SIGNAL( providerDialogsRefreshRequested() ), dlg, SLOT( refresh() ) );
 }
 
 void QgsDataSourceManagerDialog::showEvent( QShowEvent *e )

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -116,9 +116,7 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
   private:
     // Return the dialog from the provider
     QgsAbstractDataSourceWidget *providerDialog( const QString providerKey, const QString providerName, const QString icon, QString title = QString() );
-    QgsAbstractDataSourceWidget *addDbProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
-    QgsAbstractDataSourceWidget *addRasterProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
-    QgsAbstractDataSourceWidget *addVectorProviderDialog( QString const providerKey, QString const providerName, QString const icon, QString title = QString() );
+    void makeConnections( QgsAbstractDataSourceWidget *dlg, const QString &providerKey );
     Ui::QgsDataSourceManagerDialog *ui;
     QgsBrowserDockWidget *mBrowserWidget = nullptr;
     int mPreviousRow;

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -114,8 +114,7 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
     void providerDialogsRefreshRequested();
 
   private:
-    // Return the dialog from the provider
-    QgsAbstractDataSourceWidget *providerDialog( const QString providerKey, const QString providerName, const QString icon, QString title = QString() );
+    void addProviderDialog( QgsAbstractDataSourceWidget *dlg, const QString &providerKey, const QString &providerName, const QIcon &icon, QString toolTip = QString() );
     void makeConnections( QgsAbstractDataSourceWidget *dlg, const QString &providerKey );
     Ui::QgsDataSourceManagerDialog *ui;
     QgsBrowserDockWidget *mBrowserWidget = nullptr;

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -19,6 +19,7 @@
 #include "qgseditorwidgetregistry.h"
 #include "qgslayertreeembeddedwidgetregistry.h"
 #include "qgsmaplayeractionregistry.h"
+#include "qgssourceselectproviderregistry.h"
 #include "qgslayoutitemregistry.h"
 #include "qgslayoutitemguiregistry.h"
 #include "qgslayoutviewrubberband.h"
@@ -43,6 +44,11 @@ QgsNative *QgsGui::nativePlatformInterface()
 QgsEditorWidgetRegistry *QgsGui::editorWidgetRegistry()
 {
   return instance()->mEditorWidgetRegistry;
+}
+
+QgsSourceSelectProviderRegistry *QgsGui::sourceSelectProviderRegistry()
+{
+  return instance()->mSourceSelectProviderRegistry;
 }
 
 QgsShortcutsManager *QgsGui::shortcutsManager()
@@ -71,6 +77,7 @@ QgsGui::~QgsGui()
   delete mLayerTreeEmbeddedWidgetRegistry;
   delete mEditorWidgetRegistry;
   delete mMapLayerActionRegistry;
+  delete mSourceSelectProviderRegistry;
   delete mShortcutsManager;
   delete mNative;
 }
@@ -87,6 +94,7 @@ QgsGui::QgsGui()
   mShortcutsManager = new QgsShortcutsManager();
   mLayerTreeEmbeddedWidgetRegistry = new QgsLayerTreeEmbeddedWidgetRegistry();
   mMapLayerActionRegistry = new QgsMapLayerActionRegistry();
+  mSourceSelectProviderRegistry = new QgsSourceSelectProviderRegistry();
   mLayoutItemGuiRegistry = new QgsLayoutItemGuiRegistry();
   mLayoutItemGuiRegistry->populate();
 }

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -25,6 +25,7 @@ class QgsEditorWidgetRegistry;
 class QgsShortcutsManager;
 class QgsLayerTreeEmbeddedWidgetRegistry;
 class QgsMapLayerActionRegistry;
+class QgsSourceSelectProviderRegistry;
 class QgsNative;
 class QgsLayoutItemGuiRegistry;
 
@@ -62,6 +63,11 @@ class GUI_EXPORT QgsGui
     static QgsEditorWidgetRegistry *editorWidgetRegistry();
 
     /**
+     * Returns the global source select provider registry, used for managing all known source select widget factories.
+     */
+    static QgsSourceSelectProviderRegistry *sourceSelectProviderRegistry();
+
+    /**
      * Returns the global shortcuts manager, used for managing a QAction and QShortcut sequences.
      */
     static QgsShortcutsManager *shortcutsManager();
@@ -89,6 +95,7 @@ class GUI_EXPORT QgsGui
 
     QgsNative *mNative = nullptr;
     QgsEditorWidgetRegistry *mEditorWidgetRegistry = nullptr;
+    QgsSourceSelectProviderRegistry *mSourceSelectProviderRegistry = nullptr;
     QgsShortcutsManager *mShortcutsManager = nullptr;
     QgsLayerTreeEmbeddedWidgetRegistry *mLayerTreeEmbeddedWidgetRegistry = nullptr;
     QgsMapLayerActionRegistry *mMapLayerActionRegistry = nullptr;

--- a/src/gui/qgssourceselectprovider.cpp
+++ b/src/gui/qgssourceselectprovider.cpp
@@ -1,0 +1,20 @@
+/***************************************************************************
+  qgssourceselectprovider.cpp - QgsSourceSelectProvider
+
+ ---------------------
+ begin                : 1.9.2017
+ copyright            : (C) 2017 by Alessandro Pasotti
+ email                : apasotti at boundlessgeo dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgssourceselectprovider.h"
+
+
+// no implementation currently
+

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+  qgssourceselectprovider.h - QgsSourceSelectProvider
+
+ ---------------------
+ begin                : 1.9.2017
+ copyright            : (C) 2017 by Alessandro Pasotti
+ email                : apasotti at boundlessgeo dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSSOURCESELECTPROVIDER_H
+#define QGSSOURCESELECTPROVIDER_H
+
+
+#include "qgis_gui.h"
+#include "qgis.h"
+#include "qgsabstractdatasourcewidget.h"
+
+class QString;
+
+/** \ingroup gui
+ * This is the interface for those who want to add entries to the \see QgsDataSourceManagerDialog
+ *
+ * \since QGIS 3.0
+ */
+class GUI_EXPORT QgsSourceSelectProvider
+{
+  public:
+    virtual ~QgsSourceSelectProvider() = default;
+
+    //! Provider key
+    virtual QString providerKey() const = 0;
+
+    //! Text for the menu item entry
+    virtual QString text() const = 0;
+
+    //! Creates a new instance of an QIcon for the menu item entry
+    //! Caller takes responsibility of deleting created.
+    virtual QIcon icon() const = 0 SIP_FACTORY;
+
+    //! Create a new instance of QgsAbstractDataSourceWidget (or null).
+    //! Caller takes responsibility of deleting created.
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( ) = 0 SIP_FACTORY;
+
+};
+
+
+#endif // QGSSOURCESELECTPROVIDER_H

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -27,7 +27,7 @@ class QString;
 class QWidget;
 
 /** \ingroup gui
- * This is the interface for those who want to add entries to the \see QgsDataSourceManagerDialog
+ * This is the interface for those who want to add entries to the QgsDataSourceManagerDialog
  *
  * \since QGIS 3.0
  */
@@ -50,10 +50,14 @@ class GUI_EXPORT QgsSourceSelectProvider
     //! Text for the menu item entry, it will be visible to the user so make sure it's translatable
     virtual QString text() const = 0;
 
-    /** Creates a new instance of an QIcon for the menu item entry
-     * Caller takes responsibility of deleting created.
+    /** Text for the tooltip menu item entry, it will be visible to the user so make sure it's translatable
+     *
+     * The default implementation returns an empty string.
      */
-    virtual QIcon icon() const = 0 SIP_FACTORY;
+    virtual QString toolTip() const { return QString(); }
+
+    //! Creates a new instance of an QIcon for the menu item entry
+    virtual QIcon icon() const = 0;
 
     /** Ordering: the source select provider registry will be able to sort
      * the source selects (ascending) using this integer value

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -22,6 +22,7 @@
 #include "qgsabstractdatasourcewidget.h"
 
 class QString;
+class QWidget;
 
 /** \ingroup gui
  * This is the interface for those who want to add entries to the \see QgsDataSourceManagerDialog
@@ -33,19 +34,34 @@ class GUI_EXPORT QgsSourceSelectProvider
   public:
     virtual ~QgsSourceSelectProvider() = default;
 
-    //! Provider key
+    //! Data Provider key
     virtual QString providerKey() const = 0;
 
-    //! Text for the menu item entry
+    /** Source select provider name, this is useful to retrieve
+     * a particular source select in case the provider has more
+     * than one, it should be unique among all providers.
+     *
+     * The default implementation returns the providerKey()
+     */
+    virtual QString name() const { return providerKey(); }
+
+    //! Text for the menu item entry, it will be visible to the user so make sure it's translatable
     virtual QString text() const = 0;
 
-    //! Creates a new instance of an QIcon for the menu item entry
-    //! Caller takes responsibility of deleting created.
+    /** Creates a new instance of an QIcon for the menu item entry
+     * Caller takes responsibility of deleting created.
+     */
     virtual QIcon icon() const = 0 SIP_FACTORY;
 
-    //! Create a new instance of QgsAbstractDataSourceWidget (or null).
-    //! Caller takes responsibility of deleting created.
-    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( ) = 0 SIP_FACTORY;
+    /** Ordering: the source select provider registry will be able to sort
+     * the source selects (ascending) using this integer value
+     */
+    virtual int ordering( ) const { return 0; }
+
+    /** Create a new instance of QgsAbstractDataSourceWidget (or null).
+     * Caller takes responsibility of deleting created.
+     */
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr ) const = 0 SIP_FACTORY;
 
 };
 

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -19,6 +19,8 @@
 
 #include "qgis_gui.h"
 #include "qgis.h"
+#include "qgsguiutils.h"
+#include "qgsproviderregistry.h"
 #include "qgsabstractdatasourcewidget.h"
 
 class QString;
@@ -61,7 +63,7 @@ class GUI_EXPORT QgsSourceSelectProvider
     /** Create a new instance of QgsAbstractDataSourceWidget (or null).
      * Caller takes responsibility of deleting created.
      */
-    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const = 0 SIP_FACTORY;
 
 };
 

--- a/src/gui/qgssourceselectproviderregistry.cpp
+++ b/src/gui/qgssourceselectproviderregistry.cpp
@@ -91,8 +91,8 @@ void QgsSourceSelectProviderRegistry::init()
   {
     return;
   }
-  QStringList providersList = QgsProviderRegistry::instance()->providerList();
-  Q_FOREACH ( const QString &key, providersList )
+  const QStringList providersList = QgsProviderRegistry::instance()->providerList();
+  for ( const QString &key : providersList )
   {
     std::unique_ptr< QLibrary > library( QgsProviderRegistry::instance()->createProviderLibrary( key ) );
     if ( !library )

--- a/src/gui/qgssourceselectproviderregistry.cpp
+++ b/src/gui/qgssourceselectproviderregistry.cpp
@@ -47,11 +47,15 @@ void QgsSourceSelectProviderRegistry::addProvider( QgsSourceSelectProvider *prov
   } );
 }
 
-void QgsSourceSelectProviderRegistry::removeProvider( QgsSourceSelectProvider *provider )
+bool QgsSourceSelectProviderRegistry::removeProvider( QgsSourceSelectProvider *provider )
 {
   int index = mProviders.indexOf( provider );
   if ( index >= 0 )
+  {
     delete mProviders.takeAt( index );
+    return true;
+  }
+  return false;
 }
 
 QgsSourceSelectProvider *QgsSourceSelectProviderRegistry::providerByName( const QString &name )

--- a/src/gui/qgssourceselectproviderregistry.cpp
+++ b/src/gui/qgssourceselectproviderregistry.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+  qgssourceselectproviderregistry.cpp - QgsSourceSelectProviderRegistry
+
+ ---------------------
+ begin                : 1.9.2017
+ copyright            : (C) 2017 by Alessandro Pasotti
+ email                : apasotti at boundlessgeo dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgssourceselectprovider.h"
+#include "qgssourceselectproviderregistry.h"
+#include "qgsproviderregistry.h"
+
+#include <memory>
+
+typedef QList<QgsSourceSelectProvider *> *sourceSelectProviders_t();
+
+
+QgsSourceSelectProviderRegistry::QgsSourceSelectProviderRegistry()
+{
+  QStringList providersList = QgsProviderRegistry::instance()->providerList();
+
+  Q_FOREACH ( const QString &key, providersList )
+  {
+    std::unique_ptr< QLibrary > library( QgsProviderRegistry::instance()->createProviderLibrary( key ) );
+    if ( !library )
+      continue;
+
+    sourceSelectProviders_t *sourceSelectProvidersFn = reinterpret_cast< sourceSelectProviders_t * >( cast_to_fptr( library->resolve( "sourceSelectProviders" ) ) );
+    if ( sourceSelectProvidersFn )
+    {
+      QList<QgsSourceSelectProvider *> *providerList = sourceSelectProvidersFn();
+      // the function is a factory - we keep ownership of the returned providers
+      for ( auto provider : qgsAsConst( *providerList ) )
+      {
+        addProvider( provider );
+      }
+      delete providerList;
+    }
+  }
+}
+
+QgsSourceSelectProviderRegistry::~QgsSourceSelectProviderRegistry()
+{
+  qDeleteAll( mProviders );
+}
+
+void QgsSourceSelectProviderRegistry::addProvider( QgsSourceSelectProvider *provider )
+{
+  mProviders.append( provider );
+  std::sort( mProviders.begin(), mProviders.end(), [ ]( const QgsSourceSelectProvider * first, const QgsSourceSelectProvider * second ) -> bool
+  {
+    return first->ordering() < second->ordering();
+  } );
+}
+
+void QgsSourceSelectProviderRegistry::removeProvider( QgsSourceSelectProvider *provider )
+{
+  int index = mProviders.indexOf( provider );
+  if ( index >= 0 )
+    delete mProviders.takeAt( index );
+}
+
+QgsSourceSelectProvider *QgsSourceSelectProviderRegistry::providerByName( const QString &name ) const
+{
+  for ( const auto provider : qgsAsConst( mProviders ) )
+  {
+    if ( provider->name() == name )
+    {
+      return provider;
+    }
+  }
+  return nullptr;
+}
+
+QList<QgsSourceSelectProvider *> QgsSourceSelectProviderRegistry::providersByKey( const QString &providerKey ) const
+{
+  QList<QgsSourceSelectProvider *> providerList;
+  for ( const auto provider : qgsAsConst( mProviders ) )
+  {
+    if ( provider->providerKey() == providerKey )
+    {
+      providerList << provider;
+    }
+  }
+  return providerList;
+}

--- a/src/gui/qgssourceselectproviderregistry.h
+++ b/src/gui/qgssourceselectproviderregistry.h
@@ -28,6 +28,10 @@ class QgsSourceSelectProvider;
  * QgsSourceSelectProviderRegistry is not usually directly created, but rather accessed through
  * QgsGui::sourceSelectProviderRegistry().
  *
+ * \note This class access to QgsProviderRegistry instance to initialize, but QgsProviderRegistry is
+ * typically initialized after QgsGui is constructed, for this reason a delayed initialization has been
+ * implemented in the class.
+ *
  * \since QGIS 3.0
  */
 class GUI_EXPORT QgsSourceSelectProviderRegistry
@@ -43,7 +47,7 @@ class GUI_EXPORT QgsSourceSelectProviderRegistry
     QgsSourceSelectProviderRegistry &operator=( const QgsSourceSelectProviderRegistry &rh ) = delete;
 
     //! Get list of available providers
-    QList< QgsSourceSelectProvider *> providers() const { return mProviders; }
+    QList< QgsSourceSelectProvider *> providers();
 
     //! Add a provider implementation. Takes ownership of the object.
     void addProvider( QgsSourceSelectProvider *provider SIP_TRANSFER );
@@ -52,13 +56,17 @@ class GUI_EXPORT QgsSourceSelectProviderRegistry
     void removeProvider( QgsSourceSelectProvider *provider );
 
     //! Return a provider by name or nullptr if not found
-    QgsSourceSelectProvider *providerByName( const QString &name ) const;
+    QgsSourceSelectProvider *providerByName( const QString &name );
 
     //! Return a (possibly empty) list of providers by data provider's key
-    QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey ) const;
+    QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey );
 
 
   private:
+    //! Populate the providers list, this needs to happen after the data provider
+    //! registry has been initialized.
+    void init();
+    bool mInitialized = false;
 #ifdef SIP_RUN
     QgsSourceSelectProviderRegistry( const QgsSourceSelectProviderRegistry &rh );
 #endif

--- a/src/gui/qgssourceselectproviderregistry.h
+++ b/src/gui/qgssourceselectproviderregistry.h
@@ -25,6 +25,9 @@ class QgsSourceSelectProvider;
  * This class keeps a list of source select providers that may add items to the QgsDataSourceManagerDialog
  * When created, it automatically adds providers from data provider plugins (e.g. PostGIS, WMS, ...)
  *
+ * QgsSourceSelectProviderRegistry is not usually directly created, but rather accessed through
+ * QgsGui::sourceSelectProviderRegistry().
+ *
  * \since QGIS 3.0
  */
 class GUI_EXPORT QgsSourceSelectProviderRegistry

--- a/src/gui/qgssourceselectproviderregistry.h
+++ b/src/gui/qgssourceselectproviderregistry.h
@@ -49,16 +49,17 @@ class GUI_EXPORT QgsSourceSelectProviderRegistry
     //! Get list of available providers
     QList< QgsSourceSelectProvider *> providers();
 
-    //! Add a provider implementation. Takes ownership of the object.
+    //! Add a \a provider implementation. Takes ownership of the object.
     void addProvider( QgsSourceSelectProvider *provider SIP_TRANSFER );
 
-    //! Remove provider implementation from the list (provider object is deleted)
-    void removeProvider( QgsSourceSelectProvider *provider );
+    //! Remove \a provider implementation from the list (\a provider object is deleted)
+    //! \returns true if the provider was actually removed and deleted
+    bool removeProvider( QgsSourceSelectProvider *provider SIP_TRANSFER );
 
-    //! Return a provider by name or nullptr if not found
+    //! Return a provider by \a name or nullptr if not found
     QgsSourceSelectProvider *providerByName( const QString &name );
 
-    //! Return a (possibly empty) list of providers by data provider's key
+    //! Return a (possibly empty) list of providers by data \a providerkey
     QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey );
 
 

--- a/src/gui/qgssourceselectproviderregistry.h
+++ b/src/gui/qgssourceselectproviderregistry.h
@@ -1,0 +1,68 @@
+/***************************************************************************
+  qgssourceselectproviderregistry.h - QgsSourceSelectProviderRegistry
+
+ ---------------------
+ begin                : 1.9.2017
+ copyright            : (C) 2017 by Alessandro Pasotti
+ email                : apasotti at boundlessgeo dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSSOURCESELECTPROVIDERREGISTRY_H
+#define QGSSOURCESELECTPROVIDERREGISTRY_H
+
+#include "qgis_gui.h"
+#include "qgis.h"
+
+class QgsSourceSelectProvider;
+
+/** \ingroup gui
+ * This class keeps a list of source select providers that may add items to the QgsDataSourceManagerDialog
+ * When created, it automatically adds providers from data provider plugins (e.g. PostGIS, WMS, ...)
+ *
+ * \since QGIS 3.0
+ */
+class GUI_EXPORT QgsSourceSelectProviderRegistry
+{
+  public:
+    QgsSourceSelectProviderRegistry();
+
+    ~QgsSourceSelectProviderRegistry();
+
+    //! QgsDataItemProviderRegistry cannot be copied.
+    QgsSourceSelectProviderRegistry( const QgsSourceSelectProviderRegistry &rh ) = delete;
+    //! QgsDataItemProviderRegistry cannot be copied.
+    QgsSourceSelectProviderRegistry &operator=( const QgsSourceSelectProviderRegistry &rh ) = delete;
+
+    //! Get list of available providers
+    QList< QgsSourceSelectProvider *> providers() const { return mProviders; }
+
+    //! Add a provider implementation. Takes ownership of the object.
+    void addProvider( QgsSourceSelectProvider *provider SIP_TRANSFER );
+
+    //! Remove provider implementation from the list (provider object is deleted)
+    void removeProvider( QgsSourceSelectProvider *provider );
+
+    //! Return a provider by name or nullptr if not found
+    QgsSourceSelectProvider *providerByName( const QString &name ) const;
+
+    //! Return a (possibly empty) list of providers by data provider's key
+    QList<QgsSourceSelectProvider *> providersByKey( const QString &providerKey ) const;
+
+
+  private:
+#ifdef SIP_RUN
+    QgsSourceSelectProviderRegistry( const QgsSourceSelectProviderRegistry &rh );
+#endif
+
+    //! available providers. this class owns the pointers
+    QList<QgsSourceSelectProvider *> mProviders;
+
+};
+
+#endif // QGSSOURCESELECTPROVIDERREGISTRY_H

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -23,6 +23,11 @@
 #include "geometry/qgsgeometry.h"
 #include "qgsnetworkaccessmanager.h"
 
+#ifdef HAVE_GUI
+#include "qgsafssourceselect.h"
+#include "qgssourceselectprovider.h"
+#endif
+
 #include <QEventLoop>
 #include <QMessageBox>
 #include <QNetworkRequest>
@@ -196,3 +201,33 @@ void QgsAfsProvider::reloadData()
 {
   mSharedData->mCache.clear();
 }
+
+
+#ifdef HAVE_GUI
+
+//! Provider for AFS layers source select
+class QgsAfsSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "arcgisfeatureserver" ); }
+    virtual QString text() const override { return QObject::tr( "ArcGIS Feature Server" ); }
+    virtual int ordering() const override { return 140; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddAfsLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsAfsSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsAfsSourceSelectProvider;
+
+  return providers;
+}
+#endif

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -24,6 +24,11 @@
 #include "qgsfeaturestore.h"
 #include "qgsgeometry.h"
 
+#ifdef HAVE_GUI
+#include "qgsamssourceselect.h"
+#include "qgssourceselectprovider.h"
+#endif
+
 #include <cstring>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -449,3 +454,32 @@ void QgsAmsProvider::readBlock( int /*bandNo*/, const QgsRectangle &viewExtent, 
   }
   std::memcpy( data, mCachedImage.constBits(), mCachedImage.bytesPerLine() * mCachedImage.height() );
 }
+
+#ifdef HAVE_GUI
+
+//! Provider for AMS layers source select
+class QgsAmsSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "arcgismapserver" ); }
+    virtual QString text() const override { return QObject::tr( "ArcGIS Map Server" ); }
+    virtual int ordering() const override { return 130; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddAmsLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsAmsSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsAmsSourceSelectProvider;
+
+  return providers;
+}
+#endif

--- a/src/providers/arcgisrest/qgsamssourceselect.h
+++ b/src/providers/arcgisrest/qgsamssourceselect.h
@@ -28,7 +28,7 @@ class QgsAmsSourceSelect: public QgsArcGisServiceSourceSelect
     Q_OBJECT
 
   public:
-    QgsAmsSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode =  QgsProviderRegistry::WidgetMode::None );
+    QgsAmsSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode =  QgsProviderRegistry::WidgetMode::None );
 
   protected:
     bool connectToService( const QgsOwsConnection &connection ) override;

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -27,6 +27,7 @@
 
 #ifdef HAVE_GUI
 #include "qgsdb2sourceselect.h"
+#include "qgssourceselectprovider.h"
 #endif
 
 static const QString PROVIDER_KEY = QStringLiteral( "DB2" );
@@ -1748,3 +1749,34 @@ QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
            oldToNewAttrIdxMap, errorMessage, options
          );
 }
+
+
+#ifdef HAVE_GUI
+
+//! Provider for DB2 source select
+class QgsDb2SourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "DB2" ); }
+    virtual QString text() const override { return QObject::tr( "DB2" ); }
+    virtual int ordering() const override { return 70; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddDb2Layer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsDb2SourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsDb2SourceSelectProvider;
+
+  return providers;
+}
+
+#endif

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -41,6 +41,9 @@
 #include "qgsspatialindex.h"
 #include "qgis.h"
 #include "qgsproviderregistry.h"
+#ifdef HAVE_GUI
+#include "qgssourceselectprovider.h"
+#endif
 
 #include "qgsdelimitedtextfeatureiterator.h"
 #include "qgsdelimitedtextfile.h"
@@ -1196,4 +1199,33 @@ QGISEXTERN QgsDelimitedTextSourceSelect *selectWidget( QWidget *parent, Qt::Wind
 {
   return new QgsDelimitedTextSourceSelect( parent, fl, widgetMode );
 }
+
+//! Provider for delimited text source select
+class QgsDelimitedTextSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "delimitedtext" ); }
+    virtual QString text() const override { return QObject::tr( "Delimited Text" ); }
+    virtual int ordering() const override { return 30; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddDelimitedTextLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsDelimitedTextSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsDelimitedTextSourceSelectProvider;
+
+  return providers;
+}
+
 #endif
+
+

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -35,6 +35,11 @@
 #include "qgspointxy.h"
 #include "qgssettings.h"
 
+#ifdef HAVE_GUI
+#include "qgssourceselectprovider.h"
+#include "qgsgdalsourceselect.h"
+#endif
+
 #include <QImage>
 #include <QColor>
 #include <QProcess>
@@ -3041,3 +3046,34 @@ QGISEXTERN void cleanupProvider()
   // nothing to do here, QgsApplication takes care of
   // calling GDALDestroyDriverManager()
 }
+
+
+#ifdef HAVE_GUI
+
+//! Provider for gdal raster source select
+class QgsGdalRasterSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "gdal" ); }
+    virtual QString text() const override { return QObject::tr( "Raster" ); }
+    virtual int ordering() const override { return 20; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddRasterLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsGdalSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsGdalRasterSourceSelectProvider;
+
+  return providers;
+}
+
+#endif

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -49,6 +49,7 @@
 
 #ifdef HAVE_GUI
 #include "qgsmssqlsourceselect.h"
+#include "qgssourceselectprovider.h"
 #endif
 
 static const QString TEXT_PROVIDER_KEY = QStringLiteral( "mssql" );
@@ -2307,3 +2308,34 @@ QGISEXTERN QString getStyleById( const QString &uri, QString styleId, QString &e
   }
   return style;
 }
+
+
+#ifdef HAVE_GUI
+
+//! Provider for msssql raster source select
+class QgsMssqlSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "mssql" ); }
+    virtual QString text() const override { return QObject::tr( "MSSQL" ); }
+    virtual int ordering() const override { return 60; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddMssqlLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsMssqlSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsMssqlSourceSelectProvider ;
+
+  return providers;
+}
+
+#endif

--- a/src/providers/ogr/qgsogrdataitems.h
+++ b/src/providers/ogr/qgsogrdataitems.h
@@ -50,4 +50,5 @@ class QgsOgrDataCollectionItem : public QgsDataCollectionItem
 };
 
 
+
 #endif // QGSOGRDATAITEMS_H

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -35,6 +35,8 @@ email                : sherman at mrcc.com
 #include "qgsogrdataitems.h"
 #include "qgsgeopackagedataitems.h"
 #include "qgswkbtypes.h"
+#include "qgssourceselectprovider.h"
+#include "qgsogrsourceselect.h"
 #include "qgis.h"
 
 
@@ -4345,4 +4347,30 @@ QGISEXTERN bool deleteLayer( const QString &uri, QString &errCause )
   // This should never happen:
   errCause = QObject::tr( "Layer not found: %1" ).arg( uri );
   return false;
+}
+
+
+//! Provider for OGR vector source select
+class QgsOgrVectorSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "ogr" ); }
+    virtual QString text() const override { return QObject::tr( "Vector" ); }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddOgrLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr ) const override
+    {
+      return new QgsOgrSourceSelect( parent );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsOgrVectorSourceSelectProvider;
+
+  return providers;
 }

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -35,8 +35,12 @@ email                : sherman at mrcc.com
 #include "qgsogrdataitems.h"
 #include "qgsgeopackagedataitems.h"
 #include "qgswkbtypes.h"
+
+#ifdef HAVE_GUI
 #include "qgssourceselectprovider.h"
 #include "qgsogrsourceselect.h"
+#endif
+
 #include "qgis.h"
 
 
@@ -4349,6 +4353,7 @@ QGISEXTERN bool deleteLayer( const QString &uri, QString &errCause )
   return false;
 }
 
+#ifdef HAVE_GUI
 
 //! Provider for OGR vector source select
 class QgsOgrVectorSourceSelectProvider : public QgsSourceSelectProvider
@@ -4357,10 +4362,11 @@ class QgsOgrVectorSourceSelectProvider : public QgsSourceSelectProvider
 
     virtual QString providerKey() const override { return QStringLiteral( "ogr" ); }
     virtual QString text() const override { return QObject::tr( "Vector" ); }
+    virtual int ordering() const override { return 10; }
     virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddOgrLayer.svg" ) ); }
-    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr ) const override
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
     {
-      return new QgsOgrSourceSelect( parent );
+      return new QgsOgrSourceSelect( parent, fl, widgetMode );
     }
 };
 
@@ -4374,3 +4380,5 @@ QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
 
   return providers;
 }
+
+#endif

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -33,6 +33,7 @@
 
 #ifdef HAVE_GUI
 #include "qgsoraclesourceselect.h"
+#include "qgssourceselectprovider.h"
 #endif
 
 #include <QSqlRecord>
@@ -3582,4 +3583,36 @@ QGISEXTERN QString getStyleById( const QString &uri, QString styleId, QString &e
   return style;
 }
 
-// vim: set sw=2 :
+
+#ifdef HAVE_GUI
+
+//! Provider for Oracle source select
+class QgsOracleSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "oracle" ); }
+    virtual QString text() const override { return QObject::tr( "Oracle" ); }
+    virtual int ordering() { return 80; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddOracleLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsOracleSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsOracleSourceSelectProvider;
+
+  return providers;
+}
+
+#endif
+
+
+// vim: set sw=2

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -40,6 +40,7 @@
 
 #ifdef HAVE_GUI
 #include "qgspgsourceselect.h"
+#include "qgssourceselectprovider.h"
 #endif
 
 const QString POSTGRES_KEY = QStringLiteral( "postgres" );
@@ -4751,6 +4752,36 @@ QGISEXTERN void cleanupProvider()
 {
   QgsPostgresConnPool::cleanupInstance();
 }
+
+
+#ifdef HAVE_GUI
+
+//! Provider for postgres source select
+class QgsPostgresSourceSelectProvider : public QgsSourceSelectProvider  //#spellok
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "postgres" ); }
+    virtual QString text() const override { return QObject::tr( "PostgreSQL" ); }
+    virtual int ordering() const override { return 40; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddPostgisLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsPgSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsPostgresSourceSelectProvider;  //#spellok
+
+  return providers;
+}
+#endif
 
 // ----------
 

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -34,6 +34,11 @@ email                : a.furieri@lqt.it
 #include "qgsjsonutils.h"
 #include "qgsvectorlayer.h"
 
+#ifdef HAVE_GUI
+#include "qgssourceselectprovider.h"
+#include "qgsspatialitesourceselect.h"
+#endif
+
 #include <QMessageBox>
 #include <QFileInfo>
 #include <QDir>
@@ -5917,3 +5922,31 @@ QGISEXTERN void cleanupProvider()
   QgsSqliteHandle::closeAll();
 }
 
+#ifdef HAVE_GUI
+
+//! Provider for spatialite source select
+class QgsSpatialiteSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "spatialite" ); }
+    virtual QString text() const override { return QObject::tr( "SpatiaLite" ); }
+    virtual int ordering() const override { return 50; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddSpatiaLiteLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsSpatiaLiteSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsSpatialiteSourceSelectProvider;
+
+  return providers;
+}
+#endif

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -664,6 +664,7 @@ class QgsVirtualSourceSelectProvider : public QgsSourceSelectProvider
     virtual QString providerKey() const override { return QStringLiteral( "virtual" ); }
     virtual QString text() const override { return QObject::tr( "Virtual Layer" ); }
     virtual int ordering() const override { return 90; }
+    virtual QString toolTip() const override { return QObject::tr( "Add Virtual Layer" ); }
     virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVirtualLayer.svg" ) ); }
     virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
     {

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -36,6 +36,11 @@ extern "C"
 #include "qgsvirtuallayersqlitemodule.h"
 #include "qgsvirtuallayerqueryparser.h"
 
+#ifdef HAVE_GUI
+#include "qgssourceselectprovider.h"
+#include "qgsvirtuallayersourceselect.h"
+#endif
+
 const QString VIRTUAL_LAYER_KEY = QStringLiteral( "virtual" );
 const QString VIRTUAL_LAYER_DESCRIPTION = QStringLiteral( "Virtual layer data provider" );
 
@@ -647,3 +652,33 @@ QGISEXTERN bool isProvider()
 QGISEXTERN void cleanupProvider()
 {
 }
+
+
+#ifdef HAVE_GUI
+
+//! Provider for virtual layers source select
+class QgsVirtualSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "virtual" ); }
+    virtual QString text() const override { return QObject::tr( "Virtual Layer" ); }
+    virtual int ordering() const override { return 90; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVirtualLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsVirtualLayerSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsVirtualSourceSelectProvider;
+
+  return providers;
+}
+#endif

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -53,9 +53,6 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     void onTableRowChanged( const QModelIndex &current, const QModelIndex &previous );
     void updateLayersList();
 
-  signals:
-    //! Old_id, source, name, provider
-    void replaceVectorLayer( QString, QString, QString, QString );
 
   private:
     QgsVirtualLayerDefinition getVirtualLayerDef();

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -32,6 +32,11 @@
 #include "qgsmessagelog.h"
 #include "qgsexception.h"
 
+#ifdef HAVE_GUI
+#include "qgswcssourceselect.h"
+#include "qgssourceselectprovider.h"
+#endif
+
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QNetworkProxy>
@@ -1925,3 +1930,32 @@ void QgsWcsDownloadHandler::canceled()
     mCacheReply->abort();
   }
 }
+
+#ifdef HAVE_GUI
+
+//! Provider for WCS layers source select
+class QgsWcsSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "wcs" ); }
+    virtual QString text() const override { return QObject::tr( "WCS" ); }
+    virtual int ordering() const override { return 110; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddWcsLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsWCSSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsWcsSourceSelectProvider;
+
+  return providers;
+}
+#endif

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -35,6 +35,11 @@
 #include "qgswfsutils.h"
 #include "qgssettings.h"
 
+#ifdef HAVE_GUI
+#include "qgswfssourceselect.h"
+#include "qgssourceselectprovider.h"
+#endif
+
 #include <QDomDocument>
 #include <QMessageBox>
 #include <QDomNodeList>
@@ -1698,3 +1703,32 @@ QGISEXTERN bool isProvider()
 
   return true;
 }
+
+#ifdef HAVE_GUI
+
+//! Provider for WFS layers source select
+class QgsWfsSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "WFS" ); }
+    virtual QString text() const override { return QObject::tr( "WFS" ); }
+    virtual int ordering() const override { return 120; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddWfsLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsWFSSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsWfsSourceSelectProvider;
+
+  return providers;
+}
+#endif

--- a/src/providers/wms/CMakeLists.txt
+++ b/src/providers/wms/CMakeLists.txt
@@ -64,16 +64,21 @@ TARGET_LINK_LIBRARIES(wmsprovider
   ${GDAL_LIBRARY}  # for OGR_G_CreateGeometryFromJson()
 )
 
-IF (WITH_GUI)
-  TARGET_LINK_LIBRARIES (wmsprovider
-    qgis_gui
-  )
-ENDIF ()
 
 TARGET_LINK_LIBRARIES(wmsprovider_a
   qgis_core
   ${QT_QTSCRIPT_LIBRARY}
 )
+
+
+IF (WITH_GUI)
+  TARGET_LINK_LIBRARIES (wmsprovider
+    qgis_gui
+  )
+  TARGET_LINK_LIBRARIES (wmsprovider_a
+    qgis_gui
+  )
+ENDIF ()
 
 INSTALL (TARGETS wmsprovider
   RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -47,6 +47,13 @@
 #include "qgsexception.h"
 #include "qgssettings.h"
 
+
+#ifdef HAVE_GUI
+#include "qgswmssourceselect.h"
+#include "qgssourceselectprovider.h"
+#endif
+
+
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QNetworkProxy>
@@ -4218,3 +4225,34 @@ QgsCachedImageFetcher::start()
 {
   QTimer::singleShot( 1, this, SLOT( send() ) );
 }
+
+
+#ifdef HAVE_GUI
+
+//! Provider for WMS layers source select
+class QgsWmsSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    virtual QString providerKey() const override { return QStringLiteral( "wms" ); }
+    virtual QString text() const override { return QObject::tr( "WMS" ); }
+    virtual int ordering() const override { return 100; }
+    virtual QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddWmsLayer.svg" ) ); }
+    virtual QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsWMSSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QGISEXTERN QList<QgsSourceSelectProvider *> *sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> *providers = new QList<QgsSourceSelectProvider *>();
+
+  *providers
+      << new QgsWmsSourceSelectProvider;
+
+  return providers;
+}
+#endif
+

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -176,6 +176,7 @@ ADD_PYTHON_TEST(PyQgsDBManagerGpkg test_db_manager_gpkg.py)
 ADD_PYTHON_TEST(PyQgsFileDownloader test_qgsfiledownloader.py)
 ADD_PYTHON_TEST(PyQgsSettings test_qgssettings.py)
 ADD_PYTHON_TEST(PyQgsZipUtils test_qgsziputils.py)
+ADD_PYTHON_TEST(PyQgsSourceSelectProvider test_qgssourceselectprovider.py)
 
 IF (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_qgssourceselectprovider.py
+++ b/tests/src/python/test_qgssourceselectprovider.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-Test the QgsSourceSelectProvider class
+Test the QgsSourceSelectProvider 
+and QgsSourceSelectProviderRegistry classes
 
 Run with: ctest -V -R PyQgsSourceSelectProvider
 
@@ -12,7 +13,7 @@ the Free Software Foundation; either version 2 of the License, or
 
 import os
 import tempfile
-from qgis.gui import (QgsSourceSelectProvider, QgsSourceSelectProviderRegistry, QgsAbstractDataSourceWidget)
+from qgis.gui import (QgsGui, QgsSourceSelectProvider, QgsSourceSelectProviderRegistry, QgsAbstractDataSourceWidget)
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QWidget
@@ -90,9 +91,8 @@ class TestQgsSourceSelectProvider(unittest.TestCase):
         self.assertEqual(provider.ordering(), 1)
         self.assertTrue(isinstance(provider.icon(), QIcon))
 
-    def testRegistry(self):
+    def _testRegistry(self, registry):
 
-        registry = QgsSourceSelectProviderRegistry()
         registry.addProvider(ConcreteSourceSelectProvider())
         registry.addProvider(ConcreteSourceSelectProvider2())
 
@@ -113,12 +113,20 @@ class TestQgsSourceSelectProvider(unittest.TestCase):
         # Get not existent by name
         self.assertFalse(registry.providerByName('Oh This Is Missing!'))
 
-        # Get providers by provider key
+        # Get providers by data provider key
         self.assertGreater(len(registry.providersByKey('MyTestProviderKey')), 0)
         self.assertGreater(len(registry.providersByKey('MyTestProviderKey2')), 0)
 
         # Get not existent by key
         self.assertEqual(len(registry.providersByKey('Oh This Is Missing!')), 0)
+
+    def testRegistry(self):
+        registry = QgsSourceSelectProviderRegistry()
+        self._testRegistry(registry)
+
+    def testRegistrySingleton(self):
+        registry = QgsGui.sourceSelectProviderRegistry()
+        self._testRegistry(registry)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssourceselectprovider.py
+++ b/tests/src/python/test_qgssourceselectprovider.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Test the QgsSourceSelectProvider class
+
+Run with: ctest -V -R PyQgsSourceSelectProvider
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+
+import os
+import tempfile
+from qgis.gui import (QgsSourceSelectProvider, QgsAbstractDataSourceWidget)
+from qgis.testing import start_app, unittest
+from qgis.PyQt.QtGui import QIcon
+
+__author__ = 'Alessandro Pasotti'
+__date__ = '01/09/2017'
+__copyright__ = 'Copyright 2017, The QGIS Project'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+
+start_app()
+
+
+class ConcreteDataSourceWidget(QgsAbstractDataSourceWidget):
+    pass
+
+
+class ConcreteSourceSelectProvider(QgsSourceSelectProvider):
+
+    def providerKey(self):
+        return "MyTestProviderKey"
+
+    def text(self):
+        return "MyTestProviderText"
+
+    def icon(self):
+        return QIcon()
+
+    def createDataSourceWidget(self):
+        return ConcreteDataSourceWidget()
+
+
+class TestQgsSourceSelectProvider(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testConcreteClass(self):
+
+        provider = ConcreteSourceSelectProvider()
+        self.assertTrue(isinstance(provider, ConcreteSourceSelectProvider))
+        widget = provider.createDataSourceWidget()
+        self.assertTrue(isinstance(widget, ConcreteDataSourceWidget))
+        self.assertEqual(provider.providerKey(), "MyTestProviderKey")
+        self.assertEqual(provider.text(), "MyTestProviderText")
+        self.assertTrue(isinstance(provider.icon(), QIcon))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/src/python/test_qgssourceselectprovider.py
+++ b/tests/src/python/test_qgssourceselectprovider.py
@@ -61,6 +61,9 @@ class ConcreteSourceSelectProvider2(QgsSourceSelectProvider):
     def name(self):
         return "MyName"
 
+    def toolTip(self):
+        return "MyToolTip"
+
     def icon(self):
         return QIcon()
 
@@ -88,8 +91,13 @@ class TestQgsSourceSelectProvider(unittest.TestCase):
         self.assertEqual(provider.providerKey(), "MyTestProviderKey")
         self.assertEqual(provider.name(), "MyTestProviderKey")
         self.assertEqual(provider.text(), "MyTestProviderText")
+        self.assertEqual(provider.toolTip(), "")
         self.assertEqual(provider.ordering(), 1)
         self.assertTrue(isinstance(provider.icon(), QIcon))
+
+        # test toolTip
+        provider = ConcreteSourceSelectProvider2()
+        self.assertEqual(provider.toolTip(), "MyToolTip")
 
     def _testRegistry(self, registry):
 

--- a/tests/src/python/test_qgssourceselectprovider.py
+++ b/tests/src/python/test_qgssourceselectprovider.py
@@ -120,6 +120,18 @@ class TestQgsSourceSelectProvider(unittest.TestCase):
         # Get not existent by key
         self.assertEqual(len(registry.providersByKey('Oh This Is Missing!')), 0)
 
+    def testRemoveProvider(self):
+        registry = QgsSourceSelectProviderRegistry()
+        registry.addProvider(ConcreteSourceSelectProvider())
+        registry.addProvider(ConcreteSourceSelectProvider2())
+        self.assertEqual(['MyTestProviderKey', 'MyName'], [p.name() for p in registry.providers() if p.providerKey().startswith('MyTestProviderKey')])
+
+        self.assertTrue(registry.removeProvider(registry.providerByName('MyName')))
+        self.assertEqual(['MyTestProviderKey'], [p.name() for p in registry.providers() if p.providerKey().startswith('MyTestProviderKey')])
+
+        self.assertTrue(registry.removeProvider(registry.providerByName('MyTestProviderKey')))
+        self.assertEqual([], [p.name() for p in registry.providers() if p.providerKey().startswith('MyTestProviderKey')])
+
     def testRegistry(self):
         registry = QgsSourceSelectProviderRegistry()
         self._testRegistry(registry)
@@ -127,6 +139,9 @@ class TestQgsSourceSelectProvider(unittest.TestCase):
     def testRegistrySingleton(self):
         registry = QgsGui.sourceSelectProviderRegistry()
         self._testRegistry(registry)
+        # Check that at least OGR and GDAL are here
+        self.assertTrue(registry.providersByKey('ogr'))
+        self.assertTrue(registry.providersByKey('gdal'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Implementation of QEP 101

Needs some tiny bits and polishing but it is ready for comments.

Providers and C++ or Python plugins can now provide one or more `QgsSourceSelectProvider` implementations that will be used to build the `QgsDataSourceManagerDialog`.

This will make it easier for providers to provide more than one GUI for managing their sources, for example:
- WMS could also add an XYZ data source dialog
- gdal/ogr could add a GeoPackage specialized source select (and maybe a SpatiaLite one too)
- GeoNode integration will not need to mess up with QgsDataSourceManagerDialog implementation
- plugins can add their own source select GUIs

A similar system is already in place for browser items but it's currently only used by WMS provider, in this PR I also migrated all existing providers.

```
class ConcreteDataSourceWidget(QgsAbstractDataSourceWidget):
    pass


class ConcreteSourceSelectProvider(QgsSourceSelectProvider):

    def providerKey(self):
        return "MyTestProviderKey"

    def text(self):
        return "MyTestProviderText"

    def icon(self):
        return QgsApplication.getThemeIcon( "/mActionAddDb2Layer.svg" )

    def createDataSourceWidget(self, *args):
        return ConcreteDataSourceWidget()

    def ordering(self):
        return 1
registry = QgsGui.sourceSelectProviderRegistry()
registry.addProvider(ConcreteSourceSelectProvider())

```

With tests.

## TODO
- [ ] add an optional toolTip member to the `QgsSourceSelectProvider` and pass it along

