### PR TITLE
[bugfix] Browser keeps scanning directory with gpkg file

### DIFF
--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -761,7 +761,6 @@ QVector<QgsDataItem *> QgsDirectoryItem::createChildren()
     }
 
   }
-  mLastScan = QDateTime::currentDateTime();
   return children;
 }
 
@@ -777,6 +776,7 @@ void QgsDirectoryItem::setState( State state )
       mFileSystemWatcher->addPath( mDirPath );
       connect( mFileSystemWatcher, &QFileSystemWatcher::directoryChanged, this, &QgsDirectoryItem::directoryChanged );
     }
+    mLastScan = QDateTime::currentDateTime();
   }
   else if ( state == NotPopulated )
   {
@@ -791,7 +791,7 @@ void QgsDirectoryItem::setState( State state )
 void QgsDirectoryItem::directoryChanged()
 {
   // If the last scan was less than 10 seconds ago, skip this
-  if ( mLastScan.msecsTo( QDateTime::currentDateTime() ) < 10000 )
+  if ( mLastScan.msecsTo( QDateTime::currentDateTime() ) < QgsSettings().value( QStringLiteral( "browser/minscaninterval" ), 10000 ).toInt() )
   {
     return;
   }

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -761,7 +761,7 @@ QVector<QgsDataItem *> QgsDirectoryItem::createChildren()
     }
 
   }
-
+  mLastScan = QDateTime::currentDateTime();
   return children;
 }
 
@@ -790,6 +790,11 @@ void QgsDirectoryItem::setState( State state )
 
 void QgsDirectoryItem::directoryChanged()
 {
+  // If the last scan was less than 10 seconds ago, skip this
+  if ( mLastScan.msecsTo( QDateTime::currentDateTime() ) < 10000 )
+  {
+    return;
+  }
   if ( state() == Populating )
   {
     // schedule to refresh later, because refresh() simply returns if Populating

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -28,6 +28,7 @@
 #include <QString>
 #include <QTreeWidget>
 #include <QVector>
+#include <QDateTime>
 
 #include "qgsmaplayer.h"
 #include "qgscoordinatereferencesystem.h"
@@ -482,6 +483,7 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
   private:
     QFileSystemWatcher *mFileSystemWatcher = nullptr;
     bool mRefreshLater;
+    QDateTime mLastScan;
 };
 
 /** \ingroup core


### PR DESCRIPTION
Fixes #17043 by introducing a check for last directory
scan timestamp and skipping the directoryChanged signal
is the last scan was less than 10 seconds in the past.

Tested with > 300 gpkg files in a single directory.

This fix is of course far from perfect but the alternative
is to write a custom `QFileSystemWatcher` that keeps
track of all files and only emits the signal on real changes 
(with some kind of hashing) by skipping WAL and SHM 
(and possibly others) temporary files at the same time.

I suspect that set aside the complexity of a thread-safe
implementation of the a.m., it would introduce some
performance issues in this already critical piece of
code.

As a side note, according to @rouault  there is no way to 
completely avoid the creation of SHM/WAL files when opening
a gpkg/sqlite even if we are opening it in read-only mode.
