### PR TITLE
fix highlight showing when hidden

### DIFF
--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -256,7 +256,7 @@ void QgsHighlight::paintPolygon( QPainter *p, QgsPolygon polygon )
 
 void QgsHighlight::updatePosition()
 {
-  updateRect();
+  if ( isVisible() ) updateRect();
 }
 
 void QgsHighlight::paint( QPainter *p )


### PR DESCRIPTION
## Description
This fixes a regression introduced in commit dbd86d0ddcef07 , whereas QgsHighlight items that were hidden (by calling hide()) would show up again when dragging around the canvas. This resulted in identify feature tool highlight reappearing after the tool was deactivated.

@blazek , could you make sure this doesn't negatively impact on the scenario you were trying to fix? Cheers.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
