### PR TITLE
Restore functionality to remove the defaultWindowState

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1662,14 +1662,6 @@ QStringList QgsOptions::i18nList()
   return myList;
 }
 
-void QgsOptions::on_mRestoreDefaultWindowStateBtn_clicked()
-{
-  // richard
-  if ( QMessageBox::warning( this, tr( "Restore UI defaults" ), tr( "Are you sure to reset the UI to default (needs restart)?" ), QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
-    return;
-  mSettings->setValue( QStringLiteral( "/qgis/restoreDefaultWindowState" ), true );
-}
-
 void QgsOptions::on_mCustomVariablesChkBx_toggled( bool chkd )
 {
   mAddCustomVarBtn->setEnabled( chkd );

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -121,9 +121,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     //! Remove an URL to exclude from Proxy
     void on_mRemoveUrlPushButton_clicked();
 
-    //! Slot to flag restoring/delete window state settings upon restart
-    void on_mRestoreDefaultWindowStateBtn_clicked();
-
     //! Slot to enable custom environment variables table and buttons
     void on_mCustomVariablesChkBx_toggled( bool chkd );
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1235,49 +1235,6 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="mQSettingsGrpBx">
-                 <property name="title">
-                  <string>QgsSettings</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_13">
-                  <item row="0" column="1">
-                   <spacer name="horizontalSpacer_42">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QToolButton" name="mRestoreDefaultWindowStateBtn">
-                    <property name="toolTip">
-                     <string>Reset</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mRestoreDefaultWindowStateLbl">
-                    <property name="text">
-                     <string>Reset user interface to default settings (restart required)</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
                 <widget class="QgsCollapsibleGroupBox" name="mEnvironmentGrpBx">
                  <property name="minimumSize">
                   <size>


### PR DESCRIPTION
## Description

Now that we have profiles in QGIS and we do not put the QSettings
in the registry anymore (QGIS did that on Windows), this button is not so
much needed anymore.

This functionality was added by myself some time ago because people 'lost their panels', and did not know how to get them back again.

Now with the new QGIS profiles since 2.99 it is just easier to either create a new profile or to remove your default profile (which is nowadays a directory instead of a directory and a file/registry).

So I think it is better to clean this up.

This part of the docs:
http://docs.qgis.org/testing/en/docs/user_manual/introduction/qgis_configuration.html?highlight=restore#system-settings
Should be removed too after this commit.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
