### PR TITLE
[processing] Fix intersection and union tools don't work with input layers with Z or M values present

### DIFF
--- a/python/plugins/processing/algs/qgis/Intersection.py
+++ b/python/plugins/processing/algs/qgis/Intersection.py
@@ -46,15 +46,6 @@ from processing.tools import vector
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
-wkbTypeGroups = {
-    'Point': (QgsWkbTypes.Point, QgsWkbTypes.MultiPoint, QgsWkbTypes.Point25D, QgsWkbTypes.MultiPoint25D,),
-    'LineString': (QgsWkbTypes.LineString, QgsWkbTypes.MultiLineString, QgsWkbTypes.LineString25D, QgsWkbTypes.MultiLineString25D,),
-    'Polygon': (QgsWkbTypes.Polygon, QgsWkbTypes.MultiPolygon, QgsWkbTypes.Polygon25D, QgsWkbTypes.MultiPolygon25D,),
-}
-for key, value in list(wkbTypeGroups.items()):
-    for const in value:
-        wkbTypeGroups[const] = key
-
 
 class Intersection(QgisAlgorithm):
 
@@ -186,7 +177,8 @@ class Intersection(QgisAlgorithm):
                                     'more input features have invalid '
                                     'geometry.'))
                     try:
-                        if int_geom.wkbType() in wkbTypeGroups[wkbTypeGroups[int_geom.wkbType()]]:
+                        if QgsWkbTypes.geometryType(int_geom.wkbType()) == QgsWkbTypes.geometryType(geomType):
+                            int_geom.convertToMultiType()
                             outFeat.setGeometry(int_geom)
                             outFeat.setAttributes(out_attributes)
                             sink.addFeature(outFeat, QgsFeatureSink.FastInsert)

--- a/python/plugins/processing/algs/qgis/Union.py
+++ b/python/plugins/processing/algs/qgis/Union.py
@@ -44,15 +44,6 @@ from processing.tools import vector
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
-wkbTypeGroups = {
-    'Point': (QgsWkbTypes.Point, QgsWkbTypes.MultiPoint, QgsWkbTypes.Point25D, QgsWkbTypes.MultiPoint25D,),
-    'LineString': (QgsWkbTypes.LineString, QgsWkbTypes.MultiLineString, QgsWkbTypes.LineString25D, QgsWkbTypes.MultiLineString25D,),
-    'Polygon': (QgsWkbTypes.Polygon, QgsWkbTypes.MultiPolygon, QgsWkbTypes.Polygon25D, QgsWkbTypes.MultiPolygon25D,),
-}
-for key, value in list(wkbTypeGroups.items()):
-    for const in value:
-        wkbTypeGroups[const] = key
-
 
 class Union(QgisAlgorithm):
 
@@ -113,6 +104,7 @@ class Union(QgisAlgorithm):
             intersects = indexB.intersects(geom.boundingBox())
             if len(intersects) < 1:
                 try:
+                    geom.convertToMultiType()
                     outFeat.setGeometry(geom)
                     outFeat.setAttributes(atMapA)
                     sink.addFeature(outFeat, QgsFeatureSink.FastInsert)
@@ -149,6 +141,7 @@ class Union(QgisAlgorithm):
                                 if i.type() == geom.type():
                                     int_geom = QgsGeometry(i)
                                     try:
+                                        int_geom.convertToMultiType()
                                         outFeat.setGeometry(int_geom)
                                         outFeat.setAttributes(atMapA + atMapB)
                                         sink.addFeature(outFeat, QgsFeatureSink.FastInsert)
@@ -159,8 +152,9 @@ class Union(QgisAlgorithm):
                             # in geometries of different types
                             # produced by the intersection
                             # fix #3549
-                            if int_geom.wkbType() in wkbTypeGroups[wkbTypeGroups[int_geom.wkbType()]]:
+                            if QgsWkbTypes.geometryType(int_geom.wkbType()) == QgsWkbTypes.geometryType(geomType):
                                 try:
+                                    int_geom.convertToMultiType()
                                     outFeat.setGeometry(int_geom)
                                     outFeat.setAttributes(atMapA + atMapB)
                                     sink.addFeature(outFeat, QgsFeatureSink.FastInsert)
@@ -180,6 +174,7 @@ class Union(QgisAlgorithm):
                         if i.type() == geom.type():
                             diff_geom = QgsGeometry(i)
                 try:
+                    diff_geom.convertToMultiType()
                     outFeat.setGeometry(diff_geom)
                     outFeat.setAttributes(atMapA)
                     sink.addFeature(outFeat, QgsFeatureSink.FastInsert)
@@ -205,6 +200,7 @@ class Union(QgisAlgorithm):
 
             if len(intersects) < 1:
                 try:
+                    geom.convertToMultiType()
                     outFeat.setGeometry(geom)
                     outFeat.setAttributes(atMap)
                     sink.addFeature(outFeat, QgsFeatureSink.FastInsert)
@@ -229,6 +225,7 @@ class Union(QgisAlgorithm):
                         try:
                             # Ihis only happens if the bounding box
                             # intersects, but the geometry doesn't
+                            diff_geom.convertToMultiType()
                             outFeat.setGeometry(diff_geom)
                             outFeat.setAttributes(atMap)
                             sink.addFeature(outFeat, QgsFeatureSink.FastInsert)
@@ -237,6 +234,7 @@ class Union(QgisAlgorithm):
 
             if add:
                 try:
+                    diff_geom.convertToMultiType()
                     outFeat.setGeometry(diff_geom)
                     outFeat.setAttributes(atMap)
                     sink.addFeature(outFeat, QgsFeatureSink.FastInsert)


### PR DESCRIPTION
The algorithm would halt instantly, claiming the input geometries were invalid (even if they weren't).

Also ensure that written geometries are always multitype, to match the created layer geometry type (before the layer was being created as a multi* layer, but single part geometries were sometimes created. This causes errors with some data providers)

