### PR TITLE
[FEATURE] [needs-docs] classifyAroundZero

### DIFF
--- a/python/core/symbology/qgsgraduatedsymbolrenderer.sip
+++ b/python/core/symbology/qgsgraduatedsymbolrenderer.sip
@@ -254,6 +254,7 @@ Moves the category at index position from to index position to.
       Jenks,
       StdDev,
       Pretty,
+      AroundZero,
       Custom
     };
 

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -564,23 +564,23 @@ static QList<double> _calcEqualIntervalBreaks( double minimum, double maximum, i
 }
 
 static QList<double> _calcAroundZeroBreaks( double minimum, double maximum, int classes )
-{  
+{
   // we will use prettyBreaks and merge the classes around zero
   // and remove the classes that are above the existing opposite
   // sign classes to keep colors symmetrically balanced around zero
-  QList<double> breaks = QgsSymbolLayerUtils::prettyBreaks( minimum, maximum, classes ); 
+  QList<double> breaks = QgsSymbolLayerUtils::prettyBreaks( minimum, maximum, classes );
 
-  breaks.removeAt( breaks.indexOf(0) );
-  
+  breaks.removeAt( breaks.indexOf( 0 ) );
+
   std::sort( breaks.begin(), breaks.end() );
-  double absMin = qMin( qAbs(maximum), qAbs( minimum ) );
-  
-  for ( int i = 1; i < breaks.size()-1; ++i ) //not the first nor the last (expect them to be ordered)
+  double absMin = qMin( qAbs( maximum ), qAbs( minimum ) );
+
+  for ( int i = 1; i < breaks.size() - 1; ++i ) //not the first nor the last (expect them to be ordered)
   {
-    if ( qAbs( breaks.at(i) ) > absMin )
+    if ( qAbs( breaks.at( i ) ) > absMin )
     {
-        breaks.removeAt(i);
-        --i;
+      breaks.removeAt( i );
+      --i;
     }
   }
   return breaks;
@@ -1143,9 +1143,9 @@ QDomElement QgsGraduatedSymbolRenderer::save( QDomDocument &doc, const QgsReadWr
   else if ( mMode == Pretty )
     modeString = QStringLiteral( "pretty" );
   else if ( mMode == AroundZero )
-    modeString = QStringLiteral( "aroundZero" );    
-    
-    
+    modeString = QStringLiteral( "aroundZero" );
+
+
   if ( !modeString.isEmpty() )
   {
     QDomElement modeElem = doc.createElement( QStringLiteral( "mode" ) );

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -204,6 +204,7 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
       Jenks,
       StdDev,
       Pretty,
+      AroundZero,
       Custom
     };
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -815,22 +815,22 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
     if ( QMessageBox::Cancel == QMessageBox::question( this, tr( "Warning" ), tr( "Natural break classification (Jenks) is O(n2) complexity, your classification may take a long time.\nPress cancel to abort breaks calculation or OK to continue." ), QMessageBox::Cancel, QMessageBox::Ok ) )
       return;
   }
-  
-  // For the AroundZero method, display a warning if data are not around zero and stop //p
+
+  // For the AroundZero method, display a warning if data are not around zero and stop
   if ( QgsGraduatedSymbolRenderer::AroundZero == mode )
   {
     int attrNum = mLayer->fields().lookupField( attrName );
-    
-    bool negativeValuesPresent = mLayer->minimumValue(attrNum).toDouble() < 0;
-    bool positiveValuesPresent = mLayer->maximumValue(attrNum).toDouble() > 0;
-    
-    if (negativeValuesPresent != positiveValuesPresent)
+
+    bool negativeValuesPresent = mLayer->minimumValue( attrNum ).toDouble() < 0;
+    bool positiveValuesPresent = mLayer->maximumValue( attrNum ).toDouble() > 0;
+
+    if ( negativeValuesPresent != positiveValuesPresent )
     {
-      QMessageBox::information( this, tr ( "Warning" ), tr( "Symmetric classification around zero only applies to data with both positive and negative values" ) );    
+      QMessageBox::information( this, tr( "Warning" ), tr( "Symmetric classification around zero only applies to data with both positive and negative values" ) );
       return;
     }
   }
-  
+
   // create and set new renderer
   mRenderer->setClassAttribute( attrName );
   mRenderer->setMode( mode );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -803,6 +803,8 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
     mode = QgsGraduatedSymbolRenderer::StdDev;
   else if ( cboGraduatedMode->currentIndex() == 4 )
     mode = QgsGraduatedSymbolRenderer::Pretty;
+  else if ( cboGraduatedMode->currentIndex() == 5 )
+    mode = QgsGraduatedSymbolRenderer::AroundZero;
   else // default should be quantile for now
     mode = QgsGraduatedSymbolRenderer::Quantile;
 
@@ -813,9 +815,23 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
     if ( QMessageBox::Cancel == QMessageBox::question( this, tr( "Warning" ), tr( "Natural break classification (Jenks) is O(n2) complexity, your classification may take a long time.\nPress cancel to abort breaks calculation or OK to continue." ), QMessageBox::Cancel, QMessageBox::Ok ) )
       return;
   }
-
+  
+  // For the AroundZero method, display a warning if data are not around zero and stop //p
+  if ( QgsGraduatedSymbolRenderer::AroundZero == mode )
+  {
+    int attrNum = mLayer->fields().lookupField( attrName );
+    
+    bool negativeValuesPresent = mLayer->minimumValue(attrNum).toDouble() < 0;
+    bool positiveValuesPresent = mLayer->maximumValue(attrNum).toDouble() > 0;
+    
+    if (negativeValuesPresent != positiveValuesPresent)
+    {
+      QMessageBox::information( this, tr ( "Warning" ), tr( "Symmetric classification around zero only applies to data with both positive and negative values" ) );    
+      return;
+    }
+  }
+  
   // create and set new renderer
-
   mRenderer->setClassAttribute( attrName );
   mRenderer->setMode( mode );
 

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>442</width>
+    <width>481</width>
     <height>554</height>
    </rect>
   </property>
@@ -206,7 +206,7 @@ Negative rounds to powers of 10</string>
        <property name="value">
         <double>1.000000000000000</double>
        </property>
-       <property name="showClearButton">
+       <property name="showClearButton" stdset="0">
         <bool>false</bool>
        </property>
       </widget>
@@ -238,7 +238,7 @@ Negative rounds to powers of 10</string>
        <property name="value">
         <double>10.000000000000000</double>
        </property>
-       <property name="showClearButton">
+       <property name="showClearButton" stdset="0">
         <bool>false</bool>
        </property>
       </widget>
@@ -316,6 +316,9 @@ Negative rounds to powers of 10</string>
          </item>
          <item>
           <widget class="QComboBox" name="cboGraduatedMode">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
            <item>
             <property name="text">
              <string>Equal Interval</string>
@@ -339,6 +342,11 @@ Negative rounds to powers of 10</string>
            <item>
             <property name="text">
              <string>Pretty Breaks</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Symmetric around zero</string>
             </property>
            </item>
           </widget>


### PR DESCRIPTION
## Description
I added a new method of classification in the graduated methods. It is aimed at plotting data that are centered on zero, with a class around zero (like [-1,1] instead of [-1,0],[0,1] ), and with a colorbar that stay symmetric around zero. It uses the prettyBreaks method. If data are all positive or negative, an alert box appear. 

It didn't pass every test (I guess it's normal since some test not passed were very far from what I modified)
It passed the test qgis_graduatedsymbolrenderertest. I didn't add anything in this test.

![aroundzero2](https://user-images.githubusercontent.com/8809578/30244261-3c768934-95bb-11e7-9d0a-2fbc7c7614c9.png)
