### PR TITLE
Set the most accurate User Manual page to Options tabs

### DIFF
--- a/python/gui/qgsoptionswidgetfactory.sip
+++ b/python/gui/qgsoptionswidgetfactory.sip
@@ -25,6 +25,19 @@ class QgsOptionsPageWidget : QWidget
  Constructor for QgsOptionsPageWidget.
 %End
 
+    virtual QString helpKey() const;
+%Docstring
+ Returns the optional help key for the options page. The default implementation
+ returns an empty string.
+
+ If a non-empty string is returned by this method, it will be used as the help key
+ retrieved when the "help" button is clicked while this options page is active.
+
+ If an empty string is returned by this method the default QGIS options
+ help will be retrieved.
+ :rtype: str
+%End
+
   public slots:
 
     virtual void apply() = 0;

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -81,6 +81,9 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
     def apply(self):
         self.config_widget.accept()
 
+    def helpKey(self):
+        return 'processing/toolbox.html#configuring-the-processing-framework'
+
 
 class ConfigDialog(BASE, WIDGET):
 

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -82,7 +82,7 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
         self.config_widget.accept()
 
     def helpKey(self):
-        return 'processing/toolbox.html#configuring-the-processing-framework'
+        return 'processing/index.html'
 
 
 class ConfigDialog(BASE, WIDGET):

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2355,19 +2355,34 @@ void QgsOptions::setZoomFactorValue()
 void QgsOptions::showHelp()
 {
   QWidget *activeTab = mOptionsStackedWidget->currentWidget();
-  QString link = QStringLiteral( "introduction/qgis_configuration.html" );
+  QString link;
 
-  if ( activeTab == mOptionsPageAuth )
+  // give first priority to created pages which have specified a help key
+  for ( const QgsOptionsPageWidget *widget : qgsAsConst( mAdditionalOptionWidgets ) )
   {
-    link = QStringLiteral( "auth_system/index.html" );
+    if ( widget == activeTab )
+    {
+      link = widget->helpKey();
+      break;
+    }
   }
-  else if ( activeTab == mOptionsPageVariables )
+
+  if ( link.isEmpty() )
   {
-    link = QStringLiteral( "introduction/general_tools.html#variables" );
-  }
-  else if ( activeTab == mOptionsPageCRS )
-  {
-    link = QStringLiteral( "working_with_projections/working_with_projections.html" );
+    link = QStringLiteral( "introduction/qgis_configuration.html" );
+
+    if ( activeTab == mOptionsPageAuth )
+    {
+      link = QStringLiteral( "auth_system/index.html" );
+    }
+    else if ( activeTab == mOptionsPageVariables )
+    {
+      link = QStringLiteral( "introduction/general_tools.html#variables" );
+    }
+    else if ( activeTab == mOptionsPageCRS )
+    {
+      link = QStringLiteral( "working_with_projections/working_with_projections.html" );
+    }
   }
   QgsHelp::openHelp( link );
 }

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2354,5 +2354,20 @@ void QgsOptions::setZoomFactorValue()
 
 void QgsOptions::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#options" ) );
+  QWidget *activeTab = mOptionsStackedWidget->currentWidget();
+  QString link = QStringLiteral( "introduction/qgis_configuration.html" );
+
+  if ( activeTab == mOptionsPageAuth )
+  {
+    link = QStringLiteral( "auth_system/index.html" );
+  }
+  else if ( activeTab == mOptionsPageVariables )
+  {
+    link = QStringLiteral( "introduction/general_tools.html#variables" );
+  }
+  else if ( activeTab == mOptionsPageCRS )
+  {
+    link = QStringLiteral( "working_with_projections/working_with_projections.html" );
+  }
+  QgsHelp::openHelp( link );
 }

--- a/src/gui/qgsoptionswidgetfactory.h
+++ b/src/gui/qgsoptionswidgetfactory.h
@@ -38,6 +38,18 @@ class GUI_EXPORT QgsOptionsPageWidget : public QWidget
       : QWidget( parent )
     {}
 
+    /**
+     * Returns the optional help key for the options page. The default implementation
+     * returns an empty string.
+     *
+     * If a non-empty string is returned by this method, it will be used as the help key
+     * retrieved when the "help" button is clicked while this options page is active.
+     *
+     * If an empty string is returned by this method the default QGIS options
+     * help will be retrieved.
+     */
+    virtual QString helpKey() const { return QString(); }
+
   public slots:
 
     /**


### PR DESCRIPTION
Supersedes #5139, adding support for retrieving the correct help page for processing options.