### PR TITLE
Fix build using mingw

### DIFF
--- a/src/app/mainwin.cpp
+++ b/src/app/mainwin.cpp
@@ -105,7 +105,13 @@ int CALLBACK WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
     }
   }
 
+#ifdef _MSC_VER
   HINSTANCE hGetProcIDDLL = LoadLibrary( "qgis_app.dll" );
+#else
+  // MinGW
+  HINSTANCE hGetProcIDDLL = LoadLibrary( "libqgis_app.dll" );
+#endif
+
   if ( !hGetProcIDDLL )
   {
     std::cerr << "Could not load the qgis_app.dll" << std::endl;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12090,7 +12090,7 @@ void QgisApp::keyPressEvent( QKeyEvent *e )
   {
     stopRendering();
   }
-#if defined(Q_OS_WIN) && defined(QGISDEBUG)
+#if defined(_MSC_VER) && defined(QGISDEBUG)
   else if ( e->key() == Qt::Key_Backslash && e->modifiers() & Qt::ControlModifier )
   {
     QgsCrashHandler::handle( 0 );

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -23,7 +23,7 @@
 #include "qgscrashreport.h"
 #include "qgsstacktrace.h"
 
-#ifdef Q_OS_WIN
+#ifdef _MSC_VER
 LONG WINAPI QgsCrashHandler::handle( struct _EXCEPTION_POINTERS *ExceptionInfo )
 {
   QgsStackLines stack = QgsStackTrace::trace( ExceptionInfo );

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -32,7 +32,7 @@ class APP_EXPORT QgsCrashHandler
 {
 
   public:
-#ifdef Q_OS_WIN
+#ifdef _MSC_VER
     static LONG WINAPI handle( struct _EXCEPTION_POINTERS *ExceptionInfo );
 #endif
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -732,7 +732,7 @@ QString QgsApplication::userLoginName()
   if ( !sUserName.isEmpty() )
     return sUserName;
 
-#ifdef Q_OS_WIN
+#ifdef _MSC_VER
   TCHAR name [ UNLEN + 1 ];
   DWORD size = UNLEN + 1;
 
@@ -767,7 +767,7 @@ QString QgsApplication::userFullName()
   if ( !sUserFullName.isEmpty() )
     return sUserFullName;
 
-#ifdef Q_OS_WIN
+#ifdef _MSC_VER
   TCHAR name [ UNLEN + 1 ];
   DWORD size = UNLEN + 1;
 

--- a/src/core/qgsoptionalexpression.h
+++ b/src/core/qgsoptionalexpression.h
@@ -77,8 +77,10 @@ class CORE_EXPORT QgsOptionalExpression : public QgsOptional<QgsExpression>
 };
 
 
-#if defined(Q_OS_WIN)
+#if defined(_MSC_VER)
+#ifndef SIP_RUN
 template CORE_EXPORT QgsOptional<QgsExpression>;
+#endif
 #endif
 
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -60,10 +60,10 @@
 #include <QDir>
 #include <QUrl>
 
-#ifdef Q_OS_UNIX
-#include <utime.h>
-#elif _MSC_VER
+#ifdef _MSC_VER
 #include <sys/utime.h>
+#else
+#include <utime.h>
 #endif
 
 // canonical project instance

--- a/src/core/qgsstacktrace.cpp
+++ b/src/core/qgsstacktrace.cpp
@@ -28,7 +28,7 @@
 
 ///@cond PRIVATE
 
-#ifdef Q_OS_WIN
+#ifdef _MSC_VER
 QVector<QgsStackTrace::StackLine> QgsStackTrace::trace( _EXCEPTION_POINTERS *ExceptionInfo )
 {
   QgsStackLines stack;
@@ -145,7 +145,7 @@ void QgsStackTrace::setSymbolPath( QString symbolPaths )
   mSymbolPaths = symbolPaths;
 }
 
-#endif // Q_OS_WIN
+#endif // _MSC_VER
 
 #ifdef Q_OS_LINUX
 QVector<QgsStackTrace::StackLine> QgsStackTrace::trace( unsigned int maxFrames )

--- a/src/core/qgsstacktrace.h
+++ b/src/core/qgsstacktrace.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsStackTrace
       bool isValid() const;
     };
 
-#ifdef Q_OS_WIN
+#ifdef _MSC_VER
 
     /**
      * Return a demangled stack backtrace of the caller function.


### PR DESCRIPTION
Changes many  #if defined (Q_OS_WIN) to #ifdef _MSC_VER, where they relate specifically to msvc compiler. Submitted on behalf of Theuns Heydenrych.