### PR TITLE
[FEATURE] Expression function represent_value

### DIFF
--- a/resources/function_help/json/represent_value
+++ b/resources/function_help/json/represent_value
@@ -4,9 +4,9 @@
   "description": "Returns the configured representation value for a field value. It depends on the configured widget type. Often, this is useful for 'Value Map' widgets.",
   "arguments": [
     {"arg":"fieldName", "description": "The field name for which the widget configuration should be loaded."},
-    {"arg":"value", "description": "The value which should be resolved. Most likely a field." },	
+    {"arg":"value", "description": "The value which should be resolved. Most likely a field." }
   ],
   "examples": [
-    { "expression":"represent_value('field_with_value_map', \"field_with_value_map\")", "returns":"Description for value"},
+    { "expression":"represent_value('field_with_value_map', \"field_with_value_map\")", "returns":"Description for value"}
   ]
 }

--- a/resources/function_help/json/represent_value
+++ b/resources/function_help/json/represent_value
@@ -1,0 +1,12 @@
+{
+  "name": "represent_value",
+  "type": "function",
+  "description": "Returns the configured representation value for a field value. It depends on the configured widget type. Often, this is useful for 'Value Map' widgets.",
+  "arguments": [
+    {"arg":"fieldName", "description": "The field name for which the widget configuration should be loaded."},
+    {"arg":"value", "description": "The value which should be resolved. Most likely a field." },	
+  ],
+  "examples": [
+    { "expression":"represent_value('field_with_value_map', \"field_with_value_map\")", "returns":"Description for value"},
+  ]
+}

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -378,6 +378,47 @@ class TestQgsExpression: public QObject
       QCOMPARE( exp.dump(), dump );
     }
 
+    void represent_value()
+    {
+      QVariantMap config;
+      QVariantMap map;
+      map.insert( QStringLiteral( "one" ), QStringLiteral( "1" ) );
+      map.insert( QStringLiteral( "two" ), QStringLiteral( "2" ) );
+      map.insert( QStringLiteral( "three" ), QStringLiteral( "3" ) );
+
+      config.insert( QStringLiteral( "map" ), map );
+      mPointsLayer->setEditorWidgetSetup( 3, QgsEditorWidgetSetup( QStringLiteral( "ValueMap" ), config ) );
+
+      // Usage on a value map
+      QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mPointsLayer ) );
+      QgsExpression expression( "represent_value('Pilots', \"Pilots\")" );
+      if ( expression.hasParserError() )
+        qDebug() << expression.parserErrorString();
+      Q_ASSERT( !expression.hasParserError() );
+      if ( expression.hasEvalError() )
+        qDebug() << expression.evalErrorString();
+      Q_ASSERT( !expression.hasEvalError() );
+      expression.prepare( &context );
+
+      QgsFeature feature;
+      mPointsLayer->getFeatures( QgsFeatureRequest().setFilterExpression( "Pilots = 1" ) ).nextFeature( feature );
+      context.setFeature( feature );
+      QCOMPARE( expression.evaluate( &context ).toString(), QStringLiteral( "one" ) );
+
+      // Usage on a simple string
+      QgsExpression expression2( "represent_value('Class', \"Class\")" );
+      if ( expression2.hasParserError() )
+        qDebug() << expression2.parserErrorString();
+      Q_ASSERT( !expression2.hasParserError() );
+      if ( expression2.hasEvalError() )
+        qDebug() << expression2.evalErrorString();
+      Q_ASSERT( !expression2.hasEvalError() );
+      expression2.prepare( &context );
+      mPointsLayer->getFeatures( QgsFeatureRequest().setFilterExpression( "Class = 'Jet'" ) ).nextFeature( feature );
+      context.setFeature( feature );
+      QCOMPARE( expression2.evaluate( &context ).toString(), QStringLiteral( "Jet" ) );
+    }
+
     void evaluation_data()
     {
       QTest::addColumn<QString>( "string" );


### PR DESCRIPTION
This will lookup the representation value given the widget
configuration. This is helpful to get nicely formatted messages for
value maps, value relations and others in expressions.

```
represent_value('my_field', "my_field")
```

Returns the represented value. E.g. 'One' for a value 1 and a value map `{1: 'one', 2: 'two', 3: 'three'}`