### PR TITLE
[processing] Transparently map 'qgis' algorithms to 'native' algorithms

### DIFF
--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -95,6 +95,15 @@ const QgsProcessingAlgorithm *QgsProcessingRegistry::algorithmById( const QStrin
       if ( alg->id() == id )
         return alg;
   }
+
+  // try mapping 'qgis' algs to 'native' algs - this allows us to freely move algorithms
+  // from the python 'qgis' provider to the c++ 'native' provider without breaking API
+  // or existing models
+  if ( id.startsWith( QStringLiteral( "qgis:" ) ) )
+  {
+    QString newId = QStringLiteral( "native:" ) + id.mid( 5 );
+    return algorithmById( newId );
+  }
   return nullptr;
 }
 

--- a/tests/src/core/testqgsprocessing.cpp
+++ b/tests/src/core/testqgsprocessing.cpp
@@ -848,6 +848,12 @@ void TestQgsProcessing::algorithm()
   QVERIFY( !r.algorithmById( "p1:alg3" ) );
   QVERIFY( !r.algorithmById( "px:alg1" ) );
 
+  // test that algorithmById can transparently map 'qgis' algorithms across to matching 'native' algorithms
+  // this allows us the freedom to convert qgis python algs to c++ without breaking api or existing models
+  QCOMPARE( QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "qgis:dissolve" ) )->id(), QStringLiteral( "native:dissolve" ) );
+  QCOMPARE( QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "qgis:clip" ) )->id(), QStringLiteral( "native:clip" ) );
+  QVERIFY( !QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "qgis:notanalg" ) ) );
+
   // createAlgorithmById
   QVERIFY( !r.createAlgorithmById( "p1:alg3" ) );
   std::unique_ptr< QgsProcessingAlgorithm > creation( r.createAlgorithmById( "p1:alg1" ) );


### PR DESCRIPTION
This allows us to freely move algorithms from the qgis python library to the c++ native provider without breaking API or existing models
