### PR TITLE
Fix vertex+segment vs segment snapping type

### DIFF
--- a/python/core/qgssnappingutils.sip
+++ b/python/core/qgssnappingutils.sip
@@ -54,7 +54,7 @@ Snap to map according to the current configuration. Optional filter allows disca
  :rtype: QgsPointLocator.Match
 %End
 
-    QgsPointLocator::Match snapToCurrentLayer( QPoint point, int type, QgsPointLocator::MatchFilter *filter = 0 );
+    QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = 0 );
 %Docstring
 Snap to current layer
  :rtype: QgsPointLocator.Match

--- a/src/app/qgsmaptooldeletepart.cpp
+++ b/src/app/qgsmaptooldeletepart.cpp
@@ -127,7 +127,7 @@ QgsGeometry QgsMapToolDeletePart::partUnderPoint( QPoint point, QgsFeatureId &fi
     case QgsWkbTypes::PointGeometry:
     case QgsWkbTypes::LineGeometry:
     {
-      QgsPointLocator::Match match = mCanvas->snappingUtils()->snapToCurrentLayer( point, QgsPointLocator::Vertex | QgsPointLocator::Edge );
+      QgsPointLocator::Match match = mCanvas->snappingUtils()->snapToCurrentLayer( point, QgsPointLocator::Types( QgsPointLocator::Vertex | QgsPointLocator::Edge ) );
       if ( !match.isValid() )
         return geomPart;
 

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -182,7 +182,7 @@ static void _replaceIfBetter( QgsPointLocator::Match &bestMatch, const QgsPointL
 }
 
 
-static void _updateBestMatch( QgsPointLocator::Match &bestMatch, const QgsPointXY &pointMap, QgsPointLocator *loc, int type, double tolerance, QgsPointLocator::MatchFilter *filter )
+static void _updateBestMatch( QgsPointLocator::Match &bestMatch, const QgsPointXY &pointMap, QgsPointLocator *loc, QgsPointLocator::Types type, double tolerance, QgsPointLocator::MatchFilter *filter )
 {
   if ( type & QgsPointLocator::Vertex )
   {
@@ -191,6 +191,23 @@ static void _updateBestMatch( QgsPointLocator::Match &bestMatch, const QgsPointX
   if ( bestMatch.type() != QgsPointLocator::Vertex && ( type & QgsPointLocator::Edge ) )
   {
     _replaceIfBetter( bestMatch, loc->nearestEdge( pointMap, tolerance, filter ), tolerance );
+  }
+}
+
+
+static QgsPointLocator::Types _snappingTypeToPointLocatorType( QgsSnappingConfig::SnappingType type )
+{
+  // watch out: vertex+segment vs segment are in different order in the two enums
+  switch ( type )
+  {
+    case QgsSnappingConfig::Vertex:
+      return QgsPointLocator::Vertex;
+    case QgsSnappingConfig::VertexAndSegment:
+      return QgsPointLocator::Types( QgsPointLocator::Vertex | QgsPointLocator::Edge );
+    case QgsSnappingConfig::Segment:
+      return QgsPointLocator::Edge;
+    default:
+      return QgsPointLocator::Invalid;
   }
 }
 
@@ -220,7 +237,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
 
     // data from project
     double tolerance = QgsTolerance::toleranceInProjectUnits( mSnappingConfig.tolerance(), mCurrentLayer, mMapSettings, mSnappingConfig.units() );
-    int type = mSnappingConfig.type();
+    QgsPointLocator::Types type = _snappingTypeToPointLocatorType( mSnappingConfig.type() );
 
     prepareIndex( QList<LayerAndAreaOfInterest>() << qMakePair( mCurrentLayer, _areaOfInterest( pointMap, tolerance ) ) );
 
@@ -279,7 +296,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
   {
     // data from project
     double tolerance = QgsTolerance::toleranceInProjectUnits( mSnappingConfig.tolerance(), nullptr, mMapSettings, mSnappingConfig.units() );
-    int type = mSnappingConfig.type();
+    QgsPointLocator::Types type = _snappingTypeToPointLocatorType( mSnappingConfig.type() );
     QgsRectangle aoi = _areaOfInterest( pointMap, tolerance );
 
     QList<LayerAndAreaOfInterest> layers;
@@ -430,7 +447,7 @@ void QgsSnappingUtils::toggleEnabled()
   emit configChanged( mSnappingConfig );
 }
 
-QgsPointLocator::Match QgsSnappingUtils::snapToCurrentLayer( QPoint point, int type, QgsPointLocator::MatchFilter *filter )
+QgsPointLocator::Match QgsSnappingUtils::snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter )
 {
   if ( !mCurrentLayer )
     return QgsPointLocator::Match();
@@ -482,14 +499,14 @@ QString QgsSnappingUtils::dump()
       return msg;
     }
 
-    layers << LayerConfig( mCurrentLayer, QgsPointLocator::Types( mSnappingConfig.type() ), mSnappingConfig.tolerance(), mSnappingConfig.units() );
+    layers << LayerConfig( mCurrentLayer, _snappingTypeToPointLocatorType( mSnappingConfig.type() ), mSnappingConfig.tolerance(), mSnappingConfig.units() );
   }
   else if ( mSnappingConfig.mode() == QgsSnappingConfig::AllLayers )
   {
     Q_FOREACH ( QgsMapLayer *layer, mMapSettings.layers() )
     {
       if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer ) )
-        layers << LayerConfig( vl, QgsPointLocator::Types( mSnappingConfig.type() ), mSnappingConfig.tolerance(), mSnappingConfig.units() );
+        layers << LayerConfig( vl, _snappingTypeToPointLocatorType( mSnappingConfig.type() ), mSnappingConfig.tolerance(), mSnappingConfig.units() );
     }
   }
   else if ( mSnappingConfig.mode() == QgsSnappingConfig::AdvancedConfiguration )
@@ -558,13 +575,7 @@ void QgsSnappingUtils::onIndividualLayerSettingsChanged( const QHash<QgsVectorLa
   {
     if ( i->enabled() )
     {
-      QgsPointLocator::Types t( i->type() == QgsSnappingConfig::Vertex ? QgsPointLocator::Vertex :
-                                ( i->type() == QgsSnappingConfig::Segment ? QgsPointLocator::Edge :
-                                  QgsPointLocator::Vertex | QgsPointLocator::Edge
-                                )
-                              );
-
-      mLayers.append( LayerConfig( i.key(), t, i->tolerance(), i->units() ) );
+      mLayers.append( LayerConfig( i.key(), _snappingTypeToPointLocatorType( i->type() ), i->tolerance(), i->units() ) );
     }
   }
 }

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = nullptr );
 
     //! Snap to current layer
-    QgsPointLocator::Match snapToCurrentLayer( QPoint point, int type, QgsPointLocator::MatchFilter *filter = nullptr );
+    QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = nullptr );
 
     // environment setup
 


### PR DESCRIPTION
When user picked snapping to current layer / all layers, snapping to vertex+segment vs segment were working the other way around (advanced configuration was working correctly though).
