### PR TITLE
[FEATURE] Add 'open directory' action to right click menu for folders in browser dock

### DIFF
--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -533,6 +533,9 @@ Check if the given path is hidden from the browser model
  :rtype: bool
 %End
 
+    virtual QList<QAction *> actions();
+
+
 
   public slots:
     virtual void childrenCreated();

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -27,6 +27,7 @@
 #include <QTreeWidgetItem>
 #include <QVector>
 #include <QStyle>
+#include <QDesktopServices>
 
 #include "qgis.h"
 #include "qgsdataitem.h"
@@ -850,6 +851,18 @@ bool QgsDirectoryItem::hiddenPath( const QString &path )
                             QStringList() ).toStringList();
   int idx = hiddenItems.indexOf( path );
   return ( idx > -1 );
+}
+
+QList<QAction *> QgsDirectoryItem::actions()
+{
+  QList<QAction *> result;
+  QAction *openFolder = new QAction( tr( "Open Directory…" ), this );
+  connect( openFolder, &QAction::triggered, this, [ = ]
+  {
+    QDesktopServices::openUrl( QUrl::fromLocalFile( mDirPath ) );
+  } );
+  result << openFolder;
+  return result;
 }
 
 

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -670,7 +670,7 @@ QgsDataCollectionItem::~QgsDataCollectionItem()
 //-----------------------------------------------------------------------
 
 QgsDirectoryItem::QgsDirectoryItem( QgsDataItem *parent, const QString &name, const QString &path )
-  : QgsDataCollectionItem( parent, name, path )
+  : QgsDataCollectionItem( parent, QDir::toNativeSeparators( name ), path )
   , mDirPath( path )
   , mRefreshLater( false )
 {
@@ -679,7 +679,7 @@ QgsDirectoryItem::QgsDirectoryItem( QgsDataItem *parent, const QString &name, co
 }
 
 QgsDirectoryItem::QgsDirectoryItem( QgsDataItem *parent, const QString &name, const QString &dirPath, const QString &path )
-  : QgsDataCollectionItem( parent, name, path )
+  : QgsDataCollectionItem( parent, QDir::toNativeSeparators( name ), path )
   , mDirPath( dirPath )
   , mRefreshLater( false )
 {

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -689,6 +689,7 @@ QgsDirectoryItem::QgsDirectoryItem( QgsDataItem *parent, const QString &name, co
 
 void QgsDirectoryItem::init()
 {
+  setToolTip( QDir::toNativeSeparators( mDirPath ) );
 }
 
 QIcon QgsDirectoryItem::icon()

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -476,6 +476,8 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
     //! Check if the given path is hidden from the browser model
     static bool hiddenPath( const QString &path );
 
+    QList<QAction *> actions() override;
+
 
   public slots:
     virtual void childrenCreated() override;

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -234,7 +234,7 @@ void QgsBrowserDirectoryProperties::setItem( QgsDataItem *item )
   if ( !item )
     return;
 
-  mPathLabel->setText( directoryItem->dirPath() );
+  mPathLabel->setText( QDir::toNativeSeparators( directoryItem->dirPath() ) );
   mDirectoryWidget = new QgsDirectoryParamWidget( directoryItem->dirPath(), this );
   mLayout->addWidget( mDirectoryWidget );
 }


### PR DESCRIPTION
Allows easy navigation to a folder shown in the dock by opening the OS' native file explorer at that location.