### PR TITLE
[expression] fix caching for aggregate() and @parent exp. (fixes #15797)

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -504,8 +504,7 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
   QVariant result;
   if ( context )
   {
-    QString cacheKey = QStringLiteral( "aggfcn:%1:%2:%3:%4" ).arg( vl->id(), QString::number( aggregate ), subExpression, parameters.filter );
-
+    QString cacheKey;
     QgsExpression subExp( subExpression );
     QgsExpression filterExp( parameters.filter );
     if ( filterExp.referencedVariables().contains( "parent" )
@@ -513,7 +512,12 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
          || subExp.referencedVariables().contains( "parent" )
          || subExp.referencedVariables().contains( QString() ) )
     {
-      cacheKey += ':' + qHash( context->feature() );
+      cacheKey = QStringLiteral( "aggfcn:%1:%2:%3:%4:%5%6" ).arg( vl->id(), QString::number( aggregate ), subExpression, parameters.filter,
+                 QString::number( context->feature().id() ), QString( qHash( context->feature() ) ) );
+    }
+    else
+    {
+      cacheKey = QStringLiteral( "aggfcn:%1:%2:%3:%4" ).arg( vl->id(), QString::number( aggregate ), subExpression, parameters.filter );
     }
 
     if ( context && context->hasCachedValue( cacheKey ) )


### PR DESCRIPTION
## Description
@m-kuhn , this PR fixes a long-standing issue with the aggregate() function and the use of @parent. Turns out using `qHash( context->feature() )` ended up creating same hash value for different features, which in return would provide the wrong aggregate() result for different features sharing the same qHash value.

Using qHash ( context->feature().id() ) fixed the test case attached in this issue (https://issues.qgis.org/issues/15797).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
