### PR TITLE
Disable Travis OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,18 +66,18 @@ matrix:
             - coreutils
             - libyaml-tiny-perl
     # OSX based build with QT4 and Python 2
-    - os: osx
-      osx_image: xcode8.3 # MacOS 10.12: Sierra
-      cache:
-        pip: true
-        directories:
-          - $HOME/.ccache
-      env:
-        - TRAVIS_CONFIG=macos
-        - IGNORE_BUILD_FAILURES=YES
-
-  allow_failures:
-    - os: osx
+#    - os: osx
+#      osx_image: xcode8.3 # MacOS 10.12: Sierra
+#      cache:
+#        pip: true
+#        directories:
+#          - $HOME/.ccache
+#      env:
+#        - TRAVIS_CONFIG=macos
+#        - IGNORE_BUILD_FAILURES=YES
+#
+#  allow_failures:
+#    - os: osx
 
 git:
   depth: 30


### PR DESCRIPTION
They are broken and ignored at the moment, but still causing a massive backlog and delay in obtaining
the valid test results.