### PR TITLE
[OGR] List TIN and PolyhedralSurface as Polygon when searching sublayers

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -765,15 +765,15 @@ QStringList QgsOgrProvider::subLayers() const
         fCount[wkbUnknown] = 0;
       }
 
-      // List TIN and PolyhedralSurface as MultiPolygon
+      // List TIN and PolyhedralSurface as Polygon
       if ( fCount.contains( wkbTIN ) )
       {
-        fCount[wkbMultiPolygon] = fCount.value( wkbMultiPolygon ) + fCount[wkbTIN];
+        fCount[wkbPolygon] = fCount.value( wkbPolygon ) + fCount[wkbTIN];
         fCount.remove( wkbTIN );
       }
       if ( fCount.contains( wkbPolyhedralSurface ) )
       {
-        fCount[wkbMultiPolygon] = fCount.value( wkbMultiPolygon ) + fCount[wkbPolyhedralSurface];
+        fCount[wkbPolygon] = fCount.value( wkbPolygon ) + fCount[wkbPolyhedralSurface];
         fCount.remove( wkbPolyhedralSurface );
       }
       // When there are CurvePolygons, promote Polygons


### PR DESCRIPTION
List TIN and PolyhedralSurface as Polygon when searching sublayers since sublayer geometry types are always single types.