### PR TITLE
geonode integration - copy style action

### DIFF
--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -148,6 +148,7 @@ Create new data item.
  created menus is correctly handled by parenting them to the specified parent widget.
  \param parent a parent widget of the menu
  :return: list of menus
+.. versionadded:: 3.0
  :rtype: list of QMenu
 %End
 

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -141,6 +141,22 @@ Create new data item.
  :rtype: list of QAction
 %End
 
+    void setActions( QList<QAction *> actions );
+%Docstring
+ Sets the actions for the data item.
+%End
+
+    virtual  QList<QMenu *> menus();
+%Docstring
+ Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
+ the item. Subclasses should override this to provide actions.
+%End
+
+    void setMenus( QList<QMenu *> menus );
+%Docstring
+ Sets the menus for the data item.
+%End
+
     virtual bool acceptDrop();
 %Docstring
  Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -141,12 +141,14 @@ Create new data item.
  :rtype: list of QAction
 %End
 
-    virtual  QList<QMenu *> menus();
+    virtual QList<QMenu *> menus( QWidget *parent );
 %Docstring
  Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
- the item. Subclasses should override this to provide actions. Ownership of the returned menus is unchanged.
- Implementations should take care to ensure that created menus are correctly parented
- (e.g. by setting the parent to the data item) to avoid leaking the returned menus.
+ the item. Subclasses should override this to provide actions. Subclasses should ensure that ownership of
+ created menus is correctly handled by parenting them to the specified parent widget.
+ \param parent a parent widget of the menu
+ :return: list of menus
+ :rtype: list of QMenu
 %End
 
     virtual bool acceptDrop();

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -141,20 +141,10 @@ Create new data item.
  :rtype: list of QAction
 %End
 
-    void setActions( QList<QAction *> actions );
-%Docstring
- Sets the actions for the data item.
-%End
-
     virtual  QList<QMenu *> menus();
 %Docstring
  Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
  the item. Subclasses should override this to provide actions.
-%End
-
-    void setMenus( QList<QMenu *> menus );
-%Docstring
- Sets the menus for the data item.
 %End
 
     virtual bool acceptDrop();

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -144,7 +144,9 @@ Create new data item.
     virtual  QList<QMenu *> menus();
 %Docstring
  Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
- the item. Subclasses should override this to provide actions.
+ the item. Subclasses should override this to provide actions. Ownership of the returned menus is unchanged.
+ Implementations should take care to ensure that created menus are correctly parented
+ (e.g. by setting the parent to the data item) to avoid leaking the returned menus.
 %End
 
     virtual bool acceptDrop();

--- a/python/core/symbology/qgsstyle.sip
+++ b/python/core/symbology/qgsstyle.sip
@@ -15,6 +15,7 @@
 typedef QMap<QString, QgsColorRamp * > QgsVectorColorRampMap;
 typedef QMap<int, QString> QgsSymbolGroupMap;
 
+
 typedef QMultiMap<QString, QString> QgsSmartConditionMap;
 
 enum SymbolTable { SymbolId, SymbolName, SymbolXML, SymbolFavoriteId };

--- a/src/app/qgsclipboard.h
+++ b/src/app/qgsclipboard.h
@@ -46,11 +46,6 @@
 class QgsVectorLayer;
 class QgsFeatureStore;
 
-/*
- * Constants used to describe copy-paste MIME types
- */
-#define QGSCLIPBOARD_STYLE_MIME "application/qgis.style"
-
 class APP_EXPORT QgsClipboard : public QObject
 {
     Q_OBJECT

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -558,6 +558,12 @@ void QgsDataItem::setState( State state )
     updateIcon();
 }
 
+QList<QMenu *> QgsDataItem::menus( QWidget *parent )
+{
+  Q_UNUSED( parent );
+  return QList<QMenu *>();
+}
+
 // ---------------------------------------------------------------------
 
 QgsLayerItem::QgsLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &uri, LayerType layerType, const QString &providerKey )

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -148,6 +148,21 @@ class CORE_EXPORT QgsDataItem : public QObject
      */
     virtual QList<QAction *> actions( QWidget *parent );
 
+    /**
+     * Sets the actions for the data item.
+     */
+    void setActions( QList<QAction *> actions ) { mActions = actions; }
+
+    /** Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
+     * the item. Subclasses should override this to provide actions.
+     */
+    virtual  QList<QMenu *> menus() { return mMenus; }
+
+    /**
+     * Sets the menus for the data item.
+     */
+    void setMenus( QList<QMenu *> menus ) { mMenus = menus; }
+
     /** Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.
      * Subclasses should override this and handleDrop() to accept dropped layers.
      * \see handleDrop()
@@ -278,6 +293,8 @@ class CORE_EXPORT QgsDataItem : public QObject
     QString mIconName;
     QIcon mIcon;
     QMap<QString, QIcon> mIconMap;
+    QList<QAction *> mActions;
+    QList<QMenu *> mMenus;
 
   public slots:
 

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -148,20 +148,10 @@ class CORE_EXPORT QgsDataItem : public QObject
      */
     virtual QList<QAction *> actions( QWidget *parent );
 
-    /**
-     * Sets the actions for the data item.
-     */
-    void setActions( QList<QAction *> actions ) { mActions = actions; }
-
     /** Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
      * the item. Subclasses should override this to provide actions.
      */
-    virtual  QList<QMenu *> menus() { return mMenus; }
-
-    /**
-     * Sets the menus for the data item.
-     */
-    void setMenus( QList<QMenu *> menus ) { mMenus = menus; }
+    virtual  QList<QMenu *> menus() { return QList<QMenu *>(); }
 
     /** Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.
      * Subclasses should override this and handleDrop() to accept dropped layers.
@@ -293,8 +283,6 @@ class CORE_EXPORT QgsDataItem : public QObject
     QString mIconName;
     QIcon mIcon;
     QMap<QString, QIcon> mIconMap;
-    QList<QAction *> mActions;
-    QList<QMenu *> mMenus;
 
   public slots:
 

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -153,12 +153,9 @@ class CORE_EXPORT QgsDataItem : public QObject
      * created menus is correctly handled by parenting them to the specified parent widget.
      * \param parent a parent widget of the menu
      * \returns list of menus
+     * \since QGIS 3.0
      */
-    virtual QList<QMenu *> menus( QWidget *parent )
-    {
-      Q_UNUSED( parent );
-      return QList<QMenu *>();
-    }
+    virtual QList<QMenu *> menus( QWidget *parent );
 
     /** Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.
      * Subclasses should override this and handleDrop() to accept dropped layers.

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -149,11 +149,16 @@ class CORE_EXPORT QgsDataItem : public QObject
     virtual QList<QAction *> actions( QWidget *parent );
 
     /** Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
-     * the item. Subclasses should override this to provide actions. Ownership of the returned menus is unchanged.
-     * Implementations should take care to ensure that created menus are correctly parented
-     * (e.g. by setting the parent to the data item) to avoid leaking the returned menus.
+     * the item. Subclasses should override this to provide actions. Subclasses should ensure that ownership of
+     * created menus is correctly handled by parenting them to the specified parent widget.
+     * \param parent a parent widget of the menu
+     * \returns list of menus
      */
-    virtual  QList<QMenu *> menus() { return QList<QMenu *>(); }
+    virtual QList<QMenu *> menus( QWidget *parent )
+    {
+      Q_UNUSED( parent );
+      return QList<QMenu *>();
+    }
 
     /** Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.
      * Subclasses should override this and handleDrop() to accept dropped layers.

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -149,7 +149,9 @@ class CORE_EXPORT QgsDataItem : public QObject
     virtual QList<QAction *> actions( QWidget *parent );
 
     /** Returns the list of menus available for this item. This is usually used for the popup menu on right-clicking
-     * the item. Subclasses should override this to provide actions.
+     * the item. Subclasses should override this to provide actions. Ownership of the returned menus is unchanged.
+     * Implementations should take care to ensure that created menus are correctly parented
+     * (e.g. by setting the parent to the data item) to avoid leaking the returned menus.
      */
     virtual  QList<QMenu *> menus() { return QList<QMenu *>(); }
 

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -36,6 +36,11 @@ class QDomElement;
 typedef QMap<QString, QgsColorRamp * > QgsVectorColorRampMap;
 typedef QMap<int, QString> QgsSymbolGroupMap;
 
+/*
+ * Constants used to describe copy-paste MIME types
+ */
+#define QGSCLIPBOARD_STYLE_MIME "application/qgis.style"
+
 /** \ingroup core
  *  A multimap to hold the smart group conditions as constraint and parameter pairs.
  *  Both the key and the value of the map are QString. The key is the constraint of the condition and the value is the parameter which is applied for the constraint.

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -209,15 +209,14 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
     menu->addAction( tr( "Add a Directory..." ), this, SLOT( addFavoriteDirectory() ) );
   }
 
-  const QList<QMenu *> menus = item->menus();
+  const QList<QMenu *> menus = item->menus( menu );
   QList<QAction *> actions = item->actions( menu );
 
   if ( !menus.isEmpty() )
   {
     for ( QMenu *mn : menus )
     {
-      QMenu *newMenu = menu->addMenu( mn->title() );  // this method will transfer the ownership
-      newMenu->addActions( mn->actions() );
+      menu->addMenu( mn );
     }
   }
 

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -216,7 +216,8 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
   {
     for ( QMenu *mn : menus )
     {
-      menu->addMenu( mn );
+      QMenu *newMenu = menu->addMenu( mn->title() );  // this method will transfer the ownership
+      newMenu->addActions( mn->actions() );
     }
   }
 

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -209,12 +209,12 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
     menu->addAction( tr( "Add a Directory..." ), this, SLOT( addFavoriteDirectory() ) );
   }
 
-  QList<QMenu *> menus = item->menus();
+  const QList<QMenu *> menus = item->menus();
   QList<QAction *> actions = item->actions( menu );
 
   if ( !menus.isEmpty() )
   {
-    Q_FOREACH ( QMenu *mn, menus )
+    for ( QMenu *mn : menus )
     {
       menu->addMenu( mn );
     }

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -209,7 +209,17 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
     menu->addAction( tr( "Add a Directory..." ), this, SLOT( addFavoriteDirectory() ) );
   }
 
+  QList<QMenu *> menus = item->menus();
   QList<QAction *> actions = item->actions( menu );
+
+  if ( !menus.isEmpty() )
+  {
+    Q_FOREACH ( QMenu *mn, menus )
+    {
+      menu->addMenu( mn );
+    }
+  }
+
   if ( !actions.isEmpty() )
   {
     if ( !menu->actions().isEmpty() )

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -49,11 +49,18 @@ QgsWfsLayerItem::QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDa
   mUri = QgsWFSDataSourceURI::build( uri.uri(), featureType, crsString, QString(), useCurrentViewExtent );
   setState( Populated );
   mIconName = QStringLiteral( "mIconConnect.png" );
+}
+
+QgsWfsLayerItem::~QgsWfsLayerItem()
+{
+}
+
+QList<QMenu *> QgsWfsLayerItem::menus()
+{
+  QList<QMenu *> menus;
 
   if ( mPath.startsWith( QLatin1String( "geonode:/" ) ) )
   {
-    QList<QMenu *> menus;
-
     QAction *actionCopyStyle = new QAction( tr( "Copy Style" ), this );
     connect( actionCopyStyle, &QAction::triggered, this, &QgsWfsLayerItem::copyStyle );
 
@@ -61,12 +68,9 @@ QgsWfsLayerItem::QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDa
     menuStyleManager->setTitle( tr( "Styles" ) );
     menuStyleManager->addAction( actionCopyStyle );
     menus << menuStyleManager;
-    setMenus( menus );
   }
-}
 
-QgsWfsLayerItem::~QgsWfsLayerItem()
-{
+  return menus;
 }
 
 void QgsWfsLayerItem::copyStyle()

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -55,18 +55,17 @@ QgsWfsLayerItem::~QgsWfsLayerItem()
 {
 }
 
-QList<QMenu *> QgsWfsLayerItem::menus()
+QList<QMenu *> QgsWfsLayerItem::menus( QWidget *parent )
 {
   QList<QMenu *> menus;
 
   if ( mPath.startsWith( QLatin1String( "geonode:/" ) ) )
   {
-    QMenu *menuStyleManager = new QMenu();
+    QMenu *menuStyleManager = new QMenu( tr( "Styles" ), parent );
 
     QAction *actionCopyStyle = new QAction( tr( "Copy Style" ), menuStyleManager );
     connect( actionCopyStyle, &QAction::triggered, this, &QgsWfsLayerItem::copyStyle );
 
-    menuStyleManager->setTitle( tr( "Styles" ) );
     menuStyleManager->addAction( actionCopyStyle );
     menus << menuStyleManager;
   }
@@ -101,7 +100,7 @@ void QgsWfsLayerItem::copyStyle()
   }
 
   QString url( connection->uri().encodedUri() );
-  QgsGeoNodeRequest geoNodeRequest( url.replace( QString( "url=" ), QString( "" ) ), true );
+  QgsGeoNodeRequest geoNodeRequest( url.replace( QString( "url=" ), QString() ), true );
   QgsGeoNodeStyle style = geoNodeRequest.fetchDefaultStyleBlocking( this->name() );
   if ( style.name.isEmpty() )
   {
@@ -122,9 +121,8 @@ void QgsWfsLayerItem::copyStyle()
   mdata->setData( QGSCLIPBOARD_STYLE_MIME, style.body.toByteArray() );
   mdata->setText( style.body.toString() );
   // Copies data in text form as well, so the XML can be pasted into a text editor
-#ifdef Q_OS_LINUX
-  clipboard->setMimeData( mdata, QClipboard::Selection );
-#endif
+  if ( clipboard->supportsSelection() )
+    clipboard->setMimeData( mdata, QClipboard::Selection );
   clipboard->setMimeData( mdata, QClipboard::Clipboard );
   // Enables the paste menu element
   // actionPasteStyle->setEnabled( true );

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -61,10 +61,11 @@ QList<QMenu *> QgsWfsLayerItem::menus()
 
   if ( mPath.startsWith( QLatin1String( "geonode:/" ) ) )
   {
-    QAction *actionCopyStyle = new QAction( tr( "Copy Style" ), this );
+    QMenu *menuStyleManager = new QMenu();
+
+    QAction *actionCopyStyle = new QAction( tr( "Copy Style" ), menuStyleManager );
     connect( actionCopyStyle, &QAction::triggered, this, &QgsWfsLayerItem::copyStyle );
 
-    QMenu *menuStyleManager = new QMenu();
     menuStyleManager->setTitle( tr( "Styles" ) );
     menuStyleManager->addAction( actionCopyStyle );
     menus << menuStyleManager;
@@ -122,9 +123,9 @@ void QgsWfsLayerItem::copyStyle()
   mdata->setText( style.body.toString() );
   // Copies data in text form as well, so the XML can be pasted into a text editor
 #ifdef Q_OS_LINUX
-  clipboard->setMimeData( mdata, QClipboard::Clipboard );
-#endif
   clipboard->setMimeData( mdata, QClipboard::Selection );
+#endif
+  clipboard->setMimeData( mdata, QClipboard::Clipboard );
   // Enables the paste menu element
   // actionPasteStyle->setEnabled( true );
 }

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -49,6 +49,7 @@ QgsWfsLayerItem::QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDa
   mUri = QgsWFSDataSourceURI::build( uri.uri(), featureType, crsString, QString(), useCurrentViewExtent );
   setState( Populated );
   mIconName = QStringLiteral( "mIconConnect.png" );
+  mBaseUri = uri.param( QString( "url" ) );
 }
 
 QgsWfsLayerItem::~QgsWfsLayerItem()
@@ -75,15 +76,15 @@ QList<QMenu *> QgsWfsLayerItem::menus( QWidget *parent )
 
 void QgsWfsLayerItem::copyStyle()
 {
-  QString layerUri = this->uri();
-
   std::unique_ptr< QgsGeoNodeConnection > connection;
   const QStringList connections = QgsGeoNodeConnectionUtils::connectionList();
   for ( const QString &connName : connections )
   {
     connection.reset( new QgsGeoNodeConnection( connName ) );
-    if ( layerUri.contains( connection->uri().uri() ) )
+    if ( mBaseUri.contains( connection->uri().param( QString( "url" ) ) ) )
       break;
+    else
+      connection.reset( nullptr );
   }
 
   if ( !connection )

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -81,7 +81,10 @@ class QgsWfsLayerItem : public QgsLayerItem
 
     virtual QList<QMenu *> menus( QWidget *parent ) override;
 
-  public slots:
+  protected:
+    QString mBaseUri;
+
+  private slots:
 
     /** Get style of the active data item (geonode layer item) and copy it to the clipboard.
      */

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -82,20 +82,14 @@ class QgsWfsLayerItem : public QgsLayerItem
     virtual QList<QMenu *> menus() override;
 
   public slots:
-    //! get style of the active data item (geonode layer item) and copy it to the clipboard
 
-    /**
-       \param sourceItem  The data item where the style will be taken from
-                                        (defaults to the active data item on the browser dock widget)
+    /** Get style of the active data item (geonode layer item) and copy it to the clipboard.
      */
     void copyStyle();
-    //! paste style on the clipboard to the active data item (geonode layer item) and push it to the source
 
-    /**
-       \param destinationItem  The data item that the clipboard will be pasted to
-                                (defaults to the active data item on the browser dock widget)
+    /** Paste style on the clipboard to the active data item (geonode layer item) and push it to the source.
      */
-    //    void pasteStyle( QgsDataItem *destinationItem = nullptr );
+    //    void pasteStyle();
 };
 
 

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -79,7 +79,7 @@ class QgsWfsLayerItem : public QgsLayerItem
     QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDataSourceUri &uri, QString featureType, QString title, QString crsString );
     ~QgsWfsLayerItem();
 
-    virtual QList<QMenu *> menus() override;
+    virtual QList<QMenu *> menus( QWidget *parent ) override;
 
   public slots:
 

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -79,6 +79,8 @@ class QgsWfsLayerItem : public QgsLayerItem
     QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDataSourceUri &uri, QString featureType, QString title, QString crsString );
     ~QgsWfsLayerItem();
 
+    virtual QList<QMenu *> menus() override;
+
   public slots:
     //! get style of the active data item (geonode layer item) and copy it to the clipboard
 

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -79,6 +79,21 @@ class QgsWfsLayerItem : public QgsLayerItem
     QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDataSourceUri &uri, QString featureType, QString title, QString crsString );
     ~QgsWfsLayerItem();
 
+  public slots:
+    //! get style of the active data item (geonode layer item) and copy it to the clipboard
+
+    /**
+       \param sourceItem  The data item where the style will be taken from
+                                        (defaults to the active data item on the browser dock widget)
+     */
+    void copyStyle();
+    //! paste style on the clipboard to the active data item (geonode layer item) and push it to the source
+
+    /**
+       \param destinationItem  The data item that the clipboard will be pasted to
+                                (defaults to the active data item on the browser dock widget)
+     */
+    //    void pasteStyle( QgsDataItem *destinationItem = nullptr );
 };
 
 


### PR DESCRIPTION
## Description
This is an update for PR #5153 . I'm adding an action to copy a style for wfs layer item from geonode instance. The copy action will request a default style for selected layer from geonode api and will put it into the clipboard.

![geonode-style-copy](https://user-images.githubusercontent.com/11134669/30519686-8fbd639a-9bc6-11e7-979e-2fa3ca85debb.gif)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
