### PR TITLE
Add section in beginGroup and remove Setting.

### DIFF
--- a/python/core/qgssettings.sip
+++ b/python/core/qgssettings.sip
@@ -130,7 +130,7 @@ class QgsSettings : QObject
 %End
     ~QgsSettings();
 
-    void beginGroup( const QString &prefix );
+    void beginGroup( const QString &prefix, const QgsSettings::Section section = QgsSettings::NoSection );
 %Docstring
  Appends prefix to the current group.
  The current group is automatically prepended to all keys specified to QSettings.
@@ -245,9 +245,9 @@ Returns the path where settings written using this QSettings object are stored.
  This function is called automatically from QSettings's destructor and by the event
  loop at regular intervals, so you normally don't need to call it yourself.
 %End
-    void remove( const QString &key );
+    void remove( const QString &key, const QgsSettings::Section section = QgsSettings::NoSection );
 %Docstring
-Removes the setting key and any sub-settings of key.
+Removes the setting key and any sub-settings of key in a section.
 %End
     QString prefixedKey( const QString &key, const QgsSettings::Section section ) const;
 %Docstring

--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -83,12 +83,13 @@ QgsSettings::~QgsSettings()
 }
 
 
-void QgsSettings::beginGroup( const QString &prefix )
+void QgsSettings::beginGroup( const QString &prefix, const QgsSettings::Section section )
 {
-  mUserSettings->beginGroup( sanitizeKey( prefix ) );
+  QString pKey = prefixedKey( prefix, section );
+  mUserSettings->beginGroup( pKey );
   if ( mGlobalSettings )
   {
-    mGlobalSettings->beginGroup( sanitizeKey( prefix ) );
+    mGlobalSettings->beginGroup( pKey );
   }
 }
 
@@ -191,9 +192,10 @@ void QgsSettings::sync()
   return mUserSettings->sync();
 }
 
-void QgsSettings::remove( const QString &key )
+void QgsSettings::remove( const QString &key, const QgsSettings::Section section )
 {
-  mUserSettings->remove( sanitizeKey( key ) );
+  QString pKey = prefixedKey( key, section );
+  mUserSettings->remove( pKey );
 }
 
 QString QgsSettings::prefixedKey( const QString &key, const Section section ) const

--- a/src/core/qgssettings.h
+++ b/src/core/qgssettings.h
@@ -141,7 +141,7 @@ class CORE_EXPORT QgsSettings : public QObject
      * In addition, query functions such as childGroups(), childKeys(), and allKeys()
      * are based on the group. By default, no group is set.
      */
-    void beginGroup( const QString &prefix );
+    void beginGroup( const QString &prefix, const QgsSettings::Section section = QgsSettings::NoSection );
     //! Resets the group to what it was before the corresponding beginGroup() call.
     void endGroup();
     //! Returns a list of all keys, including subkeys, that can be read using the QSettings object.
@@ -218,8 +218,8 @@ class CORE_EXPORT QgsSettings : public QObject
      * loop at regular intervals, so you normally don't need to call it yourself.
      */
     void sync();
-    //! Removes the setting key and any sub-settings of key.
-    void remove( const QString &key );
+    //! Removes the setting key and any sub-settings of key in a section.
+    void remove( const QString &key, const QgsSettings::Section section = QgsSettings::NoSection );
     //! Return the sanitized and prefixed key
     QString prefixedKey( const QString &key, const QgsSettings::Section section ) const;
     //! Removes all entries in the user settings

--- a/tests/src/python/test_qgssettings.py
+++ b/tests/src/python/test_qgssettings.py
@@ -224,6 +224,30 @@ class TestQgsSettings(unittest.TestCase):
         self.assertEqual([], self.settings.globalChildGroups())
         self.settings.endGroup()
 
+    def test_group_section(self):
+        # Test group by using Section
+        self.settings.beginGroup('firstgroup', section=QgsSettings.Core)
+        self.assertEqual([], self.settings.childGroups())
+        self.settings.setValue('key', 'value')
+        self.settings.setValue('key2/subkey1', 'subvalue1')
+        self.settings.setValue('key2/subkey2', 'subvalue2')
+        self.settings.setValue('key3', 'value3')
+
+        self.assertEqual(['key', 'key2/subkey1', 'key2/subkey2', 'key3'], self.settings.allKeys())
+        self.assertEqual(['key', 'key3'], self.settings.childKeys())
+        self.assertEqual(['key2'], self.settings.childGroups())
+        self.settings.endGroup()
+        # Set value by writing the group manually
+        self.settings.setValue('firstgroup/key4', 'value4', section=QgsSettings.Core)
+        # Checking the value that have been set
+        self.assertEqual(self.settings.value('firstgroup/key', section=QgsSettings.Core), 'value')
+        self.assertEqual(self.settings.value('firstgroup/key2/subkey1', section=QgsSettings.Core), 'subvalue1')
+        self.assertEqual(self.settings.value('firstgroup/key2/subkey2', section=QgsSettings.Core), 'subvalue2')
+        self.assertEqual(self.settings.value('firstgroup/key3', section=QgsSettings.Core), 'value3')
+        self.assertEqual(self.settings.value('firstgroup/key4', section=QgsSettings.Core), 'value4')
+        # Clean up firstgroup
+        self.settings.remove('firstgroup', section=QgsSettings.Core)
+
     def test_array(self):
         self.assertEqual(self.settings.allKeys(), [])
         self.addArrayToDefaults('testqgissettings', 'key', ['qgisrocks1', 'qgisrocks2', 'qgisrocks3'])
@@ -360,6 +384,12 @@ class TestQgsSettings(unittest.TestCase):
         self.assertEqual(self.settings.value('testQgisSettings/temp'), True)
         self.settings.remove('testQgisSettings/temp')
         self.assertEqual(self.settings.value('testqQgisSettings/temp'), None)
+
+        # Test remove by using Section
+        self.settings.setValue('testQgisSettings/tempSection', True, section=QgsSettings.Core)
+        self.assertEqual(self.settings.value('testQgisSettings/tempSection', section=QgsSettings.Core), True)
+        self.settings.remove('testQgisSettings/temp', section=QgsSettings.Core)
+        self.assertEqual(self.settings.value('testqQgisSettings/temp', section=QgsSettings.Core), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
I saw that there is a `QgsSettings::Section` parameter in the `setValue` and `contains` method in QgsSettings, but there is no in `remove` or `beginGroup`. So I add it to make it uniform. Without this change, I need to prepend my key with a string when I want to remove a value, if I set the value using section.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit