### PR TITLE
[Server][Tests] Fix WMS tests locally

### DIFF
--- a/tests/testdata/qgis_server/describelayer.txt
+++ b/tests/testdata/qgis_server/describelayer.txt
@@ -1,7 +1,7 @@
 *****
 Content-Type: text/xml; charset=utf-8
 
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <DescribeLayerResponse xmlns="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/DescribeLayer.xsd" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink">
  <Version>1.1.0</Version>
  <LayerDescription>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -6,7 +6,7 @@ Content-Type: text/xml; charset=utf-8
  <Service>
   <Name>WMS</Name>
   <Title>QGIS TestProject</Title>
-  <Abstract>Some UTF8 text èòù</Abstract>
+  <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -6,7 +6,7 @@ Content-Type: text/xml; charset=utf-8
  <Service>
   <Name>WMS</Name>
   <Title>QGIS TestProject</Title>
-  <Abstract>Some UTF8 text èòù</Abstract>
+  <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>

--- a/tests/testdata/qgis_server/getcontext.txt
+++ b/tests/testdata/qgis_server/getcontext.txt
@@ -6,18 +6,18 @@ Content-Type: text/xml; charset=utf-8
  <General>
   <Window width="800" height="600"/>
   <ows:Title>QGIS TestProject</ows:Title>
-  <ows:Abstract>Some UTF8 text èòù</ows:Abstract>
+  <ows:Abstract><![CDATA[Some UTF8 text èòù]]></ows:Abstract>
   <ows:BoundingBox crs="EPSG:4326">
    <ows:LowerCorner>44.9012 8.20315</ows:LowerCorner>
    <ows:UpperCorner>44.9016 8.20416</ows:UpperCorner>
   </ows:BoundingBox>
  </General>
  <ResourceList>
-  <Layer opacity="1" queryable="true" hidden="false" id="testlayer_èé" name="testlayer èé">
+  <Layer hidden="true" queryable="true" id="testlayer_èé" name="testlayer èé" opacity="1">
    <ows:Title>A test vector layer</ows:Title>
    <ows:OutputFormat>image/png</ows:OutputFormat>
    <Server version="1.3.0" default="true" service="urn:ogc:serviceType:WMS">
-    <OnlineResource xlink:href="https://www.qgis.org/?*****&amp;"/>
+    <OnlineResource xlink:href="https://www.qgis.org/?*****"/>
    </Server>
    <ows:Abstract>A test vector layer with unicode òà</ows:Abstract>
    <StyleList>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -6,7 +6,7 @@ Content-Type: text/xml; charset=utf-8
  <Service>
   <Name>WMS</Name>
   <Title>QGIS TestProject</Title>
-  <Abstract>Some UTF8 text èòù</Abstract>
+  <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>
@@ -113,7 +113,7 @@ Content-Type: text/xml; charset=utf-8
   <WFSLayers>
    <WFSLayer name="testlayer èé"/>
   </WFSLayers>
-  <Layer queryable="1">
+  <Layer>
    <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <CRS>CRS:84</CRS>
@@ -128,7 +128,7 @@ Content-Type: text/xml; charset=utf-8
    <BoundingBox maxy="5.60604e+06" maxx="913283" miny="5.60599e+06" CRS="EPSG:3857" minx="913171"/>
    <BoundingBox maxy="8.20416" maxx="44.9016" miny="8.20315" CRS="EPSG:4326" minx="44.9012"/>
    <TreeName>QGIS Test Project</TreeName>
-   <Layer geometryType="Point" queryable="1" displayField="name" visible="1">
+   <Layer geometryType="Point" queryable="1" displayField="name">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
@@ -153,9 +153,9 @@ Content-Type: text/xml; charset=utf-8
     </Style>
     <TreeName>testlayer èé</TreeName>
     <Attributes>
-     <Attribute precision="0" type="qlonglong" editType="" typeName="Integer64" name="id" comment="" length="10"/>
-     <Attribute precision="0" type="QString" editType="" typeName="String" name="name" comment="" length="10"/>
-     <Attribute precision="0" type="QString" editType="" typeName="String" name="utf8nameè" comment="" length="13"/>
+     <Attribute precision="0" type="qlonglong" editType="TextEdit" typeName="Integer64" name="id" comment="" length="10"/>
+     <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="name" comment="" length="10"/>
+     <Attribute precision="0" type="QString" editType="TextEdit" typeName="String" name="utf8nameè" comment="" length="13"/>
     </Attributes>
    </Layer>
   </Layer>

--- a/tests/testdata/qgis_server/getstyles.txt
+++ b/tests/testdata/qgis_server/getstyles.txt
@@ -1,7 +1,7 @@
 *****
 Content-Type: text/xml; charset=utf-8
 
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" version="1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
  <NamedLayer>
   <se:Name>testlayer èé</se:Name>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
@@ -8,6 +8,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
@@ -8,6 +8,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
@@ -15,6 +16,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="2" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
    <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
@@ -8,6 +8,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
@@ -15,6 +16,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="2" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
    <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>


### PR DESCRIPTION
## Description

The commit enhancement assertXMLEqual and update the references
It completes:
* [server] WIP : reactivate flaky server tests for WMS requests #5399
* [server][bugfix] Fix regression by adding visible tag to layer's node in GetProjectSettings #5400

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
