### PR TITLE
Fix browser action item lifetime

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -961,6 +961,8 @@ QgsDataItem        {#qgis_api_break_3_0_QgsDataItem}
 - capabilities() has been removed. Use capabilities2() instead (TODO: rename back to capabilities()).
 - emitBeginInsertItems(), emitEndInsertItems(), emitBeginRemoveItems(), emitEndRemoveItems(), emitDataChanged(), emitStateChanged() have been removed.
 - Favourites was renamed to Favorites
+- actions() now requires a new QWidget parent argument. Subclasses should ensure that returned items have been
+correctly parented to this widget.
 
 QgsDataItemProviderRegistry        {#qgis_api_break_3_0_QgsDataItemProviderRegistry}
 ---------------------------

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -131,10 +131,13 @@ Create new data item.
  :rtype: QWidget
 %End
 
-    virtual QList<QAction *> actions();
+    virtual QList<QAction *> actions( QWidget *parent );
 %Docstring
  Returns the list of actions available for this item. This is usually used for the popup menu on right-clicking
  the item. Subclasses should override this to provide actions.
+
+ Subclasses should ensure that ownership of created actions is correctly handled by parenting them
+ to the specified parent widget.
  :rtype: list of QAction
 %End
 
@@ -543,7 +546,7 @@ Check if the given path is hidden from the browser model
  :rtype: bool
 %End
 
-    virtual QList<QAction *> actions();
+    virtual QList<QAction *> actions( QWidget *parent );
 
 
 

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -511,6 +511,12 @@ bool QgsDataItem::equal( const QgsDataItem *other )
            mPath == other->path() );
 }
 
+QList<QAction *> QgsDataItem::actions( QWidget *parent )
+{
+  Q_UNUSED( parent );
+  return QList<QAction *>();
+}
+
 bool QgsDataItem::handleDoubleClick()
 {
   return false;
@@ -859,10 +865,10 @@ bool QgsDirectoryItem::hiddenPath( const QString &path )
   return ( idx > -1 );
 }
 
-QList<QAction *> QgsDirectoryItem::actions()
+QList<QAction *> QgsDirectoryItem::actions( QWidget *parent )
 {
   QList<QAction *> result;
-  QAction *openFolder = new QAction( tr( "Open Directory…" ), this );
+  QAction *openFolder = new QAction( tr( "Open Directory…" ), parent );
   connect( openFolder, &QAction::triggered, this, [ = ]
   {
     QDesktopServices::openUrl( QUrl::fromLocalFile( mDirPath ) );

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -139,10 +139,14 @@ class CORE_EXPORT QgsDataItem : public QObject
 
     virtual QWidget *paramWidget() SIP_FACTORY { return nullptr; }
 
-    /** Returns the list of actions available for this item. This is usually used for the popup menu on right-clicking
+    /**
+     * Returns the list of actions available for this item. This is usually used for the popup menu on right-clicking
      * the item. Subclasses should override this to provide actions.
+     *
+     * Subclasses should ensure that ownership of created actions is correctly handled by parenting them
+     * to the specified parent widget.
      */
-    virtual QList<QAction *> actions() { return QList<QAction *>(); }
+    virtual QList<QAction *> actions( QWidget *parent );
 
     /** Returns whether the item accepts drag and dropped layers - e.g. for importing a dataset to a provider.
      * Subclasses should override this and handleDrop() to accept dropped layers.
@@ -485,7 +489,7 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
     //! Check if the given path is hidden from the browser model
     static bool hiddenPath( const QString &path );
 
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 
 
   public slots:

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -209,7 +209,7 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
     menu->addAction( tr( "Add a Directory..." ), this, SLOT( addFavoriteDirectory() ) );
   }
 
-  QList<QAction *> actions = item->actions();
+  QList<QAction *> actions = item->actions( menu );
   if ( !actions.isEmpty() )
   {
     if ( !menu->actions().isEmpty() )

--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -50,9 +50,9 @@ QVector<QgsDataItem *> QgsAfsRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsAfsRootItem::actions()
+QList<QAction *> QgsAfsRootItem::actions( QWidget *parent )
 {
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsAfsRootItem::newConnection );
   return QList<QAction *>() << actionNew;
 }
@@ -120,15 +120,15 @@ bool QgsAfsConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsAfsConnectionItem::actions()
+QList<QAction *> QgsAfsConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionEdit = new QAction( tr( "Edit..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsAfsConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsAfsConnectionItem::deleteConnection );
   lst.append( actionDelete );
 

--- a/src/providers/arcgisrest/qgsafsdataitems.h
+++ b/src/providers/arcgisrest/qgsafsdataitems.h
@@ -26,7 +26,7 @@ class QgsAfsRootItem : public QgsDataCollectionItem
     QgsAfsRootItem( QgsDataItem *parent, const QString &name, const QString &path );
     QVector<QgsDataItem *> createChildren() override;
 #ifdef HAVE_GUI
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
     QWidget *paramWidget() override;
 #endif
 
@@ -46,7 +46,7 @@ class QgsAfsConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 #ifdef HAVE_GUI
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -48,9 +48,9 @@ QVector<QgsDataItem *> QgsAmsRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsAmsRootItem::actions()
+QList<QAction *> QgsAmsRootItem::actions( QWidget *parent )
 {
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsAmsRootItem::newConnection );
   return QList<QAction *>() << actionNew;
 }
@@ -136,15 +136,15 @@ bool QgsAmsConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsAmsConnectionItem::actions()
+QList<QAction *> QgsAmsConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionEdit = new QAction( tr( "Edit..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsAmsConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsAmsConnectionItem::deleteConnection );
   lst.append( actionDelete );
 

--- a/src/providers/arcgisrest/qgsamsdataitems.h
+++ b/src/providers/arcgisrest/qgsamsdataitems.h
@@ -29,7 +29,7 @@ class QgsAmsRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    virtual QList<QAction *> actions( QWidget *parent ) override;
     virtual QWidget *paramWidget() override;
 #endif
 
@@ -49,7 +49,7 @@ class QgsAmsConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 #ifdef HAVE_GUI
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -254,15 +254,15 @@ QList<QAction *> QgsDb2ConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionRefresh = new QAction( tr( "Refresh connection" ), parent );
+  QAction *actionRefresh = new QAction( tr( "Refresh Connection" ), parent );
   connect( actionRefresh, &QAction::triggered, this, &QgsDb2ConnectionItem::refreshConnection );
   lst.append( actionRefresh );
 
-  QAction *actionEdit = new QAction( tr( "Edit connection..." ), parent );
+  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsDb2ConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete connection" ), parent );
+  QAction *actionDelete = new QAction( tr( "Delete Connection" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsDb2ConnectionItem::deleteConnection );
   lst.append( actionDelete );
 

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -250,19 +250,19 @@ bool QgsDb2ConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsDb2ConnectionItem::actions()
+QList<QAction *> QgsDb2ConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionRefresh = new QAction( tr( "Refresh connection" ), this );
+  QAction *actionRefresh = new QAction( tr( "Refresh connection" ), parent );
   connect( actionRefresh, &QAction::triggered, this, &QgsDb2ConnectionItem::refreshConnection );
   lst.append( actionRefresh );
 
-  QAction *actionEdit = new QAction( tr( "Edit connection..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit connection..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsDb2ConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete connection" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete connection" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsDb2ConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
@@ -430,14 +430,13 @@ QVector<QgsDataItem *> QgsDb2RootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsDb2RootItem::actions()
+QList<QAction *> QgsDb2RootItem::actions( QWidget *parent )
 {
   QList<QAction *> actionList;
 
-  QAction *action = new QAction( tr( "New Connection..." ), this );
+  QAction *action = new QAction( tr( "New Connection..." ), parent );
   connect( action, &QAction::triggered, this, &QgsDb2RootItem::newConnection );
   actionList.append( action );
-  QgsDebugMsg( "DB2: Browser Panel; New Connection option added." );
 
   return actionList;
 }

--- a/src/providers/db2/qgsdb2dataitems.h
+++ b/src/providers/db2/qgsdb2dataitems.h
@@ -45,7 +45,7 @@ class QgsDb2RootItem : public QgsDataCollectionItem
 #ifdef HAVE_GUI
     virtual QWidget *paramWidget() override;
 
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:
@@ -90,10 +90,7 @@ class QgsDb2ConnectionItem : public QgsDataCollectionItem
 
 #ifdef HAVE_GUI
 
-    /**
-     * Add Refresh, Edit, and Delete actions for every QgsDb2ConnectionItem.
-     */
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     virtual bool acceptDrop() override { return true; }

--- a/src/providers/geonode/qgsgeonodedataitems.cpp
+++ b/src/providers/geonode/qgsgeonodedataitems.cpp
@@ -66,10 +66,10 @@ QVector<QgsDataItem *> QgsGeoNodeConnectionItem::createChildren()
   return services;
 }
 
-QList<QAction *> QgsGeoNodeConnectionItem::actions()
+QList<QAction *> QgsGeoNodeConnectionItem::actions( QWidget *parent )
 {
-  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), this );
-  QAction *actionDelete = new QAction( tr( "Delete Connection" ), this );
+  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), parent );
+  QAction *actionDelete = new QAction( tr( "Delete Connection" ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsGeoNodeConnectionItem::editConnection );
   connect( actionDelete, &QAction::triggered, this, &QgsGeoNodeConnectionItem::deleteConnection );
   return QList<QAction *>() << actionEdit << actionDelete;
@@ -239,9 +239,9 @@ QVector<QgsDataItem *> QgsGeoNodeRootItem::createChildren()
   return connections;
 }
 
-QList<QAction *> QgsGeoNodeRootItem::actions()
+QList<QAction *> QgsGeoNodeRootItem::actions( QWidget *parent )
 {
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsGeoNodeRootItem::newConnection );
   return QList<QAction *>() << actionNew;
 }

--- a/src/providers/geonode/qgsgeonodedataitems.h
+++ b/src/providers/geonode/qgsgeonodedataitems.h
@@ -28,7 +28,7 @@ class QgsGeoNodeConnectionItem : public QgsDataCollectionItem
   public:
     QgsGeoNodeConnectionItem( QgsDataItem *parent, QString name, QString path, std::unique_ptr< QgsGeoNodeConnection > conn );
     QVector<QgsDataItem *> createChildren() override;
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 
     QString mGeoNodeName;
 
@@ -67,7 +67,7 @@ class QgsGeoNodeRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
-    virtual QList<QAction *> actions() override;
+    virtual QList<QAction *> actions( QWidget *parent ) override;
 
   private slots:
     void newConnection();

--- a/src/providers/grass/qgsgrassprovidermodule.cpp
+++ b/src/providers/grass/qgsgrassprovidermodule.cpp
@@ -51,11 +51,11 @@ QgsGrassItemActions::QgsGrassItemActions( const QgsGrassObject &grassObject, boo
 {
 }
 
-QList<QAction *> QgsGrassItemActions::actions()
+QList<QAction *> QgsGrassItemActions::actions( QWidget *parent )
 {
   QList<QAction *> list;
 
-  QAction *optionsAction = new QAction( tr( "GRASS Options" ), this );
+  QAction *optionsAction = new QAction( tr( "GRASS Options" ), parent );
   connect( optionsAction, &QAction::triggered, QgsGrass::instance(), &QgsGrass::openOptions );
   list << optionsAction;
 
@@ -65,14 +65,14 @@ QList<QAction *> QgsGrassItemActions::actions()
   // TODO: check ownership
   if ( mGrassObject.type() == QgsGrassObject::Location )
   {
-    QAction *newMapsetAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "grass_new_mapset.png" ) ), tr( "New mapset" ), this );
+    QAction *newMapsetAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "grass_new_mapset.png" ) ), tr( "New mapset" ), parent );
     connect( newMapsetAction, &QAction::triggered, this, &QgsGrassItemActions::newMapset );
     list << newMapsetAction;
   }
 
   if ( mGrassObject.type() == QgsGrassObject::Mapset && isMapsetOwner )
   {
-    QAction *openMapsetAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "grass_open_mapset.png" ) ), tr( "Open mapset" ), this );
+    QAction *openMapsetAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "grass_open_mapset.png" ) ), tr( "Open mapset" ), parent );
     connect( openMapsetAction, &QAction::triggered, this, &QgsGrassItemActions::openMapset );
     list << openMapsetAction;
   }
@@ -82,13 +82,13 @@ QList<QAction *> QgsGrassItemActions::actions()
   {
     if ( !QgsGrass::instance()->isMapsetInSearchPath( mGrassObject.mapset() ) )
     {
-      QAction *openMapsetAction = new QAction( tr( "Add mapset to search path" ), this );
+      QAction *openMapsetAction = new QAction( tr( "Add mapset to search path" ), parent );
       connect( openMapsetAction, &QAction::triggered, this, &QgsGrassItemActions::addMapsetToSearchPath );
       list << openMapsetAction;
     }
     else
     {
-      QAction *openMapsetAction = new QAction( tr( "Remove mapset from search path" ), this );
+      QAction *openMapsetAction = new QAction( tr( "Remove mapset from search path" ), parent );
       connect( openMapsetAction, &QAction::triggered, this, &QgsGrassItemActions::removeMapsetFromSearchPath );
       list << openMapsetAction;
     }
@@ -97,11 +97,11 @@ QList<QAction *> QgsGrassItemActions::actions()
   if ( ( mGrassObject.type() == QgsGrassObject::Raster || mGrassObject.type() == QgsGrassObject::Vector
          ||  mGrassObject.type() == QgsGrassObject::Group ) && isMapsetOwner )
   {
-    QAction *renameAction = new QAction( tr( "Rename" ), this );
+    QAction *renameAction = new QAction( tr( "Rename" ), parent );
     connect( renameAction, &QAction::triggered, this, &QgsGrassItemActions::renameGrassObject );
     list << renameAction;
 
-    QAction *deleteAction = new QAction( tr( "Delete" ), this );
+    QAction *deleteAction = new QAction( tr( "Delete" ), parent );
     connect( deleteAction, &QAction::triggered, this, &QgsGrassItemActions::deleteGrassObject );
     list << deleteAction;
   }
@@ -110,15 +110,15 @@ QList<QAction *> QgsGrassItemActions::actions()
        && mValid && isMapsetOwner )
   {
     // TODO: disable new layer actions on maps currently being edited
-    QAction *newPointAction = new QAction( tr( "New Point Layer" ), this );
+    QAction *newPointAction = new QAction( tr( "New Point Layer" ), parent );
     connect( newPointAction, &QAction::triggered, this, &QgsGrassItemActions::newPointLayer );
     list << newPointAction;
 
-    QAction *newLineAction = new QAction( tr( "New Line Layer" ), this );
+    QAction *newLineAction = new QAction( tr( "New Line Layer" ), parent );
     connect( newLineAction, &QAction::triggered, this, &QgsGrassItemActions::newLineLayer );
     list << newLineAction;
 
-    QAction *newPolygonAction = new QAction( tr( "New Polygon Layer" ), this );
+    QAction *newPolygonAction = new QAction( tr( "New Polygon Layer" ), parent );
     connect( newPolygonAction, &QAction::triggered, this, &QgsGrassItemActions::newPolygonLayer );
     list << newPolygonAction;
   }
@@ -1178,11 +1178,11 @@ QgsGrassImportItem::~QgsGrassImportItem()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsGrassImportItem::actions()
+QList<QAction *> QgsGrassImportItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionRename = new QAction( tr( "Cancel" ), this );
+  QAction *actionRename = new QAction( tr( "Cancel" ), parent );
   connect( actionRename, &QAction::triggered, this, &QgsGrassImportItem::cancel );
   lst.append( actionRename );
 

--- a/src/providers/grass/qgsgrassprovidermodule.h
+++ b/src/providers/grass/qgsgrassprovidermodule.h
@@ -37,7 +37,7 @@ class QgsGrassItemActions : public QObject
   public:
     QgsGrassItemActions( const QgsGrassObject &grassObject, bool valid, QObject *parent );
 
-    QList<QAction *> actions();
+    QList<QAction *> actions( QWidget *parent );
 
   public slots:
     void newMapset();
@@ -86,7 +86,7 @@ class QgsGrassLocationItem : public QgsDirectoryItem, public QgsGrassObjectItemB
 
     QVector<QgsDataItem *> createChildren() override;
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override { return mActions->actions(); }
+    QList<QAction *> actions( QWidget *parent ) override { return mActions->actions( parent ); }
 #endif
 
   private:
@@ -105,7 +105,7 @@ class QgsGrassMapsetItem : public QgsDirectoryItem, public QgsGrassObjectItemBas
 
     QVector<QgsDataItem *> createChildren() override;
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override { return mActions->actions(); }
+    QList<QAction *> actions( QWidget *parent ) override { return mActions->actions( parent ); }
 #endif
     virtual bool acceptDrop() override;
     virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
@@ -134,7 +134,7 @@ class QgsGrassObjectItem : public QgsLayerItem, public QgsGrassObjectItemBase
                         LayerType layerType, QString providerKey );
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override { return mActions->actions(); }
+    QList<QAction *> actions( QWidget *parent ) override { return mActions->actions( parent ); }
 #endif
     virtual bool equal( const QgsDataItem *other ) override;
 
@@ -153,7 +153,7 @@ class QgsGrassVectorItem : public QgsDataCollectionItem, public QgsGrassObjectIt
     ~QgsGrassVectorItem();
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override { return mActions->actions(); }
+    QList<QAction *> actions( QWidget *parent ) override { return mActions->actions( parent ); }
 #endif
     virtual bool equal( const QgsDataItem *other ) override;
 
@@ -237,7 +237,7 @@ class QgsGrassImportItem : public QgsDataItem, public QgsGrassObjectItemBase
     //  QgsDataItem::setState(state);
     //} // do nothing to keep Populating
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
     virtual QWidget *paramWidget() override;
 #endif
     virtual QIcon icon() override;

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -331,20 +331,20 @@ bool QgsMssqlConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsMssqlConnectionItem::actions()
+QList<QAction *> QgsMssqlConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
-  QAction *actionShowNoGeom = new QAction( tr( "Show Non-Spatial Tables" ), this );
+  QAction *actionShowNoGeom = new QAction( tr( "Show Non-Spatial Tables" ), parent );
   actionShowNoGeom->setCheckable( true );
   actionShowNoGeom->setChecked( mAllowGeometrylessTables );
   connect( actionShowNoGeom, &QAction::toggled, this, &QgsMssqlConnectionItem::setAllowGeometrylessTables );
   lst.append( actionShowNoGeom );
 
-  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsMssqlConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete Connection" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete Connection" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsMssqlConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
@@ -605,11 +605,11 @@ QVector<QgsDataItem *> QgsMssqlRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsMssqlRootItem::actions()
+QList<QAction *> QgsMssqlRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsMssqlRootItem::newConnection );
   lst.append( actionNew );
 

--- a/src/providers/mssql/qgsmssqldataitems.h
+++ b/src/providers/mssql/qgsmssqldataitems.h
@@ -40,7 +40,7 @@ class QgsMssqlRootItem : public QgsDataCollectionItem
 
 #ifdef HAVE_GUI
     virtual QWidget *paramWidget() override;
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:
@@ -60,7 +60,7 @@ class QgsMssqlConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     virtual bool equal( const QgsDataItem *other ) override;
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     virtual bool acceptDrop() override { return true; }

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -70,15 +70,15 @@ QVector<QgsDataItem *> QgsGeoPackageRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsGeoPackageRootItem::actions()
+QList<QAction *> QgsGeoPackageRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsGeoPackageRootItem::newConnection );
   lst.append( actionNew );
 
-  QAction *actionCreateDatabase = new QAction( tr( "Create Database..." ), this );
+  QAction *actionCreateDatabase = new QAction( tr( "Create Database..." ), parent );
   connect( actionCreateDatabase, &QAction::triggered, this, &QgsGeoPackageRootItem::createDatabase );
   lst.append( actionCreateDatabase );
 
@@ -163,26 +163,26 @@ bool QgsGeoPackageCollectionItem::equal( const QgsDataItem *other )
 
 #ifdef HAVE_GUI
 
-QList<QAction *> QgsGeoPackageCollectionItem::actions()
+QList<QAction *> QgsGeoPackageCollectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
   if ( QgsOgrDbConnection::connectionList( QStringLiteral( "GPKG" ) ).contains( mName ) )
   {
-    QAction *actionDeleteConnection = new QAction( tr( "Remove connection" ), this );
+    QAction *actionDeleteConnection = new QAction( tr( "Remove connection" ), parent );
     connect( actionDeleteConnection, &QAction::triggered, this, &QgsGeoPackageConnectionItem::deleteConnection );
     lst.append( actionDeleteConnection );
   }
   else
   {
     // Add to stored connections
-    QAction *actionAddConnection = new QAction( tr( "Add connection" ), this );
+    QAction *actionAddConnection = new QAction( tr( "Add connection" ), parent );
     connect( actionAddConnection, &QAction::triggered, this, &QgsGeoPackageCollectionItem::addConnection );
     lst.append( actionAddConnection );
   }
 
   // Add table to existing DB
-  QAction *actionAddTable = new QAction( tr( "Create a new layer or table..." ), this );
+  QAction *actionAddTable = new QAction( tr( "Create a new layer or table..." ), parent );
   connect( actionAddTable, &QAction::triggered, this, &QgsGeoPackageCollectionItem::addTable );
   lst.append( actionAddTable );
 
@@ -482,16 +482,16 @@ bool QgsGeoPackageConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsGeoPackageConnectionItem::actions()
+QList<QAction *> QgsGeoPackageConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionDeleteConnection = new QAction( tr( "Remove connection" ), this );
+  QAction *actionDeleteConnection = new QAction( tr( "Remove connection" ), parent );
   connect( actionDeleteConnection, &QAction::triggered, this, &QgsGeoPackageConnectionItem::deleteConnection );
   lst.append( actionDeleteConnection );
 
   // Add table to existing DB
-  QAction *actionAddTable = new QAction( tr( "Create a new layer or table..." ), this );
+  QAction *actionAddTable = new QAction( tr( "Create a new layer or table..." ), parent );
   connect( actionAddTable, &QAction::triggered, this, &QgsGeoPackageConnectionItem::addTable );
   lst.append( actionAddTable );
 

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -169,14 +169,14 @@ QList<QAction *> QgsGeoPackageCollectionItem::actions( QWidget *parent )
 
   if ( QgsOgrDbConnection::connectionList( QStringLiteral( "GPKG" ) ).contains( mName ) )
   {
-    QAction *actionDeleteConnection = new QAction( tr( "Remove connection" ), parent );
+    QAction *actionDeleteConnection = new QAction( tr( "Remove Connection" ), parent );
     connect( actionDeleteConnection, &QAction::triggered, this, &QgsGeoPackageConnectionItem::deleteConnection );
     lst.append( actionDeleteConnection );
   }
   else
   {
     // Add to stored connections
-    QAction *actionAddConnection = new QAction( tr( "Add connection" ), parent );
+    QAction *actionAddConnection = new QAction( tr( "Add Connection" ), parent );
     connect( actionAddConnection, &QAction::triggered, this, &QgsGeoPackageCollectionItem::addConnection );
     lst.append( actionAddConnection );
   }
@@ -486,12 +486,12 @@ QList<QAction *> QgsGeoPackageConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionDeleteConnection = new QAction( tr( "Remove connection" ), parent );
+  QAction *actionDeleteConnection = new QAction( tr( "Remove Connection" ), parent );
   connect( actionDeleteConnection, &QAction::triggered, this, &QgsGeoPackageConnectionItem::deleteConnection );
   lst.append( actionDeleteConnection );
 
   // Add table to existing DB
-  QAction *actionAddTable = new QAction( tr( "Create a new layer or table..." ), parent );
+  QAction *actionAddTable = new QAction( tr( "Create a New Layer or Table..." ), parent );
   connect( actionAddTable, &QAction::triggered, this, &QgsGeoPackageConnectionItem::addTable );
   lst.append( actionAddTable );
 
@@ -541,7 +541,7 @@ void QgsGeoPackageCollectionItem::addConnection()
 QList<QAction *> QgsGeoPackageAbstractLayerItem::actions()
 {
   QList<QAction *> lst;
-  QAction *actionDeleteLayer = new QAction( tr( "Delete layer '%1'..." ).arg( mName ), this );
+  QAction *actionDeleteLayer = new QAction( tr( "Delete Layer '%1'..." ).arg( mName ), this );
   connect( actionDeleteLayer, &QAction::triggered, this, &QgsGeoPackageAbstractLayerItem::deleteLayer );
   lst.append( actionDeleteLayer );
   return lst;

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -81,7 +81,7 @@ class QgsGeoPackageCollectionItem : public QgsDataCollectionItem
 #ifdef HAVE_GUI
     virtual bool acceptDrop() override { return true; }
     virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     //! Return the layer type from \a geometryType
@@ -115,7 +115,7 @@ class QgsGeoPackageConnectionItem : public QgsGeoPackageCollectionItem
     virtual bool equal( const QgsDataItem *other ) override;
 
 #ifdef HAVE_GUI
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:
@@ -137,7 +137,7 @@ class QgsGeoPackageRootItem : public QgsDataCollectionItem
 
 #ifdef HAVE_GUI
     virtual QWidget *paramWidget() override;
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 
   public slots:
     void newConnection();

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -275,12 +275,12 @@ QString QgsOgrLayerItem::layerName() const
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsOgrLayerItem::actions()
+QList<QAction *> QgsOgrLayerItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
   // Messages are different for files and tables
   QString message = mIsSubLayer ? QObject::tr( "Delete layer '%1'..." ).arg( mName ) : QObject::tr( "Delete file '%1'..." ).arg( mUri );
-  QAction *actionDeleteLayer = new QAction( message, this );
+  QAction *actionDeleteLayer = new QAction( message, parent );
   connect( actionDeleteLayer, &QAction::triggered, this, &QgsOgrLayerItem::deleteLayer );
   lst.append( actionDeleteLayer );
   return lst;

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -279,7 +279,7 @@ QList<QAction *> QgsOgrLayerItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
   // Messages are different for files and tables
-  QString message = mIsSubLayer ? QObject::tr( "Delete layer '%1'..." ).arg( mName ) : QObject::tr( "Delete file '%1'..." ).arg( mUri );
+  QString message = mIsSubLayer ? QObject::tr( "Delete Layer '%1'..." ).arg( mName ) : QObject::tr( "Delete File '%1'..." ).arg( mUri );
   QAction *actionDeleteLayer = new QAction( message, parent );
   connect( actionDeleteLayer, &QAction::triggered, this, &QgsOgrLayerItem::deleteLayer );
   lst.append( actionDeleteLayer );

--- a/src/providers/ogr/qgsogrdataitems.h
+++ b/src/providers/ogr/qgsogrdataitems.h
@@ -68,7 +68,7 @@ class QgsOgrLayerItem : public QgsLayerItem
     static QgsLayerItem::LayerType layerTypeFromDb( const QString &geometryType );
 
 #ifdef HAVE_GUI
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
   public slots:
     void deleteLayer();
 #endif

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -170,23 +170,23 @@ bool QgsOracleConnectionItem::equal( const QgsDataItem *other )
   return ( mPath == o->mPath && mName == o->mName && o->parent() == parent() );
 }
 
-QList<QAction *> QgsOracleConnectionItem::actions()
+QList<QAction *> QgsOracleConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+  QAction *actionRefresh = new QAction( tr( "Refresh" ), parent );
   connect( actionRefresh, SIGNAL( triggered() ), this, SLOT( refreshConnection() ) );
   lst.append( actionRefresh );
 
-  QAction *separator = new QAction( this );
+  QAction *separator = new QAction( parent );
   separator->setSeparator( true );
   lst.append( separator );
 
-  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), parent );
   connect( actionEdit, SIGNAL( triggered() ), this, SLOT( editConnection() ) );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete Connection" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete Connection" ), parent );
   connect( actionDelete, SIGNAL( triggered() ), this, SLOT( deleteConnection() ) );
   lst.append( actionDelete );
 
@@ -320,11 +320,11 @@ QgsOracleLayerItem::~QgsOracleLayerItem()
 {
 }
 
-QList<QAction *> QgsOracleLayerItem::actions()
+QList<QAction *> QgsOracleLayerItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionDeleteLayer = new QAction( tr( "Delete Table" ), this );
+  QAction *actionDeleteLayer = new QAction( tr( "Delete Table" ), parent );
   connect( actionDeleteLayer, SIGNAL( triggered() ), this, SLOT( deleteLayer() ) );
   lst.append( actionDeleteLayer );
 
@@ -459,11 +459,11 @@ QVector<QgsDataItem *> QgsOracleRootItem::createChildren()
   return connections;
 }
 
-QList<QAction *> QgsOracleRootItem::actions()
+QList<QAction *> QgsOracleRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, SIGNAL( triggered() ), this, SLOT( newConnection() ) );
   lst.append( actionNew );
 

--- a/src/providers/oracle/qgsoracledataitems.h
+++ b/src/providers/oracle/qgsoracledataitems.h
@@ -39,11 +39,11 @@ class QgsOracleRootItem : public QgsDataCollectionItem
     QgsOracleRootItem( QgsDataItem *parent, QString name, QString path );
     ~QgsOracleRootItem();
 
-    QVector<QgsDataItem *> createChildren();
+    QVector<QgsDataItem *> createChildren() override;
 
-    virtual QWidget *paramWidget();
+    virtual QWidget *paramWidget() override;
 
-    virtual QList<QAction *> actions();
+    QList<QAction *> actions( QWidget *parent ) override;
 
     static QMainWindow *sMainWindow;
 
@@ -59,14 +59,14 @@ class QgsOracleConnectionItem : public QgsDataCollectionItem
     QgsOracleConnectionItem( QgsDataItem *parent, QString name, QString path );
     ~QgsOracleConnectionItem();
 
-    QVector<QgsDataItem *> createChildren();
-    virtual bool equal( const QgsDataItem *other );
-    virtual QList<QAction *> actions();
+    QVector<QgsDataItem *> createChildren() override;
+    virtual bool equal( const QgsDataItem *other ) override;
+    QList<QAction *> actions( QWidget *parent ) override;
 
-    virtual bool acceptDrop() { return true; }
-    virtual bool handleDrop( const QMimeData *data, Qt::DropAction action );
+    virtual bool acceptDrop() override { return true; }
+    virtual bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
 
-    void refresh();
+    void refresh() override;
 
   signals:
     void addGeometryColumn( QgsOracleLayerProperty );
@@ -110,7 +110,7 @@ class QgsOracleLayerItem : public QgsLayerItem
 
     QString createUri();
 
-    virtual QList<QAction *> actions();
+    QList<QAction *> actions( QWidget *parent ) override;
 
   public slots:
     void deleteLayer();

--- a/src/providers/ows/qgsowsdataitems.cpp
+++ b/src/providers/ows/qgsowsdataitems.cpp
@@ -134,15 +134,15 @@ bool QgsOWSConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsOWSConnectionItem::actions()
+QList<QAction *> QgsOWSConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionEdit = new QAction( tr( "Edit..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsOWSConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsOWSConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
@@ -212,12 +212,13 @@ QVector<QgsDataItem *> QgsOWSRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsOWSRootItem::actions()
+QList<QAction *> QgsOWSRootItem::actions( QWidget *parent )
 {
+  Q_UNUSED( parent );
   QList<QAction *> lst;
 
 #if 0
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, SIGNAL( triggered() ), this, SLOT( newConnection() ) );
   lst.append( actionNew );
 #endif

--- a/src/providers/ows/qgsowsdataitems.h
+++ b/src/providers/ows/qgsowsdataitems.h
@@ -28,7 +28,7 @@ class QgsOWSConnectionItem : public QgsDataCollectionItem
     virtual bool equal( const QgsDataItem *other ) override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:
@@ -51,7 +51,7 @@ class QgsOWSRootItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
     virtual QWidget *paramWidget() override;
 #endif
 

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -96,19 +96,19 @@ bool QgsPGConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsPGConnectionItem::actions()
+QList<QAction *> QgsPGConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+  QAction *actionRefresh = new QAction( tr( "Refresh" ), parent );
   connect( actionRefresh, &QAction::triggered, this, &QgsPGConnectionItem::refreshConnection );
   lst.append( actionRefresh );
 
-  QAction *separator = new QAction( this );
+  QAction *separator = new QAction( parent );
   separator->setSeparator( true );
   lst.append( separator );
 
-  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit Connection..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsPGConnectionItem::editConnection );
   lst.append( actionEdit );
 
@@ -116,11 +116,11 @@ QList<QAction *> QgsPGConnectionItem::actions()
   connect( actionDelete, &QAction::triggered, this, &QgsPGConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
-  QAction *separator2 = new QAction( this );
+  QAction *separator2 = new QAction( parent );
   separator2->setSeparator( true );
   lst.append( separator2 );
 
-  QAction *actionCreateSchema = new QAction( tr( "Create Schema..." ), this );
+  QAction *actionCreateSchema = new QAction( tr( "Create Schema..." ), parent );
   connect( actionCreateSchema, &QAction::triggered, this, &QgsPGConnectionItem::createSchema );
   lst.append( actionCreateSchema );
 
@@ -303,23 +303,23 @@ QString QgsPGLayerItem::comments() const
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsPGLayerItem::actions()
+QList<QAction *> QgsPGLayerItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
   QString typeName = mLayerProperty.isView ? tr( "View" ) : tr( "Table" );
 
-  QAction *actionRenameLayer = new QAction( tr( "Rename %1..." ).arg( typeName ), this );
+  QAction *actionRenameLayer = new QAction( tr( "Rename %1..." ).arg( typeName ), parent );
   connect( actionRenameLayer, &QAction::triggered, this, &QgsPGLayerItem::renameLayer );
   lst.append( actionRenameLayer );
 
-  QAction *actionDeleteLayer = new QAction( tr( "Delete %1" ).arg( typeName ), this );
+  QAction *actionDeleteLayer = new QAction( tr( "Delete %1" ).arg( typeName ), parent );
   connect( actionDeleteLayer, &QAction::triggered, this, &QgsPGLayerItem::deleteLayer );
   lst.append( actionDeleteLayer );
 
   if ( !mLayerProperty.isView )
   {
-    QAction *actionTruncateLayer = new QAction( tr( "Truncate %1" ).arg( typeName ), this );
+    QAction *actionTruncateLayer = new QAction( tr( "Truncate %1" ).arg( typeName ), parent );
     connect( actionTruncateLayer, &QAction::triggered, this, &QgsPGLayerItem::truncateTable );
     lst.append( actionTruncateLayer );
   }
@@ -529,23 +529,23 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsPGSchemaItem::actions()
+QList<QAction *> QgsPGSchemaItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+  QAction *actionRefresh = new QAction( tr( "Refresh" ), parent );
   connect( actionRefresh, &QAction::triggered, this, static_cast<void ( QgsDataItem::* )()>( &QgsDataItem::refresh ) );
   lst.append( actionRefresh );
 
-  QAction *separator = new QAction( this );
+  QAction *separator = new QAction( parent );
   separator->setSeparator( true );
   lst.append( separator );
 
-  QAction *actionRename = new QAction( tr( "Rename Schema..." ), this );
+  QAction *actionRename = new QAction( tr( "Rename Schema..." ), parent );
   connect( actionRename, &QAction::triggered, this, &QgsPGSchemaItem::renameSchema );
   lst.append( actionRename );
 
-  QAction *actionDelete = new QAction( tr( "Delete Schema" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete Schema" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsPGSchemaItem::deleteSchema );
   lst.append( actionDelete );
 
@@ -725,11 +725,11 @@ QVector<QgsDataItem *> QgsPGRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsPGRootItem::actions()
+QList<QAction *> QgsPGRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsPGRootItem::newConnection );
   lst.append( actionNew );
 

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -39,7 +39,7 @@ class QgsPGRootItem : public QgsDataCollectionItem
 #ifdef HAVE_GUI
     virtual QWidget *paramWidget() override;
 
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     static QMainWindow *sMainWindow;
@@ -60,7 +60,7 @@ class QgsPGConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     virtual bool equal( const QgsDataItem *other ) override;
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     virtual bool acceptDrop() override { return true; }
@@ -92,7 +92,7 @@ class QgsPGSchemaItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     virtual bool acceptDrop() override { return true; }
@@ -120,7 +120,7 @@ class QgsPGLayerItem : public QgsLayerItem
     QString createUri();
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
     virtual QString comments() const override;
 

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -41,11 +41,11 @@ QgsSLLayerItem::QgsSLLayerItem( QgsDataItem *parent, const QString &name, const 
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsSLLayerItem::actions()
+QList<QAction *> QgsSLLayerItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionDeleteLayer = new QAction( tr( "Delete Layer" ), this );
+  QAction *actionDeleteLayer = new QAction( tr( "Delete Layer" ), parent );
   connect( actionDeleteLayer, &QAction::triggered, this, &QgsSLLayerItem::deleteLayer );
   lst.append( actionDeleteLayer );
 
@@ -165,15 +165,15 @@ bool QgsSLConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsSLConnectionItem::actions()
+QList<QAction *> QgsSLConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  //QAction* actionEdit = new QAction( tr( "Edit..." ), this );
+  //QAction* actionEdit = new QAction( tr( "Edit..." ), parent );
   //connect( actionEdit, SIGNAL( triggered() ), this, SLOT( editConnection() ) );
   //lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsSLConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
@@ -295,15 +295,15 @@ QVector<QgsDataItem *> QgsSLRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsSLRootItem::actions()
+QList<QAction *> QgsSLRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsSLRootItem::newConnection );
   lst.append( actionNew );
 
-  QAction *actionCreateDatabase = new QAction( tr( "Create Database..." ), this );
+  QAction *actionCreateDatabase = new QAction( tr( "Create Database..." ), parent );
   connect( actionCreateDatabase, &QAction::triggered, this, &QgsSLRootItem::createDatabase );
   lst.append( actionCreateDatabase );
 

--- a/src/providers/spatialite/qgsspatialitedataitems.h
+++ b/src/providers/spatialite/qgsspatialitedataitems.h
@@ -24,7 +24,7 @@ class QgsSLLayerItem : public QgsLayerItem
     QgsSLLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &uri, LayerType layerType );
 
 #ifdef HAVE_GUI
-    QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:
@@ -43,7 +43,7 @@ class QgsSLConnectionItem : public QgsDataCollectionItem
     virtual bool equal( const QgsDataItem *other ) override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     virtual bool acceptDrop() override { return true; }
@@ -69,7 +69,7 @@ class QgsSLRootItem : public QgsDataCollectionItem
 
 #ifdef HAVE_GUI
     virtual QWidget *paramWidget() override;
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:

--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -86,15 +86,15 @@ bool QgsWCSConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsWCSConnectionItem::actions()
+QList<QAction *> QgsWCSConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionEdit = new QAction( tr( "Edit..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsWCSConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsWCSConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
@@ -246,11 +246,11 @@ QVector<QgsDataItem *>QgsWCSRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsWCSRootItem::actions()
+QList<QAction *> QgsWCSRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsWCSRootItem::newConnection );
   lst.append( actionNew );
 

--- a/src/providers/wcs/qgswcsdataitems.h
+++ b/src/providers/wcs/qgswcsdataitems.h
@@ -30,7 +30,7 @@ class QgsWCSConnectionItem : public QgsDataCollectionItem
     virtual bool equal( const QgsDataItem *other ) override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     QgsWcsCapabilities mWcsCapabilities;
@@ -74,7 +74,7 @@ class QgsWCSRootItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
     virtual QWidget *paramWidget() override;
 #endif
 

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -99,15 +99,15 @@ QVector<QgsDataItem *> QgsWfsConnectionItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsWfsConnectionItem::actions()
+QList<QAction *> QgsWfsConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionEdit = new QAction( tr( "Edit..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsWfsConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsWfsConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
@@ -166,11 +166,11 @@ QVector<QgsDataItem *> QgsWfsRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsWfsRootItem::actions()
+QList<QAction *> QgsWfsRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsWfsRootItem::newConnection );
   lst.append( actionNew );
 

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -31,7 +31,7 @@ class QgsWfsRootItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
     virtual QWidget *paramWidget() override;
 #endif
 
@@ -55,7 +55,7 @@ class QgsWfsConnectionItem : public QgsDataCollectionItem
     //virtual bool equal( const QgsDataItem *other );
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   private slots:

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -200,15 +200,15 @@ bool QgsWMSConnectionItem::equal( const QgsDataItem *other )
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsWMSConnectionItem::actions()
+QList<QAction *> QgsWMSConnectionItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionEdit = new QAction( tr( "Edit..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsWMSConnectionItem::editConnection );
   lst.append( actionEdit );
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsWMSConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
@@ -384,11 +384,11 @@ QVector<QgsDataItem *> QgsWMSRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsWMSRootItem::actions()
+QList<QAction *> QgsWMSRootItem::actions( QWidget *parent )
 {
   QList<QAction *> lst;
 
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsWMSRootItem::newConnection );
   lst.append( actionNew );
 
@@ -485,9 +485,9 @@ QVector<QgsDataItem *> QgsXyzTileRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsXyzTileRootItem::actions()
+QList<QAction *> QgsXyzTileRootItem::actions( QWidget *parent )
 {
-  QAction *actionNew = new QAction( tr( "New Connection..." ), this );
+  QAction *actionNew = new QAction( tr( "New Connection..." ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsXyzTileRootItem::newConnection );
   return QList<QAction *>() << actionNew;
 }
@@ -514,15 +514,15 @@ QgsXyzLayerItem::QgsXyzLayerItem( QgsDataItem *parent, QString name, QString pat
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsXyzLayerItem::actions()
+QList<QAction *> QgsXyzLayerItem::actions( QWidget *parent )
 {
-  QList<QAction *> lst = QgsLayerItem::actions();
+  QList<QAction *> lst = QgsLayerItem::actions( parent );
 
-  QAction *actionEdit = new QAction( tr( "Edit..." ), this );
+  QAction *actionEdit = new QAction( tr( "Edit..." ), parent );
   connect( actionEdit, &QAction::triggered, this, &QgsXyzLayerItem::editConnection );
   lst << actionEdit;
 
-  QAction *actionDelete = new QAction( tr( "Delete" ), this );
+  QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsXyzLayerItem::deleteConnection );
   lst << actionDelete;
 

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -34,7 +34,7 @@ class QgsWMSConnectionItem : public QgsDataCollectionItem
     virtual bool equal( const QgsDataItem *other ) override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    virtual QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:
@@ -102,7 +102,7 @@ class QgsWMSRootItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    virtual QList<QAction *> actions( QWidget *parent ) override;
     virtual QWidget *paramWidget() override;
 #endif
 
@@ -138,7 +138,7 @@ class QgsXyzTileRootItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    virtual QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   private slots:
@@ -155,7 +155,7 @@ class QgsXyzLayerItem : public QgsLayerItem
     QgsXyzLayerItem( QgsDataItem *parent, QString name, QString path, const QString &encodedUri );
 
 #ifdef HAVE_GUI
-    virtual QList<QAction *> actions() override;
+    virtual QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:


### PR DESCRIPTION
Currently most browser item actions are parented to the item itself, which is often long-lived (e.g. connection items which last for the duration of the qgis session). This commit adds an explicit parent widget parameter to QgsDataItem::actions to ensure that the newly created actions are correctly parented to the menu, and deleted after the menu is removed.

Follows the same pattern as discussed in #5207