### PR TITLE
Fix map theme visibility of children in groups

### DIFF
--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -103,7 +103,7 @@ void QgsMapThemeCollection::applyThemeToLayer( QgsLayerTreeLayer *nodeLayer, Qgs
   MapThemeLayerRecord layerRec;
   bool isVisible = findRecordForLayer( nodeLayer->layer(), rec, layerRec );
 
-  nodeLayer->setItemVisibilityChecked( isVisible );
+  nodeLayer->setItemVisibilityCheckedParentRecursive( isVisible );
 
   if ( !isVisible )
     return;


### PR DESCRIPTION
When importing a 2.18 project where all layers within a group are hidden
and switching to a map theme where they will be visible, this will not
become visible.

This patch recursively applies visibility also to parent groups.

@rouault I guess it's related to the visibility toggling you implemented. Does this seem to you like a safe thing to do?