### PR TITLE
[bugfix] Fixes #17118 Reshape tool with z support

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -396,6 +396,15 @@ class QgsGeometry
      */
     int reshapeGeometry( const QList<QgsPoint>& reshapeWithLine );
 
+    /**
+      * Replaces a part of this geometry with another line with Z support
+      *
+      * @return 0 in case of success
+      *
+      * @note added in 2.18
+      */
+    int reshapeGeometry( const QList<QgsPointV2>& reshapeWithLine );
+
     /** Changes this geometry such that it does not intersect the other geometry
      * @param other geometry that should not be intersect
      * @return 0 in case of success

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -164,6 +164,15 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QList<QgsPoint> points();
 
     /**
+     * List of digitized points with z support
+     *
+     * @return List of points
+     *
+     * @node added in 2.18
+     */
+    QList<QgsPointV2> pointsV2();
+
+    /**
      * Set the points on which to work
      *
      * @param pointList A list of points

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -97,7 +97,7 @@ void QgsMapToolReshape::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       QgsGeometry* geom = f.geometry();
       if ( geom )
       {
-        reshapeReturn = geom->reshapeGeometry( points() );
+        reshapeReturn = geom->reshapeGeometry( pointsV2() );
         if ( reshapeReturn == 0 )
         {
           //avoid intersections on polygon layers

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -801,27 +801,33 @@ int QgsGeometry::splitGeometry( const QList<QgsPoint>& splitLine, QList<QgsGeome
 /** Replaces a part of this geometry with another line*/
 int QgsGeometry::reshapeGeometry( const QList<QgsPoint>& reshapeWithLine )
 {
+  QgsPointSequenceV2 reshapeLine;
+  convertPointList( reshapeWithLine, reshapeLine );
+  return reshapeGeometry( reshapeLine );
+}
+
+int QgsGeometry::reshapeGeometry( const QList<QgsPointV2>& reshapeLine )
+{
   if ( !d->geometry )
   {
     return 0;
   }
 
-  QgsPointSequenceV2 reshapeLine;
-  convertPointList( reshapeWithLine, reshapeLine );
   QgsLineStringV2 reshapeLineString;
   reshapeLineString.setPoints( reshapeLine );
-
   QgsGeos geos( d->geometry );
   int errorCode = 0;
   QgsAbstractGeometryV2* geom = geos.reshapeGeometry( reshapeLineString, &errorCode );
+
   if ( errorCode == 0 && geom )
   {
-    detach( false );
+    detach( true );
     delete d->geometry;
-    d->geometry = geom;
     removeWkbGeos();
+    d->geometry = geom;
     return 0;
   }
+
   return errorCode;
 }
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -821,12 +821,13 @@ int QgsGeometry::reshapeGeometry( const QList<QgsPointV2>& reshapeLine )
 
   if ( errorCode == 0 && geom )
   {
-    detach( true );
-    delete d->geometry;
+    detach( false );
     removeWkbGeos();
     d->geometry = geom;
     return 0;
   }
+
+  delete geom;
 
   return errorCode;
 }

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -438,6 +438,15 @@ class CORE_EXPORT QgsGeometry
      */
     int reshapeGeometry( const QList<QgsPoint>& reshapeWithLine );
 
+    /**
+     * Replaces a part of this geometry with another line with Z support
+     *
+     * @return 0 in case of success
+     *
+     * @note added in 2.18
+     */
+    int reshapeGeometry( const QList<QgsPointV2>& reshapeLine );
+
     /** Changes this geometry such that it does not intersect the other geometry
      * @param other geometry that should not be intersect
      * @return 0 in case of success

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -722,6 +722,13 @@ QList<QgsPoint> QgsMapToolCapture::points()
   return points;
 }
 
+QgsPointSequenceV2 QgsMapToolCapture::pointsV2()
+{
+  QgsPointSequenceV2 pts;
+  mCaptureCurve.points( pts );
+  return pts;
+}
+
 void QgsMapToolCapture::setPoints( const QList<QgsPoint>& pointList )
 {
   QgsPointSequenceV2 pts;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -199,7 +199,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      *
      * @return List of points
      *
-     * @node added in 2.18
+     * @note added in 2.18
      */
     QgsPointSequenceV2 pointsV2();
 

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -195,6 +195,15 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QList<QgsPoint> points();
 
     /**
+     * List of digitized points with z support
+     *
+     * @return List of points
+     *
+     * @node added in 2.18
+     */
+    QgsPointSequenceV2 pointsV2();
+
+    /**
      * Set the points on which to work
      *
      * @param pointList A list of points

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1685,6 +1685,16 @@ class TestQgsGeometry(unittest.TestCase):
         wkt = g.exportToWkt()
         assert compareWkt(expWkt, wkt), "testReshape failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
 
+        # Test reshape with z support
+        wkt = 'LineStringZ (-1 0 -3, 0 0 20, 5 0 9999)'
+        g = QgsGeometry.fromWkt(wkt)
+
+        self.assertEqual(g.reshapeGeometry([QgsPointV2(QgsWKBTypes.PointZ, -1, 0, -3), QgsPointV2(QgsWKBTypes.PointZ, -6, 5, 55)]), 0)
+        wkt = g.exportToWkt()
+
+        expWkt = 'LineStringZ (-6 5 55, -1 0 -3, 0 0 20, 5 0 9999)'
+        assert compareWkt(expWkt, wkt), "testReshape failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
+
     def testConvertToMultiType(self):
         """ Test converting geometries to multi type """
         point = QgsGeometry.fromWkt('Point (1 2)')

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -3525,5 +3525,6 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertAlmostEqual(polygon.angleAtVertex(3), math.radians(225.0), places=3)
         self.assertAlmostEqual(polygon.angleAtVertex(4), math.radians(135.0), places=3)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

As described in this ticket https://issues.qgis.org/issues/17118, the current reshape map tool resets z values. This PR fixes this issue by using `QgsPointV2` instead of `QgsPoint` for reshaping.

A simple test with a `LineStringZ` has been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
