### PR TITLE
Spin box: fix input of double values in locales with non-point decimal separator

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -471,7 +471,9 @@ double QgsExpression::evaluateToDouble( const QString &text, const double fallba
 {
   bool ok;
   //first test if text is directly convertible to double
-  double convertedValue = text.toDouble( &ok );
+  // use system locale: e.g. in German locale, user is presented with numbers "1,23" instead of "1.23" in C locale
+  // so we also want to allow user to rewrite it to "5,23" and it is still accepted
+  double convertedValue = QLocale::system().toDouble( text, &ok );
   if ( ok )
   {
     return convertedValue;


### PR DESCRIPTION
If you use some European locales, decimal numbers in spin boxes are shown as "1,23" but then QgsDoubleSpinBox would not allow me to change the value to "5,23" and it would insist that I use "5.23" which would be afterwards displayed as "5,23" which is quite confusing. This fix makes spin boxes accept decimal separator according to the current locale (and then falling back to expression parsing as usual).
