### PR TITLE
[OGR] Defer repacking while in explicit updateMode

### DIFF
--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -252,6 +252,8 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     int mUpdateModeStackDepth;
 
+    bool mDeferRepack;
+
     void computeCapabilities();
 
     QgsVectorDataProvider::Capabilities mCapabilities;

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -459,7 +459,23 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
         # Test the content of the shapefile while it is still opened
         ds = osgeo.ogr.Open(datasource)
         # Test repacking has been done
-        self.assertTrue(ds.GetLayer(0).GetFeatureCount(), feature_count - 1)
+        self.assertTrue(ds.GetLayer(0).GetFeatureCount() == feature_count - 1)
+        ds = None
+
+        # Delete another feature while in update mode
+        self.assertTrue(2 == 2)
+        vl.dataProvider().enterUpdateMode()
+        vl.dataProvider().deleteFeatures([0])
+
+        # Test that repacking has not been done (since in update mode)
+        ds = osgeo.ogr.Open(datasource)
+        self.assertTrue(ds.GetLayer(0).GetFeatureCount() == feature_count - 1)
+        ds = None
+
+        # Test that repacking was performed when leaving updateMode
+        vl.dataProvider().leaveUpdateMode()
+        ds = osgeo.ogr.Open(datasource)
+        self.assertTrue(ds.GetLayer(0).GetFeatureCount() == feature_count - 2)
         ds = None
 
         vl = None


### PR DESCRIPTION
Defer repacking while in explicit update mode.
This allows third-parties, i.e. plugins, to have control over when repacking occurs. This is necessary if plugins rely on stable feature ids while they are processing the layer features, since repacking can lead to feature ids being re-assigned.

See discussion at https://lists.osgeo.org/pipermail/qgis-developer/2017-July/049156.html
