### PR TITLE
Advanced digitizing cleanup - part 2

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -474,7 +474,7 @@ QgsAction             {#qgis_api_break_3_0_QgsAction}
 QgsAdvancedDigitizingDockWidget        {#qgis_api_break_3_0_QgsAdvancedDigitizingDockWidget}
 -------------------------------
 
-- canvasReleaseEvent() does not take second argument anymore. Map tools are expected to clear CAD points themselves whenever needed.
+- canvasPressEvent(), canvasReleaseEvent(), canvasMoveEvent() were removed. Handling of events is done in QgsMapToolAdvancedDigitizing.
 - snappingMode() was removed. Advanced digitizing now always uses project's snapping configuration.
 
 

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1577,7 +1577,8 @@ QgsMapMouseEvent        {#qgis_api_break_3_0_QgsMapMouseEvent}
 ----------------
 
 - SnappingMode enum was removed.
-- snapPoint() and snapSegment() do not take SnappingMode argument anymore. Snapping is done according to project's snapping configuration.
+- snapPoint() does not take SnappingMode argument anymore. Snapping is done according to project's snapping configuration.
+- snapSegment() was removed.
 
 
 QgsMapOverviewCanvas        {#qgis_api_break_3_0_QgsMapOverviewCanvas}

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1624,6 +1624,12 @@ QgsMapTool        {#qgis_api_break_3_0_QgsMapTool}
 - isTransient() and isEditTool() were removed. Use flags() instead.
 
 
+QgsMapToolAdvancedDigitizing         {#qgis_api_break_3_0_QgsMapToolAdvancedDigitizing}
+----------------------------
+
+- setMode() was replaced by setAdvancedDigitizingAllowed() and setAutoSnapEnabled()
+
+
 QgsMapToolCapture        {#qgis_api_break_3_0_QgsMapToolCapture}
 -----------------
 

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -474,7 +474,7 @@ QgsAction             {#qgis_api_break_3_0_QgsAction}
 QgsAdvancedDigitizingDockWidget        {#qgis_api_break_3_0_QgsAdvancedDigitizingDockWidget}
 -------------------------------
 
-- canvasReleaseEvent takes now QgsAdvancedDigitizingDockWidget::CaptureMode as second argument.
+- canvasReleaseEvent() does not take second argument anymore. Map tools are expected to clear CAD points themselves whenever needed.
 - snappingMode() was removed. Advanced digitizing now always uses project's snapping configuration.
 
 
@@ -1628,6 +1628,7 @@ QgsMapToolAdvancedDigitizing         {#qgis_api_break_3_0_QgsMapToolAdvancedDigi
 ----------------------------
 
 - setMode() was replaced by setAdvancedDigitizingAllowed() and setAutoSnapEnabled()
+- mode() and CaptureMode enum have been moved to QgsMapToolCapture subclass
 
 
 QgsMapToolCapture        {#qgis_api_break_3_0_QgsMapToolCapture}

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -273,6 +273,15 @@ Constraint on a common angle
  :rtype: bool
 %End
 
+    void setPoints( const QList<QgsPointXY> &points );
+%Docstring
+ Configures list of current CAD points
+
+ Some map tools may find it useful to override list of CAD points that is otherwise
+ automatically populated when user clicks with left mouse button on map canvas.
+.. versionadded:: 3.0
+%End
+
     QgsPointXY currentPoint( bool *exists  = 0 ) const;
 %Docstring
  The last point.

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -172,33 +172,6 @@ class QgsAdvancedDigitizingDockWidget : QgsDockWidget
  Disables the CAD tools when hiding the dock
 %End
 
-    bool canvasPressEvent( QgsMapMouseEvent *e );
-%Docstring
- Will react on a canvas press event
-
- \param e A mouse event (may be modified)
- :return:  If the event is hidden (construction mode hides events from the maptool)
- :rtype: bool
-%End
-
-    bool canvasReleaseEvent( QgsMapMouseEvent *e );
-%Docstring
- Will react on a canvas release event
-
- \param e A mouse event (may be modified)
- :return:  If the event is hidden (construction mode hides events from the maptool)
- :rtype: bool
-%End
-
-    bool canvasMoveEvent( QgsMapMouseEvent *e );
-%Docstring
- Will react on a canvas move event
-
- \param e A mouse event (may be modified)
- :return:  If the event is hidden (construction mode hides events from the maptool)
- :rtype: bool
-%End
-
     bool canvasKeyPressEventFilter( QKeyEvent *e );
 %Docstring
  Filter key events to e.g. toggle construction mode or adapt constraints
@@ -212,6 +185,17 @@ class QgsAdvancedDigitizingDockWidget : QgsDockWidget
 %Docstring
 :return: false if no solution was found (invalid constraints)
  :rtype: bool
+%End
+
+    bool alignToSegment( QgsMapMouseEvent *e, QgsAdvancedDigitizingDockWidget::CadConstraint::LockMode lockMode = QgsAdvancedDigitizingDockWidget::CadConstraint::HardLock );
+%Docstring
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
+    void releaseLocks( bool releaseRepeatingLocks = true );
+%Docstring
+.. versionadded:: 3.0
 %End
 
     void clear();
@@ -268,6 +252,12 @@ Constraint on a common angle
     void clearPoints();
 %Docstring
  Removes all points from the CAD point list
+.. versionadded:: 3.0
+%End
+
+    void addPoint( const QgsPointXY &point );
+%Docstring
+ Adds point to the CAD point list
 .. versionadded:: 3.0
 %End
 
@@ -339,6 +329,11 @@ return the action used to enable/disable the tools
     void disable();
 %Docstring
  Disable the widget. Normally done automatically from QgsMapToolAdvancedDigitizing.deactivate().
+%End
+
+    void updateCadPaintItem();
+%Docstring
+.. versionadded:: 3.0
 %End
 
   signals:

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -42,13 +42,6 @@ class QgsAdvancedDigitizingDockWidget : QgsDockWidget
       Parallel
     };
 
-    enum AdvancedDigitizingMode
-    {
-      SinglePoint,
-      TwoPoints,
-      ManyPoints
-    };
-
     class CadConstraint
 {
 %Docstring
@@ -188,12 +181,11 @@ class QgsAdvancedDigitizingDockWidget : QgsDockWidget
  :rtype: bool
 %End
 
-    bool canvasReleaseEvent( QgsMapMouseEvent *e, AdvancedDigitizingMode mode );
+    bool canvasReleaseEvent( QgsMapMouseEvent *e );
 %Docstring
  Will react on a canvas release event
 
  \param e A mouse event (may be modified)
- \param mode determines if the dock has to record one, two or many points.
  :return:  If the event is hidden (construction mode hides events from the maptool)
  :rtype: bool
 %End
@@ -216,7 +208,7 @@ class QgsAdvancedDigitizingDockWidget : QgsDockWidget
  :rtype: bool
 %End
 
-    virtual bool applyConstraints( QgsMapMouseEvent *e );
+    bool applyConstraints( QgsMapMouseEvent *e );
 %Docstring
 :return: false if no solution was found (invalid constraints)
  :rtype: bool
@@ -271,6 +263,12 @@ Constraint on the Y coordinate
 %Docstring
 Constraint on a common angle
  :rtype: bool
+%End
+
+    void clearPoints();
+%Docstring
+ Removes all points from the CAD point list
+.. versionadded:: 3.0
 %End
 
     void setPoints( const QList<QgsPointXY> &points );

--- a/python/gui/qgsmapmouseevent.sip
+++ b/python/gui/qgsmapmouseevent.sip
@@ -61,16 +61,6 @@ class QgsMapMouseEvent : QMouseEvent
  :rtype: QgsPointXY
 %End
 
-    QList<QgsPointXY> snapSegment( bool *snapped = 0, bool allLayers = false ) const;
-%Docstring
- Returns the first snapped segment. If the cached snapped match is a segment, it will simply return it.
- Otherwise it will try to snap a segment according to the event's snapping mode. In this case the cache
- will not be overwritten.
- \param snapped if given, determines if a segment has been snapped
- \param allLayers if true, override snapping mode
- :rtype: list of QgsPointXY
-%End
-
     bool isSnapped() const;
 %Docstring
  Returns true if there is a snapped point cached.

--- a/python/gui/qgsmaptooladvanceddigitizing.sip
+++ b/python/gui/qgsmaptooladvanceddigitizing.sip
@@ -27,14 +27,6 @@ class QgsMapToolAdvancedDigitizing : QgsMapToolEdit
 #include "qgsmaptooladvanceddigitizing.h"
 %End
   public:
-    enum CaptureMode
-    {
-      CaptureNone,
-      CapturePoint,
-      CaptureSegment,
-      CaptureLine,
-      CapturePolygon
-    };
 
     explicit QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 %Docstring
@@ -54,14 +46,6 @@ Catch the mouse release event, filters it, transforms it to map coordinates and 
     virtual void canvasMoveEvent( QgsMapMouseEvent *e );
 %Docstring
 Catch the mouse move event, filters it, transforms it to map coordinates and send it to virtual method
-%End
-
-    CaptureMode mode() const;
-%Docstring
- The capture mode
-
- :return: Capture mode
- :rtype: CaptureMode
 %End
 
     virtual void activate();
@@ -155,7 +139,6 @@ Catch the mouse move event, filters it, transforms it to map coordinates and sen
 
  \param e Mouse events prepared by the cad system
 %End
-
 
 };
 

--- a/python/gui/qgsmaptooladvanceddigitizing.sip
+++ b/python/gui/qgsmaptooladvanceddigitizing.sip
@@ -64,14 +64,6 @@ Catch the mouse move event, filters it, transforms it to map coordinates and sen
  :rtype: CaptureMode
 %End
 
-    void setMode( CaptureMode mode );
-%Docstring
- Set capture mode. This should correspond to the layer on which the digitizing
- happens.
-
- \param mode Capture Mode
-%End
-
     virtual void activate();
 %Docstring
  Registers this maptool with the cad dock widget
@@ -87,8 +79,50 @@ Catch the mouse move event, filters it, transforms it to map coordinates and sen
  :rtype: QgsAdvancedDigitizingDockWidget
 %End
 
+    bool isAdvancedDigitizingAllowed() const;
+%Docstring
+ Returns whether functionality of advanced digitizing dock widget is currently allowed.
+
+ Tools may decide to switch this support on/off based on the current state of the map tool.
+ For example, in node tool before user picks a vertex to move, advanced digitizing dock
+ widget should be disabled and only enabled once a vertex is being moved. Other map tools
+ may keep advanced digitizing allowed all the time.
+
+ If true is returned, that does not mean that advanced digitizing is actually active,
+ because it is up to the user to enable/disable it when it is allowed.
+ \sa setAdvancedDigitizingAllowed()
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
+    bool isAutoSnapEnabled() const;
+%Docstring
+ Returns whether mouse events (press/move/release) should automatically try to snap mouse position
+ (according to the snapping configuration of map canvas) before passing the mouse coordinates
+ to the tool. This may be desirable default behavior for some map tools, but not for other map tools.
+ It is therefore possible to configure the behavior by the map tool.
+ \sa isAutoSnapEnabled()
+.. versionadded:: 3.0
+ :rtype: bool
+%End
 
   protected:
+
+    void setAdvancedDigitizingAllowed( bool allowed );
+%Docstring
+ Sets whether functionality of advanced digitizing dock widget is currently allowed.
+ This method is protected because it should be a decision of the map tool and not from elsewhere.
+ \sa isAdvancedDigitizingAllowed()
+.. versionadded:: 3.0
+%End
+
+    void setAutoSnapEnabled( bool enabled );
+%Docstring
+ Sets whether mouse events (press/move/release) should automatically try to snap mouse position
+ This method is protected because it should be a decision of the map tool and not from elsewhere.
+ \sa isAutoSnapEnabled()
+.. versionadded:: 3.0
+%End
 
     virtual void cadCanvasPressEvent( QgsMapMouseEvent *e );
 %Docstring

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -18,6 +18,15 @@ class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
 #include "qgsmaptoolcapture.h"
 %End
   public:
+
+    enum CaptureMode
+    {
+      CaptureNone,
+      CapturePoint,
+      CaptureLine,
+      CapturePolygon
+    };
+
     QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 %Docstring
 constructor
@@ -27,6 +36,14 @@ constructor
 
     virtual void activate();
     virtual void deactivate();
+
+    CaptureMode mode() const;
+%Docstring
+ The capture mode
+
+ :return: Capture mode
+ :rtype: CaptureMode
+%End
 
     int addCurve( QgsCurve *c );
 %Docstring

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -18,7 +18,7 @@ class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
 #include "qgsmaptoolcapture.h"
 %End
   public:
-    QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode = CaptureNone );
+    QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 %Docstring
 constructor
 %End

--- a/src/app/nodetool/qgsnodetool.cpp
+++ b/src/app/nodetool/qgsnodetool.cpp
@@ -200,6 +200,8 @@ class MatchCollectingFilter : public QgsPointLocator::MatchFilter
 QgsNodeTool::QgsNodeTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock )
   : QgsMapToolAdvancedDigitizing( canvas, cadDock )
 {
+  setAdvancedDigitizingAllowed( false );
+
   mSnapMarker = new QgsVertexMarker( canvas );
   mSnapMarker->setIconType( QgsVertexMarker::ICON_CROSS );
   mSnapMarker->setColor( Qt::magenta );
@@ -1029,7 +1031,7 @@ void QgsNodeTool::startDragging( QgsMapMouseEvent *e )
     return;
 
   // activate advanced digitizing dock
-  setMode( CaptureLine );
+  setAdvancedDigitizingAllowed( true );
 
   // adding a new vertex instead of moving a vertex
   if ( m.hasEdge() )
@@ -1260,7 +1262,7 @@ void QgsNodeTool::startDraggingAddVertex( const QgsPointLocator::Match &m )
   Q_ASSERT( m.hasEdge() );
 
   // activate advanced digitizing dock
-  setMode( CaptureLine );
+  setAdvancedDigitizingAllowed( true );
 
   mDraggingVertex.reset( new Vertex( m.layer(), m.featureId(), m.vertexIndex() + 1 ) );
   mDraggingVertexType = AddingVertex;
@@ -1290,7 +1292,7 @@ void QgsNodeTool::startDraggingAddVertexAtEndpoint( const QgsPointXY &mapPoint )
   Q_ASSERT( mMouseAtEndpoint );
 
   // activate advanced digitizing dock
-  setMode( CaptureLine );
+  setAdvancedDigitizingAllowed( true );
 
   mDraggingVertex.reset( new Vertex( mMouseAtEndpoint->layer, mMouseAtEndpoint->fid, mMouseAtEndpoint->vertexId ) );
   mDraggingVertexType = AddingEndpoint;
@@ -1315,7 +1317,7 @@ void QgsNodeTool::startDraggingEdge( const QgsPointLocator::Match &m, const QgsP
   Q_ASSERT( m.hasEdge() );
 
   // activate advanced digitizing
-  setMode( CaptureLine );
+  setAdvancedDigitizingAllowed( true );
 
   mDraggingEdge = true;
   mDraggingExtraVertices.clear();
@@ -1354,7 +1356,7 @@ void QgsNodeTool::startDraggingEdge( const QgsPointLocator::Match &m, const QgsP
 void QgsNodeTool::stopDragging()
 {
   // deactivate advanced digitizing
-  setMode( CaptureNone );
+  setAdvancedDigitizingAllowed( false );
 
   // stop adv digitizing
   QMouseEvent mouseEvent( QEvent::MouseButtonRelease,
@@ -1399,7 +1401,7 @@ void QgsNodeTool::moveEdge( const QgsPointXY &mapPoint )
 void QgsNodeTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocator::Match *mapPointMatch )
 {
   // deactivate advanced digitizing
-  setMode( CaptureNone );
+  setAdvancedDigitizingAllowed( false );
 
   QgsVectorLayer *dragLayer = mDraggingVertex->layer;
   QgsFeatureId dragFid = mDraggingVertex->fid;

--- a/src/app/nodetool/qgsnodetool.h
+++ b/src/app/nodetool/qgsnodetool.h
@@ -299,11 +299,6 @@ class APP_EXPORT QgsNodeTool : public QgsMapToolAdvancedDigitizing
     //! to stick with the same highlighted feature next time if there are more options
     std::unique_ptr<QgsPointLocator::Match> mLastSnap;
 
-    //! List of two points that will be forced into CAD dock with fake mouse events
-    //! to allow correct functioning of node tool with CAD dock.
-    //! (CAD dock does various assumptions that work with simple capture tools, but not with node tool)
-    QList<QgsPointXY> mOverrideCadPoints;
-
     //! When double-clicking to add a new vertex, this member keeps the snap
     //! match from "press" event used to be used in following "release" event
     std::unique_ptr<QgsPointLocator::Match> mNewVertexFromDoubleClick;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3178,7 +3178,7 @@ void QgisApp::createCanvasTools()
   mMapTools.mSvgAnnotation->setAction( mActionSvgAnnotation );
   mMapTools.mAnnotation = new QgsMapToolAnnotation( mMapCanvas );
   mMapTools.mAnnotation->setAction( mActionAnnotation );
-  mMapTools.mAddFeature = new QgsMapToolAddFeature( mMapCanvas );
+  mMapTools.mAddFeature = new QgsMapToolAddFeature( mMapCanvas, QgsMapToolCapture::CaptureNone );
   mMapTools.mAddFeature->setAction( mActionAddFeature );
   mMapTools.mCircularStringCurvePoint = new QgsMapToolCircularStringCurvePoint( dynamic_cast<QgsMapToolAddFeature *>( mMapTools.mAddFeature ), mMapCanvas );
   mMapTools.mCircularStringCurvePoint->setAction( mActionCircularStringCurvePoint );

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -40,20 +40,6 @@ QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapToolCapture *par
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddCircularString::stopCapturing );
 }
 
-QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapCanvas *canvas )
-  : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget() )
-  , mParentTool( nullptr )
-  , mRubberBand( nullptr )
-  , mTempRubberBand( nullptr )
-  , mShowCenterPointRubberBand( false )
-  , mCenterPointRubberBand( nullptr )
-{
-  if ( mCanvas )
-  {
-    connect( mCanvas, &QgsMapCanvas::mapToolSet, this, &QgsMapToolAddCircularString::setParentTool );
-  }
-}
-
 QgsMapToolAddCircularString::~QgsMapToolAddCircularString()
 {
   delete mRubberBand;

--- a/src/app/qgsmaptooladdcircularstring.h
+++ b/src/app/qgsmaptooladdcircularstring.h
@@ -38,7 +38,6 @@ class QgsMapToolAddCircularString: public QgsMapToolCapture
     void setParentTool( QgsMapTool *newTool, QgsMapTool *oldTool );
 
   protected:
-    explicit QgsMapToolAddCircularString( QgsMapCanvas *canvas ); //forbidden
 
     /** The parent map tool, e.g. the add feature tool.
      *  Completed circular strings will be added to this tool by calling its addCurve() method.

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsmaptooladdfeature.h"
+#include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsapplication.h"
 #include "qgsattributedialog.h"
 #include "qgsexception.h"
@@ -183,6 +184,9 @@ void QgsMapToolAddFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       addFeature( vlayer, &f, false );
 
       vlayer->triggerRepaint();
+
+      // we are done with digitizing for now so instruct advanced digitizing dock to reset its CAD points
+      cadDockWidget()->clearPoints();
     }
   }
 

--- a/src/app/qgsmaptooladdfeature.h
+++ b/src/app/qgsmaptooladdfeature.h
@@ -22,7 +22,7 @@ class APP_EXPORT QgsMapToolAddFeature : public QgsMapToolCapture
     Q_OBJECT
   public:
     //! \since QGIS 2.12
-    QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mode = CaptureNone );
+    QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mode );
     virtual ~QgsMapToolAddFeature();
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -28,7 +28,7 @@
 #include <QMouseEvent>
 
 QgsMapToolAddPart::QgsMapToolAddPart( QgsMapCanvas *canvas )
-  : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget() )
+  : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), CaptureNone )
 {
   mToolName = tr( "Add part" );
   connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddPart::stopCapturing );

--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -37,15 +37,6 @@ QgsMapToolMoveFeature::QgsMapToolMoveFeature( QgsMapCanvas *canvas, MoveMode mod
   , mMode( mode )
 {
   mToolName = tr( "Move feature" );
-  switch ( mode )
-  {
-    case Move:
-      mCaptureMode = QgsMapToolAdvancedDigitizing::CaptureSegment;
-      break;
-    case CopyMove:
-      mCaptureMode = QgsMapToolAdvancedDigitizing::CaptureLine; // we copy/move several times
-      break;
-  }
 }
 
 QgsMapToolMoveFeature::~QgsMapToolMoveFeature()
@@ -178,6 +169,7 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         }
         delete mRubberBand;
         mRubberBand = nullptr;
+        cadDockWidget()->clear();
         break;
 
       case CopyMove:

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -911,7 +911,7 @@ bool QgsAdvancedDigitizingDockWidget::canvasPressEvent( QgsMapMouseEvent *e )
   return mCadEnabled && mConstructionMode;
 }
 
-bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent *e, AdvancedDigitizingMode mode )
+bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
   if ( !mCadEnabled )
     return false;
@@ -940,14 +940,6 @@ bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent *e, A
 
   releaseLocks( false );
 
-  if ( e->button() == Qt::LeftButton )
-  {
-    // stop digitizing if not intermediate point and enough points are recorded with respect to the mode
-    if ( !mConstructionMode && ( mode == SinglePoint || ( mode == TwoPoints && mCadPointList.count() > 2 ) ) )
-    {
-      clearPoints();
-    }
-  }
   return mConstructionMode;
 }
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -222,8 +222,7 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
   mCadButtons->setEnabled( enabled );
   mInputWidgets->setEnabled( enabled );
 
-  clearPoints();
-  releaseLocks();
+  clear();
   setConstructionMode( false );
 }
 
@@ -921,8 +920,7 @@ bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent *e, A
 
   if ( e->button() == Qt::RightButton )
   {
-    clearPoints();
-    releaseLocks();
+    clear();
     return false;
   }
 
@@ -1038,6 +1036,15 @@ void QgsAdvancedDigitizingDockWidget::keyPressEvent( QKeyEvent *e )
       filterKeyPress( e );
       break;
     }
+  }
+}
+
+void QgsAdvancedDigitizingDockWidget::setPoints( const QList<QgsPointXY> &points )
+{
+  clearPoints();
+  Q_FOREACH ( const QgsPointXY &pt, points )
+  {
+    addPoint( pt );
   }
 }
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -872,12 +872,12 @@ bool QgsAdvancedDigitizingDockWidget::alignToSegment( QgsMapMouseEvent *e, CadCo
     return false;
   }
 
-  bool previousPointExist, penulPointExist, mSnappedSegmentExist;
+  bool previousPointExist, penulPointExist, snappedSegmentExist;
   QgsPointXY previousPt = previousPoint( &previousPointExist );
   QgsPointXY penultimatePt = penultimatePoint( &penulPointExist );
-  QList<QgsPointXY> mSnappedSegment = e->snapSegment( &mSnappedSegmentExist, true );
+  mSnappedSegment = e->snapSegment( &snappedSegmentExist, true );
 
-  if ( !previousPointExist || !mSnappedSegmentExist )
+  if ( !previousPointExist || !snappedSegmentExist )
   {
     return false;
   }

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -408,6 +408,14 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     //! If additional constraints are used, this will determine the angle to be locked depending on the snapped segment.
     bool alignToSegment( QgsMapMouseEvent *e, CadConstraint::LockMode lockMode = CadConstraint::HardLock );
 
+    /**
+     * Returns the first snapped segment. Will try to snap a segment according to the event's snapping mode.
+     * \param originalMapPoint point to be snapped (in map coordinates)
+     * \param snapped if given, determines if a segment has been snapped
+     * \param allLayers if true, override snapping mode
+     */
+    QList<QgsPointXY> snapSegment( const QgsPointXY &originalMapPoint, bool *snapped = nullptr, bool allLayers = false ) const;
+
     //! add point to the CAD point list
     void addPoint( const QgsPointXY &point );
     //! update the current point in the CAD point list

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -278,6 +278,15 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     bool commonAngleConstraint() const { return mCommonAngleConstraint; }
 
     /**
+     * Configures list of current CAD points
+     *
+     * Some map tools may find it useful to override list of CAD points that is otherwise
+     * automatically populated when user clicks with left mouse button on map canvas.
+     * \since QGIS 3.0
+     */
+    void setPoints( const QList<QgsPointXY> &points );
+
+    /**
      * The last point.
      * Helper for the CAD point list. The CAD point list is the list of points
      * currently digitized. It contains both  "normal" points and intermediate points (construction mode).

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -73,16 +73,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
       Parallel       //!< Parallel
     };
 
-    /**
-     * Determines if the dock has to record one, two or many points.
-     */
-    enum AdvancedDigitizingMode
-    {
-      SinglePoint, //!< Capture a single point (e.g. for point digitizing)
-      TwoPoints,   //!< Capture two points (e.g. for translation)
-      ManyPoints   //!< Capture two or more points (e.g. line or polygon digitizing)
-    };
-
     /** \ingroup gui
      * \brief The CadConstraint is an abstract class for all basic constraints (angle/distance/x/y).
      * It contains all values (locked, value, relative) and pointers to corresponding widgets.
@@ -226,10 +216,9 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Will react on a canvas release event
      *
      * \param e A mouse event (may be modified)
-     * \param mode determines if the dock has to record one, two or many points.
      * \returns  If the event is hidden (construction mode hides events from the maptool)
      */
-    bool canvasReleaseEvent( QgsMapMouseEvent *e, AdvancedDigitizingMode mode );
+    bool canvasReleaseEvent( QgsMapMouseEvent *e );
 
     /**
      * Will react on a canvas move event
@@ -249,7 +238,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     //! apply the CAD constraints. The will modify the position of the map event in map coordinates by applying the CAD constraints.
     //! \returns false if no solution was found (invalid constraints)
-    virtual bool applyConstraints( QgsMapMouseEvent *e );
+    bool applyConstraints( QgsMapMouseEvent *e );
 
     /**
      * Clear any cached previous clicks and helper lines
@@ -276,6 +265,11 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     const CadConstraint *constraintY() const { return mYConstraint.get(); }
     //! Constraint on a common angle
     bool commonAngleConstraint() const { return mCommonAngleConstraint; }
+
+    /** Removes all points from the CAD point list
+     * \since QGIS 3.0
+     */
+    void clearPoints();
 
     /**
      * Configures list of current CAD points
@@ -420,8 +414,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void updateCurrentPoint( const QgsPointXY &point );
     //! remove previous point in the CAD point list
     void removePreviousPoint();
-    //! remove all points from the CAD point list
-    void clearPoints();
 
     //! filters key press
     //! \note called by eventFilter (filter on line edits), canvasKeyPressEvent (filter on map tool) and keyPressEvent (filter on dock)

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -205,30 +205,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void hideEvent( QHideEvent * ) override;
 
     /**
-     * Will react on a canvas press event
-     *
-     * \param e A mouse event (may be modified)
-     * \returns  If the event is hidden (construction mode hides events from the maptool)
-     */
-    bool canvasPressEvent( QgsMapMouseEvent *e );
-
-    /**
-     * Will react on a canvas release event
-     *
-     * \param e A mouse event (may be modified)
-     * \returns  If the event is hidden (construction mode hides events from the maptool)
-     */
-    bool canvasReleaseEvent( QgsMapMouseEvent *e );
-
-    /**
-     * Will react on a canvas move event
-     *
-     * \param e A mouse event (may be modified)
-     * \returns  If the event is hidden (construction mode hides events from the maptool)
-     */
-    bool canvasMoveEvent( QgsMapMouseEvent *e );
-
-    /**
      * Filter key events to e.g. toggle construction mode or adapt constraints
      *
      * \param e A mouse event (may be modified)
@@ -239,6 +215,16 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     //! apply the CAD constraints. The will modify the position of the map event in map coordinates by applying the CAD constraints.
     //! \returns false if no solution was found (invalid constraints)
     bool applyConstraints( QgsMapMouseEvent *e );
+
+    //! align to segment for additional constraint.
+    //! If additional constraints are used, this will determine the angle to be locked depending on the snapped segment.
+    //! \since QGIS 3.0
+    bool alignToSegment( QgsMapMouseEvent *e, QgsAdvancedDigitizingDockWidget::CadConstraint::LockMode lockMode = QgsAdvancedDigitizingDockWidget::CadConstraint::HardLock );
+
+    //! unlock all constraints
+    //! \param releaseRepeatingLocks set to false to preserve the lock for any constraints set to repeating lock mode
+    //! \since QGIS 3.0
+    void releaseLocks( bool releaseRepeatingLocks = true );
 
     /**
      * Clear any cached previous clicks and helper lines
@@ -270,6 +256,11 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * \since QGIS 3.0
      */
     void clearPoints();
+
+    /** Adds point to the CAD point list
+     * \since QGIS 3.0
+     */
+    void addPoint( const QgsPointXY &point );
 
     /**
      * Configures list of current CAD points
@@ -332,6 +323,10 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     void disable();
 
+    //! Updates canvas item that displays constraints on the ma
+    //! \since QGIS 3.0
+    void updateCadPaintItem();
+
   signals:
 
     /**
@@ -369,10 +364,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     //! will be converted to their calculated value
     void constraintFocusOut();
 
-    //! unlock all constraints
-    //! \param releaseRepeatingLocks set to false to preserve the lock for any constraints set to repeating lock mode
-    void releaseLocks( bool releaseRepeatingLocks = true );
-
     //! set the relative properties of constraints
     void setConstraintRelative( bool activate );
 
@@ -404,10 +395,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     QList<QgsPointXY> snapSegment( const QgsPointLocator::Match &snapMatch );
 
-    //! align to segment for additional constraint.
-    //! If additional constraints are used, this will determine the angle to be locked depending on the snapped segment.
-    bool alignToSegment( QgsMapMouseEvent *e, CadConstraint::LockMode lockMode = CadConstraint::HardLock );
-
     /**
      * Returns the first snapped segment. Will try to snap a segment according to the event's snapping mode.
      * \param originalMapPoint point to be snapped (in map coordinates)
@@ -416,8 +403,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     QList<QgsPointXY> snapSegment( const QgsPointXY &originalMapPoint, bool *snapped = nullptr, bool allLayers = false ) const;
 
-    //! add point to the CAD point list
-    void addPoint( const QgsPointXY &point );
     //! update the current point in the CAD point list
     void updateCurrentPoint( const QgsPointXY &point );
     //! remove previous point in the CAD point list

--- a/src/gui/qgsmapmouseevent.h
+++ b/src/gui/qgsmapmouseevent.h
@@ -73,15 +73,6 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
     QgsPointXY snapPoint();
 
     /**
-     * Returns the first snapped segment. If the cached snapped match is a segment, it will simply return it.
-     * Otherwise it will try to snap a segment according to the event's snapping mode. In this case the cache
-     * will not be overwritten.
-     * \param snapped if given, determines if a segment has been snapped
-     * \param allLayers if true, override snapping mode
-     */
-    QList<QgsPointXY> snapSegment( bool *snapped = nullptr, bool allLayers = false ) const;
-
-    /**
      * Returns true if there is a snapped point cached.
      * Will only be useful after snapPoint has previously been called.
      *

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -20,7 +20,6 @@
 
 QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolEdit( canvas )
-  , mCaptureMode( CapturePoint )
   , mCadDockWidget( cadDockWidget )
 {
 }
@@ -42,24 +41,9 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
 
 void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
-  QgsAdvancedDigitizingDockWidget::AdvancedDigitizingMode dockMode;
-  switch ( mCaptureMode )
-  {
-    case CaptureLine:
-    case CapturePolygon:
-      dockMode = QgsAdvancedDigitizingDockWidget::ManyPoints;
-      break;
-    case CaptureSegment:
-      dockMode = QgsAdvancedDigitizingDockWidget::TwoPoints;
-      break;
-    default:
-      dockMode = QgsAdvancedDigitizingDockWidget::SinglePoint;
-      break;
-  }
-
   if ( isAdvancedDigitizingAllowed() && mCadDockWidget->cadEnabled() )
   {
-    if ( mCadDockWidget->canvasReleaseEvent( e, dockMode ) )
+    if ( mCadDockWidget->canvasReleaseEvent( e ) )
       return;  // decided to eat the event and not pass it to the map tool (construction mode or picking a segment)
   }
   else if ( isAutoSnapEnabled() )

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -67,14 +67,6 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     CaptureMode mode() const { return mCaptureMode; }
 
     /**
-     * Set capture mode. This should correspond to the layer on which the digitizing
-     * happens.
-     *
-     * \param mode Capture Mode
-     */
-    void setMode( CaptureMode mode ) { mCaptureMode = mode; }
-
-    /**
      * Registers this maptool with the cad dock widget
      */
     virtual void activate() override;
@@ -86,8 +78,48 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
 
     QgsAdvancedDigitizingDockWidget *cadDockWidget() const { return mCadDockWidget; }
 
+    /**
+     * Returns whether functionality of advanced digitizing dock widget is currently allowed.
+     *
+     * Tools may decide to switch this support on/off based on the current state of the map tool.
+     * For example, in node tool before user picks a vertex to move, advanced digitizing dock
+     * widget should be disabled and only enabled once a vertex is being moved. Other map tools
+     * may keep advanced digitizing allowed all the time.
+     *
+     * If true is returned, that does not mean that advanced digitizing is actually active,
+     * because it is up to the user to enable/disable it when it is allowed.
+     * \sa setAdvancedDigitizingAllowed()
+     * \since QGIS 3.0
+     */
+    bool isAdvancedDigitizingAllowed() const { return mAdvancedDigitizingAllowed; }
+
+    /**
+     * Returns whether mouse events (press/move/release) should automatically try to snap mouse position
+     * (according to the snapping configuration of map canvas) before passing the mouse coordinates
+     * to the tool. This may be desirable default behavior for some map tools, but not for other map tools.
+     * It is therefore possible to configure the behavior by the map tool.
+     * \sa isAutoSnapEnabled()
+     * \since QGIS 3.0
+     */
+    bool isAutoSnapEnabled() const { return mAutoSnapEnabled; }
 
   protected:
+
+    /**
+     * Sets whether functionality of advanced digitizing dock widget is currently allowed.
+     * This method is protected because it should be a decision of the map tool and not from elsewhere.
+     * \sa isAdvancedDigitizingAllowed()
+     * \since QGIS 3.0
+     */
+    void setAdvancedDigitizingAllowed( bool allowed ) { mAdvancedDigitizingAllowed = allowed; }
+
+    /**
+     * Sets whether mouse events (press/move/release) should automatically try to snap mouse position
+     * This method is protected because it should be a decision of the map tool and not from elsewhere.
+     * \sa isAutoSnapEnabled()
+     * \since QGIS 3.0
+     */
+    void setAutoSnapEnabled( bool enabled ) { mAutoSnapEnabled = enabled; }
 
     /**
      * Override this method when subclassing this class.
@@ -139,7 +171,10 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
   private:
     QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
 
-    void snap( QgsMapMouseEvent *e );
+    //! Whether to allow use of advanced digitizing dock at this point
+    bool mAdvancedDigitizingAllowed = true;
+    //! Whether to snap mouse cursor to map before passing coordinates to cadCanvas*Event()
+    bool mAutoSnapEnabled = true;
 };
 
 #endif // QGSMAPTOOLADVANCEDDIGITIZE_H

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -35,15 +35,6 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
 {
     Q_OBJECT
   public:
-    //! Different capture modes
-    enum CaptureMode
-    {
-      CaptureNone,    //!< Do not capture
-      CapturePoint,   //!< Capture points
-      CaptureSegment, //!< Capture a segment (i.e. 2 points)
-      CaptureLine,    //!< Capture lines
-      CapturePolygon  //!< Capture polygons
-    };
 
     /**
      * Creates an advanced digitizing maptool
@@ -58,13 +49,6 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     virtual void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
     //! Catch the mouse move event, filters it, transforms it to map coordinates and send it to virtual method
     virtual void canvasMoveEvent( QgsMapMouseEvent *e ) override;
-
-    /**
-     * The capture mode
-     *
-     * \returns Capture mode
-     */
-    CaptureMode mode() const { return mCaptureMode; }
 
     /**
      * Registers this maptool with the cad dock widget
@@ -152,9 +136,6 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      * \param e Mouse events prepared by the cad system
      */
     virtual void cadCanvasMoveEvent( QgsMapMouseEvent *e ) { Q_UNUSED( e ) }
-
-    //! The capture mode in which this tool operates
-    CaptureMode mCaptureMode;
 
   private slots:
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -40,6 +40,7 @@
 
 QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode )
   : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+  , mCaptureMode( mode )
   , mRubberBand( nullptr )
   , mTempRubberBand( nullptr )
   , mValidator( nullptr )
@@ -48,8 +49,6 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
   , mSkipNextContextMenuEvent( 0 )
 #endif
 {
-  mCaptureMode = mode;
-
   mCaptureModeFromLayer = mode == CaptureNone;
   mCapturing = false;
 
@@ -649,9 +648,8 @@ void QgsMapToolCapture::validateGeometry()
     case CaptureNone:
     case CapturePoint:
       return;
-    case CaptureSegment:
     case CaptureLine:
-      if ( size() < 2  || ( mCaptureMode == CaptureSegment && size() > 2 ) )
+      if ( size() < 2 )
         return;
       geom = QgsGeometry( mCaptureCurve.curveToLine() );
       break;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -39,7 +39,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
   public:
     //! constructor
-    QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode = CaptureNone );
+    QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 
     virtual ~QgsMapToolCapture();
 

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -38,6 +38,16 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     Q_OBJECT
 
   public:
+
+    //! Different capture modes
+    enum CaptureMode
+    {
+      CaptureNone,    //!< Do not capture / determine mode from layer geometry type
+      CapturePoint,   //!< Capture points
+      CaptureLine,    //!< Capture lines
+      CapturePolygon  //!< Capture polygons
+    };
+
     //! constructor
     QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 
@@ -45,6 +55,13 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
     virtual void activate() override;
     virtual void deactivate() override;
+
+    /**
+     * The capture mode
+     *
+     * \returns Capture mode
+     */
+    CaptureMode mode() const { return mCaptureMode; }
 
     //! Adds a whole curve (e.g. circularstring) to the captured geometry. Curve must be in map CRS
     int addCurve( QgsCurve *c );
@@ -190,6 +207,9 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     bool tracingAddVertex( const QgsPointXY &point );
 
   private:
+    //! The capture mode in which this tool operates
+    CaptureMode mCaptureMode;
+
     //! Flag to indicate a map canvas capture operation is taking place
     bool mCapturing;
 

--- a/src/plugins/grass/qgsgrassaddfeature.h
+++ b/src/plugins/grass/qgsgrassaddfeature.h
@@ -23,7 +23,7 @@ class QgsGrassAddFeature : public QgsMapToolAddFeature
 {
     Q_OBJECT
   public:
-    QgsGrassAddFeature( QgsMapCanvas *canvas, CaptureMode mode = CaptureNone );
+    QgsGrassAddFeature( QgsMapCanvas *canvas, CaptureMode mode );
     virtual ~QgsGrassAddFeature() override;
 };
 

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -240,15 +240,15 @@ void QgsGrassPlugin::initGui()
 
   resetEditActions();
 
-  mAddPoint = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolAdvancedDigitizing::CapturePoint );
+  mAddPoint = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolCapture::CapturePoint );
   mAddPoint->setAction( mAddPointAction );
-  mAddLine = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolAdvancedDigitizing::CaptureLine );
+  mAddLine = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolCapture::CaptureLine );
   mAddLine->setAction( mAddLineAction );
-  mAddBoundary = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolAdvancedDigitizing::CaptureLine );
+  mAddBoundary = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolCapture::CaptureLine );
   mAddBoundary->setAction( mAddBoundaryAction );
-  mAddCentroid = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolAdvancedDigitizing::CapturePoint );
+  mAddCentroid = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolCapture::CapturePoint );
   mAddCentroid->setAction( mAddCentroidAction );
-  mAddArea = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolAdvancedDigitizing::CapturePolygon );
+  mAddArea = new QgsGrassAddFeature( qGisInterface->mapCanvas(), QgsMapToolCapture::CapturePolygon );
   mAddArea->setAction( mAddAreaAction );
 
   connect( qGisInterface->actionSplitFeatures(), &QAction::triggered, this, &QgsGrassPlugin::onSplitFeaturesTriggered );


### PR DESCRIPTION
The overall intent of this PR is to clean up logic of CAD dock widget and map tools making use of it.

It removes hacks needed in the new node tool that were required to make node tool behave nicely with CAD dock widget. Until now CAD dock widget has been quite opinionated how the map tools collaborating with it actually behave:
- map tool had to indicate whether they capture one point / two points / multiple points - while that worked fine with existing capture tools, it is not great for tools with other behavior
- map tool was unable to provide anchor points for CAD dock widget explicitly

There are few API cleanups and handling of mouse events was moved to to advanced digitizing map tool base class, so it should be easier to follow the logic and override it in derived classes if necessary. Rather than having CAD dock widget do everything internally, it is becoming more of a service that has a state and map tool can manipulate it as necessary.