### PR TITLE
Fix tiny capitalisation of 'changelog' in plugin manager

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -900,7 +900,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
   if ( ! metadata->value( QStringLiteral( "changelog" ) ).isEmpty() )
   {
     html += QLatin1String( "<br/>" );
-    QString changelog = tr( "changelog:<br/>%1 <br/>" ).arg( metadata->value( QStringLiteral( "changelog" ) ) );
+    QString changelog = tr( "Changelog:<br/>%1 <br/>" ).arg( metadata->value( QStringLiteral( "changelog" ) ) );
     html += changelog.replace( '\n', QLatin1String( "<br/>" ) );
   }
 


### PR DESCRIPTION
## Description
This changes the item header from 'changelog' to 'Changelog' (as al item headers start with a capital)

See screenies, from:

![selection_085](https://user-images.githubusercontent.com/731673/30201992-23864a5c-947d-11e7-941b-e7b3fe3bc0de.png)

To 

![selection_088](https://user-images.githubusercontent.com/731673/30202006-2c4c4916-947d-11e7-9090-5ac8d1b2c44d.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
