### PR TITLE
[OGR] Ensure subset string is set when reopening dataset

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3623,7 +3623,13 @@ void QgsOgrProvider::open( OpenMode mode )
       // check that the initial encoding setting is fit for this layer
       setEncoding( encoding() );
 
-      mValid = setSubsetString( mSubsetString );
+      // Ensure subset is set (setSubsetString does nothing if the passed sql subset string is equal to mSubsetString, which is the case when reloading the dataset)
+      QString origSubsetString = mSubsetString;
+      mSubsetString = "";
+      // Block signals to avoid endless recusion reloadData -> emit dataChanged -> reloadData
+      blockSignals( true );
+      mValid = setSubsetString( origSubsetString );
+      blockSignals( false );
       if ( mValid )
       {
         if ( mode == OpenModeInitial )

--- a/tests/src/python/test_provider_ogr_sqlite.py
+++ b/tests/src/python/test_provider_ogr_sqlite.py
@@ -200,7 +200,10 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
         self.assertTrue(vl.dataProvider().defaultValue(6).secsTo(QDateTime.currentDateTime()) < 1)
 
     def testSubsetStringFids(self):
-        """ tests that feature ids are stable even if a subset string is set """
+        """
+          - tests that feature ids are stable even if a subset string is set
+          - tests that the subset string is correctly set on the ogr layer event when reloading the data source (issue #17122)
+        """
 
         tmpfile = os.path.join(self.basetestpath, 'subsetStringFids.sqlite')
         ds = ogr.GetDriverByName('SQLite').CreateDataSource(tmpfile)
@@ -242,6 +245,7 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
 
         vl = QgsVectorLayer(tmpfile + "|subset=type=2", 'test', 'ogr')
         self.assertTrue(vl.isValid())
+        self.assertTrue(vl.fields().at(0).name() == "orig_ogc_fid")
 
         req = QgsFeatureRequest()
         req.setFilterExpression("value=16")
@@ -249,6 +253,10 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
         f = QgsFeature()
         self.assertTrue(it.nextFeature(f))
         self.assertTrue(f.id() == 5)
+
+        # Check that subset string is correctly set on reload
+        vl.reload()
+        self.assertTrue(vl.fields().at(0).name() == "orig_ogc_fid")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`QgsOgrProvider::reloadData` calls `close()` and `open()`, which in turn called `setSubsetString` with `mSubsetString`.
Since `setSubsetString` does nothing if the passed sql string is equal to `mSubsetString`, this resulted in the substring not being set on re-open. This commit clears `mSubsetString` before calling `setSubsetString`, and blocks signals when calling `setSubsetString` to avoid an endless recursion of `emit dataChanged` -> `reload`.
Fixes #17122.

