### PR TITLE
Geopackage import multiple files master task

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -328,7 +328,7 @@ bool QgsGeoPackageConnectionItem::handleDrop( const QMimeData *data, Qt::DropAct
     output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QStringLiteral( "\n" ) ), QgsMessageOutput::MessageText );
     output->showMessage();
   }
-  else if ( ! importTasks.isEmpty() )
+  if ( ! importTasks.isEmpty() )
   {
     QgsApplication::taskManager()->addTask( mainTask.release() );
   }

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -193,7 +193,7 @@ bool QgsGeoPackageConnectionItem::handleDrop( const QMimeData *data, Qt::DropAct
   bool hasError = false;
 
   // Main task
-  std::unique_ptr< QgsGeoPackageImportTask > mainTask( new QgsGeoPackageImportTask( tr( "GeoPackage import" ) ) );
+  std::unique_ptr< QgsConcurrentFileWriterImportTask > mainTask( new QgsConcurrentFileWriterImportTask( tr( "GeoPackage import" ) ) );
   QgsTaskList importTasks;
 
   const auto lst = QgsMimeDataUtils::decodeUriList( data );

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -129,13 +129,18 @@ class QgsGeoPackageDataItemProvider : public QgsDataItemProvider
 };
 
 
-class QgsGeoPackageImportTask : public QgsTask
+/**
+ * \brief The QgsConcurrentFileWriterImportTask class is the parent task for
+ * importing layers from a drag and drop operation in the browser.
+ * Individual layers need to be added as individual substask.
+ */
+class QgsConcurrentFileWriterImportTask : public QgsTask
 {
     Q_OBJECT
 
   public:
 
-    QgsGeoPackageImportTask( const QString &desc = QString() ) : QgsTask( desc ) {}
+    QgsConcurrentFileWriterImportTask( const QString &desc = QString() ) : QgsTask( desc ) {}
 
     void emitProgressChanged( double progress ) { setProgress( progress ); }
 

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -18,6 +18,7 @@
 #include "qgsdataitem.h"
 #include "qgsdataitemprovider.h"
 #include "qgsdataprovider.h"
+#include "qgstaskmanager.h"
 
 
 /**
@@ -128,5 +129,24 @@ class QgsGeoPackageDataItemProvider : public QgsDataItemProvider
 };
 
 
+class QgsGeoPackageImportTask : public QgsTask
+{
+    Q_OBJECT
+
+  public:
+
+    QgsGeoPackageImportTask( const QString &desc = QString() ) : QgsTask( desc ) {}
+
+    void emitProgressChanged( double progress ) { setProgress( progress ); }
+
+
+  protected:
+
+    bool run() override
+    {
+      return true;
+    }
+
+};
 
 #endif // QGSGEOPACKAGEDATAITEMS_H


### PR DESCRIPTION
This fixes a problem when importing multiple files
into a gpkg. Previous implementation spawned multiple
independent task causing the import to fail because
of DB being write-locked.

This implementation uses a master task with subtask
and dependencies.

@nyalldawson I'm not sure I'm using the task API right, please also check if the sub tasks do not leak.
