### PR TITLE
Disable spell check in prepare-commit.sh

### DIFF
--- a/scripts/prepare-commit.sh
+++ b/scripts/prepare-commit.sh
@@ -57,7 +57,8 @@ if [ -z "$MODIFIED" ]; then
   exit 0
 fi
 
-[ -x ${TOPLEVEL}/scripts/spell_check/check_spelling.sh ] && ${TOPLEVEL}/scripts/spell_check/check_spelling.sh $MODIFIED
+if [[ -n "$QGIS_CHECK_SPELLING" && -x ${TOPLEVEL}/scripts/spell_check/check_spelling.sh ]]; then ${TOPLEVEL}/scripts/spell_check/check_spelling.sh $MODIFIED; fi
+
 
 # save original changes
 REV=$(git log -n1 --pretty=%H)


### PR DESCRIPTION
The spell check slows down the pre-commit hook a lot. Spell checking will still be done on travis.

I found this to be slowing me down sometimes, especially when working on a lot of files. On the other hand, it only found a few issues which would have also been ok for me if reported by travis.

@3nids do you want to keep this optionally available (env var)?