### PR TITLE
[auth][needs-docs] Provider connection dialogs use the new auth settings widget

### DIFF
--- a/python/gui/auth/qgsauthsettingswidget.sip
+++ b/python/gui/auth/qgsauthsettingswidget.sip
@@ -14,6 +14,10 @@ class QgsAuthSettingsWidget : QWidget
 %Docstring
  Widget for entering authentication credentials both in the form username/password
  and by using QGIS Authentication Database and its authentication configurations.
+
+ The widget also offers the functionality to convert username/password credentials
+ to an authentication configuration.
+
 .. versionadded:: 3.0
 %End
 
@@ -111,7 +115,7 @@ class QgsAuthSettingsWidget : QWidget
     static const QString formattedWarning( WarningType warning );
 %Docstring
  warning text message based upon where credentials are stored
- \param enum of warning type
+ \param warning enum of warning type
  :return: pre-formatted warning text
  :rtype: str
 %End

--- a/python/gui/auth/qgsauthsettingswidget.sip
+++ b/python/gui/auth/qgsauthsettingswidget.sip
@@ -117,16 +117,16 @@ class QgsAuthSettingsWidget : QWidget
  \param enabled
 %End
 
-    void setStoreUsername( bool checked );
+    void setStoreUsernameChecked( bool checked );
 %Docstring
- setStoreUsername check the "Store" checkbox for the username
+ setStoreUsernameChecked check the "Store" checkbox for the username
  \param checked
 .. seealso:: showStoreCheckboxes
 %End
 
-    void setStorePassword( bool checked );
+    void setStorePasswordChecked( bool checked );
 %Docstring
-  updateStorePasswordcheck the "Store" checkbox for the password
+ setStorePasswordCheched check the "Store" checkbox for the password
  \param checked
 .. seealso:: showStoreCheckboxes
 %End

--- a/python/gui/auth/qgsauthsettingswidget.sip
+++ b/python/gui/auth/qgsauthsettingswidget.sip
@@ -88,17 +88,68 @@ class QgsAuthSettingsWidget : QWidget
   param configId the authentication configuration id
 %End
 
-    int currentTabIndex( ) const;
+    void setDataprovider( const QString &dataprovider );
 %Docstring
- currentTabIndex, mainly useful for unit tests
- :return: active tab index
- :rtype: int
+ setDataprovider set the data provider key for filtering compatible authentication configurations
+ \param dataprovider data provider key
+%End
+
+    const QString dataprovider( ) const;
+%Docstring
+ dataprovider
+ :return: the data provider key used to filter compatible authentication configurations
+ :rtype: str
 %End
 
     bool btnConvertToEncryptedIsEnabled( ) const;
 %Docstring
  convertButtonEnabled, mainly useful for unit tests
  :return: true if the convert button is enabled
+ :rtype: bool
+%End
+
+    void showStoreCheckboxes( bool enabled );
+%Docstring
+ showStoreCheckboxes show the "Store" checkboxes for basic auth.
+        Some connection configurations allow the user to enter credentials
+        for testing the connection without storing them in the project.
+        "Store" checkboxes are disabled by default.
+ \param enabled
+%End
+
+    void setStoreUsername( bool checked );
+%Docstring
+ setStoreUsername check the "Store" checkbox for the username
+ \param checked
+.. seealso:: showStoreCheckboxes
+%End
+
+    void setStorePassword( bool checked );
+%Docstring
+  updateStorePasswordcheck the "Store" checkbox for the password
+ \param checked
+.. seealso:: showStoreCheckboxes
+%End
+
+    bool storePasswordIsChecked( ) const;
+%Docstring
+ storePassword
+ :return: true if "Store" checkbox for the password is checked
+ :rtype: bool
+%End
+
+    bool storeUsernameIsChecked( ) const;
+%Docstring
+ storeUsername
+ :return: true if "Store" checkbox for the username is checked
+ :rtype: bool
+%End
+
+
+    bool configurationTabIsSelected( );
+%Docstring
+ configurationTabIsSelected
+ :return: true if the configuration tab is the currently selected tab
  :rtype: bool
 %End
 

--- a/python/gui/auth/qgsauthsettingswidget.sip
+++ b/python/gui/auth/qgsauthsettingswidget.sip
@@ -56,11 +56,29 @@ class QgsAuthSettingsWidget : QWidget
  :rtype: str
 %End
 
+    void setUsername( const QString &username );
+%Docstring
+ setUsername set the username
+ \param username the user name
+%End
+
     const QString password( ) const;
 %Docstring
  password
  :return: basic authentication password
  :rtype: str
+%End
+
+    void setPassword( const QString &password );
+%Docstring
+ setPassword set the password
+ \param password the password
+%End
+
+    void setConfigId( const QString &configId );
+%Docstring
+ setConfigId set the authentication configuration id
+  param configId the authentication configuration id
 %End
 
     const QString configId( ) const;

--- a/python/gui/auth/qgsauthsettingswidget.sip
+++ b/python/gui/auth/qgsauthsettingswidget.sip
@@ -75,17 +75,17 @@ class QgsAuthSettingsWidget : QWidget
  \param password the password
 %End
 
-    void setConfigId( const QString &configId );
-%Docstring
- setConfigId set the authentication configuration id
-  param configId the authentication configuration id
-%End
-
     const QString configId( ) const;
 %Docstring
  configId
  :return: authentication configuration id
  :rtype: str
+%End
+
+    void setConfigId( const QString &configId );
+%Docstring
+ setConfigId set the authentication configuration id
+  param configId the authentication configuration id
 %End
 
     int currentTabIndex( ) const;

--- a/python/gui/auth/qgsauthsettingswidget.sip
+++ b/python/gui/auth/qgsauthsettingswidget.sip
@@ -22,6 +22,12 @@ class QgsAuthSettingsWidget : QWidget
 %End
   public:
 
+    enum WarningType
+    {
+      ProjectFile,
+      UserSettings
+    };
+
     explicit QgsAuthSettingsWidget( QWidget *parent /TransferThis/ = 0,
                                     const QString &configId = QString(),
                                     const QString &username = QString(),
@@ -41,6 +47,7 @@ class QgsAuthSettingsWidget : QWidget
 %Docstring
  setWarningText set the text of the warning label
  \param warningText the text of the warning label
+.. seealso:: formattedWarning()
 %End
 
     void setBasicText( const QString &basicText );
@@ -101,6 +108,14 @@ class QgsAuthSettingsWidget : QWidget
  :rtype: str
 %End
 
+    static const QString formattedWarning( WarningType warning );
+%Docstring
+ warning text message based upon where credentials are stored
+ \param enum of warning type
+ :return: pre-formatted warning text
+ :rtype: str
+%End
+
     bool btnConvertToEncryptedIsEnabled( ) const;
 %Docstring
  convertButtonEnabled, mainly useful for unit tests
@@ -144,7 +159,6 @@ class QgsAuthSettingsWidget : QWidget
  :return: true if "Store" checkbox for the username is checked
  :rtype: bool
 %End
-
 
     bool configurationTabIsSelected( );
 %Docstring

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -312,7 +312,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAuthSettings->setDataprovider( QStringLiteral( "proxy" ) );
   QString authcfg = mSettings->value( QStringLiteral( "proxy/authcfg" ) ).toString();
   mAuthSettings->setConfigId( authcfg );
-  mAuthSettings->setWarningText( tr( "<b style=\"color:red\">Warning: credentials are stored unencrypted (in clear text) in the system settings!</b>" ) );
+  mAuthSettings->setWarningText( mAuthSettings->formattedWarning( QgsAuthSettingsWidget::UserSettings ) );
 
   //Web proxy settings
   grpProxy->setChecked( mSettings->value( QStringLiteral( "proxy/proxyEnabled" ), "0" ).toBool() );

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -309,21 +309,18 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mDefaultTileMaxRetrySpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/defaultTileMaxRetry" ), "3" ).toInt() );
 
   // Proxy stored authentication configurations
-  mProxyAuthConfigSelect = new QgsAuthConfigSelect( this, QStringLiteral( "proxy" ) );
-  tabAuth->insertTab( 1, mProxyAuthConfigSelect, tr( "Configurations" ) );
+  mAuthSettings->setDataprovider( QStringLiteral( "proxy" ) );
   QString authcfg = mSettings->value( QStringLiteral( "proxy/authcfg" ) ).toString();
-  mProxyAuthConfigSelect->setConfigId( authcfg );
-  if ( !authcfg.isEmpty() )
-  {
-    tabAuth->setCurrentIndex( tabAuth->indexOf( mProxyAuthConfigSelect ) );
-  }
+  mAuthSettings->setConfigId( authcfg );
+  mAuthSettings->setWarningText( tr( "<b style=\"color:red\">Warning: credentials are stored unencrypted (in clear text) in the system settings!</b>" ) );
 
   //Web proxy settings
   grpProxy->setChecked( mSettings->value( QStringLiteral( "proxy/proxyEnabled" ), "0" ).toBool() );
   leProxyHost->setText( mSettings->value( QStringLiteral( "proxy/proxyHost" ), "" ).toString() );
   leProxyPort->setText( mSettings->value( QStringLiteral( "proxy/proxyPort" ), "" ).toString() );
-  leProxyUser->setText( mSettings->value( QStringLiteral( "proxy/proxyUser" ), "" ).toString() );
-  leProxyPassword->setText( mSettings->value( QStringLiteral( "proxy/proxyPassword" ), "" ).toString() );
+
+  mAuthSettings->setPassword( mSettings->value( QStringLiteral( "proxy/proxyUser" ), "" ).toString() );
+  mAuthSettings->setUsername( mSettings->value( QStringLiteral( "proxy/proxyPassword" ), "" ).toString() );
 
   //available proxy types
   mProxyTypeComboBox->insertItem( 0, QStringLiteral( "DefaultProxy" ) );
@@ -1174,14 +1171,14 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/defaultTileMaxRetry" ), mDefaultTileMaxRetrySpinBox->value() );
 
   // Proxy stored authentication configurations
-  mSettings->setValue( QStringLiteral( "proxy/authcfg" ), mProxyAuthConfigSelect->configId( ) );
+  mSettings->setValue( QStringLiteral( "proxy/authcfg" ), mAuthSettings->configId( ) );
 
   //Web proxy settings
   mSettings->setValue( QStringLiteral( "proxy/proxyEnabled" ), grpProxy->isChecked() );
   mSettings->setValue( QStringLiteral( "proxy/proxyHost" ), leProxyHost->text() );
   mSettings->setValue( QStringLiteral( "proxy/proxyPort" ), leProxyPort->text() );
-  mSettings->setValue( QStringLiteral( "proxy/proxyUser" ), leProxyUser->text() );
-  mSettings->setValue( QStringLiteral( "proxy/proxyPassword" ), leProxyPassword->text() );
+  mSettings->setValue( QStringLiteral( "proxy/proxyUser" ),  mAuthSettings->username() );
+  mSettings->setValue( QStringLiteral( "proxy/proxyPassword" ), mAuthSettings->password() );
   mSettings->setValue( QStringLiteral( "proxy/proxyType" ), mProxyTypeComboBox->currentText() );
 
   if ( !mCacheDirectory->text().isEmpty() )

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -256,7 +256,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
 
     QList< QgsOptionsPageWidget * > mAdditionalOptionWidgets;
     QgsLocatorOptionsWidget *mLocatorOptionsWidget = nullptr;
-    QgsAuthConfigSelect *mProxyAuthConfigSelect = nullptr;
 
 };
 

--- a/src/gui/auth/qgsauthsettingswidget.cpp
+++ b/src/gui/auth/qgsauthsettingswidget.cpp
@@ -39,6 +39,8 @@ QgsAuthSettingsWidget::QgsAuthSettingsWidget( QWidget *parent,
     mAuthConfigSelect->setConfigId( configId );
   }
   setBasicText( "" );
+  // default to warning about basic settings stored in project file
+  setWarningText( formattedWarning( ProjectFile ) );
   connect( btnConvertToEncrypted, &QPushButton::clicked, this, &QgsAuthSettingsWidget::convertToEncrypted );
   connect( txtUserName, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::userNameTextChanged );
   connect( txtPassword, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::passwordTextChanged );
@@ -97,6 +99,18 @@ void QgsAuthSettingsWidget::setDataprovider( const QString &dataprovider )
 const QString QgsAuthSettingsWidget::dataprovider() const
 {
   return mDataprovider;
+}
+
+const QString QgsAuthSettingsWidget::formattedWarning( WarningType warning )
+{
+  QString out = tr( "<div>Warning: credentials stored as plain text in %1.</div>" );
+  switch ( warning )
+  {
+    case ProjectFile:
+      return out.arg( tr( "project file" ) );
+    case UserSettings:
+      return out.arg( tr( "user settings" ) );
+  }
 }
 
 const QString QgsAuthSettingsWidget::configId() const

--- a/src/gui/auth/qgsauthsettingswidget.cpp
+++ b/src/gui/auth/qgsauthsettingswidget.cpp
@@ -38,6 +38,7 @@ QgsAuthSettingsWidget::QgsAuthSettingsWidget( QWidget *parent,
   {
     mAuthConfigSelect->setConfigId( configId );
   }
+  setBasicText( "" );
   connect( btnConvertToEncrypted, &QPushButton::clicked, this, &QgsAuthSettingsWidget::convertToEncrypted );
   connect( txtUserName, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::userNameTextChanged );
   connect( txtPassword, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::passwordTextChanged );
@@ -55,6 +56,8 @@ void QgsAuthSettingsWidget::setWarningText( const QString &warningText )
 void QgsAuthSettingsWidget::setBasicText( const QString &basicText )
 {
   lblBasic->setText( basicText );
+  // hide unused widget so its word wrapping does not add to parent widget's height
+  lblBasic->setVisible( ! basicText.isEmpty() );
 }
 
 const QString QgsAuthSettingsWidget::username() const

--- a/src/gui/auth/qgsauthsettingswidget.cpp
+++ b/src/gui/auth/qgsauthsettingswidget.cpp
@@ -36,13 +36,11 @@ QgsAuthSettingsWidget::QgsAuthSettingsWidget( QWidget *parent,
   if ( ! configId.isEmpty( ) )
   {
     mAuthConfigSelect->setConfigId( configId );
-    tabAuth->setCurrentIndex( tabAuth->indexOf( tabConfigurations ) );
-  }
-  else if ( !( username.isEmpty() && password.isEmpty( ) ) )
-  {
-    tabAuth->setCurrentIndex( tabAuth->indexOf( tabBasic ) );
   }
   connect( btnConvertToEncrypted, &QPushButton::clicked, this, &QgsAuthSettingsWidget::convertToEncrypted );
+  connect( txtUserName, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::userNameTextChanged );
+  connect( txtPassword, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::passwordTextChanged );
+  updateSelectedTab();
   updateConvertBtnState();
 }
 
@@ -61,9 +59,27 @@ const QString QgsAuthSettingsWidget::username() const
   return txtUserName->text();
 }
 
+void QgsAuthSettingsWidget::setUsername( const QString &username )
+{
+  txtUserName->setText( username );
+  updateSelectedTab();
+}
+
 const QString QgsAuthSettingsWidget::password() const
 {
   return txtPassword->text();
+}
+
+void QgsAuthSettingsWidget::setPassword( const QString &password )
+{
+  txtPassword->setText( password );
+  updateSelectedTab();
+}
+
+void QgsAuthSettingsWidget::setConfigId( const QString &configId )
+{
+  mAuthConfigSelect->setConfigId( configId );
+  updateSelectedTab();
 }
 
 const QString QgsAuthSettingsWidget::configId() const
@@ -102,13 +118,13 @@ bool QgsAuthSettingsWidget::convertToEncrypted( )
   }
 }
 
-void QgsAuthSettingsWidget::on_txtUserName_textChanged( const QString &text )
+void QgsAuthSettingsWidget::userNameTextChanged( const QString &text )
 {
   Q_UNUSED( text );
   updateConvertBtnState();
 }
 
-void QgsAuthSettingsWidget::on_txtPassword_textChanged( const QString &text )
+void QgsAuthSettingsWidget::passwordTextChanged( const QString &text )
 {
   Q_UNUSED( text );
   updateConvertBtnState();
@@ -117,4 +133,16 @@ void QgsAuthSettingsWidget::on_txtPassword_textChanged( const QString &text )
 void QgsAuthSettingsWidget::updateConvertBtnState()
 {
   btnConvertToEncrypted->setEnabled( ! txtUserName->text().isEmpty() || ! txtPassword->text().isEmpty() );
+}
+
+void QgsAuthSettingsWidget::updateSelectedTab()
+{
+  if ( ! mAuthConfigSelect->configId().isEmpty( ) )
+  {
+    tabAuth->setCurrentIndex( tabAuth->indexOf( tabConfigurations ) );
+  }
+  else if ( !( txtUserName->text( ).isEmpty() && txtPassword->text( ).isEmpty( ) ) )
+  {
+    tabAuth->setCurrentIndex( tabAuth->indexOf( tabBasic ) );
+  }
 }

--- a/src/gui/auth/qgsauthsettingswidget.cpp
+++ b/src/gui/auth/qgsauthsettingswidget.cpp
@@ -25,6 +25,7 @@ QgsAuthSettingsWidget::QgsAuthSettingsWidget( QWidget *parent,
     const QString &password,
     const QString &dataprovider )
   : QWidget( parent )
+  , mDataprovider( dataprovider )
 {
   setupUi( this );
   txtPassword->setText( password );
@@ -40,6 +41,8 @@ QgsAuthSettingsWidget::QgsAuthSettingsWidget( QWidget *parent,
   connect( btnConvertToEncrypted, &QPushButton::clicked, this, &QgsAuthSettingsWidget::convertToEncrypted );
   connect( txtUserName, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::userNameTextChanged );
   connect( txtPassword, &QLineEdit::textChanged, this, &QgsAuthSettingsWidget::passwordTextChanged );
+  // Hide store password and username by default
+  showStoreCheckboxes( false );
   updateSelectedTab();
   updateConvertBtnState();
 }
@@ -82,19 +85,64 @@ void QgsAuthSettingsWidget::setConfigId( const QString &configId )
   updateSelectedTab();
 }
 
+void QgsAuthSettingsWidget::setDataprovider( const QString &dataprovider )
+{
+  mDataprovider = dataprovider;
+  mAuthConfigSelect->setDataProviderKey( dataprovider );
+}
+
+const QString QgsAuthSettingsWidget::dataprovider() const
+{
+  return mDataprovider;
+}
+
 const QString QgsAuthSettingsWidget::configId() const
 {
   return mAuthConfigSelect->configId();
 }
 
-int QgsAuthSettingsWidget::currentTabIndex() const
-{
-  return tabAuth->currentIndex( );
-}
-
 bool QgsAuthSettingsWidget::btnConvertToEncryptedIsEnabled() const
 {
   return btnConvertToEncrypted->isEnabled( );
+}
+
+void QgsAuthSettingsWidget::showStoreCheckboxes( bool enabled )
+{
+  if ( enabled )
+  {
+    cbStorePassword->show();
+    cbStoreUsername->show();
+  }
+  else
+  {
+    cbStorePassword->hide();
+    cbStoreUsername->hide();
+  }
+}
+
+void QgsAuthSettingsWidget::setStoreUsername( bool checked )
+{
+  cbStoreUsername->setChecked( checked );
+}
+
+void QgsAuthSettingsWidget::setStorePassword( bool checked )
+{
+  cbStorePassword->setChecked( checked );
+}
+
+bool QgsAuthSettingsWidget::storePasswordIsChecked() const
+{
+  return cbStorePassword->isChecked( );
+}
+
+bool QgsAuthSettingsWidget::storeUsernameIsChecked() const
+{
+  return cbStoreUsername->isChecked( );
+}
+
+bool QgsAuthSettingsWidget::configurationTabIsSelected()
+{
+  return tabAuth->currentIndex( ) == tabAuth->indexOf( tabConfigurations );
 }
 
 bool QgsAuthSettingsWidget::convertToEncrypted( )

--- a/src/gui/auth/qgsauthsettingswidget.cpp
+++ b/src/gui/auth/qgsauthsettingswidget.cpp
@@ -120,12 +120,12 @@ void QgsAuthSettingsWidget::showStoreCheckboxes( bool enabled )
   }
 }
 
-void QgsAuthSettingsWidget::setStoreUsername( bool checked )
+void QgsAuthSettingsWidget::setStoreUsernameChecked( bool checked )
 {
   cbStoreUsername->setChecked( checked );
 }
 
-void QgsAuthSettingsWidget::setStorePassword( bool checked )
+void QgsAuthSettingsWidget::setStorePasswordChecked( bool checked )
 {
   cbStorePassword->setChecked( checked );
 }

--- a/src/gui/auth/qgsauthsettingswidget.h
+++ b/src/gui/auth/qgsauthsettingswidget.h
@@ -126,18 +126,18 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
     void showStoreCheckboxes( bool enabled );
 
     /**
-     * \brief setStoreUsername check the "Store" checkbox for the username
+     * \brief setStoreUsernameChecked check the "Store" checkbox for the username
      * \param checked
      * \see showStoreCheckboxes
      */
-    void setStoreUsername( bool checked );
+    void setStoreUsernameChecked( bool checked );
 
     /**
-     * \brief  updateStorePasswordcheck the "Store" checkbox for the password
+     * \brief setStorePasswordCheched check the "Store" checkbox for the password
      * \param checked
      * \see showStoreCheckboxes
      */
-    void setStorePassword( bool checked );
+    void setStorePasswordChecked( bool checked );
 
     /**
      * \brief storePassword

--- a/src/gui/auth/qgsauthsettingswidget.h
+++ b/src/gui/auth/qgsauthsettingswidget.h
@@ -26,6 +26,10 @@
 /** \ingroup gui
  * Widget for entering authentication credentials both in the form username/password
  * and by using QGIS Authentication Database and its authentication configurations.
+ *
+ * The widget also offers the functionality to convert username/password credentials
+ * to an authentication configuration.
+ *
  * \since QGIS 3.0
  */
 class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSettingsWidget
@@ -35,7 +39,13 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
 
   public:
 
-    //! Type of certificate usage
+    /**
+     * \brief The WarningType enum is used to determine the text
+     * of the message shown to the user about the destination of
+     * the stored clear-text credentials from the "Basic" tab:
+     * depending on the provider or the settings, the credentials
+     * are stored in the user settings and/or in the project file.
+     */
     enum WarningType
     {
       ProjectFile,
@@ -121,7 +131,7 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
 
     /**
      * \brief warning text message based upon where credentials are stored
-     * \param enum of warning type
+     * \param warning enum of warning type
      * \return pre-formatted warning text
      */
     static const QString formattedWarning( WarningType warning );

--- a/src/gui/auth/qgsauthsettingswidget.h
+++ b/src/gui/auth/qgsauthsettingswidget.h
@@ -69,10 +69,28 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
     const QString username( ) const;
 
     /**
+     * \brief setUsername set the username
+     * \param username the user name
+     */
+    void setUsername( const QString &username );
+
+    /**
      * \brief password
      * \return basic authentication password
      */
     const QString password( ) const;
+
+    /**
+     * \brief setPassword set the password
+     * \param password the password
+     */
+    void setPassword( const QString &password );
+
+    /**
+     * \brief setConfigId set the authentication configuration id
+     *  param configId the authentication configuration id
+     */
+    void setConfigId( const QString &configId );
 
     /**
      * \brief configId
@@ -107,19 +125,21 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
      * \param text the changet text
      * \note Not available in Python bindings
      */
-    void on_txtUserName_textChanged( const QString &text ) SIP_SKIP;
+    void userNameTextChanged( const QString &text ) SIP_SKIP;
 
     /**
      * \brief on_txtPassword_textChanged set convert button state
      * \param text the changed text
      * \note Not available in Python bindings
      */
-    void on_txtPassword_textChanged( const QString &text ) SIP_SKIP;
+    void passwordTextChanged( const QString &text ) SIP_SKIP;
 
 
   private:
 
     void updateConvertBtnState( );
+
+    void updateSelectedTab( );
 
 };
 

--- a/src/gui/auth/qgsauthsettingswidget.h
+++ b/src/gui/auth/qgsauthsettingswidget.h
@@ -35,6 +35,14 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
 
   public:
 
+    //! Type of certificate usage
+    enum WarningType
+    {
+      ProjectFile,
+      UserSettings
+    };
+    Q_ENUM( WarningType )
+
     /**
      * Create a dialog for setting an associated authentication config, either
      * from existing configs, or creating/removing them from auth database
@@ -53,6 +61,7 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
     /**
      * \brief setWarningText set the text of the warning label
      * \param warningText the text of the warning label
+     * \see formattedWarning()
      */
     void setWarningText( const QString &warningText );
 
@@ -111,6 +120,13 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
     const QString dataprovider( ) const;
 
     /**
+     * \brief warning text message based upon where credentials are stored
+     * \param enum of warning type
+     * \return pre-formatted warning text
+     */
+    static const QString formattedWarning( WarningType warning );
+
+    /**
      * \brief convertButtonEnabled, mainly useful for unit tests
      * \return true if the convert button is enabled
      */
@@ -150,7 +166,6 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
      * \return true if "Store" checkbox for the username is checked
      */
     bool storeUsernameIsChecked( ) const;
-
 
     /**
      * \brief configurationTabIsSelected

--- a/src/gui/auth/qgsauthsettingswidget.h
+++ b/src/gui/auth/qgsauthsettingswidget.h
@@ -87,16 +87,16 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
     void setPassword( const QString &password );
 
     /**
-     * \brief setConfigId set the authentication configuration id
-     *  param configId the authentication configuration id
-     */
-    void setConfigId( const QString &configId );
-
-    /**
      * \brief configId
      * \return authentication configuration id
      */
     const QString configId( ) const;
+
+    /**
+     * \brief setConfigId set the authentication configuration id
+     *  param configId the authentication configuration id
+     */
+    void setConfigId( const QString &configId );
 
     /**
      * \brief currentTabIndex, mainly useful for unit tests

--- a/src/gui/auth/qgsauthsettingswidget.h
+++ b/src/gui/auth/qgsauthsettingswidget.h
@@ -99,16 +99,64 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
     void setConfigId( const QString &configId );
 
     /**
-     * \brief currentTabIndex, mainly useful for unit tests
-     * \return active tab index
+     * \brief setDataprovider set the data provider key for filtering compatible authentication configurations
+     * \param dataprovider data provider key
      */
-    int currentTabIndex( ) const;
+    void setDataprovider( const QString &dataprovider );
+
+    /**
+     * \brief dataprovider
+     * \return the data provider key used to filter compatible authentication configurations
+     */
+    const QString dataprovider( ) const;
 
     /**
      * \brief convertButtonEnabled, mainly useful for unit tests
      * \return true if the convert button is enabled
      */
     bool btnConvertToEncryptedIsEnabled( ) const;
+
+    /**
+     * \brief showStoreCheckboxes show the "Store" checkboxes for basic auth.
+     *        Some connection configurations allow the user to enter credentials
+     *        for testing the connection without storing them in the project.
+     *        "Store" checkboxes are disabled by default.
+     * \param enabled
+     */
+    void showStoreCheckboxes( bool enabled );
+
+    /**
+     * \brief setStoreUsername check the "Store" checkbox for the username
+     * \param checked
+     * \see showStoreCheckboxes
+     */
+    void setStoreUsername( bool checked );
+
+    /**
+     * \brief  updateStorePasswordcheck the "Store" checkbox for the password
+     * \param checked
+     * \see showStoreCheckboxes
+     */
+    void setStorePassword( bool checked );
+
+    /**
+     * \brief storePassword
+     * \return true if "Store" checkbox for the password is checked
+     */
+    bool storePasswordIsChecked( ) const;
+
+    /**
+     * \brief storeUsername
+     * \return true if "Store" checkbox for the username is checked
+     */
+    bool storeUsernameIsChecked( ) const;
+
+
+    /**
+     * \brief configurationTabIsSelected
+     * \return true if the configuration tab is the currently selected tab
+     */
+    bool configurationTabIsSelected( );
 
   public slots:
 
@@ -136,6 +184,9 @@ class GUI_EXPORT QgsAuthSettingsWidget : public QWidget, private Ui::QgsAuthSett
 
 
   private:
+
+    // Mainly for tests
+    QString mDataprovider;
 
     void updateConvertBtnState( );
 

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -15,7 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgsnewhttpconnection.h"
-#include "qgsauthconfigselect.h"
+#include "qgsauthsettingswidget.h"
 #include "qgssettings.h"
 #include "qgshelp.h"
 
@@ -60,9 +60,6 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
   cmbVersion->addItem( tr( "1.1" ) );
   cmbVersion->addItem( tr( "2.0" ) );
 
-  mAuthConfigSelect = new QgsAuthConfigSelect( this );
-  tabAuth->insertTab( 1, mAuthConfigSelect, tr( "Configurations" ) );
-
   if ( !connectionName.isEmpty() )
   {
     // populate the dialog with the information stored for the connection
@@ -77,15 +74,10 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
 
     updateServiceSpecificSettings();
 
-    txtUserName->setText( settings.value( credentialsKey + "/username" ).toString() );
-    txtPassword->setText( settings.value( credentialsKey + "/password" ).toString() );
-
-    QString authcfg = settings.value( credentialsKey + "/authcfg" ).toString();
-    mAuthConfigSelect->setConfigId( authcfg );
-    if ( !authcfg.isEmpty() )
-    {
-      tabAuth->setCurrentIndex( tabAuth->indexOf( mAuthConfigSelect ) );
-    }
+    // Authentication
+    mAuthSettings->setUsername( settings.value( credentialsKey + "/username" ).toString() );
+    mAuthSettings->setPassword( settings.value( credentialsKey + "/password" ).toString() );
+    mAuthSettings->setConfigId( settings.value( credentialsKey + "/authcfg" ).toString() );
   }
 
   if ( !( mTypes & ConnectionWms ) && !( mTypes & ConnectionWcs ) )
@@ -188,7 +180,7 @@ bool QgsNewHttpConnection::validate()
     return false;
   }
 
-  if ( !txtPassword->text().isEmpty() &&
+  if ( ! mAuthSettings->password().isEmpty() &&
        QMessageBox::question( this,
                               tr( "Saving passwords" ),
                               trUtf8( "WARNING: You have entered a password. It will be stored in unsecured plain text in your project files and your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't provide a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
@@ -372,10 +364,10 @@ void QgsNewHttpConnection::accept()
     settings.setValue( wfsKey + "/maxnumfeatures", txtMaxNumFeatures->text() );
   }
 
-  settings.setValue( credentialsKey + "/username", txtUserName->text() );
-  settings.setValue( credentialsKey + "/password", txtPassword->text() );
+  settings.setValue( credentialsKey + "/username", mAuthSettings->username() );
+  settings.setValue( credentialsKey + "/password", mAuthSettings->password() );
 
-  settings.setValue( credentialsKey + "/authcfg", mAuthConfigSelect->configId() );
+  settings.setValue( credentialsKey + "/authcfg", mAuthSettings->configId() );
 
   settings.setValue( mBaseKey + "/selected", txtName->text() );
 

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -23,7 +23,7 @@
 #include "qgsguiutils.h"
 #include "qgis_gui.h"
 
-class QgsAuthConfigSelect;
+class QgsAuthSettingsWidget;
 
 /** \ingroup gui
  * \brief Dialog to allow the user to configure and save connection
@@ -139,7 +139,6 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     QString mBaseKey;
     QString mCredentialsBaseKey;
     QString mOriginalConnName; //store initial name to delete entry in case of rename
-    QgsAuthConfigSelect *mAuthConfigSelect = nullptr;
     void showHelp();
 
 };

--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -53,13 +53,13 @@ QgsDb2NewConnection::QgsDb2NewConnection( QWidget *parent, const QString &connNa
     if ( settings.value( key + "/saveUsername" ).toString() == QLatin1String( "true" ) )
     {
       mAuthSettings->setUsername( settings.value( key + "/username" ).toString() );
-      mAuthSettings->setStoreUsername( true );
+      mAuthSettings->setStoreUsernameChecked( true );
     }
 
     if ( settings.value( key + "/savePassword" ).toString() == QLatin1String( "true" ) )
     {
       mAuthSettings->setPassword( settings.value( key + "/password" ).toString() );
-      mAuthSettings->setStorePassword( true );
+      mAuthSettings->setStorePasswordChecked( true );
     }
 
     QString authcfg = settings.value( key + "/authcfg" ).toString();

--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -34,8 +34,8 @@ QgsDb2NewConnection::QgsDb2NewConnection( QWidget *parent, const QString &connNa
   setupUi( this );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDb2NewConnection::showHelp );
 
-  mAuthConfigSelect = new QgsAuthConfigSelect( this, QStringLiteral( "db2" ) );
-  tabAuthentication->insertTab( 1, mAuthConfigSelect, tr( "Configurations" ) );
+  mAuthSettings->setDataprovider( QStringLiteral( "db2" ) );
+  mAuthSettings->showStoreCheckboxes( true );
 
   if ( !connName.isEmpty() )
   {
@@ -52,23 +52,19 @@ QgsDb2NewConnection::QgsDb2NewConnection( QWidget *parent, const QString &connNa
 
     if ( settings.value( key + "/saveUsername" ).toString() == QLatin1String( "true" ) )
     {
-      txtUsername->setText( settings.value( key + "/username" ).toString() );
-      chkStoreUsername->setChecked( true );
+      mAuthSettings->setUsername( settings.value( key + "/username" ).toString() );
+      mAuthSettings->setStoreUsername( true );
     }
 
     if ( settings.value( key + "/savePassword" ).toString() == QLatin1String( "true" ) )
     {
-      txtPassword->setText( settings.value( key + "/password" ).toString() );
-      chkStorePassword->setChecked( true );
+      mAuthSettings->setPassword( settings.value( key + "/password" ).toString() );
+      mAuthSettings->setStorePassword( true );
     }
 
     QString authcfg = settings.value( key + "/authcfg" ).toString();
     QgsDebugMsg( QString( "authcfg: %1" ).arg( authcfg ) );
-    mAuthConfigSelect->setConfigId( authcfg );
-    if ( !authcfg.isEmpty() )
-    {
-      tabAuthentication->setCurrentIndex( tabAuthentication->indexOf( mAuthConfigSelect ) );
-    }
+    mAuthSettings->setConfigId( authcfg );
 
     txtName->setText( connName );
   }
@@ -81,9 +77,9 @@ void QgsDb2NewConnection::accept()
   QgsSettings settings;
   QString baseKey = QStringLiteral( "/DB2/connections/" );
   settings.setValue( baseKey + "selected", txtName->text() );
-  bool hasAuthConfigID = !mAuthConfigSelect->configId().isEmpty();
+  bool hasAuthConfigID = !mAuthSettings->configId().isEmpty();
   QgsDebugMsg( QString( "hasAuthConfigID: %1" ).arg( hasAuthConfigID ) );
-  if ( !hasAuthConfigID && chkStorePassword->isChecked() &&
+  if ( !hasAuthConfigID && mAuthSettings->storePasswordIsChecked( ) &&
        QMessageBox::question( this,
                               tr( "Saving passwords" ),
                               tr( "WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory on Unix-like systems, or in your user profile on Windows. If you do not want this to happen, please press the Cancel button.\n" ),
@@ -118,11 +114,11 @@ void QgsDb2NewConnection::accept()
   settings.setValue( baseKey + "/port", txtPort->text() );
   settings.setValue( baseKey + "/driver", txtDriver->text() );
   settings.setValue( baseKey + "/database", txtDatabase->text() );
-  settings.setValue( baseKey + "/username", chkStoreUsername->isChecked() && !hasAuthConfigID ? txtUsername->text() : QLatin1String( "" ) );
-  settings.setValue( baseKey + "/password", chkStorePassword->isChecked() && !hasAuthConfigID ? txtPassword->text() : QLatin1String( "" ) );
-  settings.setValue( baseKey + "/saveUsername", chkStoreUsername->isChecked() && !hasAuthConfigID ? "true" : "false" );
-  settings.setValue( baseKey + "/savePassword", chkStorePassword->isChecked() && !hasAuthConfigID ? "true" : "false" );
-  settings.setValue( baseKey + "/authcfg", mAuthConfigSelect->configId() );
+  settings.setValue( baseKey + "/username", mAuthSettings->storeUsernameIsChecked( ) && !hasAuthConfigID ? mAuthSettings->username( ) : QLatin1String( "" ) );
+  settings.setValue( baseKey + "/password", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? mAuthSettings->password( ) : QLatin1String( "" ) );
+  settings.setValue( baseKey + "/saveUsername", mAuthSettings->storeUsernameIsChecked() && !hasAuthConfigID ? "true" : "false" );
+  settings.setValue( baseKey + "/savePassword", mAuthSettings->storePasswordIsChecked( )  && !hasAuthConfigID ? "true" : "false" );
+  settings.setValue( baseKey + "/authcfg", mAuthSettings->configId() );
 
   QDialog::accept();
 }
@@ -151,14 +147,19 @@ bool QgsDb2NewConnection::testConnection()
   QString authcfg;
   QString connInfo;
   QString errMsg;
+  // If the configuration tab is selected, test the authcfg in the connection
+  if ( mAuthSettings->configurationTabIsSelected( ) )
+  {
+    authcfg = mAuthSettings->configId( );
+  }
   bool rc = QgsDb2ConnectionItem::ConnInfoFromParameters(
               txtService->text().trimmed(),
               txtDriver->text().trimmed(),
               txtHost->text().trimmed(),
               txtPort->text().trimmed(),
               txtDatabase->text().trimmed(),
-              txtUsername->text().trimmed(),
-              txtPassword->text().trimmed(),
+              mAuthSettings->username().trimmed(),
+              mAuthSettings->password().trimmed(),
               authcfg,
               connInfo, errMsg );
 

--- a/src/providers/db2/qgsdb2newconnection.h
+++ b/src/providers/db2/qgsdb2newconnection.h
@@ -20,7 +20,6 @@
 #include "ui_qgsdb2newconnectionbase.h"
 #include "qgsguiutils.h"
 #include "qgshelp.h"
-#include "qgsauthconfigselect.h"
 
 /** \class QgsDb2NewConnection
  * \brief Dialog to allow the user to configure and save connection

--- a/src/providers/db2/qgsdb2newconnection.h
+++ b/src/providers/db2/qgsdb2newconnection.h
@@ -47,7 +47,6 @@ class QgsDb2NewConnection : public QDialog, private Ui::QgsDb2NewConnectionBase
     void on_cb_trustedConnection_clicked();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
-    QgsAuthConfigSelect *mAuthConfigSelect = nullptr;
     void showHelp();
 };
 

--- a/src/providers/geonode/CMakeLists.txt
+++ b/src/providers/geonode/CMakeLists.txt
@@ -20,12 +20,14 @@ QT5_WRAP_CPP(GEONODE_MOC_SRCS ${GEONODE_MOC_HDRS})
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/raster
+  ${CMAKE_SOURCE_DIR}/src/core/auth
   ${CMAKE_SOURCE_DIR}/src/core/geocms/geonode
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/gui
+  ${CMAKE_SOURCE_DIR}/src/gui/auth
 
   ${CMAKE_BINARY_DIR}/src/core
   ${CMAKE_BINARY_DIR}/src/gui

--- a/src/providers/postgres/qgspgnewconnection.h
+++ b/src/providers/postgres/qgspgnewconnection.h
@@ -19,7 +19,6 @@
 #include "ui_qgspgnewconnectionbase.h"
 #include "qgsguiutils.h"
 #include "qgshelp.h"
-#include "qgsauthconfigselect.h"
 
 /** \class QgsPgNewConnection
  * \brief Dialog to allow the user to configure and save connection
@@ -40,7 +39,6 @@ class QgsPgNewConnection : public QDialog, private Ui::QgsPgNewConnectionBase
     void on_cb_geometryColumnsOnly_clicked();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
-    QgsAuthConfigSelect *mAuthConfigSelect = nullptr;
     void showHelp();
 
 };

--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -13,7 +13,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsauthconfigselect.h"
 #include "qgsxyzconnectiondialog.h"
 #include "qgsxyzconnection.h"
 
@@ -22,8 +21,6 @@ QgsXyzConnectionDialog::QgsXyzConnectionDialog( QWidget *parent )
 {
   setupUi( this );
 
-  mAuthConfigSelect = new QgsAuthConfigSelect( this );
-  mTabAuth->insertTab( 1, mAuthConfigSelect, tr( "Configurations" ) );
   // Behavior for min and max zoom checkbox
   connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
   connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
@@ -37,18 +34,10 @@ void QgsXyzConnectionDialog::setConnection( const QgsXyzConnection &conn )
   mSpinZMin->setValue( conn.zMin != -1 ? conn.zMin : 0 );
   mCheckBoxZMax->setChecked( conn.zMax != -1 );
   mSpinZMax->setValue( conn.zMax != -1 ? conn.zMax : 18 );
-  mEditUsername->setText( conn.username );
-  mEditPassword->setText( conn.password );
+  mAuthSettings->setUsername( conn.username );
+  mAuthSettings->setPassword( conn.password );
   mEditReferer->setText( conn.referer );
-  mAuthConfigSelect->setConfigId( conn.authCfg );
-  if ( ! conn.authCfg.isEmpty( ) )
-  {
-    mTabAuth->setCurrentIndex( mTabAuth->indexOf( mAuthConfigSelect ) );
-  }
-  else
-  {
-    mTabAuth->setCurrentIndex( 0 );
-  }
+  mAuthSettings->setConfigId( conn.authCfg );
 }
 
 QgsXyzConnection QgsXyzConnectionDialog::connection() const
@@ -60,9 +49,9 @@ QgsXyzConnection QgsXyzConnectionDialog::connection() const
     conn.zMin = mSpinZMin->value();
   if ( mCheckBoxZMax->isChecked() )
     conn.zMax = mSpinZMax->value();
-  conn.username = mEditUsername->text();
-  conn.password = mEditPassword->text();
+  conn.username = mAuthSettings->username();
+  conn.password = mAuthSettings->password();
   conn.referer = mEditReferer->text();
-  conn.authCfg = mAuthConfigSelect->configId( );
+  conn.authCfg = mAuthSettings->configId( );
   return conn;
 }

--- a/src/providers/wms/qgsxyzconnectiondialog.h
+++ b/src/providers/wms/qgsxyzconnectiondialog.h
@@ -20,7 +20,6 @@
 
 #include "ui_qgsxyzconnectiondialog.h"
 
-class QgsAuthConfigSelect;
 
 struct QgsXyzConnection;
 
@@ -39,8 +38,6 @@ class QgsXyzConnectionDialog : public QDialog, public Ui::QgsXyzConnectionDialog
 
     QString mBaseKey;
     QString mCredentialsBaseKey;
-    QgsAuthConfigSelect *mAuthConfigSelect = nullptr;
-
 };
 
 #endif // QGSXYZCONNECTIONDIALOG_H

--- a/src/ui/auth/qgsauthconfigselect.ui
+++ b/src/ui/auth/qgsauthconfigselect.ui
@@ -29,7 +29,7 @@
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <property name="verticalSpacing">
-      <number>10</number>
+      <number>6</number>
      </property>
      <item row="1" column="0">
       <widget class="QComboBox" name="cmbConfigSelect">
@@ -41,7 +41,7 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>250</width>
+         <width>125</width>
          <height>0</height>
         </size>
        </property>
@@ -145,12 +145,6 @@
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
      </property>
     </spacer>
    </item>

--- a/src/ui/auth/qgsauthsettingswidget.ui
+++ b/src/ui/auth/qgsauthsettingswidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>405</width>
     <height>264</height>
    </rect>
   </property>
@@ -89,16 +89,6 @@
        <string>Basic</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
-       <item row="3" column="0" colspan="2">
-        <widget class="QLabel" name="lblWarning">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning: credentials are stored unencrypted (in clear text) in the project file!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
        <item row="5" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
@@ -142,7 +132,44 @@
        <item row="1" column="1">
         <widget class="QLineEdit" name="txtUserName"/>
        </item>
-       <item row="0" column="0" colspan="2">
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="cbStoreUsername">
+         <property name="text">
+          <string>Store</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QCheckBox" name="cbStorePassword">
+         <property name="text">
+          <string>Store</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="3">
+        <widget class="QPushButton" name="btnConvertToEncrypted">
+         <property name="text">
+          <string>Convert to configuration</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="3">
+        <widget class="QLabel" name="lblWarning">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning: credentials are stored unencrypted (in clear text) in the project file!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="3">
         <widget class="QLabel" name="lblBasic">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -158,13 +185,6 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0" colspan="2">
-        <widget class="QPushButton" name="btnConvertToEncrypted">
-         <property name="text">
-          <string>Convert to configuration</string>
          </property>
         </widget>
        </item>
@@ -186,6 +206,15 @@
    <header>qgsauthconfigselect.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabAuth</tabstop>
+  <tabstop>mAuthConfigSelect</tabstop>
+  <tabstop>txtUserName</tabstop>
+  <tabstop>cbStoreUsername</tabstop>
+  <tabstop>txtPassword</tabstop>
+  <tabstop>cbStorePassword</tabstop>
+  <tabstop>btnConvertToEncrypted</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/auth/qgsauthsettingswidget.ui
+++ b/src/ui/auth/qgsauthsettingswidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>315</width>
-    <height>243</height>
+    <width>226</width>
+    <height>179</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -69,7 +69,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Choose or create a configuration.</string>
+          <string>Choose or create an authentication configuration</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -101,7 +101,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Credentials are encrypted and stored in the QGIS authentication database. </string>
+          <string>Configurations store encrypted credentials in the QGIS authentication database.</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -146,26 +146,66 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="6" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="4" column="0" colspan="3">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="btnConvertToEncrypted">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Convert to configuration</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="2">
+        <widget class="QCheckBox" name="cbStorePassword">
+         <property name="text">
+          <string>Store</string>
          </property>
-         <property name="sizeHint" stdset="0">
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="3">
+        <widget class="QLabel" name="lblWarning">
+         <property name="styleSheet">
+          <string notr="true">QLabel{color: rgb(255, 0, 0);font-weight: bold;}</string>
+         </property>
+         <property name="text">
+          <string>Warning text!</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="txtUserName">
+         <property name="minimumSize">
           <size>
-           <width>0</width>
+           <width>80</width>
            <height>0</height>
           </size>
          </property>
-        </spacer>
+        </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="cbStoreUsername">
          <property name="text">
-          <string>&amp;User name</string>
+          <string>Store</string>
          </property>
-         <property name="buddy">
-          <cstring>txtUserName</cstring>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
@@ -195,49 +235,26 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QLineEdit" name="txtUserName">
-         <property name="minimumSize">
+       <item row="6" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
           <size>
-           <width>80</width>
+           <width>0</width>
            <height>0</height>
           </size>
          </property>
-        </widget>
+        </spacer>
        </item>
-       <item row="1" column="2">
-        <widget class="QCheckBox" name="cbStoreUsername">
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Store</string>
+          <string>&amp;User name</string>
          </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QCheckBox" name="cbStorePassword">
-         <property name="text">
-          <string>Store</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="3">
-        <widget class="QLabel" name="lblWarning">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning: credentials stored unencrypted!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::RichText</enum>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
+         <property name="buddy">
+          <cstring>txtUserName</cstring>
          </property>
         </widget>
        </item>
@@ -256,23 +273,6 @@
           <set>Qt::NoTextInteraction</set>
          </property>
         </widget>
-       </item>
-       <item row="4" column="0" colspan="3">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QPushButton" name="btnConvertToEncrypted">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Convert to configuration</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
       </layout>
      </widget>

--- a/src/ui/auth/qgsauthsettingswidget.ui
+++ b/src/ui/auth/qgsauthsettingswidget.ui
@@ -7,178 +7,169 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>304</height>
+    <height>264</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Authentication</string>
+    <widget class="QTabWidget" name="tabAuth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QTabWidget" name="tabAuth">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="tabConfigurations">
-         <attribute name="title">
-          <string>Configurations</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <item>
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Choose an authentication configuration or create a new one.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QgsAuthConfigSelect" name="mAuthConfigSelect">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>20</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Credentials are safely stored in the encrypted QGIS authentication database, protected by your master password. </string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>80</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tabConfigurations">
+      <attribute name="title">
+       <string>Configurations</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Choose an authentication configuration or create a new one.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
         </widget>
-        <widget class="QWidget" name="tabBasic">
-         <attribute name="title">
-          <string>Basic</string>
-         </attribute>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="lblWarning">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning: credentials are stored unencrypted (in clear text) in the project file!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>&amp;User name</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtUserName</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsPasswordLineEdit" name="txtPassword">
-            <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Passwor&amp;d</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtPassword</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtUserName"/>
-          </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="lblBasic">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>If the service requires basic authentication, enter a user name and optional password</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QPushButton" name="btnConvertToEncrypted">
-            <property name="text">
-             <string>Convert to configuration</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+       </item>
+       <item>
+        <widget class="QgsAuthConfigSelect" name="mAuthConfigSelect">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
         </widget>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Credentials are safely stored in the encrypted QGIS authentication database, protected by your master password. </string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>80</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabBasic">
+      <attribute name="title">
+       <string>Basic</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="3" column="0" colspan="2">
+        <widget class="QLabel" name="lblWarning">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning: credentials are stored unencrypted (in clear text) in the project file!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>&amp;User name</string>
+         </property>
+         <property name="buddy">
+          <cstring>txtUserName</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QgsPasswordLineEdit" name="txtPassword">
+         <property name="echoMode">
+          <enum>QLineEdit::Password</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Passwor&amp;d</string>
+         </property>
+         <property name="buddy">
+          <cstring>txtPassword</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="txtUserName"/>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="lblBasic">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>If the service requires basic authentication, enter a user name and optional password</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QPushButton" name="btnConvertToEncrypted">
+         <property name="text">
+          <string>Convert to configuration</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -195,13 +186,6 @@
    <header>qgsauthconfigselect.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>tabAuth</tabstop>
-  <tabstop>mAuthConfigSelect</tabstop>
-  <tabstop>txtUserName</tabstop>
-  <tabstop>txtPassword</tabstop>
-  <tabstop>btnConvertToEncrypted</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/auth/qgsauthsettingswidget.ui
+++ b/src/ui/auth/qgsauthsettingswidget.ui
@@ -6,14 +6,29 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>405</width>
-    <height>264</height>
+    <width>315</width>
+    <height>243</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QTabWidget" name="tabAuth">
      <property name="sizePolicy">
@@ -30,10 +45,34 @@
        <string>Configurations</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
+        <number>6</number>
+       </property>
        <item>
         <widget class="QLabel" name="label_5">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
-          <string>Choose an authentication configuration or create a new one.</string>
+          <string>Choose or create a configuration.</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -41,28 +80,31 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsAuthConfigSelect" name="mAuthConfigSelect">
+        <widget class="QgsAuthConfigSelect" name="mAuthConfigSelect" native="true">
          <property name="enabled">
           <bool>true</bool>
          </property>
          <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>20</height>
-          </size>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLabel" name="label_6">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
-          <string>Credentials are safely stored in the encrypted QGIS authentication database, protected by your master password. </string>
+          <string>Credentials are encrypted and stored in the QGIS authentication database. </string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -76,8 +118,8 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>80</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -89,7 +131,22 @@
        <string>Basic</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
-       <item row="5" column="1">
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
+        <number>6</number>
+       </property>
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <item row="6" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -114,8 +171,17 @@
        </item>
        <item row="2" column="1">
         <widget class="QgsPasswordLineEdit" name="txtPassword">
+         <property name="minimumSize">
+          <size>
+           <width>80</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="echoMode">
           <enum>QLineEdit::Password</enum>
+         </property>
+         <property name="placeholderText">
+          <string>Optional</string>
          </property>
         </widget>
        </item>
@@ -130,7 +196,14 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QLineEdit" name="txtUserName"/>
+        <widget class="QLineEdit" name="txtUserName">
+         <property name="minimumSize">
+          <size>
+           <width>80</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
        </item>
        <item row="1" column="2">
         <widget class="QCheckBox" name="cbStoreUsername">
@@ -152,17 +225,16 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="3">
-        <widget class="QPushButton" name="btnConvertToEncrypted">
-         <property name="text">
-          <string>Convert to configuration</string>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="0" colspan="3">
         <widget class="QLabel" name="lblWarning">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning: credentials are stored unencrypted (in clear text) in the project file!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning: credentials stored unencrypted!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -171,14 +243,8 @@
        </item>
        <item row="0" column="0" colspan="3">
         <widget class="QLabel" name="lblBasic">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
          <property name="text">
-          <string>If the service requires basic authentication, enter a user name and optional password</string>
+          <string/>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -186,7 +252,27 @@
          <property name="wordWrap">
           <bool>true</bool>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
         </widget>
+       </item>
+       <item row="4" column="0" colspan="3">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="btnConvertToEncrypted">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Convert to configuration</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -202,8 +288,9 @@
   </customwidget>
   <customwidget>
    <class>QgsAuthConfigSelect</class>
-   <extends>QLineEdit</extends>
+   <extends>QWidget</extends>
    <header>qgsauthconfigselect.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsdb2newconnectionbase.ui
+++ b/src/ui/qgsdb2newconnectionbase.ui
@@ -6,66 +6,30 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>445</width>
-    <height>399</height>
+    <width>506</width>
+    <height>583</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Create a New DB2 Connection</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="1" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QgsMessageBar" name="bar" native="true">
+     <zorder>groupBox</zorder>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Connection Information</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="2" column="0">
-       <widget class="QLabel" name="DB2ServiceLabel_2">
-        <property name="text">
-         <string>Driver</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="txtDriver"/>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="DB2HostLabel">
-        <property name="text">
-         <string>Host</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QLineEdit" name="txtDatabase"/>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLineEdit" name="txtHost"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="DB2port">
-        <property name="text">
-         <string>Port</string>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="1">
        <widget class="QLineEdit" name="txtPort"/>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="database">
-        <property name="text">
-         <string>Database</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="DB2ServiceLabel_3">
-        <property name="text">
-         <string>Name</string>
-        </property>
-       </widget>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="txtHost"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="DB2ServiceLabel">
@@ -77,96 +41,73 @@
       <item row="1" column="1">
        <widget class="QLineEdit" name="txtService"/>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="DB2ServiceLabel_2">
+        <property name="text">
+         <string>Driver</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QLineEdit" name="txtName"/>
       </item>
-      <item row="7" column="0" colspan="2">
-       <widget class="QPushButton" name="btnConnect">
+      <item row="3" column="0">
+       <widget class="QLabel" name="DB2HostLabel">
         <property name="text">
-         <string>&amp;Test connection</string>
+         <string>Host</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QTabWidget" name="tabAuthentication">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="5" column="0">
+       <widget class="QLabel" name="database">
+        <property name="text">
+         <string>Database</string>
         </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="tabBasic">
-         <attribute name="title">
-          <string>Authentication</string>
-         </attribute>
-         <layout class="QGridLayout" name="gridLayout">
-          <property name="leftMargin">
-           <number>5</number>
-          </property>
-          <property name="topMargin">
-           <number>5</number>
-          </property>
-          <property name="rightMargin">
-           <number>5</number>
-          </property>
-          <property name="bottomMargin">
-           <number>5</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="TextLabel3">
-            <property name="text">
-             <string>Username</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtUsername</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QgsPasswordLineEdit" name="txtPassword">
-            <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QCheckBox" name="chkStoreUsername">
-            <property name="text">
-             <string>Save</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="TextLabel3_2">
-            <property name="text">
-             <string>Password</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtPassword</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="txtUsername"/>
-          </item>
-          <item row="1" column="2">
-           <widget class="QCheckBox" name="chkStorePassword">
-            <property name="text">
-             <string>Save</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
        </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLineEdit" name="txtDatabase"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="DB2port">
+        <property name="text">
+         <string>Port</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="DB2ServiceLabel_3">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="txtDriver"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item>
+    <widget class="QGroupBox" name="mAuthGroupBox">
+     <property name="title">
+      <string>Authentication</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnConnect">
+     <property name="text">
+      <string>&amp;Test connection</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -174,12 +115,12 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>0</height>
+       <height>40</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="3" column="0">
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -189,16 +130,14 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QgsMessageBar" name="bar" native="true"/>
-   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPasswordLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgspasswordlineedit.h</header>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMessageBar</class>
@@ -214,12 +153,6 @@
   <tabstop>txtHost</tabstop>
   <tabstop>txtPort</tabstop>
   <tabstop>txtDatabase</tabstop>
-  <tabstop>tabAuthentication</tabstop>
-  <tabstop>txtUsername</tabstop>
-  <tabstop>chkStoreUsername</tabstop>
-  <tabstop>txtPassword</tabstop>
-  <tabstop>chkStorePassword</tabstop>
-  <tabstop>btnConnect</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsdb2newconnectionbase.ui
+++ b/src/ui/qgsdb2newconnectionbase.ui
@@ -94,6 +94,18 @@
       <string>Authentication</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
       <item row="0" column="0">
        <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
       </item>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -26,7 +26,7 @@
       <string>Connection details</string>
      </property>
      <layout class="QGridLayout">
-      <item row="6" column="0" colspan="2">
+      <item row="2" column="0" colspan="2">
        <widget class="QGroupBox" name="mWfsOptionsGroupBox">
         <property name="title">
          <string>WFS Options</string>
@@ -77,14 +77,45 @@
         </layout>
        </widget>
       </item>
-      <item row="16" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QPushButton" name="mTestConnectionButton">
         <property name="text">
          <string>&amp;Test Connection</string>
         </property>
        </widget>
       </item>
-      <item row="10" column="0" colspan="2">
+      <item row="1" column="0" colspan="2">
+       <widget class="QGroupBox" name="mAuthGroupBox">
+        <property name="title">
+         <string>Authentication</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <item>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
        <widget class="QGroupBox" name="mWmsOptionsGroupBox">
         <property name="title">
          <string>WMS Options</string>
@@ -154,73 +185,88 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="0">
-       <layout class="QFormLayout" name="formLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="TextLabel1_2">
-          <property name="text">
-           <string>&amp;Name</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="margin">
-           <number>5</number>
-          </property>
-          <property name="buddy">
-           <cstring>txtName</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="txtName">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Name of the new connection</string>
-          </property>
-          <property name="frame">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="TextLabel1">
-          <property name="text">
-           <string>UR&amp;L</string>
-          </property>
-          <property name="margin">
-           <number>5</number>
-          </property>
-          <property name="buddy">
-           <cstring>txtUrl</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="txtUrl">
-          <property name="toolTip">
-           <string>HTTP address of the Web Map Server</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="4" column="0">
-       <widget class="QGroupBox" name="mAuthGroupBox">
-        <property name="title">
-         <string>Authentication</string>
+      <item row="0" column="0" colspan="2">
+       <widget class="QFrame" name="frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="TextLabel1_2">
+           <property name="text">
+            <string>Name</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="margin">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="txtName">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Name of the new connection</string>
+           </property>
+           <property name="frame">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="TextLabel1">
+           <property name="text">
+            <string>URL</string>
+           </property>
+           <property name="margin">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="txtUrl">
+           <property name="toolTip">
+            <string>HTTP address of the Web Map Server</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
+      </item>
+      <item row="5" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -26,7 +26,7 @@
       <string>Connection details</string>
      </property>
      <layout class="QGridLayout">
-      <item row="8" column="0" colspan="2">
+      <item row="6" column="0" colspan="2">
        <widget class="QGroupBox" name="mWfsOptionsGroupBox">
         <property name="title">
          <string>WFS Options</string>
@@ -77,96 +77,14 @@
         </layout>
        </widget>
       </item>
-      <item row="18" column="0" colspan="2">
+      <item row="16" column="0" colspan="2">
        <widget class="QPushButton" name="mTestConnectionButton">
         <property name="text">
          <string>&amp;Test Connection</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
-       <widget class="QTabWidget" name="tabAuth">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="tab">
-         <attribute name="title">
-          <string>Authentication</string>
-         </attribute>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>If the service requires basic authentication, enter a user name and optional password</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>&amp;User name</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtUserName</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtUserName"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Password</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtPassword</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsPasswordLineEdit" name="txtPassword">
-            <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </item>
-      <item row="12" column="0" colspan="2">
+      <item row="10" column="0" colspan="2">
        <widget class="QGroupBox" name="mWmsOptionsGroupBox">
         <property name="title">
          <string>WMS Options</string>
@@ -209,7 +127,7 @@
          <item row="1" column="0">
           <widget class="QLabel" name="lblDpiMode">
            <property name="text">
-            <string>DPI-Mode</string>
+            <string>&amp;DPI-Mode</string>
            </property>
            <property name="buddy">
             <cstring>cmbDpiMode</cstring>
@@ -241,7 +159,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="TextLabel1_2">
           <property name="text">
-           <string>Name</string>
+           <string>&amp;Name</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -273,7 +191,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="TextLabel1">
           <property name="text">
-           <string>URL</string>
+           <string>UR&amp;L</string>
           </property>
           <property name="margin">
            <number>5</number>
@@ -292,6 +210,18 @@
         </item>
        </layout>
       </item>
+      <item row="4" column="0">
+       <widget class="QGroupBox" name="mAuthGroupBox">
+        <property name="title">
+         <string>Authentication</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -307,16 +237,12 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsPasswordLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgspasswordlineedit.h</header>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>tabAuth</tabstop>
-  <tabstop>txtUserName</tabstop>
-  <tabstop>txtPassword</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1029</width>
-    <height>726</height>
+    <height>878</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -349,7 +349,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>846</width>
+                <width>580</width>
                 <height>672</height>
                </rect>
               </property>
@@ -4892,9 +4892,9 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-44</y>
-                <width>846</width>
-                <height>830</height>
+                <y>0</y>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5119,33 +5119,27 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                        <enum>QFrame::Raised</enum>
                       </property>
                       <layout class="QGridLayout" name="gridLayout_18">
-                       <property name="leftMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="rightMargin">
-                        <number>0</number>
-                       </property>
-                       <item row="0" column="2">
-                        <widget class="QLineEdit" name="leProxyHost"/>
-                       </item>
                        <item row="1" column="2">
-                        <widget class="QLineEdit" name="leProxyPort"/>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLabel" name="lblProxyPort">
-                         <property name="text">
-                          <string>Port</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1">
                         <widget class="QLabel" name="lblProxyHost">
                          <property name="text">
                           <string>Host</string>
                          </property>
                         </widget>
                        </item>
-                       <item row="1" column="0">
+                       <item row="1" column="3">
+                        <widget class="QLineEdit" name="leProxyHost"/>
+                       </item>
+                       <item row="2" column="2">
+                        <widget class="QLabel" name="lblProxyPort">
+                         <property name="text">
+                          <string>Port</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="3">
+                        <widget class="QLineEdit" name="leProxyPort"/>
+                       </item>
+                       <item row="2" column="1">
                         <spacer name="horizontalSpacer_27">
                          <property name="orientation">
                           <enum>Qt::Horizontal</enum>
@@ -5161,49 +5155,16 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                          </property>
                         </spacer>
                        </item>
-                       <item row="4" column="1" colspan="2">
-                        <widget class="QTabWidget" name="tabAuth">
-                         <property name="currentIndex">
-                          <number>0</number>
+                       <item row="3" column="2" colspan="2">
+                        <widget class="QGroupBox" name="mAuthGroupBox">
+                         <property name="title">
+                          <string>Authentication</string>
                          </property>
-                         <widget class="QWidget" name="authLegacy">
-                          <attribute name="title">
-                           <string>Authentication</string>
-                          </attribute>
-                          <layout class="QGridLayout" name="gridLayout_25">
-                           <item row="0" column="0">
-                            <widget class="QLabel" name="lblUser">
-                             <property name="text">
-                              <string>User name</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="2" column="0">
-                            <widget class="QLabel" name="lblPassword">
-                             <property name="text">
-                              <string>Password</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="1">
-                            <widget class="QLineEdit" name="leProxyUser">
-                             <property name="toolTip">
-                              <string>Leave this blank if no proxy username / password are required</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="2" column="1">
-                            <widget class="QgsPasswordLineEdit" name="leProxyPassword">
-                             <property name="toolTip">
-                              <string>Leave this blank if no proxy username / password are required</string>
-                             </property>
-                             <property name="echoMode">
-                              <enum>QLineEdit::Password</enum>
-                             </property>
-                            </widget>
-                           </item>
-                          </layout>
-                         </widget>
+                         <layout class="QVBoxLayout" name="verticalLayout_23">
+                          <item>
+                           <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+                          </item>
+                         </layout>
                         </widget>
                        </item>
                       </layout>
@@ -5478,11 +5439,6 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPasswordLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgspasswordlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsColorSchemeList</class>
    <extends>QWidget</extends>
    <header location="global">qgscolorschemelist.h</header>
@@ -5498,6 +5454,12 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
    <class>QgsAuthEditorWidgets</class>
    <extends>QTabWidget</extends>
    <header>qgsautheditorwidgets.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -320,7 +320,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>13</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -5161,6 +5161,18 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                           <string>Authentication</string>
                          </property>
                          <layout class="QVBoxLayout" name="verticalLayout_23">
+                          <property name="leftMargin">
+                           <number>6</number>
+                          </property>
+                          <property name="topMargin">
+                           <number>6</number>
+                          </property>
+                          <property name="rightMargin">
+                           <number>6</number>
+                          </property>
+                          <property name="bottomMargin">
+                           <number>6</number>
+                          </property>
                           <item>
                            <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
                           </item>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -131,6 +131,18 @@
          <string>Authentication</string>
         </property>
         <layout class="QGridLayout" name="gridLayout">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
          <item row="0" column="0">
           <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
          </item>

--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>447</width>
-    <height>599</height>
+    <height>554</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,15 +25,11 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout3">
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QgsMessageBar" name="bar" native="true"/>
    </item>
-   <item row="1" column="0">
+   <item>
     <widget class="QGroupBox" name="GroupBox1">
      <property name="title">
       <string>Connection Information</string>
@@ -44,7 +40,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="TextLabel1_2">
           <property name="text">
-           <string>Name</string>
+           <string>&amp;Name</string>
           </property>
           <property name="buddy">
            <cstring>txtName</cstring>
@@ -74,7 +70,7 @@
         <item row="2" column="0">
          <widget class="QLabel" name="TextLabel1">
           <property name="text">
-           <string>Host</string>
+           <string>Hos&amp;t</string>
           </property>
           <property name="buddy">
            <cstring>txtHost</cstring>
@@ -104,7 +100,7 @@
         <item row="4" column="0">
          <widget class="QLabel" name="TextLabel2">
           <property name="text">
-           <string>Database</string>
+           <string>&amp;Database</string>
           </property>
           <property name="buddy">
            <cstring>txtDatabase</cstring>
@@ -117,7 +113,7 @@
         <item row="5" column="0">
          <widget class="QLabel" name="TextLabel3_3">
           <property name="text">
-           <string>SSL mode</string>
+           <string>SSL &amp;mode</string>
           </property>
           <property name="buddy">
            <cstring>cbxSSLmode</cstring>
@@ -130,79 +126,15 @@
        </layout>
       </item>
       <item>
-       <widget class="QTabWidget" name="tabAuthentication">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+       <widget class="QGroupBox" name="mAuthGroupBox">
+        <property name="title">
+         <string>Authentication</string>
         </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="tabBasic">
-         <attribute name="title">
-          <string>Authentication</string>
-         </attribute>
-         <layout class="QGridLayout" name="gridLayout">
-          <property name="leftMargin">
-           <number>5</number>
-          </property>
-          <property name="topMargin">
-           <number>5</number>
-          </property>
-          <property name="rightMargin">
-           <number>5</number>
-          </property>
-          <property name="bottomMargin">
-           <number>5</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="TextLabel3">
-            <property name="text">
-             <string>Username</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtUsername</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QgsPasswordLineEdit" name="txtPassword">
-            <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QCheckBox" name="chkStoreUsername">
-            <property name="text">
-             <string>Save</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="TextLabel3_2">
-            <property name="text">
-             <string>Password</string>
-            </property>
-            <property name="buddy">
-             <cstring>txtPassword</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="txtUsername"/>
-          </item>
-          <item row="1" column="2">
-           <widget class="QCheckBox" name="chkStorePassword">
-            <property name="text">
-             <string>Save</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
@@ -292,44 +224,30 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QgsMessageBar" name="bar" native="true"/>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsPasswordLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgspasswordlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsMessageBar</class>
    <extends>QWidget</extends>
    <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>txtName</tabstop>
-  <tabstop>txtService</tabstop>
-  <tabstop>txtHost</tabstop>
-  <tabstop>txtPort</tabstop>
-  <tabstop>txtDatabase</tabstop>
-  <tabstop>cbxSSLmode</tabstop>
-  <tabstop>tabAuthentication</tabstop>
-  <tabstop>txtUsername</tabstop>
-  <tabstop>chkStoreUsername</tabstop>
-  <tabstop>txtPassword</tabstop>
-  <tabstop>chkStorePassword</tabstop>
-  <tabstop>btnConnect</tabstop>
-  <tabstop>cb_geometryColumnsOnly</tabstop>
-  <tabstop>cb_dontResolveType</tabstop>
-  <tabstop>cb_publicSchemaOnly</tabstop>
-  <tabstop>cb_allowGeometrylessTables</tabstop>
-  <tabstop>cb_useEstimatedMetadata</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ui/qgsxyzconnectiondialog.ui
+++ b/src/ui/qgsxyzconnectiondialog.ui
@@ -103,6 +103,18 @@
          <string>Authentication</string>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>6</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
          <item>
           <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
          </item>

--- a/src/ui/qgsxyzconnectiondialog.ui
+++ b/src/ui/qgsxyzconnectiondialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>869</width>
-    <height>787</height>
+    <width>525</width>
+    <height>332</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,106 +20,34 @@
       <string>Connection details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="mCheckBoxZMin">
+      <item row="9" column="0" colspan="2">
+       <widget class="QLabel" name="lblReferer">
         <property name="text">
-         <string>Min. Zoom Level</string>
+         <string>Referer</string>
+        </property>
+        <property name="buddy">
+         <cstring>mEditReferer</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="2">
+       <widget class="QLineEdit" name="mEditReferer">
+        <property name="toolTip">
+         <string>Optional custom referer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCheckBoxZMax">
+        <property name="text">
+         <string>Max. Zoom Level</string>
         </property>
         <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QTabWidget" name="mTabAuth">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="tab">
-         <attribute name="title">
-          <string>Authentication</string>
-         </attribute>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>&amp;User name</string>
-            </property>
-            <property name="buddy">
-             <cstring>mEditUsername</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="mEditUsername"/>
-          </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="label_4">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>If the service requires basic authentication, enter a user name and optional password</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Password</string>
-            </property>
-            <property name="buddy">
-             <cstring>mEditPassword</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsPasswordLineEdit" name="mEditPassword">
-            <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mEditName">
-        <property name="toolTip">
-         <string>Name of the new connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
+      <item row="8" column="2">
        <widget class="QSpinBox" name="mSpinZMax">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -132,31 +60,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QSpinBox" name="mSpinZMin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>URL</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Name</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
+      <item row="1" column="2">
        <widget class="QLineEdit" name="mEditUrl">
         <property name="toolTip">
          <string>URL of the connection, {z}, {y}, and {z} will be replaced with actual values. Use {-y} for inverted y axis.</string>
@@ -166,48 +70,74 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QCheckBox" name="mCheckBoxZMax">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Max. Zoom Level</string>
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="mEditName">
+        <property name="toolTip">
+         <string>Name of the new connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0" rowspan="2" colspan="3">
+       <widget class="QGroupBox" name="mAuthGroupBox">
+        <property name="title">
+         <string>Authentication</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QgsAuthSettingsWidget" name="mAuthSettings" native="true"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCheckBoxZMin">
+        <property name="text">
+         <string>Min. Zoom Level</string>
         </property>
         <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="lblReferer">
-        <property name="text">
-         <string>Referer</string>
-        </property>
-        <property name="buddy">
-         <cstring>mEditReferer</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QLineEdit" name="mEditReferer">
-        <property name="toolTip">
-         <string>Optional custom referer</string>
+      <item row="4" column="2">
+       <widget class="QSpinBox" name="mSpinZMin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -223,15 +153,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsPasswordLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgspasswordlineedit.h</header>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mEditUrl</tabstop>
   <tabstop>mCheckBoxZMin</tabstop>
-  <tabstop>mSpinZMin</tabstop>
   <tabstop>mCheckBoxZMax</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>

--- a/tests/src/python/test_authsettingswidget.py
+++ b/tests/src/python/test_authsettingswidget.py
@@ -178,18 +178,18 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertFalse(w.storeUsernameIsChecked())
 
         w = QgsAuthSettingsWidget()
-        w.setStorePassword(True)
+        w.setStorePasswordChecked(True)
         self.assertTrue(w.storePasswordIsChecked())
         self.assertFalse(w.storeUsernameIsChecked())
 
         w = QgsAuthSettingsWidget()
-        w.setStoreUsername(True)
+        w.setStoreUsernameChecked(True)
         self.assertFalse(w.storePasswordIsChecked())
         self.assertTrue(w.storeUsernameIsChecked())
 
         w = QgsAuthSettingsWidget()
-        w.setStoreUsername(True)
-        w.setStorePassword(True)
+        w.setStoreUsernameChecked(True)
+        w.setStorePasswordChecked(True)
         self.assertTrue(w.storePasswordIsChecked())
         self.assertTrue(w.storeUsernameIsChecked())
 

--- a/tests/src/python/test_authsettingswidget.py
+++ b/tests/src/python/test_authsettingswidget.py
@@ -139,6 +139,32 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertEqual(w.currentTabIndex(), 0)
         self.assertFalse(w.btnConvertToEncryptedIsEnabled())
 
+    def test_setters(self):
+        """
+        Test setters
+        """
+        w = QgsAuthSettingsWidget()
+        w.setUsername('username')
+        self.assertEqual(w.currentTabIndex(), 1)
+        self.assertEqual(w.username(), 'username')
+
+        w = QgsAuthSettingsWidget()
+        w.setPassword('password')
+        self.assertEqual(w.password(), 'password')
+        self.assertEqual(w.currentTabIndex(), 1)
+
+        w = QgsAuthSettingsWidget()
+        w.setConfigId(self.auth_config.id())
+        self.assertEqual(w.configId(), self.auth_config.id())
+        self.assertEqual(w.currentTabIndex(), 0)
+
+        w = QgsAuthSettingsWidget()
+        w.setUsername('username')
+        w.setPassword('password')
+        w.setConfigId(self.auth_config.id())
+        self.assertEqual(w.configId(), self.auth_config.id())
+        self.assertEqual(w.currentTabIndex(), 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_authsettingswidget.py
+++ b/tests/src/python/test_authsettingswidget.py
@@ -77,7 +77,7 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertEqual(w.username(), '')
         self.assertEqual(w.password(), '')
         self.assertEqual(w.configId(), '')
-        self.assertEqual(w.currentTabIndex(), 0)
+        self.assertTrue(w.configurationTabIsSelected())
         self.assertFalse(w.btnConvertToEncryptedIsEnabled())
 
     def testWidgetConfigId(self):
@@ -88,7 +88,7 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertEqual(w.username(), '')
         self.assertEqual(w.password(), '')
         self.assertEqual(w.configId(), self.auth_config.id())
-        self.assertEqual(w.currentTabIndex(), 0)
+        self.assertTrue(w.configurationTabIsSelected())
         self.assertFalse(w.btnConvertToEncryptedIsEnabled())
 
     def testWidgetUsername(self):
@@ -99,7 +99,7 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertEqual(w.username(), 'username')
         self.assertEqual(w.password(), '')
         self.assertEqual(w.configId(), '')
-        self.assertEqual(w.currentTabIndex(), 1)
+        self.assertFalse(w.configurationTabIsSelected())
 
     def testWidgetPassword(self):
         """
@@ -109,7 +109,7 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertEqual(w.username(), '')
         self.assertEqual(w.password(), 'password')
         self.assertEqual(w.configId(), '')
-        self.assertEqual(w.currentTabIndex(), 1)
+        self.assertFalse(w.configurationTabIsSelected())
 
     def testWidgetUsernameAndPassword(self):
         """
@@ -119,7 +119,7 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertEqual(w.username(), 'username')
         self.assertEqual(w.password(), 'password')
         self.assertEqual(w.configId(), '')
-        self.assertEqual(w.currentTabIndex(), 1)
+        self.assertFalse(w.configurationTabIsSelected())
         self.assertTrue(w.btnConvertToEncryptedIsEnabled())
 
     def testConvertToEncrypted(self):
@@ -130,13 +130,13 @@ class TestAuthenticationWidget(unittest.TestCase):
         self.assertEqual(w.username(), 'username')
         self.assertEqual(w.password(), 'password')
         self.assertEqual(w.configId(), '')
-        self.assertEqual(w.currentTabIndex(), 1)
+        self.assertFalse(w.configurationTabIsSelected())
         self.assertTrue(w.btnConvertToEncryptedIsEnabled())
         self.assertTrue(w.convertToEncrypted())
         self.assertNotEqual(w.configId(), '')
         self.assertEqual(w.username(), '')
         self.assertEqual(w.password(), '')
-        self.assertEqual(w.currentTabIndex(), 0)
+        self.assertTrue(w.configurationTabIsSelected())
         self.assertFalse(w.btnConvertToEncryptedIsEnabled())
 
     def test_setters(self):
@@ -145,25 +145,53 @@ class TestAuthenticationWidget(unittest.TestCase):
         """
         w = QgsAuthSettingsWidget()
         w.setUsername('username')
-        self.assertEqual(w.currentTabIndex(), 1)
+        self.assertFalse(w.configurationTabIsSelected())
         self.assertEqual(w.username(), 'username')
 
         w = QgsAuthSettingsWidget()
         w.setPassword('password')
         self.assertEqual(w.password(), 'password')
-        self.assertEqual(w.currentTabIndex(), 1)
+        self.assertFalse(w.configurationTabIsSelected())
 
         w = QgsAuthSettingsWidget()
         w.setConfigId(self.auth_config.id())
         self.assertEqual(w.configId(), self.auth_config.id())
-        self.assertEqual(w.currentTabIndex(), 0)
+        self.assertTrue(w.configurationTabIsSelected())
 
         w = QgsAuthSettingsWidget()
         w.setUsername('username')
         w.setPassword('password')
         w.setConfigId(self.auth_config.id())
         self.assertEqual(w.configId(), self.auth_config.id())
-        self.assertEqual(w.currentTabIndex(), 0)
+        self.assertTrue(w.configurationTabIsSelected())
+
+        w = QgsAuthSettingsWidget()
+        w.setDataprovider('db2')
+        self.assertEqual(w.dataprovider(), 'db2')
+
+    def test_storeCheckBoxes(self):
+        """
+        Test store cb setters and getters
+        """
+        w = QgsAuthSettingsWidget()
+        self.assertFalse(w.storePasswordIsChecked())
+        self.assertFalse(w.storeUsernameIsChecked())
+
+        w = QgsAuthSettingsWidget()
+        w.setStorePassword(True)
+        self.assertTrue(w.storePasswordIsChecked())
+        self.assertFalse(w.storeUsernameIsChecked())
+
+        w = QgsAuthSettingsWidget()
+        w.setStoreUsername(True)
+        self.assertFalse(w.storePasswordIsChecked())
+        self.assertTrue(w.storeUsernameIsChecked())
+
+        w = QgsAuthSettingsWidget()
+        w.setStoreUsername(True)
+        w.setStorePassword(True)
+        self.assertTrue(w.storePasswordIsChecked())
+        self.assertTrue(w.storeUsernameIsChecked())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

All the provider and connection dialogs now use the new authentication widget that embeds both the username/password and the QGIS authentication DB.

@DelazJ  the look and feel of the dialog is pretty much the same of the old GUI but the configurations tab is now the default and the username/password has a warning message.

## Example snapshot  (postgis)

![authconfigwidget-pg1](https://user-images.githubusercontent.com/142164/31085600-eddb2d72-a797-11e7-93db-5df872632cbf.png)

![authconfigwidget-pg](https://user-images.githubusercontent.com/142164/31085612-f32bc6c4-a797-11e7-8512-4f063e537115.png)


