### PR TITLE
More efficient use of QStrings

### DIFF
--- a/src/app/composer/qgscomposermapgridwidget.cpp
+++ b/src/app/composer/qgscomposermapgridwidget.cpp
@@ -438,7 +438,7 @@ bool QgsComposerMapGridWidget::hasPredefinedScales() const
     QgsSettings settings;
     QString scalesStr( settings.value( QStringLiteral( "Map/scales" ), PROJECT_SCALES ).toString() );
     QStringList myScalesList = scalesStr.split( ',' );
-    return !myScalesList.isEmpty() && myScalesList[0] != QLatin1String( "" );
+    return !myScalesList.isEmpty() && !myScalesList[0].isEmpty();
   }
   return true;
 }

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -1051,7 +1051,7 @@ bool QgsComposerMapWidget::hasPredefinedScales() const
     QgsSettings settings;
     QString scalesStr( settings.value( QStringLiteral( "Map/scales" ), PROJECT_SCALES ).toString() );
     QStringList myScalesList = scalesStr.split( ',' );
-    return !myScalesList.isEmpty() && myScalesList[0] != QLatin1String( "" );
+    return !myScalesList.isEmpty() && !myScalesList[0].isEmpty();
   }
   return true;
 }

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -564,7 +564,7 @@ int QgsComposerPictureWidget::addDirectoryToPreview( const QString &path )
       listItem->setIcon( icon );
     }
 
-    listItem->setText( QLatin1String( "" ) );
+    listItem->setText( QString() );
     //store the absolute icon file path as user data
     listItem->setData( Qt::UserRole, fileIt->absoluteFilePath() );
     ++counter;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -168,7 +168,7 @@ void usage( const QString &appName )
 // AppleEvent handler as well as by the main routine argv processing
 
 // This behavior will cause QGIS to autoload a project
-static QString sProjectFileName = QLatin1String( "" );
+static QString sProjectFileName;
 
 // This is the 'leftover' arguments collection
 static QStringList sFileList;
@@ -492,8 +492,8 @@ int main( int argc, char *argv[] )
 
   // This behavior is used to load the app, snapshot the map,
   // save the image to disk and then exit
-  QString mySnapshotFileName = QLatin1String( "" );
-  QString configLocalStorageLocation = QLatin1String( "" );
+  QString mySnapshotFileName;
+  QString configLocalStorageLocation;
   QString profileName;
   int mySnapshotWidth = 800;
   int mySnapshotHeight = 600;
@@ -520,7 +520,7 @@ int main( int argc, char *argv[] )
   // there are no command line arguments. This gives a usable map
   // extent when qgis starts with no layers loaded. When layers are
   // loaded, we let the layers define the initial extent.
-  QString myInitialExtent = QLatin1String( "" );
+  QString myInitialExtent;
   if ( argc == 1 )
     myInitialExtent = QStringLiteral( "-1,-1,1,1" );
 
@@ -1238,7 +1238,7 @@ int main( int argc, char *argv[] )
   /////////////////////////////////`////////////////////////////////////
   // Take a snapshot of the map view then exit if snapshot mode requested
   /////////////////////////////////////////////////////////////////////
-  if ( mySnapshotFileName != QLatin1String( "" ) )
+  if ( !mySnapshotFileName.isEmpty() )
   {
     /*You must have at least one paintEvent() delivered for the window to be
       rendered properly.

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -622,20 +622,19 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     return;
   }
 
-  QString html = QLatin1String( "" );
-  html += "<style>"
-          "  body, table {"
-          "    padding:0px;"
-          "    margin:0px;"
-          "    font-family:verdana;"
-          "    font-size: 10pt;"
-          "  }"
-          "  div#votes {"
-          "    width:360px;"
-          "    margin-left:98px;"
-          "    padding-top:3px;"
-          "  }"
-          "</style>";
+  QString html = "<style>"
+                 "  body, table {"
+                 "    padding:0px;"
+                 "    margin:0px;"
+                 "    font-family:verdana;"
+                 "    font-size: 10pt;"
+                 "  }"
+                 "  div#votes {"
+                 "    width:360px;"
+                 "    margin-left:98px;"
+                 "    padding-top:3px;"
+                 "  }"
+                 "</style>";
 
   if ( !metadata->value( QStringLiteral( "plugin_id" ) ).isEmpty() )
   {
@@ -1135,7 +1134,7 @@ void QgsPluginManager::setCurrentTab( int idx )
     mModelProxy->setAcceptedStatuses( acceptedStatuses );
 
     // load tab description HTML to the detail browser
-    QString tabInfoHTML = QLatin1String( "" );
+    QString tabInfoHTML;
     QMap<QString, QString>::const_iterator it = mTabDescriptions.constFind( tabTitle );
     if ( it != mTabDescriptions.constEnd() )
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5792,7 +5792,7 @@ void QgisApp::saveMapAsPdf()
 //overloaded version of the above function
 void QgisApp::saveMapAsImage( const QString &imageFileNameQString, QPixmap *theQPixmap )
 {
-  if ( imageFileNameQString == QLatin1String( "" ) )
+  if ( imageFileNameQString.isEmpty() )
   {
     //no fileName chosen
     return;
@@ -9913,7 +9913,7 @@ void QgisApp::setExtent( const QgsRectangle &rect )
  */
 bool QgisApp::saveDirty()
 {
-  QString whyDirty = QLatin1String( "" );
+  QString whyDirty;
   bool hasUnsavedEdits = false;
   // extra check to see if there are any vector layers with unsaved provider edits
   // to ensure user has opportunity to save any editing

--- a/src/app/qgsabout.cpp
+++ b/src/app/qgsabout.cpp
@@ -186,7 +186,7 @@ void QgsAbout::init()
 #endif
   if ( translatorFile.open( QIODevice::ReadOnly ) )
   {
-    QString translatorHTML = QLatin1String( "" );
+    QString translatorHTML;
     QTextStream translatorStream( &translatorFile );
     // Always use UTF-8
     translatorStream.setCodec( "UTF-8" );

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -308,7 +308,7 @@ bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem myCRS, con
 void QgsCustomProjectionDialog::on_pbnAdd_clicked()
 {
   QString name = tr( "new CRS" );
-  QString id = QLatin1String( "" );
+  QString id;
   QgsCoordinateReferenceSystem parameters;
 
   QTreeWidgetItem *newItem = new QTreeWidgetItem( leNameList, QStringList() );
@@ -331,7 +331,7 @@ void QgsCustomProjectionDialog::on_pbnRemove_clicked()
   }
   QTreeWidgetItem *item = leNameList->takeTopLevelItem( i );
   delete item;
-  if ( customCRSids[i] != QLatin1String( "" ) )
+  if ( !customCRSids[i].isEmpty() )
   {
     deletedCRSs.push_back( customCRSids[i] );
   }
@@ -361,8 +361,8 @@ void QgsCustomProjectionDialog::on_leNameList_currentItemChanged( QTreeWidgetIte
   else
   {
     //Can happen that current is null, for example if we just deleted the last element
-    leName->setText( QLatin1String( "" ) );
-    teParameters->setPlainText( QLatin1String( "" ) );
+    leName->clear();
+    teParameters->clear();
     return;
   }
 }
@@ -415,7 +415,7 @@ void QgsCustomProjectionDialog::on_buttonBox_accepted()
   {
     CRS.createFromProj4( customCRSparameters[i] );
     //Test if we just added this CRS (if it has no existing ID)
-    if ( customCRSids[i] == QLatin1String( "" ) )
+    if ( !customCRSids[i].isEmpty() )
     {
       save_success &= saveCrs( CRS, customCRSnames[i], QLatin1String( "" ), true );
     }
@@ -462,8 +462,8 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
   {
     QMessageBox::information( this, tr( "QGIS Custom Projection" ),
                               tr( "This proj4 projection definition is not valid." ) );
-    projectedX->setText( QLatin1String( "" ) );
-    projectedY->setText( QLatin1String( "" ) );
+    projectedX->clear();
+    projectedY->clear();
     pj_free( myProj );
     pj_ctx_free( pContext );
     return;
@@ -478,8 +478,8 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
   {
     QMessageBox::information( this, tr( "QGIS Custom Projection" ),
                               tr( "Northing and Easthing must be in decimal form." ) );
-    projectedX->setText( QLatin1String( "" ) );
-    projectedY->setText( QLatin1String( "" ) );
+    projectedX->clear();
+    projectedY->clear();
     pj_free( myProj );
     pj_ctx_free( pContext );
     return;
@@ -491,8 +491,8 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
   {
     QMessageBox::information( this, tr( "QGIS Custom Projection" ),
                               tr( "Internal Error (source projection invalid?)" ) );
-    projectedX->setText( QLatin1String( "" ) );
-    projectedY->setText( QLatin1String( "" ) );
+    projectedX->clear();
+    projectedY->clear();
     pj_free( wgs84Proj );
     pj_ctx_free( pContext );
     return;

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -110,8 +110,8 @@ void QgsDecorationGrid::projectRead()
   mGridAnnotationPosition = InsideMapFrame; // don't allow outside frame, doesn't make sense
   mGridAnnotationDirection = static_cast< GridAnnotationDirection >( QgsProject::instance()->readNumEntry( mNameConfig,
                              QStringLiteral( "/AnnotationDirection" ), 0 ) );
-  QString fontStr = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/AnnotationFont" ), QLatin1String( "" ) );
-  if ( fontStr != QLatin1String( "" ) )
+  QString fontStr = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/AnnotationFont" ), QString() );
+  if ( !fontStr.isEmpty() )
   {
     mGridAnnotationFont.fromString( fontStr );
   }
@@ -134,7 +134,7 @@ void QgsDecorationGrid::projectRead()
   if ( mLineSymbol )
     setLineSymbol( nullptr );
   xml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/LineSymbol" ) );
-  if ( xml != QLatin1String( "" ) )
+  if ( !xml.isEmpty() )
   {
     doc.setContent( xml );
     elem = doc.documentElement();
@@ -146,7 +146,7 @@ void QgsDecorationGrid::projectRead()
   if ( mMarkerSymbol )
     setMarkerSymbol( nullptr );
   xml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/MarkerSymbol" ) );
-  if ( xml != QLatin1String( "" ) )
+  if ( !xml.isEmpty() )
   {
     doc.setContent( xml );
     elem = doc.documentElement();

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -380,7 +380,7 @@ void QgsMapSaveDialog::onAccepted()
   if ( mDialogType == Image )
   {
     QPair< QString, QString> fileNameAndFilter = QgsGuiUtils::getSaveAsImageName( QgisApp::instance(), tr( "Choose a file name to save the map image as" ) );
-    if ( fileNameAndFilter.first != QLatin1String( "" ) )
+    if ( !fileNameAndFilter.first.isEmpty() )
     {
       QgsMapSettings ms = QgsMapSettings();
       applyMapSettings( ms );

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -340,7 +340,7 @@ bool QgsNewSpatialiteLayerDialog::apply()
 {
   // Build up the sql statement for creating the table
   QString sql = QStringLiteral( "create table %1(" ).arg( quotedIdentifier( leLayerName->text() ) );
-  QString delim = QLatin1String( "" );
+  QString delim;
 
   if ( checkBoxPrimaryKey->isChecked() )
   {

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1867,8 +1867,8 @@ void QgsProjectProperties::updateEllipsoidUI( int newIndex )
   mEllipsoidIndex = newIndex;
   leSemiMajor->setEnabled( false );
   leSemiMinor->setEnabled( false );
-  leSemiMajor->setText( QLatin1String( "" ) );
-  leSemiMinor->setText( QLatin1String( "" ) );
+  leSemiMajor->clear();
+  leSemiMinor->clear();
 
   cmbEllipsoid->setEnabled( projectionSelector->crs().isValid() );
   cmbEllipsoid->setToolTip( QLatin1String( "" ) );

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -88,7 +88,7 @@ void QgsRelationManagerDialog::on_mBtnAddRelation_clicked()
     relation.setReferencingLayer( addDlg.referencingLayerId() );
     relation.setReferencedLayer( addDlg.referencedLayerId() );
     QString relationId = addDlg.relationId();
-    if ( addDlg.relationId() == QLatin1String( "" ) )
+    if ( addDlg.relationId().isEmpty() )
       relationId = QStringLiteral( "%1_%2_%3_%4" )
                    .arg( addDlg.referencingLayerId(),
                          addDlg.references().at( 0 ).first,

--- a/src/app/qgsversioninfo.cpp
+++ b/src/app/qgsversioninfo.cpp
@@ -79,7 +79,7 @@ void QgsVersionInfo::versionReplyFinished()
       mErrorString = tr( "The host name %1 could not be resolved. Check your DNS settings or contact your system administrator." ).arg( reply->request().url().host() );
       break;
     case QNetworkReply::NoError:
-      mErrorString = QLatin1String( "" );
+      mErrorString.clear();
       break;
     default:
       mErrorString = reply->errorString();

--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -150,7 +150,7 @@ QVariant QgsWelcomePageItemsModel::data( const QModelIndex &index, int role ) co
     case PathRole:
       return QDir::toNativeSeparators( mRecentProjects.at( index.row() ).path );
     case CrsRole:
-      if ( mRecentProjects.at( index.row() ).crs != QLatin1String( "" ) )
+      if ( !mRecentProjects.at( index.row() ).crs.isEmpty() )
       {
         QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mRecentProjects.at( index.row() ).crs );
         return  QStringLiteral( "%1 (%2)" ).arg( mRecentProjects.at( index.row() ).crs, crs.description() );

--- a/src/auth/pkipaths/qgsauthpkipathsedit.cpp
+++ b/src/auth/pkipaths/qgsauthpkipathsedit.cpp
@@ -162,10 +162,7 @@ void QgsAuthPkiPathsEdit::writePkiMessage( QLineEdit *lineedit, const QString &m
       txt = tr( "Invalid: %1" ).arg( msg );
       break;
     case Unknown:
-      ss = QLatin1String( "" );
       break;
-    default:
-      ss = QLatin1String( "" );
   }
   lineedit->setStyleSheet( ss );
   lineedit->setText( txt );

--- a/src/auth/pkipkcs12/qgsauthpkcs12edit.cpp
+++ b/src/auth/pkipkcs12/qgsauthpkcs12edit.cpp
@@ -167,10 +167,7 @@ void QgsAuthPkcs12Edit::writePkiMessage( QLineEdit *lineedit, const QString &msg
       txt = tr( "Invalid: %1" ).arg( msg );
       break;
     case Unknown:
-      ss = QLatin1String( "" );
       break;
-    default:
-      ss = QLatin1String( "" );
   }
   lineedit->setStyleSheet( ss );
   lineedit->setText( txt );

--- a/src/core/annotations/qgshtmlannotation.cpp
+++ b/src/core/annotations/qgshtmlannotation.cpp
@@ -61,7 +61,7 @@ void QgsHtmlAnnotation::setSourceFile( const QString &htmlFile )
   mHtmlFile = htmlFile;
   if ( !file.open( QIODevice::ReadOnly | QIODevice::Text ) )
   {
-    mHtmlSource = QLatin1String( "" );
+    mHtmlSource.clear();
   }
   else
   {

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -804,7 +804,7 @@ const QString QgsAuthManager::uniqueConfigId() const
 
   while ( true )
   {
-    id = QLatin1String( "" );
+    id.clear();
     for ( int i = 0; i < len; i++ )
     {
       switch ( qrand() % 2 )
@@ -3025,7 +3025,7 @@ void QgsAuthManager::setPasswordHelperLoggingEnabled( const bool enabled )
 void QgsAuthManager::passwordHelperClearErrors()
 {
   mPasswordHelperErrorCode = QKeychain::NoError;
-  mPasswordHelperErrorMessage = QLatin1String( "" );
+  mPasswordHelperErrorMessage.clear();
 }
 
 void QgsAuthManager::passwordHelperProcessError()

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -158,22 +158,22 @@ QgsMemoryProvider::QgsMemoryProvider( const QString &uri )
           length = -1;
         }
 
-        if ( reFieldDef.cap( 2 ) != QLatin1String( "" ) )
+        if ( !reFieldDef.cap( 2 ).isEmpty() )
         {
           length = reFieldDef.cap( 2 ).toInt();
         }
-        if ( reFieldDef.cap( 3 ) != QLatin1String( "" ) )
+        if ( !reFieldDef.cap( 3 ).isEmpty() )
         {
           precision = reFieldDef.cap( 3 ).toInt();
         }
-        if ( reFieldDef.cap( 4 ) != QLatin1String( "" ) )
+        if ( !reFieldDef.cap( 4 ).isEmpty() )
         {
           //array
           subType = type;
           type = ( subType == QVariant::String ? QVariant::StringList : QVariant::List );
         }
       }
-      if ( name != QLatin1String( "" ) )
+      if ( !name.isEmpty() )
         attributes.append( QgsField( name, type, typeName, length, precision, QLatin1String( "" ), subType ) );
     }
     addAttributes( attributes );

--- a/src/core/qgscolorramp.cpp
+++ b/src/core/qgscolorramp.cpp
@@ -691,7 +691,7 @@ QgsStringMap QgsCptCityColorRamp::properties() const
 
 QString QgsCptCityColorRamp::fileName() const
 {
-  if ( mSchemeName == QLatin1String( "" ) )
+  if ( mSchemeName.isEmpty() )
     return QString();
   else
   {

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -83,7 +83,7 @@ QgsDataSourceUri::QgsDataSourceUri( QString uri )
         }
         else
         {
-          mSchema = QLatin1String( "" );
+          mSchema.clear();
           mTable = pval;
         }
 
@@ -376,7 +376,7 @@ void QgsDataSourceUri::setSql( const QString &sql )
 
 void QgsDataSourceUri::clearSchema()
 {
-  mSchema = QLatin1String( "" );
+  mSchema.clear();
 }
 
 void QgsDataSourceUri::setSchema( const QString &schema )
@@ -472,36 +472,36 @@ QString QgsDataSourceUri::connectionInfo( bool expandAuthConfig ) const
 {
   QStringList connectionItems;
 
-  if ( mDatabase != QLatin1String( "" ) )
+  if ( !mDatabase.isEmpty() )
   {
     connectionItems << "dbname='" + escape( mDatabase ) + '\'';
   }
 
-  if ( mService != QLatin1String( "" ) )
+  if ( !mService.isEmpty() )
   {
     connectionItems << "service='" + escape( mService ) + '\'';
   }
-  else if ( mHost != QLatin1String( "" ) )
+  else if ( !mHost.isEmpty() )
   {
     connectionItems << "host=" + mHost;
   }
 
   if ( mService.isEmpty() )
   {
-    if ( mPort != QLatin1String( "" ) )
+    if ( !mPort.isEmpty() )
       connectionItems << "port=" + mPort;
   }
 
-  if ( mDriver != QLatin1String( "" ) )
+  if ( !mDriver.isEmpty() )
   {
     connectionItems << "driver='" + escape( mDriver ) + '\'';
   }
 
-  if ( mUsername != QLatin1String( "" ) )
+  if ( !mUsername.isEmpty() )
   {
     connectionItems << "user='" + escape( mUsername ) + '\'';
 
-    if ( mPassword != QLatin1String( "" ) )
+    if ( !mPassword.isEmpty() )
     {
       connectionItems << "password='" + escape( mPassword ) + '\'';
     }

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -221,7 +221,7 @@ QStringList QgsMimeDataUtils::decode( const QString &encoded )
     else if ( c == ':' && !inEscape )
     {
       items.append( item );
-      item = QLatin1String( "" );
+      item.clear();
     }
     else
     {

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -495,11 +495,11 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
 
   // create table
   QString sql = QStringLiteral( "CREATE TABLE '%1' (" ).arg( tableName );
-  QString delim = QLatin1String( "" );
+  QString delim;
   const QgsFields providerFields = layer->dataProvider()->fields();
   for ( const auto &field : providerFields )
   {
-    QString dataType = QLatin1String( "" );
+    QString dataType;
     QVariant::Type type = field.type();
     if ( type == QVariant::Int || type == QVariant::LongLong )
     {
@@ -528,7 +528,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
   // add geometry column
   if ( layer->isSpatial() )
   {
-    QString geomType = QLatin1String( "" );
+    QString geomType;
     switch ( layer->wkbType() )
     {
       case QgsWkbTypes::Point:

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -240,7 +240,6 @@ QgsPalLayerSettings::QgsPalLayerSettings()
   useSubstitutions = false;
 
   // text formatting
-  wrapChar = QLatin1String( "" );
   multilineAlign = MultiFollowPlacement;
   addDirectionSymbol = false;
   leftDirectionSymbol = QStringLiteral( "<" );

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -583,7 +583,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
 {
   QDomNodeList nl = doc.elementsByTagName( QStringLiteral( "title" ) );
 
-  title = QLatin1String( "" );               // by default the title will be empty
+  title.clear();               // by default the title will be empty
 
   if ( !nl.count() )
   {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1349,7 +1349,7 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, const QgsReadWriteCont
 
   if ( pkeyNode.isNull() )
   {
-    mProviderKey = QLatin1String( "" );
+    mProviderKey.clear();
   }
   else
   {
@@ -4000,7 +4000,7 @@ QString QgsVectorLayer::htmlMetadata() const
   for ( int i = 0; i < myFields.size(); ++i )
   {
     QgsField myField = myFields.at( i );
-    QString rowClass = QLatin1String( "" );
+    QString rowClass;
     if ( i % 2 )
       rowClass = QStringLiteral( "class=\"odd-row\"" );
     myMetadata += "<tr " + rowClass + "><td>" + myField.name() + "</td><td>" + myField.typeName() + "</td><td>" + QString::number( myField.length() ) + "</td><td>" + QString::number( myField.precision() ) + "</td><td>" + myField.comment() + "</td></tr>\n";

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -428,7 +428,7 @@ QString QgsRasterLayer::htmlMetadata() const
   QgsRasterDataProvider *provider = const_cast< QgsRasterDataProvider * >( mDataProvider );
   for ( int i = 1; i <= bandCount(); i++ )
   {
-    QString rowClass = QLatin1String( "" );
+    QString rowClass;
     if ( i % 2 )
       rowClass = QStringLiteral( "class=\"odd-row\"" );
     myMetadata += "<tr " + rowClass + "><td>" + QString::number( i ) + "</td><td>" + bandName( i ) + "</td><td>";

--- a/src/core/symbology/qgscptcityarchive.cpp
+++ b/src/core/symbology/qgscptcityarchive.cpp
@@ -140,7 +140,7 @@ QString QgsCptCityArchive::findFileName( const QString &target, const QString &s
 {
   // QgsDebugMsg( "target= " + target +  " startDir= " + startDir +  " baseDir= " + baseDir );
 
-  if ( startDir == QLatin1String( "" ) || ! startDir.startsWith( baseDir ) )
+  if ( startDir.isEmpty() || ! startDir.startsWith( baseDir ) )
     return QString();
 
   QDir dir = QDir( startDir );
@@ -751,7 +751,7 @@ void QgsCptCityColorRampItem::init()
   }
   else
   {
-    mInfo = QLatin1String( "" );
+    mInfo.clear();
   }
 
 }
@@ -797,7 +797,7 @@ QIcon QgsCptCityColorRampItem::icon( QSize size )
     QPixmap blankPixmap( size );
     blankPixmap.fill( Qt::white );
     icon = QIcon( blankPixmap );
-    mInfo = QLatin1String( "" );
+    mInfo.clear();
   }
 
   mIcons.append( icon );
@@ -877,7 +877,7 @@ QgsCptCityDirectoryItem::QgsCptCityDirectoryItem( QgsCptCityDataItem *parent,
   }
 
   // parse DESC.xml to get mInfo
-  mInfo = QLatin1String( "" );
+  mInfo.clear();
   QString fileName = QgsCptCityArchive::defaultBaseDir() + '/' +
                      mPath + '/' + "DESC.xml";
   QgsStringMap descMap = QgsCptCityArchive::description( fileName );
@@ -944,7 +944,7 @@ QMap< QString, QStringList > QgsCptCityDirectoryItem::rampsMap()
     // QgsDebugMsg("=============");
     // QgsDebugMsg("scheme = "+schemeName);
     curName = schemeName;
-    curVariant = QLatin1String( "" );
+    curVariant.clear();
 
     // find if name ends with 1-3 digit number
     // TODO need to detect if ends with b/c also
@@ -972,13 +972,13 @@ QMap< QString, QStringList > QgsCptCityDirectoryItem::rampsMap()
       curVariant = curSep + curVariant;
     }
 
-    if ( prevName == QLatin1String( "" ) )
+    if ( prevName.isEmpty() )
       prevName = curName;
 
     // add element, unless it is empty, or a variant of last element
     prevAdd = false;
     curAdd = false;
-    if ( curName == QLatin1String( "" ) )
+    if ( curName.isEmpty() )
       curName = QStringLiteral( "__empty__" );
     // if current is a variant of last, don't add previous and append current variant
     if ( curName == prevName )
@@ -990,7 +990,7 @@ QMap< QString, QStringList > QgsCptCityDirectoryItem::rampsMap()
     }
     else
     {
-      if ( prevName != QLatin1String( "" ) )
+      if ( !prevName.isEmpty() )
       {
         prevAdd = true;
       }
@@ -1031,7 +1031,7 @@ QMap< QString, QStringList > QgsCptCityDirectoryItem::rampsMap()
     }
     if ( curAdd )
     {
-      if ( curVariant != QLatin1String( "" ) )
+      if ( !curVariant.isEmpty() )
         curName += curVariant;
       schemeNames << curName;
       mRampsMap[ mPath + '/' + curName ] = QStringList();
@@ -1040,7 +1040,7 @@ QMap< QString, QStringList > QgsCptCityDirectoryItem::rampsMap()
     if ( prevAdd || curAdd )
     {
       prevName = curName;
-      if ( curVariant != QLatin1String( "" ) )
+      if ( !curVariant.isEmpty() )
         listVariant << curVariant;
     }
 

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -213,7 +213,7 @@ void QgsRendererRangeLabelFormat::setPrecision( int precision )
   precision = qBound( MIN_PRECISION, precision, MAX_PRECISION );
   mPrecision = precision;
   mNumberScale = 1.0;
-  mNumberSuffix = QLatin1String( "" );
+  mNumberSuffix.clear();
   while ( precision < 0 )
   {
     precision++;

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -269,10 +269,9 @@ QgsSymbol *QgsSymbol::defaultSymbol( QgsWkbTypes::GeometryType geomType )
       defaultSymbol = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Fill" ), QLatin1String( "" ) );
       break;
     default:
-      defaultSymbol = QLatin1String( "" );
       break;
   }
-  if ( defaultSymbol != QLatin1String( "" ) )
+  if ( !defaultSymbol.isEmpty() )
     s = QgsStyle::defaultStyle()->symbol( defaultSymbol );
 
   // if no default found for this type, get global default (as previously)
@@ -308,7 +307,7 @@ QgsSymbol *QgsSymbol::defaultSymbol( QgsWkbTypes::GeometryType geomType )
   s->setOpacity( opacity );
 
   // set random color, it project prefs allow
-  if ( defaultSymbol == QLatin1String( "" ) ||
+  if ( defaultSymbol.isEmpty() ||
        QgsProject::instance()->readBoolEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/RandomColors" ), true ) )
   {
     s->setColor( QColor::fromHsv( qrand() % 360, 64 + qrand() % 192, 128 + qrand() % 128 ) );

--- a/src/gui/auth/qgsauthimportidentitydialog.cpp
+++ b/src/gui/auth/qgsauthimportidentitydialog.cpp
@@ -177,8 +177,6 @@ void QgsAuthImportIdentityDialog::writeValidation( const QString &msg,
       txt = tr( "Invalid: %1" ).arg( msg );
       break;
     case Unknown:
-    default:
-      ss = QLatin1String( "" );
       break;
   }
   teValidation->setStyleSheet( ss );

--- a/src/gui/auth/qgsauthsslconfigwidget.cpp
+++ b/src/gui/auth/qgsauthsslconfigwidget.cpp
@@ -65,7 +65,7 @@ QgsAuthSslConfigWidget::QgsAuthSslConfigWidget( QWidget *parent,
     setUpSslConfigTree();
 
     lblLoadedConfig->setVisible( false );
-    lblLoadedConfig->setText( QLatin1String( "" ) );
+    lblLoadedConfig->clear();
 
     connect( leHost, &QLineEdit::textChanged,
              this, &QgsAuthSslConfigWidget::validateHostPortText );
@@ -324,7 +324,7 @@ void QgsAuthSslConfigWidget::resetSslCertConfig()
   leHost->clear();
 
   lblLoadedConfig->setVisible( false );
-  lblLoadedConfig->setText( QLatin1String( "" ) );
+  lblLoadedConfig->clear();
   resetSslProtocol();
   resetSslIgnoreErrors();
   resetSslPeerVerify();

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -101,7 +101,7 @@ QVariantMap QgsRangeConfigDlg::config()
   cfg.insert( QStringLiteral( "Style" ), rangeWidget->currentData().toString() );
   cfg.insert( QStringLiteral( "AllowNull" ), allowNullCheckBox->isChecked() );
 
-  if ( suffixLineEdit->text() != QLatin1String( "" ) )
+  if ( !suffixLineEdit->text().isEmpty() )
   {
     cfg.insert( QStringLiteral( "Suffix" ), suffixLineEdit->text() );
   }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -302,7 +302,7 @@ void QgsRelationReferenceWidget::deleteForeignKey()
   QVariant nullValue = QgsApplication::nullRepresentation();
   if ( mReadOnlySelector )
   {
-    QString nullText = QLatin1String( "" );
+    QString nullText;
     if ( mAllowNull )
     {
       nullText = tr( "%1 (no selection)" ).arg( nullValue.toString() );

--- a/src/gui/ogr/qgsogrhelperfunctions.cpp
+++ b/src/gui/ogr/qgsogrhelperfunctions.cpp
@@ -22,7 +22,7 @@
 
 QString createDatabaseURI( const QString &connectionType, const QString &host, const QString &database, QString port, const QString &user, const QString &password )
 {
-  QString uri = QLatin1String( "" );
+  QString uri;
 
   //todo:add default ports for all kind of databases
   if ( connectionType == QLatin1String( "ESRI Personal GeoDatabase" ) )
@@ -192,7 +192,7 @@ QString createDatabaseURI( const QString &connectionType, const QString &host, c
 
 QString createProtocolURI( const QString &type, const QString &url )
 {
-  QString uri = QLatin1String( "" );
+  QString uri;
   if ( type == QLatin1String( "GeoJSON" ) )
   {
     uri = url;

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -49,7 +49,6 @@ void QgsCollapsibleGroupBoxBasic::init()
   mShown = false;
   mParentScrollArea = nullptr;
   mSyncParent = nullptr;
-  mSyncGroup = QLatin1String( "" );
   mAltDown = false;
   mShiftDown = false;
   mTitleClicked = false;
@@ -516,7 +515,6 @@ void QgsCollapsibleGroupBox::init()
   // NOTE: only turn on mSaveCheckedState for groupboxes NOT used
   // in multiple places or used as options for different parent objects
   mSaveCheckedState = false;
-  mSettingGroup = QLatin1String( "" ); // if not set, use window object name
 
   connect( this, &QObject::objectNameChanged, this, &QgsCollapsibleGroupBox::loadState );
 }

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -38,8 +38,8 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QString &layerName, cons
   mHideDeprecatedCheckBox->setChecked( settings.value( QStringLiteral( "Windows/DatumTransformDialog/hideDeprecated" ), false ).toBool() );
   mRememberSelectionCheckBox->setChecked( settings.value( QStringLiteral( "Windows/DatumTransformDialog/rememberSelection" ), false ).toBool() );
 
-  mLabelSrcDescription->setText( QLatin1String( "" ) );
-  mLabelDstDescription->setText( QLatin1String( "" ) );
+  mLabelSrcDescription->clear();
+  mLabelDstDescription->clear();
 
   for ( int i = 0; i < 2; i++ )
   {

--- a/src/gui/qgsdetaileditemdelegate.cpp
+++ b/src/gui/qgsdetaileditemdelegate.cpp
@@ -336,8 +336,8 @@ QStringList QgsDetailedItemDelegate::wordWrap( const QString &string,
   //qDebug(myDebug.toLocal8Bit());
   //iterate the string
   QStringList myList;
-  QString myCumulativeLine = QLatin1String( "" );
-  QString myStringToPreviousSpace = QLatin1String( "" );
+  QString myCumulativeLine;
+  QString myStringToPreviousSpace;
   int myPreviousSpacePos = 0;
   for ( int i = 0; i < string.count(); ++i )
   {
@@ -355,8 +355,8 @@ QStringList QgsDetailedItemDelegate::wordWrap( const QString &string,
       //forcing a break at current pos...
       myList << myStringToPreviousSpace.trimmed();
       i = myPreviousSpacePos;
-      myStringToPreviousSpace = QLatin1String( "" );
-      myCumulativeLine = QLatin1String( "" );
+      myStringToPreviousSpace.clear();
+      myCumulativeLine.clear();
     }
   }//end of i loop
   //add whatever is left in the string to the list

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -103,7 +103,7 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   QModelIndex firstItem = mProxyModel->index( 0, 0, QModelIndex() );
   expressionTree->setCurrentIndex( firstItem );
 
-  lblAutoSave->setText( QLatin1String( "" ) );
+  lblAutoSave->clear();
   txtExpressionString->setWrapMode( QsciScintilla::WrapWord );
 }
 
@@ -133,7 +133,7 @@ void QgsExpressionBuilderWidget::setLayer( QgsVectorLayer *layer )
 
 void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const QModelIndex & )
 {
-  txtSearchEditValues->setText( QLatin1String( "" ) );
+  txtSearchEditValues->clear();
 
   // Get the item
   QModelIndex idx = mProxyModel->mapToSource( index );
@@ -561,7 +561,7 @@ void QgsExpressionBuilderWidget::on_txtExpressionString_textChanged()
   // we don't show the user an error as it will be confusing.
   if ( text.isEmpty() )
   {
-    lblPreview->setText( QLatin1String( "" ) );
+    lblPreview->clear();
     lblPreview->setStyleSheet( QLatin1String( "" ) );
     txtExpressionString->setToolTip( QLatin1String( "" ) );
     lblPreview->setToolTip( QLatin1String( "" ) );

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -85,7 +85,7 @@ void QgsFileWidget::setFilePath( QString path )
 {
   if ( path == QgsApplication::nullRepresentation() )
   {
-    path = QLatin1String( "" );
+    path.clear();
   }
 
   //will trigger textEdited slot

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -207,7 +207,7 @@ void QgsManageConnectionsDialog::doExportImport()
     accept();
   }
 
-  mFileName = QLatin1String( "" );
+  mFileName.clear();
 }
 
 bool QgsManageConnectionsDialog::populateConnections()

--- a/src/gui/qgsmessageviewer.cpp
+++ b/src/gui/qgsmessageviewer.cpp
@@ -30,8 +30,6 @@ QgsMessageViewer::QgsMessageViewer( QWidget *parent, Qt::WindowFlags fl, bool de
   setCheckBoxVisible( false );
   setCheckBoxState( Qt::Unchecked );
 
-  mCheckBoxQgsSettingsLabel = QLatin1String( "" );
-
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/MessageViewer/geometry" ) ).toByteArray() );
 }

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -112,7 +112,7 @@ void QgsNewGeoPackageLayerDialog::on_mFieldTypeBox_currentIndexChanged( int )
   QString myType = mFieldTypeBox->currentData( Qt::UserRole ).toString();
   mFieldLengthEdit->setEnabled( myType == QLatin1String( "text" ) );
   if ( myType != QLatin1String( "text" ) )
-    mFieldLengthEdit->setText( QLatin1String( "" ) );
+    mFieldLengthEdit->clear();
 }
 
 

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -450,8 +450,8 @@ void QgsOWSSourceSelect::populateCrs()
 void QgsOWSSourceSelect::clearCrs()
 {
   mCRSLabel->setText( tr( "Coordinate Reference System" ) + ':' );
-  mSelectedCRS = QLatin1String( "" );
-  mSelectedCRSLabel->setText( QLatin1String( "" ) );
+  mSelectedCRS.clear();
+  mSelectedCRSLabel->clear();
   mChangeCRSButton->setEnabled( false );
 }
 

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -234,8 +234,8 @@ void QgsProjectionSelectionTreeWidget::applySelection( int column, QString value
     // deselect the selected item to avoid confusing the user
     lstCoordinateSystems->clearSelection();
     lstRecent->clearSelection();
-    teProjection->setText( QLatin1String( "" ) );
-    teSelected->setText( QLatin1String( "" ) );
+    teProjection->clear();
+    teSelected->clear();
   }
 }
 
@@ -724,8 +724,8 @@ void QgsProjectionSelectionTreeWidget::on_lstCoordinateSystems_currentItemChange
   {
     // Not an CRS - remove the highlight so the user doesn't get too confused
     current->setSelected( false );
-    teProjection->setText( QLatin1String( "" ) );
-    teSelected->setText( QLatin1String( "" ) );
+    teProjection->clear();
+    teSelected->clear();
     lstRecent->clearSelection();
   }
 }
@@ -790,8 +790,8 @@ void QgsProjectionSelectionTreeWidget::hideDeprecated( QTreeWidgetItem *item )
     if ( item->isSelected() && item->isHidden() )
     {
       item->setSelected( false );
-      teProjection->setText( QLatin1String( "" ) );
-      teSelected->setText( QLatin1String( "" ) );
+      teProjection->clear();
+      teSelected->clear();
     }
   }
 

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -164,7 +164,7 @@ void QgsRasterFormatSaveOptionsWidget::updateProfiles()
     if ( ! profileKeys.contains( profileKey ) && !it.value().isEmpty() )
     {
       // insert key if is for all formats or this format (GTiff)
-      if ( it.value()[0] == QLatin1String( "" ) ||  it.value()[0] == format )
+      if ( it.value()[0].isEmpty() ||  it.value()[0] == format )
       {
         profileKeys.insert( 0, profileKey );
       }
@@ -253,7 +253,7 @@ void QgsRasterFormatSaveOptionsWidget::helpOptions()
 {
   QString message;
 
-  if ( mProvider == QLatin1String( "gdal" ) && mFormat != QLatin1String( "" ) && ! mPyramids )
+  if ( mProvider == QLatin1String( "gdal" ) && !mFormat.isEmpty() && ! mPyramids )
   {
     // get helpCreationOptionsFormat() function ptr for provider
     std::unique_ptr< QLibrary > library( QgsProviderRegistry::instance()->createProviderLibrary( mProvider ) );
@@ -342,7 +342,7 @@ QString QgsRasterFormatSaveOptionsWidget::validateOptions( bool gui, bool report
       message = tr( "cannot validate pyramid options" );
     }
   }
-  else if ( !createOptions.isEmpty() && mProvider == QLatin1String( "gdal" ) && mFormat != QLatin1String( "" ) )
+  else if ( !createOptions.isEmpty() && mProvider == QLatin1String( "gdal" ) && !mFormat.isEmpty() )
   {
     if ( rasterLayer && rasterLayer->dataProvider() )
     {
@@ -428,7 +428,7 @@ void QgsRasterFormatSaveOptionsWidget::on_mProfileNewButton_clicked()
   if ( ! profileName.isEmpty() )
   {
     profileName = profileName.trimmed();
-    mOptionsMap[ profileName ] = QLatin1String( "" );
+    mOptionsMap[ profileName ] = QString();
     mProfileComboBox->addItem( profileName, profileName );
     mProfileComboBox->setCurrentIndex( mProfileComboBox->count() - 1 );
   }
@@ -454,7 +454,7 @@ void QgsRasterFormatSaveOptionsWidget::on_mProfileResetButton_clicked()
   }
   else
   {
-    mOptionsMap[ profileKey ] = QLatin1String( "" );
+    mOptionsMap[ profileKey ] = QString();
   }
   mOptionsLineEdit->setText( mOptionsMap.value( currentProfileKey() ) );
   mOptionsLineEdit->setCursorPosition( 0 );
@@ -490,7 +490,7 @@ void QgsRasterFormatSaveOptionsWidget::on_mOptionsDeleteButton_clicked()
 
 QString QgsRasterFormatSaveOptionsWidget::settingsKey( QString profileName ) const
 {
-  if ( profileName != QLatin1String( "" ) )
+  if ( !profileName.isEmpty() )
     profileName = "/profile_" + profileName;
   else
     profileName = "/profile_default" + profileName;
@@ -580,7 +580,7 @@ void QgsRasterFormatSaveOptionsWidget::swapOptionsUI( int newIndex )
 
 void QgsRasterFormatSaveOptionsWidget::updateControls()
 {
-  bool valid = mProvider == QLatin1String( "gdal" ) && mFormat != QLatin1String( "" );
+  bool valid = mProvider == QLatin1String( "gdal" ) && !mFormat.isEmpty();
   mOptionsValidateButton->setEnabled( valid );
   mOptionsHelpButton->setEnabled( valid );
 }

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -190,7 +190,7 @@ void QgsRasterLayerSaveAsDialog::on_mBrowseButton_clicked()
                                  QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Ok )
         break;
 
-      fileName = QLatin1String( "" );
+      fileName.clear();
     }
   }
   else

--- a/src/gui/qgsrasterpyramidsoptionswidget.cpp
+++ b/src/gui/qgsrasterpyramidsoptionswidget.cpp
@@ -133,7 +133,7 @@ void QgsRasterPyramidsOptionsWidget::apply()
   mySettings.setValue( prefix + "overviewStr", lePyramidsLevels->text().trimmed() );
 
   // overview list
-  tmpStr = QLatin1String( "" );
+  tmpStr.clear();
   for ( auto it = mOverviewCheckBoxes.constBegin(); it != mOverviewCheckBoxes.constEnd(); ++it )
   {
     if ( it.value()->isChecked() )

--- a/src/gui/raster/qgsrasterhistogramwidget.cpp
+++ b/src/gui/raster/qgsrasterhistogramwidget.cpp
@@ -629,7 +629,7 @@ void QgsRasterHistogramWidget::on_mSaveAsImageButton_clicked()
 
   QPair< QString, QString> myFileNameAndFilter = QgsGuiUtils::getSaveAsImageName( this, tr( "Choose a file name to save the map image as" ) );
   QFileInfo myInfo( myFileNameAndFilter.first );
-  if ( myInfo.baseName() != QLatin1String( "" ) )
+  if ( !myInfo.baseName().isEmpty() )
   {
     histoSaveAsImage( myFileNameAndFilter.first );
   }
@@ -708,7 +708,7 @@ void QgsRasterHistogramWidget::histoActionTriggered( QAction *action )
 
 void QgsRasterHistogramWidget::histoAction( const QString &actionName, bool actionFlag )
 {
-  if ( actionName == QLatin1String( "" ) )
+  if ( actionName.isEmpty() )
     return;
 
   // this approach is a bit of a hack, but this way we don't have to define slots for each action
@@ -1067,9 +1067,9 @@ void QgsRasterHistogramWidget::updateHistoMarkers()
   double maxVal = mHistoMax;
   QString minStr = leHistoMin->text();
   QString maxStr = leHistoMax->text();
-  if ( minStr != QLatin1String( "" ) )
+  if ( !minStr.isEmpty() )
     minVal = minStr.toDouble();
-  if ( maxStr != QLatin1String( "" ) )
+  if ( !maxStr.isEmpty() )
     maxVal = maxStr.toDouble();
 
   QPen linePen = QPen( mHistoColors.at( bandNo ) );

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -418,7 +418,7 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
 
   // set project default color ramp
   QString defaultColorRamp = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QLatin1String( "" ) );
-  if ( defaultColorRamp != QLatin1String( "" ) )
+  if ( !defaultColorRamp.isEmpty() )
   {
     btnColorRamp->setColorRampFromName( defaultColorRamp );
   }

--- a/src/gui/symbology/qgscptcitycolorrampdialog.cpp
+++ b/src/gui/symbology/qgscptcitycolorrampdialog.cpp
@@ -225,7 +225,7 @@ void QgsCptCityColorRampDialog::updateTreeView( QgsCptCityDataItem *item, bool r
     {
       mRamp.setName( QLatin1String( "" ), QLatin1String( "" ) );
       QgsDebugMsg( QString( "variant= %1 - %2 variants" ).arg( mRamp.variantName() ).arg( mRamp.variantList().count() ) );
-      lblSchemeName->setText( QLatin1String( "" ) );
+      lblSchemeName->clear();
       populateVariants();
     }
     updateListWidget( item );
@@ -235,14 +235,14 @@ void QgsCptCityColorRampDialog::updateTreeView( QgsCptCityDataItem *item, bool r
   }
   else if ( item->type() == QgsCptCityDataItem::Selection )
   {
-    lblSchemePath->setText( QLatin1String( "" ) );
+    lblSchemePath->clear();
     clearCopyingInfo();
     updateListWidget( item );
     lblCollectionInfo->setText( QStringLiteral( "%1 (%2)" ).arg( item->info() ).arg( item->leafCount() ) );
   }
   else if ( item->type() == QgsCptCityDataItem::AllRamps )
   {
-    lblSchemePath->setText( QLatin1String( "" ) );
+    lblSchemePath->clear();
     clearCopyingInfo();
     updateListWidget( item );
     lblCollectionInfo->setText( tr( "All Ramps (%1)" ).arg( item->leafCount() ) );
@@ -377,11 +377,11 @@ void QgsCptCityColorRampDialog::updatePreview( bool clear )
 {
   QSize size = lblPreview->size();
 
-  if ( clear || mRamp.schemeName() == QLatin1String( "" ) )
+  if ( clear || mRamp.schemeName().isEmpty() )
   {
-    lblSchemeName->setText( QLatin1String( "" ) );
-    lblSchemePath->setText( QLatin1String( "" ) );
-    lblLicensePreview->setText( QLatin1String( "" ) );
+    lblSchemeName->clear();
+    lblSchemePath->clear();
+    lblLicensePreview->clear();
     QPixmap blankPixmap( size );
     blankPixmap.fill( Qt::transparent );
     lblPreview->setPixmap( blankPixmap );
@@ -429,7 +429,7 @@ void QgsCptCityColorRampDialog::updateCopyingInfo( const QMap< QString, QString 
   if ( copyingMap.contains( QStringLiteral( "src/link" ) ) )
     lblSrcLink->setText( copyingMap.value( QStringLiteral( "src/link" ) ) );
   else
-    lblSrcLink->setText( QLatin1String( "" ) );
+    lblSrcLink->clear();
 }
 
 void QgsCptCityColorRampDialog::on_cboVariantName_currentIndexChanged( int index )
@@ -466,7 +466,7 @@ void QgsCptCityColorRampDialog::updateUi()
 {
   // look for item, if not found in selections archive, look for in authors
   QgsDebugMsg( "looking for ramp " + mRamp.schemeName() );
-  if ( mRamp.schemeName() != QLatin1String( "" ) )
+  if ( !mRamp.schemeName().isEmpty() )
   {
     bool found = updateRamp();
     if ( ! found )
@@ -573,7 +573,7 @@ bool QgsCptCityColorRampDialog::updateRamp()
   updatePreview( true );
 
   QgsDebugMsg( "schemeName= " + mRamp.schemeName() );
-  if ( mRamp.schemeName() == QLatin1String( "" ) )
+  if ( mRamp.schemeName().isEmpty() )
   {
     showAll();
     return false;

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -456,7 +456,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
 
   // set project default color ramp
   QString defaultColorRamp = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QLatin1String( "" ) );
-  if ( defaultColorRamp != QLatin1String( "" ) )
+  if ( !defaultColorRamp.isEmpty() )
   {
     btnColorRamp->setColorRampFromName( defaultColorRamp );
   }

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -58,7 +58,6 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
   mTempStyle->createMemoryDatabase();
 
   // TODO validate
-  mFileName = QLatin1String( "" );
   mProgressDlg = nullptr;
   mGroupSelectionDlg = nullptr;
   mTempFile = nullptr;
@@ -169,7 +168,7 @@ void QgsStyleExportImportDialog::doExportImport()
     accept();
   }
 
-  mFileName = QLatin1String( "" );
+  mFileName.clear();
   mTempStyle->clear();
 }
 
@@ -458,7 +457,7 @@ void QgsStyleExportImportDialog::importTypeChanged( int index )
 {
   QString type = importTypeCombo->itemData( index ).toString();
 
-  locationLineEdit->setText( QLatin1String( "" ) );
+  locationLineEdit->clear();
 
   if ( type == QLatin1String( "file" ) )
   {
@@ -548,7 +547,7 @@ void QgsStyleExportImportDialog::httpFinished()
   if ( mNetReply->error() )
   {
     mTempFile->remove();
-    mFileName = QLatin1String( "" );
+    mFileName.clear();
     mProgressDlg->hide();
     QMessageBox::information( this, tr( "HTTP Error!" ),
                               tr( "Download failed: %1." ).arg( mNetReply->errorString() ) );
@@ -577,7 +576,7 @@ void QgsStyleExportImportDialog::downloadCanceled()
 {
   mNetReply->abort();
   mTempFile->remove();
-  mFileName = QLatin1String( "" );
+  mFileName.clear();
 }
 
 void QgsStyleExportImportDialog::selectionChanged( const QItemSelection &selected, const QItemSelection &deselected )

--- a/src/gui/symbology/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology/qgssymbolslistwidget.cpp
@@ -77,7 +77,7 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbol *symbol, QgsStyle *style, 
 
   connect( openStyleManagerButton, &QPushButton::pressed, this, &QgsSymbolsListWidget::openStyleManager );
 
-  lblSymbolName->setText( QLatin1String( "" ) );
+  lblSymbolName->clear();
 
   populateGroups();
 

--- a/src/gui/symbology/qgsvectorfieldsymbollayerwidget.cpp
+++ b/src/gui/symbology/qgsvectorfieldsymbollayerwidget.cpp
@@ -159,7 +159,7 @@ void QgsVectorFieldSymbolLayerWidget::on_mHeightRadioButton_toggled( bool checke
   if ( mLayer && checked )
   {
     mLayer->setVectorFieldType( QgsVectorFieldSymbolLayer::Height );
-    mXAttributeLabel->setText( QLatin1String( "" ) );
+    mXAttributeLabel->clear();
     mXAttributeComboBox->setEnabled( false );
     mYAttributeLabel->setText( tr( "Height attribute" ) );
     emit changed();

--- a/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
+++ b/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
@@ -165,7 +165,7 @@ void eVisDatabaseConnectionGui::on_cboxDatabaseType_currentIndexChanged( int cur
     leDatabaseUsername->setEnabled( true );
     lblDatabasePassword->setEnabled( true );
     leDatabasePassword->setEnabled( true );
-    leDatabaseName->setText( QLatin1String( "" ) );
+    leDatabaseName->clear();
   }
   else if ( cboxDatabaseType->currentText() == QLatin1String( "PostGreSQL" ) )
   {
@@ -179,38 +179,38 @@ void eVisDatabaseConnectionGui::on_cboxDatabaseType_currentIndexChanged( int cur
     leDatabaseUsername->setEnabled( true );
     lblDatabasePassword->setEnabled( true );
     leDatabasePassword->setEnabled( true );
-    leDatabaseName->setText( QLatin1String( "" ) );
+    leDatabaseName->clear();
   }
   else if ( cboxDatabaseType->currentText() == QLatin1String( "SQLITE" ) || cboxDatabaseType->currentText() == QLatin1String( "MSAccess" ) )
   {
     lblDatabaseHost->setEnabled( false );
-    leDatabaseHost->setText( QLatin1String( "" ) );
+    leDatabaseHost->clear();
     leDatabaseHost->setEnabled( false );
     lblDatabasePort->setEnabled( false );
-    leDatabasePort->setText( QLatin1String( "" ) );
+    leDatabasePort->clear();
     leDatabasePort->setEnabled( false );
     pbtnOpenFile->setEnabled( true );
     lblDatabaseUsername->setEnabled( false );
-    leDatabaseUsername->setText( QLatin1String( "" ) );
+    leDatabaseUsername->clear();
     leDatabaseUsername->setEnabled( false );
     lblDatabasePassword->setEnabled( false );
-    leDatabasePassword->setText( QLatin1String( "" ) );
+    leDatabasePassword->clear();
     leDatabasePassword->setEnabled( false );
-    leDatabaseName->setText( QLatin1String( "" ) );
+    leDatabaseName->clear();
   }
   else
   {
     lblDatabaseHost->setEnabled( true );
     leDatabaseHost->setEnabled( true );
     lblDatabasePort->setEnabled( false );
-    leDatabasePort->setText( QLatin1String( "" ) );
+    leDatabasePort->clear();
     leDatabasePort->setEnabled( false );
     pbtnOpenFile->setEnabled( false );
     lblDatabaseUsername->setEnabled( true );
     leDatabaseUsername->setEnabled( true );
     lblDatabasePassword->setEnabled( true );
     leDatabasePassword->setEnabled( true );
-    leDatabaseName->setText( QLatin1String( "" ) );
+    leDatabaseName->clear();
   }
 }
 
@@ -311,7 +311,7 @@ void eVisDatabaseConnectionGui::on_pbtnLoadPredefinedQueries_clicked()
 
   //Select the XML file to parse
   QString myFilename = QFileDialog::getOpenFileName( this, tr( "Open File" ), QDir::homePath(), QStringLiteral( "XML ( *.xml )" ) );
-  if ( myFilename != QLatin1String( "" ) )
+  if ( !myFilename.isEmpty() )
   {
     //Display the name of the file being parsed
     lblPredefinedQueryFilename->setText( myFilename );
@@ -347,7 +347,7 @@ void eVisDatabaseConnectionGui::on_pbtnLoadPredefinedQueries_clicked()
             while ( !myChildNodes.isNull() )
             {
               QDomNode myDataNode = myChildNodes.toElement().firstChild();
-              QString myDataNodeContent = QLatin1String( "" );
+              QString myDataNodeContent;
               if ( !myDataNode.isNull() )
               {
                 myDataNodeContent = myDataNode.toText().data();
@@ -355,7 +355,7 @@ void eVisDatabaseConnectionGui::on_pbtnLoadPredefinedQueries_clicked()
 
               if ( myChildNodes.toElement().tagName() == QLatin1String( "shortdescription" ) )
               {
-                if ( myDataNodeContent != QLatin1String( "" ) )
+                if ( !myDataNodeContent.isEmpty() )
                 {
                   myQueryDefinition.setShortDescription( myDataNodeContent );
                   myQueryCount++;

--- a/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.cpp
+++ b/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.cpp
@@ -89,7 +89,7 @@ void eVisDatabaseLayerFieldSelectionGui::on_buttonBox_accepted()
   close();
 
   //reset the layer name line edit
-  leLayerName->setText( QLatin1String( "" ) );
+  leLayerName->clear();
 }
 
 /**
@@ -98,5 +98,5 @@ void eVisDatabaseLayerFieldSelectionGui::on_buttonBox_accepted()
 void eVisDatabaseLayerFieldSelectionGui::on_buttonBox_rejected()
 {
   close();
-  leLayerName->setText( QLatin1String( "" ) );
+  leLayerName->clear();
 }

--- a/src/plugins/evis/databaseconnection/evisquerydefinition.cpp
+++ b/src/plugins/evis/databaseconnection/evisquerydefinition.cpp
@@ -31,13 +31,5 @@
 */
 eVisQueryDefinition::eVisQueryDefinition()
 {
-  mDatabaseType = QLatin1String( "" );
-  mDatabaseHost = QLatin1String( "" );
-  mDatabasePort = -1;
-  mDatabaseName = QLatin1String( "" );
-  mDatabaseUsername = QLatin1String( "" );
-  mDatabasePassword = QLatin1String( "" );
-  mSqlStatement = QLatin1String( "" );
-  mAutoConnect = false;
 }
 

--- a/src/plugins/evis/databaseconnection/evisquerydefinition.h
+++ b/src/plugins/evis/databaseconnection/evisquerydefinition.h
@@ -130,7 +130,7 @@ class eVisQueryDefinition
     QString mDatabaseHost;
 
     //! \brief The port/socket on the database host to which a connection should be made
-    int mDatabasePort;
+    int mDatabasePort = -1;
 
     //! \brief The name, or filename, of the database to which a connection should be made
     QString mDatabaseName;
@@ -145,6 +145,6 @@ class eVisQueryDefinition
     QString mSqlStatement;
 
     //! \brief Boolean to allow for automated connection to the database when query definition is successfully loaded
-    bool mAutoConnect;
+    bool mAutoConnect = false;
 };
 #endif

--- a/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
+++ b/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
@@ -655,7 +655,7 @@ void eVisGenericEventBrowserGui::restoreDefaultOptions()
   rbtnManualCompassOffset->setChecked( true );
   dsboxCompassOffset->setValue( 0.0 );
 
-  leBasePath->setText( QLatin1String( "" ) );
+  leBasePath->clear();
   chkboxUseOnlyFilename->setChecked( false );
 
   chkboxSaveEventImagePathData->setChecked( false );
@@ -1039,7 +1039,7 @@ void eVisGenericEventBrowserGui::on_pbtnResetApplyPathRulesToDocs_clicked()
 
 void eVisGenericEventBrowserGui::on_pbtnResetBasePathData_clicked()
 {
-  leBasePath->setText( QLatin1String( "" ) );
+  leBasePath->clear();
   if ( chkboxEventImagePathRelative->isChecked() )
   {
     setBasePathToDataSource();

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckfixdialog.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckfixdialog.cpp
@@ -89,7 +89,7 @@ void QgsGeometryCheckerFixDialog::setupNextError()
   mFixBtn->setVisible( true );
   mFixBtn->setFocus();
   mSkipBtn->setVisible( true );
-  mStatusLabel->setText( QLatin1String( "" ) );
+  mStatusLabel->clear();
   mResolutionsBox->setEnabled( true );
 
   QgsGeometryCheckError *error = mErrors.at( 0 );

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -173,7 +173,7 @@ void QgsGeorefPluginGui::closeEvent( QCloseEvent *e )
       writeSettings();
       clearGCPData();
       removeOldLayer();
-      mRasterFileName = QLatin1String( "" );
+      mRasterFileName.clear();
       e->accept();
       return;
     case QgsGeorefPluginGui::GCPSILENTSAVE:
@@ -181,13 +181,13 @@ void QgsGeorefPluginGui::closeEvent( QCloseEvent *e )
         saveGCPs();
       clearGCPData();
       removeOldLayer();
-      mRasterFileName = QLatin1String( "" );
+      mRasterFileName.clear();
       return;
     case QgsGeorefPluginGui::GCPDISCARD:
       writeSettings();
       clearGCPData();
       removeOldLayer();
-      mRasterFileName = QLatin1String( "" );
+      mRasterFileName.clear();
       e->accept();
       return;
     case QgsGeorefPluginGui::GCPCANCEL:
@@ -247,7 +247,7 @@ void QgsGeorefPluginGui::openRaster()
   filters.prepend( otherFiles + ";;" );
   filters.chop( otherFiles.size() + 2 );
   mRasterFileName = QFileDialog::getOpenFileName( this, tr( "Open raster" ), dir, filters, &lastUsedFilter );
-  mModifiedRasterFileName = QLatin1String( "" );
+  mModifiedRasterFileName.clear();
 
   if ( mRasterFileName.isEmpty() )
     return;
@@ -2083,7 +2083,7 @@ int QgsGeorefPluginGui::polynomialOrder( QgsGeorefTransform::TransformParametris
 
 QString QgsGeorefPluginGui::guessWorldFileName( const QString &rasterFileName )
 {
-  QString worldFileName = QLatin1String( "" );
+  QString worldFileName;
   int point = rasterFileName.lastIndexOf( '.' );
   if ( point != -1 && point != rasterFileName.length() - 1 )
     worldFileName = rasterFileName.left( point + 1 ) + "wld";

--- a/src/plugins/georeferencer/qgstransformsettingsdialog.cpp
+++ b/src/plugins/georeferencer/qgstransformsettingsdialog.cpp
@@ -101,7 +101,7 @@ void QgsTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::Trans
   comprMethod = mListCompression.at( cmbCompressionComboBox->currentIndex() ).toUpper();
   if ( mWorldFileCheckBox->isChecked() )
   {
-    raster = QLatin1String( "" );
+    raster.clear();
   }
   else
   {

--- a/src/plugins/gps_importer/qgsgpsdevicedialog.cpp
+++ b/src/plugins/gps_importer/qgsgpsdevicedialog.cpp
@@ -93,10 +93,10 @@ void QgsGPSDeviceDialog::on_pbnUpdateDevice_clicked()
 void QgsGPSDeviceDialog::slotUpdateDeviceList( const QString &selection )
 {
   QString selected;
-  if ( selection == QLatin1String( "" ) )
+  if ( selection.isEmpty() )
   {
     QListWidgetItem *item = lbDeviceList->currentItem();
-    selected = ( item ? item->text() : QLatin1String( "" ) );
+    selected = ( item ? item->text() : QString() );
   }
   else
   {

--- a/src/plugins/gps_importer/qgsgpsplugingui.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugingui.cpp
@@ -205,8 +205,8 @@ void QgsGPSPluginGui::enableRelevantControls()
   // import other file
   else if ( tabWidget->currentIndex() == 1 )
   {
-    if ( ( leIMPInput->text() == QLatin1String( "" ) ) || ( leIMPOutput->text() == QLatin1String( "" ) ) ||
-         ( leIMPLayer->text() == QLatin1String( "" ) ) )
+    if ( ( leIMPInput->text().isEmpty() ) || ( leIMPOutput->text().isEmpty() ) ||
+         ( leIMPLayer->text().isEmpty() ) )
       pbnOK->setEnabled( false );
     else
       pbnOK->setEnabled( true );
@@ -215,8 +215,8 @@ void QgsGPSPluginGui::enableRelevantControls()
   // download from device
   else if ( tabWidget->currentIndex() == 2 )
   {
-    if ( cmbDLDevice->currentText() == QLatin1String( "" ) || leDLBasename->text() == QLatin1String( "" ) ||
-         leDLOutput->text() == QLatin1String( "" ) )
+    if ( cmbDLDevice->currentText().isEmpty() || leDLBasename->text().isEmpty() ||
+         leDLOutput->text().isEmpty() )
       pbnOK->setEnabled( false );
     else
       pbnOK->setEnabled( true );
@@ -225,7 +225,7 @@ void QgsGPSPluginGui::enableRelevantControls()
   // upload to device
   else if ( tabWidget->currentIndex() == 3 )
   {
-    if ( cmbULDevice->currentText() == QLatin1String( "" ) || cmbULLayer->currentText() == QLatin1String( "" ) )
+    if ( cmbULDevice->currentText().isEmpty() || cmbULLayer->currentText().isEmpty() )
       pbnOK->setEnabled( false );
     else
       pbnOK->setEnabled( true );
@@ -234,8 +234,8 @@ void QgsGPSPluginGui::enableRelevantControls()
   // convert between waypoint/routes
   else if ( tabWidget->currentIndex() == 4 )
   {
-    if ( ( leCONVInput->text() == QLatin1String( "" ) ) || ( leCONVOutput->text() == QLatin1String( "" ) ) ||
-         ( leCONVLayer->text() == QLatin1String( "" ) ) )
+    if ( ( leCONVInput->text().isEmpty() ) || ( leCONVOutput->text().isEmpty() ) ||
+         ( leCONVLayer->text().isEmpty() ) )
       pbnOK->setEnabled( false );
     else
       pbnOK->setEnabled( true );
@@ -369,7 +369,7 @@ void QgsGPSPluginGui::populateULLayerComboBox()
 
 void QgsGPSPluginGui::populateIMPBabelFormats()
 {
-  mBabelFilter = QLatin1String( "" );
+  mBabelFilter.clear();
   cmbULDevice->clear();
   cmbDLDevice->clear();
   QgsSettings settings;

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -162,7 +162,7 @@ void QgsOfflineEditingPlugin::setLayerProgress( int layer, int numLayers )
 
 void QgsOfflineEditingPlugin::setProgressMode( QgsOfflineEditing::ProgressMode mode, int maximum )
 {
-  QString format = QLatin1String( "" );
+  QString format;
   switch ( mode )
   {
     case QgsOfflineEditing::CopyFeatures:

--- a/src/providers/db2/qgsdb2expressioncompiler.cpp
+++ b/src/providers/db2/qgsdb2expressioncompiler.cpp
@@ -114,7 +114,7 @@ QgsSqlExpressionCompiler::Result QgsDb2ExpressionCompiler::compileNode( const Qg
         rr = compileNode( n->operand(), result );
         if ( "NULL" == result.toUpper() )
         {
-          result = QLatin1String( "" );
+          result.clear();
           return Fail;
         }
 

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -78,7 +78,7 @@ QgsDb2FeatureIterator::~QgsDb2FeatureIterator()
 void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
 {
   bool limitAtProvider = ( mRequest.limit() >= 0 );
-  QString delim = QLatin1String( "" );
+  QString delim;
 
   // build sql statement
   mStatement = QStringLiteral( "SELECT " );

--- a/src/providers/db2/qgsdb2geometrycolumns.cpp
+++ b/src/providers/db2/qgsdb2geometrycolumns.cpp
@@ -110,8 +110,8 @@ bool QgsDb2GeometryColumns::populateLayerProperty( QgsDb2LayerProperty &layer )
   layer.type = mQuery.value( 3 ).toString();
   if ( mQuery.value( 4 ).isNull() )
   {
-    layer.srid = QLatin1String( "" );
-    layer.srsName = QLatin1String( "" );
+    layer.srid.clear();
+    layer.srsName.clear();
   }
   else
   {

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -245,7 +245,7 @@ QSqlDatabase QgsDb2Provider::getDatabase( const QString &connInfo, QString &errM
     if ( db.open() )
     {
       connected = true;
-      errMsg = QLatin1String( "" );
+      errMsg.clear();
     }
     else
     {
@@ -405,7 +405,7 @@ QVariant::Type QgsDb2Provider::decodeSqlType( int typeId )
 // Return the DB2 type name for the type numeric value
 QString QgsDb2Provider::db2TypeName( int typeId )
 {
-  QString typeName = QLatin1String( "" );
+  QString typeName;
   switch ( typeId )
   {
     case -3:     //VARBINARY
@@ -1408,7 +1408,7 @@ QgsVectorLayerExporter::ExportError QgsDb2Provider::createEmptyLayer( const QStr
   // add fields to the layer
   if ( oldToNewAttrIdxMap )
     oldToNewAttrIdxMap->clear();
-  QString attr2Create = QLatin1String( "" );
+  QString attr2Create;
   if ( fields.size() > 0 )
   {
     int offset = 0;
@@ -1563,7 +1563,7 @@ QgsVectorLayerExporter::ExportError QgsDb2Provider::createEmptyLayer( const QStr
 
 QString QgsDb2Provider::qgsFieldToDb2Field( const QgsField &field )
 {
-  QString result = QLatin1String( "" );
+  QString result;
   switch ( field.type() )
   {
     case QVariant::LongLong:

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -625,7 +625,7 @@ void QgsDb2SourceSelect::addSearchGeometryColumn( const QString &connectionName,
 
 QString QgsDb2SourceSelect::fullDescription( const QString &schema, const QString &table, const QString &column, const QString &type )
 {
-  QString full_desc = QLatin1String( "" );
+  QString full_desc;
   if ( !schema.isEmpty() )
     full_desc = schema + ".";
   full_desc += table + " (" + column + ") " + type;
@@ -751,8 +751,8 @@ void QgsDb2GeomColumnTypeThread::run()
     }
     else
     {
-      layerProperty.type = QLatin1String( "" );
-      layerProperty.srid = QLatin1String( "" );
+      layerProperty.type.clear();
+      layerProperty.srid.clear();
     }
 
     // Now tell the layer list dialog box...

--- a/src/providers/db2/qgsdb2tablemodel.cpp
+++ b/src/providers/db2/qgsdb2tablemodel.cpp
@@ -93,11 +93,11 @@ void QgsDb2TableModel::addTableEntry( const QgsDb2LayerProperty &layerProperty )
   QStandardItem *sridItem = new QStandardItem( layerProperty.srid );
   sridItem->setEditable( false );
 
-  QString pkText, pkCol = QLatin1String( "" );
+  QString pkText;
+  QString pkCol;
   switch ( layerProperty.pkCols.size() )
   {
     case 0:
-      pkText = QLatin1String( "" );
       break;
     case 1:
       pkText = layerProperty.pkCols[0];

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
@@ -169,13 +169,13 @@ bool QgsDelimitedTextFile::setFromUrl( const QUrl &url )
     if ( type == QLatin1String( "plain" ) )
     {
       quote = QStringLiteral( "'\"" );
-      escape = QLatin1String( "" );
+      escape.clear();
     }
     else if ( type == QLatin1String( "regexp " ) )
     {
-      delimiter = QLatin1String( "" );
-      quote = QLatin1String( "" );
-      escape = QLatin1String( "" );
+      delimiter.clear();
+      quote.clear();
+      escape.clear();
     }
   }
   if ( url.hasQueryItem( QStringLiteral( "delimiter" ) ) )

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -200,7 +200,7 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
 QString QgsDelimitedTextSourceSelect::selectedChars()
 {
-  QString chars = QLatin1String( "" );
+  QString chars;
   if ( cbxDelimComma->isChecked() )
     chars.append( ',' );
   if ( cbxDelimSpace->isChecked() )

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -177,7 +177,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
                     + " suffix= " + suffix + " vsiPrefix= " + vsiPrefix, 3 );
 
   // allow only normal files or VSIFILE items to continue
-  if ( !info.isFile() && vsiPrefix == QLatin1String( "" ) )
+  if ( !info.isFile() && vsiPrefix.isEmpty() )
     return nullptr;
 
   // get supported extensions
@@ -225,7 +225,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   }
 
   // fix vsifile path and name
-  if ( vsiPrefix != QLatin1String( "" ) )
+  if ( !vsiPrefix.isEmpty() )
   {
     // add vsiPrefix to path if needed
     if ( !path.startsWith( vsiPrefix ) )

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -159,7 +159,7 @@ QgsGdalProvider::QgsGdalProvider( const QString &uri, bool update )
 
   // Try to open using VSIFileHandler (see qgsogrprovider.cpp)
   QString vsiPrefix = QgsZipItem::vsiPrefix( uri );
-  if ( vsiPrefix != QLatin1String( "" ) )
+  if ( !vsiPrefix.isEmpty() )
   {
     if ( !uri.startsWith( vsiPrefix ) )
       setDataSourceUri( vsiPrefix + uri );
@@ -948,7 +948,7 @@ QString QgsGdalProvider::generateBandName( int bandNumber ) const
               QString dim = ( *j );
               if ( values.at( 0 ) != "NETCDF_DIM_" + dim )
                 continue;
-              if ( unitsMap.contains( dim ) && unitsMap[ dim ] != QLatin1String( "" ) && unitsMap[ dim ] != QLatin1String( "none" ) )
+              if ( unitsMap.contains( dim ) && !unitsMap[ dim ].isEmpty() && unitsMap[ dim ] != QLatin1String( "none" ) )
                 bandNameValues.append( dim + '=' + values.at( 1 ) + " (" + unitsMap[ dim ] + ')' );
               else
                 bandNameValues.append( dim + '=' + values.at( 1 ) );
@@ -1943,7 +1943,7 @@ void buildSupportedRasterFileFilterAndExtensions( QString &fileFiltersString, QS
   // driver, which will be found in DMD_LONGNAME, which will have the
   // same form.
 
-  fileFiltersString = QLatin1String( "" );
+  fileFiltersString.clear();
 
   QgsDebugMsg( QString( "GDAL driver count: %1" ).arg( GDALGetDriverCount() ) );
 
@@ -1970,7 +1970,8 @@ void buildSupportedRasterFileFilterAndExtensions( QString &fileFiltersString, QS
     myGdalDriverDescription = GDALGetDescription( myGdalDriver );
     // QgsDebugMsg(QString("got driver string %1").arg(myGdalDriverDescription));
 
-    myGdalDriverExtension = myGdalDriverLongName = QLatin1String( "" );
+    myGdalDriverExtension.clear();
+    myGdalDriverLongName.clear();
 
     myGdalDriverMetadata = GDALGetMetadata( myGdalDriver, nullptr );
 
@@ -2146,7 +2147,7 @@ QGISEXTERN bool isValidRasterFileName( QString const &fileNameQString, QString &
   // Try to open using VSIFileHandler (see qgsogrprovider.cpp)
   // TODO suppress error messages and report in debug, like in OGR provider
   QString vsiPrefix = QgsZipItem::vsiPrefix( fileName );
-  if ( vsiPrefix != QLatin1String( "" ) )
+  if ( !vsiPrefix.isEmpty() )
   {
     if ( !fileName.startsWith( vsiPrefix ) )
       fileName = vsiPrefix + fileName;

--- a/src/providers/gpx/gpsdata.cpp
+++ b/src/providers/gpx/gpsdata.cpp
@@ -492,7 +492,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
          parseModes.top() == ParsingTrack )
     {
       mString = &mObj->name;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingString );
     }
     else
@@ -505,7 +505,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
          parseModes.top() == ParsingTrack )
     {
       mString = &mObj->cmt;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingString );
     }
     else
@@ -518,7 +518,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
          parseModes.top() == ParsingTrack )
     {
       mString = &mObj->desc;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingString );
     }
     else
@@ -531,7 +531,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
          parseModes.top() == ParsingTrack )
     {
       mString = &mObj->src;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingString );
     }
     else
@@ -544,7 +544,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
          parseModes.top() == ParsingTrack )
     {
       mString = &mObj->url;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingString );
     }
     else
@@ -557,7 +557,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
          parseModes.top() == ParsingTrack )
     {
       mString = &mObj->urlname;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingString );
     }
     else
@@ -570,7 +570,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
     if ( parseModes.top() == ParsingWaypoint )
     {
       mDouble = &mWpt.ele;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingDouble );
     }
     else
@@ -581,7 +581,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
     if ( parseModes.top() == ParsingWaypoint )
     {
       mString = &mWpt.sym;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingString );
     }
     else
@@ -594,7 +594,7 @@ bool QgsGPXHandler::startElement( const XML_Char *qName, const XML_Char **attr )
     if ( parseModes.top() == ParsingRoute )
     {
       mInt = &mRte.number;
-      mCharBuffer = QLatin1String( "" );
+      mCharBuffer.clear();
       parseModes.push( ParsingInt );
     }
     else if ( parseModes.top() == ParsingTrack )
@@ -713,17 +713,17 @@ bool QgsGPXHandler::endElement( const std::string &qName )
   else if ( parseModes.top() == ParsingDouble )
   {
     *mDouble = QString( mCharBuffer ).toDouble();
-    mCharBuffer = QLatin1String( "" );
+    mCharBuffer.clear();
   }
   else if ( parseModes.top() == ParsingInt )
   {
     *mInt = QString( mCharBuffer ).toInt();
-    mCharBuffer = QLatin1String( "" );
+    mCharBuffer.clear();
   }
   else if ( parseModes.top() == ParsingString )
   {
     *mString = mCharBuffer;
-    mCharBuffer = QLatin1String( "" );
+    mCharBuffer.clear();
   }
   parseModes.pop();
 

--- a/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
+++ b/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
@@ -97,8 +97,8 @@ void QgsMssqlGeomColumnTypeThread::run()
     }
     else
     {
-      layerProperty.type = QLatin1String( "" );
-      layerProperty.srid = QLatin1String( "" );
+      layerProperty.type.clear();
+      layerProperty.srid.clear();
     }
 
     // Now tell the layer list dialog box...

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -130,9 +130,9 @@ void QgsMssqlNewConnection::on_cb_trustedConnection_clicked()
   if ( cb_trustedConnection->checkState() == Qt::Checked )
   {
     txtUsername->setEnabled( false );
-    txtUsername->setText( QLatin1String( "" ) );
+    txtUsername->clear();
     txtPassword->setEnabled( false );
-    txtPassword->setText( QLatin1String( "" ) );
+    txtPassword->clear();
   }
   else
   {

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -242,7 +242,7 @@ QSqlDatabase QgsMssqlProvider::GetDatabase( const QString &service, const QStrin
     db = QSqlDatabase::database( connectionName );
 
   db.setHostName( host );
-  QString connectionString = QLatin1String( "" );
+  QString connectionString;
   if ( !service.isEmpty() )
   {
     // driver was specified explicitly
@@ -2289,7 +2289,7 @@ QGISEXTERN QString getStyleById( const QString &uri, QString styleId, QString &e
   QSqlQuery query = QSqlQuery( mDatabase );
   query.setForwardOnly( true );
 
-  QString style = QLatin1String( "" );
+  QString style;
   QString selectQmlQuery = QStringLiteral( "SELECT styleQml FROM layer_styles WHERE id=%1" ).arg( QgsMssqlProvider::quotedValue( styleId ) );
   bool queryOk = query.exec( selectQmlQuery );
   if ( !queryOk )

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -581,8 +581,8 @@ void QgsMssqlSourceSelect::on_btnConnect_clicked()
         if ( type == QLatin1String( "GEOMETRY" ) || type.isNull() || srid.isEmpty() )
         {
           addSearchGeometryColumn( connectionName, layer, estimateMetadata );
-          type = QLatin1String( "" );
-          srid = QLatin1String( "" );
+          type.clear();
+          srid.clear();
         }
       }
 
@@ -707,7 +707,7 @@ void QgsMssqlSourceSelect::addSearchGeometryColumn( const QString &connectionNam
 
 QString QgsMssqlSourceSelect::fullDescription( const QString &schema, const QString &table, const QString &column, const QString &type )
 {
-  QString full_desc = QLatin1String( "" );
+  QString full_desc;
   if ( !schema.isEmpty() )
     full_desc = schema + '.';
   full_desc += table + " (" + column + ") " + type;

--- a/src/providers/mssql/qgsmssqltablemodel.cpp
+++ b/src/providers/mssql/qgsmssqltablemodel.cpp
@@ -89,11 +89,11 @@ void QgsMssqlTableModel::addTableEntry( const QgsMssqlLayerProperty &layerProper
   QStandardItem *sridItem = new QStandardItem( layerProperty.srid );
   sridItem->setEditable( false );
 
-  QString pkText, pkCol = QLatin1String( "" );
+  QString pkText;
+  QString pkCol;
   switch ( layerProperty.pkCols.size() )
   {
     case 0:
-      pkText = QLatin1String( "" );
       break;
     case 1:
       pkText = layerProperty.pkCols[0];

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -513,7 +513,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
 
   // allow only normal files, supported directories, or VSIFILE items to continue
   bool isOgrSupportedDirectory = info.isDir() && dirExtensions.contains( suffix );
-  if ( !isOgrSupportedDirectory && !info.isFile() && vsiPrefix == QLatin1String( "" ) )
+  if ( !isOgrSupportedDirectory && !info.isFile() && vsiPrefix.isEmpty() )
     return nullptr;
 
   // skip *.aux.xml files (GDAL auxiliary metadata files),
@@ -556,7 +556,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   }
 
   // fix vsifile path and name
-  if ( vsiPrefix != QLatin1String( "" ) )
+  if ( !vsiPrefix.isEmpty() )
   {
     // add vsiPrefix to path if needed
     if ( !path.startsWith( vsiPrefix ) )

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3598,7 +3598,7 @@ void QgsOgrProvider::open( OpenMode mode )
   // Try to open using VSIFileHandler
   //   see http://trac.osgeo.org/gdal/wiki/UserDocs/ReadInZip
   QString vsiPrefix = QgsZipItem::vsiPrefix( dataSourceUri() );
-  if ( vsiPrefix != QLatin1String( "" ) )
+  if ( !vsiPrefix.isEmpty() )
   {
     // GDAL>=1.8.0 has write support for zip, but read and write operations
     // cannot be interleaved, so for now just use read-only.
@@ -3690,7 +3690,7 @@ void QgsOgrProvider::open( OpenMode mode )
 
       // Ensure subset is set (setSubsetString does nothing if the passed sql subset string is equal to mSubsetString, which is the case when reloading the dataset)
       QString origSubsetString = mSubsetString;
-      mSubsetString = QLatin1String( "" );
+      mSubsetString.clear();
       // Block signals to avoid endless recusion reloadData -> emit dataChanged -> reloadData
       blockSignals( true );
       mValid = setSubsetString( origSubsetString );

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -143,7 +143,7 @@ void QgsPgSourceSelectDelegate::setEditorData( QWidget *editor, const QModelInde
     bool ok;
     value.toInt( &ok );
     if ( index.column() == QgsPgTableModel::DbtmSrid && !ok )
-      value = QLatin1String( "" );
+      value.clear();
 
     le->setText( value );
   }
@@ -620,7 +620,7 @@ void QgsPgSourceSelect::setSql( const QModelIndex &index )
 
 QString QgsPgSourceSelect::fullDescription( const QString &schema, const QString &table, const QString &column, const QString &type )
 {
-  QString full_desc = QLatin1String( "" );
+  QString full_desc;
   if ( !schema.isEmpty() )
     full_desc = QgsPostgresConn::quotedIdentifier( schema ) + '.';
   full_desc += QgsPostgresConn::quotedIdentifier( table ) + " (" + column + ") " + type;

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -532,7 +532,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
         type += QLatin1String( "ZM" );
       layerProperty.types = QList<QgsWkbTypes::Type>() << ( QgsPostgresConn::wkbTypeFromPostgis( type ) );
       layerProperty.srids = QList<int>() << srid;
-      layerProperty.sql = QLatin1String( "" );
+      layerProperty.sql.clear();
       layerProperty.relKind = relkind;
       layerProperty.isView = isView;
       layerProperty.tableComment = comment;
@@ -669,7 +669,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
         continue;
       }
 
-      layerProperty.sql = QLatin1String( "" );
+      layerProperty.sql.clear();
 
       mLayersSupported << layerProperty;
       nColumns++;
@@ -745,7 +745,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
         continue;
 
       addColumnInfo( layerProperty, schema, table, isView );
-      layerProperty.sql = QLatin1String( "" );
+      layerProperty.sql.clear();
 
       mLayersSupported << layerProperty;
       nColumns++;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -121,7 +121,7 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri )
   {
     mIsQuery = true;
     mQuery = mTableName;
-    mTableName = QLatin1String( "" );
+    mTableName.clear();
   }
   else
   {
@@ -407,7 +407,7 @@ QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias )
 
     case PktFidMap:
     {
-      QString delim = QLatin1String( "" );
+      QString delim;
       for ( int i = 0; i < mPrimaryKeyAttrs.size(); i++ )
       {
         int idx = mPrimaryKeyAttrs[i];
@@ -524,7 +524,7 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields &
       {
         Q_ASSERT( pkVals.size() == pkAttrs.size() );
 
-        QString delim = QLatin1String( "" );
+        QString delim;
         for ( int i = 0; i < pkAttrs.size(); i++ )
         {
           int idx = pkAttrs[i];
@@ -868,7 +868,7 @@ bool QgsPostgresProvider::loadFields()
       {
         fieldType = QVariant::Double;
 
-        if ( formattedFieldType == QLatin1String( "numeric" ) || formattedFieldType == QLatin1String( "" ) )
+        if ( formattedFieldType == QLatin1String( "numeric" ) || formattedFieldType.isEmpty() )
         {
           fieldSize = -1;
           fieldPrec = -1;
@@ -1362,7 +1362,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
 
       bool mightBeNull = false;
       QString primaryKey;
-      QString delim = QLatin1String( "" );
+      QString delim;
 
       mPrimaryKeyType = PktFidMap; // map by default, will downgrade if needed
       for ( int i = 0; i < res.PQntuples(); i++ )
@@ -1441,7 +1441,7 @@ QStringList QgsPostgresProvider::parseUriKey( const QString &key )
         else
         {
           cols << col;
-          col = QLatin1String( "" );
+          col.clear();
 
           if ( ++i == key.size() )
             break;
@@ -1450,7 +1450,7 @@ QStringList QgsPostgresProvider::parseUriKey( const QString &key )
           i++;
           Q_ASSERT( key[i] == '"' );
           i++;
-          col = QLatin1String( "" );
+          col.clear();
           continue;
         }
       }
@@ -1479,8 +1479,8 @@ void QgsPostgresProvider::determinePrimaryKeyFromUriKeyColumn()
   {
     QStringList cols = parseUriKey( primaryKey );
 
-    primaryKey = QLatin1String( "" );
-    QString del = QLatin1String( "" );
+    primaryKey.clear();
+    QString del;
     Q_FOREACH ( const QString &col, cols )
     {
       primaryKey += del + quotedIdentifier( col );
@@ -1986,7 +1986,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     // Prepare the INSERT statement
     QString insert = QStringLiteral( "INSERT INTO %1(" ).arg( mQuery );
     QString values = QStringLiteral( ") VALUES (" );
-    QString delim = QLatin1String( "" );
+    QString delim;
     int offset = 1;
 
     QStringList defaultValues;
@@ -2386,7 +2386,7 @@ bool QgsPostgresProvider::addAttributes( const QList<QgsField> &attributes )
   {
     conn->begin();
 
-    QString delim = QLatin1String( "" );
+    QString delim;
     QString sql = QStringLiteral( "ALTER TABLE %1 " ).arg( mQuery );
     for ( QList<QgsField>::const_iterator iter = attributes.begin(); iter != attributes.end(); ++iter )
     {
@@ -3305,7 +3305,7 @@ bool QgsPostgresProvider::getGeometryDetails()
       }
       else
       {
-        schemaName = QLatin1String( "" );
+        schemaName.clear();
         tableName = mQuery;
       }
     }
@@ -3503,7 +3503,7 @@ bool QgsPostgresProvider::getGeometryDetails()
 
   if ( mDetectedGeomType == QgsWkbTypes::Unknown )
   {
-    mDetectedSrid = QLatin1String( "" );
+    mDetectedSrid.clear();
 
     QgsPostgresLayerProperty layerProperty;
     if ( !mIsQuery )
@@ -3513,14 +3513,14 @@ bool QgsPostgresProvider::getGeometryDetails()
     }
     else
     {
-      layerProperty.schemaName = QLatin1String( "" );
+      layerProperty.schemaName.clear();
       layerProperty.tableName  = mQuery;
     }
     layerProperty.geometryColName = mGeometryColumn;
     layerProperty.geometryColType = mSpatialColType;
     layerProperty.force2d         = false;
 
-    QString delim = QLatin1String( "" );
+    QString delim;
 
     if ( !mSqlWhereClause.isEmpty() )
     {
@@ -3702,7 +3702,7 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
   QStringList pkList;
   QStringList pkType;
 
-  QString schemaTableName = QLatin1String( "" );
+  QString schemaTableName;
   if ( !schemaName.isEmpty() )
   {
     schemaTableName += quotedIdentifier( schemaName ) + '.';

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3840,7 +3840,7 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
     sql = QStringLiteral( "INSERT INTO %1(" ).arg( quotedIdentifier( mTableName ) );
     values = QStringLiteral( ") VALUES (" );
-    separator = QLatin1String( "" );
+    separator.clear();
 
     if ( !mGeometryColumn.isEmpty() )
     {

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -531,7 +531,7 @@ void QgsSpatiaLiteSourceSelect::setSql( const QModelIndex &index )
 
 QString QgsSpatiaLiteSourceSelect::fullDescription( const QString &table, const QString &column, const QString &type )
 {
-  QString full_desc = QLatin1String( "" );
+  QString full_desc;
   full_desc += table + "\" (" + column + ") " + type;
   return full_desc;
 }

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -68,7 +68,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     struct SourceLayer
     {
       SourceLayer() {}
-      SourceLayer( QgsVectorLayer *l, const QString &n = QLatin1String( "" ) )
+      SourceLayer( QgsVectorLayer *l, const QString &n = QString() )
         : layer( l )
         , name( n )
       {}

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -136,7 +136,7 @@ QString QgsWcsCapabilities::getCoverageUrl() const
 bool QgsWcsCapabilities::sendRequest( QString const &url )
 {
   QgsDebugMsg( "url = " + url );
-  mError = QLatin1String( "" );
+  mError.clear();
   QNetworkRequest request( url );
   if ( !setAuthorization( request ) )
   {

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -987,7 +987,7 @@ void QgsWcsProvider::parseServiceException( QDomElement const &e, const QString 
       seCode = e.attribute( QStringLiteral( "locator" ) );
       if ( ! exceptions.contains( seCode ) )
       {
-        seCode = QLatin1String( "" );
+        seCode.clear();
       }
     }
     seText = QgsWcsCapabilities::firstChildText( e, QStringLiteral( "ExceptionText" ) );
@@ -1233,7 +1233,7 @@ QString QgsWcsProvider::coverageMetadata( const QgsWcsCoverageSummary &coverage 
 
 QString QgsWcsProvider::metadata()
 {
-  QString metadata = QLatin1String( "" );
+  QString metadata;
 
   metadata += QLatin1String( "<tr><td>" );
 

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -66,7 +66,7 @@ void QgsWfsCapabilities::Capabilities::clear()
   supportsHits = false;
   supportsPaging = false;
   supportsJoins = false;
-  version = QLatin1String( "" );
+  version.clear();
   featureTypes.clear();
   spatialPredicatesList.clear();
   functionList.clear();

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -286,7 +286,7 @@ bool QgsWFSProvider::processSQL( const QString &sqlString, QString &errorMsg, QS
   {
     QString parserErrorString( sql.parserErrorString() );
     QStringList parts( parserErrorString.split( QStringLiteral( "," ) ) );
-    parserErrorString = QLatin1String( "" );
+    parserErrorString.clear();
     Q_FOREACH ( const QString &part, parts )
     {
       QString newPart( part );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1847,7 +1847,7 @@ QString QgsWmsProvider::layerMetadata( QgsWmsLayerProperty &layer )
 
 QString QgsWmsProvider::metadata()
 {
-  QString metadata = QLatin1String( "" );
+  QString metadata;
 
   metadata += QLatin1String( "<tr><td>" );
 
@@ -3379,7 +3379,7 @@ QImage QgsWmsProvider::getLegendGraphic( double scale, bool forceRefresh, const 
   if ( !forceRefresh )
     return mGetLegendGraphicImage;
 
-  mError = QLatin1String( "" );
+  mError.clear();
 
   QUrl url( getLegendGraphicFullURL( scale, mGetLegendGraphicExtent ) );
   if ( !url.isValid() )

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -847,8 +847,8 @@ void QgsWMSSourceSelect::on_lstLayers_itemSelectionChanged()
   }
   else if ( layers.isEmpty() || mCRSs.isEmpty() )
   {
-    mCRS = QLatin1String( "" );
-    labelCoordRefSys->setText( QLatin1String( "" ) );
+    mCRS.clear();
+    labelCoordRefSys->clear();
   }
 
   updateLayerOrderTab( layers, styles, titles );
@@ -970,7 +970,7 @@ void QgsWMSSourceSelect::updateButtons()
     }
     else
     {
-      mLastLayerName = QLatin1String( "" );
+      mLastLayerName.clear();
       leLayerName->setText( mLastLayerName );
     }
   }

--- a/tests/bench/main.cpp
+++ b/tests/bench/main.cpp
@@ -105,7 +105,7 @@ void usage( std::string const &appName )
 // AppleEvent handler as well as by the main routine argv processing
 
 // This behavior will cause QGIS to autoload a project
-static QString myProjectFileName = QLatin1String( "" );
+static QString myProjectFileName;
 
 // This is the 'leftover' arguments collection
 static QStringList sFileList;
@@ -131,12 +131,12 @@ int main( int argc, char *argv[] )
   //
 
   int myIterations = 1;
-  QString mySnapshotFileName = QLatin1String( "" );
-  QString myLogFileName = QLatin1String( "" );
-  QString myPrefixPath = QLatin1String( "" );
+  QString mySnapshotFileName;
+  QString myLogFileName;
+  QString myPrefixPath;
   int mySnapshotWidth = 800;
   int mySnapshotHeight = 600;
-  QString myQuality = QLatin1String( "" );
+  QString myQuality;
   bool myParallel = false;
   QString myPrintTime = QStringLiteral( "total" );
 
@@ -144,7 +144,7 @@ int main( int argc, char *argv[] )
   // there are no command line arguments. This gives a usable map
   // extent when qgis starts with no layers loaded. When layers are
   // loaded, we let the layers define the initial extent.
-  QString myInitialExtent = QLatin1String( "" );
+  QString myInitialExtent;
   if ( argc == 1 )
     myInitialExtent = QStringLiteral( "-1,-1,1,1" );
 
@@ -582,12 +582,12 @@ int main( int argc, char *argv[] )
 
   qbench->render();
 
-  if ( mySnapshotFileName != QLatin1String( "" ) )
+  if ( !mySnapshotFileName.isEmpty() )
   {
     qbench->saveSnapsot( mySnapshotFileName );
   }
 
-  if ( myLogFileName != QLatin1String( "" ) )
+  if ( !myLogFileName.isEmpty() )
   {
     qbench->saveLog( myLogFileName );
   }

--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -264,7 +264,7 @@ void TestQgisAppClipboard::pasteGeoJson()
 void TestQgisAppClipboard::retrieveFields()
 {
   //empty string
-  mQgisApp->clipboard()->setText( QLatin1String( "" ) );
+  mQgisApp->clipboard()->setText( QString() );
 
   QgsFields fields = mQgisApp->clipboard()->fields();
   QCOMPARE( fields.count(), 0 );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -388,7 +388,7 @@ void TestQgsCoordinateReferenceSystem::createFromESRIWkt()
 
     // do test with shapefiles
     CPLSetConfigOption( "GDAL_FIX_ESRI_WKT", configOld );
-    if ( myFiles[i] != QLatin1String( "" ) )
+    if ( !myFiles[i].isEmpty() )
     {
       // use ogr to open file, make sure CRS is OK
       // this probably could be in another test, but leaving it here since it deals with CRS

--- a/tests/src/core/testziplayer.cpp
+++ b/tests/src/core/testziplayer.cpp
@@ -51,7 +51,7 @@ class TestZipLayer: public QObject
     // get map layer using QgsZipItem (only 1 child)
     QgsMapLayer *getZipLayer( const QString &myPath, const QString &myName );
     // test item(s) in zip item (supply name or test all)
-    bool testZipItem( const QString &myFileName, const QString &myChildName = QStringLiteral( "" ), const QString &myDriverName = QStringLiteral( "" ) );
+    bool testZipItem( const QString &myFileName, const QString &myChildName = QString(), const QString &myDriverName = QString() );
     // get layer transparency to test for .qml loading
     int getLayerTransparency( const QString &myFileName, const QString &myProviderKey, const QString &myScanZipSetting = QStringLiteral( "basic" ) );
     bool testZipItemTransparency( const QString &myFileName, const QString &myProviderKey, int myTarget );
@@ -100,7 +100,7 @@ class TestZipLayer: public QObject
 QgsMapLayer *TestZipLayer::getLayer( const QString &myPath, const QString &myName, const QString &myProviderKey )
 {
   QString fullName = myName;
-  if ( fullName == QLatin1String( "" ) )
+  if ( fullName.isEmpty() )
   {
     QFileInfo myFileInfo( myPath );
     fullName = myFileInfo.completeBaseName();
@@ -175,7 +175,7 @@ bool TestZipLayer::testZipItem( const QString &myFileName, const QString &myChil
       if ( layerItem )
       {
         QgsDebugMsg( QString( "child name=%1 provider=%2 path=%3" ).arg( layerItem->name(), layerItem->providerKey(), layerItem->path() ) );
-        if ( myChildName == QLatin1String( "" ) || myChildName == item->name() )
+        if ( myChildName.isEmpty() || myChildName == item->name() )
         {
           QgsMapLayer *layer = getLayer( layerItem->path(), layerItem->name(), layerItem->providerKey() );
           if ( layer )
@@ -189,7 +189,7 @@ bool TestZipLayer::testZipItem( const QString &myFileName, const QString &myChil
             {
               QWARN( QString( "Invalid layer %1" ).arg( layerItem->path() ).toLocal8Bit().data() );
             }
-            if ( myChildName == QLatin1String( "" ) )
+            if ( myChildName.isEmpty() )
             {
               if ( ! ok )
                 break;
@@ -197,7 +197,7 @@ bool TestZipLayer::testZipItem( const QString &myFileName, const QString &myChil
             else
             {
               //verify correct provider was used
-              if ( myProviderName != QLatin1String( "" ) )
+              if ( !myProviderName.isEmpty() )
               {
                 ok = ( myProviderName == layerItem->providerKey() );
                 if ( ! ok )

--- a/tests/src/gui/testqgsscalecombobox.cpp
+++ b/tests/src/gui/testqgsscalecombobox.cpp
@@ -190,7 +190,7 @@ void TestQgsScaleComboBox::toDouble()
 void TestQgsScaleComboBox::enterScale( const QString &scale )
 {
   QLineEdit *l = s->lineEdit();
-  l->setText( QLatin1String( "" ) );
+  l->clear();
   QTest::keyClicks( l, scale );
   QTest::keyClick( l, Qt::Key_Return );
 }


### PR DESCRIPTION
- use .isEmpty() instead of == QLatin1String( "" ) to check for
empty strings
- use .clear() instead of = QLatin1String( "" ) to empty a string
- remove unnecessary QString initializations

Carefully checked to ensure we have no .isNull issues here!