### PR TITLE
[bugfix] Properly update filter comboboxes of relation reference widget 

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -310,6 +310,15 @@ void QgsRelationReferenceWidget::setForeignKey( const QVariant& value )
 void QgsRelationReferenceWidget::deleteForeignKey()
 {
   QVariant nullValue = QSettings().value( "qgis/nullValue", "NULL" );
+
+  // deactivate filter comboboxes
+  if ( mChainFilters && !mFilterComboBoxes.isEmpty() )
+  {
+    QComboBox *cb = mFilterComboBoxes.first();
+    cb->setCurrentIndex( 0 );
+    disableChainedComboBoxes( cb );
+  }
+
   if ( mReadOnlySelector )
   {
     QString nullText = "";
@@ -521,6 +530,13 @@ void QgsRelationReferenceWidget::init()
             QString nf = nv.isNull() ? nullValue.toString() : nv.toString();
             mFilterCache[mFilterFields[i]][cf] << nf;
           }
+        }
+
+        if ( !mFilterComboBoxes.isEmpty() )
+        {
+          QComboBox *cb = mFilterComboBoxes.first();
+          cb->setCurrentIndex( 0 );
+          disableChainedComboBoxes( cb );
         }
       }
     }

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -38,6 +38,7 @@ class TestQgsRelationReferenceWidget : public QObject
 
     void testChainFilter();
     void testChainFilterRefreshed();
+    void testChainFilterDeleteForeignKey();
 
   private:
     QgsVectorLayer* mLayer1;
@@ -218,6 +219,49 @@ void TestQgsRelationReferenceWidget::testChainFilterRefreshed()
   QCOMPARE( cbs[0]->currentText(), QString( "iron" ) );
   QCOMPARE( cbs[1]->currentText(), QString( "120" ) );
   QCOMPARE( cbs[2]->currentText(), QString( "sleeve" ) );
+}
+
+void TestQgsRelationReferenceWidget::testChainFilterDeleteForeignKey()
+{
+  // init a relation reference widget
+  QStringList filterFields = QStringList() << "material" << "diameter" << "raccord";
+
+  QgsRelationReferenceWidget w( new QWidget() );
+  w.setChainFilters( true );
+  w.setFilterFields( filterFields );
+  w.setRelation( *mRelation, true );
+  w.init();
+
+  // check the default status of filter comboboxes
+  QList<QComboBox *> cbs = w.mFilterComboBoxes;
+
+  QCOMPARE( cbs[0]->currentText(), QString( "material" ) );
+  QCOMPARE( cbs[0]->isEnabled(), true );
+
+  QCOMPARE( cbs[1]->currentText(), QString( "diameter" ) );
+  QCOMPARE( cbs[1]->isEnabled(), false );
+
+  QCOMPARE( cbs[2]->currentText(), QString( "raccord" ) );
+  QCOMPARE( cbs[2]->isEnabled(), false );
+
+  // set a foreign key
+  w.setForeignKey( QVariant( 11 ) );
+
+  QCOMPARE( cbs[0]->currentText(), QString( "iron" ) );
+  QCOMPARE( cbs[1]->currentText(), QString( "120" ) );
+  QCOMPARE( cbs[2]->currentText(), QString( "sleeve" ) );
+
+  // delete the foreign key
+  w.deleteForeignKey();
+
+  QCOMPARE( cbs[0]->currentText(), QString( "material" ) );
+  QCOMPARE( cbs[0]->isEnabled(), true );
+
+  QCOMPARE( cbs[1]->currentText(), QString( "diameter" ) );
+  QCOMPARE( cbs[1]->isEnabled(), false );
+
+  QCOMPARE( cbs[2]->currentText(), QString( "raccord" ) );
+  QCOMPARE( cbs[2]->isEnabled(), false );
 }
 
 QTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
## Description

Backport of : https://github.com/qgis/QGIS/pull/5287

This PR fixes two issues regarding the relation reference widget when the `chain filter` option is activated:
- filter comboboxes are reset when the widget is initialised
- filter comboboxes are reset when the foreign key is deleted

Some tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
