### PR TITLE
[FEATURE][processing] raster layer unique values count algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/raster_unique_values_count.html
+++ b/python/plugins/processing/tests/testdata/expected/raster_unique_values_count.html
@@ -1,0 +1,24 @@
+<html><head>
+<meta http-equiv="Content-Type" content="text/html;                     charset=utf-8" /></head><body>
+<p>Analyzed file: /home/webmaster/dev/cpp/QGIS/python/plugins/processing/tests/testdata/raster.tif (band 1)</p><p>Total cell count: 224</p><p>NODATA count: 104 </p><table>
+<tr><td>Value</td><td>Count</td></tr>
+<tr><td>826.0</td><td>4</td></tr>
+<tr><td>837.0</td><td>6</td></tr>
+<tr><td>843.0</td><td>6</td></tr>
+<tr><td>845.0</td><td>4</td></tr>
+<tr><td>851.0</td><td>9</td></tr>
+<tr><td>853.0</td><td>6</td></tr>
+<tr><td>859.0</td><td>10</td></tr>
+<tr><td>861.0</td><td>4</td></tr>
+<tr><td>864.0</td><td>6</td></tr>
+<tr><td>866.0</td><td>9</td></tr>
+<tr><td>868.0</td><td>6</td></tr>
+<tr><td>872.0</td><td>4</td></tr>
+<tr><td>873.0</td><td>9</td></tr>
+<tr><td>878.0</td><td>6</td></tr>
+<tr><td>880.0</td><td>6</td></tr>
+<tr><td>881.0</td><td>6</td></tr>
+<tr><td>890.0</td><td>13</td></tr>
+<tr><td>899.0</td><td>6</td></tr>
+</table>
+</body></html>

--- a/python/plugins/processing/tests/testdata/expected/raster_unique_values_count.html
+++ b/python/plugins/processing/tests/testdata/expected/raster_unique_values_count.html
@@ -1,24 +1,25 @@
-<html><head>
-<meta http-equiv="Content-Type" content="text/html;                     charset=utf-8" /></head><body>
-<p>Analyzed file: /home/webmaster/dev/cpp/QGIS/python/plugins/processing/tests/testdata/raster.tif (band 1)</p><p>Total cell count: 224</p><p>NODATA count: 104 </p><table>
-<tr><td>Value</td><td>Count</td></tr>
-<tr><td>826.0</td><td>4</td></tr>
-<tr><td>837.0</td><td>6</td></tr>
-<tr><td>843.0</td><td>6</td></tr>
-<tr><td>845.0</td><td>4</td></tr>
-<tr><td>851.0</td><td>9</td></tr>
-<tr><td>853.0</td><td>6</td></tr>
-<tr><td>859.0</td><td>10</td></tr>
-<tr><td>861.0</td><td>4</td></tr>
-<tr><td>864.0</td><td>6</td></tr>
-<tr><td>866.0</td><td>9</td></tr>
-<tr><td>868.0</td><td>6</td></tr>
-<tr><td>872.0</td><td>4</td></tr>
-<tr><td>873.0</td><td>9</td></tr>
-<tr><td>878.0</td><td>6</td></tr>
-<tr><td>880.0</td><td>6</td></tr>
-<tr><td>881.0</td><td>6</td></tr>
-<tr><td>890.0</td><td>13</td></tr>
-<tr><td>899.0</td><td>6</td></tr>
+<html><head><meta http-equiv="Content-Type" content="text/html;charset=utf-8"/></head><body>
+<p>Analyzed file: /home/webmaster/dev/cpp/QGIS/python/plugins/processing/tests/testdata/raster.tif (band 1)</p>
+<p>Total cell count: 224</p>
+<p>NODATA count: 104</p>
+<table><tr><td>Value</td><td>Count</td></tr>
+<tr><td>826</td><td>4</td></tr>
+<tr><td>837</td><td>6</td></tr>
+<tr><td>843</td><td>6</td></tr>
+<tr><td>845</td><td>4</td></tr>
+<tr><td>851</td><td>9</td></tr>
+<tr><td>853</td><td>6</td></tr>
+<tr><td>859</td><td>10</td></tr>
+<tr><td>861</td><td>4</td></tr>
+<tr><td>864</td><td>6</td></tr>
+<tr><td>866</td><td>9</td></tr>
+<tr><td>868</td><td>6</td></tr>
+<tr><td>872</td><td>4</td></tr>
+<tr><td>873</td><td>9</td></tr>
+<tr><td>878</td><td>6</td></tr>
+<tr><td>880</td><td>6</td></tr>
+<tr><td>881</td><td>6</td></tr>
+<tr><td>890</td><td>13</td></tr>
+<tr><td>899</td><td>6</td></tr>
 </table>
 </body></html>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -3236,6 +3236,39 @@ tests:
           - 'Standard deviation: 43.9618116337985'
           - 'Sum of the squares: 252304334.52061242'
 
+  - algorithm: qgis:rasterlayeruniquevaluescount
+    name: Raster layer statistics
+    params:
+      INPUT:
+        name: raster.tif
+        type: raster
+      BAND: 1
+    results:
+      OUTPUT_HTML_FILE:
+        name: raster_unique_values_count.html
+        type: regex
+        rules:
+          - 'Total cell count: 224'
+          - 'NODATA count: 104'
+          - '826.0</td><td>4</td>'
+          - '837.0</td><td>6</td>'
+          - '843.0</td><td>6</td>'
+          - '845.0</td><td>4</td>'
+          - '851.0</td><td>9</td>'
+          - '853.0</td><td>6</td>'
+          - '859.0</td><td>10</td>'
+          - '861.0</td><td>4</td>'
+          - '864.0</td><td>6</td>'
+          - '866.0</td><td>9</td>'
+          - '868.0</td><td>6</td>'
+          - '872.0</td><td>4</td>'
+          - '873.0</td><td>9</td>'
+          - '878.0</td><td>6</td>'
+          - '880.0</td><td>6</td>'
+          - '881.0</td><td>6</td>'
+          - '890.0</td><td>13</td>'
+          - '899.0</td><td>6</td>'
+
   - algorithm: qgis:pointsdisplacement
     name: Point displacement
     params:

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -3237,7 +3237,7 @@ tests:
           - 'Sum of the squares: 252304334.52061242'
 
   - algorithm: qgis:rasterlayeruniquevaluescount
-    name: Raster layer statistics
+    name: Raster layer unique values count
     params:
       INPUT:
         name: raster.tif
@@ -3250,24 +3250,24 @@ tests:
         rules:
           - 'Total cell count: 224'
           - 'NODATA count: 104'
-          - '826.0</td><td>4</td>'
-          - '837.0</td><td>6</td>'
-          - '843.0</td><td>6</td>'
-          - '845.0</td><td>4</td>'
-          - '851.0</td><td>9</td>'
-          - '853.0</td><td>6</td>'
-          - '859.0</td><td>10</td>'
-          - '861.0</td><td>4</td>'
-          - '864.0</td><td>6</td>'
-          - '866.0</td><td>9</td>'
-          - '868.0</td><td>6</td>'
-          - '872.0</td><td>4</td>'
-          - '873.0</td><td>9</td>'
-          - '878.0</td><td>6</td>'
-          - '880.0</td><td>6</td>'
-          - '881.0</td><td>6</td>'
-          - '890.0</td><td>13</td>'
-          - '899.0</td><td>6</td>'
+          - '826</td><td>4</td>'
+          - '837</td><td>6</td>'
+          - '843</td><td>6</td>'
+          - '845</td><td>4</td>'
+          - '851</td><td>9</td>'
+          - '853</td><td>6</td>'
+          - '859</td><td>10</td>'
+          - '861</td><td>4</td>'
+          - '864</td><td>6</td>'
+          - '866</td><td>9</td>'
+          - '868</td><td>6</td>'
+          - '872</td><td>4</td>'
+          - '873</td><td>9</td>'
+          - '878</td><td>6</td>'
+          - '880</td><td>6</td>'
+          - '881</td><td>6</td>'
+          - '890</td><td>13</td>'
+          - '899</td><td>6</td>'
 
   - algorithm: qgis:pointsdisplacement
     name: Point displacement

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -21,6 +21,7 @@
 #include "qgsprocessingfeedback.h"
 #include "qgsprocessingutils.h"
 #include "qgsvectorlayer.h"
+#include "qgsrasterlayer.h"
 #include "qgsgeometry.h"
 #include "qgsgeometryengine.h"
 #include "qgswkbtypes.h"
@@ -88,6 +89,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsLineIntersectionAlgorithm() );
   addAlgorithm( new QgsSplitWithLinesAlgorithm() );
   addAlgorithm( new QgsMeanCoordinatesAlgorithm() );
+  addAlgorithm( new QgsRasterLayerUniqueValuesCountAlgorithm() );
 }
 
 void QgsSaveSelectedFeatures::initAlgorithm( const QVariantMap & )
@@ -2583,6 +2585,96 @@ QVariantMap QgsMeanCoordinatesAlgorithm::processAlgorithm( const QVariantMap &pa
 
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  return outputs;
+}
+
+
+void QgsRasterLayerUniqueValuesCountAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT" ),
+                QObject::tr( "Input layer" ) ) );
+  addParameter( new QgsProcessingParameterBand( QStringLiteral( "BAND" ),
+                QObject::tr( "Band number" ), 1, QStringLiteral( "INPUT" ) ) );
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT_HTML_FILE" ),
+                QObject::tr( "Unique values count" ), QObject::tr( "HTML files (*.html)" ), QVariant(), true ) );
+  addOutput( new QgsProcessingOutputHtml( QStringLiteral( "OUTPUT_HTML_FILE" ), QObject::tr( "Unique values count" ) ) );
+}
+
+QString QgsRasterLayerUniqueValuesCountAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "TODO." );
+}
+
+QgsRasterLayerUniqueValuesCountAlgorithm *QgsRasterLayerUniqueValuesCountAlgorithm::createInstance() const
+{
+  return new QgsRasterLayerUniqueValuesCountAlgorithm();
+}
+
+QVariantMap QgsRasterLayerUniqueValuesCountAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  QgsRasterLayer *layer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT" ), context );
+  int band = parameterAsInt( parameters, QStringLiteral( "BAND" ), context );
+  QString outputFile = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT_HTML_FILE" ), context );
+
+
+  QMap< double, int > uniqueValues;
+  int width = layer->width();
+  int height = layer->height();
+
+  QgsRasterBlock *rasterBlock = layer->dataProvider()->block( band, layer->extent(), width, height );
+  int noDataCount = -1;
+  if ( rasterBlock->hasNoDataValue() )
+    noDataCount = 0;
+
+  for ( int row = 0; row < height; row++ )
+  {
+    feedback->setProgress( 100 * row / height );
+    for ( int column = 0; column < width; column++ )
+    {
+      if ( feedback->isCanceled() )
+        break;
+      if ( noDataCount > -1 && rasterBlock->isNoData( row, column ) )
+      {
+        noDataCount += 1;
+      }
+      else
+      {
+        double value = rasterBlock->value( row, column );
+        if ( uniqueValues.contains( value ) )
+        {
+          uniqueValues[ value ]++;
+        }
+        else
+        {
+          uniqueValues.insert( value, 1 );
+        }
+      }
+    }
+  }
+
+  QVariantMap outputs;
+
+  if ( !outputFile.isEmpty() )
+  {
+    QFile file( outputFile );
+    if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    {
+      QTextStream out( &file );
+      out << QString( "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"/></head><body>\n" );
+      out << QObject::tr( "<p>Analyzed file: %1 (band %2)</p>\n" ).arg( layer->source() ).arg( band );
+      out << QObject::tr( "<p>Total cell count: %1</p>\n" ).arg( width * height );
+      if ( noDataCount > -1 )
+        out << QObject::tr( "<p>NODATA count: %1</p>\n" ).arg( noDataCount );
+      out << QString( "<table><tr><td>%1</td><td>%2</td></tr>\n" ).arg( QObject::tr( "Value" ) ).arg( QObject::tr( "Count" ) );
+      for ( double key : uniqueValues.keys() )
+      {
+        out << QString( "<tr><td>%1</td><td>%2</td></tr>\n" ).arg( key ).arg( uniqueValues[key] );
+      }
+      out << QString( "</table>\n</body></html>" );
+      outputs.insert( QStringLiteral( "OUTPUT_HTML_FILE" ), outputFile );
+    }
+  }
+
   return outputs;
 }
 

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -2640,14 +2640,7 @@ QVariantMap QgsRasterLayerUniqueValuesCountAlgorithm::processAlgorithm( const QV
       else
       {
         double value = rasterBlock->value( row, column );
-        if ( uniqueValues.contains( value ) )
-        {
-          uniqueValues[ value ]++;
-        }
-        else
-        {
-          uniqueValues.insert( value, 1 );
-        }
+        uniqueValues[ value ]++;
       }
     }
   }

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -2602,7 +2602,7 @@ void QgsRasterLayerUniqueValuesCountAlgorithm::initAlgorithm( const QVariantMap 
 
 QString QgsRasterLayerUniqueValuesCountAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "TODO." );
+  return QObject::tr( "This algorithm returns the count of each unique value in a given raster layer." );
 }
 
 QgsRasterLayerUniqueValuesCountAlgorithm *QgsRasterLayerUniqueValuesCountAlgorithm::createInstance() const
@@ -2617,7 +2617,7 @@ QVariantMap QgsRasterLayerUniqueValuesCountAlgorithm::processAlgorithm( const QV
   QString outputFile = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT_HTML_FILE" ), context );
 
 
-  QMap< double, int > uniqueValues;
+  QHash< double, int > uniqueValues;
   int width = layer->width();
   int height = layer->height();
 
@@ -2652,8 +2652,13 @@ QVariantMap QgsRasterLayerUniqueValuesCountAlgorithm::processAlgorithm( const QV
     }
   }
 
-  QVariantMap outputs;
+  QMap< double, int > sortedUniqueValues;
+  for ( auto it = uniqueValues.constBegin(); it != uniqueValues.constEnd(); ++it )
+  {
+    sortedUniqueValues.insert( it.key(), it.value() );
+  }
 
+  QVariantMap outputs;
   if ( !outputFile.isEmpty() )
   {
     QFile file( outputFile );
@@ -2666,9 +2671,10 @@ QVariantMap QgsRasterLayerUniqueValuesCountAlgorithm::processAlgorithm( const QV
       if ( noDataCount > -1 )
         out << QObject::tr( "<p>NODATA count: %1</p>\n" ).arg( noDataCount );
       out << QString( "<table><tr><td>%1</td><td>%2</td></tr>\n" ).arg( QObject::tr( "Value" ) ).arg( QObject::tr( "Count" ) );
-      for ( double key : uniqueValues.keys() )
+
+      for ( double key : sortedUniqueValues.keys() )
       {
-        out << QString( "<tr><td>%1</td><td>%2</td></tr>\n" ).arg( key ).arg( uniqueValues[key] );
+        out << QString( "<tr><td>%1</td><td>%2</td></tr>\n" ).arg( key ).arg( sortedUniqueValues[key] );
       }
       out << QString( "</table>\n</body></html>" );
       outputs.insert( QStringLiteral( "OUTPUT_HTML_FILE" ), outputFile );

--- a/src/core/processing/qgsnativealgorithms.h
+++ b/src/core/processing/qgsnativealgorithms.h
@@ -810,6 +810,29 @@ class QgsMeanCoordinatesAlgorithm : public QgsProcessingAlgorithm
 
 };
 
+/**
+ * Native raster layer unique values count algorithm.
+ */
+class QgsRasterLayerUniqueValuesCountAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsRasterLayerUniqueValuesCountAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override { return QStringLiteral( "rasterlayeruniquevaluescount" ); }
+    QString displayName() const override { return QObject::tr( "Raster layer unique values count" ); }
+    QString group() const override { return QObject::tr( "Raster analysis" ); }
+    QString shortHelpString() const override;
+    QgsRasterLayerUniqueValuesCountAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    virtual QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                          QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+};
+
 ///@endcond PRIVATE
 
 #endif // QGSNATIVEALGORITHMS_H


### PR DESCRIPTION
## Description
It's about time QGIS offers a simple way to get a raster layer unique values count feature 😉. The algorithm uses QGIS API, so any raster layer (i.e. non-GDAL sources) will work. Plus, thanks to the nice work of Nyall, we have process indicator and can cancel the process at any given time.

@nyalldawson , @alexbruy , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
