### PR TITLE
Segfault when tests timeout

### DIFF
--- a/.ci/travis/linux/install.sh
+++ b/.ci/travis/linux/install.sh
@@ -54,6 +54,7 @@ CMAKE_FLAGS="
       -DWITH_ASTYLE=OFF
       -DDISABLE_DEPRECATED=ON
       -DCXX_EXTRA_FLAGS=${CLANG_WARNINGS}
+      -DPYTHON_TEST_WRAPPER="timeout -sSIGSEGV 55s"
       "
 
 # The following options trigger a minimalized build to

--- a/cmake/UsePythonTest.cmake
+++ b/cmake/UsePythonTest.cmake
@@ -62,11 +62,12 @@ MESSAGE(\"export LD_LIBRARY_PATH=\$ENV{LD_LIBRARY_PATH}\")
 ")
   ENDFOREACH(_in)
 
+  SET (PYTHON_TEST_WRAPPER "" CACHE STRING "Wrapper command for python tests (e.g. `timeout -sSIGSEGV 55s` to segfault after 55 seconds)")
   FILE(APPEND ${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}.cmake "
 MESSAGE(\"export PYTHONPATH=\$ENV{PYTHONPATH}\")
-MESSAGE(STATUS \"Running ${PYTHON_EXECUTABLE} ${loc} ${wo_semicolon}\")
+MESSAGE(STATUS \"Running ${PYTHON_TEST_WRAPPER} ${PYTHON_EXECUTABLE} ${loc} ${wo_semicolon}\")
 EXECUTE_PROCESS(
-  COMMAND ${PYTHON_EXECUTABLE} ${loc} ${wo_semicolon}
+  COMMAND ${PYTHON_TEST_WRAPPER} ${PYTHON_EXECUTABLE} ${loc} ${wo_semicolon}
   RESULT_VARIABLE import_res
 )
 # Pass the output back to ctest


### PR DESCRIPTION
Because we want to see their trace with libSegFault to check where they are hanging out so late.

If we are lucky we get a lead on this



```
244/356 Test #244: PyQgsLocator ............................***Timeout  60.00 sec
```

https://travis-ci.org/qgis/QGIS/jobs/275786435#L6522