### PR TITLE
 [auth] Re-designed authentication configuration selector widget

### DIFF
--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -31,6 +31,7 @@
 #include <QDomElement>
 #include <QFileDialog>
 #include <QPushButton>
+#include <QToolButton>
 #include <QMessageBox>
 #include <QUrl>
 

--- a/src/gui/auth/qgsauthconfigselect.cpp
+++ b/src/gui/auth/qgsauthconfigselect.cpp
@@ -26,6 +26,7 @@
 #include "qgsauthmanager.h"
 #include "qgsauthconfigedit.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 QgsAuthConfigSelect::QgsAuthConfigSelect( QWidget *parent, const QString &dataprovider )
@@ -43,6 +44,17 @@ QgsAuthConfigSelect::QgsAuthConfigSelect( QWidget *parent, const QString &datapr
   else
   {
     setupUi( this );
+
+    // Set icons and remove texts
+    btnConfigAdd->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionAdd.svg" ) ) );
+    btnConfigRemove->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteSelected.svg" ) ) );
+    btnConfigEdit->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionToggleEditing.svg" ) ) );
+    btnConfigMsgClear->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIconClose.svg" ) ) );
+
+    btnConfigAdd->setText( QStringLiteral( "" ) );
+    btnConfigRemove->setText( QStringLiteral( "" ) );
+    btnConfigEdit->setText( QStringLiteral( "" ) );
+    btnConfigMsgClear->setText( QStringLiteral( "" ) );
 
     leConfigMsg->setStyleSheet( QStringLiteral( "QLineEdit{background-color: %1}" )
                                 .arg( QgsAuthGuiUtils::yellowColor().name() ) );
@@ -94,9 +106,8 @@ void QgsAuthConfigSelect::loadConfig()
     {
       methoddesc = authmethod->description();
     }
-    leConfigMethodDesc->setText( methoddesc );
-    leConfigMethodDesc->setCursorPosition( 0 ); // left justify
-    leConfigId->setText( config.id() );
+    cmbConfigSelect->setToolTip( tr( "<ul><li><b>Method type:</b> %1</li>"
+                                     "<li><b>Configuration ID:</b> %2</li></ul>" ).arg( methoddesc, config.id( ) ) );
     btnConfigEdit->setEnabled( true );
     btnConfigRemove->setEnabled( true );
   }
@@ -105,8 +116,7 @@ void QgsAuthConfigSelect::loadConfig()
 
 void QgsAuthConfigSelect::clearConfig()
 {
-  leConfigMethodDesc->clear();
-  leConfigId->clear();
+  cmbConfigSelect->setToolTip( QStringLiteral( "" ) );
   btnConfigEdit->setEnabled( false );
   btnConfigRemove->setEnabled( false );
 }
@@ -134,7 +144,7 @@ void QgsAuthConfigSelect::populateConfigSelector()
   for ( cit = mConfigs.constBegin(); cit != mConfigs.constEnd(); ++cit )
   {
     QgsAuthMethodConfig config = cit.value();
-    sortmap.insert( config.name(), cit.key() );
+    sortmap.insert( QStringLiteral( "%1 (%2)" ).arg( config.name(), config.method() ), cit.key() );
   }
 
   QgsStringMap::const_iterator sm = sortmap.constBegin();

--- a/src/gui/auth/qgsauthconfigselect.h
+++ b/src/gui/auth/qgsauthconfigselect.h
@@ -18,6 +18,7 @@
 #define QGSAUTHCONFIGSELECT_H
 
 #include <QWidget>
+#include <QLabel>
 #include "qgis.h"
 
 #include "ui_qgsauthconfigselect.h"

--- a/src/ui/auth/qgsauthconfigselect.ui
+++ b/src/ui/auth/qgsauthconfigselect.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>546</width>
-    <height>90</height>
+    <width>547</width>
+    <height>94</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,7 +47,27 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" colspan="6">
+     <item row="1" column="1">
+      <widget class="QToolButton" name="btnConfigEdit">
+       <property name="toolTip">
+        <string>Edit selected configuration</string>
+       </property>
+       <property name="text">
+        <string>Edit</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QToolButton" name="btnConfigRemove">
+       <property name="toolTip">
+        <string>Delete selected configuration</string>
+       </property>
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0" colspan="5">
       <widget class="QFrame" name="frConfigMsg">
        <property name="frameShape">
         <enum>QFrame::StyledPanel</enum>
@@ -79,7 +99,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btnConfigMsgClear">
+         <widget class="QToolButton" name="btnConfigMsgClear">
           <property name="minimumSize">
            <size>
             <width>26</width>
@@ -104,50 +124,18 @@
             <height>22</height>
            </size>
           </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
          </widget>
         </item>
        </layout>
       </widget>
      </item>
-     <item row="1" column="4">
-      <widget class="QPushButton" name="btnConfigAdd">
+     <item row="1" column="3">
+      <widget class="QToolButton" name="btnConfigAdd">
        <property name="toolTip">
         <string>Create a new authentication configuration</string>
        </property>
        <property name="text">
         <string>New</string>
-       </property>
-       <property name="flat">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QPushButton" name="btnConfigRemove">
-       <property name="toolTip">
-        <string>Delete selected configuration</string>
-       </property>
-       <property name="text">
-        <string>Delete</string>
-       </property>
-       <property name="flat">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QPushButton" name="btnConfigEdit">
-       <property name="toolTip">
-        <string>Edit selected configuration</string>
-       </property>
-       <property name="text">
-        <string>Edit</string>
-       </property>
-       <property name="flat">
-        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -173,8 +161,6 @@
   <tabstop>btnConfigMsgClear</tabstop>
   <tabstop>cmbConfigSelect</tabstop>
  </tabstops>
- <resources>
-  <include location="../../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/ui/auth/qgsauthconfigselect.ui
+++ b/src/ui/auth/qgsauthconfigselect.ui
@@ -6,15 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>278</width>
-    <height>176</height>
+    <width>546</width>
+    <height>90</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Authentication Configuration</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
     <number>6</number>
    </property>
    <item>
@@ -22,13 +31,6 @@
      <property name="verticalSpacing">
       <number>10</number>
      </property>
-     <item row="1" column="1">
-      <widget class="QToolButton" name="btnConfigAdd">
-       <property name="text">
-        <string>Add</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="0">
       <widget class="QComboBox" name="cmbConfigSelect">
        <property name="sizePolicy">
@@ -39,13 +41,13 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>200</width>
+         <width>250</width>
          <height>0</height>
         </size>
        </property>
       </widget>
      </item>
-     <item row="0" column="0" colspan="2">
+     <item row="0" column="0" colspan="6">
       <widget class="QFrame" name="frConfigMsg">
        <property name="frameShape">
         <enum>QFrame::StyledPanel</enum>
@@ -57,7 +59,16 @@
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -68,7 +79,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QToolButton" name="btnConfigMsgClear">
+         <widget class="QPushButton" name="btnConfigMsgClear">
           <property name="minimumSize">
            <size>
             <width>26</width>
@@ -81,91 +92,61 @@
             <height>22</height>
            </size>
           </property>
-          <property name="text">
-           <string/>
+          <property name="toolTip">
+           <string>Dismiss</string>
           </property>
-          <property name="icon">
-           <iconset resource="../../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIconClose.svg</normaloff>:/images/themes/default/mIconClose.svg</iconset>
+          <property name="text">
+           <string>Dismiss</string>
           </property>
           <property name="iconSize">
            <size>
-            <width>14</width>
-            <height>14</height>
+            <width>22</width>
+            <height>22</height>
            </size>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
        </layout>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="styleSheet">
-        <string notr="true">QLabel{color: rgb(128, 128, 128);}</string>
+     <item row="1" column="4">
+      <widget class="QPushButton" name="btnConfigAdd">
+       <property name="toolTip">
+        <string>Create a new authentication configuration</string>
        </property>
        <property name="text">
-        <string>Method</string>
+        <string>New</string>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="styleSheet">
-        <string notr="true">QLabel{color: rgb(128, 128, 128);}</string>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="btnConfigRemove">
+       <property name="toolTip">
+        <string>Delete selected configuration</string>
        </property>
        <property name="text">
-        <string>Id</string>
+        <string>Delete</string>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QLineEdit" name="leConfigId">
-         <property name="minimumSize">
-          <size>
-           <width>80</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">QLineEdit{color: rgb(128, 128, 128);}</string>
-         </property>
-         <property name="frame">
-          <bool>true</bool>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="btnConfigEdit">
-         <property name="text">
-          <string>Edit</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="btnConfigRemove">
-         <property name="text">
-          <string>Remove</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="leConfigMethodDesc">
-       <property name="styleSheet">
-        <string notr="true">QLineEdit{color: rgb(128, 128, 128);}</string>
+      <widget class="QPushButton" name="btnConfigEdit">
+       <property name="toolTip">
+        <string>Edit selected configuration</string>
        </property>
-       <property name="readOnly">
+       <property name="text">
+        <string>Edit</string>
+       </property>
+       <property name="flat">
         <bool>true</bool>
        </property>
       </widget>
@@ -180,7 +161,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>0</height>
+       <height>40</height>
       </size>
      </property>
     </spacer>
@@ -191,11 +172,6 @@
   <tabstop>leConfigMsg</tabstop>
   <tabstop>btnConfigMsgClear</tabstop>
   <tabstop>cmbConfigSelect</tabstop>
-  <tabstop>btnConfigAdd</tabstop>
-  <tabstop>leConfigMethodDesc</tabstop>
-  <tabstop>leConfigId</tabstop>
-  <tabstop>btnConfigEdit</tabstop>
-  <tabstop>btnConfigRemove</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>


### PR DESCRIPTION
## What's new:
- single line widget
- takes much less space
- it has the same functionality of the previous version
- use `QgsApplication` themes icons and tooltips to convey information

## Images

![authconfigselect6](https://user-images.githubusercontent.com/142164/31017117-c3a8c4f0-a527-11e7-9cc5-8e9b030da715.png)


![authconfigselect4](https://user-images.githubusercontent.com/142164/30967036-345fd328-a45b-11e7-93a9-85493e56ea3b.png)

@dakcarto not sure if for accessibility purposes we do want to add a constructor optional argument to NOT hide the text from the buttons. Note that this could be easily done later on. Or as an alternative a method to restore the texts could be also easiliy added.

