### PR TITLE
[processing] Always list native algorithms before 3rd party providers

### DIFF
--- a/python/core/processing/qgsprocessingprovider.sip
+++ b/python/core/processing/qgsprocessingprovider.sip
@@ -56,8 +56,22 @@ class QgsProcessingProvider : QObject
 
     virtual QString name() const = 0;
 %Docstring
- Returns the full provider name, which is used to describe the provider within the GUI.
+ Returns the provider name, which is used to describe the provider within the GUI.
+ This string should be short (e.g. "Lastools") and localised.
+.. seealso:: longName()
+.. seealso:: id()
+ :rtype: str
+%End
+
+    virtual QString longName() const;
+%Docstring
+ Returns the a longer version of the provider name, which can include extra details
+ such as version numbers. E.g. "Lastools LIDAR tools (version 2.2.1)".
  This string should be localised.
+
+ The default implementation returns the same string as name().
+
+.. seealso:: name()
 .. seealso:: id()
  :rtype: str
 %End

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -124,6 +124,10 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
     def name(self):
         return 'GDAL'
 
+    def longName(self):
+        version = GdalUtils.readableVersion()
+        return 'GDAL ({})'.format(version)
+
     def id(self):
         return 'gdal'
 

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -122,8 +122,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
         ProcessingConfig.setSettingValue('ACTIVATE_GDAL', active)
 
     def name(self):
-        version = GdalUtils.readableVersion()
-        return 'GDAL ({})'.format(version)
+        return 'GDAL'
 
     def id(self):
         return 'gdal'

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -58,6 +58,14 @@ WIDGET, BASE = uic.loadUiType(
 
 class ProcessingToolbox(BASE, WIDGET):
 
+    ALG_ITEM = 'ALG_ITEM'
+    PROVIDER_ITEM = 'PROVIDER_ITEM'
+    GROUP_ITEM = 'GROUP_ITEM'
+
+    NAME_ROLE = Qt.UserRole
+    TAG_ROLE = Qt.UserRole + 1
+    TYPE_ROLE = Qt.UserRole + 2
+
     def __init__(self):
         super(ProcessingToolbox, self).__init__(None)
         self.tipWasClosed = False
@@ -143,10 +151,10 @@ class ProcessingToolbox(BASE, WIDGET):
             return show
         elif isinstance(item, (TreeAlgorithmItem, TreeActionItem)):
             # hide if every part of text is not contained somewhere in either the item text or item user role
-            item_text = [item.text(0).lower(), item.data(0, Qt.UserRole).lower()]
+            item_text = [item.text(0).lower(), item.data(0, ProcessingToolbox.NAME_ROLE).lower()]
             if isinstance(item, TreeAlgorithmItem):
                 item_text.append(item.alg.id())
-                item_text.extend(item.data(0, Qt.UserRole + 1))
+                item_text.extend(item.data(0, ProcessingToolbox.TAG_ROLE))
 
             hide = bool(text) and not all(
                 any(part in t for t in item_text)
@@ -356,20 +364,37 @@ class ProcessingToolbox(BASE, WIDGET):
     def fillTreeUsingProviders(self):
         self.algorithmTree.clear()
         self.disabledProviderItems = {}
-        disabled = []
+
+        # TODO - replace with proper model for toolbox!
+
+        # first add qgis/native providers, since they create top level groups
         for provider in QgsApplication.processingRegistry().providers():
             if provider.id() in ('qgis', 'native'):
                 self.addAlgorithmsFromProvider(provider, self.algorithmTree.invisibleRootItem())
             else:
-                if provider.isActive():
-                    providerItem = TreeProviderItem(provider, self.algorithmTree, self)
-                else:
-                    disabled.append(provider)
+                continue
         self.algorithmTree.sortItems(0, Qt.AscendingOrder)
-        for provider in disabled:
-            providerItem = TreeProviderItem(provider, self.algorithmTree, self)
-            providerItem.setHidden(True)
-            self.disabledProviderItems[provider.id()] = providerItem
+
+        for provider in QgsApplication.processingRegistry().providers():
+            if provider.id() in ('qgis', 'native'):
+                # already added
+                continue
+            else:
+                providerItem = TreeProviderItem(provider, self.algorithmTree, self)
+
+                if not provider.isActive():
+                    providerItem.setHidden(True)
+                    self.disabledProviderItems[provider.id()] = providerItem
+
+                # insert non-native providers at end of tree, alphabetically
+
+                for i in range(self.algorithmTree.invisibleRootItem().childCount()):
+                    child = self.algorithmTree.invisibleRootItem().child(i)
+                    if isinstance(child, TreeProviderItem):
+                        if child.text(0) > providerItem.text(0):
+                            break
+
+                self.algorithmTree.insertTopLevelItem(i + 1, providerItem)
 
     def addAlgorithmsFromProvider(self, provider, parent):
         groups = {}
@@ -393,12 +418,9 @@ class ProcessingToolbox(BASE, WIDGET):
                         break
 
                 if not groupItem:
-                    groupItem = QTreeWidgetItem()
-                    name = alg.group()
+                    groupItem = TreeGroupItem(alg.group())
                     if not active:
-                        groupItem.setForeground(0, Qt.darkGray)
-                    groupItem.setText(0, name)
-                    groupItem.setToolTip(0, name)
+                        groupItem.setInactive()
                     if provider.id() in ('qgis', 'native'):
                         groupItem.setIcon(0, provider.icon())
                     groups[alg.group()] = groupItem
@@ -414,8 +436,7 @@ class ProcessingToolbox(BASE, WIDGET):
                 if action.group in groups:
                     groupItem = groups[action.group]
                 else:
-                    groupItem = QTreeWidgetItem()
-                    groupItem.setText(0, action.group)
+                    groupItem = TreeGroupItem(action.group)
                     groups[action.group] = groupItem
                 algItem = TreeActionItem(action)
                 groupItem.addChild(algItem)
@@ -456,8 +477,22 @@ class TreeAlgorithmItem(QTreeWidgetItem):
         self.setIcon(0, icon)
         self.setToolTip(0, name)
         self.setText(0, name)
-        self.setData(0, Qt.UserRole, nameEn)
-        self.setData(0, Qt.UserRole + 1, alg.tags())
+        self.setData(0, ProcessingToolbox.NAME_ROLE, nameEn)
+        self.setData(0, ProcessingToolbox.TAG_ROLE, alg.tags())
+        self.setData(0, ProcessingToolbox.TYPE_ROLE, ProcessingToolbox.ALG_ITEM)
+
+
+class TreeGroupItem(QTreeWidgetItem):
+
+    def __init__(self, name):
+        QTreeWidgetItem.__init__(self)
+        self.setToolTip(0, name)
+        self.setText(0, name)
+        self.setData(0, ProcessingToolbox.NAME_ROLE, name)
+        self.setData(0, ProcessingToolbox.TYPE_ROLE, ProcessingToolbox.GROUP_ITEM)
+
+    def setInactive(self):
+        self.setForeground(0, Qt.darkGray)
 
 
 class TreeActionItem(QTreeWidgetItem):
@@ -467,17 +502,18 @@ class TreeActionItem(QTreeWidgetItem):
         self.action = action
         self.setText(0, action.i18n_name)
         self.setIcon(0, action.getIcon())
-        self.setData(0, Qt.UserRole, action.name)
+        self.setData(0, ProcessingToolbox.NAME_ROLE, action.name)
 
 
 class TreeProviderItem(QTreeWidgetItem):
 
     def __init__(self, provider, tree, toolbox):
-        QTreeWidgetItem.__init__(self, tree)
+        QTreeWidgetItem.__init__(self, None)
         self.tree = tree
         self.toolbox = toolbox
         self.provider = provider
         self.setIcon(0, self.provider.icon())
+        self.setData(0, ProcessingToolbox.TYPE_ROLE, ProcessingToolbox.PROVIDER_ITEM)
         self.populate()
 
     def refresh(self):

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -454,7 +454,6 @@ class ProcessingToolbox(BASE, WIDGET):
                 self.algorithmTree.setItemWidget(parent, 0, label)
             else:
                 parent.setText(0, text)
-            parent.setToolTip(0, parent.text(0))
 
         for groupItem in list(groups.values()):
             parent.addChild(groupItem)
@@ -512,6 +511,7 @@ class TreeProviderItem(QTreeWidgetItem):
         self.provider = provider
         self.setIcon(0, self.provider.icon())
         self.setData(0, ProcessingToolbox.TYPE_ROLE, ProcessingToolbox.PROVIDER_ITEM)
+        self.setToolTip(0, self.provider.longName())
         self.populate()
 
     def refresh(self):

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -452,9 +452,7 @@ class ProcessingToolbox(BASE, WIDGET):
                 label.setStyleSheet("QLabel {background-color: white; color: grey;}")
                 label.linkActivated.connect(activateProvider)
                 self.algorithmTree.setItemWidget(parent, 0, label)
-
             else:
-                text += QCoreApplication.translate("TreeProviderItem", " [{0} geoalgorithms]").format(count)
                 parent.setText(0, text)
             parent.setToolTip(0, parent.text(0))
 

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -39,6 +39,11 @@ QString QgsProcessingProvider::svgIconPath() const
   return QgsApplication::iconPath( QStringLiteral( "processingAlgorithm.svg" ) );
 }
 
+QString QgsProcessingProvider::longName() const
+{
+  return name();
+}
+
 void QgsProcessingProvider::refreshAlgorithms()
 {
   qDeleteAll( mAlgorithms );

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -70,11 +70,24 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     virtual QString id() const = 0;
 
     /**
-     * Returns the full provider name, which is used to describe the provider within the GUI.
-     * This string should be localised.
+     * Returns the provider name, which is used to describe the provider within the GUI.
+     * This string should be short (e.g. "Lastools") and localised.
+     * \see longName()
      * \see id()
      */
     virtual QString name() const = 0;
+
+    /**
+     * Returns the a longer version of the provider name, which can include extra details
+     * such as version numbers. E.g. "Lastools LIDAR tools (version 2.2.1)".
+     * This string should be localised.
+     *
+     * The default implementation returns the same string as name().
+     *
+     * \see name()
+     * \see id()
+     */
+    virtual QString longName() const;
 
     /**
      * Returns true if the provider can be activated, or false if it cannot be activated (e.g. due to


### PR DESCRIPTION
In QGIS 3.0 we are trying to push users towards trying native QGIS algorithms first. 

This change ensures that searching for algorithms always returns native algorithms before matching 3rd party algorithms:

![image](https://user-images.githubusercontent.com/1829991/31583481-4403c6d0-b1e0-11e7-918f-2740f1fc6a64.png)



Question: should we be removing the "[45 geoalgorithms]" text from the GDAL group? I don't see it as particular relevant and just additional noise, and it's also a bit odd in the above screenshot since there's clearly not 45 matching algorithms for that search phrase... 