### PR TITLE
Add render context flag to indicate canvas preview jobs

### DIFF
--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -222,6 +222,7 @@ Get color that is used for drawing of selected vector features
       DrawSymbolBounds,
       RenderMapTile,
       RenderPartialOutput,
+      RenderPreviewJob,
       // TODO
     };
     typedef QFlags<QgsMapSettings::Flag> Flags;

--- a/python/core/qgsrendercontext.sip
+++ b/python/core/qgsrendercontext.sip
@@ -41,6 +41,7 @@ class QgsRenderContext
       RenderMapTile,
       Antialiasing,
       RenderPartialOutput,
+      RenderPreviewJob,
     };
     typedef QFlags<QgsRenderContext::Flag> Flags;
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -214,6 +214,7 @@ class CORE_EXPORT QgsMapSettings
       DrawSymbolBounds         = 0x80,  //!< Draw bounds of symbols (for debugging/testing)
       RenderMapTile            = 0x100, //!< Draw map such that there are no problems between adjacent tiles
       RenderPartialOutput      = 0x200, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
+      RenderPreviewJob         = 0x400, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
       // TODO: ignore scale-based visibility (overview)
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -134,6 +134,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.setFlag( RenderMapTile, mapSettings.testFlag( QgsMapSettings::RenderMapTile ) );
   ctx.setFlag( Antialiasing, mapSettings.testFlag( QgsMapSettings::Antialiasing ) );
   ctx.setFlag( RenderPartialOutput, mapSettings.testFlag( QgsMapSettings::RenderPartialOutput ) );
+  ctx.setFlag( RenderPreviewJob, mapSettings.testFlag( QgsMapSettings::RenderPreviewJob ) );
   ctx.setScaleFactor( mapSettings.outputDpi() / 25.4 ); // = pixels per mm
   ctx.setRendererScale( mapSettings.scale() );
   ctx.setExpressionContext( mapSettings.expressionContext() );

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -69,6 +69,7 @@ class CORE_EXPORT QgsRenderContext
       RenderMapTile            = 0x40,  //!< Draw map such that there are no problems between adjacent tiles
       Antialiasing             = 0x80,  //!< Use antialiasing while drawing
       RenderPartialOutput      = 0x100, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
+      RenderPreviewJob         = 0x200, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -214,7 +214,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   // copy the whole raster pipe!
   mPipe = new QgsRasterPipe( *layer->pipe() );
   QgsRasterRenderer *rasterRenderer = mPipe->renderer();
-  if ( rasterRenderer )
+  if ( rasterRenderer && !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob ) )
     layer->refreshRendererIfNeeded( rasterRenderer, rendererContext.extent() );
 }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2266,6 +2266,7 @@ void QgsMapCanvas::startPreviewJob( int number )
 
   jobSettings.setExtent( jobExtent );
   jobSettings.setFlag( QgsMapSettings::DrawLabeling, false );
+  jobSettings.setFlag( QgsMapSettings::RenderPreviewJob, true );
 
   QgsMapRendererQImageJob *job = new QgsMapRendererSequentialJob( jobSettings );
   mPreviewJobs.append( job );


### PR DESCRIPTION
In future we can use this to optimise the preview job and shortcut by doing lower quality/faster renders.

For now, use this flag to identify preview jobs and only apply 'updated canvas' min/max to rasters for non-preview jobs

Fixes #16988
