### PR TITLE
Fix dxf export when CRS is not canvas CRS and not limiting to canvas extent

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -499,6 +499,9 @@ int QgsDxfExport::writeToFile( QIODevice *d, const QString &encoding )
   mTextStream.setDevice( d );
   mTextStream.setCodec( encoding.toLocal8Bit() );
 
+  if ( mCrs.isValid() )
+    mMapSettings.setDestinationCrs( mCrs );
+
   if ( mExtent.isEmpty() )
   {
     const QList< QgsMapLayer * > layers = mMapSettings.layers();
@@ -529,8 +532,6 @@ int QgsDxfExport::writeToFile( QIODevice *d, const QString &encoding )
   mFactor = 1000 * dpi / mSymbologyScale / 25.4 * QgsUnitTypes::fromUnitToUnitFactor( mapUnits, QgsUnitTypes::DistanceMeters );
   mMapSettings.setOutputSize( QSize( mExtent.width() * mFactor, mExtent.height() * mFactor ) );
   mMapSettings.setOutputDpi( dpi );
-  if ( mCrs.isValid() )
-    mMapSettings.setDestinationCrs( mCrs );
 
   writeHeader( dxfEncoding( encoding ) );
   writeTables();


### PR DESCRIPTION
@jef-n 

Here's a fix for an issue I identified in the dxf export. Steps to reproduce are:

1. Have a layer in a CRS
2. Project in same crs as layer 
3. Export to DXF, choosing a different CRS
4. Make sure "export features intersecting current map extent" is unchecked

The generated dxf will always be empty, because the extent creation is reprojecting layer extents to the canvas CRS, not the actual selected DXF export CRS.