### PR TITLE
Optimize spacing in Color settings dialog

### DIFF
--- a/src/ui/qgscompoundcolorwidget.ui
+++ b/src/ui/qgscompoundcolorwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>620</width>
-    <height>402</height>
+    <width>597</width>
+    <height>329</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -256,7 +256,7 @@
            <property name="sizeHint" stdset="0">
             <size>
              <width>20</width>
-             <height>40</height>
+             <height>0</height>
             </size>
            </property>
           </spacer>
@@ -430,7 +430,7 @@
           <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
-            <height>40</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
@@ -440,6 +440,18 @@
      </item>
      <item row="1" column="0">
       <widget class="QWidget" name="mPreviewWidget" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>80</height>
+        </size>
+       </property>
        <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
         <item row="0" column="0">
          <widget class="QLabel" name="label_3">
@@ -464,7 +476,7 @@
         <item row="0" column="2" rowspan="2">
          <widget class="QPushButton" name="mAddCustomColorButton">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -535,6 +547,12 @@
      </item>
      <item row="1" column="1">
       <widget class="QWidget" name="mSwatchesWidget" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <layout class="QGridLayout" name="gridLayout_4">
         <property name="spacing">
          <number>1</number>


### PR DESCRIPTION
Gain some vertical spacing in the dialog to customize colors
![image](https://user-images.githubusercontent.com/7983394/31588943-7318b61a-b1f9-11e7-9475-29e517a25fc5.png)
![image](https://user-images.githubusercontent.com/7983394/31589006-637fdfa2-b1fa-11e7-92b9-5f87c8760df8.png)
