### PR TITLE
[processing] fix file filter construction for output files

### DIFF
--- a/python/plugins/processing/gui/ParameterGuiUtils.py
+++ b/python/plugins/processing/gui/ParameterGuiUtils.py
@@ -77,7 +77,7 @@ def getFileFilter(param):
         return QgsProviderRegistry.instance().fileVectorFilters()
     elif param.type() == 'vector':
         return QgsProviderRegistry.instance().fileVectorFilters()
-    elif param.type() == 'fileOut':
+    elif param.type() == 'fileDestination':
         return tr('All files (*.*)') + ';;' + param.fileFilter()
 
     return ''


### PR DESCRIPTION
## Description
Fixes construction of the file filter string for output files.

@nyalldawson maybe we should homogenize this? As I can see `QgsProcessingParameterFile` uses extension while `QgsProcessingParameterFileDestination` uses full filter string.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
