### PR TITLE
[FEATURE] Add a flag to dirty edit buffer when using executeSql in transactions

### DIFF
--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -167,7 +167,7 @@ class QgsTransaction : QObject /Abstract/
  Emitted after a rollback
 %End
 
-    void dirty( const QString &sql );
+    void dirtied( const QString &sql );
 %Docstring
  Emitted if a sql query is executed and the underlying data is modified
 %End

--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -97,10 +97,16 @@ class QgsTransaction : QObject /Abstract/
  :rtype: bool
 %End
 
-    virtual bool executeSql( const QString &sql, QString &error /Out/ ) = 0;
+    virtual bool executeSql( const QString &sql, QString &error /Out/, bool isDirty = false ) = 0;
 %Docstring
  Execute the ``sql`` string. The result must not be a tuple, so running a
  ``SELECT`` query will return an error.
+
+ \param sql The sql query to execute
+ \param error The error message
+ \param isDirty Flag to indicate if the underlying data will be modified
+
+ :return: true if everything is OK, false otherwise
  :rtype: bool
 %End
 
@@ -159,6 +165,11 @@ class QgsTransaction : QObject /Abstract/
     void afterRollback();
 %Docstring
  Emitted after a rollback
+%End
+
+    void dirty( const QString &sql );
+%Docstring
+ Emitted if a sql query is executed and the underlying data is modified
 %End
 
   protected:

--- a/python/core/qgsvectorlayereditpassthrough.sip
+++ b/python/core/qgsvectorlayereditpassthrough.sip
@@ -41,6 +41,19 @@ class QgsVectorLayerEditPassthrough : QgsVectorLayerEditBuffer
     virtual void rollBack();
 
 
+    bool update( QgsTransaction *transaction, const QString &sql );
+%Docstring
+ Update underlying data with a SQL query embedded in a transaction.
+
+ \param transaction Transaction in which the sql query has been run
+ \param sql The SQL query updating data
+
+ :return: true if the undo/redo command is well added to the stack, false otherwise
+
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
 };
 
 /************************************************************************

--- a/python/core/qgsvectorlayerundopassthroughcommand.sip
+++ b/python/core/qgsvectorlayerundopassthroughcommand.sip
@@ -60,8 +60,6 @@ class QgsVectorLayerUndoPassthroughCommand : QgsVectorLayerUndoCommand
 %End
 
 
-  protected:
-
 };
 
 

--- a/python/core/qgsvectorlayerundopassthroughcommand.sip
+++ b/python/core/qgsvectorlayerundopassthroughcommand.sip
@@ -47,10 +47,12 @@ class QgsVectorLayerUndoPassthroughCommand : QgsVectorLayerUndoCommand
  :rtype: bool
 %End
 
-    bool setSavePoint();
+    bool setSavePoint( const QString &savePointId = QString() );
 %Docstring
- Set the command savepoint or set error status
- error satus should be false prior to call
+ Set the command savepoint or set error status.
+ Error satus should be false prior to call. If the savepoint given in
+ parameter is empty, then a new one is created if none is currently
+ available in the transaction.
  :rtype: bool
 %End
 
@@ -59,6 +61,20 @@ class QgsVectorLayerUndoPassthroughCommand : QgsVectorLayerUndoCommand
  Set error flag and append "failed" to text
 %End
 
+    void setErrorMessage( const QString &errorMessage );
+%Docstring
+ Sets the error message.
+
+.. versionadded:: 3.0
+%End
+
+    QString errorMessage() const;
+%Docstring
+ Returns the error message or an empty string if there's none.
+
+.. versionadded:: 3.0
+ :rtype: str
+%End
 
 };
 

--- a/python/core/qgsvectorlayerundopassthroughcommand.sip
+++ b/python/core/qgsvectorlayerundopassthroughcommand.sip
@@ -23,11 +23,12 @@ class QgsVectorLayerUndoPassthroughCommand : QgsVectorLayerUndoCommand
 %End
   public:
 
-    QgsVectorLayerUndoPassthroughCommand( QgsVectorLayerEditBuffer *buffer, const QString &text );
+    QgsVectorLayerUndoPassthroughCommand( QgsVectorLayerEditBuffer *buffer, const QString &text, bool autocreate = true );
 %Docstring
  Constructor for QgsVectorLayerUndoPassthroughCommand
  \param buffer associated edit buffer
  \param text text associated with command
+ \param autocreate flag allowing to automatically create a savepoint if necessary
 %End
 
     bool hasError() const;
@@ -57,6 +58,9 @@ class QgsVectorLayerUndoPassthroughCommand : QgsVectorLayerUndoCommand
 %Docstring
  Set error flag and append "failed" to text
 %End
+
+
+  protected:
 
 };
 
@@ -239,6 +243,32 @@ class QgsVectorLayerUndoPassthroughCommandRenameAttribute : QgsVectorLayerUndoPa
  \param buffer associated edit buffer
  \param attr
  \param newName
+%End
+
+    virtual void undo();
+    virtual void redo();
+
+};
+
+
+class QgsVectorLayerUndoPassthroughCommandUpdate : QgsVectorLayerUndoPassthroughCommand
+{
+%Docstring
+ Undo command for running a specific sql query in transaction group.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsvectorlayerundopassthroughcommand.h"
+%End
+  public:
+
+    QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer /Transfer/, QgsTransaction *transaction, const QString &sql );
+%Docstring
+ Constructor for QgsVectorLayerUndoCommandUpdate
+ \param buffer associated edit buffer
+ \param transaction transaction running the sql query
+ \param sql the query
 %End
 
     virtual void undo();

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -201,7 +201,7 @@ QString QgsTransaction::createSavepoint( QString &error SIP_OUT )
   if ( !mTransactionActive )
     return QString();
 
-  if ( !mLastSavePointIsDirty )
+  if ( !mLastSavePointIsDirty && !mSavepoints.isEmpty() )
     return mSavepoints.top();
 
   const QString name( QUuid::createUuid().toString() );

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -174,7 +174,7 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     /**
      * Emitted if a sql query is executed and the underlying data is modified
      */
-    void dirty( const QString &sql );
+    void dirtied( const QString &sql );
 
   protected:
     QgsTransaction( const QString &connString ) SIP_SKIP;

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -111,8 +111,14 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     /**
      * Execute the \a sql string. The result must not be a tuple, so running a
      * ``SELECT`` query will return an error.
+     *
+     * \param sql The sql query to execute
+     * \param error The error message
+     * \param isDirty Flag to indicate if the underlying data will be modified
+     *
+     * \returns true if everything is OK, false otherwise
      */
-    virtual bool executeSql( const QString &sql, QString &error SIP_OUT ) = 0;
+    virtual bool executeSql( const QString &sql, QString &error SIP_OUT, bool isDirty = false ) = 0;
 
     /**
      * Checks if a the provider of a given \a layer supports transactions.
@@ -164,6 +170,11 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
      * Emitted after a rollback
      */
     void afterRollback();
+
+    /**
+     * Emitted if a sql query is executed and the underlying data is modified
+     */
+    void dirty( const QString &sql );
 
   protected:
     QgsTransaction( const QString &connString ) SIP_SKIP;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1346,7 +1346,7 @@ bool QgsVectorLayer::startEditing()
   {
     mEditBuffer = new QgsVectorLayerEditPassthrough( this );
 
-    connect( mDataProvider->transaction(), &QgsTransaction::dirty, this, &QgsVectorLayer::onDirtyTransaction, Qt::UniqueConnection );
+    connect( mDataProvider->transaction(), &QgsTransaction::dirtied, this, &QgsVectorLayer::onDirtyTransaction, Qt::UniqueConnection );
   }
   else
   {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1345,6 +1345,8 @@ bool QgsVectorLayer::startEditing()
   if ( mDataProvider->transaction() )
   {
     mEditBuffer = new QgsVectorLayerEditPassthrough( this );
+
+    connect( mDataProvider->transaction(), &QgsTransaction::dirty, this, &QgsVectorLayer::onDirtyTransaction, Qt::UniqueConnection );
   }
   else
   {
@@ -4575,3 +4577,11 @@ bool QgsVectorLayer::readExtentFromXml() const
   return mReadExtentFromXml;
 }
 
+void QgsVectorLayer::onDirtyTransaction( const QString &sql )
+{
+  QgsTransaction *tr = dataProvider()->transaction();
+  if ( tr && mEditBuffer )
+  {
+    dynamic_cast<QgsVectorLayerEditPassthrough *>( mEditBuffer )->update( tr, sql );
+  }
+}

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4582,6 +4582,6 @@ void QgsVectorLayer::onDirtyTransaction( const QString &sql )
   QgsTransaction *tr = dataProvider()->transaction();
   if ( tr && mEditBuffer )
   {
-    dynamic_cast<QgsVectorLayerEditPassthrough *>( mEditBuffer )->update( tr, sql );
+    qobject_cast<QgsVectorLayerEditPassthrough *>( mEditBuffer )->update( tr, sql );
   }
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2066,6 +2066,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onFeatureDeleted( QgsFeatureId fid );
     void onRelationsLoaded();
     void onSymbolsCounted();
+    void onDirtyTransaction( const QString &sql );
 
   protected:
     //! Set the extent

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -267,6 +267,7 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     friend class QgsVectorLayerUndoPassthroughCommandAddAttribute;
     friend class QgsVectorLayerUndoPassthroughCommandDeleteAttribute;
     friend class QgsVectorLayerUndoPassthroughCommandRenameAttribute;
+    friend class QgsVectorLayerUndoPassthroughCommandUpdate;
 
     /**
      * Deleted feature IDs which are not committed.  Note a feature can be added and then deleted

--- a/src/core/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/qgsvectorlayereditpassthrough.cpp
@@ -17,6 +17,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayerundopassthroughcommand.h"
+#include "qgstransaction.h"
 
 QgsVectorLayerEditPassthrough::QgsVectorLayerEditPassthrough( QgsVectorLayer *layer )
   : mModified( false )
@@ -35,7 +36,12 @@ bool QgsVectorLayerEditPassthrough::modify( QgsVectorLayerUndoPassthroughCommand
   if ( cmd->hasError() )
     return false;
 
-  mModified = true;
+  if ( !mModified )
+  {
+    mModified = true;
+    emit layerModified();
+  }
+
   return true;
 }
 
@@ -104,4 +110,9 @@ bool QgsVectorLayerEditPassthrough::commitChanges( QStringList & /*commitErrors*
 void QgsVectorLayerEditPassthrough::rollBack()
 {
   mModified = false;
+}
+
+bool QgsVectorLayerEditPassthrough::update( QgsTransaction *tr, const QString &sql )
+{
+  return modify( new QgsVectorLayerUndoPassthroughCommandUpdate( this, tr, sql ) );
 }

--- a/src/core/qgsvectorlayereditpassthrough.h
+++ b/src/core/qgsvectorlayereditpassthrough.h
@@ -20,6 +20,7 @@
 
 class QgsVectorLayer;
 class QgsVectorLayerUndoPassthroughCommand;
+class QgsTransaction;
 
 /**
  * \ingroup core
@@ -42,6 +43,18 @@ class CORE_EXPORT QgsVectorLayerEditPassthrough : public QgsVectorLayerEditBuffe
     bool renameAttribute( int attr, const QString &newName ) override;
     bool commitChanges( QStringList &commitErrors ) override;
     void rollBack() override;
+
+    /**
+     * Update underlying data with a SQL query embedded in a transaction.
+     *
+     * \param transaction Transaction in which the sql query has been run
+     * \param sql The SQL query updating data
+     *
+     * \returns true if the undo/redo command is well added to the stack, false otherwise
+     *
+     * \since QGIS 3.0
+     */
+    bool update( QgsTransaction *transaction, const QString &sql );
 
   private:
     bool mModified;

--- a/src/core/qgsvectorlayerundopassthroughcommand.cpp
+++ b/src/core/qgsvectorlayerundopassthroughcommand.cpp
@@ -54,18 +54,35 @@ void QgsVectorLayerUndoPassthroughCommand::setError()
   }
 }
 
-bool QgsVectorLayerUndoPassthroughCommand::setSavePoint()
+void QgsVectorLayerUndoPassthroughCommand::setErrorMessage( const QString &errorMessage )
+{
+  mError = errorMessage;
+}
+
+QString QgsVectorLayerUndoPassthroughCommand::errorMessage() const
+{
+  return mError;
+}
+
+bool QgsVectorLayerUndoPassthroughCommand::setSavePoint( const QString &savePointId )
 {
   if ( !hasError() )
   {
-    // re-create savepoint only if mRecreateSavePoint and rollBackToSavePoint as occurred
-    if ( mRecreateSavePoint && mBuffer->L->dataProvider()->transaction()->savePoints().indexOf( mSavePointId ) == -1 )
+    if ( savePointId.isEmpty() )
     {
-      mSavePointId = mBuffer->L->dataProvider()->transaction()->createSavepoint( mSavePointId, mError );
-      if ( mSavePointId.isEmpty() )
+      // re-create savepoint only if mRecreateSavePoint and rollBackToSavePoint as occurred
+      if ( mRecreateSavePoint && mBuffer->L->dataProvider()->transaction()->savePoints().indexOf( mSavePointId ) == -1 )
       {
-        setError();
+        mSavePointId = mBuffer->L->dataProvider()->transaction()->createSavepoint( mSavePointId, mError );
+        if ( mSavePointId.isEmpty() )
+        {
+          setError();
+        }
       }
+    }
+    else
+    {
+      mSavePointId = savePointId;
     }
   }
   return !hasError();
@@ -360,21 +377,27 @@ void QgsVectorLayerUndoPassthroughCommandUpdate::redo()
   // itself. So the redo has to be executed only after an undo action.
   if ( mUndone )
   {
-    mSavePointId = mTransaction->createSavepoint( mError );
+    QString errorMessage;
 
-    if ( mError.isEmpty() )
+    QString savePointId = mTransaction->createSavepoint( errorMessage );
+
+    if ( errorMessage.isEmpty() )
     {
-      if ( mTransaction->executeSql( mSql, mError ) )
+      setSavePoint( savePointId );
+
+      if ( mTransaction->executeSql( mSql, errorMessage ) )
       {
         mUndone = false;
       }
       else
       {
+        setErrorMessage( errorMessage );
         setError();
       }
     }
     else
     {
+      setErrorMessage( errorMessage );
       setError();
     }
   }

--- a/src/core/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/qgsvectorlayerundopassthroughcommand.h
@@ -66,8 +66,6 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommand : public QgsVectorLayerUn
     void setError();
 
     QString mSavePointId;
-
-  protected:
     QString mError;
 
   private:

--- a/src/core/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/qgsvectorlayerundopassthroughcommand.h
@@ -55,20 +55,35 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommand : public QgsVectorLayerUn
     bool rollBackToSavePoint();
 
     /**
-     * Set the command savepoint or set error status
-     * error satus should be false prior to call
+     * Set the command savepoint or set error status.
+     * Error satus should be false prior to call. If the savepoint given in
+     * parameter is empty, then a new one is created if none is currently
+     * available in the transaction.
      */
-    bool setSavePoint();
+    bool setSavePoint( const QString &savePointId = QString() );
 
     /**
      * Set error flag and append "failed" to text
      */
     void setError();
 
-    QString mSavePointId;
-    QString mError;
+    /**
+     * Sets the error message.
+     *
+     * \since QGIS 3.0
+     */
+    void setErrorMessage( const QString &errorMessage );
+
+    /**
+     * Returns the error message or an empty string if there's none.
+     *
+     * \since QGIS 3.0
+     */
+    QString errorMessage() const;
 
   private:
+    QString mSavePointId;
+    QString mError;
     bool mHasError;
     bool mRecreateSavePoint;
 };

--- a/src/core/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/qgsvectorlayerundopassthroughcommand.h
@@ -36,19 +36,14 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommand : public QgsVectorLayerUn
      * Constructor for QgsVectorLayerUndoPassthroughCommand
      * \param buffer associated edit buffer
      * \param text text associated with command
+     * \param autocreate flag allowing to automatically create a savepoint if necessary
      */
-    QgsVectorLayerUndoPassthroughCommand( QgsVectorLayerEditBuffer *buffer, const QString &text );
+    QgsVectorLayerUndoPassthroughCommand( QgsVectorLayerEditBuffer *buffer, const QString &text, bool autocreate = true );
 
     /**
      * Returns error status
      */
     bool hasError() const { return mHasError; }
-
-  private:
-    QString mError;
-    QString mSavePointId;
-    bool mHasError;
-    bool mRecreateSavePoint;
 
   protected:
 
@@ -70,6 +65,14 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommand : public QgsVectorLayerUn
      */
     void setError();
 
+    QString mSavePointId;
+
+  protected:
+    QString mError;
+
+  private:
+    bool mHasError;
+    bool mRecreateSavePoint;
 };
 
 /**
@@ -263,6 +266,34 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandRenameAttribute : public Q
     const int mAttr;
     const QString mNewName;
     const QString mOldName;
+};
+
+/**
+ * \ingroup core
+ * \class QgsVectorLayerUndoPassthroughCommandUpdate
+ * \brief Undo command for running a specific sql query in transaction group.
+ * \since QGIS 3.0
+ */
+
+class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandUpdate : public QgsVectorLayerUndoPassthroughCommand
+{
+  public:
+
+    /**
+     * Constructor for QgsVectorLayerUndoCommandUpdate
+     * \param buffer associated edit buffer
+     * \param transaction transaction running the sql query
+     * \param sql the query
+     */
+    QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer SIP_TRANSFER, QgsTransaction *transaction, const QString &sql );
+
+    virtual void undo() override;
+    virtual void redo() override;
+
+  private:
+    QgsTransaction *mTransaction = nullptr;
+    QString mSql;
+    bool mUndone = false;
 };
 
 #endif

--- a/src/providers/postgres/qgspostgrestransaction.cpp
+++ b/src/providers/postgres/qgspostgrestransaction.cpp
@@ -90,7 +90,7 @@ bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg, 
   if ( isDirty )
   {
     dirtyLastSavePoint();
-    emit dirty( sql );
+    emit dirtied( sql );
   }
 
   QgsDebugMsg( QString( "Status %1 (OK)" ).arg( r.PQresultStatus() ) );

--- a/src/providers/postgres/qgspostgrestransaction.cpp
+++ b/src/providers/postgres/qgspostgrestransaction.cpp
@@ -57,11 +57,17 @@ bool QgsPostgresTransaction::rollbackTransaction( QString &error )
   return false;
 }
 
-bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg )
+bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg, bool isDirty )
 {
   if ( !mConn )
   {
     return false;
+  }
+
+  QString err;
+  if ( isDirty )
+  {
+    createSavepoint( err );
   }
 
   QgsDebugMsg( QString( "Transaction sql: %1" ).arg( sql ) );
@@ -72,8 +78,21 @@ bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg )
   {
     errorMsg = QStringLiteral( "Status %1 (%2)" ).arg( r.PQresultStatus() ).arg( r.PQresultErrorMessage() );
     QgsDebugMsg( errorMsg );
+
+    if ( isDirty )
+    {
+      rollbackToSavepoint( savePoints().last(), err );
+    }
+
     return false;
   }
+
+  if ( isDirty )
+  {
+    dirtyLastSavePoint();
+    emit dirty( sql );
+  }
+
   QgsDebugMsg( QString( "Status %1 (OK)" ).arg( r.PQresultStatus() ) );
   return true;
 }

--- a/src/providers/postgres/qgspostgrestransaction.h
+++ b/src/providers/postgres/qgspostgrestransaction.h
@@ -29,7 +29,7 @@ class QgsPostgresTransaction : public QgsTransaction
 
   public:
     explicit QgsPostgresTransaction( const QString &connString );
-    bool executeSql( const QString &sql, QString &error ) override;
+    bool executeSql( const QString &sql, QString &error, bool isDirty = false ) override;
     QgsPostgresConn *connection() const { return mConn; }
 
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -33,7 +33,8 @@ from qgis.core import (
     QgsReadWriteContext,
     QgsRectangle,
     QgsDefaultValue,
-    QgsDataSourceUri
+    QgsDataSourceUri,
+    QgsProject
 )
 from qgis.gui import QgsGui
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QObject
@@ -311,6 +312,54 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         f['pk'] = NULL
         self.vl.addFeature(f)  # Should not deadlock during an active iteration
         f = next(it)
+
+    def testTransactionNotDirty(self):
+        # create a vector ayer based on postgres
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'pk\' srid=4326 type=POLYGON table="qgis_test"."some_poly_data" (geom) sql=', 'test', 'postgres')
+        self.assertTrue(vl.isValid())
+
+        # prepare a project with transactions enabled
+        p = QgsProject()
+        p.setAutoTransaction(True)
+        p.addMapLayers([vl])
+        vl.startEditing()
+
+        # check that the feature used for testing is ok
+        ft0 = vl.getFeatures('pk=1')
+        f = QgsFeature()
+        self.assertTrue(ft0.nextFeature(f))
+
+        # update the data within the transaction
+        tr = vl.dataProvider().transaction()
+        sql = "update qgis_test.some_poly_data set pk=33 where pk=1"
+        self.assertTrue(tr.executeSql(sql, True)[0])
+
+        # check that the pk of the feature has been changed
+        ft = vl.getFeatures('pk=1')
+        self.assertFalse(ft.nextFeature(f))
+
+        ft = vl.getFeatures('pk=33')
+        self.assertTrue(ft.nextFeature(f))
+
+        # underlying data has been modified but the layer is not tagged as
+        # modified
+        self.assertTrue(vl.isModified())
+
+        # undo sql query
+        vl.undoStack().undo()
+
+        # check that the original feature with pk is back
+        ft0 = vl.getFeatures('pk=1')
+        self.assertTrue(ft0.nextFeature(f))
+
+        # redo
+        vl.undoStack().redo()
+
+        # check that the pk of the feature has been changed
+        ft1 = vl.getFeatures('pk=1')
+        self.assertFalse(ft1.nextFeature(f))
+
+        p.setAutoTransaction(False)
 
     def testDomainTypes(self):
         """Test that domain types are correctly mapped"""


### PR DESCRIPTION
## Description

This PR adds the possibility to dirty the edition buffer in transactions while using the `executeSql` method.

This way:
- the `Save layer edits` button become available when the dirty flag is true (the vector layer is considered as modified)
- the undo/redo stack is working (thanks to savepoints and rollback)

I added some tests to validate the current behavior.

However, I still have a question about the current implementation of the `executeSql` method for Postgres. As described in the documentation:

```
Execute the \a sql string. The result must not be a tuple, so running a ``SELECT`` query will return an error.
```

Is there a reason? Because it seems pretty limiting. Moreover, the method may return `False` whereas the underlying SQL query is run without errors.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
