### PR TITLE
Geopackage: browser homogenize

### DIFF
--- a/python/core/qgsdataitemprovider.sip
+++ b/python/core/qgsdataitemprovider.sip
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsDataItemProvider
 {
 %Docstring
@@ -53,6 +55,20 @@ Caller takes responsibility of deleting created items.
 %Docstring
 Caller takes responsibility of deleting created items.
  :rtype: list of QgsDataItem
+%End
+
+    virtual bool handlesDirectoryPath( const QString &path );
+%Docstring
+ Returns true if the provider will handle the directory at the specified ``path``.
+
+ If the provider indicates that it will handle the directory, the default creation and
+ population of directory items for the path will be avoided and it is left to the
+ provider to correctly populate relevant entries for the path.
+
+ The default implementation returns false for all paths.
+
+.. versionadded:: 3.0
+ :rtype: bool
 %End
 };
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9690,7 +9690,7 @@ bool QgisApp::setActiveLayer( QgsMapLayer *layer )
 
 void QgisApp::reloadConnections()
 {
-  emit( connectionsChanged( ) );
+  emit connectionsChanged( );
 }
 
 

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -345,8 +345,16 @@ void QgsDataItem::refresh()
 
 void QgsDataItem::refreshConnections()
 {
-  refresh();
-  emit connectionsChanged();
+  // Walk up until the root node is reached
+  if ( mParent )
+  {
+    mParent->refreshConnections();
+  }
+  else
+  {
+    refresh();
+    emit connectionsChanged();
+  }
 }
 
 void QgsDataItem::refresh( const QVector<QgsDataItem *> &children )

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -1312,7 +1312,6 @@ QVector<QgsDataItem *> QgsZipItem::createChildren()
           // the item comes with zipped file name, set the name to relative path within zip file
           item->setName( fileName );
           children.append( item );
-          break;
         }
         else
         {

--- a/src/core/qgsdataitemprovider.cpp
+++ b/src/core/qgsdataitemprovider.cpp
@@ -16,3 +16,8 @@
 #include "qgsdataitemprovider.h"
 
 // no implementation currently
+
+bool QgsDataItemProvider::handlesDirectoryPath( const QString & )
+{
+  return false;
+}

--- a/src/core/qgsdataitemprovider.h
+++ b/src/core/qgsdataitemprovider.h
@@ -24,6 +24,10 @@ class QgsDataItem;
 
 class QString;
 
+//! handlesDirectoryPath function
+typedef bool handlesDirectoryPath_t( const QString &path ) SIP_SKIP;
+
+
 /** \ingroup core
  * This is the interface for those who want to add custom data items to the browser tree.
  *
@@ -54,6 +58,19 @@ class CORE_EXPORT QgsDataItemProvider
     //! Create a vector of instances of QgsDataItem (or null) for given path and parent item.
     //! Caller takes responsibility of deleting created items.
     virtual QVector<QgsDataItem *> createDataItems( const QString &path, QgsDataItem *parentItem ) { Q_UNUSED( path ); Q_UNUSED( parentItem ); return QVector<QgsDataItem *>(); }
+
+    /**
+     * Returns true if the provider will handle the directory at the specified \a path.
+     *
+     * If the provider indicates that it will handle the directory, the default creation and
+     * population of directory items for the path will be avoided and it is left to the
+     * provider to correctly populate relevant entries for the path.
+     *
+     * The default implementation returns false for all paths.
+     *
+     * \since QGIS 3.0
+     */
+    virtual bool handlesDirectoryPath( const QString &path );
 };
 
 #endif // QGSDATAITEMPROVIDER_H

--- a/src/core/qgsdataitemproviderregistry.cpp
+++ b/src/core/qgsdataitemproviderregistry.cpp
@@ -36,10 +36,11 @@ typedef QList<QgsDataItemProvider *> *dataItemProviders_t();
 class QgsDataItemProviderFromPlugin : public QgsDataItemProvider
 {
   public:
-    QgsDataItemProviderFromPlugin( const QString &name, dataCapabilities_t *capabilitiesFunc, dataItem_t *dataItemFunc )
+    QgsDataItemProviderFromPlugin( const QString &name, dataCapabilities_t *capabilitiesFunc, dataItem_t *dataItemFunc, handlesDirectoryPath_t *handlesDirectoryPathFunc )
       : mName( name )
       , mCapabilitiesFunc( capabilitiesFunc )
       , mDataItemFunc( dataItemFunc )
+      , mHandlesDirectoryPathFunc( handlesDirectoryPathFunc )
     {
     }
 
@@ -49,10 +50,19 @@ class QgsDataItemProviderFromPlugin : public QgsDataItemProvider
 
     QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override { return mDataItemFunc( path, parentItem ); }
 
+    bool handlesDirectoryPath( const QString &path ) override
+    {
+      if ( mHandlesDirectoryPathFunc )
+        return mHandlesDirectoryPathFunc( path );
+      else
+        return false;
+    }
+
   protected:
     QString mName;
     dataCapabilities_t *mCapabilitiesFunc = nullptr;
     dataItem_t *mDataItemFunc = nullptr;
+    handlesDirectoryPath_t *mHandlesDirectoryPathFunc = nullptr;
 };
 
 
@@ -93,7 +103,9 @@ QgsDataItemProviderRegistry::QgsDataItemProviderRegistry()
       continue;
     }
 
-    mProviders.append( new QgsDataItemProviderFromPlugin( library->fileName(), dataCapabilities, dataItem ) );
+    handlesDirectoryPath_t *handlesDirectoryPath = reinterpret_cast< handlesDirectoryPath_t * >( cast_to_fptr( library->resolve( "handlesDirectoryPath" ) ) );
+
+    mProviders.append( new QgsDataItemProviderFromPlugin( library->fileName(), dataCapabilities, dataItem, handlesDirectoryPath ) );
   }
 }
 

--- a/src/core/qgsdataitemproviderregistry.cpp
+++ b/src/core/qgsdataitemproviderregistry.cpp
@@ -36,6 +36,14 @@ typedef QList<QgsDataItemProvider *> *dataItemProviders_t();
 class QgsDataItemProviderFromPlugin : public QgsDataItemProvider
 {
   public:
+
+    /**
+     * QgsDataItemProviderFromPlugin constructor
+     * \param name plugin name
+     * \param capabilitiesFunc function pointer to the data capabilities
+     * \param dataItemFunc function pointer to the data items
+     * \param handlesDirectoryPathFunc function pointer to handlesDirectoryPath
+     */
     QgsDataItemProviderFromPlugin( const QString &name, dataCapabilities_t *capabilitiesFunc, dataItem_t *dataItemFunc, handlesDirectoryPath_t *handlesDirectoryPathFunc )
       : mName( name )
       , mCapabilitiesFunc( capabilitiesFunc )

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -241,12 +241,32 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
 #endif
   }
 
+  // Filters out the OGR/GDAL supported formats that can contain multiple layers
+  // and should be treated like a DB: GeoPackage and SQLite
+  // NOTE: this formats are scanned for rasters too and they are handled
+  //       by the "ogr" provider. For this reason they must
+  //       be skipped by "gdal" provider or the rasters will be listed
+  //       twice. ogrSupportedDbLayersExtensions must be kept in sync
+  //       with the companion variable (same name) in the ogr provider
+  //       class
+  // TODO: add more OGR supported multiple layers formats here!
+  QStringList ogrSupportedDbLayersExtensions;
+  ogrSupportedDbLayersExtensions << QLatin1String( "gpkg" ) << QLatin1String( "sqlite" ) << QLatin1String( "db" );
+  QStringList ogrSupportedDbDriverNames;
+  ogrSupportedDbDriverNames << QLatin1String( "GPKG" ) << QLatin1String( "db" );
+
   // return item without testing if:
   // scanExtSetting
   // or zipfile and scan zip == "Basic scan"
   if ( scanExtSetting ||
        ( ( is_vsizip || is_vsitar ) && scanZipSetting == QLatin1String( "basic" ) ) )
   {
+    // Skip this layer if it's handled by ogr:
+    if ( ogrSupportedDbLayersExtensions.contains( suffix ) )
+    {
+      return nullptr;
+    }
+
     // if this is a VRT file make sure it is raster VRT to avoid duplicates
     if ( suffix == QLatin1String( "vrt" ) )
     {
@@ -280,6 +300,15 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   if ( ! hDS )
   {
     QgsDebugMsg( QString( "GDALOpen error # %1 : %2 " ).arg( CPLGetLastErrorNo() ).arg( CPLGetLastErrorMsg() ) );
+    return nullptr;
+  }
+
+  GDALDriverH hDriver = GDALGetDatasetDriver( hDS );
+  QString ogrDriverName = GDALGetDriverShortName( hDriver );
+
+  // Skip this layer if it's handled by ogr:
+  if ( ogrSupportedDbDriverNames.contains( ogrDriverName ) )
+  {
     return nullptr;
   }
 

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -251,9 +251,9 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   //       class
   // TODO: add more OGR supported multiple layers formats here!
   QStringList ogrSupportedDbLayersExtensions;
-  ogrSupportedDbLayersExtensions << QLatin1String( "gpkg" ) << QLatin1String( "sqlite" ) << QLatin1String( "db" );
+  ogrSupportedDbLayersExtensions << QLatin1String( "gpkg" ) << QLatin1String( "sqlite" ) << QLatin1String( "db" ) << QLatin1String( "gdb" );
   QStringList ogrSupportedDbDriverNames;
-  ogrSupportedDbDriverNames << QLatin1String( "GPKG" ) << QLatin1String( "db" );
+  ogrSupportedDbDriverNames << QLatin1String( "GPKG" ) << QLatin1String( "db" ) << QLatin1String( "gdb" );
 
   // return item without testing if:
   // scanExtSetting

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -166,10 +166,19 @@ QList<QAction *> QgsGeoPackageCollectionItem::actions()
 {
   QList<QAction *> lst;
 
-  // Add to stored connections
-  QAction *actionAddConnection = new QAction( tr( "Add connection" ), this );
-  connect( actionAddConnection, &QAction::triggered, this, &QgsGeoPackageCollectionItem::addConnection );
-  lst.append( actionAddConnection );
+  if ( QgsOgrDbConnection::connectionList( QStringLiteral( "GPKG" ) ).contains( mName ) )
+  {
+    QAction *actionDeleteConnection = new QAction( tr( "Remove connection" ), this );
+    connect( actionDeleteConnection, &QAction::triggered, this, &QgsGeoPackageConnectionItem::deleteConnection );
+    lst.append( actionDeleteConnection );
+  }
+  else
+  {
+    // Add to stored connections
+    QAction *actionAddConnection = new QAction( tr( "Add connection" ), this );
+    connect( actionAddConnection, &QAction::triggered, this, &QgsGeoPackageCollectionItem::addConnection );
+    lst.append( actionAddConnection );
+  }
 
   // Add table to existing DB
   QAction *actionAddTable = new QAction( tr( "Create a new layer or table..." ), this );
@@ -481,7 +490,7 @@ QList<QAction *> QgsGeoPackageConnectionItem::actions()
   return lst;
 }
 
-void QgsGeoPackageConnectionItem::deleteConnection()
+void QgsGeoPackageCollectionItem::deleteConnection()
 {
   QgsOgrDbConnection::deleteConnection( name(), QStringLiteral( "GPKG" ) );
   mParent->refreshConnections();

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -512,6 +512,7 @@ void QgsGeoPackageCollectionItem::addTable()
 void QgsGeoPackageCollectionItem::addConnection()
 {
   QgsOgrDbConnection connection( mName, QStringLiteral( "GPKG" ) );
+  connection.setPath( mPath );
   connection.save();
   mParent->refreshConnections();
 }

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -124,6 +124,7 @@ QgsGeoPackageCollectionItem::QgsGeoPackageCollectionItem( QgsDataItem *parent, c
   : QgsDataCollectionItem( parent, name, path )
   , mPath( path )
 {
+  mToolTip = path;
   mCapabilities |= Collapse;
 }
 
@@ -510,9 +511,9 @@ void QgsGeoPackageCollectionItem::addTable()
 
 void QgsGeoPackageCollectionItem::addConnection()
 {
-  QgsOgrDbConnection connection( mName, QStringLiteral( "GeoPackage" ) );
+  QgsOgrDbConnection connection( mName, QStringLiteral( "GPKG" ) );
   connection.save();
-  emit connectionsChanged();
+  mParent->refreshConnections();
 }
 
 #endif

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -64,12 +64,16 @@ class QgsGeoPackageVectorLayerItem : public QgsGeoPackageAbstractLayerItem
 };
 
 
-class QgsGeoPackageConnectionItem : public QgsDataCollectionItem
+/**
+ * \brief The QgsGeoPackageCollectionItem class is the base class for
+ *        GeoPackage container
+ */
+class QgsGeoPackageCollectionItem : public QgsDataCollectionItem
 {
     Q_OBJECT
 
   public:
-    QgsGeoPackageConnectionItem( QgsDataItem *parent, const QString &name, const QString &path );
+    QgsGeoPackageCollectionItem( QgsDataItem *parent, const QString &name, const QString &path );
     QVector<QgsDataItem *> createChildren() override;
     virtual bool equal( const QgsDataItem *other ) override;
 
@@ -87,13 +91,37 @@ class QgsGeoPackageConnectionItem : public QgsDataCollectionItem
 
   public slots:
 #ifdef HAVE_GUI
-    void editConnection();
-    void deleteConnection();
     void addTable();
+    void addConnection();
 #endif
 
   protected:
     QString mPath;
+};
+
+
+/**
+ * \brief The QgsGeoPackageConnectionItem class adds the stored
+ *        connection management to QgsGeoPackageCollectionItem
+ */
+class QgsGeoPackageConnectionItem : public QgsGeoPackageCollectionItem
+{
+    Q_OBJECT
+
+  public:
+    QgsGeoPackageConnectionItem( QgsDataItem *parent, const QString &name, const QString &path );
+    virtual bool equal( const QgsDataItem *other ) override;
+
+#ifdef HAVE_GUI
+    QList<QAction *> actions() override;
+#endif
+
+  public slots:
+#ifdef HAVE_GUI
+    void editConnection();
+    void deleteConnection();
+#endif
+
 };
 
 

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -93,6 +93,7 @@ class QgsGeoPackageCollectionItem : public QgsDataCollectionItem
 #ifdef HAVE_GUI
     void addTable();
     void addConnection();
+    void deleteConnection();
 #endif
 
   protected:
@@ -119,7 +120,6 @@ class QgsGeoPackageConnectionItem : public QgsGeoPackageCollectionItem
   public slots:
 #ifdef HAVE_GUI
     void editConnection();
-    void deleteConnection();
 #endif
 
 };

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -668,3 +668,12 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   OGR_DS_Destroy( hDataSource );
   return item;
 }
+
+QGISEXTERN bool handlesDirectoryPath( const QString &path )
+{
+  QFileInfo info( path );
+  QString suffix = info.suffix().toLower();
+
+  QStringList dirExtensions = directoryExtensions();
+  return dirExtensions.contains( suffix );
+}

--- a/src/providers/ogr/qgsogrdataitems.h
+++ b/src/providers/ogr/qgsogrdataitems.h
@@ -91,7 +91,7 @@ class QgsOgrDataCollectionItem : public QgsDataCollectionItem
      */
     static bool storeConnection( const QString &path, const QString &ogrDriverName );
 
-    /** Utility function to create and tore a new DB connection
+    /** Utility function to create and store a new DB connection
      * \param name is the translatable name of the managed layers (e.g. "GeoPackage")
      * \param extensions is a string with file extensions (e.g. "GeoPackage Database (*.gpkg *.GPKG)")
      * \param ogrDriverName the OGR/GDAL driver name (e.g. "GPKG")

--- a/src/providers/ogr/qgsogrdbconnection.cpp
+++ b/src/providers/ogr/qgsogrdbconnection.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-    qgsogrdbconnection.cpp
+    qgsogrdbconnection.cpp  QgsOgrDbConnection handles connection storage
+                            for OGR/GDAL file-based DBs (i.e. GeoPackage)
                              -------------------
     begin                : August 2017
     copyright            : (C) 2017 by Alessandro Pasotti

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -2171,6 +2171,8 @@ QString createFilters( const QString &type )
   static QString sDirectoryDrivers;
   //! Extensions
   static QStringList sExtensions;
+  //! Directory extensions
+  static QStringList sDirectoryExtensions;
   //! Wildcards
   static QStringList sWildcards;
 
@@ -2238,6 +2240,8 @@ QString createFilters( const QString &type )
       else if ( driverName.startsWith( QLatin1String( "FileGDB" ) ) )
       {
         sDirectoryDrivers += QObject::tr( "ESRI FileGDB" ) + ",FileGDB;";
+        if ( !sDirectoryExtensions.contains( QStringLiteral( "gdb" ) ) )
+          sDirectoryExtensions << QStringLiteral( "gdb" );
       }
       else if ( driverName.startsWith( QLatin1String( "PGeo" ) ) )
       {
@@ -2352,6 +2356,8 @@ QString createFilters( const QString &type )
       else if ( driverName.startsWith( QLatin1String( "OpenFileGDB" ) ) )
       {
         sDirectoryDrivers += QObject::tr( "OpenFileGDB" ) + ",OpenFileGDB;";
+        if ( !sDirectoryExtensions.contains( QStringLiteral( "gdb" ) ) )
+          sDirectoryExtensions << QStringLiteral( "gdb" );
       }
       else if ( driverName.startsWith( QLatin1String( "PostgreSQL" ) ) )
       {
@@ -2567,6 +2573,10 @@ QString createFilters( const QString &type )
   {
     return sExtensions.join( QStringLiteral( "|" ) );
   }
+  if ( type == QStringLiteral( "directory_extensions" ) )
+  {
+    return sDirectoryExtensions.join( QStringLiteral( "|" ) );
+  }
   if ( type == QLatin1String( "wildcards" ) )
   {
     return sWildcards.join( QStringLiteral( "|" ) );
@@ -2621,6 +2631,11 @@ QString QgsOgrProvider::directoryDrivers() const
 QGISEXTERN QStringList fileExtensions()
 {
   return  createFilters( QStringLiteral( "extensions" ) ).split( '|' );
+}
+
+QGISEXTERN QStringList directoryExtensions()
+{
+  return createFilters( QStringLiteral( "directory_extensions" ) ).split( '|' );
 }
 
 QGISEXTERN QStringList wildcards()


### PR DESCRIPTION
## Description

This PR fixes a couple of issues with the gpkg data items in the file browser that now use the geopackage specialized data items and adds the possibility to add/remove gpkg connections from the file browser.

Drag and drop from/to gpkg is now possible in the browser too.

![gpkg-dataitems](https://user-images.githubusercontent.com/142164/30542393-885bbeda-9c7f-11e7-9376-e4318e61876c.png)


