### PR TITLE
[style dock] fix wrong label settings when switching layers

### DIFF
--- a/src/app/qgslabelingwidget.cpp
+++ b/src/app/qgslabelingwidget.cpp
@@ -36,8 +36,6 @@ QgsLabelingWidget::QgsLabelingWidget( QgsVectorLayer *layer, QgsMapCanvas *canva
 
   connect( mEngineSettingsButton, &QAbstractButton::clicked, this, &QgsLabelingWidget::showEngineConfigDialog );
 
-  mLabelModeComboBox->setCurrentIndex( -1 );
-
   connect( mLabelModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLabelingWidget::labelModeChanged );
   setLayer( layer );
 }
@@ -80,6 +78,8 @@ void QgsLabelingWidget::adaptToLayer()
 {
   if ( !mLayer )
     return;
+
+  whileBlocking( mLabelModeComboBox )->setCurrentIndex( -1 );
 
   // pick the right mode of the layer
   if ( mLayer->labeling() && mLayer->labeling()->type() == QLatin1String( "rule-based" ) )


### PR DESCRIPTION
## Description
This PR fixes a regression whereas switching layers would not properly update the style dock's label settings properly (https://issues.qgis.org/issues/17029).

Long story short, if a user would switch from one vector layer to another with both having the same label type (i.e. simple / rule-based / obstacle), the settings population wouldn't be triggered.

@wonder-sk , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
