### PR TITLE
[3d] add show labels toggle, default to off

### DIFF
--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -38,6 +38,7 @@ Qgs3DMapSettings::Qgs3DMapSettings()
   , mMaxTerrainGroundError( 1.f )
   , mShowTerrainBoundingBoxes( false )
   , mShowTerrainTileInfo( false )
+  , mShowLabels( false )
   , mSkyboxEnabled( false )
 {
 }
@@ -87,6 +88,7 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
   mMapTileResolution = elemTerrain.attribute( "texture-size", "512" ).toInt();
   mMaxTerrainScreenError = elemTerrain.attribute( "max-terrain-error", "3" ).toFloat();
   mMaxTerrainGroundError = elemTerrain.attribute( "max-ground-error", "1" ).toFloat();
+  mShowLabels = elemTerrain.attribute( "show-labels", "0" ).toInt();
   QDomElement elemMapLayers = elemTerrain.firstChildElement( "layers" );
   QDomElement elemMapLayer = elemMapLayers.firstChildElement( "layer" );
   QList<QgsMapLayerRef> mapLayers;
@@ -168,6 +170,7 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   elemTerrain.setAttribute( "texture-size", mMapTileResolution );
   elemTerrain.setAttribute( "max-terrain-error", QString::number( mMaxTerrainScreenError ) );
   elemTerrain.setAttribute( "max-ground-error", QString::number( mMaxTerrainGroundError ) );
+  elemTerrain.setAttribute( "show-labels", mShowLabels ? 1 : 0 );
   QDomElement elemMapLayers = doc.createElement( "layers" );
   Q_FOREACH ( const QgsMapLayerRef &layerRef, mLayers )
   {
@@ -375,4 +378,13 @@ void Qgs3DMapSettings::setShowTerrainTilesInfo( bool enabled )
 
   mShowTerrainTileInfo = enabled;
   emit showTerrainTilesInfoChanged();
+}
+
+void Qgs3DMapSettings::setShowLabels( bool enabled )
+{
+  if ( mShowLabels == enabled )
+    return;
+
+  mShowLabels = enabled;
+  emit showLabelsChanged();
 }

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -176,6 +176,10 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     void setShowTerrainTilesInfo( bool enabled );
     //! Returns whether to display extra tile info on top of terrain tiles (for debugging)
     bool showTerrainTilesInfo() const { return mShowTerrainTileInfo; }
+    //! Sets whether to display labels on terrain tiles
+    void setShowLabels( bool enabled );
+    //! Returns whether to display labels on terrain tiles
+    bool showLabels() const { return mShowLabels; }
 
   signals:
     //! Emitted when the background color has changed
@@ -198,6 +202,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     void showTerrainBoundingBoxesChanged();
     //! Emitted when the flag whether terrain's tile info is shown has changed
     void showTerrainTilesInfoChanged();
+    //! Emitted when the flag whether labels are displayed on terrain tiles has changed
+    void showLabelsChanged();
 
   private:
     double mOriginX, mOriginY, mOriginZ;   //!< Coordinates in map CRS at which our 3D world has origin (0,0,0)
@@ -211,6 +217,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     float mMaxTerrainGroundError;  //!< Maximum allowed horizontal map error in map units (determines how many zoom levels will be used)
     bool mShowTerrainBoundingBoxes;  //!< Whether to show bounding boxes of entities - useful for debugging
     bool mShowTerrainTileInfo;  //!< Whether to draw extra information about terrain tiles to the textures - useful for debugging
+    bool mShowLabels; //!< Whether to display labels on terrain tiles
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
     QList<QgsAbstract3DRenderer *> mRenderers;  //!< Extra stuff to render as 3D object
     bool mSkyboxEnabled;  //!< Whether to render skybox

--- a/src/3d/terrain/qgsterrainentity_p.cpp
+++ b/src/3d/terrain/qgsterrainentity_p.cpp
@@ -63,6 +63,7 @@ QgsTerrainEntity::QgsTerrainEntity( int maxLevel, const Qgs3DMapSettings &map, Q
 
   connect( &map, &Qgs3DMapSettings::showTerrainBoundingBoxesChanged, this, &QgsTerrainEntity::onShowBoundingBoxesChanged );
   connect( &map, &Qgs3DMapSettings::showTerrainTilesInfoChanged, this, &QgsTerrainEntity::invalidateMapImages );
+  connect( &map, &Qgs3DMapSettings::showLabelsChanged, this, &QgsTerrainEntity::invalidateMapImages );
   connect( &map, &Qgs3DMapSettings::layersChanged, this, &QgsTerrainEntity::onLayersChanged );
   connect( &map, &Qgs3DMapSettings::backgroundColorChanged, this, &QgsTerrainEntity::invalidateMapImages );
 

--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -131,6 +131,7 @@ QgsMapSettings QgsTerrainTextureGenerator::baseMapSettings()
   mapSettings.setOutputSize( QSize( mMap.mapTileResolution(), mMap.mapTileResolution() ) );
   mapSettings.setDestinationCrs( mMap.crs() );
   mapSettings.setBackgroundColor( mMap.backgroundColor() );
+  mapSettings.setFlag( QgsMapSettings::DrawLabeling, mMap.showLabels() );
   return mapSettings;
 }
 

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -55,6 +55,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   spinMapResolution->setValue( mMap->mapTileResolution() );
   spinScreenError->setValue( mMap->maxTerrainScreenError() );
   spinGroundError->setValue( mMap->maxTerrainGroundError() );
+  chkShowLabels->setChecked( mMap->showLabels() );
   chkShowTileInfo->setChecked( mMap->showTerrainTilesInfo() );
   chkShowBoundingBoxes->setChecked( mMap->showTerrainBoundingBoxes() );
 
@@ -93,6 +94,7 @@ void Qgs3DMapConfigWidget::apply()
   mMap->setMapTileResolution( spinMapResolution->value() );
   mMap->setMaxTerrainScreenError( spinScreenError->value() );
   mMap->setMaxTerrainGroundError( spinGroundError->value() );
+  mMap->setShowLabels( chkShowLabels->isChecked() );
   mMap->setShowTerrainTilesInfo( chkShowTileInfo->isChecked() );
   mMap->setShowTerrainBoundingBoxes( chkShowBoundingBoxes->isChecked() );
 }

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -143,6 +143,13 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="chkShowLabels">
+     <property name="text">
+      <string>Show labels</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="chkShowTileInfo">
      <property name="text">
       <string>Show map tile info</string>


### PR DESCRIPTION
## Description
@wonder-sk , you give me a working mouse pan, I give you a label toggle setting 😉 

Newly-added setting is found right here:
![screenshot from 2017-10-13 15-25-48](https://user-images.githubusercontent.com/1728657/31537003-ea7fde34-b02a-11e7-9087-a23ae968c31a.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
