### PR TITLE
Some fixes for cross compiling

### DIFF
--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -26,7 +26,7 @@
 #include "qgis_core.h"
 #include "qgis.h"
 
-#include "raster/qgsrasterdataprovider.h" // for QgsImageFetcher dtor visibility
+#include "qgsrasterdataprovider.h" // for QgsImageFetcher dtor visibility
 
 class QgsLayerTreeLayer;
 class QgsLayerTreeModel;
@@ -140,7 +140,7 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
     QString mUserLabel;
 };
 
-#include "symbology/qgslegendsymbolitem.h"
+#include "qgslegendsymbolitem.h"
 
 /** \ingroup core
  * Implementation of legend node interface for displaying preview of vector symbols and their labels

--- a/src/core/layout/qgslayoutitemregistry.h
+++ b/src/core/layout/qgslayoutitemregistry.h
@@ -263,7 +263,13 @@ class CORE_EXPORT QgsLayoutItemRegistry : public QObject
 #ifndef SIP_RUN
 ///@cond TEMPORARY
 //simple item for testing
+#ifdef ANDROID
+// For some reason, the Android NDK toolchain requires this to link properly.
+// Note to self: Please try to remove this again once Qt ships their libs built with gcc-5
+class CORE_EXPORT TestLayoutItem : public QgsLayoutItem
+#else
 class TestLayoutItem : public QgsLayoutItem
+#endif
 {
     Q_OBJECT
 
@@ -274,15 +280,13 @@ class TestLayoutItem : public QgsLayoutItem
 
     //implement pure virtual methods
     int type() const override { return QgsLayoutItemRegistry::LayoutItem + 102; }
-    QString stringType() const override { return QStringLiteral( "ItemTest" ); }
+    virtual QString stringType() const override { return QStringLiteral( "ItemTest" ); }
     void draw( QgsRenderContext &context, const QStyleOptionGraphicsItem *itemStyle = nullptr ) override;
 
   private:
     QColor mColor;
     QgsFillSymbol *mShapeStyleSymbol = nullptr;
 };
-
-
 ///@endcond
 #endif
 

--- a/src/plugins/offline_editing/CMakeLists.txt
+++ b/src/plugins/offline_editing/CMakeLists.txt
@@ -56,6 +56,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/raster
+  ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/gui
   ${CMAKE_SOURCE_DIR}/src/gui/layertree
   ${CMAKE_SOURCE_DIR}/src/plugins

--- a/src/providers/virtual/CMakeLists.txt
+++ b/src/providers/virtual/CMakeLists.txt
@@ -39,6 +39,8 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/metadata
+  ${CMAKE_SOURCE_DIR}/src/core/raster
+  ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/gui
   ${CMAKE_SOURCE_DIR}/src/gui/auth
 


### PR DESCRIPTION
One fix to cross compile for android. Seems to be more of a workaround for a toolchain problem (linker was complaining about `the vtable symbol may be undefined because the class is missing its key function`).

And one fix to allow `#include`ing core headers without getting compiler errors