### PR TITLE
Fix tracing

### DIFF
--- a/src/gui/qgsmapcanvastracer.cpp
+++ b/src/gui/qgsmapcanvastracer.cpp
@@ -24,16 +24,13 @@
 
 #include <QAction>
 
-QHash<QgsMapCanvas*, QgsMapCanvasTracer*> QgsMapCanvasTracer::sTracers;
-
-
 QgsMapCanvasTracer::QgsMapCanvasTracer( QgsMapCanvas* canvas, QgsMessageBar* messageBar )
     : mCanvas( canvas )
     , mMessageBar( messageBar )
     , mLastMessage( nullptr )
     , mActionEnableTracing( nullptr )
 {
-  sTracers.insert( canvas, this );
+  tracers().insert( mCanvas, this );
 
   // when things change we just invalidate the graph - and set up new parameters again only when necessary
   connect( canvas, SIGNAL( destinationCrsChanged() ), this, SLOT( invalidateGraph() ) );
@@ -49,12 +46,12 @@ QgsMapCanvasTracer::QgsMapCanvasTracer( QgsMapCanvas* canvas, QgsMessageBar* mes
 
 QgsMapCanvasTracer::~QgsMapCanvasTracer()
 {
-  sTracers.remove( mCanvas );
+  tracers().remove( mCanvas );
 }
 
 QgsMapCanvasTracer* QgsMapCanvasTracer::tracerForCanvas( QgsMapCanvas* canvas )
 {
-  return sTracers.value( canvas, 0 );
+  return tracers().value( canvas );
 }
 
 void QgsMapCanvasTracer::reportError( QgsTracer::PathError err, bool addingVertex )
@@ -136,4 +133,10 @@ void QgsMapCanvasTracer::onCurrentLayerChanged()
   // no need to bother if we are not snapping
   if ( mCanvas->snappingUtils()->snapToMapMode() == QgsSnappingUtils::SnapCurrentLayer )
     invalidateGraph();
+}
+
+QHash<QgsMapCanvas*, QgsMapCanvasTracer*> &QgsMapCanvasTracer::tracers()
+{
+  static QHash<QgsMapCanvas*, QgsMapCanvasTracer*> sTracers;
+  return sTracers;
 }

--- a/src/gui/qgsmapcanvastracer.h
+++ b/src/gui/qgsmapcanvastracer.h
@@ -67,13 +67,13 @@ class GUI_EXPORT QgsMapCanvasTracer : public QgsTracer
     void onCurrentLayerChanged();
 
   private:
+    static QHash<QgsMapCanvas*, QgsMapCanvasTracer*>& tracers();
+
     QgsMapCanvas* mCanvas;
     QgsMessageBar* mMessageBar;
     QgsMessageBarItem* mLastMessage;
 
     QAction* mActionEnableTracing;
-
-    static QHash<QgsMapCanvas*, QgsMapCanvasTracer*> sTracers;
 };
 
 #endif // QGSMAPCANVASTRACER_H


### PR DESCRIPTION
For some reason, tracing doesn't work here.
This is because the tracer cannot be retrieved from the static canvas -> tracers map.

I did some checks, and the tracer gets added to the map but when some other part of the code tries to resolve it again, the map is empty (although remove has never been called) and even though the memory address of the map is equal to the one where it was added.

I am wondering if different .so files have their own copy of the static map, whatever it is, this patch fixes the issue for me.

Does it work for others? Any thoughts from your side @wonder-sk 