### PR TITLE
Server wms print layers

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgswmsparameters.h"
+#include "qgsdatasourceuri.h"
 #include "qgsmessagelog.h"
 #include <iostream>
 
@@ -510,6 +511,16 @@ namespace QgsWms
           if ( !value.canConvert( mParameters[name].mType ) )
           {
             raiseError( name );
+          }
+        }
+        else //maybe an external wms parameter?
+        {
+          int separator = key.indexOf( ":" );
+          if ( separator >= 1 )
+          {
+            QString id = key.left( separator );
+            QString param = key.right( key.length() - separator - 1 );
+            mExternalWMSParameters[id].insert( param, parameters[key] );
           }
         }
       }
@@ -1872,6 +1883,23 @@ namespace QgsWms
     param.mHighlightLayers = hParams;
 
     return param;
+  }
+
+  QString QgsWmsParameters::externalWMSUri( const QString &id ) const
+  {
+    if ( !mExternalWMSParameters.contains( id ) )
+    {
+      return QString();
+    }
+
+    QgsDataSourceUri wmsUri;
+    const QMap<QString, QString> &paramMap = mExternalWMSParameters[ id ];
+    QMap<QString, QString>::const_iterator paramIt = paramMap.constBegin();
+    for ( ; paramIt != paramMap.constEnd(); ++paramIt )
+    {
+      wmsUri.setParam( paramIt.key().toLower(), paramIt.value() );
+    }
+    return wmsUri.encodedUri();
   }
 
   QString QgsWmsParameters::name( ParameterName name ) const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -909,6 +909,13 @@ namespace QgsWms
        */
       QgsWmsParametersComposerMap composerMapParameters( int mapId ) const;
 
+      /**
+       * @brief externalWMSUri
+       * @param id the id of the external wms
+       * @return uri string or an empty string if the external wms id does not exist
+       */
+      QString externalWMSUri( const QString &id ) const;
+
     private:
       QString name( ParameterName name ) const;
       void raiseError( ParameterName name ) const;
@@ -955,6 +962,7 @@ namespace QgsWms
       QgsServerRequest::Parameters mRequestParameters;
       QMap<ParameterName, Parameter> mParameters;
       QMap<int, QMap<ParameterName, Parameter>> mComposerParameters;
+      QMap<QString, QMap<QString, QString> > mExternalWMSParameters;
       QList<QgsProjectVersion> mVersions;
   };
 }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2624,6 +2624,7 @@ namespace QgsWms
         if ( externalWMSLayer )
         {
           layers.append( externalWMSLayer );
+          mNicknameLayers[nickname] = externalWMSLayer; //might be used later in GetPrint request
           mTemporaryLayers.append( externalWMSLayer );
         }
       }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2653,24 +2653,8 @@ namespace QgsWms
 
   QgsMapLayer *QgsRenderer::createExternalWMSLayer( const QString &externalLayerId ) const
   {
-    QgsMapLayer *wmsLayer = 0;
-    QgsDataSourceUri wmsUri;
-
-    QgsServerRequest::Parameters::const_iterator it = mParameters.lowerBound( externalLayerId.toUpper() + ":" );
-    while ( it != mParameters.constEnd() )
-    {
-      if ( !it.key().startsWith( externalLayerId.toUpper() + ":" ) )
-      {
-        break;
-      }
-
-      QString paramKey = it.key();
-      paramKey.remove( 0, externalLayerId.size() + 1 );
-      wmsUri.setParam( paramKey.toLower(), it.value() );
-      ++it;
-    }
-
-    wmsLayer = new QgsRasterLayer( wmsUri.encodedUri(), externalLayerId, QStringLiteral( "wms" ) );
+    QString wmsUri = mWmsParameters.externalWMSUri( externalLayerId.toUpper() );
+    QgsMapLayer *wmsLayer = new QgsRasterLayer( wmsUri, externalLayerId, QStringLiteral( "wms" ) );
     if ( !wmsLayer->isValid() )
     {
       delete wmsLayer;

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2610,7 +2610,17 @@ namespace QgsWms
     {
       QString nickname = param.mNickname;
       QString style = param.mStyle;
-      if ( mNicknameLayers.contains( nickname ) && !mRestrictedLayers.contains( nickname ) )
+      if ( nickname.startsWith( "EXTERNAL_WMS:" ) )
+      {
+        QString externalLayerId = nickname;
+        externalLayerId.remove( 0, 13 );
+        QgsMapLayer *externalWMSLayer = createExternalWMSLayer( externalLayerId );
+        if ( externalWMSLayer )
+        {
+          layers.append( externalWMSLayer );
+        }
+      }
+      else if ( mNicknameLayers.contains( nickname ) && !mRestrictedLayers.contains( nickname ) )
       {
         if ( !style.isEmpty() )
         {
@@ -2631,6 +2641,35 @@ namespace QgsWms
     }
 
     return layers;
+  }
+
+  QgsMapLayer *QgsRenderer::createExternalWMSLayer( const QString &externalLayerId ) const
+  {
+    QgsMapLayer *wmsLayer = 0;
+    QgsDataSourceUri wmsUri;
+
+    QgsServerRequest::Parameters::const_iterator it = mParameters.lowerBound( externalLayerId.toUpper() + ":" );
+    while ( it != mParameters.constEnd() )
+    {
+      if ( !it.key().startsWith( externalLayerId.toUpper() + ":" ) )
+      {
+        break;
+      }
+
+      QString paramKey = it.key();
+      paramKey.remove( 0, externalLayerId.size() + 1 );
+      wmsUri.setParam( paramKey.toLower(), it.value() );
+      ++it;
+    }
+
+    wmsLayer = new QgsRasterLayer( wmsUri.encodedUri(), externalLayerId, QStringLiteral( "wms" ) );
+    if ( !wmsLayer->isValid() )
+    {
+      delete wmsLayer;
+      return 0;
+    }
+
+    return wmsLayer;
   }
 
   QPainter *QgsRenderer::layersRendering( const QgsMapSettings &mapSettings, QImage &image, HitTest *hitTest ) const

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -132,6 +132,11 @@ namespace QgsWms
     initNicknameLayers();
   }
 
+  QgsRenderer::~QgsRenderer()
+  {
+    removeTemporaryLayers();
+  }
+
 
   QImage *QgsRenderer::getLegendGraphics()
   {
@@ -2557,6 +2562,7 @@ namespace QgsWms
       }
     }
 
+    mTemporaryLayers.append( highlightLayers );
     return highlightLayers;
   }
 
@@ -2602,7 +2608,7 @@ namespace QgsWms
     return layers;
   }
 
-  QList<QgsMapLayer *> QgsRenderer::stylizedLayers( const QList<QgsWmsParametersLayer> &params ) const
+  QList<QgsMapLayer *> QgsRenderer::stylizedLayers( const QList<QgsWmsParametersLayer> &params )
   {
     QList<QgsMapLayer *> layers;
 
@@ -2618,6 +2624,7 @@ namespace QgsWms
         if ( externalWMSLayer )
         {
           layers.append( externalWMSLayer );
+          mTemporaryLayers.append( externalWMSLayer );
         }
       }
       else if ( mNicknameLayers.contains( nickname ) && !mRestrictedLayers.contains( nickname ) )
@@ -2670,6 +2677,12 @@ namespace QgsWms
     }
 
     return wmsLayer;
+  }
+
+  void QgsRenderer::removeTemporaryLayers()
+  {
+    qDeleteAll( mTemporaryLayers );
+    mTemporaryLayers.clear();
   }
 
   QPainter *QgsRenderer::layersRendering( const QgsMapSettings &mapSettings, QImage &image, HitTest *hitTest ) const

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -84,6 +84,8 @@ namespace QgsWms
                    const QgsProject *project,
                    const QgsServerRequest::Parameters &parameters );
 
+      ~QgsRenderer();
+
       /**
        * Returns the map legend as an image (or a null pointer in case of error). The caller takes ownership
       of the image object*/
@@ -154,7 +156,7 @@ namespace QgsWms
       void annotationsRendering( QPainter *painter ) const;
 
       // Return a list of layers stylized with LAYERS/STYLES parameters
-      QList<QgsMapLayer *> stylizedLayers( const QList<QgsWmsParametersLayer> &params ) const;
+      QList<QgsMapLayer *> stylizedLayers( const QList<QgsWmsParametersLayer> &params );
 
       // Return a list of layers stylized with SLD parameter
       QList<QgsMapLayer *> sldStylizedLayers( const QString &sld ) const;
@@ -277,6 +279,8 @@ namespace QgsWms
       //! Creates external WMS layer. Caller takes ownership
       QgsMapLayer *createExternalWMSLayer( const QString &externalLayerId ) const;
 
+      void removeTemporaryLayers();
+
     private:
 
       const QgsServerRequest::Parameters &mParameters;
@@ -289,6 +293,7 @@ namespace QgsWms
       QgsWmsParameters mWmsParameters;
       QStringList mRestrictedLayers;
       QMap<QString, QgsMapLayer *> mNicknameLayers;
+      QList<QgsMapLayer *> mTemporaryLayers;
 
     public:
 

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -274,6 +274,9 @@ namespace QgsWms
       //! configure the composition for the GetPrint request
       bool configureComposition( QgsComposition *c, const QgsMapSettings &mapSettings );
 
+      //! Creates external WMS layer. Caller takes ownership
+      QgsMapLayer *createExternalWMSLayer( const QString &externalLayerId ) const;
+
     private:
 
       const QgsServerRequest::Parameters &mParameters;


### PR DESCRIPTION
This pull request adds the possibility to request external WMS layers (which are not defined in the project) in GetMap and GetPrint requests. In web maps, there  are often WMS/WMTS background layers that we want to have directly in the Web map (not through QGIS server). However, for printing, these layers should be enabled (and WMTS layers replaced by WMS layers). Also, some web clients allow the user to add external WMS services to a web map, which also need to be in the printed output.

The proposed solution is to have the dynamic wms layers as EXTERNAL_WMS:&lt;identifier&gt; in the LAYERS parameter and pass the needed wms parameters as &lt;identifier&gt;:url,&lt;identifier&gt;:format,&lt;identifier&gt;:crs etc. in the request. Like this, it is possible to have several external WMS layers in a request and they can be at any position (not only as background layers). An example to request an external wms layer with a vector layer (defined in the project) is  the following:

http://localhost/cgi-bin/qgis_mapserv.fcgi?SERVICE=WMS&REQUEST=GetMap&LAYERS=EXTERNAL_WMS:sogis_avwms,eisenbahnen&STYLES=,&BBOX=xmin,ymin,xmax,ymax&FORMAT=image/png&sogis_avwms:url=http://geoweb.so.ch/wms/avwms?&sogis_avwms:layers=AVWMS_farbig&sogis_avwms:styles=&sogis_avwms:format=image/png&sogis_avwms:crs=EPSG:21781

Are there any security considerations related to passing external wms services to QGIS server? One thing I could imagine is that someone could try to exploit overflows in image libraries by setting up a wms service that always returns a malicious image. Are there other possible dangers?

If other devs are fine with the proposed approach, I'll add a unit test and I'm planning to extend the GetProjectSettings output such that web clients can easily directly access WMTS layers and replace them by WMS layers for printing.