### PR TITLE
resize the contents of resultview better

### DIFF
--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -369,9 +369,8 @@ void QgsLocatorResultsView::recalculateSize()
   // resize the floating widget this is contained within
   parentWidget()->resize( newSize );
   QTreeView::resize( newSize );
-
-  header()->resizeSection( 0, width / 2 );
-  header()->resizeSection( 1, 0 );
+  header()->setStretchLastSection(false);
+  header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 }
 
 void QgsLocatorResultsView::selectNextResult()


### PR DESCRIPTION
## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

At this moment the results of a qgslocator is hardcoded in two 50% columns, resulting in this view:

![project_default - qgis 25d40f367d_123](https://user-images.githubusercontent.com/731673/31578299-d9e5c0d0-b11e-11e7-9753-98a2ba69ce7b.png)

(You can check by downloading the experimental 'PDOK Locator Plugin')

With this change it becomes:

![project_default - qgis b91b854a19_122](https://user-images.githubusercontent.com/731673/31578326-2f1791fa-b11f-11e7-8208-193bd911069a.png)

with something which can be seen as a small drawback: a scrollbar in case of long results
BUT at least when the result has more then one colomn you also see that (if you scroll to the right):

![project_default - qgis b91b854a19_125](https://user-images.githubusercontent.com/731673/31578333-758407c2-b11f-11e7-8d49-7cfe30e94591.png)
