### PR TITLE
[layouts] Nicer detection of rendering in a view

### DIFF
--- a/python/core/layout/qgslayoutitem.sip
+++ b/python/core/layout/qgslayoutitem.sip
@@ -511,6 +511,14 @@ class QgsLayoutItem : QgsLayoutObject, QGraphicsRectItem, QgsLayoutUndoObjectInt
  Draws the background for the item.
 %End
 
+    bool isPreviewRender( QPainter *painter ) const;
+%Docstring
+ Returns true if the render to the specified ``painter`` is a preview render,
+ i.e. is being rendered inside a QGraphicsView widget as opposed to a destination
+ device (such as an image).
+ :rtype: bool
+%End
+
     virtual void setFixedSize( const QgsLayoutSize &size );
 %Docstring
  Sets a fixed ``size`` for the layout item, which prevents it from being freely

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -666,6 +666,31 @@ void QgsLayoutItem::drawBackground( QgsRenderContext &context )
   p->restore();
 }
 
+bool QgsLayoutItem::isPreviewRender( QPainter *painter ) const
+{
+  if ( !painter || !painter->device() )
+    return false;
+
+  // if rendering to a QGraphicsView, we are in preview mode
+  QPaintDevice *device = painter->device();
+  if ( dynamic_cast< QPixmap * >( device ) )
+    return true;
+
+  QObject *obj = dynamic_cast< QObject *>( device );
+  if ( !obj )
+    return false;
+
+  const QMetaObject *mo = obj->metaObject();
+  while ( mo )
+  {
+    if ( mo->className() == QStringLiteral( "QGraphicsView" ) )
+      return true;
+
+    mo = mo->superClass();
+  }
+  return false;
+}
+
 void QgsLayoutItem::setFixedSize( const QgsLayoutSize &size )
 {
   mFixedSize = size;

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -510,6 +510,13 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     virtual void drawBackground( QgsRenderContext &context );
 
     /**
+     * Returns true if the render to the specified \a painter is a preview render,
+     * i.e. is being rendered inside a QGraphicsView widget as opposed to a destination
+     * device (such as an image).
+     */
+    bool isPreviewRender( QPainter *painter ) const;
+
+    /**
      * Sets a fixed \a size for the layout item, which prevents it from being freely
      * resized. Set an empty size if item can be freely resized.
      * \see fixedSize()
@@ -657,6 +664,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     bool shouldBlockUndoCommands() const;
 
     friend class TestQgsLayoutItem;
+    friend class TestQgsLayoutView;
     friend class QgsLayoutItemGroup;
 };
 

--- a/tests/src/gui/testqgslayoutview.cpp
+++ b/tests/src/gui/testqgslayoutview.cpp
@@ -23,9 +23,12 @@
 #include "qgslayoutitemregistry.h"
 #include "qgslayoutitemguiregistry.h"
 #include "qgslayoutitemwidget.h"
+#include "qgslayoutitemshape.h"
 #include "qgsproject.h"
 #include "qgsgui.h"
 #include <QtTest/QSignalSpy>
+#include <QSvgGenerator>
+#include <QPrinter>
 
 class TestQgsLayoutView: public QObject
 {
@@ -40,6 +43,7 @@ class TestQgsLayoutView: public QObject
     void events();
     void guiRegistry();
     void rubberBand();
+    void isPreviewRender();
 
   private:
 
@@ -325,6 +329,89 @@ void TestQgsLayoutView::rubberBand()
   QCOMPARE( band.brush().color(), QColor( 255, 0, 0 ) );
   band.setPen( QPen( QColor( 0, 255, 0 ) ) );
   QCOMPARE( band.pen().color(), QColor( 0, 255, 0 ) );
+}
+
+class TestViewItem : public QgsLayoutItem
+{
+    Q_OBJECT
+
+  public:
+
+    TestViewItem( QgsLayout *layout ) : QgsLayoutItem( layout )
+    {
+    }
+
+    //implement pure virtual methods
+    int type() const override { return QgsLayoutItemRegistry::LayoutItem + 101; }
+    QString stringType() const override { return QStringLiteral( "TestItemType" ); }
+    bool mDrawn = false;
+    bool mPreview = false;
+
+  protected:
+    void paint( QPainter *painter, const QStyleOptionGraphicsItem *, QWidget * ) override
+    {
+      mDrawn = true;
+      mPreview = isPreviewRender( painter );
+    }
+    void draw( QgsRenderContext &, const QStyleOptionGraphicsItem * ) override
+    {
+
+    }
+
+};
+
+void TestQgsLayoutView::isPreviewRender()
+{
+  // test if items can detect whether a preview render is occurring
+  QgsProject p;
+  QgsLayoutView *view = new QgsLayoutView();
+  QgsLayout *layout = new QgsLayout( &p );
+  view->setCurrentLayout( layout );
+
+  TestViewItem *item = new TestViewItem( layout );
+  layout->addLayoutItem( item );
+  item->attemptMove( QgsLayoutPoint( 0, 0 ) );
+  item->attemptResize( QgsLayoutSize( 100, 100 ) );
+  layout->updateBounds();
+
+
+  // render to image
+  QVERIFY( !item->isPreviewRender( nullptr ) );
+  QImage im = QImage( 250, 250, QImage::Format_RGB32 );
+  QPainter painter;
+  QVERIFY( painter.begin( &im ) );
+  QVERIFY( !item->isPreviewRender( &painter ) );
+  painter.end();
+
+  // render to svg
+  QSvgGenerator generator;
+  generator.setFileName( QDir::tempPath() + "/layout_text.svg" );
+  QVERIFY( painter.begin( &generator ) );
+  QVERIFY( !item->isPreviewRender( &painter ) );
+  painter.end();
+
+  // render to pdf
+  QPrinter printer;
+  printer.setOutputFileName( QString() );
+  printer.setOutputFormat( QPrinter::PdfFormat );
+  printer.setOutputFileName( QDir::tempPath() + "/layout_text.pdf" );
+  QVERIFY( painter.begin( &printer ) );
+  QVERIFY( !item->isPreviewRender( &painter ) );
+  painter.end();
+
+  // render in view - kinda gross!
+  item->mDrawn = false;
+  item->mPreview = false;
+  view->show();
+  view->zoomFull();
+  while ( !item->mDrawn )
+  {
+    QApplication::processEvents();
+  }
+
+  QVERIFY( item->mDrawn );
+  QVERIFY( item->mPreview );
+
 }
 
 QGSTEST_MAIN( TestQgsLayoutView )


### PR DESCRIPTION
In compositions, a flag must be explicitly set to indicate whether the render occuring is for "previews" (i.e.
rendering in a graphics view) or outputs (i.e. rendering to a image/pdf/other destination device)

This isn't nice api, and i'd like to avoid it for 3.0

So this PR attempts to avoid the need to explicitly set this flag, by instead checking the paint device type when an item is being rendered.

If it's not a QGraphicsView subclass , and not a QPixmap we consider it a final output - otherwise we trat it as a "preview" render.

The QPixmap check is necessary because graphics items are cached in a view - so the device is often not the widget, but instead a temporary cache pixmap.

The tricky bit here... is there ANY times when an output will use a QPixmap paint device? I suspect not (and there's unit tests here to ensure that's the case for the standard SVG/image/PDF output types)... but i'm not 100% sure.

So ideas/thoughts on this approach are eagerly sought, or alternative approaches...