### PR TITLE
[expression] represent_value also determines implicitly provided column name

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1154,6 +1154,8 @@ QgsExpression::Function       {#qgis_api_break_3_0_QgsExpression_Function}
 - `QgsExpression::Function::usesgeometry()` has been renamed to `QgsExpression::Function::usesGeometry( const NodeFunction* node )`
 - `QStringList QgsExpression::Function::referencedColumns()` has been changed to `QSet<QString> QgsExpression::Function::referencedColumns( const NodeFunction* node )`
 - `QgsExpression::Function::helptext()` has been renamed to `helpText()`
+- `QgsExpression::Function::func` has an additional parameter `node` that
+  provides access to the original node.
 
 QgsExpressionItem        {#qgis_api_break_3_0_QgsExpressionItem}
 -----------------

--- a/python/core/__init__.py
+++ b/python/core/__init__.py
@@ -84,7 +84,7 @@ def register_function(function, arg_count, group, usesgeometry=False,
             self.uses_geometry = usesGeometry
             self.referenced_columns = referencedColumns
 
-        def func(self, values, context, parent):
+        def func(self, values, context, parent, node):
             feature = None
             if context:
                 feature = context.feature()

--- a/python/core/expression/qgsexpressionfunction.sip
+++ b/python/core/expression/qgsexpressionfunction.sip
@@ -239,17 +239,18 @@ The help text for the function.
  :rtype: str
 %End
 
-    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) = 0;
+    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) = 0;
 %Docstring
  Returns result of evaluating the function.
  \param values list of values passed to the function
  \param context context expression is being evaluated against
  \param parent parent expression
+ \param node expression node
  :return: result of function
  :rtype: QVariant
 %End
 
-    virtual QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent );
+    virtual QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node );
 %Docstring
  :rtype: QVariant
 %End

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -53,7 +53,7 @@ class QgsScopedExpressionFunction : QgsExpressionFunction
 .. versionadded:: 3.0
 %End
 
-    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) = 0;
+    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) = 0;
 
     virtual QgsScopedExpressionFunction *clone() const = 0 /Factory/;
 %Docstring

--- a/resources/function_help/json/represent_value
+++ b/resources/function_help/json/represent_value
@@ -3,10 +3,11 @@
   "type": "function",
   "description": "Returns the configured representation value for a field value. It depends on the configured widget type. Often, this is useful for 'Value Map' widgets.",
   "arguments": [
-    {"arg":"fieldName", "description": "The field name for which the widget configuration should be loaded."},
-    {"arg":"value", "description": "The value which should be resolved. Most likely a field." }
+    {"arg":"value", "description": "The value which should be resolved. Most likely a field." },
+    {"arg":"fieldName", "description": "The field name for which the widget configuration should be loaded. (Optional)"}
   ],
   "examples": [
-    { "expression":"represent_value('field_with_value_map', \"field_with_value_map\")", "returns":"Description for value"}
+    { "expression":"represent_value(\"field_with_value_map\")", "returns":"Description for value"},
+    { "expression":"represent_value('static value', 'field_name')", "returns":"Description for static value"}
   ]
 }

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -240,9 +240,15 @@ bool QgsExpression::isValid() const
   return d->mRootNode;
 }
 
-bool QgsExpression::hasParserError() const { return !d->mParserErrorString.isNull(); }
+bool QgsExpression::hasParserError() const
+{
+  return !d->mParserErrorString.isNull();
+}
 
-QString QgsExpression::parserErrorString() const { return d->mParserErrorString; }
+QString QgsExpression::parserErrorString() const
+{
+  return d->mParserErrorString;
+}
 
 QSet<QString> QgsExpression::referencedColumns() const
 {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -49,8 +49,9 @@ const QString QgsExpressionFunction::helpText() const
   return mHelpText.isEmpty() ? QgsExpression::helpText( mName ) : mHelpText;
 }
 
-QVariant QgsExpressionFunction::run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent )
+QVariant QgsExpressionFunction::run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node )
 {
+  Q_UNUSED( node )
   // evaluate arguments
   QVariantList argValues;
   if ( args )
@@ -78,7 +79,7 @@ QVariant QgsExpressionFunction::run( QgsExpressionNode::NodeList *args, const Qg
     }
   }
 
-  return func( argValues, context, parent );
+  return func( argValues, context, parent, node );
 }
 
 bool QgsExpressionFunction::usesGeometry( const QgsExpressionNodeFunction *node ) const
@@ -220,7 +221,7 @@ bool QgsExpressionFunction::allParamsStatic( const QgsExpressionNodeFunction *no
 
 
 
-static QVariant fcnGetVariable( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnGetVariable( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( !context )
     return QVariant();
@@ -229,7 +230,7 @@ static QVariant fcnGetVariable( const QVariantList &values, const QgsExpressionC
   return context->variable( name );
 }
 
-static QVariant fcnEval( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnEval( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( !context )
     return QVariant();
@@ -239,84 +240,84 @@ static QVariant fcnEval( const QVariantList &values, const QgsExpressionContext 
   return expression.evaluate( context );
 }
 
-static QVariant fcnSqrt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSqrt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::sqrt( x ) );
 }
 
-static QVariant fcnAbs( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAbs( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double val = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::fabs( val ) );
 }
 
-static QVariant fcnRadians( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRadians( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double deg = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return ( deg * M_PI ) / 180;
 }
-static QVariant fcnDegrees( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnDegrees( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double rad = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return ( 180 * rad ) / M_PI;
 }
-static QVariant fcnSin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::sin( x ) );
 }
-static QVariant fcnCos( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnCos( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::cos( x ) );
 }
-static QVariant fcnTan( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnTan( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::tan( x ) );
 }
-static QVariant fcnAsin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAsin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::asin( x ) );
 }
-static QVariant fcnAcos( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAcos( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::acos( x ) );
 }
-static QVariant fcnAtan( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAtan( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::atan( x ) );
 }
-static QVariant fcnAtan2( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAtan2( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double y = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   double x = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
   return QVariant( std::atan2( y, x ) );
 }
-static QVariant fcnExp( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnExp( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::exp( x ) );
 }
-static QVariant fcnLn( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLn( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( std::log( x ) );
 }
-static QVariant fcnLog10( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLog10( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( log10( x ) );
 }
-static QVariant fcnLog( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLog( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double b = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   double x = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -324,7 +325,7 @@ static QVariant fcnLog( const QVariantList &values, const QgsExpressionContext *
     return QVariant();
   return QVariant( std::log( x ) / std::log( b ) );
 }
-static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double min = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   double max = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -335,7 +336,7 @@ static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext 
   double f = static_cast< double >( qrand() ) / RAND_MAX;
   return QVariant( min + f * ( max - min ) );
 }
-static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   qlonglong min = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
   qlonglong max = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -346,7 +347,7 @@ static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *
   return QVariant( min + ( qrand() % static_cast< qlonglong >( max - min + 1 ) ) );
 }
 
-static QVariant fcnLinearScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLinearScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double val = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   double domainMin = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -378,7 +379,7 @@ static QVariant fcnLinearScale( const QVariantList &values, const QgsExpressionC
   return QVariant( m * val + c );
 }
 
-static QVariant fcnExpScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnExpScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double val = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   double domainMin = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -412,7 +413,7 @@ static QVariant fcnExpScale( const QVariantList &values, const QgsExpressionCont
   return QVariant( ( ( rangeMax - rangeMin ) / std::pow( domainMax - domainMin, exponent ) ) * std::pow( val - domainMin, exponent ) + rangeMin );
 }
 
-static QVariant fcnMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   //initially set max as first value
   double maxVal = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
@@ -430,7 +431,7 @@ static QVariant fcnMax( const QVariantList &values, const QgsExpressionContext *
   return QVariant( maxVal );
 }
 
-static QVariant fcnMin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   //initially set min as first value
   double minVal = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
@@ -448,7 +449,7 @@ static QVariant fcnMin( const QVariantList &values, const QgsExpressionContext *
   return QVariant( minVal );
 }
 
-static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   //lazy eval, so we need to evaluate nodes now
 
@@ -546,7 +547,7 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
   return result;
 }
 
-static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( !context )
   {
@@ -734,97 +735,97 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
 }
 
 
-static QVariant fcnAggregateCount( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateCount( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Count, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateCountDistinct( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateCountDistinct( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::CountDistinct, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateCountMissing( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateCountMissing( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::CountMissing, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMin( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMin( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Min, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMax( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMax( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Max, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateSum( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateSum( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Sum, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMean( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMean( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Mean, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMedian( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMedian( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Median, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateStdev( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateStdev( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::StDevSample, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateRange( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateRange( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Range, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMinority( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMinority( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Minority, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMajority( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMajority( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::Majority, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateQ1( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateQ1( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::FirstQuartile, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateQ3( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateQ3( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::ThirdQuartile, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateIQR( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateIQR( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::InterQuartileRange, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMinLength( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMinLength( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::StringMinimumLength, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateMaxLength( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateMaxLength( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::StringMaximumLength, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateCollectGeometry( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateCollectGeometry( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::GeometryCollect, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnAggregateStringConcat( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateStringConcat( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsAggregateCalculator::AggregateParameters parameters;
 
@@ -841,12 +842,12 @@ static QVariant fcnAggregateStringConcat( const QVariantList &values, const QgsE
   return fcnAggregateGeneric( QgsAggregateCalculator::StringConcatenate, values, parameters, context, parent );
 }
 
-static QVariant fcnAggregateArray( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnAggregateArray( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return fcnAggregateGeneric( QgsAggregateCalculator::ArrayAggregate, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
-static QVariant fcnClamp( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnClamp( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double minValue = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   double testValue = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -867,37 +868,37 @@ static QVariant fcnClamp( const QVariantList &values, const QgsExpressionContext
   }
 }
 
-static QVariant fcnFloor( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnFloor( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::floor( x ) );
 }
 
-static QVariant fcnCeil( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnCeil( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   return QVariant( std::ceil( x ) );
 }
 
-static QVariant fcnToInt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnToInt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToReal( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnToReal( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToString( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnToString( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getStringValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToDateTime( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnToDateTime( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnCoalesce( const QVariantList &values, const QgsExpressionContext *, QgsExpression * )
+static QVariant fcnCoalesce( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   for ( const QVariant &value : values )
   {
@@ -907,17 +908,17 @@ static QVariant fcnCoalesce( const QVariantList &values, const QgsExpressionCont
   }
   return QVariant();
 }
-static QVariant fcnLower( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLower( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   return QVariant( str.toLower() );
 }
-static QVariant fcnUpper( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnUpper( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   return QVariant( str.toUpper() );
 }
-static QVariant fcnTitle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnTitle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QStringList elems = str.split( ' ' );
@@ -929,27 +930,27 @@ static QVariant fcnTitle( const QVariantList &values, const QgsExpressionContext
   return QVariant( elems.join( QStringLiteral( " " ) ) );
 }
 
-static QVariant fcnTrim( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnTrim( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   return QVariant( str.trimmed() );
 }
 
-static QVariant fcnLevenshtein( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLevenshtein( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string1 = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString string2 = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   return QVariant( QgsStringUtils::levenshteinDistance( string1, string2, true ) );
 }
 
-static QVariant fcnLCS( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLCS( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string1 = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString string2 = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   return QVariant( QgsStringUtils::longestCommonSubstring( string1, string2, true ) );
 }
 
-static QVariant fcnHamming( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnHamming( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string1 = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString string2 = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -957,19 +958,19 @@ static QVariant fcnHamming( const QVariantList &values, const QgsExpressionConte
   return ( dist < 0 ? QVariant() : QVariant( QgsStringUtils::hammingDistance( string1, string2, true ) ) );
 }
 
-static QVariant fcnSoundex( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSoundex( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   return QVariant( QgsStringUtils::soundex( string ) );
 }
 
-static QVariant fcnChar( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnChar( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QChar character = QChar( QgsExpressionUtils::getNativeIntValue( values.at( 0 ), parent ) );
   return QVariant( QString( character ) );
 }
 
-static QVariant fcnWordwrap( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnWordwrap( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() == 2 || values.length() == 3 )
   {
@@ -1048,7 +1049,7 @@ static QVariant fcnWordwrap( const QVariantList &values, const QgsExpressionCont
   return QVariant();
 }
 
-static QVariant fcnLength( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLength( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // two variants, one for geometry, one for string
   if ( values.at( 0 ).canConvert<QgsGeometry>() )
@@ -1066,7 +1067,7 @@ static QVariant fcnLength( const QVariantList &values, const QgsExpressionContex
   return QVariant( str.length() );
 }
 
-static QVariant fcnReplace( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnReplace( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.count() == 2 && values.at( 1 ).type() == QVariant::Map )
   {
@@ -1125,7 +1126,7 @@ static QVariant fcnReplace( const QVariantList &values, const QgsExpressionConte
     return QVariant();
   }
 }
-static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -1140,7 +1141,7 @@ static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressio
   return QVariant( str.replace( re, after ) );
 }
 
-static QVariant fcnRegexpMatch( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRegexpMatch( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -1154,7 +1155,7 @@ static QVariant fcnRegexpMatch( const QVariantList &values, const QgsExpressionC
   return QVariant( ( str.indexOf( re ) + 1 ) );
 }
 
-static QVariant fcnRegexpMatches( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRegexpMatches( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -1187,7 +1188,7 @@ static QVariant fcnRegexpMatches( const QVariantList &values, const QgsExpressio
   }
 }
 
-static QVariant fcnRegexpSubstr( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRegexpSubstr( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -1212,12 +1213,12 @@ static QVariant fcnRegexpSubstr( const QVariantList &values, const QgsExpression
   }
 }
 
-static QVariant fcnUuid( const QVariantList &, const QgsExpressionContext *, QgsExpression * )
+static QVariant fcnUuid( const QVariantList &, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   return QUuid::createUuid().toString();
 }
 
-static QVariant fcnSubstr( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSubstr( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( !values.at( 0 ).isValid() || !values.at( 1 ).isValid() )
     return QVariant();
@@ -1256,21 +1257,21 @@ static QVariant fcnSubstr( const QVariantList &values, const QgsExpressionContex
 
   return QVariant( str.mid( from, len ) );
 }
-static QVariant fcnFeatureId( const QVariantList &, const QgsExpressionContext *context, QgsExpression * )
+static QVariant fcnFeatureId( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   FEAT_FROM_CONTEXT( context, f );
   // TODO: handling of 64-bit feature ids?
   return QVariant( static_cast< int >( f.id() ) );
 }
 
-static QVariant fcnFeature( const QVariantList &, const QgsExpressionContext *context, QgsExpression * )
+static QVariant fcnFeature( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   if ( !context )
     return QVariant();
 
   return context->feature();
 }
-static QVariant fcnAttribute( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAttribute( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsFeature feat = QgsExpressionUtils::getFeature( values.at( 0 ), parent );
   QString attr = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -1278,7 +1279,7 @@ static QVariant fcnAttribute( const QVariantList &values, const QgsExpressionCon
   return feat.attribute( attr );
 }
 
-static QVariant fcnIsSelected( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnIsSelected( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsVectorLayer *layer = nullptr;
   QgsFeature feature;
@@ -1312,7 +1313,7 @@ static QVariant fcnIsSelected( const QVariantList &values, const QgsExpressionCo
   return layer->selectedFeatureIds().contains( feature.id() );
 }
 
-static QVariant fcnNumSelected( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnNumSelected( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsVectorLayer *layer = nullptr;
 
@@ -1334,7 +1335,7 @@ static QVariant fcnNumSelected( const QVariantList &values, const QgsExpressionC
   return layer->selectedFeatureCount();
 }
 
-static QVariant fcnConcat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnConcat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString concat;
   for ( const QVariant &value : values )
@@ -1344,27 +1345,27 @@ static QVariant fcnConcat( const QVariantList &values, const QgsExpressionContex
   return concat;
 }
 
-static QVariant fcnStrpos( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnStrpos( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   return string.indexOf( QgsExpressionUtils::getStringValue( values.at( 1 ), parent ) ) + 1;
 }
 
-static QVariant fcnRight( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRight( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   qlonglong pos = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
   return string.right( pos );
 }
 
-static QVariant fcnLeft( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLeft( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   qlonglong pos = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
   return string.left( pos );
 }
 
-static QVariant fcnRPad( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRPad( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   qlonglong length = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -1372,7 +1373,7 @@ static QVariant fcnRPad( const QVariantList &values, const QgsExpressionContext 
   return string.leftJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnLPad( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLPad( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   qlonglong length = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -1380,7 +1381,7 @@ static QVariant fcnLPad( const QVariantList &values, const QgsExpressionContext 
   return string.rightJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnFormatString( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnFormatString( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   for ( int n = 1; n < values.length(); n++ )
@@ -1391,27 +1392,27 @@ static QVariant fcnFormatString( const QVariantList &values, const QgsExpression
 }
 
 
-static QVariant fcnNow( const QVariantList &, const QgsExpressionContext *, QgsExpression * )
+static QVariant fcnNow( const QVariantList &, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   return QVariant( QDateTime::currentDateTime() );
 }
 
-static QVariant fcnToDate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnToDate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getDateValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToTime( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnToTime( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnToInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant::fromValue( QgsExpressionUtils::getInterval( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnAge( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAge( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QDateTime d1 = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
   QDateTime d2 = QgsExpressionUtils::getDateTimeValue( values.at( 1 ), parent );
@@ -1419,7 +1420,7 @@ static QVariant fcnAge( const QVariantList &values, const QgsExpressionContext *
   return QVariant::fromValue( QgsInterval( seconds ) );
 }
 
-static QVariant fcnDayOfWeek( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnDayOfWeek( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( !values.at( 0 ).canConvert<QDate>() )
     return QVariant();
@@ -1433,7 +1434,7 @@ static QVariant fcnDayOfWeek( const QVariantList &values, const QgsExpressionCon
   return date.dayOfWeek() % 7;
 }
 
-static QVariant fcnDay( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnDay( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant value = values.at( 0 );
   QgsInterval inter = QgsExpressionUtils::getInterval( value, parent, false );
@@ -1448,7 +1449,7 @@ static QVariant fcnDay( const QVariantList &values, const QgsExpressionContext *
   }
 }
 
-static QVariant fcnYear( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnYear( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant value = values.at( 0 );
   QgsInterval inter = QgsExpressionUtils::getInterval( value, parent, false );
@@ -1463,7 +1464,7 @@ static QVariant fcnYear( const QVariantList &values, const QgsExpressionContext 
   }
 }
 
-static QVariant fcnMonth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMonth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant value = values.at( 0 );
   QgsInterval inter = QgsExpressionUtils::getInterval( value, parent, false );
@@ -1478,7 +1479,7 @@ static QVariant fcnMonth( const QVariantList &values, const QgsExpressionContext
   }
 }
 
-static QVariant fcnWeek( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnWeek( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant value = values.at( 0 );
   QgsInterval inter = QgsExpressionUtils::getInterval( value, parent, false );
@@ -1493,7 +1494,7 @@ static QVariant fcnWeek( const QVariantList &values, const QgsExpressionContext 
   }
 }
 
-static QVariant fcnHour( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnHour( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant value = values.at( 0 );
   QgsInterval inter = QgsExpressionUtils::getInterval( value, parent, false );
@@ -1508,7 +1509,7 @@ static QVariant fcnHour( const QVariantList &values, const QgsExpressionContext 
   }
 }
 
-static QVariant fcnMinute( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMinute( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant value = values.at( 0 );
   QgsInterval inter = QgsExpressionUtils::getInterval( value, parent, false );
@@ -1523,7 +1524,7 @@ static QVariant fcnMinute( const QVariantList &values, const QgsExpressionContex
   }
 }
 
-static QVariant fcnSeconds( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSeconds( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant value = values.at( 0 );
   QgsInterval inter = QgsExpressionUtils::getInterval( value, parent, false );
@@ -1538,7 +1539,7 @@ static QVariant fcnSeconds( const QVariantList &values, const QgsExpressionConte
   }
 }
 
-static QVariant fcnEpoch( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnEpoch( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QDateTime dt = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
   if ( dt.isValid() )
@@ -1558,7 +1559,7 @@ static QVariant fcnEpoch( const QVariantList &values, const QgsExpressionContext
   if ( (g).type() != (geomtype) ) \
     return QVariant();
 
-static QVariant fcnX( const QVariantList &, const QgsExpressionContext *context, QgsExpression * )
+static QVariant fcnX( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QgsWkbTypes::PointGeometry );
@@ -1572,7 +1573,7 @@ static QVariant fcnX( const QVariantList &, const QgsExpressionContext *context,
   }
 }
 
-static QVariant fcnY( const QVariantList &, const QgsExpressionContext *context, QgsExpression * )
+static QVariant fcnY( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QgsWkbTypes::PointGeometry );
@@ -1586,7 +1587,7 @@ static QVariant fcnY( const QVariantList &, const QgsExpressionContext *context,
   }
 }
 
-static QVariant fcnGeomX( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomX( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -1604,7 +1605,7 @@ static QVariant fcnGeomX( const QVariantList &values, const QgsExpressionContext
   return result;
 }
 
-static QVariant fcnGeomY( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomY( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -1622,7 +1623,7 @@ static QVariant fcnGeomY( const QVariantList &values, const QgsExpressionContext
   return result;
 }
 
-static QVariant fcnGeomZ( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomZ( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -1639,7 +1640,7 @@ static QVariant fcnGeomZ( const QVariantList &values, const QgsExpressionContext
   return QVariant();
 }
 
-static QVariant fcnGeomM( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomM( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -1656,7 +1657,7 @@ static QVariant fcnGeomM( const QVariantList &values, const QgsExpressionContext
   return QVariant();
 }
 
-static QVariant fcnPointN( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnPointN( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1677,7 +1678,7 @@ static QVariant fcnPointN( const QVariantList &values, const QgsExpressionContex
   return QVariant::fromValue( QgsGeometry( new QgsPoint( point ) ) );
 }
 
-static QVariant fcnStartPoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnStartPoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1694,7 +1695,7 @@ static QVariant fcnStartPoint( const QVariantList &values, const QgsExpressionCo
   return QVariant::fromValue( QgsGeometry( new QgsPoint( point ) ) );
 }
 
-static QVariant fcnEndPoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnEndPoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1711,7 +1712,7 @@ static QVariant fcnEndPoint( const QVariantList &values, const QgsExpressionCont
   return QVariant::fromValue( QgsGeometry( new QgsPoint( point ) ) );
 }
 
-static QVariant fcnNodesToPoints( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnNodesToPoints( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1747,7 +1748,7 @@ static QVariant fcnNodesToPoints( const QVariantList &values, const QgsExpressio
   return QVariant::fromValue( QgsGeometry( mp ) );
 }
 
-static QVariant fcnSegmentsToLines( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSegmentsToLines( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1774,7 +1775,7 @@ static QVariant fcnSegmentsToLines( const QVariantList &values, const QgsExpress
   return QVariant::fromValue( QgsGeometry( ml ) );
 }
 
-static QVariant fcnInteriorRingN( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnInteriorRingN( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1796,7 +1797,7 @@ static QVariant fcnInteriorRingN( const QVariantList &values, const QgsExpressio
   return result;
 }
 
-static QVariant fcnGeometryN( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeometryN( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1818,7 +1819,7 @@ static QVariant fcnGeometryN( const QVariantList &values, const QgsExpressionCon
   return result;
 }
 
-static QVariant fcnBoundary( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnBoundary( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1832,7 +1833,7 @@ static QVariant fcnBoundary( const QVariantList &values, const QgsExpressionCont
   return QVariant::fromValue( QgsGeometry( boundary ) );
 }
 
-static QVariant fcnLineMerge( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLineMerge( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1846,7 +1847,7 @@ static QVariant fcnLineMerge( const QVariantList &values, const QgsExpressionCon
   return QVariant::fromValue( merged );
 }
 
-static QVariant fcnSimplify( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSimplify( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1862,7 +1863,7 @@ static QVariant fcnSimplify( const QVariantList &values, const QgsExpressionCont
   return simplified;
 }
 
-static QVariant fcnSimplifyVW( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSimplifyVW( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1880,7 +1881,7 @@ static QVariant fcnSimplifyVW( const QVariantList &values, const QgsExpressionCo
   return simplified;
 }
 
-static QVariant fcnSmooth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSmooth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -1899,7 +1900,7 @@ static QVariant fcnSmooth( const QVariantList &values, const QgsExpressionContex
   return smoothed;
 }
 
-static QVariant fcnMakePoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakePoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.count() < 2 || values.count() > 4 )
   {
@@ -1923,7 +1924,7 @@ static QVariant fcnMakePoint( const QVariantList &values, const QgsExpressionCon
   return QVariant(); //avoid warning
 }
 
-static QVariant fcnMakePointM( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakePointM( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double x = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   double y = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -1931,7 +1932,7 @@ static QVariant fcnMakePointM( const QVariantList &values, const QgsExpressionCo
   return QVariant::fromValue( QgsGeometry( new QgsPoint( QgsWkbTypes::PointM, x, y, 0.0, m ) ) );
 }
 
-static QVariant fcnMakeLine( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakeLine( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.count() < 2 )
   {
@@ -1960,7 +1961,7 @@ static QVariant fcnMakeLine( const QVariantList &values, const QgsExpressionCont
   return QVariant::fromValue( QgsGeometry( lineString ) );
 }
 
-static QVariant fcnMakePolygon( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakePolygon( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.count() < 1 )
   {
@@ -1990,7 +1991,7 @@ static QVariant fcnMakePolygon( const QVariantList &values, const QgsExpressionC
   return QVariant::fromValue( QgsGeometry( polygon ) );
 }
 
-static QVariant fcnMakeTriangle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakeTriangle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   std::unique_ptr<QgsTriangle> tr( new QgsTriangle() );
   std::unique_ptr<QgsLineString> lineString( new QgsLineString() );
@@ -2017,7 +2018,7 @@ static QVariant fcnMakeTriangle( const QVariantList &values, const QgsExpression
   return QVariant::fromValue( QgsGeometry( tr.release() ) );
 }
 
-static QVariant fcnMakeCircle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakeCircle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -2039,7 +2040,7 @@ static QVariant fcnMakeCircle( const QVariantList &values, const QgsExpressionCo
   return QVariant::fromValue( QgsGeometry( circ.toPolygon( segment ) ) );
 }
 
-static QVariant fcnMakeEllipse( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakeEllipse( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -2062,7 +2063,7 @@ static QVariant fcnMakeEllipse( const QVariantList &values, const QgsExpressionC
   return QVariant::fromValue( QgsGeometry( elp.toPolygon( segment ) ) );
 }
 
-static QVariant fcnMakeRegularPolygon( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMakeRegularPolygon( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
 
   QgsGeometry pt1 = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
@@ -2123,7 +2124,7 @@ static QVariant pointAt( const QVariantList &values, const QgsExpressionContext 
   return QVariant( QPointF( p.x(), p.y() ) );
 }
 
-static QVariant fcnXat( const QVariantList &values, const QgsExpressionContext *f, QgsExpression *parent )
+static QVariant fcnXat( const QVariantList &values, const QgsExpressionContext *f, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -2131,7 +2132,7 @@ static QVariant fcnXat( const QVariantList &values, const QgsExpressionContext *
   else
     return QVariant();
 }
-static QVariant fcnYat( const QVariantList &values, const QgsExpressionContext *f, QgsExpression *parent )
+static QVariant fcnYat( const QVariantList &values, const QgsExpressionContext *f, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -2139,7 +2140,7 @@ static QVariant fcnYat( const QVariantList &values, const QgsExpressionContext *
   else
     return QVariant();
 }
-static QVariant fcnGeometry( const QVariantList &, const QgsExpressionContext *context, QgsExpression * )
+static QVariant fcnGeometry( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   FEAT_FROM_CONTEXT( context, f );
   QgsGeometry geom = f.geometry();
@@ -2148,14 +2149,14 @@ static QVariant fcnGeometry( const QVariantList &, const QgsExpressionContext *c
   else
     return QVariant( QVariant::UserType );
 }
-static QVariant fcnGeomFromWKT( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomFromWKT( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString wkt = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QgsGeometry geom = QgsGeometry::fromWkt( wkt );
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
-static QVariant fcnGeomFromGML( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomFromGML( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString gml = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QgsGeometry geom = QgsOgcUtils::geometryFromGML( gml );
@@ -2163,7 +2164,7 @@ static QVariant fcnGeomFromGML( const QVariantList &values, const QgsExpressionC
   return result;
 }
 
-static QVariant fcnGeomArea( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnGeomArea( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QgsWkbTypes::PolygonGeometry );
@@ -2180,7 +2181,7 @@ static QVariant fcnGeomArea( const QVariantList &, const QgsExpressionContext *c
   }
 }
 
-static QVariant fcnArea( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArea( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -2190,7 +2191,7 @@ static QVariant fcnArea( const QVariantList &values, const QgsExpressionContext 
   return QVariant( geom.area() );
 }
 
-static QVariant fcnGeomLength( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnGeomLength( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QgsWkbTypes::LineGeometry );
@@ -2207,7 +2208,7 @@ static QVariant fcnGeomLength( const QVariantList &, const QgsExpressionContext 
   }
 }
 
-static QVariant fcnGeomPerimeter( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnGeomPerimeter( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QgsWkbTypes::PolygonGeometry );
@@ -2224,7 +2225,7 @@ static QVariant fcnGeomPerimeter( const QVariantList &, const QgsExpressionConte
   }
 }
 
-static QVariant fcnPerimeter( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnPerimeter( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -2235,13 +2236,13 @@ static QVariant fcnPerimeter( const QVariantList &values, const QgsExpressionCon
   return QVariant( geom.length() );
 }
 
-static QVariant fcnGeomNumPoints( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomNumPoints( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   return QVariant( geom.isNull() ? 0 : geom.geometry()->nCoordinates() );
 }
 
-static QVariant fcnGeomNumGeometries( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomNumGeometries( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -2250,7 +2251,7 @@ static QVariant fcnGeomNumGeometries( const QVariantList &values, const QgsExpre
   return QVariant( geom.geometry()->partCount() );
 }
 
-static QVariant fcnGeomNumInteriorRings( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomNumInteriorRings( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -2278,7 +2279,7 @@ static QVariant fcnGeomNumInteriorRings( const QVariantList &values, const QgsEx
   return QVariant();
 }
 
-static QVariant fcnGeomNumRings( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomNumRings( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -2312,7 +2313,7 @@ static QVariant fcnGeomNumRings( const QVariantList &values, const QgsExpression
   return QVariant( ringCount );
 }
 
-static QVariant fcnBounds( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnBounds( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry geomBounds = QgsGeometry::fromRect( geom.boundingBox() );
@@ -2320,43 +2321,43 @@ static QVariant fcnBounds( const QVariantList &values, const QgsExpressionContex
   return result;
 }
 
-static QVariant fcnBoundsWidth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnBoundsWidth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().width() );
 }
 
-static QVariant fcnBoundsHeight( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnBoundsHeight( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().height() );
 }
 
-static QVariant fcnXMin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnXMin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMinimum() );
 }
 
-static QVariant fcnXMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnXMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMaximum() );
 }
 
-static QVariant fcnYMin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnYMin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMinimum() );
 }
 
-static QVariant fcnYMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnYMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMaximum() );
 }
 
-static QVariant fcnIsClosed( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnIsClosed( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( fGeom.isNull() )
@@ -2369,7 +2370,7 @@ static QVariant fcnIsClosed( const QVariantList &values, const QgsExpressionCont
   return QVariant::fromValue( curve->isClosed() );
 }
 
-static QVariant fcnRelate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRelate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() < 2 || values.length() > 3 )
     return QVariant();
@@ -2397,55 +2398,55 @@ static QVariant fcnRelate( const QVariantList &values, const QgsExpressionContex
   }
 }
 
-static QVariant fcnBbox( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnBbox( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( sGeom.boundingBox() ) ? TVL_True : TVL_False;
 }
-static QVariant fcnDisjoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnDisjoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.disjoint( sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnIntersects( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnIntersects( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnTouches( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnTouches( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.touches( sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnCrosses( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnCrosses( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.crosses( sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnContains( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnContains( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.contains( sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnOverlaps( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnOverlaps( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.overlaps( sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnWithin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnWithin( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return fGeom.within( sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnBuffer( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnBuffer( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() < 2 || values.length() > 3 )
     return QVariant();
@@ -2461,7 +2462,7 @@ static QVariant fcnBuffer( const QVariantList &values, const QgsExpressionContex
   return result;
 }
 
-static QVariant fcnOffsetCurve( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnOffsetCurve( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   double dist = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -2476,7 +2477,7 @@ static QVariant fcnOffsetCurve( const QVariantList &values, const QgsExpressionC
   return result;
 }
 
-static QVariant fcnSingleSidedBuffer( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSingleSidedBuffer( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   double dist = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -2491,7 +2492,7 @@ static QVariant fcnSingleSidedBuffer( const QVariantList &values, const QgsExpre
   return result;
 }
 
-static QVariant fcnExtend( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnExtend( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   double distStart = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -2502,7 +2503,7 @@ static QVariant fcnExtend( const QVariantList &values, const QgsExpressionContex
   return result;
 }
 
-static QVariant fcnTranslate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnTranslate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   double dx = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -2510,14 +2511,14 @@ static QVariant fcnTranslate( const QVariantList &values, const QgsExpressionCon
   fGeom.translate( dx, dy );
   return QVariant::fromValue( fGeom );
 }
-static QVariant fcnCentroid( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnCentroid( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry geom = fGeom.centroid();
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
-static QVariant fcnPointOnSurface( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnPointOnSurface( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry geom = fGeom.pointOnSurface();
@@ -2525,7 +2526,7 @@ static QVariant fcnPointOnSurface( const QVariantList &values, const QgsExpressi
   return result;
 }
 
-static QVariant fcnPoleOfInaccessibility( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnPoleOfInaccessibility( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   double tolerance = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -2534,7 +2535,7 @@ static QVariant fcnPoleOfInaccessibility( const QVariantList &values, const QgsE
   return result;
 }
 
-static QVariant fcnConvexHull( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnConvexHull( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry geom = fGeom.convexHull();
@@ -2543,7 +2544,7 @@ static QVariant fcnConvexHull( const QVariantList &values, const QgsExpressionCo
 }
 
 
-static QVariant fcnMinimalCircle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMinimalCircle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   unsigned int segments = 36;
@@ -2554,7 +2555,7 @@ static QVariant fcnMinimalCircle( const QVariantList &values, const QgsExpressio
   return result;
 }
 
-static QVariant fcnOrientedBBox( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnOrientedBBox( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry geom = fGeom.orientedMinimumBoundingBox( );
@@ -2562,7 +2563,7 @@ static QVariant fcnOrientedBBox( const QVariantList &values, const QgsExpression
   return result;
 }
 
-static QVariant fcnDifference( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnDifference( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2571,7 +2572,7 @@ static QVariant fcnDifference( const QVariantList &values, const QgsExpressionCo
   return result;
 }
 
-static QVariant fcnReverse( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnReverse( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( fGeom.isNull() )
@@ -2586,7 +2587,7 @@ static QVariant fcnReverse( const QVariantList &values, const QgsExpressionConte
   return result;
 }
 
-static QVariant fcnExteriorRing( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnExteriorRing( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( fGeom.isNull() )
@@ -2601,14 +2602,14 @@ static QVariant fcnExteriorRing( const QVariantList &values, const QgsExpression
   return result;
 }
 
-static QVariant fcnDistance( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnDistance( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
   return QVariant( fGeom.distance( sGeom ) );
 }
 
-static QVariant fcnHausdorffDistance( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnHausdorffDistance( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry g1 = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry g2 = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2628,7 +2629,7 @@ static QVariant fcnHausdorffDistance( const QVariantList &values, const QgsExpre
   return res > -1 ? QVariant( res ) : QVariant();
 }
 
-static QVariant fcnIntersection( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnIntersection( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2636,7 +2637,7 @@ static QVariant fcnIntersection( const QVariantList &values, const QgsExpression
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
-static QVariant fcnSymDifference( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnSymDifference( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2644,7 +2645,7 @@ static QVariant fcnSymDifference( const QVariantList &values, const QgsExpressio
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
-static QVariant fcnCombine( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnCombine( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2652,7 +2653,7 @@ static QVariant fcnCombine( const QVariantList &values, const QgsExpressionConte
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
-static QVariant fcnGeomToWKT( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGeomToWKT( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() < 1 || values.length() > 2 )
     return QVariant();
@@ -2665,7 +2666,7 @@ static QVariant fcnGeomToWKT( const QVariantList &values, const QgsExpressionCon
   return QVariant( wkt );
 }
 
-static QVariant fcnAzimuth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAzimuth( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() != 2 )
   {
@@ -2734,7 +2735,7 @@ static QVariant fcnAzimuth( const QVariantList &values, const QgsExpressionConte
   }
 }
 
-static QVariant fcnProject( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnProject( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
 
@@ -2754,7 +2755,7 @@ static QVariant fcnProject( const QVariantList &values, const QgsExpressionConte
   return QVariant::fromValue( QgsGeometry( new QgsPoint( newPoint ) ) );
 }
 
-static QVariant fcnInclination( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnInclination( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom1 = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry fGeom2 = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2773,7 +2774,7 @@ static QVariant fcnInclination( const QVariantList &values, const QgsExpressionC
 
 }
 
-static QVariant fcnExtrude( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnExtrude( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() != 3 )
     return QVariant();
@@ -2788,7 +2789,7 @@ static QVariant fcnExtrude( const QVariantList &values, const QgsExpressionConte
   return result;
 }
 
-static QVariant fcnOrderParts( const QVariantList &values, const QgsExpressionContext *ctx, QgsExpression *parent )
+static QVariant fcnOrderParts( const QVariantList &values, const QgsExpressionContext *ctx, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() < 2 )
     return QVariant();
@@ -2865,7 +2866,7 @@ static QVariant fcnOrderParts( const QVariantList &values, const QgsExpressionCo
   return result;
 }
 
-static QVariant fcnClosestPoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnClosestPoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fromGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry toGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2876,7 +2877,7 @@ static QVariant fcnClosestPoint( const QVariantList &values, const QgsExpression
   return result;
 }
 
-static QVariant fcnShortestLine( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnShortestLine( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fromGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry toGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2887,7 +2888,7 @@ static QVariant fcnShortestLine( const QVariantList &values, const QgsExpression
   return result;
 }
 
-static QVariant fcnLineInterpolatePoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLineInterpolatePoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry lineGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   double distance = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -2898,7 +2899,7 @@ static QVariant fcnLineInterpolatePoint( const QVariantList &values, const QgsEx
   return result;
 }
 
-static QVariant fcnLineInterpolateAngle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLineInterpolateAngle( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry lineGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   double distance = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
@@ -2906,7 +2907,7 @@ static QVariant fcnLineInterpolateAngle( const QVariantList &values, const QgsEx
   return lineGeom.interpolateAngle( distance ) * 180.0 / M_PI;
 }
 
-static QVariant fcnAngleAtVertex( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnAngleAtVertex( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   qlonglong vertex = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -2914,7 +2915,7 @@ static QVariant fcnAngleAtVertex( const QVariantList &values, const QgsExpressio
   return geom.angleAtVertex( vertex ) * 180.0 / M_PI;
 }
 
-static QVariant fcnDistanceToVertex( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnDistanceToVertex( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   qlonglong vertex = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -2922,7 +2923,7 @@ static QVariant fcnDistanceToVertex( const QVariantList &values, const QgsExpres
   return geom.distanceToVertex( vertex );
 }
 
-static QVariant fcnLineLocatePoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnLineLocatePoint( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry lineGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry pointGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
@@ -2932,7 +2933,7 @@ static QVariant fcnLineLocatePoint( const QVariantList &values, const QgsExpress
   return distance >= 0 ? distance : QVariant();
 }
 
-static QVariant fcnRound( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnRound( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() == 2 && values.at( 1 ).toInt() != 0 )
   {
@@ -2950,14 +2951,14 @@ static QVariant fcnRound( const QVariantList &values, const QgsExpressionContext
   return QVariant();
 }
 
-static QVariant fcnPi( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnPi( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   Q_UNUSED( values );
   Q_UNUSED( parent );
   return M_PI;
 }
 
-static QVariant fcnFormatNumber( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnFormatNumber( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double value = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
   int places = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -2969,14 +2970,14 @@ static QVariant fcnFormatNumber( const QVariantList &values, const QgsExpression
   return QStringLiteral( "%L1" ).arg( value, 0, 'f', places );
 }
 
-static QVariant fcnFormatDate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnFormatDate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QDateTime dt = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
   QString format = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   return dt.toString( format );
 }
 
-static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   int red = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
   int green = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -2991,7 +2992,7 @@ static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionCont
   return QStringLiteral( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fcnIf( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnIf( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsExpressionNode *node = QgsExpressionUtils::getNode( values.at( 0 ), parent );
   ENSURE_NO_EVAL_ERROR;
@@ -3014,7 +3015,7 @@ static QVariant fcnIf( const QVariantList &values, const QgsExpressionContext *c
   return value;
 }
 
-static QVariant fncColorRgba( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncColorRgba( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   int red = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
   int green = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -3029,7 +3030,7 @@ static QVariant fncColorRgba( const QVariantList &values, const QgsExpressionCon
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-QVariant fcnRampColor( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+QVariant fcnRampColor( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGradientColorRamp expRamp;
   const QgsColorRamp *ramp;
@@ -3054,7 +3055,7 @@ QVariant fcnRampColor( const QVariantList &values, const QgsExpressionContext *,
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-static QVariant fcnColorHsl( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnColorHsl( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Hue ranges from 0 - 360
   double hue = QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -3074,7 +3075,7 @@ static QVariant fcnColorHsl( const QVariantList &values, const QgsExpressionCont
   return QStringLiteral( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsla( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncColorHsla( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Hue ranges from 0 - 360
   double hue = QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -3094,7 +3095,7 @@ static QVariant fncColorHsla( const QVariantList &values, const QgsExpressionCon
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-static QVariant fcnColorHsv( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnColorHsv( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Hue ranges from 0 - 360
   double hue = QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -3114,7 +3115,7 @@ static QVariant fcnColorHsv( const QVariantList &values, const QgsExpressionCont
   return QStringLiteral( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsva( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncColorHsva( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Hue ranges from 0 - 360
   double hue = QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -3134,7 +3135,7 @@ static QVariant fncColorHsva( const QVariantList &values, const QgsExpressionCon
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-static QVariant fcnColorCmyk( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnColorCmyk( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Cyan ranges from 0 - 100
   double cyan = QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -3156,7 +3157,7 @@ static QVariant fcnColorCmyk( const QVariantList &values, const QgsExpressionCon
   return QStringLiteral( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorCmyka( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncColorCmyka( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   // Cyan ranges from 0 - 100
   double cyan = QgsExpressionUtils::getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -3178,7 +3179,7 @@ static QVariant fncColorCmyka( const QVariantList &values, const QgsExpressionCo
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-static QVariant fncColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
   if ( ! color.isValid() )
@@ -3221,7 +3222,7 @@ static QVariant fncColorPart( const QVariantList &values, const QgsExpressionCon
   return QVariant();
 }
 
-static QVariant fcnCreateRamp( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnCreateRamp( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariantMap map = QgsExpressionUtils::getMapValue( values.at( 0 ), parent );
   if ( map.count() < 1 )
@@ -3262,7 +3263,7 @@ static QVariant fcnCreateRamp( const QVariantList &values, const QgsExpressionCo
   return QVariant::fromValue( QgsGradientColorRamp( colors.first(), colors.last(), discrete, stops ) );
 }
 
-static QVariant fncSetColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncSetColorPart( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
   if ( ! color.isValid() )
@@ -3309,7 +3310,7 @@ static QVariant fncSetColorPart( const QVariantList &values, const QgsExpression
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-static QVariant fncDarker( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncDarker( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
   if ( ! color.isValid() )
@@ -3323,7 +3324,7 @@ static QVariant fncDarker( const QVariantList &values, const QgsExpressionContex
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-static QVariant fncLighter( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fncLighter( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
   if ( ! color.isValid() )
@@ -3337,7 +3338,7 @@ static QVariant fncLighter( const QVariantList &values, const QgsExpressionConte
   return QgsSymbolLayerUtils::encodeColor( color );
 }
 
-static QVariant fcnGetGeometry( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGetGeometry( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsFeature feat = QgsExpressionUtils::getFeature( values.at( 0 ), parent );
   QgsGeometry geom = feat.geometry();
@@ -3346,7 +3347,7 @@ static QVariant fcnGetGeometry( const QVariantList &values, const QgsExpressionC
   return QVariant();
 }
 
-static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QString sAuthId = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -3374,7 +3375,7 @@ static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpre
 }
 
 
-static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant result;
   QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
@@ -3394,7 +3395,7 @@ static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressi
   return result;
 }
 
-static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   //arguments: 1. layer id / name, 2. key attribute, 3. eq value
   QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
@@ -3430,11 +3431,21 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   return QVariant();
 }
 
-static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node )
 {
   QVariant result;
-  QString fieldName = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
-  QVariant value = values.at( 1 );
+  QString fieldName;
+  if ( values.size() == 1 )
+  {
+    QgsExpressionNodeColumnRef *col = dynamic_cast<QgsExpressionNodeColumnRef *>( node->args()->at( 0 ) );
+    if ( col )
+      fieldName = col->name();
+  }
+  else
+  {
+    fieldName = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
+  }
+  QVariant value = values.at( 0 );
 
   QgsVectorLayer *layer = QgsExpressionUtils::getVectorLayer( context->variable( "layer" ), parent );
 
@@ -3470,7 +3481,7 @@ static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressi
   return result;
 }
 
-static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsMapLayer *layer = QgsExpressionUtils::getMapLayer( values.at( 0 ), parent );
 
@@ -3540,7 +3551,7 @@ static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpres
   return QVariant();
 }
 
-static QVariant fcnGetRasterBandStat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnGetRasterBandStat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString layerIdOrName = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
 
@@ -3609,27 +3620,27 @@ static QVariant fcnGetRasterBandStat( const QVariantList &values, const QgsExpre
   return QVariant();
 }
 
-static QVariant fcnArray( const QVariantList &values, const QgsExpressionContext *, QgsExpression * )
+static QVariant fcnArray( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   return values;
 }
 
-static QVariant fcnArrayLength( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayLength( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QgsExpressionUtils::getListValue( values.at( 0 ), parent ).length();
 }
 
-static QVariant fcnArrayContains( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayContains( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QVariant( QgsExpressionUtils::getListValue( values.at( 0 ), parent ).contains( values.at( 1 ) ) );
 }
 
-static QVariant fcnArrayFind( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayFind( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QgsExpressionUtils::getListValue( values.at( 0 ), parent ).indexOf( values.at( 1 ) );
 }
 
-static QVariant fcnArrayGet( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayGet( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   const qlonglong pos = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -3637,13 +3648,13 @@ static QVariant fcnArrayGet( const QVariantList &values, const QgsExpressionCont
   return list.at( pos );
 }
 
-static QVariant fcnArrayFirst( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayFirst( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   return list.value( 0 );
 }
 
-static QVariant fcnArrayLast( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayLast( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   return list.value( list.size() - 1 );
@@ -3656,42 +3667,42 @@ static QVariant convertToSameType( const QVariant &value, QVariant::Type type )
   return result;
 }
 
-static QVariant fcnArrayAppend( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayAppend( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   list.append( values.at( 1 ) );
   return convertToSameType( list, values.at( 0 ).type() );
 }
 
-static QVariant fcnArrayPrepend( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayPrepend( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   list.prepend( values.at( 1 ) );
   return convertToSameType( list, values.at( 0 ).type() );
 }
 
-static QVariant fcnArrayInsert( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayInsert( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   list.insert( QgsExpressionUtils::getIntValue( values.at( 1 ), parent ), values.at( 2 ) );
   return convertToSameType( list, values.at( 0 ).type() );
 }
 
-static QVariant fcnArrayRemoveAt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayRemoveAt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   list.removeAt( QgsExpressionUtils::getIntValue( values.at( 1 ), parent ) );
   return convertToSameType( list, values.at( 0 ).type() );
 }
 
-static QVariant fcnArrayRemoveAll( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayRemoveAll( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   list.removeAll( values.at( 1 ) );
   return convertToSameType( list, values.at( 0 ).type() );
 }
 
-static QVariant fcnArrayCat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayCat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list;
   for ( const QVariant &cur : values )
@@ -3701,7 +3712,7 @@ static QVariant fcnArrayCat( const QVariantList &values, const QgsExpressionCont
   return convertToSameType( list, values.at( 0 ).type() );
 }
 
-static QVariant fcnArraySlice( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArraySlice( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   qlonglong start_pos = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
@@ -3729,14 +3740,14 @@ static QVariant fcnArraySlice( const QVariantList &values, const QgsExpressionCo
   return list;
 }
 
-static QVariant fcnArrayReverse( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayReverse( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   std::reverse( list.begin(), list.end() );
   return list;
 }
 
-static QVariant fcnArrayIntersect( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayIntersect( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QVariantList array1 = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   const QVariantList array2 = QgsExpressionUtils::getListValue( values.at( 1 ), parent );
@@ -3748,7 +3759,7 @@ static QVariant fcnArrayIntersect( const QVariantList &values, const QgsExpressi
   return QVariant( false );
 }
 
-static QVariant fcnArrayDistinct( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayDistinct( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList array = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
 
@@ -3765,7 +3776,7 @@ static QVariant fcnArrayDistinct( const QVariantList &values, const QgsExpressio
   return distinct;
 }
 
-static QVariant fcnArrayToString( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnArrayToString( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList array = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   QString delimiter = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -3785,7 +3796,7 @@ static QVariant fcnArrayToString( const QVariantList &values, const QgsExpressio
   return QVariant( str );
 }
 
-static QVariant fcnStringToArray( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnStringToArray( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString delimiter = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -3802,7 +3813,7 @@ static QVariant fcnStringToArray( const QVariantList &values, const QgsExpressio
   return array;
 }
 
-static QVariant fcnMap( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMap( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantMap result;
   for ( int i = 0; i + 1 < values.length(); i += 2 )
@@ -3812,31 +3823,31 @@ static QVariant fcnMap( const QVariantList &values, const QgsExpressionContext *
   return result;
 }
 
-static QVariant fcnMapGet( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMapGet( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QgsExpressionUtils::getMapValue( values.at( 0 ), parent ).value( values.at( 1 ).toString() );
 }
 
-static QVariant fcnMapExist( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMapExist( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QgsExpressionUtils::getMapValue( values.at( 0 ), parent ).contains( values.at( 1 ).toString() );
 }
 
-static QVariant fcnMapDelete( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMapDelete( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantMap map = QgsExpressionUtils::getMapValue( values.at( 0 ), parent );
   map.remove( values.at( 1 ).toString() );
   return map;
 }
 
-static QVariant fcnMapInsert( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMapInsert( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantMap map = QgsExpressionUtils::getMapValue( values.at( 0 ), parent );
   map.insert( values.at( 1 ).toString(),  values.at( 2 ) );
   return map;
 }
 
-static QVariant fcnMapConcat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMapConcat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantMap result;
   for ( const QVariant &cur : values )
@@ -3848,17 +3859,17 @@ static QVariant fcnMapConcat( const QVariantList &values, const QgsExpressionCon
   return result;
 }
 
-static QVariant fcnMapAKeys( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMapAKeys( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QStringList( QgsExpressionUtils::getMapValue( values.at( 0 ), parent ).keys() );
 }
 
-static QVariant fcnMapAVals( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
+static QVariant fcnMapAVals( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QgsExpressionUtils::getMapValue( values.at( 0 ), parent ).values();
 }
 
-static QVariant fcnEnvVar( const QVariantList &values, const QgsExpressionContext *, QgsExpression * )
+static QVariant fcnEnvVar( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   QString envVarName = values.at( 0 ).toString();
   return QProcessEnvironment::systemEnvironment().value( envVarName );
@@ -4285,27 +4296,27 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 
     // **Record** functions
 
-    QgsStaticExpressionFunction *idFunc = new QgsStaticExpressionFunction( QStringLiteral( "$id" ), 0, fcnFeatureId, QStringLiteral( "Record" ) );
+    QgsStaticExpressionFunction *idFunc = new QgsStaticExpressionFunction( QStringLiteral( "$id" ), 0, fcnFeatureId, QStringLiteral( "Record and Attributes" ) );
     idFunc->setIsStatic( false );
     sFunctions << idFunc;
 
-    QgsStaticExpressionFunction *currentFeatureFunc = new QgsStaticExpressionFunction( QStringLiteral( "$currentfeature" ), 0, fcnFeature, QStringLiteral( "Record" ) );
+    QgsStaticExpressionFunction *currentFeatureFunc = new QgsStaticExpressionFunction( QStringLiteral( "$currentfeature" ), 0, fcnFeature, QStringLiteral( "Record and Attributes" ) );
     currentFeatureFunc->setIsStatic( false );
     sFunctions << currentFeatureFunc;
 
-    QgsStaticExpressionFunction *uuidFunc = new QgsStaticExpressionFunction( QStringLiteral( "uuid" ), 0, fcnUuid, QStringLiteral( "Record" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "$uuid" ) );
+    QgsStaticExpressionFunction *uuidFunc = new QgsStaticExpressionFunction( QStringLiteral( "uuid" ), 0, fcnUuid, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "$uuid" ) );
     uuidFunc->setIsStatic( true );
     sFunctions << uuidFunc;
 
     sFunctions
-        << new QgsStaticExpressionFunction( QStringLiteral( "get_feature" ), 3, fcnGetFeature, QStringLiteral( "Record" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "QgsExpressionUtils::getFeature" ) )
-        << new QgsStaticExpressionFunction( QStringLiteral( "get_feature_by_id" ), 2, fcnGetFeatureById, QStringLiteral( "Record" ), QString(), false, QSet<QString>(), false );
+        << new QgsStaticExpressionFunction( QStringLiteral( "get_feature" ), 3, fcnGetFeature, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "QgsExpressionUtils::getFeature" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "get_feature_by_id" ), 2, fcnGetFeatureById, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false );
 
     QgsStaticExpressionFunction *isSelectedFunc = new QgsStaticExpressionFunction(
       QStringLiteral( "is_selected" ),
       -1,
       fcnIsSelected,
-      QStringLiteral( "Record" ),
+      QStringLiteral( "Record and Attributes" ),
       QString(),
       false,
       QSet<QString>()
@@ -4318,15 +4329,44 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
           QStringLiteral( "num_selected" ),
           -1,
           fcnNumSelected,
-          QStringLiteral( "Record" ),
+          QStringLiteral( "Record and Attributes" ),
           QString(),
           false,
           QSet<QString>()
         );
 
     // **Fields and Values** functions
-    sFunctions
-        << new QgsStaticExpressionFunction( QStringLiteral( "represent_value" ), 2, fcnRepresentValue, QStringLiteral( "Fields and Values" ) );
+    QgsStaticExpressionFunction *representValueFunc = new QgsStaticExpressionFunction( QStringLiteral( "represent_value" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "attribute" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "field_name" ), true ), fcnRepresentValue, QStringLiteral( "Record and Attributes" ) );
+
+    representValueFunc->setPrepareFunction( []( const QgsExpressionNodeFunction * node, QgsExpression * parent, const QgsExpressionContext * context )
+    {
+      Q_UNUSED( context )
+      if ( node->args()->count() == 1 )
+      {
+        QgsExpressionNodeColumnRef *colRef = dynamic_cast<QgsExpressionNodeColumnRef *>( node->args()->at( 0 ) );
+        if ( colRef )
+        {
+          return true;
+        }
+        else
+        {
+          parent->setEvalErrorString( tr( "If represent_value is called with 1 parameter, it must be an attribute." ) );
+          return false;
+        }
+      }
+      else if ( node->args()->count() == 2 )
+      {
+        return true;
+      }
+      else
+      {
+        parent->setEvalErrorString( tr( "represent_value must be called with exaactly 1 or 2 parameters." ) );
+        return false;
+      }
+    }
+                                          );
+
+    sFunctions << representValueFunc;
 
     // **General** functions
     sFunctions
@@ -4390,7 +4430,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     sFunctions
         << new QgsStaticExpressionFunction( QStringLiteral( "env" ), 1, fcnEnvVar, QStringLiteral( "General" ), QString() )
         << new QgsWithVariableExpressionFunction()
-        << new QgsStaticExpressionFunction( QStringLiteral( "attribute" ), 2, fcnAttribute, QStringLiteral( "Record" ), QString(), false, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES )
+        << new QgsStaticExpressionFunction( QStringLiteral( "attribute" ), 2, fcnAttribute, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES )
 
         // functions for arrays
         << new QgsStaticExpressionFunction( QStringLiteral( "array" ), -1, fcnArray, QStringLiteral( "Arrays" ), QString(), false, QSet<QString>(), false, QStringList(), true )
@@ -4468,8 +4508,9 @@ bool QgsWithVariableExpressionFunction::isStatic( const QgsExpressionNodeFunctio
   return isStatic;
 }
 
-QVariant QgsWithVariableExpressionFunction::run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent )
+QVariant QgsWithVariableExpressionFunction::run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node )
 {
+  Q_UNUSED( node )
   QVariant result;
 
   if ( args->count() < 3 )
@@ -4492,12 +4533,13 @@ QVariant QgsWithVariableExpressionFunction::run( QgsExpressionNode::NodeList *ar
   return result;
 }
 
-QVariant QgsWithVariableExpressionFunction::func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+QVariant QgsWithVariableExpressionFunction::func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node )
 {
   // This is a dummy function, all the real handling is in run
   Q_UNUSED( values )
   Q_UNUSED( context )
   Q_UNUSED( parent )
+  Q_UNUSED( node )
 
   Q_ASSERT( false );
   return QVariant();

--- a/src/core/expression/qgsexpressionfunction.h
+++ b/src/core/expression/qgsexpressionfunction.h
@@ -40,7 +40,7 @@ class CORE_EXPORT QgsExpressionFunction
 
     /** Function definition for evaluation against an expression context, using a list of values as parameters to the function.
      */
-    typedef QVariant( *FcnEval )( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) SIP_SKIP;
+    typedef QVariant( *FcnEval )( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) SIP_SKIP;
 
     /** \ingroup core
       * Represents a single parameter passed to a function.
@@ -271,11 +271,12 @@ class CORE_EXPORT QgsExpressionFunction
      * \param values list of values passed to the function
      * \param context context expression is being evaluated against
      * \param parent parent expression
+     * \param node expression node
      * \returns result of function
      */
-    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) = 0;
+    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) = 0;
 
-    virtual QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent );
+    virtual QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node );
 
     bool operator==( const QgsExpressionFunction &other ) const;
 
@@ -402,9 +403,9 @@ class QgsStaticExpressionFunction : public QgsExpressionFunction
      * \param parent parent expression
      * \returns result of function
      */
-    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) override
+    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) override
     {
-      return mFnc ? mFnc( values, context, parent ) : QVariant();
+      return mFnc ? mFnc( values, context, parent, node ) : QVariant();
     }
 
     virtual QStringList aliases() const override;
@@ -471,9 +472,9 @@ class QgsWithVariableExpressionFunction : public QgsExpressionFunction
 
     bool isStatic( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
 
-    QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent ) override;
+    QVariant run( QgsExpressionNode::NodeList *args, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) override;
 
-    QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) override;
+    QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) override;
 
     bool prepare( const QgsExpressionNodeFunction *node, QgsExpression *parent, const QgsExpressionContext *context ) const override;
 

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -846,7 +846,7 @@ QVariant QgsExpressionNodeFunction::evalNode( QgsExpression *parent, const QgsEx
   QString name = QgsExpression::QgsExpression::Functions()[mFnIndex]->name();
   QgsExpressionFunction *fd = context && context->hasFunction( name ) ? context->function( name ) : QgsExpression::QgsExpression::Functions()[mFnIndex];
 
-  QVariant res = fd->run( mArgs, context, parent );
+  QVariant res = fd->run( mArgs, context, parent, this );
   ENSURE_NO_EVAL_ERROR;
 
   // everything went fine

--- a/src/core/expression/qgsexpressionnodeimpl.h
+++ b/src/core/expression/qgsexpressionnodeimpl.h
@@ -241,7 +241,6 @@ class CORE_EXPORT QgsExpressionNodeFunction : public QgsExpressionNode
   private:
     int mFnIndex;
     NodeList *mArgs = nullptr;
-
 };
 
 /** \ingroup core

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -626,7 +626,7 @@ class GetNamedProjectColor : public QgsScopedExpressionFunction
       }
     }
 
-    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression * ) override
+    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * ) override
     {
       QString colorName = values.at( 0 ).toString().toLower();
       if ( mColors.contains( colorName ) )
@@ -657,7 +657,7 @@ class GetComposerItemVariables : public QgsScopedExpressionFunction
       , mComposition( c )
     {}
 
-    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression * ) override
+    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * ) override
     {
       if ( !mComposition )
         return QVariant();
@@ -692,7 +692,7 @@ class GetLayerVisibility : public QgsScopedExpressionFunction
       , mLayers( layers )
     {}
 
-    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression * ) override
+    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * ) override
     {
       if ( mLayers.isEmpty() )
       {
@@ -729,7 +729,7 @@ class GetProcessingParameterValue : public QgsScopedExpressionFunction
       , mParams( params )
     {}
 
-    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression * ) override
+    QVariant func( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * ) override
     {
       return mParams.value( values.at( 0 ).toString() );
     }

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -91,7 +91,7 @@ class CORE_EXPORT QgsScopedExpressionFunction : public QgsExpressionFunction
       , mReferencedColumns( referencedColumns )
     {}
 
-    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent ) override = 0;
+    virtual QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node ) override = 0;
 
     /** Returns a clone of the function.
      */

--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -777,8 +777,8 @@ void qgisFunctionWrapper( sqlite3_context *ctxt, int nArgs, sqlite3_value **args
     };
   }
 
-  QgsExpression parentExpr( QLatin1String( "" ) );
-  QVariant ret = foo->func( variants, &qgisFunctionExpressionContext, &parentExpr );
+  QgsExpression parentExpr = QgsExpression( QString() );
+  QVariant ret = foo->func( variants, &qgisFunctionExpressionContext, &parentExpr, nullptr );
   if ( parentExpr.hasEvalError() )
   {
     QByteArray ba = parentExpr.evalErrorString().toUtf8();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -386,7 +386,7 @@ class TestQgsExpression: public QObject
 
       // Usage on a value map
       QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mPointsLayer ) );
-      QgsExpression expression( "represent_value('Pilots', \"Pilots\")" );
+      QgsExpression expression( "represent_value(\"Pilots\", 'Pilots')" );
       if ( expression.hasParserError() )
         qDebug() << expression.parserErrorString();
       Q_ASSERT( !expression.hasParserError() );
@@ -401,7 +401,7 @@ class TestQgsExpression: public QObject
       QCOMPARE( expression.evaluate( &context ).toString(), QStringLiteral( "one" ) );
 
       // Usage on a simple string
-      QgsExpression expression2( "represent_value('Class', \"Class\")" );
+      QgsExpression expression2( "represent_value(\"Class\", 'Class')" );
       if ( expression2.hasParserError() )
         qDebug() << expression2.parserErrorString();
       Q_ASSERT( !expression2.hasParserError() );
@@ -412,6 +412,19 @@ class TestQgsExpression: public QObject
       mPointsLayer->getFeatures( QgsFeatureRequest().setFilterExpression( "Class = 'Jet'" ) ).nextFeature( feature );
       context.setFeature( feature );
       QCOMPARE( expression2.evaluate( &context ).toString(), QStringLiteral( "Jet" ) );
+
+      // Test with implicit field name discovery
+      QgsExpression expression3( "represent_value(\"Pilots\")" );
+      if ( expression3.hasParserError() )
+        qDebug() << expression.parserErrorString();
+      Q_ASSERT( !expression3.hasParserError() );
+      if ( expression3.hasEvalError() )
+        qDebug() << expression3.evalErrorString();
+      Q_ASSERT( !expression3.hasEvalError() );
+      expression3.prepare( &context );
+      mPointsLayer->getFeatures( QgsFeatureRequest().setFilterExpression( "Pilots = 1" ) ).nextFeature( feature );
+      context.setFeature( feature );
+      QCOMPARE( expression.evaluate( &context ).toString(), QStringLiteral( "one" ) );
     }
 
     void evaluation_data()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -425,6 +425,13 @@ class TestQgsExpression: public QObject
       mPointsLayer->getFeatures( QgsFeatureRequest().setFilterExpression( "Pilots = 1" ) ).nextFeature( feature );
       context.setFeature( feature );
       QCOMPARE( expression.evaluate( &context ).toString(), QStringLiteral( "one" ) );
+
+
+      QgsExpression expression4( "represent_value('Class')" );
+      if ( expression4.hasParserError() )
+        qDebug() << expression4.parserErrorString();
+      Q_ASSERT( !expression4.hasParserError() );
+      Q_ASSERT( expression4.hasEvalError() );
     }
 
     void evaluation_data()

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -62,7 +62,7 @@ class TestQgsExpressionContext : public QObject
         GetTestValueFunction()
           : QgsScopedExpressionFunction( QStringLiteral( "get_test_value" ), 1, QStringLiteral( "test" ) ) {}
 
-        virtual QVariant func( const QVariantList &, const QgsExpressionContext *, QgsExpression * ) override
+        virtual QVariant func( const QVariantList &, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * ) override
         {
           return 42;
         }
@@ -80,7 +80,7 @@ class TestQgsExpressionContext : public QObject
         GetTestValueFunction2()
           : QgsScopedExpressionFunction( QStringLiteral( "get_test_value" ), 1, QStringLiteral( "test" ) ) {}
 
-        virtual QVariant func( const QVariantList &, const QgsExpressionContext *, QgsExpression * ) override
+        virtual QVariant func( const QVariantList &, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * ) override
         {
           return 43;
         }
@@ -99,7 +99,7 @@ class TestQgsExpressionContext : public QObject
           , mVal( v )
         {}
 
-        virtual QVariant func( const QVariantList &, const QgsExpressionContext *, QgsExpression * ) override
+        virtual QVariant func( const QVariantList &, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * ) override
         {
           if ( !mVal )
             return QVariant();
@@ -228,7 +228,7 @@ void TestQgsExpressionContext::contextScopeFunctions()
   QVERIFY( scope.hasFunction( "get_test_value" ) );
   QVERIFY( scope.function( "get_test_value" ) );
   QgsExpressionContext temp;
-  QCOMPARE( scope.function( "get_test_value" )->func( QVariantList(), &temp, 0 ).toInt(), 42 );
+  QCOMPARE( scope.function( "get_test_value" )->func( QVariantList(), &temp, 0, nullptr ).toInt(), 42 );
 
   //test functionNames
   scope.addFunction( QStringLiteral( "get_test_value2" ), new GetTestValueFunction() );
@@ -371,27 +371,27 @@ void TestQgsExpressionContext::contextStackFunctions()
   QVERIFY( context.hasFunction( "get_test_value" ) );
   QVERIFY( context.function( "get_test_value" ) );
   QgsExpressionContext temp;
-  QCOMPARE( context.function( "get_test_value" )->func( QVariantList(), &temp, 0 ).toInt(), 42 );
+  QCOMPARE( context.function( "get_test_value" )->func( QVariantList(), &temp, 0, nullptr ).toInt(), 42 );
 
   //add a second scope, should override the first
   context << new QgsExpressionContextScope();
   //test without setting function first...
   QVERIFY( context.hasFunction( "get_test_value" ) );
   QVERIFY( context.function( "get_test_value" ) );
-  QCOMPARE( context.function( "get_test_value" )->func( QVariantList(), &temp, 0 ).toInt(), 42 );
+  QCOMPARE( context.function( "get_test_value" )->func( QVariantList(), &temp, 0, nullptr ).toInt(), 42 );
 
   //then set the variable so it overrides
   QgsExpressionContextScope *scope2 = context.scope( 1 );
   scope2->addFunction( QStringLiteral( "get_test_value" ), new GetTestValueFunction2() );
   QVERIFY( context.hasFunction( "get_test_value" ) );
   QVERIFY( context.function( "get_test_value" ) );
-  QCOMPARE( context.function( "get_test_value" )->func( QVariantList(), &temp, 0 ).toInt(), 43 );
+  QCOMPARE( context.function( "get_test_value" )->func( QVariantList(), &temp, 0, nullptr ).toInt(), 43 );
 
   //make sure stack falls back to earlier contexts
   scope2->addFunction( QStringLiteral( "get_test_value2" ), new GetTestValueFunction() );
   QVERIFY( context.hasFunction( "get_test_value2" ) );
   QVERIFY( context.function( "get_test_value2" ) );
-  QCOMPARE( context.function( "get_test_value2" )->func( QVariantList(), &temp, 0 ).toInt(), 42 );
+  QCOMPARE( context.function( "get_test_value2" )->func( QVariantList(), &temp, 0, nullptr ).toInt(), 42 );
 
   //test functionNames
   QStringList names = context.functionNames();

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -97,7 +97,7 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         self.assertEqual(args, 3)
         values = [1, 2, 3]
         exp = QgsExpression("")
-        result = function.func(values, None, exp)
+        result = function.func(values, None, exp, None)
         # Make sure there is no eval error
         self.assertEqual(exp.evalErrorString(), "")
         self.assertEqual(result, (1, 2, 3))


### PR DESCRIPTION
After:

    represent_value("colname")
    # or
    represent_value("colname", 'colname')

Before:

    represent_value('colname', "colname")
