### PR TITLE
[processing] Proper progress reports during model execution 

### DIFF
--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -176,7 +176,6 @@
 %Include processing/qgsprocessingoutputs.sip
 %Include processing/qgsprocessingparameters.sip
 %Include processing/qgsprocessingutils.sip
-%Include processing/models/qgsprocessingmodelalgorithm.sip
 %Include processing/models/qgsprocessingmodelchildalgorithm.sip
 %Include processing/models/qgsprocessingmodelchildparametersource.sip
 %Include processing/models/qgsprocessingmodelcomponent.sip
@@ -384,6 +383,7 @@
 %Include processing/qgsprocessingfeedback.sip
 %Include processing/qgsprocessingprovider.sip
 %Include processing/qgsprocessingregistry.sip
+%Include processing/models/qgsprocessingmodelalgorithm.sip
 %Include raster/qgsrasterfilewritertask.sip
 %Include raster/qgsrasterlayer.sip
 %Include raster/qgsrasterdataprovider.sip

--- a/python/core/processing/models/qgsprocessingmodelalgorithm.sip
+++ b/python/core/processing/models/qgsprocessingmodelalgorithm.sip
@@ -374,6 +374,8 @@ Translated description of variable
 };
 
 
+
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/qgsfeedback.sip
+++ b/python/core/qgsfeedback.sip
@@ -40,11 +40,6 @@ class QgsFeedback : QObject
 Construct a feedback object
 %End
 
-    void cancel();
-%Docstring
-Tells the internal routines that the current operation should be canceled. This should be run by the main thread
-%End
-
     bool isCanceled() const;
 %Docstring
 Tells whether the operation has been canceled already
@@ -69,6 +64,13 @@ Tells whether the operation has been canceled already
 .. seealso:: progressChanged()
 .. versionadded:: 3.0
  :rtype: float
+%End
+
+  public slots:
+
+    void cancel();
+%Docstring
+Tells the internal routines that the current operation should be canceled. This should be run by the main thread
 %End
 
   signals:

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -682,6 +682,7 @@ SET(QGIS_CORE_MOC_HDRS
   processing/qgsprocessingfeedback.h
   processing/qgsprocessingprovider.h
   processing/qgsprocessingregistry.h
+  processing/models/qgsprocessingmodelalgorithm.h
 
   providers/memory/qgsmemoryprovider.h
 
@@ -978,7 +979,6 @@ SET(QGIS_CORE_HDRS
   processing/qgsprocessingoutputs.h
   processing/qgsprocessingparameters.h
   processing/qgsprocessingutils.h
-  processing/models/qgsprocessingmodelalgorithm.h
   processing/models/qgsprocessingmodelchildalgorithm.h
   processing/models/qgsprocessingmodelchildparametersource.h
   processing/models/qgsprocessingmodelcomponent.h

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -256,8 +256,16 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
 
       QVariantMap childParams = parametersForChildAlgorithm( child, parameters, childResults, expContext );
       feedback->setProgressText( QObject::tr( "Running %1 [%2/%3]" ).arg( child.description() ).arg( executed.count() + 1 ).arg( toExecute.count() ) );
-      //feedback->pushDebugInfo( "Parameters: " + ', '.join( [str( p ).strip() +
-      //           '=' + str( p.value ) for p in alg.algorithm.parameters] ) )
+
+      QStringList params;
+      for ( auto childParamIt = childParams.constBegin(); childParamIt != childParams.constEnd(); ++childParamIt )
+      {
+        params << QStringLiteral( "%1: %2" ).arg( childParamIt.key(),
+               child.algorithm()->parameterDefinition( childParamIt.key() )->valueAsPythonString( childParamIt.value(), context ) );
+      }
+
+      feedback->pushInfo( QObject::tr( "Input Parameters:" ) );
+      feedback->pushCommandInfo( QStringLiteral( "{ %1 }" ).arg( params.join( QStringLiteral( ", " ) ) ) );
 
       QTime childTime;
       childTime.start();
@@ -285,7 +293,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
 
       executed.insert( childId );
       modelFeedback.setCurrentStep( executed.count() );
-      feedback->pushDebugInfo( QObject::tr( "OK. Execution took %1 s (%2 outputs)." ).arg( childTime.elapsed() / 1000.0 ).arg( results.count() ) );
+      feedback->pushInfo( QObject::tr( "OK. Execution took %1 s (%2 outputs)." ).arg( childTime.elapsed() / 1000.0 ).arg( results.count() ) );
     }
 
     if ( feedback && feedback->isCanceled() )

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -403,6 +403,53 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     friend class TestQgsProcessing;
 };
 
+
+#ifndef SIP_RUN
+
+/**
+ * Model algorithm feedback which proxies its calls to an underlying
+ * feedback object, but scales overall progress reports to account
+ * for the number of child steps in a model.
+ */
+class QgsProcessingModelFeedback : public QgsProcessingFeedback
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProcessingModelFeedback, for a model with the specified
+     * number of active child algorithms. This feedback object will proxy calls
+     * to the specified \a feedback object.
+     */
+    QgsProcessingModelFeedback( int childAlgorithmCount, QgsProcessingFeedback *feedback );
+
+    /**
+     * Sets the current child algorithm \a step which is being executed. This is used
+     * to scale the overall progress to account for progress through the overall model.
+     */
+    void setCurrentStep( int step );
+
+    void setProgressText( const QString &text ) override;
+    void reportError( const QString &error ) override;
+    void pushInfo( const QString &info ) override;
+    void pushCommandInfo( const QString &info ) override;
+    void pushDebugInfo( const QString &info ) override;
+    void pushConsoleInfo( const QString &info ) override;
+
+  private slots:
+
+    void updateOverallProgress( double progress );
+
+  private:
+
+    int mChildSteps = 0;
+    int mCurrentStep = 0;
+    QgsProcessingFeedback *mFeedback = nullptr;
+};
+
+#endif
+
 ///@endcond
 
 #endif // QGSPROCESSINGMODELALGORITHM_H

--- a/src/core/qgsfeedback.h
+++ b/src/core/qgsfeedback.h
@@ -50,15 +50,6 @@ class CORE_EXPORT QgsFeedback : public QObject
       , mCanceled( false )
     {}
 
-    //! Tells the internal routines that the current operation should be canceled. This should be run by the main thread
-    void cancel()
-    {
-      if ( mCanceled )
-        return;  // only emit the signal once
-      mCanceled = true;
-      emit canceled();
-    }
-
     //! Tells whether the operation has been canceled already
     bool isCanceled() const { return mCanceled; }
 
@@ -87,6 +78,17 @@ class CORE_EXPORT QgsFeedback : public QObject
      * \since QGIS 3.0
      */
     double progress() const { return mProgress; }
+
+  public slots:
+
+    //! Tells the internal routines that the current operation should be canceled. This should be run by the main thread
+    void cancel()
+    {
+      if ( mCanceled )
+        return;  // only emit the signal once
+      mCanceled = true;
+      emit canceled();
+    }
 
   signals:
     //! Internal routines can connect to this signal if they use event loop


### PR DESCRIPTION
Instead of showing the progress reports for each child algorithm individually, which leads to repeated 0->100% progress for every step of a model, we proxy the progress reports and account for the overall progress through a model as well. This means that the progress accounts for both the progress within the current model step AND the total number of steps left to execute.