### PR TITLE
use the metadata API for the metadata viewer

### DIFF
--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -168,6 +168,7 @@
 %Include layout/qgslayoututils.sip
 %Include metadata/qgslayermetadata.sip
 %Include metadata/qgslayermetadatavalidator.sip
+%Include metadata/qgslayermetadataformatter.sip
 %Include processing/qgsprocessing.sip
 %Include processing/qgsprocessingalgorithm.sip
 %Include processing/qgsprocessingcontext.sip

--- a/python/core/metadata/qgslayermetadataformatter.sip
+++ b/python/core/metadata/qgslayermetadataformatter.sip
@@ -1,0 +1,79 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/metadata/qgslayermetadataformatter.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsLayerMetadataFormatter
+{
+%Docstring
+ Class for metadata formatter.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgslayermetadataformatter.h"
+%End
+  public:
+
+    QgsLayerMetadataFormatter( const QgsLayerMetadata &metadata );
+%Docstring
+ Constructor for QgsLayerMetadataFormatter
+%End
+
+    QString accessSectionHtml() const;
+%Docstring
+ Formats the "Access" section according to a ``metadata`` object.
+ This will return a HTML table.
+ :rtype: str
+%End
+
+    QString contactsSectionHtml() const;
+%Docstring
+ Formats the "Contacts" section according to a ``metadata`` object.
+ This will return a HTML table.
+ :rtype: str
+%End
+
+    QString extentSectionHtml() const;
+%Docstring
+ Formats the "Extents" section according to a ``metadata`` object.
+ This will return a HTML table.
+ :rtype: str
+%End
+
+    QString identificationSectionHtml() const;
+%Docstring
+ Formats the "Identification" section according to a ``metadata`` object.
+ This will return a HTML table.
+ :rtype: str
+%End
+
+    QString historySectionHtml() const;
+%Docstring
+ Formats the "History" section according to a ``metadata`` object.
+ This will return a HTML table.
+ :rtype: str
+%End
+
+    QString linksSectionHtml() const;
+%Docstring
+ Formats the "Links" section according to a ``metadata`` object.
+ This will return a HTML table.
+ :rtype: str
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/metadata/qgslayermetadataformatter.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -73,6 +73,7 @@ SET(QGIS_CORE_SRCS
 
   metadata/qgslayermetadata.cpp
   metadata/qgslayermetadatavalidator.cpp
+  metadata/qgslayermetadataformatter.cpp
 
   auth/qgsauthcertutils.cpp
   auth/qgsauthconfig.cpp
@@ -959,6 +960,7 @@ SET(QGIS_CORE_HDRS
 
   metadata/qgslayermetadata.h
   metadata/qgslayermetadatavalidator.h
+  metadata/qgslayermetadataformatter.h
 
   processing/qgsprocessing.h
   processing/qgsprocessingalgorithm.h

--- a/src/core/metadata/qgslayermetadataformatter.cpp
+++ b/src/core/metadata/qgslayermetadataformatter.cpp
@@ -1,0 +1,260 @@
+#include <QStringBuilder>
+
+#include "qgslayermetadataformatter.h"
+#include "qgslayermetadata.h"
+
+
+QgsLayerMetadataFormatter::QgsLayerMetadataFormatter( const QgsLayerMetadata &metadata )
+  : mMetadata( metadata )
+{
+}
+
+QString QgsLayerMetadataFormatter::accessSectionHtml() const
+{
+  QString myMetadata = QStringLiteral( "<table class=\"list-view\">\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Fees" ) + QLatin1String( "</td><td>" ) + mMetadata.fees() + QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Licenses" ) + QLatin1String( "</td><td>" ) + mMetadata.licenses().join( QStringLiteral( "<br />" ) ) + QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Rights" ) + QLatin1String( "</td><td>" ) + mMetadata.rights().join( QStringLiteral( "<br />" ) ) + QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Constraints" ) + QLatin1String( "</td><td>" );
+  const QList<QgsLayerMetadata::Constraint> &constraints = mMetadata.constraints();
+  bool notFirstRow = false;
+  for ( const QgsLayerMetadata::Constraint &constraint : constraints )
+  {
+    if ( notFirstRow )
+    {
+      myMetadata += QLatin1String( "<br />" );
+    }
+    myMetadata += QLatin1String( "<strong>" ) + constraint.type + QLatin1String( ": </strong>" ) + constraint.constraint;
+    notFirstRow = true;
+  }
+  myMetadata += QLatin1String( "</td></tr>\n" );
+  mMetadata.rights().join( QStringLiteral( "<br />" ) ) + QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "</table>\n" );
+  return myMetadata;
+}
+
+QString QgsLayerMetadataFormatter::contactsSectionHtml() const
+{
+  const QList<QgsLayerMetadata::Contact> &contacts = mMetadata.contacts();
+  QString myMetadata;
+  if ( contacts.isEmpty() )
+  {
+    myMetadata += QLatin1String( "<p>" ) + QObject::tr( "No contact yet." ) + QLatin1String( "</p>" );
+  }
+  else
+  {
+    myMetadata = QStringLiteral( "<table width=\"100%\" class=\"tabular-view\">\n" );
+    myMetadata += "<tr><th>" + QObject::tr( "ID" ) + "</th><th>" + QObject::tr( "Name" ) + "</th><th>" + QObject::tr( "Position" ) + "</th><th>" + QObject::tr( "Organization" ) + "</th><th>" + QObject::tr( "Role" ) + "</th><th>" + QObject::tr( "Email" ) + "</th><th>" + QObject::tr( "Voice" ) + "</th><th>" + QObject::tr( "Fax" ) + "</th><th>" + QObject::tr( "Addresses" ) + "</th></tr>\n";
+    int i = 1;
+    for ( const QgsLayerMetadata::Contact &contact : contacts )
+    {
+      QString rowClass;
+      if ( i % 2 )
+        rowClass = QString( "class=\"odd-row\"" );
+      myMetadata += "<tr " + rowClass + "><td>" + QString::number( i ) + "</td><td>" + contact.name + "</td><td>" + contact.position + "</td><td>" + contact.organization + "</td><td>" + contact.role + "</td><td>" + contact.email + "</td><td>" + contact.voice + "</td><td>" + contact.fax + "</td><td>";
+      bool notFirstRow = false;
+      for ( const QgsLayerMetadata::Address &oneAddress : contact.addresses )
+      {
+        if ( notFirstRow )
+        {
+          myMetadata += QLatin1String( "<br />\n" );
+        }
+        if ( ! oneAddress.type.isEmpty() )
+        {
+          myMetadata += oneAddress.type + QLatin1String( "<br />" );
+        }
+        if ( ! oneAddress.address.isEmpty() )
+        {
+          myMetadata += oneAddress.address + QLatin1String( "<br />" );
+        }
+        if ( ! oneAddress.postalCode.isEmpty() )
+        {
+          myMetadata += oneAddress.postalCode + QLatin1String( "<br />" );
+        }
+        if ( ! oneAddress.city.isEmpty() )
+        {
+          myMetadata += oneAddress.city + QLatin1String( "<br />" );
+        }
+        if ( ! oneAddress.administrativeArea.isEmpty() )
+        {
+          myMetadata += oneAddress.administrativeArea + QLatin1String( "<br />" );
+        }
+        if ( ! oneAddress.country.isEmpty() )
+        {
+          myMetadata += oneAddress.country;
+        }
+        notFirstRow = true;
+      }
+      myMetadata += "</td></tr>\n";
+      i++;
+    }
+    myMetadata += QLatin1String( "</table>\n" );
+  }
+  return myMetadata;
+}
+
+QString QgsLayerMetadataFormatter::extentSectionHtml() const
+{
+  QString myMetadata = QStringLiteral( "<table class=\"list-view\">\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + QObject::tr( "CRS" ) + QLatin1String( "</td><td>" ) + mMetadata.crs().authid() + QLatin1String( " - " );
+  myMetadata += mMetadata.crs().description() + QLatin1String( " - " );
+  if ( mMetadata.crs().isGeographic() )
+    myMetadata += QObject::tr( "Geographic" );
+  else
+    myMetadata += QObject::tr( "Projected" );
+  myMetadata += QLatin1String( "</td></tr>\n" );
+
+  const QgsLayerMetadata::Extent extent = mMetadata.extent();
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + QObject::tr( "Spatial Extent" ) + QLatin1String( "</td><td>" );
+  const QList< QgsLayerMetadata::SpatialExtent > spatialExtents = extent.spatialExtents();
+  bool notFirstRow = false;
+  for ( const QgsLayerMetadata::SpatialExtent &spatialExtent : spatialExtents )
+  {
+    if ( notFirstRow )
+    {
+      myMetadata += QLatin1String( "<br />\n" );
+    }
+    myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "CRS" ) + QStringLiteral( ": </strong>" ) + spatialExtent.extentCrs.authid() + QLatin1String( " - " );
+    myMetadata += spatialExtent.extentCrs.description() + QLatin1String( " - " );
+    if ( spatialExtent.extentCrs.isGeographic() )
+      myMetadata += QObject::tr( "Geographic" );
+    else
+      myMetadata += QObject::tr( "Projected" );
+    myMetadata += QStringLiteral( "<br />" );
+    myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "X Minimum" ) + QStringLiteral( ": </strong>" ) +  qgsDoubleToString( spatialExtent.bounds.xMinimum() ) + QStringLiteral( "<br />" );
+    myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "Y Minimum" ) + QStringLiteral( ": </strong>" ) +  qgsDoubleToString( spatialExtent.bounds.yMinimum() ) + QStringLiteral( "<br />" );
+    myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "X Maximum" ) + QStringLiteral( ": </strong>" ) +  qgsDoubleToString( spatialExtent.bounds.xMaximum() ) + QStringLiteral( "<br />" );
+    myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "Y Maximum" ) + QStringLiteral( ": </strong>" ) +  qgsDoubleToString( spatialExtent.bounds.yMaximum() ) + QStringLiteral( "<br />" );
+    if ( spatialExtent.bounds.zMinimum() || spatialExtent.bounds.zMinimum() )
+    {
+      myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "Z Minimum" ) + QStringLiteral( ": </strong>" ) +  qgsDoubleToString( spatialExtent.bounds.zMinimum() ) + QStringLiteral( "<br />" );
+      myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "Z Maximum" ) + QStringLiteral( ": </strong>" ) +  qgsDoubleToString( spatialExtent.bounds.zMaximum() );
+    }
+    notFirstRow = true;
+  }
+  myMetadata += QLatin1String( "</td></tr>\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + QObject::tr( "Temporal Extent" ) + QLatin1String( "</td><td>" );
+  const QList< QgsDateTimeRange > temporalExtents = extent.temporalExtents();
+  notFirstRow = false;
+  for ( const QgsDateTimeRange &temporalExtent : temporalExtents )
+  {
+    if ( notFirstRow )
+    {
+      myMetadata += QLatin1String( "<br />\n" );
+    }
+    if ( temporalExtent.isInstant() )
+    {
+      myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "Instant" ) + QStringLiteral( ": </strong>" ) + temporalExtent.begin().toTimeSpec( Qt::OffsetFromUTC ).toString( Qt::ISODate );
+    }
+    else
+    {
+      myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "Start" ) + QStringLiteral( ": </strong>" ) + temporalExtent.begin().toTimeSpec( Qt::OffsetFromUTC ).toString( Qt::ISODate ) + QStringLiteral( "<br />\n" );
+      myMetadata += QStringLiteral( "<strong>" ) + QObject::tr( "End" ) + QStringLiteral( ": </strong>" ) + temporalExtent.end().toTimeSpec( Qt::OffsetFromUTC ).toString( Qt::ISODate );
+    }
+    notFirstRow = true;
+  }
+  myMetadata += QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "</table>\n" );
+  return myMetadata;
+}
+
+QString QgsLayerMetadataFormatter::identificationSectionHtml() const
+{
+  QString myMetadata = QStringLiteral( "<table class=\"list-view\">\n" );
+
+  // Identifier
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + QObject::tr( "Identifier" ) + QLatin1String( "</td><td>" ) + mMetadata.identifier() + QLatin1String( "</td></tr>\n" );
+
+  // Parent Identifier
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Parent Identifier" ) + QLatin1String( "</td><td>" ) + mMetadata.parentIdentifier() + QLatin1String( "</td></tr>\n" );
+
+  // Title
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Title" ) + QLatin1String( "</td><td>" ) + mMetadata.title() + QLatin1String( "</td></tr>\n" );
+
+  // Type
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Type" ) + QLatin1String( "</td><td>" ) + mMetadata.type() + QLatin1String( "</td></tr>\n" );
+
+  // Language
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Language" ) + QLatin1String( "</td><td>" ) + mMetadata.language() + QLatin1String( "</td></tr>\n" );
+
+  // Abstract
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Abstract" ) + QLatin1String( "</td><td>" ) + mMetadata.abstract() + QLatin1String( "</td></tr>\n" );
+
+  // Categories
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Categories" ) + QLatin1String( "</td><td>" ) + mMetadata.categories().join( QStringLiteral( ", " ) ) + QLatin1String( "</td></tr>\n" );
+
+  // Keywords
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + QObject::tr( "Keywords" ) + QLatin1String( "</td><td>\n" );
+  QMapIterator<QString, QStringList> i( mMetadata.keywords() );
+  if ( i.hasNext() )
+  {
+    myMetadata += QStringLiteral( "<table width=\"100%\" class=\"tabular-view\">\n" );
+    myMetadata += "<tr><th>" + QObject::tr( "Vocabulary" ) + "</th><th>" + QObject::tr( "Items" ) + "</th></tr>\n";
+    int j = 1;
+    while ( i.hasNext() )
+    {
+      i.next();
+      QString rowClass;
+      if ( j % 2 )
+        rowClass = QString( "class=\"odd-row\"" );
+      myMetadata += "<tr " + rowClass + "><td>" + i.key() + "</td><td>" + i.value().join( QStringLiteral( ", " ) ) + "</td></tr>\n";
+      j++;
+    }
+    myMetadata += QLatin1String( "</table>\n" ); // End keywords table
+  }
+  myMetadata += QLatin1String( "</td></tr>\n" ); // End of keywords row
+  myMetadata += QLatin1String( "</table>\n" ); // End identification table
+  return myMetadata;
+}
+
+QString QgsLayerMetadataFormatter::historySectionHtml() const
+{
+  QString myMetadata;
+  const QStringList historyItems = mMetadata.history();
+  if ( historyItems.isEmpty() )
+  {
+    myMetadata += QLatin1String( "<p>" ) + QObject::tr( "No history yet." ) + QLatin1String( "</p>\n" );
+  }
+  else
+  {
+    myMetadata = QStringLiteral( "<table width=\"100%\" class=\"tabular-view\">\n" );
+    myMetadata += "<tr><th>" + QObject::tr( "ID" ) + "</th><th>" + QObject::tr( "Action" ) + "</th></tr>\n";
+    int i = 1;
+    for ( const QString &history : historyItems )
+    {
+      QString rowClass;
+      if ( i % 2 )
+        rowClass = QString( "class=\"odd-row\"" );
+      myMetadata += "<tr " + rowClass + "><td width=\"5%\">" + QString::number( i ) + "</td><td>" + history + "</td></tr>\n";
+      i++;
+    }
+    myMetadata += QLatin1String( "</table>\n" );
+  }
+  return myMetadata;
+}
+
+QString QgsLayerMetadataFormatter::linksSectionHtml() const
+{
+  QString myMetadata;
+  const QList<QgsLayerMetadata::Link> &links = mMetadata.links();
+  if ( links.isEmpty() )
+  {
+    myMetadata += QLatin1String( "<p>" ) + QObject::tr( "No links yet." ) + QLatin1String( "</p>\n" );
+  }
+  else
+  {
+    myMetadata = QStringLiteral( "<table width=\"100%\" class=\"tabular-view\">\n" );
+    myMetadata += "<tr><th>" + QObject::tr( "ID" ) + "</th><th>" + QObject::tr( "Name" ) + "</th><th>" + QObject::tr( "Type" ) + "</th><th>" + QObject::tr( "URL" ) + "</th><th>" + QObject::tr( "Description" ) + "</th><th>" + QObject::tr( "Format" ) + "</th><th>" + QObject::tr( "MIME Type" ) + "</th><th>" + QObject::tr( "Size" ) + "</th></tr>\n";
+    int i = 1;
+    for ( const QgsLayerMetadata::Link &link : links )
+    {
+      QString rowClass;
+      if ( i % 2 )
+        rowClass = QString( "class=\"odd-row\"" );
+      myMetadata += "<tr " + rowClass + "><td>" + QString::number( i ) + "</td><td>" + link.name + "</td><td>" + link.type + "</td><td>" + link.url + "</td><td>" + link.description + "</td><td>" + link.format + "</td><td>" + link.mimeType + "</td><td>" + link.size + "</td></tr>\n";
+      i++;
+    }
+    myMetadata += QLatin1String( "</table>\n" );
+  }
+  return myMetadata;
+}

--- a/src/core/metadata/qgslayermetadataformatter.h
+++ b/src/core/metadata/qgslayermetadataformatter.h
@@ -1,0 +1,80 @@
+/***************************************************************************
+                             qgslayermetadataformatter.h
+                             ---------------------------
+    begin                : September 2017
+    copyright            : (C) 2017 by Etienne Trimaille
+    email                : etienne dot trimaille at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERMETADATAFORMATTER_H
+#define QGSLAYERMETADATAFORMATTER_H
+
+#include "qgis.h"
+#include "qgis_core.h"
+#include "qgslayermetadata.h"
+
+/**
+ * \ingroup core
+ * \class QgsLayerMetadataFormatter
+ * \brief Class for metadata formatter.
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsLayerMetadataFormatter
+{
+  public:
+
+    /**
+     * Constructor for QgsLayerMetadataFormatter
+     */
+    QgsLayerMetadataFormatter( const QgsLayerMetadata &metadata );
+
+    /**
+     * Formats the "Access" section according to a \a metadata object.
+     * This will return a HTML table.
+     */
+    QString accessSectionHtml() const;
+
+    /**
+     * Formats the "Contacts" section according to a \a metadata object.
+     * This will return a HTML table.
+     */
+    QString contactsSectionHtml() const;
+
+    /**
+     * Formats the "Extents" section according to a \a metadata object.
+     * This will return a HTML table.
+     */
+    QString extentSectionHtml() const;
+
+    /**
+     * Formats the "Identification" section according to a \a metadata object.
+     * This will return a HTML table.
+     */
+    QString identificationSectionHtml() const;
+
+    /**
+     * Formats the "History" section according to a \a metadata object.
+     * This will return a HTML table.
+     */
+    QString historySectionHtml() const;
+
+    /**
+     * Formats the "Links" section according to a \a metadata object.
+     * This will return a HTML table.
+     */
+    QString linksSectionHtml() const;
+
+  private:
+    QgsLayerMetadata mMetadata;
+};
+
+#endif // QGSLAYERMETADATAFORMATTER_H

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -51,6 +51,7 @@
 #include "qgsfeaturerequest.h"
 #include "qgsfields.h"
 #include "qgsgeometry.h"
+#include "qgslayermetadataformatter.h"
 #include "qgslogger.h"
 #include "qgsmaplayerlegend.h"
 #include "qgsmaptopixel.h"
@@ -3907,52 +3908,35 @@ void QgsVectorLayer::setDiagramLayerSettings( const QgsDiagramLayerSettings &s )
 
 QString QgsVectorLayer::htmlMetadata() const
 {
+  QgsLayerMetadataFormatter htmlFormatter( metadata() );
   QString myMetadata = QStringLiteral( "<html>\n<body>\n" );
 
-  // Identification section
-  myMetadata += QLatin1String( "<h1>" ) % tr( "Identification" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  // identification section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Identification" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.identificationSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // ID
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "ID" ) % QLatin1String( "</td><td>" ) % id() % QLatin1String( "</td></tr>\n" );
+  // Begin Provider section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Information from provider" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += QLatin1String( "<table class=\"list-view\">\n" );
 
   // original name
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Original" ) % QLatin1String( "</td><td>" ) % originalName() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Original" ) + QLatin1String( "</td><td>" ) + originalName() + QLatin1String( "</td></tr>\n" );
 
   // name
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Name" ) % QLatin1String( "</td><td>" ) % name() % QLatin1String( "</td></tr>\n" );
-
-  // short
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Short" ) % QLatin1String( "</td><td>" ) % shortName() % QLatin1String( "</td></tr>\n" );
-
-  // title
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Title" ) % QLatin1String( "</td><td>" ) % title() % QLatin1String( "</td></tr>\n" );
-
-  // abstract
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Abstract" ) % QLatin1String( "</td><td>" ) % abstract() % QLatin1String( "</td></tr>\n" );
-
-  // keywords
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Keywords" ) % QLatin1String( "</td><td>" ) % keywordList() % QLatin1String( "</td></tr>\n" );
-
-  // lang, waiting for the proper metadata implementation QEP #91 Work package 2
-  // myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Language" ) % QLatin1String( "</td><td>en-CA</td></tr>\n" );
-
-  // comment
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Comment" ) % QLatin1String( "</td><td>" ) % dataComment() % QLatin1String( "</td></tr>\n" );
-
-  // date, waiting for the proper metadata implementation QEP #91 Work package 2
-  // myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Date" ) % QLatin1String( "</td><td>28/03/17</td></tr>\n" );
-
-  // storage type
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Storage" ) % QLatin1String( "</td><td>" ) % storageType() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QLatin1String( "</td><td>" ) + name() + QLatin1String( "</td></tr>\n" );
 
   // data source
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Source" ) % QLatin1String( "</td><td>" ) % publicSource() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QLatin1String( "</td><td>" ) + publicSource() + QLatin1String( "</td></tr>\n" );
+
+  // storage type
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Storage" ) + QLatin1String( "</td><td>" ) + storageType() + QLatin1String( "</td></tr>\n" );
+
+  // comment
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Comment" ) + QLatin1String( "</td><td>" ) + dataComment() + QLatin1String( "</td></tr>\n" );
 
   // encoding
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Encoding" ) % QLatin1String( "</td><td>" ) % dataProvider()->encoding() % QLatin1String( "</td></tr>\n" );
-
-  // Section spatial
-  myMetadata += QLatin1String( "</table>\n<br><br><h1>" ) % tr( "Spatial" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Encoding" ) + QLatin1String( "</td><td>" ) + dataProvider()->encoding() + QLatin1String( "</td></tr>\n" );
 
   // geom type
   QgsWkbTypes::GeometryType type =  geometryType();
@@ -3964,12 +3948,12 @@ QString QgsVectorLayer::htmlMetadata() const
   {
     QString typeString( QStringLiteral( "%1 (%2)" ).arg( QgsWkbTypes::geometryDisplayString( geometryType() ),
                         QgsWkbTypes::displayString( wkbType() ) ) );
-    myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Geometry" ) % QLatin1String( "</td><td>" ) % typeString % QLatin1String( "</td></tr>\n" );
+    myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Geometry" ) + QLatin1String( "</td><td>" ) + typeString + QLatin1String( "</td></tr>\n" );
   }
 
   // EPSG
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "CRS" ) % QLatin1String( "</td><td>" ) % crs().authid() % QLatin1String( " - " );
-  myMetadata += crs().description() % QLatin1String( " - " );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QLatin1String( "</td><td>" ) + crs().authid() + QLatin1String( " - " );
+  myMetadata += crs().description() + QLatin1String( " - " );
   if ( crs().isGeographic() )
     myMetadata += tr( "Geographic" );
   else
@@ -3977,31 +3961,38 @@ QString QgsVectorLayer::htmlMetadata() const
   myMetadata += QLatin1String( "</td></tr>\n" );
 
   // Extent
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Extent" ) % QLatin1String( "</td><td>" ) % extent().toString() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QLatin1String( "</td><td>" ) + extent().toString() + QLatin1String( "</td></tr>\n" );
 
   // unit
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Unit" ) % QLatin1String( "</td><td>" ) % QgsUnitTypes::toString( crs().mapUnits() ) % QLatin1String( "</td></tr>\n" );
-
-  // max scale
-  // myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Max scale" ) % QLatin1String( "</td><td>" ) % QString::number( maximumScale() ) % QLatin1String( "</td></tr>\n" );
-
-  // min scale
-  // myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Min scale" ) % QLatin1String( "</td><td>" ) % QString::number( minimumScale() ) % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Unit" ) + QLatin1String( "</td><td>" ) + QgsUnitTypes::toString( crs().mapUnits() ) + QLatin1String( "</td></tr>\n" );
 
   // feature count
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Feature count" ) % QLatin1String( "</td><td>" ) % QString::number( featureCount() ) % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Feature count" ) + QLatin1String( "</td><td>" ) + QString::number( featureCount() ) + QLatin1String( "</td></tr>\n" );
+
+  // End Provider section
+  myMetadata += QLatin1String( "</table>\n<br><br>" );
+
+  // extent section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Extent" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.extentSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
+
+  // Start the Access section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Access" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.accessSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
   // Fields section
-  myMetadata += QLatin1String( "</table>\n<br><br><h1>" ) % tr( "Fields" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Fields" ) + QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
 
   // primary key
   QgsAttributeList pkAttrList = pkAttributeList();
   if ( !pkAttrList.isEmpty() )
   {
-    myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Primary key attributes" ) % QLatin1String( "</td><td>" );
+    myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Primary key attributes" ) + QLatin1String( "</td><td>" );
     Q_FOREACH ( int idx, pkAttrList )
     {
-      myMetadata += fields().at( idx ).name() % ' ';
+      myMetadata += fields().at( idx ).name() + ' ';
     }
     myMetadata += QLatin1String( "</td></tr>\n" );
   }
@@ -4009,10 +4000,10 @@ QString QgsVectorLayer::htmlMetadata() const
   const QgsFields &myFields = pendingFields();
 
   // count fields
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Count" ) % QLatin1String( "</td><td>" ) % QString::number( myFields.size() ) % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Count" ) + QLatin1String( "</td><td>" ) + QString::number( myFields.size() ) + QLatin1String( "</td></tr>\n" );
 
   myMetadata += "</table>\n<br><table width=\"100%\" class=\"tabular-view\">\n";
-  myMetadata += "<tr><th>" % tr( "Field" ) % "</th><th>" % tr( "Type" ) % "</th><th>" % tr( "Length" ) % "</th><th>" % tr( "Precision" ) % "</th><th>" % tr( "Comment" ) % "</th></tr>\n";
+  myMetadata += "<tr><th>" + tr( "Field" ) + "</th><th>" + tr( "Type" ) + "</th><th>" + tr( "Length" ) + "</th><th>" + tr( "Precision" ) + "</th><th>" + tr( "Comment" ) + "</th></tr>\n";
 
   for ( int i = 0; i < myFields.size(); ++i )
   {
@@ -4020,30 +4011,28 @@ QString QgsVectorLayer::htmlMetadata() const
     QString rowClass = QString( "" );
     if ( i % 2 )
       rowClass = QString( "class=\"odd-row\"" );
-    myMetadata += "<tr " % rowClass % "><td>" % myField.name() % "</td><td>" % myField.typeName() % "</td><td>" % QString::number( myField.length() ) % "</td><td>" % QString::number( myField.precision() ) % "</td><td>" % myField.comment() % "</td></tr>\n";
+    myMetadata += "<tr " + rowClass + "><td>" + myField.name() + "</td><td>" + myField.typeName() + "</td><td>" + QString::number( myField.length() ) + "</td><td>" + QString::number( myField.precision() ) + "</td><td>" + myField.comment() + "</td></tr>\n";
   }
 
-  //close field list and start references
-  myMetadata += QLatin1String( "</table>\n<br><br><h1>" ) % tr( "References" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  //close field list
+  myMetadata += QLatin1String( "</table>\n<br><br>" );
 
-  // data URL
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Data URL" ) % QLatin1String( "</td><td>" ) % dataUrl() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Data Format" ) % QLatin1String( "</td><td>" ) % dataUrlFormat() % QLatin1String( "</td></tr>\n" );
+  // Start the contacts section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Contacts" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.contactsSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // attribution
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Attribution" ) % QLatin1String( "</td><td>" ) % attribution() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Attribution URL" ) % QLatin1String( "</td><td>" ) % attributionUrl() % QLatin1String( "</td></tr>\n" );
+  // Start the links section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Links" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.linksSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // metadata URL
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Metadata URL" ) % QLatin1String( "</td><td>" ) % metadataUrl() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Metadata Type" ) % QLatin1String( "</td><td>" ) % metadataUrlType() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Metadata Format" ) % QLatin1String( "</td><td>" ) % metadataUrlFormat() % QLatin1String( "</td></tr>\n" );
+  // Start the history section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "History" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.historySectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // legend URL
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Legend URL" ) % QLatin1String( "</td><td>" ) % legendUrl() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Legend Format" ) % QLatin1String( "</td><td>" ) % legendUrlFormat() % QLatin1String( "</td></tr>\n" );
-
-  myMetadata += QStringLiteral( "</table>\n</body>\n</html>\n" );
+  myMetadata += QStringLiteral( "\n</body>\n</html>\n" );
   return myMetadata;
 }
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -21,6 +21,7 @@ email                : tim at linfiniti.com
 #include "qgscoordinatetransform.h"
 #include "qgsdatasourceuri.h"
 #include "qgshuesaturationfilter.h"
+#include "qgslayermetadataformatter.h"
 #include "qgslogger.h"
 #include "qgsmaplayerlegend.h"
 #include "qgsmaptopixel.h"
@@ -303,53 +304,33 @@ QgsLegendColorList QgsRasterLayer::legendSymbologyItems() const
 
 QString QgsRasterLayer::htmlMetadata() const
 {
+  QgsLayerMetadataFormatter htmlFormatter( metadata() );
   QString myMetadata = QStringLiteral( "<html>\n<body>\n" );
 
   // Identification section
-  myMetadata += QLatin1String( "<h1>" ) % tr( "Identification" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Identification" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.identificationSectionHtml();
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // ID
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "ID" ) % QLatin1String( "</td><td>" ) % id() % QLatin1String( "</td></tr>\n" );
+  // Begin Provider section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Information from provider" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += QLatin1String( "<table class=\"list-view\">\n" );
 
   // original name
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Original" ) % QLatin1String( "</td><td>" ) % originalName() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Original" ) + QLatin1String( "</td><td>" ) + originalName() + QLatin1String( "</td></tr>\n" );
 
   // name
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Name" ) % QLatin1String( "</td><td>" ) % name() % QLatin1String( "</td></tr>\n" );
-
-  // short
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Short" ) % QLatin1String( "</td><td>" ) % shortName() % QLatin1String( "</td></tr>\n" );
-
-  // title
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Title" ) % QLatin1String( "</td><td>" ) % title() % QLatin1String( "</td></tr>\n" );
-
-  // abstract
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Abstract" ) % QLatin1String( "</td><td>" ) % abstract() % QLatin1String( "</td></tr>\n" );
-
-  // keywords
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Keywords" ) % QLatin1String( "</td><td>" ) % keywordList() % QLatin1String( "</td></tr>\n" );
-
-  // lang, waiting for the proper metadata implementation QEP #91 Work package 2
-  // myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Language" ) % QLatin1String( "</td><td>en-CA</td></tr>\n" );
-
-  // comment, not existing for rasters for now
-  // myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Comment" ) % QLatin1String( "</td><td>" ) % dataComment() % QLatin1String( "</td></tr>\n" );
-
-  // date, waiting for the proper metadata implementation QEP #91 Work package 2
-  // myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Date" ) % QLatin1String( "</td><td>28/03/17</td></tr>\n" );
-
-  // storage type
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Provider" ) % QLatin1String( "</td><td>" ) % providerType() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QLatin1String( "</td><td>" ) + name() + QLatin1String( "</td></tr>\n" );
 
   // data source
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Source" ) % QLatin1String( "</td><td>" ) % publicSource() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QLatin1String( "</td><td>" ) + publicSource() + QLatin1String( "</td></tr>\n" );
 
-  // Section spatial
-  myMetadata += QLatin1String( "</table>\n<br><br><h1>" ) % tr( "Spatial" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  // storage type
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Provider" ) + QLatin1String( "</td><td>" ) + providerType() + QLatin1String( "</td></tr>\n" );
 
   // EPSG
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "CRS" ) % QLatin1String( "</td><td>" ) % crs().authid() % QLatin1String( " - " );
-  myMetadata += crs().description() % QLatin1String( " - " );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QLatin1String( "</td><td>" ) + crs().authid() + QLatin1String( " - " );
+  myMetadata += crs().description() + QLatin1String( " - " );
   if ( crs().isGeographic() )
     myMetadata += tr( "Geographic" );
   else
@@ -357,13 +338,13 @@ QString QgsRasterLayer::htmlMetadata() const
   myMetadata += QLatin1String( "</td></tr>\n" );
 
   // Extent
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Extent" ) % QLatin1String( "</td><td>" ) % extent().toString() % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QLatin1String( "</td><td>" ) + extent().toString() + QLatin1String( "</td></tr>\n" );
 
   // unit
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Unit" ) % QLatin1String( "</td><td>" ) % QgsUnitTypes::toString( crs().mapUnits() ) % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Unit" ) + QLatin1String( "</td><td>" ) + QgsUnitTypes::toString( crs().mapUnits() ) + QLatin1String( "</td></tr>\n" );
 
   // Raster Width
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Width" ) % QLatin1String( "</td><td>" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Width" ) + QLatin1String( "</td><td>" );
   if ( dataProvider()->capabilities() & QgsRasterDataProvider::Size )
     myMetadata += QString::number( width() );
   else
@@ -371,7 +352,7 @@ QString QgsRasterLayer::htmlMetadata() const
   myMetadata += QLatin1String( "</td></tr>\n" );
 
   // Raster height
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Height" ) % QLatin1String( "</td><td>" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Height" ) + QLatin1String( "</td><td>" );
   if ( dataProvider()->capabilities() & QgsRasterDataProvider::Size )
     myMetadata += QString::number( height() );
   else
@@ -379,7 +360,7 @@ QString QgsRasterLayer::htmlMetadata() const
   myMetadata += QLatin1String( "</td></tr>\n" );
 
   // Data type
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Data type" ) % QLatin1String( "</td><td>" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Data type" ) + QLatin1String( "</td><td>" );
   // Just use the first band
   switch ( mDataProvider->sourceDataType( 1 ) )
   {
@@ -421,15 +402,28 @@ QString QgsRasterLayer::htmlMetadata() const
   }
   myMetadata += QLatin1String( "</td></tr>\n" );
 
+  // End Provider section
+  myMetadata += QLatin1String( "</table>\n<br><br>" );
+
+  // extent section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Extent" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.extentSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
+
+  // Start the Access section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Access" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.accessSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
+
   // Bands section
-  myMetadata += QLatin1String( "</table>\n<br><br><h1>" ) % tr( "Bands" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  myMetadata += QLatin1String( "</table>\n<br><br><h1>" ) + tr( "Bands" ) + QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
 
   // Band count
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Band count" ) % QLatin1String( "</td><td>" ) % QString::number( bandCount() ) % QLatin1String( "</td></tr>\n" );
+  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) + tr( "Band count" ) + QLatin1String( "</td><td>" ) + QString::number( bandCount() ) + QLatin1String( "</td></tr>\n" );
 
   // Band table
   myMetadata += "</table>\n<br><table width=\"100%\" class=\"tabular-view\">\n";
-  myMetadata += "<tr><th>" % tr( "Number" ) % "</th><th>" % tr( "Band" ) % "</th><th>" % tr( "No-Data" ) % "</th><th>" % tr( "Min" ) % "</th><th>" % tr( "Max" ) % "</th></tr>\n";
+  myMetadata += "<tr><th>" + tr( "Number" ) + "</th><th>" + tr( "Band" ) + "</th><th>" + tr( "No-Data" ) + "</th><th>" + tr( "Min" ) + "</th><th>" + tr( "Max" ) + "</th></tr>\n";
 
   QgsRasterDataProvider *provider = const_cast< QgsRasterDataProvider * >( mDataProvider );
   for ( int i = 1; i <= bandCount(); i++ )
@@ -437,7 +431,7 @@ QString QgsRasterLayer::htmlMetadata() const
     QString rowClass = QString( "" );
     if ( i % 2 )
       rowClass = QString( "class=\"odd-row\"" );
-    myMetadata += "<tr " % rowClass % "><td>" % QString::number( i ) % "</td><td>" % bandName( i ) % "</td><td>";
+    myMetadata += "<tr " + rowClass + "><td>" + QString::number( i ) + "</td><td>" + bandName( i ) + "</td><td>";
 
     if ( dataProvider()->sourceHasNoDataValue( i ) )
       myMetadata += QString::number( dataProvider()->sourceNoDataValue( i ) );
@@ -448,38 +442,36 @@ QString QgsRasterLayer::htmlMetadata() const
     if ( provider->hasStatistics( i ) )
     {
       QgsRasterBandStats myRasterBandStats = provider->bandStatistics( i );
-      myMetadata += "<td>" % QString::number( myRasterBandStats.minimumValue, 'f', 10 ) % "</td>";
-      myMetadata += "<td>" % QString::number( myRasterBandStats.maximumValue, 'f', 10 ) % "</td>";
+      myMetadata += "<td>" + QString::number( myRasterBandStats.minimumValue, 'f', 10 ) + "</td>";
+      myMetadata += "<td>" + QString::number( myRasterBandStats.maximumValue, 'f', 10 ) + "</td>";
     }
     else
     {
-      myMetadata += "<td>" % tr( "n/a" ) % "</td><td>" % tr( "n/a" ) % "</td>";
+      myMetadata += "<td>" + tr( "n/a" ) + "</td><td>" + tr( "n/a" ) + "</td>";
     }
 
     myMetadata += "</tr>\n";
   }
 
-  //close previous bands table and start references
-  myMetadata += QLatin1String( "</table>\n<br><br><h1>" ) % tr( "References" ) % QLatin1String( "</h1>\n<hr>\n<table class=\"list-view\">\n" );
+  //close previous bands table
+  myMetadata += QLatin1String( "</table>\n<br><br>" );
 
-  // data URL
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Data URL" ) % QLatin1String( "</td><td>" ) % dataUrl() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Data Format" ) % QLatin1String( "</td><td>" ) % dataUrlFormat() % QLatin1String( "</td></tr>\n" );
+  // Start the contacts section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "Contacts" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.contactsSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // attribution
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Attribution" ) % QLatin1String( "</td><td>" ) % attribution() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Attribution URL" ) % QLatin1String( "</td><td>" ) % attributionUrl() % QLatin1String( "</td></tr>\n" );
+  // Start the links section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "References" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.linksSectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // metadata URL
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Metadata URL" ) % QLatin1String( "</td><td>" ) % metadataUrl() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Metadata Type" ) % QLatin1String( "</td><td>" ) % metadataUrlType() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Metadata Format" ) % QLatin1String( "</td><td>" ) % metadataUrlFormat() % QLatin1String( "</td></tr>\n" );
+  // Start the history section
+  myMetadata += QLatin1String( "<h1>" ) + tr( "History" ) + QLatin1String( "</h1>\n<hr>\n" );
+  myMetadata += htmlFormatter.historySectionHtml( );
+  myMetadata += QLatin1String( "<br><br>\n" );
 
-  // legend URL
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Legend URL" ) % QLatin1String( "</td><td>" ) % legendUrl() % QLatin1String( "</td></tr>\n" );
-  myMetadata += QLatin1String( "<tr><td class=\"highlight\">" ) % tr( "Legend Format" ) % QLatin1String( "</td><td>" ) % legendUrlFormat() % QLatin1String( "</td></tr>\n" );
-
-  myMetadata += QStringLiteral( "</table>\n</body>\n</html>\n" );
+  myMetadata += QStringLiteral( "\n</body>\n</html>\n" );
   return myMetadata;
 }
 


### PR DESCRIPTION
## Description

I would like to have:
* identificationSectionHTML
* linksSectionHTML
* accessSectionHTML
* contactsSectionHTML
* extentSectionHTML

to generate HTML in QgsLayerMetadata then in the QgsVectorLayer and QgsRasterLayer it will combine these small blocks together and adding extra informations in each block like QgsMapLayer::publicSource, encoding, layer CRS, fields ...

These sections are based on the tabs in the editor: https://github.com/qgis/QGIS/pull/5036

As discussed with @timlinux and @nyalldawson metadata settings related to QGIS Server will not be displayed anymore in this tab. It might be renamed Server Settings, right?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

Funded by World Bank