### PR TITLE
[FEATURE] Flash features

### DIFF
--- a/python/gui/qgsattributeform.sip
+++ b/python/gui/qgsattributeform.sip
@@ -165,6 +165,12 @@ class QgsAttributeForm : QWidget
 .. versionadded:: 3.0
 %End
 
+    void flashFeatures( const QString &filter );
+%Docstring
+ Emitted when the user chooses to flash a filtered set of features.
+.. versionadded:: 3.0
+%End
+
   public slots:
 
     void changeAttribute( const QString &field, const QVariant &value, const QString &hintText = QString() );

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -234,6 +234,19 @@ Zoom to the next extent (view)
 Pan to the selected features of current (vector) layer keeping same extent.
 %End
 
+    void flashFeatureIds( QgsVectorLayer *layer, const QgsFeatureIds &ids,
+                          const QColor &startColor = QColor( 255, 0, 0, 255 ), const QColor &endColor = QColor( 255, 0, 0, 0 ),
+                          int flashes = 3, int duration = 500 );
+%Docstring
+ Causes a set of features with matching ``ids`` from a vector ``layer`` to flash
+ within the canvas.
+
+ The ``startColor`` and ``endColor`` can be specified, along with the number of
+ ``flashes`` and ``duration`` of each flash (in milliseconds).
+
+.. versionadded:: 3.0
+%End
+
     void setMapTool( QgsMapTool *mapTool );
 %Docstring
  Sets the map tool currently being used on the canvas

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -252,14 +252,14 @@ Pan to the selected features of current (vector) layer keeping same extent.
 .. seealso:: flashGeometries()
 %End
 
-    void flashGeometries( QgsVectorLayer *layer, const QList< QgsGeometry > &geometries,
+    void flashGeometries( const QList< QgsGeometry > &geometries, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
                           const QColor &startColor = QColor( 255, 0, 0, 255 ), const QColor &endColor = QColor( 255, 0, 0, 0 ),
                           int flashes = 3, int duration = 500 );
 %Docstring
  Causes a set of ``geometries`` to flash within the canvas.
 
- If ``layer`` is non-null, the geometries will be automatically transformed from the layer
- CRS to canvas CRS.
+ If ``crs`` is a valid coordinate reference system, the geometries will be automatically
+ transformed from this CRS to the canvas CRS.
 
  The ``startColor`` and ``endColor`` can be specified, along with the number of
  ``flashes`` and ``duration`` of each flash (in milliseconds).

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -244,7 +244,28 @@ Pan to the selected features of current (vector) layer keeping same extent.
  The ``startColor`` and ``endColor`` can be specified, along with the number of
  ``flashes`` and ``duration`` of each flash (in milliseconds).
 
+.. note::
+
+   If the features or geometries are already available, flashGeometries() is much more efficient.
+
 .. versionadded:: 3.0
+.. seealso:: flashGeometries()
+%End
+
+    void flashGeometries( QgsVectorLayer *layer, const QList< QgsGeometry > &geometries,
+                          const QColor &startColor = QColor( 255, 0, 0, 255 ), const QColor &endColor = QColor( 255, 0, 0, 0 ),
+                          int flashes = 3, int duration = 500 );
+%Docstring
+ Causes a set of ``geometries`` to flash within the canvas.
+
+ If ``layer`` is non-null, the geometries will be automatically transformed from the layer
+ CRS to canvas CRS.
+
+ The ``startColor`` and ``endColor`` can be specified, along with the number of
+ ``flashes`` and ``duration`` of each flash (in milliseconds).
+
+.. versionadded:: 3.0
+.. seealso:: flashFeatureIds()
 %End
 
     void setMapTool( QgsMapTool *mapTool );

--- a/python/gui/qgsrubberband.sip
+++ b/python/gui/qgsrubberband.sip
@@ -275,7 +275,7 @@ for tracking the mouse while drawing polylines or polygons.
   \param p The QPainter object
 %End
 
-    void drawShape( QPainter *p, QVector<QPointF> &pts );
+    void drawShape( QPainter *p, const QVector<QPointF> &pts );
 %Docstring
  Draws shape of the rubber band.
   \param p The QPainter object

--- a/python/gui/qgsrubberband.sip
+++ b/python/gui/qgsrubberband.sip
@@ -216,7 +216,7 @@ for tracking the mouse while drawing polylines or polygons.
   \param rect rectangle in canvas coordinates
 %End
 
-    void addGeometry( const QgsGeometry &geom, QgsVectorLayer *layer );
+    void addGeometry( const QgsGeometry &geometry, QgsVectorLayer *layer );
 %Docstring
  Adds the geometry of an existing feature to a rubberband
  This is useful for multi feature highlighting.
@@ -224,9 +224,19 @@ for tracking the mouse while drawing polylines or polygons.
  of the rubberband explicitly by calling reset() or setToGeometry() with appropriate arguments.
  setToGeometry() is also to be preferred for backwards-compatibility.
 
-  \param geom the geometry object. Will be treated as a collection of vertices.
+  \param geometry the geometry object. Will be treated as a collection of vertices.
   \param layer the layer containing the feature, used for coord transformation to map
                crs. In case of 0 pointer, the coordinates are not going to be transformed.
+%End
+
+    void addGeometry( const QgsGeometry &geometry, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+%Docstring
+ Adds a ``geometry`` to the rubberband.
+
+ If ``crs`` is specified, the geometry will be automatically reprojected from ``crs``
+ to the canvas CRS.
+
+.. versionadded:: 3.0
 %End
 
     void setTranslationOffset( double dx, double dy );

--- a/src/app/qgsselectbyformdialog.cpp
+++ b/src/app/qgsselectbyformdialog.cpp
@@ -63,6 +63,7 @@ void QgsSelectByFormDialog::setMapCanvas( QgsMapCanvas *canvas )
 {
   mMapCanvas = canvas;
   connect( mForm, &QgsAttributeForm::zoomToFeatures, this, &QgsSelectByFormDialog::zoomToFeatures );
+  connect( mForm, &QgsAttributeForm::flashFeatures, this, &QgsSelectByFormDialog::flashFeatures );
 }
 
 void QgsSelectByFormDialog::zoomToFeatures( const QString &filter )
@@ -103,6 +104,38 @@ void QgsSelectByFormDialog::zoomToFeatures( const QString &filter )
                                 QgsMessageBar::INFO,
                                 timeout );
     }
+  }
+  else if ( mMessageBar )
+  {
+    mMessageBar->pushMessage( QString(),
+                              tr( "No matching features found" ),
+                              QgsMessageBar::INFO,
+                              timeout );
+  }
+}
+
+void QgsSelectByFormDialog::flashFeatures( const QString &filter )
+{
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+
+  QgsFeatureRequest request = QgsFeatureRequest().setFilterExpression( filter )
+                              .setFlags( QgsFeatureRequest::NoGeometry )
+                              .setExpressionContext( context )
+                              .setSubsetOfAttributes( QgsAttributeList() );
+
+  QgsFeatureIterator features = mLayer->getFeatures( request );
+  QgsFeature feat;
+  QgsFeatureIds ids;
+  while ( features.nextFeature( feat ) )
+  {
+    ids.insert( feat.id() );
+  }
+
+  QgsSettings settings;
+  int timeout = settings.value( QStringLiteral( "qgis/messageTimeout" ), 5 ).toInt();
+  if ( !ids.empty() )
+  {
+    mMapCanvas->flashFeatureIds( mLayer, ids );
   }
   else if ( mMessageBar )
   {

--- a/src/app/qgsselectbyformdialog.cpp
+++ b/src/app/qgsselectbyformdialog.cpp
@@ -119,23 +119,23 @@ void QgsSelectByFormDialog::flashFeatures( const QString &filter )
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
 
   QgsFeatureRequest request = QgsFeatureRequest().setFilterExpression( filter )
-                              .setFlags( QgsFeatureRequest::NoGeometry )
                               .setExpressionContext( context )
                               .setSubsetOfAttributes( QgsAttributeList() );
 
   QgsFeatureIterator features = mLayer->getFeatures( request );
   QgsFeature feat;
-  QgsFeatureIds ids;
+  QList< QgsGeometry > geoms;
   while ( features.nextFeature( feat ) )
   {
-    ids.insert( feat.id() );
+    if ( feat.hasGeometry() )
+      geoms << feat.geometry();
   }
 
   QgsSettings settings;
   int timeout = settings.value( QStringLiteral( "qgis/messageTimeout" ), 5 ).toInt();
-  if ( !ids.empty() )
+  if ( !geoms.empty() )
   {
-    mMapCanvas->flashFeatureIds( mLayer, ids );
+    mMapCanvas->flashGeometries( mLayer, geoms );
   }
   else if ( mMessageBar )
   {

--- a/src/app/qgsselectbyformdialog.cpp
+++ b/src/app/qgsselectbyformdialog.cpp
@@ -135,7 +135,7 @@ void QgsSelectByFormDialog::flashFeatures( const QString &filter )
   int timeout = settings.value( QStringLiteral( "qgis/messageTimeout" ), 5 ).toInt();
   if ( !geoms.empty() )
   {
-    mMapCanvas->flashGeometries( mLayer, geoms );
+    mMapCanvas->flashGeometries( geoms, mLayer->crs() );
   }
   else if ( mMessageBar )
   {

--- a/src/app/qgsselectbyformdialog.h
+++ b/src/app/qgsselectbyformdialog.h
@@ -64,6 +64,7 @@ class APP_EXPORT QgsSelectByFormDialog : public QDialog
   private slots:
 
     void zoomToFeatures( const QString &filter );
+    void flashFeatures( const QString &filter );
 
   private:
 

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -408,15 +408,15 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
   QgsRectangle rect = mCanvas->mapSettings().mapToLayerCoordinates( layer(), mCanvas->extent() );
   QgsRenderContext renderContext;
   renderContext.expressionContext().appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( layer() ) );
-  QgsFeatureRenderer *renderer = layer()->renderer();
 
   mFilteredFeatures.clear();
-
-  if ( !renderer )
+  if ( !layer()->renderer() )
   {
     QgsDebugMsg( "Cannot get renderer" );
     return;
   }
+
+  std::unique_ptr< QgsFeatureRenderer > renderer( layer()->renderer()->clone() );
 
   const QgsMapSettings &ms = mCanvas->mapSettings();
   if ( !layer()->isInScaleRange( ms.scale() ) )
@@ -425,7 +425,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
   }
   else
   {
-    if ( renderer && renderer->capabilities() & QgsFeatureRenderer::ScaleDependent )
+    if ( renderer->capabilities() & QgsFeatureRenderer::ScaleDependent )
     {
       // setup scale
       // mapRenderer()->renderContext()->scale is not automatically updated when
@@ -436,7 +436,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
       renderContext.setRendererScale( ms.scale() );
     }
 
-    filter = renderer && renderer->capabilities() & QgsFeatureRenderer::Filter;
+    filter = renderer->capabilities() & QgsFeatureRenderer::Filter;
   }
 
   renderer->startRender( renderContext, layer()->fields() );
@@ -476,7 +476,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
 
   features.close();
 
-  if ( renderer && renderer->capabilities() & QgsFeatureRenderer::ScaleDependent )
+  if ( renderer->capabilities() & QgsFeatureRenderer::ScaleDependent )
   {
     renderer->stopRender( renderContext );
   }

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -540,6 +540,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &atInd
   {
     menu->addAction( tr( "Zoom to feature" ), this, SLOT( zoomToCurrentFeature() ) );
     menu->addAction( tr( "Pan to feature" ), this, SLOT( panToCurrentFeature() ) );
+    menu->addAction( tr( "Flash feature" ), this, SLOT( flashCurrentFeature() ) );
   }
 
   //add user-defined actions to context menu
@@ -777,6 +778,23 @@ void QgsDualView::panToCurrentFeature()
   if ( canvas )
   {
     canvas->panToFeatureIds( mLayer, ids );
+  }
+}
+
+void QgsDualView::flashCurrentFeature()
+{
+  QModelIndex currentIndex = mTableView->currentIndex();
+  if ( !currentIndex.isValid() )
+  {
+    return;
+  }
+
+  QgsFeatureIds ids;
+  ids.insert( mFilterModel->rowToId( currentIndex ) );
+  QgsMapCanvas *canvas = mFilterModel->mapCanvas();
+  if ( canvas )
+  {
+    canvas->flashFeatureIds( mLayer, ids );
   }
 }
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -328,6 +328,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     //! Pans to the active feature
     void panToCurrentFeature();
 
+    void flashCurrentFeature();
+
     void rebuildFullLayerCache();
 
   private:

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -410,6 +410,15 @@ void QgsAttributeForm::searchZoomTo()
   emit zoomToFeatures( filter );
 }
 
+void QgsAttributeForm::searchFlash()
+{
+  QString filter = createFilterExpression();
+  if ( filter.isEmpty() )
+    return;
+
+  emit flashFeatures( filter );
+}
+
 void QgsAttributeForm::filterAndTriggered()
 {
   QString filter = createFilterExpression();
@@ -1352,6 +1361,12 @@ void QgsAttributeForm::init()
     connect( clearButton, &QPushButton::clicked, this, &QgsAttributeForm::resetSearch );
     boxLayout->addWidget( clearButton );
     boxLayout->addStretch( 1 );
+
+    QPushButton *flashButton = new QPushButton();
+    flashButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );
+    flashButton->setText( tr( "&Flash features" ) );
+    connect( flashButton, &QToolButton::clicked, this, &QgsAttributeForm::searchFlash );
+    boxLayout->addWidget( flashButton );
 
     QPushButton *zoomButton = new QPushButton();
     zoomButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -202,6 +202,12 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void zoomToFeatures( const QString &filter );
 
+    /**
+     * Emitted when the user chooses to flash a filtered set of features.
+     * \since QGIS 3.0
+     */
+    void flashFeatures( const QString &filter );
+
   public slots:
 
     /**
@@ -263,6 +269,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void filterTriggered();
 
     void searchZoomTo();
+    void searchFlash();
     void searchSetSelection();
     void searchAddToSelection();
     void searchRemoveFromSelection();

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1078,12 +1078,17 @@ void QgsMapCanvas::flashFeatureIds( QgsVectorLayer *layer, const QgsFeatureIds &
     geoms << fet.geometry();
   }
 
-  if ( geoms.isEmpty() )
+  flashGeometries( layer, geoms, color1, color2, flashes, duration );
+}
+
+void QgsMapCanvas::flashGeometries( QgsVectorLayer *layer, const QList<QgsGeometry> &geometries, const QColor &color1, const QColor &color2, int flashes, int duration )
+{
+  if ( geometries.isEmpty() )
     return;
 
-  QgsWkbTypes::GeometryType geomType = QgsWkbTypes::geometryType( layer->wkbType() );
+  QgsWkbTypes::GeometryType geomType = QgsWkbTypes::geometryType( geometries.at( 0 ).wkbType() );
   QgsRubberBand *rb = new QgsRubberBand( this, geomType );
-  for ( const QgsGeometry &geom : qgsAsConst( geoms ) )
+  for ( const QgsGeometry &geom : geometries )
     rb->addGeometry( geom, layer );
 
   if ( geomType == QgsWkbTypes::LineGeometry || geomType == QgsWkbTypes::PointGeometry )

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1078,10 +1078,10 @@ void QgsMapCanvas::flashFeatureIds( QgsVectorLayer *layer, const QgsFeatureIds &
     geoms << fet.geometry();
   }
 
-  flashGeometries( layer, geoms, color1, color2, flashes, duration );
+  flashGeometries( geoms, layer->crs(), color1, color2, flashes, duration );
 }
 
-void QgsMapCanvas::flashGeometries( QgsVectorLayer *layer, const QList<QgsGeometry> &geometries, const QColor &color1, const QColor &color2, int flashes, int duration )
+void QgsMapCanvas::flashGeometries( const QList<QgsGeometry> &geometries, const QgsCoordinateReferenceSystem &crs, const QColor &color1, const QColor &color2, int flashes, int duration )
 {
   if ( geometries.isEmpty() )
     return;
@@ -1089,7 +1089,7 @@ void QgsMapCanvas::flashGeometries( QgsVectorLayer *layer, const QList<QgsGeomet
   QgsWkbTypes::GeometryType geomType = QgsWkbTypes::geometryType( geometries.at( 0 ).wkbType() );
   QgsRubberBand *rb = new QgsRubberBand( this, geomType );
   for ( const QgsGeometry &geom : geometries )
-    rb->addGeometry( geom, layer );
+    rb->addGeometry( geom, crs );
 
   if ( geomType == QgsWkbTypes::LineGeometry || geomType == QgsWkbTypes::PointGeometry )
   {

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1058,6 +1058,101 @@ void QgsMapCanvas::panToSelected( QgsVectorLayer *layer )
   refresh();
 }
 
+void QgsMapCanvas::flashFeatureIds( QgsVectorLayer *layer, const QgsFeatureIds &ids,
+                                    const QColor &color1, const QColor &color2,
+                                    int flashes, int duration )
+{
+  if ( !layer )
+  {
+    return;
+  }
+
+  QList< QgsGeometry > geoms;
+
+  QgsFeatureIterator it = layer->getFeatures( QgsFeatureRequest().setFilterFids( ids ).setSubsetOfAttributes( QgsAttributeList() ) );
+  QgsFeature fet;
+  while ( it.nextFeature( fet ) )
+  {
+    if ( !fet.hasGeometry() )
+      continue;
+    geoms << fet.geometry();
+  }
+
+  if ( geoms.isEmpty() )
+    return;
+
+  QgsWkbTypes::GeometryType geomType = QgsWkbTypes::geometryType( layer->wkbType() );
+  QgsRubberBand *rb = new QgsRubberBand( this, geomType );
+  for ( const QgsGeometry &geom : qgsAsConst( geoms ) )
+    rb->addGeometry( geom, layer );
+
+  if ( geomType == QgsWkbTypes::LineGeometry || geomType == QgsWkbTypes::PointGeometry )
+  {
+    rb->setWidth( 2 );
+    rb->setSecondaryStrokeColor( QColor( 255, 255, 255 ) );
+  }
+  if ( geomType == QgsWkbTypes::PointGeometry )
+    rb->setIcon( QgsRubberBand::ICON_CIRCLE );
+
+  QColor startColor = color1;
+  if ( !startColor.isValid() )
+  {
+    if ( geomType == QgsWkbTypes::PolygonGeometry )
+    {
+      startColor = rb->fillColor();
+    }
+    else
+    {
+      startColor = rb->strokeColor();
+    }
+    startColor.setAlpha( 255 );
+  }
+  QColor endColor = color2;
+  if ( !endColor.isValid() )
+  {
+    endColor = startColor;
+    endColor.setAlpha( 0 );
+  }
+
+
+  QVariantAnimation *animation = new QVariantAnimation( this );
+  connect( animation, &QVariantAnimation::finished, this, [animation, rb]
+  {
+    animation->deleteLater();
+    delete rb;
+  } );
+  connect( animation, &QPropertyAnimation::valueChanged, this, [rb, geomType]( const QVariant & value )
+  {
+    QColor c = value.value<QColor>();
+    if ( geomType == QgsWkbTypes::PolygonGeometry )
+    {
+      rb->setFillColor( c );
+    }
+    else
+    {
+      rb->setStrokeColor( c );
+      QColor c = rb->secondaryStrokeColor();
+      c.setAlpha( c.alpha() );
+      rb->setSecondaryStrokeColor( c );
+    }
+    rb->update();
+  } );
+
+  animation->setDuration( duration * flashes );
+  animation->setStartValue( endColor );
+  double midStep = 0.2 / flashes;
+  for ( int i = 0; i < flashes; ++i )
+  {
+    double start = static_cast< double >( i ) / flashes;
+    animation->setKeyValueAt( start + midStep, startColor );
+    double end = static_cast< double >( i + 1 ) / flashes;
+    if ( !qgsDoubleNear( end, 1.0 ) )
+      animation->setKeyValueAt( end, endColor );
+  }
+  animation->setEndValue( endColor );
+  animation->start();
+}
+
 void QgsMapCanvas::keyPressEvent( QKeyEvent *e )
 {
   if ( mCanvasProperties->mouseButtonDown || mCanvasProperties->panSelectorDown )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -243,9 +243,28 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      * The \a startColor and \a endColor can be specified, along with the number of
      * \a flashes and \a duration of each flash (in milliseconds).
      *
+     * \note If the features or geometries are already available, flashGeometries() is much more efficient.
+     *
      * \since QGIS 3.0
+     * \see flashGeometries()
      */
     void flashFeatureIds( QgsVectorLayer *layer, const QgsFeatureIds &ids,
+                          const QColor &startColor = QColor( 255, 0, 0, 255 ), const QColor &endColor = QColor( 255, 0, 0, 0 ),
+                          int flashes = 3, int duration = 500 );
+
+    /**
+     * Causes a set of \a geometries to flash within the canvas.
+     *
+     * If \a layer is non-null, the geometries will be automatically transformed from the layer
+     * CRS to canvas CRS.
+     *
+     * The \a startColor and \a endColor can be specified, along with the number of
+     * \a flashes and \a duration of each flash (in milliseconds).
+     *
+     * \since QGIS 3.0
+     * \see flashFeatureIds()
+     */
+    void flashGeometries( QgsVectorLayer *layer, const QList< QgsGeometry > &geometries,
                           const QColor &startColor = QColor( 255, 0, 0, 255 ), const QColor &endColor = QColor( 255, 0, 0, 0 ),
                           int flashes = 3, int duration = 500 );
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -255,8 +255,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     /**
      * Causes a set of \a geometries to flash within the canvas.
      *
-     * If \a layer is non-null, the geometries will be automatically transformed from the layer
-     * CRS to canvas CRS.
+     * If \a crs is a valid coordinate reference system, the geometries will be automatically
+     * transformed from this CRS to the canvas CRS.
      *
      * The \a startColor and \a endColor can be specified, along with the number of
      * \a flashes and \a duration of each flash (in milliseconds).
@@ -264,7 +264,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      * \since QGIS 3.0
      * \see flashFeatureIds()
      */
-    void flashGeometries( QgsVectorLayer *layer, const QList< QgsGeometry > &geometries,
+    void flashGeometries( const QList< QgsGeometry > &geometries, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
                           const QColor &startColor = QColor( 255, 0, 0, 255 ), const QColor &endColor = QColor( 255, 0, 0, 0 ),
                           int flashes = 3, int duration = 500 );
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -236,6 +236,19 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Pan to the selected features of current (vector) layer keeping same extent.
     void panToSelected( QgsVectorLayer *layer = nullptr );
 
+    /**
+     * Causes a set of features with matching \a ids from a vector \a layer to flash
+     * within the canvas.
+     *
+     * The \a startColor and \a endColor can be specified, along with the number of
+     * \a flashes and \a duration of each flash (in milliseconds).
+     *
+     * \since QGIS 3.0
+     */
+    void flashFeatureIds( QgsVectorLayer *layer, const QgsFeatureIds &ids,
+                          const QColor &startColor = QColor( 255, 0, 0, 255 ), const QColor &endColor = QColor( 255, 0, 0, 0 ),
+                          int flashes = 3, int duration = 500 );
+
     //! \brief Sets the map tool currently being used on the canvas
     void setMapTool( QgsMapTool *mapTool );
 

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -249,7 +249,7 @@ void QgsRubberBand::addGeometry( const QgsGeometry &geometry, QgsVectorLayer *la
     geom.transform( ct );
   }
 
-  switch ( geom.wkbType() )
+  switch ( QgsWkbTypes::flatType( geom.wkbType() ) )
   {
 
     case QgsWkbTypes::Point:

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -232,6 +232,18 @@ void QgsRubberBand::setToGeometry( const QgsGeometry &geom, QgsVectorLayer *laye
 
 void QgsRubberBand::addGeometry( const QgsGeometry &geometry, QgsVectorLayer *layer )
 {
+  QgsGeometry geom = geometry;
+  if ( layer )
+  {
+    QgsCoordinateTransform ct = mMapCanvas->mapSettings().layerTransform( layer );
+    geom.transform( ct );
+  }
+
+  addGeometry( geom );
+}
+
+void QgsRubberBand::addGeometry( const QgsGeometry &geometry, const QgsCoordinateReferenceSystem &crs )
+{
   if ( geometry.isEmpty() )
   {
     return;
@@ -243,9 +255,9 @@ void QgsRubberBand::addGeometry( const QgsGeometry &geometry, QgsVectorLayer *la
   int idx = mPoints.size();
 
   QgsGeometry geom = geometry;
-  if ( layer )
+  if ( crs.isValid() )
   {
-    QgsCoordinateTransform ct = ms.layerTransform( layer );
+    QgsCoordinateTransform ct( crs, ms.destinationCrs() );
     geom.transform( ct );
   }
 

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -257,11 +257,21 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
      * of the rubberband explicitly by calling reset() or setToGeometry() with appropriate arguments.
      * setToGeometry() is also to be preferred for backwards-compatibility.
      *
-     *  \param geom the geometry object. Will be treated as a collection of vertices.
+     *  \param geometry the geometry object. Will be treated as a collection of vertices.
      *  \param layer the layer containing the feature, used for coord transformation to map
      *               crs. In case of 0 pointer, the coordinates are not going to be transformed.
      */
-    void addGeometry( const QgsGeometry &geom, QgsVectorLayer *layer );
+    void addGeometry( const QgsGeometry &geometry, QgsVectorLayer *layer );
+
+    /**
+     * Adds a \a geometry to the rubberband.
+     *
+     * If \a crs is specified, the geometry will be automatically reprojected from \a crs
+     * to the canvas CRS.
+     *
+     * \since QGIS 3.0
+     */
+    void addGeometry( const QgsGeometry &geometry, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
 
     /**
      * Adds translation to original coordinates (all in map coordinates)

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -310,7 +310,7 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
      *  \param p The QPainter object
      *  \param pts A list of points used to draw the shape
      */
-    void drawShape( QPainter *p, QVector<QPointF> &pts );
+    void drawShape( QPainter *p, const QVector<QPointF> &pts );
 
     //! Recalculates needed rectangle
     void updateRect();


### PR DESCRIPTION
This adds:
- API call to QgsMapCanvas to flash a set of features
- A right click menu option in the attribute table to flash the clicked feature
- An option in the Search by Form dialog to flash matching features

When triggered, the features flash allowing easy identification without having to alter the current selection or map extent

Screencast at https://youtu.be/pzIxAwzqaPM
