### PR TITLE
Remove the unneeded close button

### DIFF
--- a/src/ui/qgsexpressionselectiondialogbase.ui
+++ b/src/ui/qgsexpressionselectiondialogbase.ui
@@ -26,21 +26,21 @@
    <property name="bottomMargin">
     <number>3</number>
    </property>
-   <item row="1" column="4">
+   <item row="1" column="5">
     <widget class="QPushButton" name="mPbnClose">
      <property name="text">
       <string>Close</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="2">
     <widget class="QToolButton" name="mButtonZoomToFeatures">
      <property name="text">
       <string>Zoom to features</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="1" column="1">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -53,10 +53,7 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="0" colspan="5">
-    <widget class="QgsExpressionBuilderWidget" name="mExpressionBuilder" native="true"/>
-   </item>
-   <item row="1" column="2">
+   <item row="1" column="3">
     <widget class="QToolButton" name="mButtonSelect">
      <property name="text">
       <string>…</string>
@@ -69,12 +66,15 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
+   <item row="1" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
+   </item>
+   <item row="0" column="0" colspan="6">
+    <widget class="QgsExpressionBuilderWidget" name="mExpressionBuilder" native="true"/>
    </item>
   </layout>
   <action name="mActionSelect">

--- a/src/ui/qgsexpressionselectiondialogbase.ui
+++ b/src/ui/qgsexpressionselectiondialogbase.ui
@@ -29,7 +29,7 @@
    <item row="1" column="5">
     <widget class="QPushButton" name="mPbnClose">
      <property name="text">
-      <string>Close</string>
+      <string>&amp;Close</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
fixes #17207
Also move the help button at the left of the dialog
Before
![expressiondialogold](https://user-images.githubusercontent.com/7983394/31046074-8c592280-a5f2-11e7-9076-a8bb82905cde.png)

After
![expressiondialog](https://user-images.githubusercontent.com/7983394/31046073-89fd82ba-a5f2-11e7-99fa-aaebc72a25f8.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
