### PR TITLE
[processing] use raster iterator in raster layer unique values report

### DIFF
--- a/src/core/processing/qgsnativealgorithms.h
+++ b/src/core/processing/qgsnativealgorithms.h
@@ -829,8 +829,21 @@ class QgsRasterLayerUniqueValuesReportAlgorithm : public QgsProcessingAlgorithm
 
   protected:
 
+    virtual bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     virtual QVariantMap processAlgorithm( const QVariantMap &parameters,
                                           QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+
+    std::unique_ptr< QgsRasterInterface > mInterface;
+    bool mHasNoDataValue = false;
+    int mLayerWidth;
+    int mLayerHeight;
+    QgsRectangle mExtent;
+    QgsCoordinateReferenceSystem mCrs;
+    double mRasterUnitsPerPixelX;
+    double mRasterUnitsPerPixelY;
+    QString mSource;
 
 };
 


### PR DESCRIPTION
## Description
OK, turns out we do need to put some restrains to the QgsRasterBlock size in the raster layer uniqu values report algorithm. While trying the algorithm against a large raster (35,989 x 75,497 pixels), I discovered that a QgsRasterBlock cannot have a size value greater than the maximum value of an int (i.e. width * height can' t be above 2,147,483,647). 

Using a QgsRasterIterator allows us to support large rasters, and actually turned out to result in a faster algorithm. On a raster that took 22 seconds to run this algorithm prior to this PR, it now takes only 20 seconds.

TIL.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
