### PR TITLE
Geometry cleanups and modernization

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1289,6 +1289,7 @@ QgsGeometryEngine        {#qgis_api_break_3_0_QgsGeometryEngine}
 - `centroid()` returns the point instead of working on a parameter. The return value is a `nullptr` when `false` has been returned in the past.
 - `pointOnSurface()` returns the point instead of working on a parameter. The return value is a `nullptr` when `false` has been returned in the past.
 - splitGeometry() now returns new geometries as QgsGeometry, instead of QgsAbstractGeometry
+- combine() now requires a list of QgsGeometry, instead of QgsAbstractGeometry
 
 
 QgsGeometrySimplifier        {#qgis_api_break_3_0_QgsGeometrySimplifier}

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1288,6 +1288,7 @@ QgsGeometryEngine        {#qgis_api_break_3_0_QgsGeometryEngine}
 - `QgsAbstractGeometry&` parameters have been changed to `QgsAbstractGeometry*` (Affects C++ only)
 - `centroid()` returns the point instead of working on a parameter. The return value is a `nullptr` when `false` has been returned in the past.
 - `pointOnSurface()` returns the point instead of working on a parameter. The return value is a `nullptr` when `false` has been returned in the past.
+- splitGeometry() now returns new geometries as QgsGeometry, instead of QgsAbstractGeometry
 
 
 QgsGeometrySimplifier        {#qgis_api_break_3_0_QgsGeometrySimplifier}

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -1170,7 +1170,7 @@ Returns an extruded version of this geometry.
  :rtype: int
 %End
 
-    QgsGeometry makeValid();
+    QgsGeometry makeValid() const;
 %Docstring
  Attempts to make an invalid geometry valid without losing vertices.
 
@@ -1225,7 +1225,7 @@ Returns an extruded version of this geometry.
       ValidatorGeos,
     };
 
-    void validateGeometry( QList<QgsGeometry::Error> &errors /Out/, ValidationMethod method = ValidatorQgisInternal );
+    void validateGeometry( QList<QgsGeometry::Error> &errors /Out/, ValidationMethod method = ValidatorQgisInternal ) const;
 %Docstring
  Validates geometry and produces a list of geometry errors.
  The ``method`` argument dictates which validator to utilize.

--- a/python/core/geometry/qgsgeometryengine.sip
+++ b/python/core/geometry/qgsgeometryengine.sip
@@ -77,7 +77,7 @@ class QgsGeometryEngine
  :rtype: QgsAbstractGeometry
 %End
 
-    virtual QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry * > &geometries, QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *combine( const QList< QgsGeometry > &geometries, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
  Calculate the combination of this and ``geometries``.
 

--- a/python/core/geometry/qgsgeometryengine.sip
+++ b/python/core/geometry/qgsgeometryengine.sip
@@ -37,7 +37,21 @@ class QgsGeometryEngine
     virtual ~QgsGeometryEngine();
 
     virtual void geometryChanged() = 0;
+%Docstring
+ Should be called whenever the geometry associated with the engine
+ has been modified and the engine must be updated to suit.
+%End
+
     virtual void prepareGeometry() = 0;
+%Docstring
+ Prepares the geometry, so that subsequent calls to spatial relation methods
+ are much faster.
+
+ This should be called for any geometry which is used for multiple relation
+ tests against other geometries.
+
+.. seealso:: geometryChanged()
+%End
 
     virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0 /Factory/;
 %Docstring
@@ -244,10 +258,17 @@ class QgsGeometryEngine
 %End
 
     virtual QgsGeometryEngine::EngineOperationResult splitGeometry( const QgsLineString &splitLine,
-        QList<QgsAbstractGeometry *> &newGeometries,
+        QList<QgsGeometry > &newGeometries /Out/,
         bool topological,
         QgsPointSequence &topologyTestPoints, QString *errorMsg = 0 ) const;
 %Docstring
+ Splits this geometry according to a given line.
+ \param splitLine the line that splits the geometry
+ \param[out] newGeometries list of new geometries that have been created with the split
+ \param topological true if topological editing is enabled
+ \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
+ \param[out] errorMsg error messages emitted, if any
+ :return: 0 in case of success, 1 if geometry has not been split, error else
  :rtype: QgsGeometryEngine.EngineOperationResult
 %End
 

--- a/src/app/layout/qgslayoutappmenuprovider.cpp
+++ b/src/app/layout/qgslayoutappmenuprovider.cpp
@@ -55,7 +55,7 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
     bool foundSelectedGroup = false;
     QList< QgsLayoutItemGroup * > groups;
     layout->layoutItems( groups );
-    for ( QgsLayoutItemGroup *group : qgsAsConst( groups ) )
+    for ( QgsLayoutItemGroup *group : qgis::as_const( groups ) )
     {
       if ( group->isSelected() )
       {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1166,7 +1166,7 @@ int main( int argc, char *argv[] )
   /////////////////////////////////////////////////////////////////////
   // autoload any file names that were passed in on the command line
   /////////////////////////////////////////////////////////////////////
-  for ( const QString &layerName : qgsAsConst( sFileList ) )
+  for ( const QString &layerName : qgis::as_const( sFileList ) )
   {
     QgsDebugMsg( QString( "Trying to load file : %1" ).arg( layerName ) );
     // don't load anything with a .qgs extension - these are project files

--- a/src/app/nodetool/qgsnodetool.cpp
+++ b/src/app/nodetool/qgsnodetool.cpp
@@ -332,11 +332,11 @@ void QgsNodeTool::clearDragBands()
   mDragPointMarkers.clear();
   mDragPointMarkersOffset.clear();
 
-  for ( const StraightBand &b : qgsAsConst( mDragStraightBands ) )
+  for ( const StraightBand &b : qgis::as_const( mDragStraightBands ) )
     delete b.band;
   mDragStraightBands.clear();
 
-  for ( const CircularBand &b : qgsAsConst( mDragCircularBands ) )
+  for ( const CircularBand &b : qgis::as_const( mDragCircularBands ) )
     delete b.band;
   mDragCircularBands.clear();
 }
@@ -352,7 +352,7 @@ void QgsNodeTool::cadCanvasPressEvent( QgsMapMouseEvent *e )
     QgsPointLocator::Match m = snapToEditableLayer( e );
     if ( m.hasVertex() )
     {
-      for ( const Vertex &selectedNode : qgsAsConst( mSelectedNodes ) )
+      for ( const Vertex &selectedNode : qgis::as_const( mSelectedNodes ) )
       {
         if ( selectedNode.layer == m.layer() && selectedNode.fid == m.featureId() && selectedNode.vertexId == m.vertexIndex() )
         {
@@ -783,7 +783,7 @@ void QgsNodeTool::mouseMoveNotDragging( QgsMapMouseEvent *e )
       QgsPointSequence points;
       QgsGeometryUtils::segmentizeArc( QgsPoint( pX ), QgsPoint( p0 ), QgsPoint( p1 ), points );
       mEdgeBand->reset();
-      for ( const QgsPoint &pt : qgsAsConst( points ) )
+      for ( const QgsPoint &pt : qgis::as_const( points ) )
         mEdgeBand->addPoint( pt );
     }
     else if ( isCircularVertex( geom, m.vertexIndex() + 1 ) )
@@ -794,7 +794,7 @@ void QgsNodeTool::mouseMoveNotDragging( QgsMapMouseEvent *e )
       QgsPointSequence points;
       QgsGeometryUtils::segmentizeArc( QgsPoint( p0 ), QgsPoint( p1 ), QgsPoint( pX ), points );
       mEdgeBand->reset();
-      for ( const QgsPoint &pt : qgsAsConst( points ) )
+      for ( const QgsPoint &pt : qgis::as_const( points ) )
         mEdgeBand->addPoint( pt );
     }
     else
@@ -974,7 +974,7 @@ void QgsNodeTool::deleteNodeEditorSelection()
   QgsVectorLayer *layer = mSelectedFeature->vlayer();
   QgsFeatureId fid = mSelectedFeature->featureId();
   QgsGeometry geometry = cachedGeometry( layer, fid );
-  for ( QgsVertexEntry *vertex : qgsAsConst( selFeatureVertices ) )
+  for ( QgsVertexEntry *vertex : qgis::as_const( selFeatureVertices ) )
   {
     if ( vertex->isSelected() )
     {
@@ -1053,7 +1053,7 @@ void QgsNodeTool::startDraggingMoveVertex( const QgsPointLocator::Match &m )
   QgsPointXY origDraggingVertexPoint = geom.vertexAt( mDraggingVertex->vertexId );
 
   // if there are other highlighted nodes, they should be dragged as well with their offset
-  for ( const Vertex &v : qgsAsConst( mSelectedNodes ) )
+  for ( const Vertex &v : qgis::as_const( mSelectedNodes ) )
   {
     if ( v != *mDraggingVertex )
     {
@@ -1100,7 +1100,7 @@ void QgsNodeTool::startDraggingMoveVertex( const QgsPointLocator::Match &m )
 
   QSet<Vertex> movingVertices;
   movingVertices << *mDraggingVertex;
-  for ( const Vertex &v : qgsAsConst( mDraggingExtraVertices ) )
+  for ( const Vertex &v : qgis::as_const( mDraggingExtraVertices ) )
     movingVertices << v;
 
   QgsPointXY dragVertexMapPoint = m.point();
@@ -1116,7 +1116,7 @@ void QgsNodeTool::buildDragBandsForVertices( const QSet<Vertex> &movingVertices,
   // i.e. every circular band is defined by its middle circular vertex
   QSet<Vertex> verticesInCircularBands;
 
-  for ( const Vertex &v : qgsAsConst( movingVertices ) )
+  for ( const Vertex &v : qgis::as_const( movingVertices ) )
   {
     int v0idx, v1idx;
     QgsGeometry geom = cachedGeometry( v.layer, v.fid );
@@ -1328,7 +1328,7 @@ void QgsNodeTool::startDraggingEdge( const QgsPointLocator::Match &m, const QgsP
 
   QgsPointXY layerPoint = toLayerCoordinates( m.layer(), mapPoint );
 
-  for ( const Vertex &v : qgsAsConst( movingVertices ) )
+  for ( const Vertex &v : qgis::as_const( movingVertices ) )
   {
     mDraggingExtraVertices << v;
     mDraggingExtraVerticesOffset << ( geom.vertexAt( v.vertexId ) - QgsPoint( layerPoint ) );
@@ -1535,7 +1535,7 @@ void QgsNodeTool::deleteVertex()
   {
     // if topo editing is enabled, delete all the vertices that are on the same location
     QSet<Vertex> topoVerticesToDelete;
-    for ( const Vertex &vertexToDelete : qgsAsConst( toDelete ) )
+    for ( const Vertex &vertexToDelete : qgis::as_const( toDelete ) )
     {
       QgsPointXY layerPt = cachedGeometryForVertex( vertexToDelete ).vertexAt( vertexToDelete.vertexId );
       QgsPointXY mapPt = toMapCoordinates( vertexToDelete.layer, layerPt );
@@ -1555,7 +1555,7 @@ void QgsNodeTool::deleteVertex()
 
   // switch from a plain list to dictionary { layer: { fid: [vertexNr1, vertexNr2, ...] } }
   QHash<QgsVectorLayer *, QHash<QgsFeatureId, QList<int> > > toDeleteGrouped;
-  for ( const Vertex &vertex : qgsAsConst( toDelete ) )
+  for ( const Vertex &vertex : qgis::as_const( toDelete ) )
   {
     toDeleteGrouped[vertex.layer][vertex.fid].append( vertex.vertexId );
   }
@@ -1591,7 +1591,7 @@ void QgsNodeTool::deleteVertex()
           }
         }
         // now delete the duplicities
-        for ( int duplicateVertexIndex : qgsAsConst( duplicateVertexIndices ) )
+        for ( int duplicateVertexIndex : qgis::as_const( duplicateVertexIndices ) )
           vertexIds.removeOne( duplicateVertexIndex );
       }
     }
@@ -1670,7 +1670,7 @@ void QgsNodeTool::setHighlightedNodes( QList<Vertex> listNodes )
   mSelectedNodesMarkers.clear();
   mSelectedNodes.clear();
 
-  for ( const Vertex &node : qgsAsConst( listNodes ) )
+  for ( const Vertex &node : qgis::as_const( listNodes ) )
   {
     QgsGeometry geom = cachedGeometryForVertex( node );
     QgsVertexId vid;
@@ -1689,7 +1689,7 @@ void QgsNodeTool::setHighlightedNodes( QList<Vertex> listNodes )
 
 void QgsNodeTool::setHighlightedNodesVisible( bool visible )
 {
-  for ( QgsVertexMarker *marker : qgsAsConst( mSelectedNodesMarkers ) )
+  for ( QgsVertexMarker *marker : qgis::as_const( mSelectedNodesMarkers ) )
     marker->setVisible( visible );
 }
 
@@ -1784,7 +1784,7 @@ void QgsNodeTool::CircularBand::updateRubberBand( const QgsPointXY &mapPoint )
   QgsGeometryUtils::segmentizeArc( QgsPoint( v0 ), QgsPoint( v1 ), QgsPoint( v2 ), points );
   // it would be useful to have QgsRubberBand::setPoints() call
   band->reset();
-  for ( const QgsPoint &p : qgsAsConst( points ) )
+  for ( const QgsPoint &p : qgis::as_const( points ) )
     band->addPoint( p );
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1423,7 +1423,7 @@ void QgisApp::dropEvent( QDropEvent *event )
   {
     freezeCanvases();
 
-    for ( const QString &file : qgsAsConst( files ) )
+    for ( const QString &file : qgis::as_const( files ) )
     {
       bool handled = false;
 
@@ -7926,7 +7926,7 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
 
   pasteVectorLayer->addFeatures( newFeatures );
   QgsFeatureIds newIds;
-  for ( const QgsFeature &f : qgsAsConst( newFeatures ) )
+  for ( const QgsFeature &f : qgis::as_const( newFeatures ) )
   {
     newIds << f.id();
   }

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -732,7 +732,7 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexe
   if ( !vlayer->auxiliaryLayer() )
     return false;
 
-  for ( const QgsPalLayerSettings::Property &p : qgsAsConst( mPalProperties ) )
+  for ( const QgsPalLayerSettings::Property &p : qgis::as_const( mPalProperties ) )
   {
     int index = -1;
 
@@ -779,7 +779,7 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsDiagramIn
   if ( !vlayer->auxiliaryLayer() )
     return false;
 
-  for ( const QgsDiagramLayerSettings::Property &p : qgsAsConst( mDiagramProperties ) )
+  for ( const QgsDiagramLayerSettings::Property &p : qgis::as_const( mDiagramProperties ) )
   {
     int index = -1;
 

--- a/src/app/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/qgsmaptoolshowhidelabels.cpp
@@ -142,7 +142,7 @@ void QgsMapToolShowHideLabels::showHideLabels( QMouseEvent *e )
     QList<QgsLabelPosition> positions;
     if ( selectedLabelFeatures( vlayer, positions ) )
     {
-      for ( const QgsLabelPosition &pos : qgsAsConst( positions ) )
+      for ( const QgsLabelPosition &pos : qgis::as_const( positions ) )
       {
         if ( showHide( pos, false ) )
           labelChanged = true;
@@ -154,7 +154,7 @@ void QgsMapToolShowHideLabels::showHideLabels( QMouseEvent *e )
     QgsFeatureIds fids;
     if ( selectedFeatures( vlayer, fids ) )
     {
-      for ( const QgsFeatureId &fid : qgsAsConst( fids ) )
+      for ( const QgsFeatureId &fid : qgis::as_const( fids ) )
       {
         QgsLabelPosition pos;
         pos.featureId = fid;

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2416,7 +2416,7 @@ void QgsOptions::showHelp()
   QString link;
 
   // give first priority to created pages which have specified a help key
-  for ( const QgsOptionsPageWidget *widget : qgsAsConst( mAdditionalOptionWidgets ) )
+  for ( const QgsOptionsPageWidget *widget : qgis::as_const( mAdditionalOptionWidgets ) )
   {
     if ( widget == activeTab )
     {

--- a/src/core/annotations/qgsannotationmanager.cpp
+++ b/src/core/annotations/qgsannotationmanager.cpp
@@ -62,7 +62,7 @@ bool QgsAnnotationManager::removeAnnotation( QgsAnnotation *annotation )
 
 void QgsAnnotationManager::clear()
 {
-  for ( auto *a : qgsAsConst( mAnnotations ) )
+  for ( auto *a : qgis::as_const( mAnnotations ) )
   {
     removeAnnotation( a );
   }
@@ -76,7 +76,7 @@ QList<QgsAnnotation *> QgsAnnotationManager::annotations() const
 QList<QgsAnnotation *> QgsAnnotationManager::cloneAnnotations() const
 {
   QList<QgsAnnotation *> results;
-  for ( const auto *a : qgsAsConst( mAnnotations ) )
+  for ( const auto *a : qgis::as_const( mAnnotations ) )
   {
     results << a->clone();
   }

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -2437,7 +2437,7 @@ const QList<QSslCertificate> QgsAuthManager::getExtraFileCAs()
     filecerts = QgsAuthCertUtils::certsFromFile( cafile );
   }
   // only CAs or certs capable of signing other certs are allowed
-  for ( const auto &cert : qgsAsConst( filecerts ) )
+  for ( const auto &cert : qgis::as_const( filecerts ) )
   {
     if ( !allowinvalid.toBool() && !cert.isValid() )
     {
@@ -3403,7 +3403,7 @@ bool QgsAuthManager::reencryptAllAuthenticationSettings( const QString &prevpass
   QStringList encryptedsettings;
   encryptedsettings << "";
 
-  for ( const auto & sett, qgsAsConst( encryptedsettings ) )
+  for ( const auto & sett, qgis::as_const( encryptedsettings ) )
   {
     if ( sett.isEmpty() || !existsAuthSetting( sett ) )
       continue;

--- a/src/core/diagram/qgshistogramdiagram.cpp
+++ b/src/core/diagram/qgshistogramdiagram.cpp
@@ -49,7 +49,7 @@ QSizeF QgsHistogramDiagram::diagramSize( const QgsFeature &feature, const QgsRen
   if ( !feature.fields().isEmpty() )
     expressionContext.setFields( feature.fields() );
 
-  for ( const QString &cat : qgsAsConst( s.categoryAttributes ) )
+  for ( const QString &cat : qgis::as_const( s.categoryAttributes ) )
   {
     QgsExpression *expression = getExpression( cat, expressionContext );
     maxValue = std::max( expression->evaluate( &expressionContext ).toDouble(), maxValue );
@@ -151,7 +151,7 @@ void QgsHistogramDiagram::renderDiagram( const QgsFeature &feature, QgsRenderCon
   if ( !feature.fields().isEmpty() )
     expressionContext.setFields( feature.fields() );
 
-  for ( const QString &cat : qgsAsConst( s.categoryAttributes ) )
+  for ( const QString &cat : qgis::as_const( s.categoryAttributes ) )
   {
     QgsExpression *expression = getExpression( cat, expressionContext );
     double currentVal = expression->evaluate( &expressionContext ).toDouble();

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -802,7 +802,7 @@ void QgsDxfExport::writeTables()
   writeGroup( 6, QStringLiteral( "CONTINUOUS" ) );
   writeHandle( 390, DXF_HANDPLOTSTYLE );
 
-  for ( const QString &layerName : qgsAsConst( layerNames ) )
+  for ( const QString &layerName : qgis::as_const( layerNames ) )
   {
     writeGroup( 0, QStringLiteral( "LAYER" ) );
     writeHandle();

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -514,7 +514,7 @@ QString QgsExpression::helpText( QString name )
                         .arg( tr( "%1 %2" ).arg( f.mType, name ),
                               f.mDescription ) );
 
-  for ( const HelpVariant &v : qgsAsConst( f.mVariants ) )
+  for ( const HelpVariant &v : qgis::as_const( f.mVariants ) )
   {
     if ( f.mVariants.size() > 1 )
     {
@@ -546,7 +546,7 @@ QString QgsExpression::helpText( QString name )
         helpContents += '(';
 
         QString delim;
-        for ( const HelpArg &a : qgsAsConst( v.mArguments ) )
+        for ( const HelpArg &a : qgis::as_const( v.mArguments ) )
         {
           helpContents += delim;
           delim = QStringLiteral( ", " );
@@ -572,7 +572,7 @@ QString QgsExpression::helpText( QString name )
     {
       helpContents += QStringLiteral( "<h4>%1</h4>\n<div class=\"arguments\">\n<table>" ).arg( tr( "Arguments" ) );
 
-      for ( const HelpArg &a : qgsAsConst( v.mArguments ) )
+      for ( const HelpArg &a : qgis::as_const( v.mArguments ) )
       {
         if ( a.mSyntaxOnly )
           continue;
@@ -587,7 +587,7 @@ QString QgsExpression::helpText( QString name )
     {
       helpContents += QStringLiteral( "<h4>%1</h4>\n<div class=\"examples\">\n<ul>\n" ).arg( tr( "Examples" ) );
 
-      for ( const HelpExample &e : qgsAsConst( v.mExamples ) )
+      for ( const HelpExample &e : qgis::as_const( v.mExamples ) )
       {
         helpContents += "<li><code>" + e.mExpression + "</code> &rarr; <code>" + e.mReturns + "</code>";
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2853,7 +2853,7 @@ static QVariant fcnOrderParts( const QVariantList &values, const QgsExpressionCo
   while ( orderedGeom->partCount() )
     orderedGeom->removeGeometry( 0 );
 
-  for ( const QgsFeature &feature : qgsAsConst( partFeatures ) )
+  for ( const QgsFeature &feature : qgis::as_const( partFeatures ) )
   {
     orderedGeom->addGeometry( feature.geometry().geometry()->clone() );
   }
@@ -4467,7 +4467,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     QgsExpressionContextUtils::registerContextFunctions();
 
     //QgsExpression has ownership of all built-in functions
-    for ( QgsExpressionFunction *func : qgsAsConst( sFunctions ) )
+    for ( QgsExpressionFunction *func : qgis::as_const( sFunctions ) )
     {
       sOwnedFunctions << func;
       sBuiltinFunctions << func->name();

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -1256,7 +1256,7 @@ QgsExpressionNode::NodeType QgsExpressionNodeCondition::nodeType() const
 
 QVariant QgsExpressionNodeCondition::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
-  for ( WhenThen *cond : qgsAsConst( mConditions ) )
+  for ( WhenThen *cond : qgis::as_const( mConditions ) )
   {
     QVariant vWhen = cond->mWhenExp->eval( parent, context );
     QgsExpressionUtils::TVL tvl = QgsExpressionUtils::getTVLValue( vWhen, parent );
@@ -1283,7 +1283,7 @@ QVariant QgsExpressionNodeCondition::evalNode( QgsExpression *parent, const QgsE
 bool QgsExpressionNodeCondition::prepareNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   bool res;
-  for ( WhenThen *cond : qgsAsConst( mConditions ) )
+  for ( WhenThen *cond : qgis::as_const( mConditions ) )
   {
     res = cond->mWhenExp->prepare( parent, context )
           & cond->mThenExp->prepare( parent, context );

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -57,7 +57,7 @@ QString QgsValueRelationFieldFormatter::representValue( QgsVectorLayer *layer, i
     QStringList keyList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
     QStringList valueList;
 
-    for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : qgsAsConst( vrCache ) )
+    for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : qgis::as_const( vrCache ) )
     {
       if ( keyList.contains( item.key.toString() ) )
       {
@@ -74,7 +74,7 @@ QString QgsValueRelationFieldFormatter::representValue( QgsVectorLayer *layer, i
       return QgsApplication::nullRepresentation();
     }
 
-    for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : qgsAsConst( vrCache ) )
+    for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : qgis::as_const( vrCache ) )
     {
       if ( item.key == value )
       {

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -284,7 +284,7 @@ QList<QgsGeoNodeRequest::ServiceLayerDetail> QgsGeoNodeRequest::parseLayers( con
 
   if ( majorVersion == 2 && minorVersion == 6 )
   {
-    for ( const QVariant &layer : qgsAsConst( layerList ) )
+    for ( const QVariant &layer : qgis::as_const( layerList ) )
     {
       QgsGeoNodeRequest::ServiceLayerDetail layerStruct;
       const QVariantMap layerMap = layer.toMap();
@@ -323,7 +323,7 @@ QList<QgsGeoNodeRequest::ServiceLayerDetail> QgsGeoNodeRequest::parseLayers( con
   // Geonode version 2.7 or newer
   else if ( ( majorVersion == 2 && minorVersion >= 7 ) || ( majorVersion >= 3 ) )
   {
-    for ( const QVariant &layer : qgsAsConst( layerList ) )
+    for ( const QVariant &layer : qgis::as_const( layerList ) )
     {
       QgsGeoNodeRequest::ServiceLayerDetail layerStruct;
       const QVariantMap layerMap = layer.toMap();

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -200,7 +200,7 @@ bool QgsCompoundCurve::fromWkt( const QString &wkt )
   //if so, update the type dimensionality of the compound curve to match
   bool hasZ = false;
   bool hasM = false;
-  for ( const QgsCurve *curve : qgsAsConst( mCurves ) )
+  for ( const QgsCurve *curve : qgis::as_const( mCurves ) )
   {
     hasZ = hasZ || curve->is3D();
     hasM = hasM || curve->isMeasure();
@@ -232,7 +232,7 @@ QByteArray QgsCompoundCurve::asWkb() const
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << static_cast<quint32>( mCurves.size() );
-  for ( const QByteArray &wkbForCurve : qgsAsConst( wkbForCurves ) )
+  for ( const QByteArray &wkbForCurve : qgis::as_const( wkbForCurves ) )
   {
     wkb << wkbForCurve;
   }
@@ -475,7 +475,7 @@ void QgsCompoundCurve::draw( QPainter &p ) const
 
 void QgsCompoundCurve::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
 {
-  for ( QgsCurve *curve : qgsAsConst( mCurves ) )
+  for ( QgsCurve *curve : qgis::as_const( mCurves ) )
   {
     curve->transform( ct, d, transformZ );
   }
@@ -484,7 +484,7 @@ void QgsCompoundCurve::transform( const QgsCoordinateTransform &ct, QgsCoordinat
 
 void QgsCompoundCurve::transform( const QTransform &t )
 {
-  for ( QgsCurve *curve : qgsAsConst( mCurves ) )
+  for ( QgsCurve *curve : qgis::as_const( mCurves ) )
   {
     curve->transform( t );
   }
@@ -795,7 +795,7 @@ bool QgsCompoundCurve::addZValue( double zValue )
 
   mWkbType = QgsWkbTypes::addZ( mWkbType );
 
-  for ( QgsCurve *curve : qgsAsConst( mCurves ) )
+  for ( QgsCurve *curve : qgis::as_const( mCurves ) )
   {
     curve->addZValue( zValue );
   }
@@ -810,7 +810,7 @@ bool QgsCompoundCurve::addMValue( double mValue )
 
   mWkbType = QgsWkbTypes::addM( mWkbType );
 
-  for ( QgsCurve *curve : qgsAsConst( mCurves ) )
+  for ( QgsCurve *curve : qgis::as_const( mCurves ) )
   {
     curve->addMValue( mValue );
   }
@@ -824,7 +824,7 @@ bool QgsCompoundCurve::dropZValue()
     return false;
 
   mWkbType = QgsWkbTypes::dropZ( mWkbType );
-  for ( QgsCurve *curve : qgsAsConst( mCurves ) )
+  for ( QgsCurve *curve : qgis::as_const( mCurves ) )
   {
     curve->dropZValue();
   }
@@ -838,7 +838,7 @@ bool QgsCompoundCurve::dropMValue()
     return false;
 
   mWkbType = QgsWkbTypes::dropM( mWkbType );
-  for ( QgsCurve *curve : qgsAsConst( mCurves ) )
+  for ( QgsCurve *curve : qgis::as_const( mCurves ) )
   {
     curve->dropMValue();
   }

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -243,7 +243,7 @@ bool QgsCurvePolygon::fromWkt( const QString &wkt )
     hasZ = hasZ || mExteriorRing->is3D();
     hasM = hasM || mExteriorRing->isMeasure();
   }
-  for ( const QgsCurve *curve : qgsAsConst( mInteriorRings ) )
+  for ( const QgsCurve *curve : qgis::as_const( mInteriorRings ) )
   {
     hasZ = hasZ || curve->is3D();
     hasM = hasM || curve->isMeasure();
@@ -290,7 +290,7 @@ QByteArray QgsCurvePolygon::asWkb() const
   wkbPtr << static_cast<char>( QgsApplication::endian() );
   wkbPtr << static_cast<quint32>( wkbType() );
   wkbPtr << static_cast<quint32>( wkbForRings.count() );
-  for ( const QByteArray &wkb : qgsAsConst( wkbForRings ) )
+  for ( const QByteArray &wkb : qgis::as_const( wkbForRings ) )
   {
     wkbPtr << wkb;
   }
@@ -545,7 +545,7 @@ void QgsCurvePolygon::setExteriorRing( QgsCurve *ring )
   }
 
   //match dimensionality for rings
-  for ( QgsCurve *ring : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *ring : qgis::as_const( mInteriorRings ) )
   {
     if ( is3D() )
       ring->addZValue();
@@ -652,7 +652,7 @@ void QgsCurvePolygon::transform( const QgsCoordinateTransform &ct, QgsCoordinate
     mExteriorRing->transform( ct, d, transformZ );
   }
 
-  for ( QgsCurve *curve : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *curve : qgis::as_const( mInteriorRings ) )
   {
     curve->transform( ct, d, transformZ );
   }
@@ -666,7 +666,7 @@ void QgsCurvePolygon::transform( const QTransform &t )
     mExteriorRing->transform( t );
   }
 
-  for ( QgsCurve *curve : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *curve : qgis::as_const( mInteriorRings ) )
   {
     curve->transform( t );
   }
@@ -928,7 +928,7 @@ bool QgsCurvePolygon::addZValue( double zValue )
 
   if ( mExteriorRing )
     mExteriorRing->addZValue( zValue );
-  for ( QgsCurve *curve : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *curve : qgis::as_const( mInteriorRings ) )
   {
     curve->addZValue( zValue );
   }
@@ -945,7 +945,7 @@ bool QgsCurvePolygon::addMValue( double mValue )
 
   if ( mExteriorRing )
     mExteriorRing->addMValue( mValue );
-  for ( QgsCurve *curve : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *curve : qgis::as_const( mInteriorRings ) )
   {
     curve->addMValue( mValue );
   }
@@ -961,7 +961,7 @@ bool QgsCurvePolygon::dropZValue()
   mWkbType = QgsWkbTypes::dropZ( mWkbType );
   if ( mExteriorRing )
     mExteriorRing->dropZValue();
-  for ( QgsCurve *curve : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *curve : qgis::as_const( mInteriorRings ) )
   {
     curve->dropZValue();
   }
@@ -977,7 +977,7 @@ bool QgsCurvePolygon::dropMValue()
   mWkbType = QgsWkbTypes::dropM( mWkbType );
   if ( mExteriorRing )
     mExteriorRing->dropMValue();
-  for ( QgsCurve *curve : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *curve : qgis::as_const( mInteriorRings ) )
   {
     curve->dropMValue();
   }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2228,17 +2228,8 @@ QgsGeometry QgsGeometry::unaryUnion( const QList<QgsGeometry> &geometries )
 {
   QgsGeos geos( nullptr );
 
-  QList<QgsAbstractGeometry *> geomV2List;
-  for ( const QgsGeometry &g : geometries )
-  {
-    if ( !( g.isNull() ) )
-    {
-      geomV2List.append( g.geometry() );
-    }
-  }
-
   QString error;
-  std::unique_ptr< QgsAbstractGeometry > geom( geos.combine( geomV2List, &error ) );
+  std::unique_ptr< QgsAbstractGeometry > geom( geos.combine( geometries, &error ) );
   QgsGeometry result( std::move( geom ) );
   result.mLastError = error;
   return result;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -730,7 +730,7 @@ QgsGeometry QgsGeometry::removeInteriorRings( double minimumRingArea ) const
       return QgsGeometry();
 
     QgsGeometry first = results.takeAt( 0 );
-    for ( const QgsGeometry &result : qgsAsConst( results ) )
+    for ( const QgsGeometry &result : qgis::as_const( results ) )
     {
       first.addPart( result );
     }
@@ -810,7 +810,7 @@ QgsGeometry::OperationResult QgsGeometry::splitGeometry( const QList<QgsPointXY>
     detachAndReset( std::unique_ptr< QgsAbstractGeometry >( newGeoms.takeFirst() ) );
 
     newGeometries.clear();
-    for ( QgsAbstractGeometry *part : qgsAsConst( newGeoms ) )
+    for ( QgsAbstractGeometry *part : qgis::as_const( newGeoms ) )
     {
       newGeometries.push_back( QgsGeometry( part ) );
     }
@@ -1624,7 +1624,7 @@ QgsGeometry QgsGeometry::offsetCurve( double distance, int segments, JoinStyle j
       return QgsGeometry();
 
     QgsGeometry first = results.takeAt( 0 );
-    for ( const QgsGeometry &result : qgsAsConst( results ) )
+    for ( const QgsGeometry &result : qgis::as_const( results ) )
     {
       first.addPart( result );
     }
@@ -1666,7 +1666,7 @@ QgsGeometry QgsGeometry::singleSidedBuffer( double distance, int segments, Buffe
       return QgsGeometry();
 
     QgsGeometry first = results.takeAt( 0 );
-    for ( const QgsGeometry &result : qgsAsConst( results ) )
+    for ( const QgsGeometry &result : qgis::as_const( results ) )
     {
       first.addPart( result );
     }
@@ -1709,7 +1709,7 @@ QgsGeometry QgsGeometry::extendLine( double startDistance, double endDistance ) 
       return QgsGeometry();
 
     QgsGeometry first = results.takeAt( 0 );
-    for ( const QgsGeometry &result : qgsAsConst( results ) )
+    for ( const QgsGeometry &result : qgis::as_const( results ) )
     {
       first.addPart( result );
     }
@@ -2132,7 +2132,7 @@ QPolygonF QgsGeometry::asQPolygonF() const
     return result;
   }
 
-  for ( const QgsPointXY &p : qgsAsConst( polyline ) )
+  for ( const QgsPointXY &p : qgis::as_const( polyline ) )
   {
     result << p.toQPointF();
   }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -797,7 +797,7 @@ QgsGeometry::OperationResult QgsGeometry::splitGeometry( const QList<QgsPointXY>
     return InvalidBaseGeometry;
   }
 
-  QList<QgsAbstractGeometry *> newGeoms;
+  QList<QgsGeometry > newGeoms;
   QgsLineString splitLineString( splitLine );
   QgsPointSequence tp;
 
@@ -807,13 +807,9 @@ QgsGeometry::OperationResult QgsGeometry::splitGeometry( const QList<QgsPointXY>
 
   if ( result == QgsGeometryEngine::Success )
   {
-    reset( std::unique_ptr< QgsAbstractGeometry >( newGeoms.takeFirst() ) );
+    *this = newGeoms.takeAt( 0 );
 
-    newGeometries.clear();
-    for ( QgsAbstractGeometry *part : qgis::as_const( newGeoms ) )
-    {
-      newGeometries.push_back( QgsGeometry( part ) );
-    }
+    newGeometries = newGeoms;
   }
 
   convertPointList( tp, topologyTestPoints );
@@ -2252,7 +2248,7 @@ QgsGeometry QgsGeometry::polygonize( const QList<QgsGeometry> &geometryList )
 {
   QgsGeos geos( nullptr );
 
-  QList<QgsAbstractGeometry *> geomV2List;
+  QList<const QgsAbstractGeometry *> geomV2List;
   for ( const QgsGeometry &g : geometryList )
   {
     if ( !( g.isNull() ) )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1537,13 +1537,13 @@ class CORE_EXPORT QgsGeometry
      * Detaches the private geometry container from this instance, and clones
      * the existing geometry ready for modification.
      */
-    void detachAndClone();
+    void detach();
 
     /**
      * Detaches the private geometry container from this instance, and resets it
      * to a new abstract geometry pointer.
      */
-    void detachAndReset( std::unique_ptr< QgsAbstractGeometry > newGeometry );
+    void reset( std::unique_ptr< QgsAbstractGeometry > newGeometry );
 
     static void convertToPolyline( const QgsPointSequence &input, QgsPolyline &output );
     static void convertPolygon( const QgsPolygonV2 &input, QgsPolygon &output );

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -24,6 +24,7 @@ email                : morb at ozemail dot com dot au
 #include <geos_c.h>
 #include <climits>
 #include <limits>
+#include <memory>
 
 #include "qgis_core.h"
 #include "qgis.h"
@@ -136,6 +137,12 @@ class CORE_EXPORT QgsGeometry
      */
     explicit QgsGeometry( QgsAbstractGeometry *geom SIP_TRANSFER );
 
+    /**
+     * Creates a geometry from an abstract geometry object. Ownership of
+     * geom is transferred.
+     * \note Not available in Python bindings
+     */
+    explicit QgsGeometry( std::unique_ptr< QgsAbstractGeometry > geom ) SIP_SKIP;
 
     ~QgsGeometry();
 
@@ -1154,7 +1161,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \since QGIS 3.0
      */
-    QgsGeometry makeValid();
+    QgsGeometry makeValid() const;
 
     /**
      * \ingroup core
@@ -1200,7 +1207,7 @@ class CORE_EXPORT QgsGeometry
      * \since QGIS 1.5
      * \note Available in Python bindings since QGIS 1.6
      **/
-    void validateGeometry( QList<QgsGeometry::Error> &errors SIP_OUT, ValidationMethod method = ValidatorQgisInternal );
+    void validateGeometry( QList<QgsGeometry::Error> &errors SIP_OUT, ValidationMethod method = ValidatorQgisInternal ) const;
 
     /**
      * Compute the unary union on a list of \a geometries. May be faster than an iterative union on a set of geometries.
@@ -1526,7 +1533,17 @@ class CORE_EXPORT QgsGeometry
     //! Last error encountered
     mutable QString mLastError;
 
-    void detach( bool cloneGeom = true ); //make sure mGeometry only referenced from this instance
+    /**
+     * Detaches the private geometry container from this instance, and clones
+     * the existing geometry ready for modification.
+     */
+    void detachAndClone();
+
+    /**
+     * Detaches the private geometry container from this instance, and resets it
+     * to a new abstract geometry pointer.
+     */
+    void detachAndReset( std::unique_ptr< QgsAbstractGeometry > newGeometry );
 
     static void convertToPolyline( const QgsPointSequence &input, QgsPolyline &output );
     static void convertPolygon( const QgsPolygonV2 &input, QgsPolygon &output );
@@ -1549,8 +1566,8 @@ class CORE_EXPORT QgsGeometry
      * \param minimumDistance minimum segment length to apply smoothing to
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
     */
-    QgsLineString *smoothLine( const QgsLineString &line, const unsigned int iterations = 1, const double offset = 0.25,
-                               double minimumDistance = -1, double maxAngle = 180.0 ) const;
+    std::unique_ptr< QgsLineString > smoothLine( const QgsLineString &line, const unsigned int iterations = 1, const double offset = 0.25,
+        double minimumDistance = -1, double maxAngle = 180.0 ) const;
 
     /**
      * Smooths a polygon using the Chaikin algorithm
@@ -1563,8 +1580,8 @@ class CORE_EXPORT QgsGeometry
      * \param minimumDistance minimum segment length to apply smoothing to
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
     */
-    QgsPolygonV2 *smoothPolygon( const QgsPolygonV2 &polygon, const unsigned int iterations = 1, const double offset = 0.25,
-                                 double minimumDistance = -1, double maxAngle = 180.0 ) const;
+    std::unique_ptr< QgsPolygonV2 > smoothPolygon( const QgsPolygonV2 &polygon, const unsigned int iterations = 1, const double offset = 0.25,
+        double minimumDistance = -1, double maxAngle = 180.0 ) const;
 
 
 }; // class QgsGeometry

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -169,7 +169,7 @@ QString QgsGeometryCollection::geometryType() const
 
 void QgsGeometryCollection::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
 {
-  for ( QgsAbstractGeometry *g : qgsAsConst( mGeometries ) )
+  for ( QgsAbstractGeometry *g : qgis::as_const( mGeometries ) )
   {
     g->transform( ct, d, transformZ );
   }
@@ -178,7 +178,7 @@ void QgsGeometryCollection::transform( const QgsCoordinateTransform &ct, QgsCoor
 
 void QgsGeometryCollection::transform( const QTransform &t )
 {
-  for ( QgsAbstractGeometry *g : qgsAsConst( mGeometries ) )
+  for ( QgsAbstractGeometry *g : qgis::as_const( mGeometries ) )
   {
     g->transform( t );
   }
@@ -262,7 +262,7 @@ QByteArray QgsGeometryCollection::asWkb() const
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << static_cast<quint32>( wkbForGeometries.count() );
-  for ( const QByteArray &wkbForGeometry : qgsAsConst( wkbForGeometries ) )
+  for ( const QByteArray &wkbForGeometry : qgis::as_const( wkbForGeometries ) )
   {
     wkb << wkbForGeometry;
   }
@@ -569,7 +569,7 @@ bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QList<Q
   //if so, update the type dimensionality of the collection to match
   bool hasZ = false;
   bool hasM = false;
-  for ( QgsAbstractGeometry *geom : qgsAsConst( mGeometries ) )
+  for ( QgsAbstractGeometry *geom : qgis::as_const( mGeometries ) )
   {
     hasZ = hasZ || geom->is3D();
     hasM = hasM || geom->isMeasure();
@@ -667,7 +667,7 @@ bool QgsGeometryCollection::addZValue( double zValue )
 
   mWkbType = QgsWkbTypes::addZ( mWkbType );
 
-  for ( QgsAbstractGeometry *geom : qgsAsConst( mGeometries ) )
+  for ( QgsAbstractGeometry *geom : qgis::as_const( mGeometries ) )
   {
     geom->addZValue( zValue );
   }
@@ -682,7 +682,7 @@ bool QgsGeometryCollection::addMValue( double mValue )
 
   mWkbType = QgsWkbTypes::addM( mWkbType );
 
-  for ( QgsAbstractGeometry *geom : qgsAsConst( mGeometries ) )
+  for ( QgsAbstractGeometry *geom : qgis::as_const( mGeometries ) )
   {
     geom->addMValue( mValue );
   }
@@ -697,7 +697,7 @@ bool QgsGeometryCollection::dropZValue()
     return false;
 
   mWkbType = QgsWkbTypes::dropZ( mWkbType );
-  for ( QgsAbstractGeometry *geom : qgsAsConst( mGeometries ) )
+  for ( QgsAbstractGeometry *geom : qgis::as_const( mGeometries ) )
   {
     geom->dropZValue();
   }
@@ -711,7 +711,7 @@ bool QgsGeometryCollection::dropMValue()
     return false;
 
   mWkbType = QgsWkbTypes::dropM( mWkbType );
-  for ( QgsAbstractGeometry *geom : qgsAsConst( mGeometries ) )
+  for ( QgsAbstractGeometry *geom : qgis::as_const( mGeometries ) )
   {
     geom->dropMValue();
   }

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -125,11 +125,11 @@ QgsGeometry::OperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry 
       std::unique_ptr<QgsCurvePolygon> poly;
       if ( QgsWkbTypes::flatType( curve->wkbType() ) == QgsWkbTypes::LineString )
       {
-        poly.reset( new QgsPolygonV2() );
+        poly = qgis::make_unique< QgsPolygonV2 >();
       }
       else
       {
-        poly.reset( new QgsCurvePolygon() );
+        poly = qgis::make_unique< QgsCurvePolygon >();
       }
       // Ownership is still with part, curve points to the same object and is transferred
       // to poly here.

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -240,7 +240,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
   if ( avoidIntersectionsLayers.isEmpty() )
     return nullptr; //no intersections stored in project does not mean error
 
-  QList< QgsAbstractGeometry * > nearGeometries;
+  QList< QgsGeometry > nearGeometries;
 
   //go through list, convert each layer to vector layer and call QgsVectorLayer::removePolygonIntersections for each
   for ( QgsVectorLayer *currentLayer : avoidIntersectionsLayers )
@@ -262,7 +262,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
       if ( !f.hasGeometry() )
         continue;
 
-      nearGeometries << f.geometry().geometry()->clone();
+      nearGeometries << f.geometry();
     }
   }
 
@@ -271,9 +271,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryEditUtils::avoidIntersections( c
     return nullptr;
   }
 
-
   std::unique_ptr< QgsAbstractGeometry > combinedGeometries( geomEngine->combine( nearGeometries ) );
-  qDeleteAll( nearGeometries );
   if ( !combinedGeometries )
   {
     return nullptr;

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -26,9 +26,8 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgsvectorlayer.h"
 #include <limits>
 
-QgsGeometry::OperationResult QgsGeometryEditUtils::addRing( QgsAbstractGeometry *geom, QgsCurve *r )
+QgsGeometry::OperationResult QgsGeometryEditUtils::addRing( QgsAbstractGeometry *geom, std::unique_ptr<QgsCurve> ring )
 {
-  std::unique_ptr<QgsCurve> ring( r );
   if ( !ring )
   {
     return QgsGeometry::InvalidInput;
@@ -96,9 +95,8 @@ QgsGeometry::OperationResult QgsGeometryEditUtils::addRing( QgsAbstractGeometry 
   return QgsGeometry::AddRingNotInExistingFeature; //not contained in any outer ring
 }
 
-QgsGeometry::OperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry *geom, QgsAbstractGeometry *p )
+QgsGeometry::OperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry *geom, std::unique_ptr<QgsAbstractGeometry> part )
 {
-  std::unique_ptr<QgsAbstractGeometry> part( p );
   if ( !geom )
   {
     return QgsGeometry::InvalidBaseGeometry;

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -45,7 +45,7 @@ class QgsGeometryEditUtils
      * \returns 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
      * 3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring
      */
-    static QgsGeometry::OperationResult addRing( QgsAbstractGeometry *geometry, QgsCurve *ring SIP_TRANSFER );
+    static QgsGeometry::OperationResult addRing( QgsAbstractGeometry *geometry, std::unique_ptr< QgsCurve > ring );
 
     /**
      * Add a \a part to multi type \a geometry.
@@ -53,7 +53,7 @@ class QgsGeometryEditUtils
      * \returns 0 in case of success, 1 if not a multigeometry, 2 if part is not a valid geometry, 3 if new polygon ring
      * not disjoint with existing polygons of the feature
      */
-    static QgsGeometry::OperationResult addPart( QgsAbstractGeometry *geometry, QgsAbstractGeometry *part SIP_TRANSFER );
+    static QgsGeometry::OperationResult addPart( QgsAbstractGeometry *geometry, std::unique_ptr< QgsAbstractGeometry > part );
 
     /**
      * Deletes a ring from a geometry.

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsGeometryEngine
      *
      * \since QGIS 3.0 \a geom is a pointer
      */
-    virtual QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry * > &geometries, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *combine( const QList< QgsGeometry > &geometries, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
 
     /**
      * Calculate the symmetric difference of this and \a geom.

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -53,7 +53,21 @@ class CORE_EXPORT QgsGeometryEngine
 
     virtual ~QgsGeometryEngine() = default;
 
+    /**
+     * Should be called whenever the geometry associated with the engine
+     * has been modified and the engine must be updated to suit.
+     */
     virtual void geometryChanged() = 0;
+
+    /**
+     * Prepares the geometry, so that subsequent calls to spatial relation methods
+     * are much faster.
+     *
+     * This should be called for any geometry which is used for multiple relation
+     * tests against other geometries.
+     *
+     * \see geometryChanged()
+     */
     virtual void prepareGeometry() = 0;
 
     /**
@@ -213,8 +227,17 @@ class CORE_EXPORT QgsGeometryEngine
      */
     virtual bool isSimple( QString *errorMsg = nullptr ) const = 0;
 
+    /**
+     * Splits this geometry according to a given line.
+     * \param splitLine the line that splits the geometry
+     * \param[out] newGeometries list of new geometries that have been created with the split
+     * \param topological true if topological editing is enabled
+     * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
+     * \param[out] errorMsg error messages emitted, if any
+     * \returns 0 in case of success, 1 if geometry has not been split, error else
+    */
     virtual QgsGeometryEngine::EngineOperationResult splitGeometry( const QgsLineString &splitLine,
-        QList<QgsAbstractGeometry *> &newGeometries,
+        QList<QgsGeometry > &newGeometries SIP_OUT,
         bool topological,
         QgsPointSequence &topologyTestPoints, QString *errorMsg = nullptr ) const
     {

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -75,51 +75,51 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryFactory::geomFromWkt( const QStr
   std::unique_ptr< QgsAbstractGeometry> geom;
   if ( trimmed.startsWith( QLatin1String( "Point" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsPoint() );
+    geom = qgis::make_unique< QgsPoint >();
   }
   else if ( trimmed.startsWith( QLatin1String( "LineString" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsLineString() );
+    geom = qgis::make_unique< QgsLineString >();
   }
   else if ( trimmed.startsWith( QLatin1String( "CircularString" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsCircularString() );
+    geom = qgis::make_unique< QgsCircularString >();
   }
   else if ( trimmed.startsWith( QLatin1String( "CompoundCurve" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsCompoundCurve() );
+    geom = qgis::make_unique< QgsCompoundCurve>();
   }
   else if ( trimmed.startsWith( QLatin1String( "Polygon" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsPolygonV2() );
+    geom = qgis::make_unique< QgsPolygonV2 >();
   }
   else if ( trimmed.startsWith( QLatin1String( "CurvePolygon" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsCurvePolygon() );
+    geom = qgis::make_unique< QgsCurvePolygon >();
   }
   else if ( trimmed.startsWith( QLatin1String( "MultiPoint" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsMultiPointV2() );
+    geom = qgis::make_unique< QgsMultiPointV2 >();
   }
   else if ( trimmed.startsWith( QLatin1String( "MultiCurve" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsMultiCurve() );
+    geom = qgis::make_unique< QgsMultiCurve >();
   }
   else if ( trimmed.startsWith( QLatin1String( "MultiLineString" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsMultiLineString() );
+    geom = qgis::make_unique< QgsMultiLineString >();
   }
   else if ( trimmed.startsWith( QLatin1String( "MultiSurface" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsMultiSurface() );
+    geom = qgis::make_unique< QgsMultiSurface >();
   }
   else if ( trimmed.startsWith( QLatin1String( "MultiPolygon" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsMultiPolygonV2() );
+    geom = qgis::make_unique< QgsMultiPolygonV2 >();
   }
   else if ( trimmed.startsWith( QLatin1String( "GeometryCollection" ), Qt::CaseInsensitive ) )
   {
-    geom.reset( new QgsGeometryCollection() );
+    geom = qgis::make_unique< QgsGeometryCollection >();
   }
 
   if ( geom )
@@ -134,12 +134,12 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryFactory::geomFromWkt( const QStr
 
 std::unique_ptr< QgsAbstractGeometry > QgsGeometryFactory::fromPoint( const QgsPointXY &point )
 {
-  return std::unique_ptr< QgsAbstractGeometry >( new QgsPoint( point.x(), point.y() ) );
+  return qgis::make_unique< QgsPoint >( point.x(), point.y() );
 }
 
 std::unique_ptr<QgsMultiPointV2> QgsGeometryFactory::fromMultiPoint( const QgsMultiPoint &multipoint )
 {
-  std::unique_ptr< QgsMultiPointV2 > mp( new QgsMultiPointV2() );
+  std::unique_ptr< QgsMultiPointV2 > mp = qgis::make_unique< QgsMultiPointV2 >();
   QgsMultiPoint::const_iterator ptIt = multipoint.constBegin();
   for ( ; ptIt != multipoint.constEnd(); ++ptIt )
   {
@@ -156,7 +156,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryFactory::fromPolyline( const Qgs
 
 std::unique_ptr<QgsMultiLineString> QgsGeometryFactory::fromMultiPolyline( const QgsMultiPolyline &multiline )
 {
-  std::unique_ptr< QgsMultiLineString > mLine( new QgsMultiLineString() );
+  std::unique_ptr< QgsMultiLineString > mLine = qgis::make_unique< QgsMultiLineString >();
   for ( int i = 0; i < multiline.size(); ++i )
   {
     mLine->addGeometry( fromPolyline( multiline.at( i ) ).release() );
@@ -166,7 +166,7 @@ std::unique_ptr<QgsMultiLineString> QgsGeometryFactory::fromMultiPolyline( const
 
 std::unique_ptr<QgsPolygonV2> QgsGeometryFactory::fromPolygon( const QgsPolygon &polygon )
 {
-  std::unique_ptr< QgsPolygonV2 > poly( new QgsPolygonV2() );
+  std::unique_ptr< QgsPolygonV2 > poly = qgis::make_unique< QgsPolygonV2 >();
 
   QList<QgsCurve *> holes;
   for ( int i = 0; i < polygon.size(); ++i )
@@ -189,7 +189,7 @@ std::unique_ptr<QgsPolygonV2> QgsGeometryFactory::fromPolygon( const QgsPolygon 
 
 std::unique_ptr< QgsMultiPolygonV2 > QgsGeometryFactory::fromMultiPolygon( const QgsMultiPolygon &multipoly )
 {
-  std::unique_ptr< QgsMultiPolygonV2 > mp( new QgsMultiPolygonV2() );
+  std::unique_ptr< QgsMultiPolygonV2 > mp = qgis::make_unique< QgsMultiPolygonV2 >();
   for ( int i = 0; i < multipoly.size(); ++i )
   {
     mp->addGeometry( fromPolygon( multipoly.at( i ) ).release() );
@@ -209,7 +209,7 @@ std::unique_ptr<QgsLineString> QgsGeometryFactory::linestringFromPolyline( const
     x << it->x();
     y << it->y();
   }
-  std::unique_ptr< QgsLineString > line( new QgsLineString( x, y ) );
+  std::unique_ptr< QgsLineString > line = qgis::make_unique< QgsLineString >( x, y );
   return line;
 }
 
@@ -219,31 +219,31 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryFactory::geomFromWkbType( QgsWkb
   switch ( type )
   {
     case QgsWkbTypes::Point:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsPoint() );
+      return qgis::make_unique< QgsPoint >();
     case QgsWkbTypes::LineString:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsLineString() );
+      return qgis::make_unique< QgsLineString >();
     case QgsWkbTypes::CircularString:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsCircularString() );
+      return qgis::make_unique< QgsCircularString >();
     case QgsWkbTypes::CompoundCurve:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsCompoundCurve() );
+      return qgis::make_unique< QgsCompoundCurve >();
     case QgsWkbTypes::Polygon:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsPolygonV2() );
+      return qgis::make_unique< QgsPolygonV2 >();
     case QgsWkbTypes::CurvePolygon:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsCurvePolygon() );
+      return qgis::make_unique< QgsCurvePolygon >();
     case QgsWkbTypes::MultiLineString:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsMultiLineString() );
+      return qgis::make_unique< QgsMultiLineString >();
     case QgsWkbTypes::MultiPolygon:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsMultiPolygonV2() );
+      return qgis::make_unique< QgsMultiPolygonV2 >();
     case QgsWkbTypes::MultiPoint:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsMultiPointV2() );
+      return qgis::make_unique< QgsMultiPointV2 >();
     case QgsWkbTypes::MultiCurve:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsMultiCurve() );
+      return qgis::make_unique< QgsMultiCurve >();
     case QgsWkbTypes::MultiSurface:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsMultiSurface() );
+      return qgis::make_unique< QgsMultiSurface >();
     case QgsWkbTypes::GeometryCollection:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsGeometryCollection() );
+      return qgis::make_unique< QgsGeometryCollection >();
     case QgsWkbTypes::Triangle:
-      return std::unique_ptr<QgsAbstractGeometry>( new QgsTriangle() );
+      return qgis::make_unique< QgsTriangle >();
     default:
       return nullptr;
   }
@@ -256,22 +256,22 @@ std::unique_ptr<QgsGeometryCollection> QgsGeometryFactory::createCollectionOfTyp
   switch ( type )
   {
     case QgsWkbTypes::MultiPoint:
-      collect.reset( new QgsMultiPointV2() );
+      collect = qgis::make_unique< QgsMultiPointV2 >();
       break;
     case QgsWkbTypes::MultiLineString:
-      collect.reset( new QgsMultiLineString() );
+      collect = qgis::make_unique< QgsMultiLineString >();
       break;
     case QgsWkbTypes::MultiCurve:
-      collect.reset( new QgsMultiCurve() );
+      collect = qgis::make_unique< QgsMultiCurve >();
       break;
     case QgsWkbTypes::MultiPolygon:
-      collect.reset( new QgsMultiPolygonV2() );
+      collect = qgis::make_unique< QgsMultiPolygonV2 >();
       break;
     case QgsWkbTypes::MultiSurface:
-      collect.reset( new QgsMultiSurface() );
+      collect = qgis::make_unique< QgsMultiSurface >();
       break;
     case QgsWkbTypes::GeometryCollection:
-      collect.reset( new QgsGeometryCollection() );
+      collect = qgis::make_unique< QgsGeometryCollection >();
       break;
     default:
       // should not be possible

--- a/src/core/geometry/qgsgeometrymakevalid.cpp
+++ b/src/core/geometry/qgsgeometrymakevalid.cpp
@@ -897,7 +897,7 @@ static GEOSGeometry *LWGEOM_GEOS_makeValid( const GEOSGeometry *gin, QString &er
 }
 
 
-QgsAbstractGeometry *_qgis_lwgeom_make_valid( const QgsAbstractGeometry *lwgeom_in, QString &errorMessage )
+std::unique_ptr< QgsAbstractGeometry > _qgis_lwgeom_make_valid( const QgsAbstractGeometry *lwgeom_in, QString &errorMessage )
 {
   //bool is3d = FLAGS_GET_Z(lwgeom_in->flags);
 
@@ -936,7 +936,7 @@ QgsAbstractGeometry *_qgis_lwgeom_make_valid( const QgsAbstractGeometry *lwgeom_
   if ( !geosout )
     return nullptr;
 
-  QgsAbstractGeometry *lwgeom_out = QgsGeos::fromGeos( geosout );
+  std::unique_ptr< QgsAbstractGeometry > lwgeom_out = QgsGeos::fromGeos( geosout );
   GEOSGeom_destroy_r( handle, geosout );
   if ( !lwgeom_out )
     return nullptr;
@@ -960,8 +960,8 @@ QgsAbstractGeometry *_qgis_lwgeom_make_valid( const QgsAbstractGeometry *lwgeom_
         collection = new QgsGeometryCollection();
         break;
     }
-    collection->addGeometry( lwgeom_out ); // takes ownership
-    lwgeom_out = collection;
+    collection->addGeometry( lwgeom_out.release() ); // takes ownership
+    lwgeom_out.reset( collection );
   }
 
   return lwgeom_out;

--- a/src/core/geometry/qgsgeometrymakevalid.h
+++ b/src/core/geometry/qgsgeometrymakevalid.h
@@ -18,10 +18,12 @@
 
 #define SIP_NO_FILE
 
+#include <memory>
+
 class QString;
 class QgsAbstractGeometry;
 
 //! Implementation of QgsGeometry::makeValid(). Not a public API.
-QgsAbstractGeometry *_qgis_lwgeom_make_valid( const QgsAbstractGeometry *lwgeom_in, QString &errorMessage );
+std::unique_ptr< QgsAbstractGeometry > _qgis_lwgeom_make_valid( const QgsAbstractGeometry *lwgeom_in, QString &errorMessage );
 
 #endif // QGSGEOMETRYMAKEVALID_H

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -183,15 +183,15 @@ void QgsGeos::cacheGeos() const
 
 QgsAbstractGeometry *QgsGeos::intersection( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
-  return overlay( geom, INTERSECTION, errorMsg );
+  return overlay( geom, INTERSECTION, errorMsg ).release();
 }
 
 QgsAbstractGeometry *QgsGeos::difference( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
-  return overlay( geom, DIFFERENCE, errorMsg );
+  return overlay( geom, DIFFERENCE, errorMsg ).release();
 }
 
-QgsAbstractGeometry *QgsGeos::clip( const QgsRectangle &rect, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QString *errorMsg ) const
 {
   if ( !mGeos || rect.isNull() || rect.isEmpty() )
   {
@@ -202,8 +202,7 @@ QgsAbstractGeometry *QgsGeos::clip( const QgsRectangle &rect, QString *errorMsg 
   {
     GEOSGeomScopedPtr opGeom;
     opGeom.reset( GEOSClipByRect_r( geosinit.ctxt, mGeos, rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() ) );
-    QgsAbstractGeometry *opResult = fromGeos( opGeom.get() );
-    return opResult;
+    return fromGeos( opGeom.get() );
   }
   catch ( GEOSException &e )
   {
@@ -225,7 +224,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
   {
     if ( partType == GEOS_POINT )
     {
-      parts->addGeometry( fromGeos( currentPart ) );
+      parts->addGeometry( fromGeos( currentPart ).release() );
       return;
     }
     else
@@ -246,7 +245,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
 
   if ( depth > 50 )
   {
-    parts->addGeometry( fromGeos( currentPart ) );
+    parts->addGeometry( fromGeos( currentPart ).release() );
     return;
   }
 
@@ -257,7 +256,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
   }
   else if ( vertexCount < maxNodes )
   {
-    parts->addGeometry( fromGeos( currentPart ) );
+    parts->addGeometry( fromGeos( currentPart ).release() );
     return;
   }
 
@@ -309,7 +308,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
   }
 }
 
-QgsAbstractGeometry *QgsGeos::subdivide( int maxNodes, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *errorMsg ) const
 {
   if ( !mGeos )
   {
@@ -326,12 +325,12 @@ QgsAbstractGeometry *QgsGeos::subdivide( int maxNodes, QString *errorMsg ) const
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 
-  return parts.release();
+  return parts;
 }
 
 QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
-  return overlay( geom, UNION, errorMsg );
+  return overlay( geom, UNION, errorMsg ).release();
 }
 
 QgsAbstractGeometry *QgsGeos::combine( const QList<QgsAbstractGeometry *> &geomList, QString *errorMsg ) const
@@ -353,14 +352,14 @@ QgsAbstractGeometry *QgsGeos::combine( const QList<QgsAbstractGeometry *> &geomL
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 
-  QgsAbstractGeometry *result = fromGeos( geomUnion );
+  std::unique_ptr< QgsAbstractGeometry > result = fromGeos( geomUnion );
   GEOSGeom_destroy_r( geosinit.ctxt, geomUnion );
-  return result;
+  return result.release();
 }
 
 QgsAbstractGeometry *QgsGeos::symDifference( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
-  return overlay( geom, SYMDIFFERENCE, errorMsg );
+  return overlay( geom, SYMDIFFERENCE, errorMsg ).release();
 }
 
 double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
@@ -816,7 +815,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitLinearGeometry( GEOSGeome
 
   for ( int i = 0; i < lineGeoms.size(); ++i )
   {
-    newGeometries << fromGeos( lineGeoms[i] );
+    newGeometries << fromGeos( lineGeoms[i] ).release();
     GEOSGeom_destroy_r( geosinit.ctxt, lineGeoms[i] );
   }
 
@@ -918,7 +917,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( GEOSGeom
   }
 
   for ( i = 0; i < testedGeometries.size(); ++i )
-    newGeometries << fromGeos( testedGeometries[i] );
+    newGeometries << fromGeos( testedGeometries[i] ).release();
 
   return Success;
 }
@@ -1045,7 +1044,7 @@ GEOSGeometry *QgsGeos::createGeosCollection( int typeId, const QVector<GEOSGeome
   return geom;
 }
 
-QgsAbstractGeometry *QgsGeos::fromGeos( const GEOSGeometry *geos )
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos )
 {
   if ( !geos )
   {
@@ -1062,7 +1061,7 @@ QgsAbstractGeometry *QgsGeos::fromGeos( const GEOSGeometry *geos )
     case GEOS_POINT:                 // a point
     {
       const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit.ctxt, geos );
-      return ( coordSeqPoint( cs, 0, hasZ, hasM ).clone() );
+      return std::unique_ptr<QgsAbstractGeometry>( coordSeqPoint( cs, 0, hasZ, hasM ).clone() );
     }
     case GEOS_LINESTRING:
     {
@@ -1074,7 +1073,7 @@ QgsAbstractGeometry *QgsGeos::fromGeos( const GEOSGeometry *geos )
     }
     case GEOS_MULTIPOINT:
     {
-      QgsMultiPointV2 *multiPoint = new QgsMultiPointV2();
+      std::unique_ptr< QgsMultiPointV2 > multiPoint( new QgsMultiPointV2() );
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
       for ( int i = 0; i < nParts; ++i )
       {
@@ -1088,43 +1087,43 @@ QgsAbstractGeometry *QgsGeos::fromGeos( const GEOSGeometry *geos )
     }
     case GEOS_MULTILINESTRING:
     {
-      QgsMultiLineString *multiLineString = new QgsMultiLineString();
+      std::unique_ptr< QgsMultiLineString > multiLineString( new QgsMultiLineString() );
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
       for ( int i = 0; i < nParts; ++i )
       {
-        QgsLineString *line = sequenceToLinestring( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ), hasZ, hasM );
+        std::unique_ptr< QgsLineString >line( sequenceToLinestring( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ), hasZ, hasM ) );
         if ( line )
         {
-          multiLineString->addGeometry( line );
+          multiLineString->addGeometry( line.release() );
         }
       }
       return multiLineString;
     }
     case GEOS_MULTIPOLYGON:
     {
-      QgsMultiPolygonV2 *multiPolygon = new QgsMultiPolygonV2();
+      std::unique_ptr< QgsMultiPolygonV2 > multiPolygon( new QgsMultiPolygonV2() );
 
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
       for ( int i = 0; i < nParts; ++i )
       {
-        QgsPolygonV2 *poly = fromGeosPolygon( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ) );
+        std::unique_ptr< QgsPolygonV2 > poly = fromGeosPolygon( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ) );
         if ( poly )
         {
-          multiPolygon->addGeometry( poly );
+          multiPolygon->addGeometry( poly.release() );
         }
       }
       return multiPolygon;
     }
     case GEOS_GEOMETRYCOLLECTION:
     {
-      QgsGeometryCollection *geomCollection = new QgsGeometryCollection();
+      std::unique_ptr< QgsGeometryCollection > geomCollection( new QgsGeometryCollection() );
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
       for ( int i = 0; i < nParts; ++i )
       {
-        QgsAbstractGeometry *geom = fromGeos( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ) );
+        std::unique_ptr< QgsAbstractGeometry > geom( fromGeos( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ) ) );
         if ( geom )
         {
-          geomCollection->addGeometry( geom );
+          geomCollection->addGeometry( geom.release() );
         }
       }
       return geomCollection;
@@ -1133,7 +1132,7 @@ QgsAbstractGeometry *QgsGeos::fromGeos( const GEOSGeometry *geos )
   return nullptr;
 }
 
-QgsPolygonV2 *QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
+std::unique_ptr<QgsPolygonV2> QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
 {
   if ( GEOSGeomTypeId_r( geosinit.ctxt, geos ) != GEOS_POLYGON )
   {
@@ -1145,12 +1144,12 @@ QgsPolygonV2 *QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
   bool hasZ = ( nCoordDims == 3 );
   bool hasM = ( ( nDims - nCoordDims ) == 1 );
 
-  QgsPolygonV2 *polygon = new QgsPolygonV2();
+  std::unique_ptr< QgsPolygonV2 > polygon( new QgsPolygonV2() );
 
   const GEOSGeometry *ring = GEOSGetExteriorRing_r( geosinit.ctxt, geos );
   if ( ring )
   {
-    polygon->setExteriorRing( sequenceToLinestring( ring, hasZ, hasM ) );
+    polygon->setExteriorRing( sequenceToLinestring( ring, hasZ, hasM ).release() );
   }
 
   QList<QgsCurve *> interiorRings;
@@ -1159,7 +1158,7 @@ QgsPolygonV2 *QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
     ring = GEOSGetInteriorRingN_r( geosinit.ctxt, geos, i );
     if ( ring )
     {
-      interiorRings.push_back( sequenceToLinestring( ring, hasZ, hasM ) );
+      interiorRings.push_back( sequenceToLinestring( ring, hasZ, hasM ).release() );
     }
   }
   polygon->setInteriorRings( interiorRings );
@@ -1167,7 +1166,7 @@ QgsPolygonV2 *QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
   return polygon;
 }
 
-QgsLineString *QgsGeos::sequenceToLinestring( const GEOSGeometry *geos, bool hasZ, bool hasM )
+std::unique_ptr<QgsLineString> QgsGeos::sequenceToLinestring( const GEOSGeometry *geos, bool hasZ, bool hasM )
 {
   const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit.ctxt, geos );
   unsigned int nPoints;
@@ -1203,7 +1202,7 @@ QgsLineString *QgsGeos::sequenceToLinestring( const GEOSGeometry *geos, bool has
       mOut << m;
     }
   }
-  QgsLineString *line = new QgsLineString( xOut, yOut, zOut, mOut );
+  std::unique_ptr< QgsLineString > line( new QgsLineString( xOut, yOut, zOut, mOut ) );
   return line;
 }
 
@@ -1338,7 +1337,7 @@ GEOSGeometry *QgsGeos::asGeos( const QgsAbstractGeometry *geom, double precision
   return nullptr;
 }
 
-QgsAbstractGeometry *QgsGeos::overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg ) const
 {
   if ( !mGeos || !geom )
   {
@@ -1385,8 +1384,7 @@ QgsAbstractGeometry *QgsGeos::overlay( const QgsAbstractGeometry *geom, Overlay 
       default:    //unknown op
         return nullptr;
     }
-    QgsAbstractGeometry *opResult = fromGeos( opGeom.get() );
-    return opResult;
+    return fromGeos( opGeom.get() );
   }
   catch ( GEOSException &e )
   {
@@ -1497,7 +1495,7 @@ QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, QString *er
     geos.reset( GEOSBuffer_r( geosinit.ctxt, mGeos, distance, segments ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr );
-  return fromGeos( geos.get() );
+  return fromGeos( geos.get() ).release();
 }
 
 QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, int endCapStyle, int joinStyle, double miterLimit, QString *errorMsg ) const
@@ -1513,7 +1511,7 @@ QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, int endCapS
     geos.reset( GEOSBufferWithStyle_r( geosinit.ctxt, mGeos, distance, segments, endCapStyle, joinStyle, miterLimit ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr );
-  return fromGeos( geos.get() );
+  return fromGeos( geos.get() ).release();
 }
 
 QgsAbstractGeometry *QgsGeos::simplify( double tolerance, QString *errorMsg ) const
@@ -1528,7 +1526,7 @@ QgsAbstractGeometry *QgsGeos::simplify( double tolerance, QString *errorMsg ) co
     geos.reset( GEOSTopologyPreserveSimplify_r( geosinit.ctxt, mGeos, tolerance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr );
-  return fromGeos( geos.get() );
+  return fromGeos( geos.get() ).release();
 }
 
 QgsAbstractGeometry *QgsGeos::interpolate( double distance, QString *errorMsg ) const
@@ -1543,7 +1541,7 @@ QgsAbstractGeometry *QgsGeos::interpolate( double distance, QString *errorMsg ) 
     geos.reset( GEOSInterpolate_r( geosinit.ctxt, mGeos, distance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr );
-  return fromGeos( geos.get() );
+  return fromGeos( geos.get() ).release();
 }
 
 QgsPoint *QgsGeos::centroid( QString *errorMsg ) const
@@ -1584,7 +1582,7 @@ QgsAbstractGeometry *QgsGeos::envelope( QString *errorMsg ) const
     geos.reset( GEOSEnvelope_r( geosinit.ctxt, mGeos ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr );
-  return fromGeos( geos.get() );
+  return fromGeos( geos.get() ).release();
 }
 
 QgsPoint *QgsGeos::pointOnSurface( QString *errorMsg ) const
@@ -1625,9 +1623,9 @@ QgsAbstractGeometry *QgsGeos::convexHull( QString *errorMsg ) const
   try
   {
     GEOSGeometry *cHull = GEOSConvexHull_r( geosinit.ctxt, mGeos );
-    QgsAbstractGeometry *cHullGeom = fromGeos( cHull );
+    std::unique_ptr< QgsAbstractGeometry > cHullGeom = fromGeos( cHull );
     GEOSGeom_destroy_r( geosinit.ctxt, cHull );
-    return cHullGeom;
+    return cHullGeom.release();
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr );
 }
@@ -1899,12 +1897,12 @@ QgsAbstractGeometry *QgsGeos::offsetCurve( double distance, int segments, int jo
     offset = GEOSOffsetCurve_r( geosinit.ctxt, mGeos, distance, segments, joinStyle, miterLimit );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
-  QgsAbstractGeometry *offsetGeom = fromGeos( offset );
+  std::unique_ptr< QgsAbstractGeometry > offsetGeom = fromGeos( offset );
   GEOSGeom_destroy_r( geosinit.ctxt, offset );
-  return offsetGeom;
+  return offsetGeom.release();
 }
 
-QgsAbstractGeometry *QgsGeos::singleSidedBuffer( double distance, int segments, int side, int joinStyle, double miterLimit, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer( double distance, int segments, int side, int joinStyle, double miterLimit, QString *errorMsg ) const
 {
   if ( !mGeos )
   {
@@ -1931,7 +1929,7 @@ QgsAbstractGeometry *QgsGeos::singleSidedBuffer( double distance, int segments, 
   return fromGeos( geos.get() );
 }
 
-QgsAbstractGeometry *QgsGeos::reshapeGeometry( const QgsLineString &reshapeWithLine, EngineOperationResult *errorCode, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineString &reshapeWithLine, EngineOperationResult *errorCode, QString *errorMsg ) const
 {
   if ( !mGeos || mGeometry->dimension() == 0 )
   {
@@ -1977,7 +1975,7 @@ QgsAbstractGeometry *QgsGeos::reshapeGeometry( const QgsLineString &reshapeWithL
 
     if ( errorCode )
       *errorCode = Success;
-    QgsAbstractGeometry *reshapeResult = fromGeos( reshapedGeometry );
+    std::unique_ptr< QgsAbstractGeometry > reshapeResult = fromGeos( reshapedGeometry );
     GEOSGeom_destroy_r( geosinit.ctxt, reshapedGeometry );
     GEOSGeom_destroy_r( geosinit.ctxt, reshapeLineGeos );
     return reshapeResult;
@@ -2032,7 +2030,7 @@ QgsAbstractGeometry *QgsGeos::reshapeGeometry( const QgsLineString &reshapeWithL
       {
         if ( errorCode )
           *errorCode = Success;
-        QgsAbstractGeometry *reshapedMultiGeom = fromGeos( newMultiGeom );
+        std::unique_ptr< QgsAbstractGeometry > reshapedMultiGeom = fromGeos( newMultiGeom );
         GEOSGeom_destroy_r( geosinit.ctxt, newMultiGeom );
         return reshapedMultiGeom;
       }

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -333,14 +333,17 @@ QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString 
   return overlay( geom, UNION, errorMsg ).release();
 }
 
-QgsAbstractGeometry *QgsGeos::combine( const QList<QgsAbstractGeometry *> &geomList, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::combine( const QList<QgsGeometry> &geomList, QString *errorMsg ) const
 {
 
   QVector< GEOSGeometry * > geosGeometries;
-  geosGeometries.resize( geomList.size() );
-  for ( int i = 0; i < geomList.size(); ++i )
+  geosGeometries.reserve( geomList.size() );
+  for ( const QgsGeometry &g : geomList )
   {
-    geosGeometries[i] = asGeos( geomList.at( i ), mPrecision );
+    if ( !g )
+      continue;
+
+    geosGeometries << asGeos( g.geometry(), mPrecision );
   }
 
   GEOSGeometry *geomUnion = nullptr;

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -325,7 +325,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 
-  return parts;
+  return std::move( parts );
 }
 
 QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg ) const
@@ -1083,7 +1083,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
           multiPoint->addGeometry( coordSeqPoint( cs, 0, hasZ, hasM ).clone() );
         }
       }
-      return multiPoint;
+      return std::move( multiPoint );
     }
     case GEOS_MULTILINESTRING:
     {
@@ -1097,7 +1097,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
           multiLineString->addGeometry( line.release() );
         }
       }
-      return multiLineString;
+      return std::move( multiLineString );
     }
     case GEOS_MULTIPOLYGON:
     {
@@ -1112,7 +1112,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
           multiPolygon->addGeometry( poly.release() );
         }
       }
-      return multiPolygon;
+      return std::move( multiPolygon );
     }
     case GEOS_GEOMETRYCOLLECTION:
     {
@@ -1126,7 +1126,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
           geomCollection->addGeometry( geom.release() );
         }
       }
-      return geomCollection;
+      return std::move( geomCollection );
     }
   }
   return nullptr;

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -563,7 +563,7 @@ double QgsGeos::length( QString *errorMsg ) const
 }
 
 QgsGeometryEngine::EngineOperationResult QgsGeos::splitGeometry( const QgsLineString &splitLine,
-    QList<QgsAbstractGeometry *> &newGeometries,
+    QList<QgsGeometry> &newGeometries,
     bool topological,
     QgsPointSequence &topologyTestPoints,
     QString *errorMsg ) const
@@ -767,7 +767,7 @@ GEOSGeometry *QgsGeos::linePointDifference( GEOSGeometry *GEOSsplitPoint ) const
   return asGeos( &lines, mPrecision );
 }
 
-QgsGeometryEngine::EngineOperationResult QgsGeos::splitLinearGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const
+QgsGeometryEngine::EngineOperationResult QgsGeos::splitLinearGeometry( GEOSGeometry *splitLine, QList<QgsGeometry> &newGeometries ) const
 {
   if ( !splitLine )
     return InvalidInput;
@@ -815,7 +815,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitLinearGeometry( GEOSGeome
 
   for ( int i = 0; i < lineGeoms.size(); ++i )
   {
-    newGeometries << fromGeos( lineGeoms[i] ).release();
+    newGeometries << QgsGeometry( fromGeos( lineGeoms[i] ) );
     GEOSGeom_destroy_r( geosinit.ctxt, lineGeoms[i] );
   }
 
@@ -823,7 +823,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitLinearGeometry( GEOSGeome
   return Success;
 }
 
-QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const
+QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( GEOSGeometry *splitLine, QList<QgsGeometry> &newGeometries ) const
 {
   if ( !splitLine )
     return InvalidInput;
@@ -917,7 +917,7 @@ QgsGeometryEngine::EngineOperationResult QgsGeos::splitPolygonGeometry( GEOSGeom
   }
 
   for ( i = 0; i < testedGeometries.size(); ++i )
-    newGeometries << fromGeos( testedGeometries[i] ).release();
+    newGeometries << QgsGeometry( fromGeos( testedGeometries[i] ) );
 
   return Success;
 }
@@ -2172,7 +2172,7 @@ double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) cons
   return distance;
 }
 
-QgsGeometry QgsGeos::polygonize( const QList<QgsAbstractGeometry *> &geometries, QString *errorMsg )
+QgsGeometry QgsGeos::polygonize( const QList<const QgsAbstractGeometry *> &geometries, QString *errorMsg )
 {
   GEOSGeometry **const lineGeosGeometries = new GEOSGeometry*[ geometries.size()];
   int validLines = 0;

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     std::unique_ptr< QgsAbstractGeometry > subdivide( int maxNodes, QString *errorMsg = nullptr ) const;
 
     QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry *> &, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *combine( const QList< QgsGeometry > &, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *buffer( double distance, int segments, int endCapStyle, int joinStyle, double miterLimit, QString *errorMsg = nullptr ) const override;

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -45,7 +45,6 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     QgsGeos( const QgsAbstractGeometry *geometry, double precision = 0 );
     ~QgsGeos();
 
-    //! Removes caches
     void geometryChanged() override;
     void prepareGeometry() override;
 
@@ -138,16 +137,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     bool isEmpty( QString *errorMsg = nullptr ) const override;
     bool isSimple( QString *errorMsg = nullptr ) const override;
 
-    /**
-     * Splits this geometry according to a given line.
-    \param splitLine the line that splits the geometry
-    \param[out] newGeometries list of new geometries that have been created with the split
-    \param topological true if topological editing is enabled
-    \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
-    \param[out] errorMsg error messages emitted, if any
-    \returns 0 in case of success, 1 if geometry has not been split, error else*/
     EngineOperationResult splitGeometry( const QgsLineString &splitLine,
-                                         QList<QgsAbstractGeometry *> &newGeometries,
+                                         QList< QgsGeometry > &newGeometries,
                                          bool topological,
                                          QgsPointSequence &topologyTestPoints,
                                          QString *errorMsg = nullptr ) const override;
@@ -226,7 +217,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * An empty geometry will be returned in the case of errors.
      * \since QGIS 3.0
      */
-    static QgsGeometry polygonize( const QList<QgsAbstractGeometry *> &geometries, QString *errorMsg = nullptr );
+    static QgsGeometry polygonize( const QList< const QgsAbstractGeometry *> &geometries, QString *errorMsg = nullptr );
 
     /**
      * Creates a Voronoi diagram for the nodes contained within the geometry.
@@ -315,8 +306,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     //utils for geometry split
     bool topologicalTestPointsSplit( const GEOSGeometry *splitLine, QgsPointSequence &testPoints, QString *errorMsg = nullptr ) const;
     GEOSGeometry *linePointDifference( GEOSGeometry *GEOSsplitPoint ) const;
-    EngineOperationResult splitLinearGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const;
-    EngineOperationResult splitPolygonGeometry( GEOSGeometry *splitLine, QList<QgsAbstractGeometry *> &newGeometries ) const;
+    EngineOperationResult splitLinearGeometry( GEOSGeometry *splitLine, QList<QgsGeometry > &newGeometries ) const;
+    EngineOperationResult splitPolygonGeometry( GEOSGeometry *splitLine, QList<QgsGeometry > &newGeometries ) const;
 
     //utils for reshape
     static GEOSGeometry *reshapeLine( const GEOSGeometry *line, const GEOSGeometry *reshapeLineGeos, double precision );

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * Performs a fast, non-robust intersection between the geometry and
      * a \a rectangle. The returned geometry may be invalid.
      */
-    QgsAbstractGeometry *clip( const QgsRectangle &rectangle, QString *errorMsg = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > clip( const QgsRectangle &rectangle, QString *errorMsg = nullptr ) const;
 
     /**
      * Subdivides the geometry. The returned geometry will be a collection containing subdivided parts
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      *
      * \since QGIS 3.0
      */
-    QgsAbstractGeometry *subdivide( int maxNodes, QString *errorMsg = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > subdivide( int maxNodes, QString *errorMsg = nullptr ) const;
 
     QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     QgsAbstractGeometry *combine( const QList< QgsAbstractGeometry *> &, QString *errorMsg = nullptr ) const override;
@@ -167,9 +167,9 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * calculated
      * \since QGIS 3.0
      */
-    QgsAbstractGeometry *singleSidedBuffer( double distance, int segments, int side,
-                                            int joinStyle, double miterLimit,
-                                            QString *errorMsg = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > singleSidedBuffer( double distance, int segments, int side,
+        int joinStyle, double miterLimit,
+        QString *errorMsg = nullptr ) const;
 
     /**
      * Reshapes the geometry using a line
@@ -178,7 +178,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * @param errorMsg if specified, provides more details about failure
      * @return the reshaped geometry
      */
-    QgsAbstractGeometry *reshapeGeometry( const QgsLineString &reshapeWithLine, EngineOperationResult *errorCode, QString *errorMsg = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > reshapeGeometry( const QgsLineString &reshapeWithLine, EngineOperationResult *errorCode, QString *errorMsg = nullptr ) const;
 
     /**
      * Merges any connected lines in a LineString/MultiLineString geometry and
@@ -260,8 +260,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * Create a geometry from a GEOSGeometry
      * \param geos GEOSGeometry. Ownership is NOT transferred.
      */
-    static QgsAbstractGeometry *fromGeos( const GEOSGeometry *geos );
-    static QgsPolygonV2 *fromGeosPolygon( const GEOSGeometry *geos );
+    static std::unique_ptr< QgsAbstractGeometry > fromGeos( const GEOSGeometry *geos );
+    static std::unique_ptr< QgsPolygonV2 > fromGeosPolygon( const GEOSGeometry *geos );
     static GEOSGeometry *asGeos( const QgsAbstractGeometry *geom, double precision = 0 );
     static QgsPoint coordSeqPoint( const GEOSCoordSequence *cs, int i, bool hasZ, bool hasM );
 
@@ -294,10 +294,10 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
 
     //geos util functions
     void cacheGeos() const;
-    QgsAbstractGeometry *overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg = nullptr ) const;
     bool relation( const QgsAbstractGeometry *geom, Relation r, QString *errorMsg = nullptr ) const;
     static GEOSCoordSequence *createCoordinateSequence( const QgsCurve *curve, double precision, bool forceClose = false );
-    static QgsLineString *sequenceToLinestring( const GEOSGeometry *geos, bool hasZ, bool hasM );
+    static std::unique_ptr< QgsLineString > sequenceToLinestring( const GEOSGeometry *geos, bool hasZ, bool hasM );
     static int numberOfGeometries( GEOSGeometry *g );
     static GEOSGeometry *nodeGeometries( const GEOSGeometry *splitLine, const GEOSGeometry *geom );
     int mergeGeometriesMultiTypeSplit( QVector<GEOSGeometry *> &splitResult ) const;

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -65,7 +65,7 @@ QgsGeometry QgsInternalGeometryEngine::extrude( double x, double y ) const
   if ( !linesToProcess.empty() )
   {
     std::unique_ptr< QgsLineString > secondline;
-    for ( QgsLineString *line : qgsAsConst( linesToProcess ) )
+    for ( QgsLineString *line : qgis::as_const( linesToProcess ) )
     {
       QTransform transform = QTransform::fromTranslate( x, y );
 
@@ -504,7 +504,7 @@ QgsGeometry QgsInternalGeometryEngine::orthogonalize( double tolerance, int maxI
     }
 
     QgsGeometry first = QgsGeometry( geometryList.takeAt( 0 ) );
-    for ( QgsAbstractGeometry *g : qgsAsConst( geometryList ) )
+    for ( QgsAbstractGeometry *g : qgis::as_const( geometryList ) )
     {
       first.addPart( g );
     }
@@ -662,7 +662,7 @@ QgsGeometry QgsInternalGeometryEngine::densifyByCount( int extraNodesPerSegment 
     }
 
     QgsGeometry first = QgsGeometry( geometryList.takeAt( 0 ) );
-    for ( QgsAbstractGeometry *g : qgsAsConst( geometryList ) )
+    for ( QgsAbstractGeometry *g : qgis::as_const( geometryList ) )
     {
       first.addPart( g );
     }
@@ -697,7 +697,7 @@ QgsGeometry QgsInternalGeometryEngine::densifyByDistance( double distance ) cons
     }
 
     QgsGeometry first = QgsGeometry( geometryList.takeAt( 0 ) );
-    for ( QgsAbstractGeometry *g : qgsAsConst( geometryList ) )
+    for ( QgsAbstractGeometry *g : qgis::as_const( geometryList ) )
     {
       first.addPart( g );
     }

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -196,7 +196,7 @@ void QgsPolygonV2::setExteriorRing( QgsCurve *ring )
   setZMTypeFromSubGeometry( ring, QgsWkbTypes::Polygon );
 
   //match dimensionality for rings
-  for ( QgsCurve *ring : qgsAsConst( mInteriorRings ) )
+  for ( QgsCurve *ring : qgis::as_const( mInteriorRings ) )
   {
     ring->convertTo( mExteriorRing->wkbType() );
   }

--- a/src/core/layout/qgslayout.cpp
+++ b/src/core/layout/qgslayout.cpp
@@ -53,7 +53,7 @@ QgsLayout::~QgsLayout()
   while ( deleted )
   {
     deleted = false;
-    for ( QGraphicsItem *item : qgsAsConst( itemList ) )
+    for ( QGraphicsItem *item : qgis::as_const( itemList ) )
     {
       if ( dynamic_cast< QgsLayoutItem * >( item ) && !dynamic_cast< QgsLayoutItemPage *>( item ) )
       {

--- a/src/core/layout/qgslayoutitemgroup.cpp
+++ b/src/core/layout/qgslayoutitemgroup.cpp
@@ -26,7 +26,7 @@ QgsLayoutItemGroup::QgsLayoutItemGroup( QgsLayout *layout )
 QgsLayoutItemGroup::~QgsLayoutItemGroup()
 {
   //loop through group members and remove them from the scene
-  for ( QgsLayoutItem *item : qgsAsConst( mItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItems ) )
   {
     if ( !item )
       continue;
@@ -84,7 +84,7 @@ void QgsLayoutItemGroup::addItem( QgsLayoutItem *item )
 
 void QgsLayoutItemGroup::removeItems()
 {
-  for ( QgsLayoutItem *item : qgsAsConst( mItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItems ) )
   {
     if ( !item )
       continue;
@@ -97,7 +97,7 @@ void QgsLayoutItemGroup::removeItems()
 QList<QgsLayoutItem *> QgsLayoutItemGroup::items() const
 {
   QList<QgsLayoutItem *> val;
-  for ( QgsLayoutItem *item : qgsAsConst( mItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItems ) )
   {
     if ( !item )
       continue;
@@ -111,7 +111,7 @@ void QgsLayoutItemGroup::setVisibility( const bool visible )
   if ( !shouldBlockUndoCommands() )
     mLayout->undoStack()->beginMacro( tr( "Set Group Visibility" ) );
   //also set visibility for all items within the group
-  for ( QgsLayoutItem *item : qgsAsConst( mItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItems ) )
   {
     if ( !item )
       continue;
@@ -140,7 +140,7 @@ void QgsLayoutItemGroup::attemptMove( const QgsLayoutPoint &point )
   double deltaY = scenePoint.y() - pos().y();
 
   //also move all items within the group
-  for ( QgsLayoutItem *item : qgsAsConst( mItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItems ) )
   {
     if ( !item )
       continue;
@@ -186,7 +186,7 @@ void QgsLayoutItemGroup::attemptResize( const QgsLayoutSize &size )
   newRect.setSize( newSizeLayoutUnits );
 
   //also resize all items within the group
-  for ( QgsLayoutItem *item : qgsAsConst( mItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItems ) )
   {
     if ( !item )
       continue;
@@ -267,7 +267,7 @@ bool QgsLayoutItemGroup::readXml( const QDomElement &itemElement, const QDomDocu
 
     QString uuid = elementNode.toElement().attribute( QStringLiteral( "uuid" ) );
 
-    for ( QgsLayoutItem *item : qgsAsConst( items ) )
+    for ( QgsLayoutItem *item : qgis::as_const( items ) )
     {
       if ( item && ( item->mUuid == uuid /* TODO || item->mTemplateUuid == uuid */ ) )
       {
@@ -294,7 +294,7 @@ void QgsLayoutItemGroup::draw( QgsRenderContext &, const QStyleOptionGraphicsIte
 void QgsLayoutItemGroup::resetBoundingRect()
 {
   mBoundingRectangle = QRectF();
-  for ( QgsLayoutItem *item : qgsAsConst( mItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItems ) )
   {
     updateBoundingRect( item );
   }

--- a/src/core/layout/qgslayoutmodel.cpp
+++ b/src/core/layout/qgslayoutmodel.cpp
@@ -73,7 +73,7 @@ void QgsLayoutModel::refreshItemsInScene()
   const QList< QGraphicsItem * > items = mLayout->items();
   //filter paper items from list
   //TODO - correctly handle grouped item z order placement
-  for ( QgsLayoutItem *item : qgsAsConst( mItemZList ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItemZList ) )
   {
     if ( item->type() != QgsLayoutItemRegistry::LayoutPage && items.contains( item ) )
     {
@@ -367,7 +367,7 @@ bool QgsLayoutModel::dropMimeData( const QMimeData *data,
 
   //calculate position to insert moved rows to
   int insertPos = destPos;
-  for ( QgsLayoutItem *item : qgsAsConst( droppedItems ) )
+  for ( QgsLayoutItem *item : qgis::as_const( droppedItems ) )
   {
     int listPos = mItemZList.indexOf( item );
     if ( listPos == -1 )
@@ -465,7 +465,7 @@ void QgsLayoutModel::rebuildSceneItemList()
   //emitting signals as required
   int row = 0;
   const QList< QGraphicsItem * > items = mLayout->items();
-  for ( QgsLayoutItem *item : qgsAsConst( mItemZList ) )
+  for ( QgsLayoutItem *item : qgis::as_const( mItemZList ) )
   {
     if ( item->type() == QgsLayoutItemRegistry::LayoutPage || !items.contains( item ) )
     {

--- a/src/core/layout/qgslayoutpagecollection.cpp
+++ b/src/core/layout/qgslayoutpagecollection.cpp
@@ -174,7 +174,7 @@ bool QgsLayoutPageCollection::readXml( const QDomElement &e, const QDomDocument 
   mBlockUndoCommands = true;
 
   int i = 0;
-  for ( QgsLayoutItemPage *page : qgsAsConst( mPages ) )
+  for ( QgsLayoutItemPage *page : qgis::as_const( mPages ) )
   {
     emit pageAboutToBeRemoved( i );
     mLayout->removeItem( page );

--- a/src/core/layout/qgslayoutsnapper.cpp
+++ b/src/core/layout/qgslayoutsnapper.cpp
@@ -367,7 +367,7 @@ double QgsLayoutSnapper::snapPointsToItems( const QList<double> &points, Qt::Ori
       }
     }
 
-    for ( double val : qgsAsConst( currentCoords ) )
+    for ( double val : qgis::as_const( currentCoords ) )
     {
       for ( double p : points )
       {

--- a/src/core/processing/qgsnativealgorithms.cpp
+++ b/src/core/processing/qgsnativealgorithms.cpp
@@ -1619,7 +1619,7 @@ void QgsLocationBasedAlgorithm::process( QgsFeatureSource *targetSource,
         engine->prepareGeometry();
       }
 
-      for ( Predicate predicate : qgsAsConst( predicates ) )
+      for ( Predicate predicate : qgis::as_const( predicates ) )
       {
         bool isMatch = false;
         switch ( predicate )
@@ -2251,11 +2251,11 @@ QVariantMap QgsLineIntersectionAlgorithm::processAlgorithm( const QVariantMap &p
           QgsMultiPoint points;
           QgsGeometry intersectGeom = inGeom.intersection( tmpGeom );
           QgsAttributes outAttributes;
-          for ( int a : qgsAsConst( fieldsAIndices ) )
+          for ( int a : qgis::as_const( fieldsAIndices ) )
           {
             outAttributes.append( inFeatureA.attribute( a ) );
           }
-          for ( int b : qgsAsConst( fieldsBIndices ) )
+          for ( int b : qgis::as_const( fieldsBIndices ) )
           {
             outAttributes.append( inFeatureB.attribute( b ) );
           }
@@ -2270,7 +2270,7 @@ QVariantMap QgsLineIntersectionAlgorithm::processAlgorithm( const QVariantMap &p
               points.append( intersectGeom.asPoint() );
             }
 
-            for ( const QgsPointXY &j : qgsAsConst( points ) )
+            for ( const QgsPointXY &j : qgis::as_const( points ) )
             {
               outFeature.setGeometry( QgsGeometry::fromPoint( j ) );
               outFeature.setAttributes( outAttributes );
@@ -2404,7 +2404,7 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
 
       if ( !splittingLines.empty() )
       {
-        for ( const QgsGeometry &splitGeom : qgsAsConst( splittingLines ) )
+        for ( const QgsGeometry &splitGeom : qgis::as_const( splittingLines ) )
         {
           QList<QgsPointXY> splitterPList;
           QList< QgsGeometry > outGeoms;
@@ -2478,7 +2478,7 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
     }
 
     QList< QgsGeometry > parts;
-    for ( const QgsGeometry &aGeom : qgsAsConst( inGeoms ) )
+    for ( const QgsGeometry &aGeom : qgis::as_const( inGeoms ) )
     {
       if ( feedback->isCanceled() )
       {

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -273,22 +273,32 @@ inline double qgsRound( double number, double places )
 ///@cond PRIVATE
 
 /**
- * Adds const to non-const objects.
+ * Contains "polyfills" for backporting c++ features from standards > c++11.
  *
- * To be used as a proxy for std::as_const until we target c++17 minimum.
+ * To be removed when minimum c++ build requirement includes the std implementation
+ * for these features.
  *
- * \since QGIS 3.0
- * \note not available in Python bindings
+ * \note not available in Python bindings.
  */
-// TODO - remove when we target c++17 minimum and can use std::as_const
-template <typename T> struct QgsAddConst { typedef const T Type; };
+namespace qgis
+{
 
-template <typename T>
-constexpr typename QgsAddConst<T>::Type &qgsAsConst( T &t ) noexcept { return t; }
+  /**
+   * Adds const to non-const objects.
+   *
+   * To be used as a proxy for std::as_const until we target c++17 minimum.
+   *
+   * \since QGIS 3.0
+   * \note not available in Python bindings
+   */
+  template <typename T> struct QgsAddConst { typedef const T Type; };
 
-template <typename T>
-void qgsAsConst( const T && ) = delete;
+  template <typename T>
+  constexpr typename QgsAddConst<T>::Type &as_const( T &t ) noexcept { return t; }
 
+  template <typename T>
+  void as_const( const T && ) = delete;
+}
 ///@endcond
 #endif
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -30,6 +30,8 @@
 #include <QHash>
 #include <cstdlib>
 #include <cfloat>
+#include <memory>
+#include <type_traits>
 #include <cmath>
 #include <qnumeric.h>
 
@@ -282,6 +284,7 @@ inline double qgsRound( double number, double places )
  */
 namespace qgis
 {
+  // as_const
 
   /**
    * Adds const to non-const objects.
@@ -298,6 +301,42 @@ namespace qgis
 
   template <typename T>
   void as_const( const T && ) = delete;
+
+  // make_unique - from https://stackoverflow.com/a/17902439/1861260
+
+  template<class T> struct _Unique_if
+  {
+    typedef std::unique_ptr<T> _Single_object;
+  };
+
+  template<class T> struct _Unique_if<T[]>
+  {
+    typedef std::unique_ptr<T[]> _Unknown_bound;
+  };
+
+  template<class T, size_t N> struct _Unique_if<T[N]>
+  {
+    typedef void _Known_bound;
+  };
+
+  template<class T, class... Args>
+  typename _Unique_if<T>::_Single_object
+  make_unique( Args &&... args )
+  {
+    return std::unique_ptr<T>( new T( std::forward<Args>( args )... ) );
+  }
+
+  template<class T>
+  typename _Unique_if<T>::_Unknown_bound
+  make_unique( size_t n )
+  {
+    typedef typename std::remove_extent<T>::type U;
+    return std::unique_ptr<T>( new U[n]() );
+  }
+
+  template<class T, class... Args>
+  typename _Unique_if<T>::_Known_bound
+  make_unique( Args &&... ) = delete;
 }
 ///@endcond
 #endif

--- a/src/core/qgsactionmanager.cpp
+++ b/src/core/qgsactionmanager.cpp
@@ -74,7 +74,7 @@ void QgsActionManager::addAction( const QgsAction &action )
 
 void QgsActionManager::onNotifyRunActions( const QString &message )
 {
-  for ( const QgsAction &act : qgsAsConst( mActions ) )
+  for ( const QgsAction &act : qgis::as_const( mActions ) )
   {
     if ( !act.notificationMessage().isEmpty() && QRegularExpression( act.notificationMessage() ).match( message ).hasMatch() )
     {
@@ -98,7 +98,7 @@ void QgsActionManager::onNotifyRunActions( const QString &message )
 void QgsActionManager::removeAction( const QUuid &actionId )
 {
   int i = 0;
-  for ( const QgsAction &action : qgsAsConst( mActions ) )
+  for ( const QgsAction &action : qgis::as_const( mActions ) )
   {
     if ( action.id() == actionId )
     {
@@ -111,7 +111,7 @@ void QgsActionManager::removeAction( const QUuid &actionId )
   if ( mOnNotifyConnected )
   {
     bool hasActionOnNotify = false;
-    for ( const QgsAction &action : qgsAsConst( mActions ) )
+    for ( const QgsAction &action : qgis::as_const( mActions ) )
       hasActionOnNotify |= !action.notificationMessage().isEmpty();
     if ( !hasActionOnNotify && mLayer && mLayer->dataProvider() )
     {
@@ -176,7 +176,7 @@ QList<QgsAction> QgsActionManager::actions( const QString &actionScope ) const
   {
     QList<QgsAction> actions;
 
-    for ( const QgsAction &action : qgsAsConst( mActions ) )
+    for ( const QgsAction &action : qgis::as_const( mActions ) )
     {
       if ( action.actionScopes().contains( actionScope ) )
         actions.append( action );
@@ -231,7 +231,7 @@ bool QgsActionManager::writeXml( QDomNode &layer_node ) const
     aActions.appendChild( defaultActionElement );
   }
 
-  for ( const QgsAction &action : qgsAsConst( mActions ) )
+  for ( const QgsAction &action : qgis::as_const( mActions ) )
   {
     action.writeXml( aActions );
   }
@@ -269,7 +269,7 @@ bool QgsActionManager::readXml( const QDomNode &layer_node )
 
 QgsAction QgsActionManager::action( const QUuid &id )
 {
-  for ( const QgsAction &action : qgsAsConst( mActions ) )
+  for ( const QgsAction &action : qgis::as_const( mActions ) )
   {
     if ( action.id() == id )
       return action;

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -1197,7 +1197,7 @@ void QgsZipItem::init()
     // keys << "ogr" << "gdal";
     keys << QStringLiteral( "gdal" ) << QStringLiteral( "ogr" );
 
-    for ( const auto &k : qgsAsConst( keys ) )
+    for ( const auto &k : qgis::as_const( keys ) )
     {
       QgsDebugMsgLevel( "provider " + k, 3 );
       // some providers hangs with empty uri (PostGIS) etc...

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -784,7 +784,7 @@ void QgsVectorLayer::updateDefaultValues( QgsFeatureId fid, QgsFeature feature )
       feature = getFeature( fid );
 
     int size = mFields.size();
-    for ( int idx : qgsAsConst( mDefaultValueOnUpdateFields ) )
+    for ( int idx : qgis::as_const( mDefaultValueOnUpdateFields ) )
     {
       if ( idx < 0 || idx >= size )
         continue;

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -320,7 +320,7 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList &commitErrors )
     {
       if ( provider->doesStrictFeatureTypeCheck() )
       {
-        for ( const auto &f : qgsAsConst( mAddedFeatures ) )
+        for ( const auto &f : qgis::as_const( mAddedFeatures ) )
         {
           if ( ( ! f.hasGeometry() ) ||
                ( f.geometry().wkbType() == provider->wkbType() ) )

--- a/src/core/qgsvectorlayerjoininfo.cpp
+++ b/src/core/qgsvectorlayerjoininfo.cpp
@@ -78,7 +78,7 @@ QStringList QgsVectorLayerJoinInfo::joinFieldNamesSubset( const QgsVectorLayerJo
     QStringList *lst = info.joinFieldNamesSubset();
     if ( lst )
     {
-      for ( const QString &s : qgsAsConst( *lst ) )
+      for ( const QString &s : qgis::as_const( *lst ) )
       {
         if ( !info.joinFieldNamesBlackList().contains( s ) )
           fieldNames.append( s );

--- a/src/core/qgsvectorlayerundopassthroughcommand.cpp
+++ b/src/core/qgsvectorlayerundopassthroughcommand.cpp
@@ -89,7 +89,7 @@ QgsVectorLayerUndoPassthroughCommandAddFeatures::QgsVectorLayerUndoPassthroughCo
   : QgsVectorLayerUndoPassthroughCommand( buffer, QObject::tr( "add features" ) )
 {
   static int sAddedIdLowWaterMark = -1;
-  for ( const QgsFeature &f : qgsAsConst( features ) )
+  for ( const QgsFeature &f : qgis::as_const( features ) )
   {
     mInitialFeatures << f;
     //assign a temporary id to the feature (use negative numbers)
@@ -103,7 +103,7 @@ void QgsVectorLayerUndoPassthroughCommandAddFeatures::undo()
 {
   if ( rollBackToSavePoint() )
   {
-    for ( const QgsFeature &f : qgsAsConst( mFeatures ) )
+    for ( const QgsFeature &f : qgis::as_const( mFeatures ) )
     {
       emit mBuffer->featureDeleted( f.id() );
     }
@@ -116,7 +116,7 @@ void QgsVectorLayerUndoPassthroughCommandAddFeatures::redo()
   mFeatures = mInitialFeatures;
   if ( setSavePoint() && mBuffer->L->dataProvider()->addFeatures( mFeatures ) )
   {
-    for ( const QgsFeature &f : qgsAsConst( mFeatures ) )
+    for ( const QgsFeature &f : qgis::as_const( mFeatures ) )
     {
       emit mBuffer->featureAdded( f.id() );
     }

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -134,7 +134,7 @@ void QgsLayoutMouseHandles::drawSelectedItemBounds( QPainter *painter )
   QList< QgsLayoutItem * > itemsToDraw;
   collectItems( selectedItems, itemsToDraw );
 
-  for ( QgsLayoutItem *item : qgsAsConst( itemsToDraw ) )
+  for ( QgsLayoutItem *item : qgis::as_const( itemsToDraw ) )
   {
     //get bounds of selected item
     QPolygonF itemBounds;

--- a/src/gui/layout/qgslayoutview.cpp
+++ b/src/gui/layout/qgslayoutview.cpp
@@ -661,7 +661,7 @@ void QgsLayoutView::ungroupSelectedItems()
 
   if ( !ungroupedItems.empty() )
   {
-    for ( QgsLayoutItem *item : qgsAsConst( ungroupedItems ) )
+    for ( QgsLayoutItem *item : qgis::as_const( ungroupedItems ) )
     {
       item->setSelected( true );
     }

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -187,7 +187,7 @@ void QgsLayoutViewToolSelect::layoutReleaseEvent( QgsLayoutViewMouseEvent *event
     itemList = layout()->items( rect.center(), selectionMode );
   else
     itemList = layout()->items( rect, selectionMode );
-  for ( QGraphicsItem *item : qgsAsConst( itemList ) )
+  for ( QGraphicsItem *item : qgis::as_const( itemList ) )
   {
     QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item );
     QgsLayoutItemPage *paperItem = dynamic_cast<QgsLayoutItemPage *>( item );

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -510,7 +510,7 @@ bool QgsMetadataWidget::checkMetadata() const
   QString errors;
   if ( results == false )
   {
-    for ( const QgsMetadataValidator::ValidationResult &result : qgsAsConst( validationResults ) )
+    for ( const QgsMetadataValidator::ValidationResult &result : qgis::as_const( validationResults ) )
     {
       errors += QLatin1String( "<b>" ) % result.section;
       if ( ! result.identifier.isNull() )

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -226,7 +226,7 @@ void QgsOptionsDialogBase::searchText( const QString &text )
     mOptListWidget->setRowHidden( r, !text.isEmpty() );
   }
 
-  for ( const QPair< QgsSearchHighlightOptionWidget *, int > &rsw : qgsAsConst( mRegisteredSearchWidgets ) )
+  for ( const QPair< QgsSearchHighlightOptionWidget *, int > &rsw : qgis::as_const( mRegisteredSearchWidgets ) )
   {
     rsw.first->reset();
     if ( !text.isEmpty() && rsw.first->searchHighlight( text ) )

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -386,7 +386,7 @@ void QgsRubberBand::paint( QPainter *p )
     return;
 
   QVector< QVector<QPointF> > shapes;
-  for ( const QList<QgsPointXY> &line : qgsAsConst( mPoints ) )
+  for ( const QList<QgsPointXY> &line : qgis::as_const( mPoints ) )
   {
     QVector<QPointF> pts;
     for ( const QgsPointXY &pt : line )
@@ -415,7 +415,7 @@ void QgsRubberBand::paint( QPainter *p )
       p->setPen( mPen );
     }
 
-    for ( const QVector<QPointF> &shape : qgsAsConst( shapes ) )
+    for ( const QVector<QPointF> &shape : qgis::as_const( shapes ) )
     {
       drawShape( p, shape );
     }

--- a/src/gui/qgssourceselectproviderregistry.cpp
+++ b/src/gui/qgssourceselectproviderregistry.cpp
@@ -97,7 +97,7 @@ void QgsSourceSelectProviderRegistry::init()
     {
       QList<QgsSourceSelectProvider *> *providerList = sourceSelectProvidersFn();
       // the function is a factory - we keep ownership of the returned providers
-      for ( auto provider : qgsAsConst( *providerList ) )
+      for ( auto provider : qgis::as_const( *providerList ) )
       {
         addProvider( provider );
       }

--- a/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometrygapcheck.cpp
@@ -25,14 +25,14 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
   if ( progressCounter ) progressCounter->fetchAndAddRelaxed( 1 );
 
   // Collect geometries, build spatial index
-  QList<QgsAbstractGeometry *> geomList;
+  QList<QgsGeometry > geomList;
   const QgsFeatureIds &featureIds = ids.isEmpty() ? mFeaturePool->getFeatureIds() : ids;
   Q_FOREACH ( QgsFeatureId id, featureIds )
   {
     QgsFeature feature;
     if ( mFeaturePool->get( id, feature ) )
     {
-      geomList.append( feature.geometry().geometry()->clone() );
+      geomList.append( feature.geometry() );
     }
   }
 
@@ -46,7 +46,6 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
   // Create union of geometry
   QString errMsg;
   QgsAbstractGeometry *unionGeom = geomEngine->combine( geomList, &errMsg );
-  qDeleteAll( geomList );
   delete geomEngine;
   if ( !unionGeom )
   {

--- a/src/providers/geonode/qgsgeonodedataitems.cpp
+++ b/src/providers/geonode/qgsgeonodedataitems.cpp
@@ -137,7 +137,7 @@ QVector<QgsDataItem *> QgsGeoNodeServiceItem::createChildren()
 
     QVector<QgsDataItem *> items;
     QList<QgsDataItemProvider *> *providerList = dataItemProvidersFn();
-    for ( QgsDataItemProvider *pr : qgsAsConst( *providerList ) )
+    for ( QgsDataItemProvider *pr : qgis::as_const( *providerList ) )
     {
       if ( !pr->name().startsWith( mServiceName ) )
         continue;
@@ -160,7 +160,7 @@ QVector<QgsDataItem *> QgsGeoNodeServiceItem::createChildren()
       return items;
     }
 
-    for ( QgsDataItem *item : qgsAsConst( items ) )
+    for ( QgsDataItem *item : qgis::as_const( items ) )
     {
       item->populate( true ); // populate in foreground - this is already run in a thread
 

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -389,7 +389,7 @@ bool QgsGeoPackageCollectionItem::deleteGeoPackageRasterLayer( const QString &ur
         QStringList optionalTables;
         optionalTables << QStringLiteral( "gpkg_extensions" )
                        << QStringLiteral( "gpkg_metadata_reference" );
-        for ( const QString &tableName : qgsAsConst( optionalTables ) )
+        for ( const QString &tableName : qgis::as_const( optionalTables ) )
         {
           char *sql = sqlite3_mprintf( "DELETE FROM %w WHERE table_name = '%q'",
                                        tableName.toUtf8().constData(),

--- a/src/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/providers/ogr/qgsogrdbsourceselect.cpp
@@ -299,11 +299,11 @@ void QgsOgrDbSourceSelect::addButtonClicked()
   else
   {
     // Use OGR
-    for ( const LayerInfo &info : qgsAsConst( selectedVectors ) )
+    for ( const LayerInfo &info : qgis::as_const( selectedVectors ) )
     {
       emit addVectorLayer( info.first, info.second );
     }
-    for ( const LayerInfo &info : qgsAsConst( selectedRasters ) )
+    for ( const LayerInfo &info : qgis::as_const( selectedRasters ) )
     {
       emit addRasterLayer( info.first, info.second, QStringLiteral( "gdal" ) );
     }

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -369,7 +369,7 @@ bool QgsWFSSharedData::createCache()
     {
       mCacheTablename = QStringLiteral( "features" );
       sql = QStringLiteral( "CREATE TABLE %1 (%2 INTEGER PRIMARY KEY" ).arg( mCacheTablename, fidName );
-      for ( const QgsField &field : qgsAsConst( cacheFields ) )
+      for ( const QgsField &field : qgis::as_const( cacheFields ) )
       {
         QString type( QStringLiteral( "VARCHAR" ) );
         if ( field.type() == QVariant::Int )

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -302,7 +302,7 @@ void TestQgis::testQgsAsConst()
   ConstTester ct;
   ct.doSomething();
   QCOMPARE( ct.mVal, 1 );
-  qgsAsConst( ct ).doSomething();
+  qgis::as_const( ct ).doSomething();
   QCOMPARE( ct.mVal, 2 );
 }
 


### PR DESCRIPTION
Following on from comments in https://github.com/qgis/QGIS/pull/5349, this PR cleans up internal memory management in QgsGeometry and related classes by moving everything possible to unique_ptrs and making cloning/non-cloning detachments more explicit.