### PR TITLE
 [FEATURE][needs-docs][DB Manager] Be able to update every Db layer from Postgres, Spatialite and Oracle

### DIFF
--- a/python/plugins/db_manager/db_manager_plugin.py
+++ b/python/plugins/db_manager/db_manager_plugin.py
@@ -79,11 +79,9 @@ class DBManagerPlugin(object):
             self.dlg.close()
 
     def onLayerWasAdded(self, aMapLayer):
+        # Be able to update every Db layer from Postgres, Spatialite and Oracle
         if hasattr(aMapLayer, 'dataProvider') and aMapLayer.dataProvider().name() in ['postgres', 'spatialite', 'oracle']:
-            uri = QgsDataSourceUri(aMapLayer.source())
-            table = uri.table()
-            if table.startswith('(') and table.endswith(')'):
-                self.iface.addCustomActionForLayer(self.layerAction, aMapLayer)
+            self.iface.addCustomActionForLayer(self.layerAction, aMapLayer)
         # virtual has QUrl source
         # url = QUrl(QUrl.fromPercentEncoding(l.source()))
         # url.queryItemValue('query')
@@ -91,12 +89,11 @@ class DBManagerPlugin(object):
         # url.queryItemValue('geometry')
 
     def onUpdateSqlLayer(self):
+        # Be able to update every Db layer from Postgres, Spatialite and Oracle
         l = self.iface.activeLayer()
         if l.dataProvider().name() in ['postgres', 'spatialite', 'oracle']:
-            table = QgsDataSourceUri(l.source()).table()
-            if table.startswith('(') and table.endswith(')'):
-                self.run()
-                self.dlg.runSqlLayerWindow(l)
+            self.run()
+            self.dlg.runSqlLayerWindow(l)
         # virtual has QUrl source
         # url = QUrl(QUrl.fromPercentEncoding(l.source()))
         # url.queryItemValue('query')

--- a/python/plugins/db_manager/dlg_sql_layer_window.py
+++ b/python/plugins/db_manager/dlg_sql_layer_window.py
@@ -31,7 +31,7 @@ from qgis.PyQt.QtGui import QKeySequence, QCursor, QClipboard, QIcon, QStandardI
 from qgis.PyQt.Qsci import QsciAPIs
 from qgis.PyQt.QtXml import QDomDocument
 
-from qgis.core import QgsProject, QgsDataSourceUri
+from qgis.core import QgsProject, QgsDataSourceUri, QgsReadWriteContext
 from qgis.utils import OverrideCursor
 
 from .db_plugins import createDbPlugin
@@ -328,11 +328,11 @@ class DlgSqlLayerWindow(QWidget, Ui_Dialog):
             XMLDocument = QDomDocument("style")
             XMLMapLayers = XMLDocument.createElement("maplayers")
             XMLMapLayer = XMLDocument.createElement("maplayer")
-            self.layer.writeLayerXML(XMLMapLayer, XMLDocument)
+            self.layer.writeLayerXml(XMLMapLayer, XMLDocument, QgsReadWriteContext())
             XMLMapLayer.firstChildElement("datasource").firstChild().setNodeValue(layer.source())
             XMLMapLayers.appendChild(XMLMapLayer)
             XMLDocument.appendChild(XMLMapLayers)
-            self.layer.readLayerXML(XMLMapLayer)
+            self.layer.readLayerXml(XMLMapLayer, QgsReadWriteContext())
             self.layer.reload()
             self.iface.actionDraw().trigger()
             self.iface.mapCanvas().refresh()

--- a/python/plugins/db_manager/dlg_sql_layer_window.py
+++ b/python/plugins/db_manager/dlg_sql_layer_window.py
@@ -151,6 +151,12 @@ class DlgSqlLayerWindow(QWidget, Ui_Dialog):
             match = re.search('^\((SELECT .+ FROM .+)\)$', sql, re.S)
             if match:
                 sql = match.group(1)
+        if not sql.startswith('(') and not sql.endswith(')'):
+            schema = uri.schema()
+            if schema and schema.upper() != 'PUBLIC':
+                sql = 'SELECT * FROM ' + schema + '.' + sql
+            else
+                sql = 'SELECT * FROM ' + sql
         self.editSql.setText(sql)
         self.executeSql()
 


### PR DESCRIPTION
## Description
Fix an issue in the way to update DB layer datasource and add the capability to update every DB layer from postgres, Spatialite and Oracle

funded by Ifremer

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
