### PR TITLE
for SQlite vectors wait rendering end to avoid file lock: fixes #15498

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8008,7 +8008,8 @@ void QgisApp::saveEdits( QgsMapLayer *layer, bool leaveEditable, bool triggerRep
   // Wait only if the current layer is in the rendering pool
   if ( mMapCanvas->mapSettings().layers().contains( vlayer->id() ) )
   {
-    if ( vlayer->dataProvider()->storageType().count( "SQLite" ) )
+    if ( vlayer->dataProvider()->storageType().count( "SQLite" ) ||
+         vlayer->dataProvider()->storageType().count( "GPKG" ) )
     {
       // notify wait the rendering end
       if ( mMapCanvas->isDrawing() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8003,34 +8003,15 @@ void QgisApp::saveEdits( QgsMapLayer *layer, bool leaveEditable, bool triggerRep
   if ( vlayer == activeLayer() )
     mSaveRollbackInProgress = true;
 
-  // wait for end of rendering to avoid lock in case of
+  // stop rendering to avoid lock in case of
   // splilte and gpkg fix #15498
-  // Wait only if the current layer is in the rendering pool
   if ( mMapCanvas->mapSettings().layers().contains( vlayer->id() ) )
   {
     if ( vlayer->dataProvider()->storageType().count( "SQLite" ) ||
          vlayer->dataProvider()->storageType().count( "GPKG" ) )
     {
-      // notify wait the rendering end
       if ( mMapCanvas->isDrawing() )
-      {
-        // notify
-        QgsMessageBarItem *item = new QgsMessageBarItem( tr( "Save edit paused" ),
-            tr( "Waiting for end of rendering" ),
-            QgsMessageBar::WARNING, 0 );
-        messageBar()->pushItem( item );
-        // wait
-        while ( mMapCanvas->isDrawing() )
-        {
-          QEventLoop loop;
-          QTimer t;
-          connect( &t, SIGNAL( timeout() ), &loop, SLOT( quit() ) );
-          t.start( 100 );
-          loop.exec();
-        }
-        // remove wait message
-        messageBar()->popWidget( item );
-      }
+        mMapCanvas->stopRendering();
     }
   }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8022,7 +8022,11 @@ void QgisApp::saveEdits( QgsMapLayer *layer, bool leaveEditable, bool triggerRep
         // wait
         while ( mMapCanvas->isDrawing() )
         {
-          QgsApplication::instance()->processEvents( QEventLoop::AllEvents, 100 );
+          QEventLoop loop;
+          QTimer t;
+          connect( &t, SIGNAL( timeout() ), &loop, SLOT( quit() ) );
+          t.start( 100 );
+          loop.exec();
         }
         // remove wait message
         messageBar()->popWidget( item );


### PR DESCRIPTION
## Description
In case of SQLite based vectors as Spatialite or GPKG, before to saveEdits, wait for end of rendering to avoid error of "File lock". The user is notified of the deferred save via messageBar. the message is automatically removed after rendering is terminated.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
