### PR TITLE
[OGR] Pass AUTO_REPACK=OFF when opening datasets for non-implicit update modes

### DIFF
--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -54,7 +54,7 @@ QgsOgrLayerItem::QgsOgrLayerItem( QgsDataItem *parent,
 
   OGRRegisterAll();
   GDALDriverH hDriver;
-  GDALDatasetH hDataSource = QgsOgrProviderUtils::GDALOpenWrapper( mPath.toUtf8().constData(), true, &hDriver );
+  GDALDatasetH hDataSource = QgsOgrProviderUtils::GDALOpenWrapper( mPath.toUtf8().constData(), true, false, &hDriver );
 
   if ( hDataSource )
   {
@@ -408,7 +408,7 @@ QVector<QgsDataItem *> QgsOgrDataCollectionItem::createChildren()
   QVector<QgsDataItem *> children;
 
   GDALDriverH hDriver;
-  GDALDatasetH hDataSource = QgsOgrProviderUtils::GDALOpenWrapper( mPath.toUtf8().constData(), false, &hDriver );
+  GDALDatasetH hDataSource = QgsOgrProviderUtils::GDALOpenWrapper( mPath.toUtf8().constData(), false, false, &hDriver );
   if ( !hDataSource )
     return children;
   int numLayers = GDALDatasetGetLayerCount( hDataSource );
@@ -639,7 +639,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   // do not print errors, but write to debug
   CPLPushErrorHandler( CPLQuietErrorHandler );
   CPLErrorReset();
-  OGRDataSourceH hDataSource = QgsOgrProviderUtils::GDALOpenWrapper( path.toUtf8().constData(), false, &hDriver );
+  OGRDataSourceH hDataSource = QgsOgrProviderUtils::GDALOpenWrapper( path.toUtf8().constData(), false, false, &hDriver );
   CPLPopErrorHandler();
 
   if ( ! hDataSource )

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -171,7 +171,7 @@ void QgsOgrProvider::repack()
       GDALClose( mGDALDataset );
       ogrLayer = ogrOrigLayer = nullptr;
 
-      mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), true, nullptr );
+      mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), true, false, nullptr );
       if ( mGDALDataset )
       {
         if ( mLayerName.isNull() )
@@ -1963,10 +1963,8 @@ bool QgsOgrProvider::doInitialActionsForEdition()
   if ( mUpdateModeStackDepth == 0 )
   {
     QgsDebugMsg( "Enter update mode implictly" );
-    if ( !enterUpdateMode() )
+    if ( !_enterUpdateMode( true ) )
       return false;
-    // For implicitly entered updateMode, don't defer repacking
-    mDeferRepack = false;
   }
 
   return true;
@@ -3169,7 +3167,7 @@ void QgsOgrProvider::forceReload()
   QgsOgrConnPool::instance()->invalidateConnections( dataSourceUri() );
 }
 
-GDALDatasetH QgsOgrProviderUtils::GDALOpenWrapper( const char *pszPath, bool bUpdate, GDALDriverH *phDriver )
+GDALDatasetH QgsOgrProviderUtils::GDALOpenWrapper( const char *pszPath, bool bUpdate, bool bDisableReapck, GDALDriverH *phDriver )
 {
   CPLErrorReset();
 
@@ -3195,6 +3193,10 @@ GDALDatasetH QgsOgrProviderUtils::GDALOpenWrapper( const char *pszPath, bool bUp
     {
       papszOpenOptions = CSLSetNameValue( papszOpenOptions, "FORCE_SRS_DETECTION", "YES" );
     }
+  }
+  if ( bDisableReapck )
+  {
+    papszOpenOptions = CSLSetNameValue( papszOpenOptions, "AUTO_REPACK", "OFF" );
   }
 
   const int nOpenFlags = GDAL_OF_VECTOR | ( bUpdate ? GDAL_OF_UPDATE : 0 );
@@ -3643,7 +3645,7 @@ void QgsOgrProvider::open( OpenMode mode )
       // on network shares
       CPLSetThreadLocalConfigOption( "OGR_SQLITE_JOURNAL", "WAL" );
     }
-    mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), true, &mGDALDriver );
+    mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), true, mode == OpenModeForceUpdateRepackOff, &mGDALDriver );
     CPLSetThreadLocalConfigOption( "OGR_SQLITE_JOURNAL", nullptr );
   }
 
@@ -3662,7 +3664,7 @@ void QgsOgrProvider::open( OpenMode mode )
     }
 
     // try to open read-only
-    mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), false, &mGDALDriver );
+    mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), false, false, &mGDALDriver );
   }
 
   if ( mGDALDataset )
@@ -3741,7 +3743,7 @@ void QgsOgrProvider::open( OpenMode mode )
     }
 #endif
 
-    mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), false, &mGDALDriver );
+    mGDALDataset = QgsOgrProviderUtils::GDALOpenWrapper( mFilePath.toUtf8().constData(), false, false, &mGDALDriver );
 
     mWriteAccess = false;
 
@@ -3813,7 +3815,7 @@ void QgsOgrProvider::reloadData()
     pushError( tr( "Cannot reopen datasource %1" ).arg( dataSourceUri() ) );
 }
 
-bool QgsOgrProvider::enterUpdateMode()
+bool QgsOgrProvider::_enterUpdateMode( bool implicit )
 {
   if ( !mWriteAccessPossible )
   {
@@ -3829,7 +3831,7 @@ bool QgsOgrProvider::enterUpdateMode()
     Q_ASSERT( mDynamicWriteAccess );
     QgsDebugMsg( QString( "Reopening %1 in update mode" ).arg( dataSourceUri() ) );
     close();
-    open( OpenModeForceUpdate );
+    open( implicit ? OpenModeForceUpdate : OpenModeForceUpdateRepackOff );
     if ( !mGDALDataset || !mWriteAccess )
     {
       QgsMessageLog::logMessage( tr( "Cannot reopen datasource %1 in update mode" ).arg( dataSourceUri() ), tr( "OGR" ) );
@@ -3838,7 +3840,8 @@ bool QgsOgrProvider::enterUpdateMode()
     }
   }
   ++mUpdateModeStackDepth;
-  mDeferRepack = true;
+  // For implicitly entered updateMode, don't defer repacking
+  mDeferRepack = !implicit;
   return true;
 }
 
@@ -3911,7 +3914,7 @@ GDALDatasetH LoadDataSourceAndLayer( const QString &uri,
                                  subsetString,
                                  ogrGeometryType );
 
-  GDALDatasetH hDS = QgsOgrProviderUtils::GDALOpenWrapper( filePath.toUtf8().constData(), true, nullptr );
+  GDALDatasetH hDS = QgsOgrProviderUtils::GDALOpenWrapper( filePath.toUtf8().constData(), true, false, nullptr );
   if ( !hDS )
   {
     QgsDebugMsg( "Connection to database failed.." );

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3409,6 +3409,8 @@ bool QgsOgrProvider::syncToDisc()
     pushError( tr( "OGR error syncing to disk: %1" ).arg( CPLGetLastErrorMsg() ) );
   }
 
+  // Repack is done automatically on OGR_L_SyncToDisk with gdal-2.2.0+
+#if !defined(GDAL_VERSION_NUM) || GDAL_VERSION_NUM < 2020000
   if ( !mDeferRepack )
   {
     if ( mShapefileMayBeCorrupted )
@@ -3416,6 +3418,7 @@ bool QgsOgrProvider::syncToDisc()
 
     mShapefileMayBeCorrupted = false;
   }
+#endif
 
   QgsOgrConnPool::instance()->ref( dataSourceUri() );
   if ( shapeIndex )

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -89,7 +89,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     virtual bool createAttributeIndex( int field ) override;
     virtual QgsVectorDataProvider::Capabilities capabilities() const override;
     virtual void setEncoding( const QString &e ) override;
-    virtual bool enterUpdateMode() override;
+    virtual bool enterUpdateMode() override { return _enterUpdateMode(); }
     virtual bool leaveUpdateMode() override;
     virtual bool isSaveAndLoadStyleToDatabaseSupported() const override;
     QString fileVectorFilters() const override;
@@ -158,10 +158,13 @@ class QgsOgrProvider : public QgsVectorDataProvider
       OpenModeSameAsCurrent,
       OpenModeForceReadOnly,
       OpenModeForceUpdate,
+      OpenModeForceUpdateRepackOff
     };
 
     void open( OpenMode mode );
     void close();
+
+    bool _enterUpdateMode( bool implicit = false );
 
   private:
     unsigned char *getGeometryPointer( OGRFeatureH fet );
@@ -273,7 +276,7 @@ class QgsOgrProviderUtils
      */
     static QString quotedValue( const QVariant &value );
 
-    static GDALDatasetH GDALOpenWrapper( const char *pszPath, bool bUpdate, GDALDriverH *phDriver );
+    static GDALDatasetH GDALOpenWrapper( const char *pszPath, bool bUpdate, bool bDisableReapck, GDALDriverH *phDriver );
     static void GDALCloseWrapper( GDALDatasetH mhDS );
 };
 

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -435,7 +435,6 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
         fet = next(vl.getFeatures())
         self.assertFalse(fet.hasGeometry())
 
-    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Fails with GDAL 2.2')
     def testDeleteShapes(self):
         ''' Test fix for #11007 '''
 


### PR DESCRIPTION
Followup for 59ed19fff08443da475424218f23499501f8e7d8, adapted for GDAL 2.2+ which does a repack internally on `OGR_L_SyncToDisk`.

Also, I've added a commit which removes the explicit repack call if compiled against gdal-2.2.0+ in `QgsOgrProvider::syncToDisc`, since it is superfluous.

(Re discussion https://github.com/qgis/QGIS/pull/5231: holding off the entire SyncToDisk resulted in a test failure in https://github.com/qgis/QGIS/blob/master/tests/src/python/test_provider_shapefile.py#L270 which makes me uncomfortable about that approach...)