### PR TITLE
[bugfix] Fix a syntax error in dlg_sql_layer_window.py

### DIFF
--- a/python/plugins/db_manager/dlg_sql_layer_window.py
+++ b/python/plugins/db_manager/dlg_sql_layer_window.py
@@ -155,7 +155,7 @@ class DlgSqlLayerWindow(QWidget, Ui_Dialog):
             schema = uri.schema()
             if schema and schema.upper() != 'PUBLIC':
                 sql = 'SELECT * FROM ' + schema + '.' + sql
-            else
+            else:
                 sql = 'SELECT * FROM ' + sql
         self.editSql.setText(sql)
         self.executeSql()


### PR DESCRIPTION
## Description
An `else` is missing a `:` in `python/plugins/db_manager/dlg_sql_layer_window.py` line 158.

This has been caught by continuous integration/delivery on Fedora (see #5333 and at the bottom of https://copr-be.cloud.fedoraproject.org/results/dani/qgis-testing/fedora-26-x86_64/00637652-qgis/build.log.gz) during `compileall` phase in rpm generation. 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
