### PR TITLE
[symbology] resurrect symbol levels dialog (fixes #16996)

### DIFF
--- a/python/gui/symbology/qgssymbollevelsdialog.sip
+++ b/python/gui/symbology/qgssymbollevelsdialog.sip
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsSymbolLevelsDialog : QDialog
 {
 
@@ -15,6 +16,10 @@ class QgsSymbolLevelsDialog : QDialog
 #include "qgssymbollevelsdialog.h"
 %End
   public:
+    QgsSymbolLevelsDialog( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent = 0 );
+%Docstring
+Constructor for QgsSymbolLevelsDialog
+%End
 
     ~QgsSymbolLevelsDialog();
 
@@ -33,8 +38,11 @@ class QgsSymbolLevelsDialog : QDialog
   protected:
 
 
+
+
   private:
     QgsSymbolLevelsDialog();
+
 };
 
 

--- a/python/gui/symbology/qgssymbollevelsdialog.sip
+++ b/python/gui/symbology/qgssymbollevelsdialog.sip
@@ -9,31 +9,40 @@
 
 
 
-class QgsSymbolLevelsDialog : QDialog
+class QgsSymbolLevelsWidget : QgsPanelWidget
 {
+%Docstring
+ A widget which allows the user to modify the rendering order of symbol layers.
+.. seealso:: QgsSymbolLevelsDialog
+.. versionadded:: 3.0
+%End
 
 %TypeHeaderCode
 #include "qgssymbollevelsdialog.h"
 %End
   public:
-    QgsSymbolLevelsDialog( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent = 0 );
+    QgsSymbolLevelsWidget( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent /TransferThis/ = 0 );
 %Docstring
-Constructor for QgsSymbolLevelsDialog
+Constructor for QgsSymbolLevelsWidget
 %End
-
-    ~QgsSymbolLevelsDialog();
 
     bool usingLevels() const;
 %Docstring
+Returns whether the level ordering is enabled
  :rtype: bool
 %End
 
     void setForceOrderingEnabled( bool enabled );
+%Docstring
+ Sets whether the level ordering is always forced on and hide the checkbox (used by rule-based renderer)
+ \param enabled toggle level ordering
+%End
 
   public slots:
-    void updateUi();
-
-    void renderingPassChanged( int row, int column );
+    void apply();
+%Docstring
+Apply button
+%End
 
   protected:
 
@@ -41,7 +50,28 @@ Constructor for QgsSymbolLevelsDialog
 
 
   private:
-    QgsSymbolLevelsDialog();
+    QgsSymbolLevelsWidget();
+
+};
+
+class QgsSymbolLevelsDialog : QDialog
+{
+%Docstring
+ A dialog which allows the user to modify the rendering order of symbol layers.
+.. seealso:: QgsSymbolLevelsWidget
+%End
+
+%TypeHeaderCode
+#include "qgssymbollevelsdialog.h"
+%End
+  public:
+
+    QgsSymbolLevelsDialog( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsSymbolLevelsDialog.
+%End
+
+    void setForceOrderingEnabled( bool enabled );
 
 };
 

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -251,7 +251,18 @@ void QgsRendererWidget::changeSymbolAngle()
 
 void QgsRendererWidget::showSymbolLevelsDialog( QgsFeatureRenderer *r )
 {
-  QgsSymbolLevelsDialog dlg( r, r->usingSymbolLevels(), this );
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( r, r->usingSymbolLevels(), panel );
+    widget->setPanelTitle( tr( "Symbol Levels" ) );
+    connect( widget, &QgsPanelWidget::widgetChanged, widget, &QgsSymbolLevelsWidget::apply );
+    connect( widget, &QgsPanelWidget::widgetChanged, this, &QgsPanelWidget::widgetChanged );
+    panel->openPanel( widget );
+    return;
+  }
+
+  QgsSymbolLevelsDialog dlg( r, r->usingSymbolLevels(), panel );
   if ( dlg.exec() )
   {
     emit widgetChanged();

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -251,11 +251,9 @@ void QgsRendererWidget::changeSymbolAngle()
 
 void QgsRendererWidget::showSymbolLevelsDialog( QgsFeatureRenderer *r )
 {
-  QgsSymbolLevelsDialog dlg( r->legendSymbolItems(), r->usingSymbolLevels(), this );
-
+  QgsSymbolLevelsDialog dlg( r, r->usingSymbolLevels(), this );
   if ( dlg.exec() )
   {
-    r->setUsingSymbolLevels( dlg.usingLevels() );
     emit widgetChanged();
   }
 }

--- a/src/gui/symbology/qgsrulebasedrendererwidget.cpp
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.cpp
@@ -396,7 +396,19 @@ void QgsRuleBasedRendererWidget::keyPressEvent( QKeyEvent *event )
 
 void QgsRuleBasedRendererWidget::setRenderingOrder()
 {
-  QgsSymbolLevelsDialog dlg( mRenderer, true, this );
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( mRenderer, true, panel );
+    widget->setForceOrderingEnabled( true );
+    widget->setPanelTitle( tr( "Symbol Levels" ) );
+    connect( widget, &QgsPanelWidget::widgetChanged, widget, &QgsSymbolLevelsWidget::apply );
+    connect( widget, &QgsPanelWidget::widgetChanged, this, &QgsPanelWidget::widgetChanged );
+    panel->openPanel( widget );
+    return;
+  }
+
+  QgsSymbolLevelsDialog dlg( mRenderer, true, panel );
   dlg.setForceOrderingEnabled( true );
   if ( dlg.exec() )
   {

--- a/src/gui/symbology/qgsrulebasedrendererwidget.cpp
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.cpp
@@ -396,10 +396,12 @@ void QgsRuleBasedRendererWidget::keyPressEvent( QKeyEvent *event )
 
 void QgsRuleBasedRendererWidget::setRenderingOrder()
 {
-  QgsSymbolLevelsDialog dlg( mRenderer->legendSymbolItems(), true, this );
+  QgsSymbolLevelsDialog dlg( mRenderer, true, this );
   dlg.setForceOrderingEnabled( true );
-
-  dlg.exec();
+  if ( dlg.exec() )
+  {
+    emit widgetChanged();
+  }
 }
 
 void QgsRuleBasedRendererWidget::saveSectionWidth( int section, int oldSize, int newSize )

--- a/src/gui/symbology/qgssymbollevelsdialog.h
+++ b/src/gui/symbology/qgssymbollevelsdialog.h
@@ -21,38 +21,41 @@
 #include <QItemDelegate>
 
 #include "qgshelp.h"
+#include "qgspanelwidget.h"
 #include "qgsrenderer.h"
 
 #include "ui_qgssymbollevelsdialogbase.h"
 #include "qgis_gui.h"
 
-/** \ingroup gui
- * \class QgsSymbolLevelsDialog
+/** \class QgsSymbolLevelsWidget
+ * \ingroup gui
+ * A widget which allows the user to modify the rendering order of symbol layers.
+ * \see QgsSymbolLevelsDialog
+ * \since QGIS 3.0
  */
-class GUI_EXPORT QgsSymbolLevelsDialog : public QDialog, private Ui::QgsSymbolLevelsDialogBase
+class GUI_EXPORT QgsSymbolLevelsWidget : public QgsPanelWidget, private Ui::QgsSymbolLevelsDialogBase
 {
     Q_OBJECT
   public:
-    //! Constructor for QgsSymbolLevelsDialog
-    QgsSymbolLevelsDialog( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent = nullptr );
+    //! Constructor for QgsSymbolLevelsWidget
+    QgsSymbolLevelsWidget( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent SIP_TRANSFERTHIS = 0 );
 
-    ~QgsSymbolLevelsDialog();
-
+    //! Returns whether the level ordering is enabled
     bool usingLevels() const;
 
-    // used by rule-based renderer (to hide checkbox to enable/disable ordering)
+    /** Sets whether the level ordering is always forced on and hide the checkbox (used by rule-based renderer)
+     * \param enabled toggle level ordering
+     */
     void setForceOrderingEnabled( bool enabled );
 
   public slots:
-    void updateUi();
-
-    void renderingPassChanged( int row, int column );
-
-  private slots:
     //! Apply button
     void apply();
 
-    void showHelp();
+  private slots:
+    void updateUi();
+
+    void renderingPassChanged( int row, int column );
 
   protected:
     //! \note not available in Python bindings
@@ -71,9 +74,31 @@ class GUI_EXPORT QgsSymbolLevelsDialog : public QDialog, private Ui::QgsSymbolLe
 
   private:
 #ifdef SIP_RUN
-    QgsSymbolLevelsDialog();
+    QgsSymbolLevelsWidget();
 
 #endif
+};
+
+/** \class QgsSymbolLevelsDialog
+ * \ingroup gui
+ * A dialog which allows the user to modify the rendering order of symbol layers.
+ * \see QgsSymbolLevelsWidget
+*/
+class GUI_EXPORT QgsSymbolLevelsDialog : public QDialog
+{
+    Q_OBJECT
+  public:
+
+    //! Constructor for QgsSymbolLevelsDialog.
+    QgsSymbolLevelsDialog( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent SIP_TRANSFERTHIS = 0 );
+
+    // used by rule-based renderer (to hide checkbox to enable/disable ordering)
+    void setForceOrderingEnabled( bool enabled );
+
+  private:
+
+    QgsSymbolLevelsWidget *mWidget = nullptr;
+
 };
 
 #ifndef SIP_RUN

--- a/src/gui/symbology/qgssymbollevelsdialog.h
+++ b/src/gui/symbology/qgssymbollevelsdialog.h
@@ -20,8 +20,9 @@
 #include <QList>
 #include <QItemDelegate>
 
-#include "qgsrenderer.h"
 #include "qgshelp.h"
+#include "qgsrenderer.h"
+
 #include "ui_qgssymbollevelsdialogbase.h"
 #include "qgis_gui.h"
 
@@ -32,8 +33,8 @@ class GUI_EXPORT QgsSymbolLevelsDialog : public QDialog, private Ui::QgsSymbolLe
 {
     Q_OBJECT
   public:
-    //! \note not available in Python bindings
-    QgsSymbolLevelsDialog( const QgsLegendSymbolList &list, bool usingSymbolLevels, QWidget *parent = nullptr ) SIP_SKIP;
+    //! Constructor for QgsSymbolLevelsDialog
+    QgsSymbolLevelsDialog( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent = nullptr );
 
     ~QgsSymbolLevelsDialog();
 
@@ -48,6 +49,9 @@ class GUI_EXPORT QgsSymbolLevelsDialog : public QDialog, private Ui::QgsSymbolLe
     void renderingPassChanged( int row, int column );
 
   private slots:
+    //! Apply button
+    void apply();
+
     void showHelp();
 
   protected:
@@ -58,13 +62,17 @@ class GUI_EXPORT QgsSymbolLevelsDialog : public QDialog, private Ui::QgsSymbolLe
 
     //! maximal number of layers from all symbols
     int mMaxLayers;
+
+    QgsFeatureRenderer *mRenderer;
     QgsLegendSymbolList mList;
+
     //! whether symbol layers always should be used (default false)
     bool mForceOrderingEnabled;
 
   private:
 #ifdef SIP_RUN
     QgsSymbolLevelsDialog();
+
 #endif
 };
 

--- a/src/ui/qgssymbollevelsdialogbase.ui
+++ b/src/ui/qgssymbollevelsdialogbase.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>QgsSymbolLevelsDialogBase</class>
- <widget class="QDialog" name="QgsSymbolLevelsDialogBase">
+ <widget class="QgsPanelWidget" name="QgsSymbolLevelsDialogBase">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -41,51 +41,14 @@
      </attribute>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>QgsSymbolLevelsDialogBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QgsSymbolLevelsDialogBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
 </ui>


### PR DESCRIPTION
## Description
This PR fixes a regression on master which broke the symbol levels dialog. The issue is described here (https://issues.qgis.org/issues/16996).

@wonder-sk , that should do it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
