### PR TITLE
[server] WIP : reactivate flaky server tests for WMS requests

### DIFF
--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -215,6 +215,46 @@ class QgsServerTestBase(unittest.TestCase):
         return b"\n".join(headers) + b"\n\n", bytes(response.body())
 
 
+class TestQgsServerTestBase(unittest.TestCase):
+
+    def test_assert_xml_equal(self):
+        engine = QgsServerTestBase()
+
+        # test bad assertion
+        expected = b'</WFSLayers>\n<Layer queryable="1">\n'
+        response = b'<Layer>\n'
+        self.assertRaises(AssertionError, engine.assertXMLEqual, response, expected)
+
+        expected = b'</WFSLayers>\n<Layer queryable="1">\n'
+        response = b'</WFSLayers>\n<Layer>\n'
+        self.assertRaises(AssertionError, engine.assertXMLEqual, response, expected)
+
+        expected = b'</WFSLayers>\n<Layer queryable="1">\n'
+        response = b'</WFSLayers>\n<Layer fake="1">\n'
+        self.assertRaises(AssertionError, engine.assertXMLEqual, response, expected)
+
+        expected = b'</WFSLayers>\n<Layer queryable="1">\n'
+        response = b'</WFSLayers>\n<Layer queryable="2">\n'
+        self.assertRaises(AssertionError, engine.assertXMLEqual, response, expected)
+
+        expected = b'<TreeName>QGIS Test Project</TreeName>\n<Layer geometryType="Point" queryable="1" displayField="name" visible="1">\n'
+        response = b'<TreeName>QGIS Test Project</TreeName>\n<Layer geometryType="Point" queryable="1" displayField="name">\n'
+        self.assertRaises(AssertionError, engine.assertXMLEqual, response, expected)
+
+        expected = b'<TreeName>QGIS Test Project</TreeName>\n<Layer geometryType="Point" queryable="1" displayField="name" visible="1">\n'
+        response = b'<TreeName>QGIS Test Project</TreeName>\n<Layer geometryType="Point" queryable="1" displayField="name" visible="0">\n'
+        self.assertRaises(AssertionError, engine.assertXMLEqual, response, expected)
+
+        # test valid assertion
+        expected = b'</WFSLayers>\n<Layer queryable="1">\n'
+        response = b'</WFSLayers>\n<Layer queryable="1">\n'
+        self.assertFalse(engine.assertXMLEqual(response, expected))
+
+        expected = b'<TreeName>QGIS Test Project</TreeName>\n<Layer geometryType="Point" queryable="1" displayField="name" visible="1">\n'
+        response = b'<TreeName>QGIS Test Project</TreeName>\n<Layer geometryType="Point" queryable="1" displayField="name" visible="1">\n'
+        self.assertFalse(engine.assertXMLEqual(response, expected))
+
+
 class TestQgsServer(QgsServerTestBase):
 
     """Tests container"""

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -1286,7 +1286,6 @@ class TestQgsServerWMS(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_Legend")
 
-    @unittest.skip('Randomly failing to draw the map layer')
     def test_wms_getprint_srs(self):
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -64,12 +64,16 @@ class TestQgsServerWMS(QgsServerTestBase):
 
         self.assertXMLEqual(response, expected, msg="request %s failed.\nQuery: %s\nExpected file: %s\nResponse:\n%s" % (query_string, request, reference_path, response.decode('utf-8')))
 
-    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Test is flaky on Travis environment')
-    def test_project_wms(self):
-        """Test some WMS request"""
-        for request in ('GetCapabilities', 'GetProjectSettings', 'GetContext'):
-            self.wms_request_compare(request)
+    def test_getcapabilities(self):
+        self.wms_request_compare('GetCapabilities')
 
+    def test_getprojectsettings(self):
+        self.wms_request_compare('GetProjectSettings')
+
+    def test_getcontext(self):
+        self.wms_request_compare('GetContext')
+
+    def test_getfeatureinfo(self):
         # Test getfeatureinfo response xml
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
@@ -174,11 +178,14 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'FEATURE_COUNT=10&FILTER_GEOM=POLYGON((8.2035381 44.901459,8.2035562 44.901459,8.2035562 44.901418,8.2035381 44.901418,8.2035381 44.901459))',
                                  'wms_getfeatureinfo_invalid_query_layers')
 
+    def test_describelayer(self):
         # Test DescribeLayer
         self.wms_request_compare('DescribeLayer',
                                  '&layers=testlayer%20%C3%A8%C3%A9&' +
                                  'SLD_VERSION=1.1.0',
                                  'describelayer')
+
+    def test_getstyles(self):
         # Test GetStyles
         self.wms_request_compare('GetStyles',
                                  '&layers=testlayer%20%C3%A8%C3%A9&',


### PR DESCRIPTION
## Description

Some WMS tests have been deactivated in Travis because of their flaky behaviors. The aim of this PR is to detect underlying issues.

For now, I just splitted some tests to have a better vision of what is happening in Travis.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
