### PR TITLE
[server][bugfix] Fix OGC test getfeatureinfo:each-queryable-layer

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -769,7 +769,6 @@ namespace QgsWms
     const QgsLayerTree *projectLayerTreeRoot = project->layerTreeRoot();
 
     QDomElement layerParentElem = doc.createElement( QStringLiteral( "Layer" ) );
-    layerParentElem.setAttribute( QStringLiteral( "queryable" ), QStringLiteral( "1" ) );
 
     // Root Layer name
     QDomElement layerParentNameElem = doc.createElement( QStringLiteral( "Name" ) );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -909,8 +909,8 @@ namespace QgsWms
     QStringList queryLayers = mWmsParameters.queryLayersNickname();
     if ( queryLayers.isEmpty() )
     {
-      throw QgsBadRequestException( QStringLiteral( "LayerNotQueryable" ),
-                                    QStringLiteral( "QUERY_LAYERS parameter is required for GetFeatureInfo" ) );
+      QString msg = QObject::tr( "QUERY_LAYERS parameter is required for GetFeatureInfo" );
+      throw QgsBadRequestException( QStringLiteral( "LayerNotQueryable" ), msg );
     }
 
     // The I/J parameters are Mandatory if they are not replaced by X/Y or FILTER or FILTER_GEOM

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -909,7 +909,7 @@ namespace QgsWms
     QStringList queryLayers = mWmsParameters.queryLayersNickname();
     if ( queryLayers.isEmpty() )
     {
-      throw QgsBadRequestException( QStringLiteral( "ParameterMissing" ),
+      throw QgsBadRequestException( QStringLiteral( "LayerNotQueryable" ),
                                     QStringLiteral( "QUERY_LAYERS parameter is required for GetFeatureInfo" ) );
     }
 

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -97,7 +97,7 @@ Content-Type: text/xml; charset=utf-8
   <Exception>
    <Format>XML</Format>
   </Exception>
-  <Layer queryable="1">
+  <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <CRS>CRS:84</CRS>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -119,7 +119,7 @@ Content-Type: text/xml; charset=utf-8
     <inspire_common:Language>ita</inspire_common:Language>
    </inspire_common:ResponseLanguage>
   </inspire_vs:ExtendedCapabilities>
-  <Layer queryable="1">
+  <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <CRS>CRS:84</CRS>


### PR DESCRIPTION
## Description

This PR fixes the OGC test on queryable layer which is currently failing: http://37.187.164.233/ogc/10_05_2017_00_55_08_wms_1_3_0.html#c7c9de2b-94fd-49c6-8e70-a13d67447cd9/d1e17334_1/d1e17422_1/d1e9517_1/d1e9608_1

I updated unit tests accordingly.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
