### PR TITLE
Crash when multiple .zips are loaded via qgisapp function (fix #17184)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3708,7 +3708,7 @@ bool QgisApp::askUserForZipItemLayers( QString path )
   // if 1 or 0 child found, exit so a normal item is created by gdal or ogr provider
   if ( zipItem->rowCount() <= 1 )
   {
-    delete zipItem;
+    zipItem->deleteLater();
     return false;
   }
 
@@ -3720,7 +3720,7 @@ bool QgisApp::askUserForZipItemLayers( QString path )
   // exit if promptLayers=Never
   else if ( promptLayers == 2 )
   {
-    delete zipItem;
+    zipItem->deleteLater();
     return false;
   }
   else
@@ -3789,7 +3789,7 @@ bool QgisApp::askUserForZipItemLayers( QString path )
     }
   }
 
-  delete zipItem;
+  zipItem->deleteLater();
   return ok;
 }
 


### PR DESCRIPTION
*Note: not just QObject::deleteLater(); see [QgsDataItem::deleteLater](https://github.com/qgis/QGIS/blob/master/src/core/qgsdataitem.cpp#L153-L174)()*

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
