### PR TITLE
[server][bugfix] Fix OGC test getfeatureinfo:invalid-query_layers

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1322,8 +1322,8 @@ namespace QgsWms
 
       if ( !validLayer )
       {
-        throw QgsBadRequestException( QStringLiteral( "LayerNotDefined" ),
-                                      QStringLiteral( "Layer '%1' not found" ).arg( queryLayer ) );
+        QString msg = QObject::tr( "Layer '%1' not found" ).arg( queryLayer );
+        throw QgsBadRequestException( QStringLiteral( "LayerNotDefined" ), msg );
       }
     }
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1255,10 +1255,13 @@ namespace QgsWms
 
     Q_FOREACH ( QString queryLayer, queryLayers )
     {
+      bool validLayer = false;
       Q_FOREACH ( QgsMapLayer *layer, layers )
       {
         if ( queryLayer == layerNickname( *layer ) )
         {
+          validLayer = true;
+
           QDomElement layerElement;
           if ( infoFormat == QgsWmsParameters::Format::GML )
           {
@@ -1315,6 +1318,12 @@ namespace QgsWms
           }
           break;
         }
+      }
+
+      if ( !validLayer )
+      {
+        throw QgsBadRequestException( QStringLiteral( "LayerNotDefined" ),
+                                      QStringLiteral( "Layer '%1' not found" ).arg( queryLayer ) );
       }
     }
 

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -145,6 +145,15 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'FEATURE_COUNT=10&FILTER_GEOM=POLYGON((8.2035381 44.901459,8.2035562 44.901459,8.2035562 44.901418,8.2035381 44.901418,8.2035381 44.901459))',
                                  'wms_getfeatureinfo_geometry_filter')
 
+        # Test feature info request with invalid query_layer
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=text%2Fxml&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&' +
+                                 'query_layers=InvalidLayer&' +
+                                 'FEATURE_COUNT=10&FILTER_GEOM=POLYGON((8.2035381 44.901459,8.2035562 44.901459,8.2035562 44.901418,8.2035381 44.901418,8.2035381 44.901459))',
+                                 'wms_getfeatureinfo_invalid_query_layers')
+
         # Test DescribeLayer
         self.wms_request_compare('DescribeLayer',
                                  '&layers=testlayer%20%C3%A8%C3%A9&' +

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_invalid_query_layers.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_invalid_query_layers.txt
@@ -1,0 +1,6 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<ServiceExceptionReport xmlns="http://www.opengis.net/ogc" version="1.3.0">
+ <ServiceException code="LayerNotDefined">Layer 'InvalidLayer' not found</ServiceException>
+</ServiceExceptionReport>


### PR DESCRIPTION
## Description

This PR fixes the OGC test verifying that an exception is well raised in case of an invalid *QUERY_LAYERS* parameter for the *GetFeatureInfo* request. This test is currently failing : http://37.187.164.233/ogc/09_08_2017_00_54_46_wms_1_3_0.html#c5715dba-a7e3-44c6-9add-18e8b99b3ed5/d1e17334_1/d1e17422_1/d1e9517_1/d1e9599_1

A new test checks that an exception is raised when an invalid layer is given in parameter.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
