### PR TITLE
[browser] Show QPT print templates and Python scripts

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -981,10 +981,14 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   registerCustomDropHandler( new QgsQlrDropHandler() );
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsQptDataItemProvider() );
   registerCustomDropHandler( new QgsQptDropHandler() );
-
   mSplash->showMessage( tr( "Starting Python" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();
   loadPythonSupport();
+
+#ifdef WITH_BINDINGS
+  QgsApplication::dataItemProviderRegistry()->addProvider( new QgsPyDataItemProvider() );
+  registerCustomDropHandler( new QgsPyDropHandler() );
+#endif
 
   // Create the plugin registry and load plugins
   // load any plugins that were running in the last session

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -979,6 +979,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsQlrDataItemProvider() );
   registerCustomDropHandler( new QgsQlrDropHandler() );
+  QgsApplication::dataItemProviderRegistry()->addProvider( new QgsQptDataItemProvider() );
+  registerCustomDropHandler( new QgsQptDropHandler() );
 
   mSplash->showMessage( tr( "Starting Python" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5554,6 +5554,7 @@ void QgisApp::runScript( const QString &filePath )
 
   mPythonUtils->runString(
     QString( "import sys\n"
+             "from qgis.utils import iface\n"
              "exec(open(\"%1\".replace(\"\\\\\", \"/\").encode(sys.getfilesystemencoding())).read())\n" ).arg( filePath )
     , tr( "Failed to run Python script:" ), false );
 #endif

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -215,6 +215,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Open a composer template file and create a new composition
     void openTemplate( const QString &fileName );
 
+    /** Attempts to run a Python script
+     * \param filePath full path to Python script
+     * \since QGIS 2.7
+     */
+    void runScript( const QString &filePath );
+
     /** Opens a qgis project file
       \returns false if unable to open the project
       */
@@ -1123,12 +1129,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Open the project file corresponding to the
     //! text)= of the given action.
     void openProject( QAction *action );
-
-    /** Attempts to run a Python script
-     * \param filePath full path to Python script
-     * \since QGIS 2.7
-     */
-    void runScript( const QString &filePath );
     //! Save the map view as an image - user is prompted for image name using a dialog
     void saveMapAsImage();
     //! Save the map view as a pdf - user is prompted for image name using a dialog

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsappbrowserproviders.h"
 #include "qgisapp.h"
+#include <QDesktopServices>
 
 //
 // QgsQlrDataItem
@@ -208,12 +209,17 @@ bool QgsPyDataItem::handleDoubleClick()
 
 QList<QAction *> QgsPyDataItem::actions()
 {
-  QAction *runScript = new QAction( tr( "Run Script" ), this );
+  QAction *runScript = new QAction( tr( "&Run Script" ), this );
   connect( runScript, &QAction::triggered, this, [ = ]
   {
     QgisApp::instance()->runScript( path() );
   } );
-  return QList<QAction *>() << runScript ;
+  QAction *editScript = new QAction( tr( "Open in External &Editor" ), this );
+  connect( editScript, &QAction::triggered, this, [ = ]
+  {
+    QDesktopServices::openUrl( QUrl::fromLocalFile( path() ) );
+  } );
+  return QList<QAction *>() << runScript << editScript;
 }
 
 //

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -172,3 +172,97 @@ QList<QAction *> QgsQptDataItem::actions()
   } );
   return QList<QAction *>() << newLayout;
 }
+
+//
+// QgsPyDataItem
+//
+
+QgsPyDataItem::QgsPyDataItem( QgsDataItem *parent, const QString &name, const QString &path )
+  : QgsDataItem( QgsDataItem::Custom, parent, name, path )
+{
+  setState( QgsDataItem::Populated ); // no children
+  setIconName( QStringLiteral( ":/images/icons/qgis-icon-16x16.png" ) );
+  setToolTip( QDir::toNativeSeparators( path ) );
+}
+
+bool QgsPyDataItem::hasDragEnabled() const
+{
+  return true;
+}
+
+QgsMimeDataUtils::Uri QgsPyDataItem::mimeUri() const
+{
+  QgsMimeDataUtils::Uri u;
+  u.layerType = QStringLiteral( "custom" );
+  u.providerKey = QStringLiteral( "py" );
+  u.name = name();
+  u.uri = path();
+  return u;
+}
+
+bool QgsPyDataItem::handleDoubleClick()
+{
+  QgisApp::instance()->runScript( path() );
+  return true;
+}
+
+QList<QAction *> QgsPyDataItem::actions()
+{
+  QAction *runScript = new QAction( tr( "Run Script" ), this );
+  connect( runScript, &QAction::triggered, this, [ = ]
+  {
+    QgisApp::instance()->runScript( path() );
+  } );
+  return QList<QAction *>() << runScript ;
+}
+
+//
+// QgsPyDataItemProvider
+//
+
+QString QgsPyDataItemProvider::name()
+{
+  return QStringLiteral( "py" );
+}
+
+int QgsPyDataItemProvider::capabilities()
+{
+  return QgsDataProvider::File;
+}
+
+QgsDataItem *QgsPyDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
+{
+  QFileInfo fileInfo( path );
+
+  if ( fileInfo.suffix().compare( QStringLiteral( "py" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return new QgsPyDataItem( parentItem, fileInfo.fileName(), path );
+  }
+  return nullptr;
+}
+
+//
+// QgsPyDropHandler
+//
+
+QString QgsPyDropHandler::customUriProviderKey() const
+{
+  return QStringLiteral( "py" );
+}
+
+void QgsPyDropHandler::handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const
+{
+  QString path = uri.uri;
+  QgisApp::instance()->runScript( path );
+}
+
+bool QgsPyDropHandler::handleFileDrop( const QString &file )
+{
+  QFileInfo fi( file );
+  if ( fi.completeSuffix().compare( QStringLiteral( "py" ), Qt::CaseInsensitive ) == 0 )
+  {
+    QgisApp::instance()->runScript( file );
+    return true;
+  }
+  return false;
+}

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -78,3 +78,97 @@ void QgsQlrDropHandler::handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) 
   QString path = uri.uri;
   QgisApp::instance()->openLayerDefinition( path );
 }
+
+//
+// QgsQptDataItemProvider
+//
+
+QString QgsQptDataItemProvider::name()
+{
+  return QStringLiteral( "QPT" );
+}
+
+int QgsQptDataItemProvider::capabilities()
+{
+  return QgsDataProvider::File;
+}
+
+QgsDataItem *QgsQptDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
+{
+  QFileInfo fileInfo( path );
+
+  if ( fileInfo.suffix().compare( QStringLiteral( "qpt" ), Qt::CaseInsensitive ) == 0 )
+  {
+    return new QgsQptDataItem( parentItem, fileInfo.fileName(), path );
+  }
+  return nullptr;
+}
+
+//
+// QgsQptDropHandler
+//
+
+QString QgsQptDropHandler::customUriProviderKey() const
+{
+  return QStringLiteral( "qpt" );
+}
+
+void QgsQptDropHandler::handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const
+{
+  QString path = uri.uri;
+  QgisApp::instance()->openTemplate( path );
+}
+
+bool QgsQptDropHandler::handleFileDrop( const QString &file )
+{
+  QFileInfo fi( file );
+  if ( fi.completeSuffix().compare( QStringLiteral( "qpt" ), Qt::CaseInsensitive ) == 0 )
+  {
+    QgisApp::instance()->openTemplate( file );
+    return true;
+  }
+  return false;
+}
+
+//
+// QgsQptDataItem
+//
+
+QgsQptDataItem::QgsQptDataItem( QgsDataItem *parent, const QString &name, const QString &path )
+  : QgsDataItem( QgsDataItem::Custom, parent, name, path )
+{
+  setState( QgsDataItem::Populated ); // no children
+  setIconName( QStringLiteral( ":/images/icons/qgis-icon-16x16.png" ) );
+  setToolTip( QDir::toNativeSeparators( path ) );
+}
+
+bool QgsQptDataItem::hasDragEnabled() const
+{
+  return true;
+}
+
+QgsMimeDataUtils::Uri QgsQptDataItem::mimeUri() const
+{
+  QgsMimeDataUtils::Uri u;
+  u.layerType = QStringLiteral( "custom" );
+  u.providerKey = QStringLiteral( "qpt" );
+  u.name = name();
+  u.uri = path();
+  return u;
+}
+
+bool QgsQptDataItem::handleDoubleClick()
+{
+  QgisApp::instance()->openTemplate( path() );
+  return true;
+}
+
+QList<QAction *> QgsQptDataItem::actions()
+{
+  QAction *newLayout = new QAction( tr( "New Layout from Template" ), this );
+  connect( newLayout, &QAction::triggered, this, [ = ]
+  {
+    QgisApp::instance()->openTemplate( path() );
+  } );
+  return QList<QAction *>() << newLayout;
+}

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -98,4 +98,46 @@ class QgsQptDropHandler : public QgsCustomDropHandler
 };
 
 
+
+/**
+ * Custom data item for py Python scripts.
+ */
+class QgsPyDataItem : public QgsDataItem
+{
+    Q_OBJECT
+
+  public:
+
+    QgsPyDataItem( QgsDataItem *parent, const QString &name, const QString &path );
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::Uri mimeUri() const override;
+    bool handleDoubleClick() override;
+    QList< QAction * > actions() override;
+
+
+};
+
+/**
+ * Data item provider for showing Python py scripts in the browser.
+ */
+class QgsPyDataItemProvider : public QgsDataItemProvider
+{
+  public:
+    QString name() override;
+    int capabilities() override;
+    QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
+};
+
+/**
+ * Handles drag and drop of Python py scripts to app.
+ */
+class QgsPyDropHandler : public QgsCustomDropHandler
+{
+  public:
+
+    QString customUriProviderKey() const override;
+    void handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const override;
+    bool handleFileDrop( const QString &file ) override;
+};
+
 #endif // QGSAPPBROWSERPROVIDERS_H

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -19,6 +19,9 @@
 #include "qgsdataprovider.h"
 #include "qgscustomdrophandler.h"
 
+/**
+ * Custom data item for QLR files.
+ */
 class QgsQlrDataItem : public QgsLayerItem
 {
     Q_OBJECT
@@ -31,6 +34,9 @@ class QgsQlrDataItem : public QgsLayerItem
 
 };
 
+/**
+ * Data item provider for showing QLR layer files in the browser.
+ */
 class QgsQlrDataItemProvider : public QgsDataItemProvider
 {
   public:
@@ -39,6 +45,9 @@ class QgsQlrDataItemProvider : public QgsDataItemProvider
     QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
 };
 
+/**
+ * Handles drag and drop of QLR files to app.
+ */
 class QgsQlrDropHandler : public QgsCustomDropHandler
 {
   public:
@@ -46,5 +55,47 @@ class QgsQlrDropHandler : public QgsCustomDropHandler
     QString customUriProviderKey() const override;
     void handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const override;
 };
+
+/**
+ * Custom data item for QPT print template files.
+ */
+class QgsQptDataItem : public QgsDataItem
+{
+    Q_OBJECT
+
+  public:
+
+    QgsQptDataItem( QgsDataItem *parent, const QString &name, const QString &path );
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::Uri mimeUri() const override;
+    bool handleDoubleClick() override;
+    QList< QAction * > actions() override;
+
+
+};
+
+/**
+ * Data item provider for showing QPT print templates in the browser.
+ */
+class QgsQptDataItemProvider : public QgsDataItemProvider
+{
+  public:
+    QString name() override;
+    int capabilities() override;
+    QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
+};
+
+/**
+ * Handles drag and drop of QPT print templates to app.
+ */
+class QgsQptDropHandler : public QgsCustomDropHandler
+{
+  public:
+
+    QString customUriProviderKey() const override;
+    void handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const override;
+    bool handleFileDrop( const QString &file ) override;
+};
+
 
 #endif // QGSAPPBROWSERPROVIDERS_H


### PR DESCRIPTION
Adds support for showing and interacting with QPT Print Templates (i.e. creating a new layout from the template) and Python scripts (executing script and opening in an external editor) to browser.

I think this exhausts my list of other "project/layer like" files which I want shown in the browser. Any other ideas for formats which may be handy here?? 