### PR TITLE
[db_manager] d&d fix from spatialite and geopackage: fixes #16296

### DIFF
--- a/python/plugins/db_manager/db_plugins/gpkg/plugin.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/plugin.py
@@ -19,6 +19,8 @@ email                : brush.tyler@gmail.com
  *                                                                         *
  ***************************************************************************/
 """
+import re
+
 from builtins import str
 
 # this will disable the dbplugin if the connector raise an ImportError
@@ -189,7 +191,7 @@ class GPKGTable(Table):
     def mimeUri(self):
 
         # QGIS has no provider to load Geopackage vectors, let's use OGR
-        return u"vector:ogr:%s:%s" % (self.name, self.ogrUri())
+        return u"vector:ogr:%s:%s" % (self.name, re.sub(":", "\:", self.ogrUri()))
 
     def toMapLayer(self):
         from qgis.core import QgsVectorLayer

--- a/python/plugins/db_manager/db_plugins/gpkg/plugin.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/plugin.py
@@ -19,8 +19,6 @@ email                : brush.tyler@gmail.com
  *                                                                         *
  ***************************************************************************/
 """
-import re
-
 from builtins import str
 
 # this will disable the dbplugin if the connector raise an ImportError
@@ -191,7 +189,7 @@ class GPKGTable(Table):
     def mimeUri(self):
 
         # QGIS has no provider to load Geopackage vectors, let's use OGR
-        return u"vector:ogr:%s:%s" % (self.name, re.sub(":", "\:", self.ogrUri()))
+        return u"vector:ogr:%s:%s" % (self.name, self.ogrUri().replace(":", "\:"))
 
     def toMapLayer(self):
         from qgis.core import QgsVectorLayer

--- a/python/plugins/db_manager/db_plugins/spatialite/plugin.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/plugin.py
@@ -19,6 +19,7 @@ email                : brush.tyler@gmail.com
  *                                                                         *
  ***************************************************************************/
 """
+import re
 
 # this will disable the dbplugin if the connector raise an ImportError
 from .connector import SpatiaLiteDBConnector
@@ -183,7 +184,8 @@ class SLTable(Table):
         return ogrUri
 
     def mimeUri(self):
-        return Table.mimeUri(self)
+        layerType = "raster" if self.type == Table.RasterType else "vector"
+        return u"%s:%s:%s:%s" % (layerType, self.database().dbplugin().providerName(), self.name, re.sub(":", "\:", self.uri().uri(False)))
 
     def toMapLayer(self):
         from qgis.core import QgsVectorLayer
@@ -268,7 +270,7 @@ class SLRasterTable(SLTable, RasterTable):
 
     def mimeUri(self):
         # QGIS has no provider to load rasters, let's use GDAL
-        uri = u"raster:gdal:%s:%s" % (self.name, self.uri().database())
+        uri = u"raster:gdal:%s:%s" % (self.name, re.sub(":", "\:", self.uri().database()))
         return uri
 
     def toMapLayer(self):

--- a/python/plugins/db_manager/db_plugins/spatialite/plugin.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/plugin.py
@@ -19,8 +19,6 @@ email                : brush.tyler@gmail.com
  *                                                                         *
  ***************************************************************************/
 """
-import re
-
 # this will disable the dbplugin if the connector raise an ImportError
 from .connector import SpatiaLiteDBConnector
 
@@ -185,7 +183,7 @@ class SLTable(Table):
 
     def mimeUri(self):
         layerType = "raster" if self.type == Table.RasterType else "vector"
-        return u"%s:%s:%s:%s" % (layerType, self.database().dbplugin().providerName(), self.name, re.sub(":", "\:", self.uri().uri(False)))
+        return u"%s:%s:%s:%s" % (layerType, self.database().dbplugin().providerName(), self.name, self.uri().uri(False).replace(":", "\:"))
 
     def toMapLayer(self):
         from qgis.core import QgsVectorLayer
@@ -270,7 +268,7 @@ class SLRasterTable(SLTable, RasterTable):
 
     def mimeUri(self):
         # QGIS has no provider to load rasters, let's use GDAL
-        uri = u"raster:gdal:%s:%s" % (self.name, re.sub(":", "\:", self.uri().database()))
+        uri = u"raster:gdal:%s:%s" % (self.name, self.uri().database().replace(":", "\:"))
         return uri
 
     def toMapLayer(self):


### PR DESCRIPTION
## Description
this path will fix: https://issues.qgis.org/issues/16296
Rationale: The fix escape ":" in the mime string because ":" is used to separate mime fields for qgis mime type.
The solution is similar to that applied for the db_manager postgis plugin mime type.

fix sponsored by Boundless Spatial Inc.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
