### PR TITLE
[needs-docs][feature] New button for empty the composer table

### DIFF
--- a/src/app/composer/qgsattributeselectiondialog.cpp
+++ b/src/app/composer/qgsattributeselectiondialog.cpp
@@ -378,7 +378,7 @@ void QgsAttributeSelectionDialog::mResetColumnsPushButton_clicked()
 void QgsAttributeSelectionDialog::mEmptyColumnsPushButton_clicked()
 {
   //remove all columns
-  mColumnModel->removeRows(0, mColumnModel->rowCount());
+  mColumnModel->removeRows( 0, mColumnModel->rowCount() );
   mSortColumnComboBox->setCurrentIndex( 0 );
 }
 

--- a/src/app/composer/qgsattributeselectiondialog.cpp
+++ b/src/app/composer/qgsattributeselectiondialog.cpp
@@ -331,12 +331,12 @@ QgsAttributeSelectionDialog::~QgsAttributeSelectionDialog()
 
 void QgsAttributeSelectionDialog::mRemoveColumnPushButton_clicked()
 {
-    //remove selected rows from model
-      QModelIndexList indexes =  mColumnsTableView->selectionModel()->selectedRows();
-      int count = indexes.count();
+  //remove selected rows from model
+  QModelIndexList indexes =  mColumnsTableView->selectionModel()->selectedRows();
+  int count = indexes.count();
 
-      for( int i = count; i > 0; --i )
-             mColumnModel->removeRow( indexes.at(i-1).row(), QModelIndex());
+  for ( int i = count; i > 0; --i )
+    mColumnModel->removeRow( indexes.at( i - 1 ).row(), QModelIndex() );
 }
 
 void QgsAttributeSelectionDialog::mAddColumnPushButton_clicked()

--- a/src/app/composer/qgsattributeselectiondialog.cpp
+++ b/src/app/composer/qgsattributeselectiondialog.cpp
@@ -280,6 +280,7 @@ QgsAttributeSelectionDialog::QgsAttributeSelectionDialog( QgsComposerAttributeTa
   connect( mColumnUpPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mColumnUpPushButton_clicked );
   connect( mColumnDownPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mColumnDownPushButton_clicked );
   connect( mResetColumnsPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mResetColumnsPushButton_clicked );
+  connect( mEmptyColumnsPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mEmptyColumnsPushButton_clicked );
   connect( mAddSortColumnPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mAddSortColumnPushButton_clicked );
   connect( mRemoveSortColumnPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mRemoveSortColumnPushButton_clicked );
   connect( mSortColumnUpPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mSortColumnUpPushButton_clicked );
@@ -371,6 +372,13 @@ void QgsAttributeSelectionDialog::mResetColumnsPushButton_clicked()
 {
   //reset columns to match vector layer's fields
   mColumnModel->resetToLayer();
+  mSortColumnComboBox->setCurrentIndex( 0 );
+}
+
+void QgsAttributeSelectionDialog::mEmptyColumnsPushButton_clicked()
+{
+  //remove all columns
+  mColumnModel->removeRows(0, mColumnModel->rowCount());
   mSortColumnComboBox->setCurrentIndex( 0 );
 }
 

--- a/src/app/composer/qgsattributeselectiondialog.cpp
+++ b/src/app/composer/qgsattributeselectiondialog.cpp
@@ -331,13 +331,12 @@ QgsAttributeSelectionDialog::~QgsAttributeSelectionDialog()
 
 void QgsAttributeSelectionDialog::mRemoveColumnPushButton_clicked()
 {
-  //remove selected row from model
-  QItemSelection viewSelection( mColumnsTableView->selectionModel()->selection() );
-  if ( viewSelection.length() > 0 )
-  {
-    int selectedRow = viewSelection.indexes().at( 0 ).row();
-    mColumnModel->removeRow( selectedRow );
-  }
+    //remove selected rows from model
+      QModelIndexList indexes =  mColumnsTableView->selectionModel()->selectedRows();
+      int count = indexes.count();
+
+      for( int i = count; i > 0; --i )
+             mColumnModel->removeRow( indexes.at(i-1).row(), QModelIndex());
 }
 
 void QgsAttributeSelectionDialog::mAddColumnPushButton_clicked()

--- a/src/app/composer/qgsattributeselectiondialog.cpp
+++ b/src/app/composer/qgsattributeselectiondialog.cpp
@@ -280,7 +280,7 @@ QgsAttributeSelectionDialog::QgsAttributeSelectionDialog( QgsComposerAttributeTa
   connect( mColumnUpPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mColumnUpPushButton_clicked );
   connect( mColumnDownPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mColumnDownPushButton_clicked );
   connect( mResetColumnsPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mResetColumnsPushButton_clicked );
-  connect( mEmptyColumnsPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mEmptyColumnsPushButton_clicked );
+  connect( mClearColumnsPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mClearColumnsPushButton_clicked );
   connect( mAddSortColumnPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mAddSortColumnPushButton_clicked );
   connect( mRemoveSortColumnPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mRemoveSortColumnPushButton_clicked );
   connect( mSortColumnUpPushButton, &QPushButton::clicked, this, &QgsAttributeSelectionDialog::mSortColumnUpPushButton_clicked );
@@ -375,7 +375,7 @@ void QgsAttributeSelectionDialog::mResetColumnsPushButton_clicked()
   mSortColumnComboBox->setCurrentIndex( 0 );
 }
 
-void QgsAttributeSelectionDialog::mEmptyColumnsPushButton_clicked()
+void QgsAttributeSelectionDialog::mClearColumnsPushButton_clicked()
 {
   //remove all columns
   mColumnModel->removeRows( 0, mColumnModel->rowCount() );

--- a/src/app/composer/qgsattributeselectiondialog.cpp
+++ b/src/app/composer/qgsattributeselectiondialog.cpp
@@ -348,23 +348,23 @@ void QgsAttributeSelectionDialog::mAddColumnPushButton_clicked()
 void QgsAttributeSelectionDialog::mColumnUpPushButton_clicked()
 {
   //move selected row up
-  QItemSelection viewSelection( mColumnsTableView->selectionModel()->selection() );
-  if ( !viewSelection.empty() )
-  {
-    int selectedRow = viewSelection.indexes().at( 0 ).row();
-    mColumnModel->moveRow( selectedRow, QgsComposerAttributeTableColumnModelV2::ShiftUp );
-  }
+
+  QModelIndexList indexes =  mColumnsTableView->selectionModel()->selectedRows();
+  int count = indexes.count();
+
+  std::reverse( indexes.begin(), indexes.end() );
+  for ( int i = count; i > 0; --i )
+    mColumnModel->moveRow( indexes.at( i - 1 ).row(), QgsComposerAttributeTableColumnModelV2::ShiftUp );
 }
 
 void QgsAttributeSelectionDialog::mColumnDownPushButton_clicked()
 {
   //move selected row down
-  QItemSelection viewSelection( mColumnsTableView->selectionModel()->selection() );
-  if ( !viewSelection.empty() )
-  {
-    int selectedRow = viewSelection.indexes().at( 0 ).row();
-    mColumnModel->moveRow( selectedRow, QgsComposerAttributeTableColumnModelV2::ShiftDown );
-  }
+  QModelIndexList indexes =  mColumnsTableView->selectionModel()->selectedRows();
+  int count = indexes.count();
+
+  for ( int i = count; i > 0; --i )
+    mColumnModel->moveRow( indexes.at( i - 1 ).row(), QgsComposerAttributeTableColumnModelV2::ShiftDown );
 }
 
 void QgsAttributeSelectionDialog::mResetColumnsPushButton_clicked()

--- a/src/app/composer/qgsattributeselectiondialog.h
+++ b/src/app/composer/qgsattributeselectiondialog.h
@@ -123,7 +123,7 @@ class QgsAttributeSelectionDialog: public QDialog, private Ui::QgsAttributeSelec
     void mColumnUpPushButton_clicked();
     void mColumnDownPushButton_clicked();
     void mResetColumnsPushButton_clicked();
-    void mEmptyColumnsPushButton_clicked();
+    void mClearColumnsPushButton_clicked();
     void mAddSortColumnPushButton_clicked();
     void mRemoveSortColumnPushButton_clicked();
     void mSortColumnUpPushButton_clicked();

--- a/src/app/composer/qgsattributeselectiondialog.h
+++ b/src/app/composer/qgsattributeselectiondialog.h
@@ -123,6 +123,7 @@ class QgsAttributeSelectionDialog: public QDialog, private Ui::QgsAttributeSelec
     void mColumnUpPushButton_clicked();
     void mColumnDownPushButton_clicked();
     void mResetColumnsPushButton_clicked();
+    void mEmptyColumnsPushButton_clicked();
     void mAddSortColumnPushButton_clicked();
     void mRemoveSortColumnPushButton_clicked();
     void mSortColumnUpPushButton_clicked();

--- a/src/ui/composer/qgsattributeselectiondialogbase.ui
+++ b/src/ui/composer/qgsattributeselectiondialogbase.ui
@@ -77,6 +77,13 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QPushButton" name="mEmptyColumnsPushButton">
+           <property name="text">
+            <string>Empty</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="1" column="1">

--- a/src/ui/composer/qgsattributeselectiondialogbase.ui
+++ b/src/ui/composer/qgsattributeselectiondialogbase.ui
@@ -78,9 +78,9 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="mEmptyColumnsPushButton">
+          <widget class="QPushButton" name="mClearColumnsPushButton">
            <property name="text">
-            <string>Empty</string>
+            <string>Clear</string>
            </property>
           </widget>
          </item>

--- a/src/ui/composer/qgsattributeselectiondialogbase.ui
+++ b/src/ui/composer/qgsattributeselectiondialogbase.ui
@@ -120,7 +120,7 @@
           <enum>Qt::IgnoreAction</enum>
          </property>
          <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
+          <enum>QAbstractItemView::MultiSelection</enum>
          </property>
          <property name="selectionBehavior">
           <enum>QAbstractItemView::SelectRows</enum>


### PR DESCRIPTION
## Description
Add a button to empty a composer table. Useful when you have a table with a lot of columns and you want only a few.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
