### PR TITLE
fix processing test in case data and tmp are in different filesystem

### DIFF
--- a/python/plugins/processing/tests/ToolsTest.py
+++ b/python/plugins/processing/tests/ToolsTest.py
@@ -68,7 +68,7 @@ class VectorTest(unittest.TestCase):
         os.mkdir(tmpdir)
 
         def linkTestfile(f, t):
-            os.link(os.path.join(dataFolder, f), os.path.join(tmpdir, t))
+            os.symlink(os.path.join(dataFolder, f), os.path.join(tmpdir, t))
 
         # URI from OGR provider
         linkTestfile('geom_data.csv', 'a.csv')


### PR DESCRIPTION
## Description
Patch to fix test in case data and temp are in different filesystems
in this case, symlink is enough respect hard link

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
