### PR TITLE
[auth] Add mutexes to protect access to authentication config cache from multiple threads

### DIFF
--- a/src/auth/basic/qgsauthbasicmethod.cpp
+++ b/src/auth/basic/qgsauthbasicmethod.cpp
@@ -21,6 +21,7 @@
 #include "qgslogger.h"
 
 #include <QNetworkProxy>
+#include <QMutexLocker>
 
 static const QString AUTH_METHOD_KEY = QStringLiteral( "Basic" );
 static const QString AUTH_METHOD_DESCRIPTION = QStringLiteral( "Basic authentication" );
@@ -169,6 +170,7 @@ void QgsAuthBasicMethod::clearCachedConfig( const QString &authcfg )
 
 QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg, bool fullconfig )
 {
+  QMutexLocker locker( &mConfigMutex );
   QgsAuthMethodConfig mconfig;
 
   // check if it is cached
@@ -187,6 +189,7 @@ QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg,
   }
 
   // cache bundle
+  locker.unlock();
   putMethodConfig( authcfg, mconfig );
 
   return mconfig;
@@ -194,12 +197,14 @@ QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg,
 
 void QgsAuthBasicMethod::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
 {
+  QMutexLocker locker( &mConfigMutex );
   QgsDebugMsg( QString( "Putting basic config for authcfg: %1" ).arg( authcfg ) );
   sAuthConfigCache.insert( authcfg, mconfig );
 }
 
 void QgsAuthBasicMethod::removeMethodConfig( const QString &authcfg )
 {
+  QMutexLocker locker( &mConfigMutex );
   if ( sAuthConfigCache.contains( authcfg ) )
   {
     sAuthConfigCache.remove( authcfg );

--- a/src/auth/basic/qgsauthbasicmethod.h
+++ b/src/auth/basic/qgsauthbasicmethod.h
@@ -18,6 +18,7 @@
 #define QGSAUTHBASICMETHOD_H
 
 #include <QObject>
+#include <QMutex>
 
 #include "qgsauthconfig.h"
 #include "qgsauthmethod.h"
@@ -61,6 +62,8 @@ class QgsAuthBasicMethod : public QgsAuthMethod
     QString escapeUserPass( const QString &val, QChar delim = '\'' ) const;
 
     static QMap<QString, QgsAuthMethodConfig> sAuthConfigCache;
+
+    QMutex mConfigMutex;
 };
 
 #endif // QGSAUTHBASICMETHOD_H

--- a/src/auth/identcert/qgsauthidentcertmethod.h
+++ b/src/auth/identcert/qgsauthidentcertmethod.h
@@ -18,6 +18,7 @@
 #define QGSAUTHIDENTCERTMETHOD_H
 
 #include <QObject>
+#include <QMutex>
 
 #include "qgsauthconfig.h"
 #include "qgsauthmethod.h"
@@ -57,6 +58,8 @@ class QgsAuthIdentCertMethod : public QgsAuthMethod
     void removePkiConfigBundle( const QString &authcfg );
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
+
+    QMutex mConfigMutex;
 };
 
 #endif // QGSAUTHIDENTCERTMETHOD_H

--- a/src/auth/pkipaths/qgsauthpkipathsmethod.h
+++ b/src/auth/pkipaths/qgsauthpkipathsmethod.h
@@ -18,6 +18,7 @@
 #define QGSAUTHPKIPATHSMETHOD_H
 
 #include <QObject>
+#include <QMutex>
 
 #include "qgsauthconfig.h"
 #include "qgsauthmethod.h"
@@ -57,6 +58,9 @@ class QgsAuthPkiPathsMethod : public QgsAuthMethod
     void removePkiConfigBundle( const QString &authcfg );
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
+
+    QMutex mConfigMutex;
+
 };
 
 #endif // QGSAUTHPKIPATHSMETHOD_H

--- a/src/auth/pkipkcs12/qgsauthpkcs12method.h
+++ b/src/auth/pkipkcs12/qgsauthpkcs12method.h
@@ -18,6 +18,7 @@
 #define QGSAUTHPKCS12METHOD_H
 
 #include <QObject>
+#include <QMutex>
 
 #include "qgsauthconfig.h"
 #include "qgsauthmethod.h"
@@ -58,6 +59,8 @@ class QgsAuthPkcs12Method : public QgsAuthMethod
     void removePkiConfigBundle( const QString &authcfg );
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
+
+    QMutex mConfigMutex;
 };
 
 #endif // QGSAUTHPKCS12METHOD_H

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -28,7 +28,7 @@
 #include <QToolTip>
 #include <QPlainTextEdit>
 #include <QScrollBar>
-
+#include <QDebug>
 
 QgsMessageLogViewer::QgsMessageLogViewer( QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
@@ -57,8 +57,7 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
     cleanedTag = tr( "General" );
 
   int i;
-  for ( i = 0; i < tabWidget->count() && tabWidget->tabText( i ) != cleanedTag; i++ )
-    ;
+  for ( i = 0; i < tabWidget->count() && tabWidget->tabText( i ).remove( QChar( '&' ) ) != cleanedTag; i++ );
 
   QPlainTextEdit *w = nullptr;
   if ( i < tabWidget->count() )

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -502,12 +502,12 @@ struct QgsWmsAuthorization
     {
       return QgsAuthManager::instance()->updateNetworkRequest( request, mAuthCfg );
     }
-    else if ( !mUserName.isNull() || !mPassword.isNull() )
+    else if ( !mUserName.isEmpty() || !mPassword.isEmpty() )
     {
       request.setRawHeader( "Authorization", "Basic " + QStringLiteral( "%1:%2" ).arg( mUserName, mPassword ).toLatin1().toBase64() );
     }
 
-    if ( !mReferer.isNull() )
+    if ( !mReferer.isEmpty() )
     {
       request.setRawHeader( "Referer", QStringLiteral( "%1" ).arg( mReferer ).toLatin1() );
     }


### PR DESCRIPTION
## Description

While testing with XYZ layer with multi-threaded rendering on, we discovered this issue, related to the fact that the config cache is accessed simultaneously from different threads, by adding mutexes the access to the cache is serialized.
