### PR TITLE
[bugfix][backport] Do not cache invalid WM(T)S responses

### DIFF
--- a/src/providers/wms/qgstilecache.cpp
+++ b/src/providers/wms/qgstilecache.cpp
@@ -33,10 +33,11 @@ void QgsTileCache::insertTile( const QUrl& url, const QImage& image )
 bool QgsTileCache::tile( const QUrl& url, QImage& image )
 {
   QMutexLocker locker( &sTileCacheMutex );
-  if ( QImage* i = sTileCache.object( url ) )
+  bool success = false;
+  if ( QImage *i = sTileCache.object( url ) )
   {
     image = *i;
-    return true;
+    success = true;
   }
   else if ( QgsNetworkAccessManager::instance()->cache()->metaData( url ).isValid() )
   {
@@ -48,10 +49,13 @@ bool QgsTileCache::tile( const QUrl& url, QImage& image )
       image = QImage::fromData( imageData );
 
       // cache it as well (mutex is already locked)
-      sTileCache.insert( url, new QImage( image ) );
-
-      return true;
+      // Check for null because it could be a redirect (see: https://issues.qgis.org/issues/16427 )
+      if ( ! image.isNull( ) )
+      {
+        sTileCache.insert( url, new QImage( image ) );
+        success = true;
+      }
     }
   }
-  return false;
+  return success;
 }


### PR DESCRIPTION
The problem here was that in case of http->https redirect
from a misconfigured server (that advertizes http and then
redirects all request to https) all http redirect requests
were cached, making all subsequent requests to the same
url hit the 301 Moved Permanently reponse page intead of
the redirected content.

Fixes #16427 WMTS rendering problems in 2.18 and Master

cherry-picked from d102404b5e6796727c0ae0c983cf016ab33ff27a
