### PR TITLE
updated NaturalNeighbour gui to use new saga parameters

### DIFF
--- a/python/plugins/processing/algs/saga/description/NaturalNeighbour.txt
+++ b/python/plugins/processing/algs/saga/description/NaturalNeighbour.txt
@@ -3,8 +3,10 @@ grid_gridding
 ParameterVector|SHAPES|Points|0|False
 ParameterTableField|FIELD|Attribute|SHAPES|-1|False
 Hardcoded|-TARGET_DEFINITION 0
-ParameterBoolean|SIBSON|Sibson|True
+ParameterSelection|METHOD|Method|[0] Linear;[1] Sibson; [2] Non-Sibson
 Extent TARGET_USER_XMIN TARGET_USER_XMAX TARGET_USER_YMIN TARGET_USER_YMAX
 ParameterNumber|TARGET_USER_SIZE|Cellsize|None|None|100.0
 ParameterSelection|TARGET_USER_FITS|Fit|[0] nodes;[1] cells
 OutputRaster|TARGET_OUT_GRID|Grid
+ParameterNumber|WEIGHT|Minimum Weight|None|None| 0.0
+ParameterRaster|TARGET_TEMPLATE|Target System|True


### PR DESCRIPTION
## Description
natural neighbor gridding would fail because the interface had changed from SIBSON=true to METHOD = Linear, Sibson,or Non-Sibson.
 see discussion on https://github.com/qgis/QGIS/pull/5098

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
