### PR TITLE
Improve triangulation for QGIS 3D

### DIFF
--- a/src/3d/qgstessellator.cpp
+++ b/src/3d/qgstessellator.cpp
@@ -264,7 +264,7 @@ void QgsTessellator::addPolygon( const QgsPolygonV2 &polygon, float extrusionHei
           mData << pNormal.x() << pNormal.z() << - pNormal.y();
       }
     }
-    else if (polyline.size() >= 3)
+    else if ( polyline.size() >= 3 )
     {
       p2t::CDT *cdt = new p2t::CDT( polyline );
 

--- a/src/3d/qgstessellator.cpp
+++ b/src/3d/qgstessellator.cpp
@@ -113,6 +113,8 @@ static void _makeWalls( const QgsCurve &ring, bool ccw, float extrusionHeight, Q
 
 static QVector3D _calculateNormal( const QgsCurve *curve )
 {
+  // Calculate the polygon's normal vector, based on Newell's method
+  // https://www.khronos.org/opengl/wiki/Calculating_a_Surface_Normal
   QgsVertexId::VertexType vt;
   QgsPoint pt1, pt2;
   QVector3D normal( 0, 0, 0 );

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -119,13 +119,6 @@ Qt3DRender::QGeometryRenderer *QgsPolygon3DSymbolEntityNode::renderer( const Qgs
     if ( QgsWkbTypes::isCurvedType( geom.geometry()->wkbType() ) )
       geom = QgsGeometry( geom.geometry()->segmentize() );
 
-    if ( !geom.isGeosValid() )
-    {
-      // invalid geometries break tessellation
-      qDebug() << "skipping invalid geometry" << f.id();
-      continue;
-    }
-
     const QgsAbstractGeometry *g = geom.geometry();
 
     if ( const QgsPolygonV2 *poly = qgsgeometry_cast< const QgsPolygonV2 *>( g ) )


### PR DESCRIPTION
This is a change on the original way that triangulation of polygons is done, in order to render QGIS 3D. Currently, true 3D geometries fail to be rendered, most of the time, because they are either flagged as invalid by GEOS or because the triangulation fails.

The triangulation was based only on the XY coordinates. This is not working with vertical planes, though, or when a polygon happens to have multiple points with the same XY but different Z coordinate.

This new solution uses a more robust approach:
- calculate plane on 3D that fits the polygon
- project the coordinates of points to this plane
- triangulate projected points
- register triangulated points on the buffer.

It has been tested with huge datasets from [our group](https://3d.bk.tudelft.nl/opendata/3dfier/).