### PR TITLE
[auth] Certs manager remembers (in the settings) the last opened tab

### DIFF
--- a/python/gui/auth/qgsauthcertificatemanager.sip
+++ b/python/gui/auth/qgsauthcertificatemanager.sip
@@ -27,6 +27,11 @@ class QgsAuthCertEditors : QWidget
  \param parent Parent widget
 %End
 
+    ~QgsAuthCertEditors( );
+%Docstring
+ Destructor: store last selected tab
+%End
+
 };
 
 

--- a/src/gui/auth/qgsauthcertificatemanager.cpp
+++ b/src/gui/auth/qgsauthcertificatemanager.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "qgsauthcertificatemanager.h"
+#include "qgssettings.h"
 
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -24,6 +25,14 @@ QgsAuthCertEditors::QgsAuthCertEditors( QWidget *parent )
   : QWidget( parent )
 {
   setupUi( this );
+  QgsSettings settings;
+  tabWidget->setCurrentIndex( settings.value( QStringLiteral( "AuthCertEditorsSelectedTab" ), 0, QgsSettings::Section::Auth ).toInt() );
+}
+
+QgsAuthCertEditors::~QgsAuthCertEditors()
+{
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "AuthCertEditorsSelectedTab" ), tabWidget->currentIndex(), QgsSettings::Section::Auth );
 }
 
 

--- a/src/gui/auth/qgsauthcertificatemanager.h
+++ b/src/gui/auth/qgsauthcertificatemanager.h
@@ -40,6 +40,11 @@ class GUI_EXPORT QgsAuthCertEditors : public QWidget, private Ui::QgsAuthCertMan
      */
     explicit QgsAuthCertEditors( QWidget *parent SIP_TRANSFERTHIS = 0 );
 
+    /**
+     * Destructor: store last selected tab
+     */
+    ~QgsAuthCertEditors( );
+
 };
 
 


### PR DESCRIPTION
This is a minor UX/UI change that remembers the latest opened
tab in the certificates manager window
