### PR TITLE
[Server][FEATURE] Handle request from QgsServer with a QgsProject

### DIFF
--- a/python/server/qgsserver.sip
+++ b/python/server/qgsserver.sip
@@ -35,7 +35,7 @@ class QgsServer
 .. versionadded:: 2.14
 %End
 
-    void handleRequest( QgsServerRequest &request, QgsServerResponse &response );
+    void handleRequest( QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project = 0 );
 %Docstring
  Handles the request.
  The query string is normally read from environment
@@ -44,6 +44,9 @@ class QgsServer
 
  \param request a QgsServerRequest holding request parameters
  \param response a QgsServerResponse for handling response I/O)
+ \param project a QgsProject or None, if it is None the project
+        is created from the MAP param specified in request or from
+        the QGIS_PROJECT_FILE setting
 %End
 
 

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -75,8 +75,11 @@ class SERVER_EXPORT QgsServer
      *
      * \param request a QgsServerRequest holding request parameters
      * \param response a QgsServerResponse for handling response I/O)
+     * \param project a QgsProject or nullptr, if it is nullptr the project
+     *        is created from the MAP param specified in request or from
+     *        the QGIS_PROJECT_FILE setting
      */
-    void handleRequest( QgsServerRequest &request, QgsServerResponse &response );
+    void handleRequest( QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project = nullptr );
 
 
     //! Returns a pointer to the server interface

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -214,6 +214,17 @@ class QgsServerTestBase(unittest.TestCase):
             headers.append(("%s: %s" % (k, rh[k])).encode('utf-8'))
         return b"\n".join(headers) + b"\n\n", bytes(response.body())
 
+    def _execute_request_project(self, qs, project, requestMethod=QgsServerRequest.GetMethod, data=None):
+        request = QgsBufferServerRequest(qs, requestMethod, {}, data)
+        response = QgsBufferServerResponse()
+        self.server.handleRequest(request, response, project)
+        headers = []
+        rh = response.headers()
+        rk = sorted(rh.keys())
+        for k in rk:
+            headers.append(("%s: %s" % (k, rh[k])).encode('utf-8'))
+        return b"\n".join(headers) + b"\n\n", bytes(response.body())
+
 
 class TestQgsServerTestBase(unittest.TestCase):
 
@@ -281,6 +292,16 @@ class TestQgsServer(QgsServerTestBase):
         request = QgsBufferServerRequest('http://somesite.com/somepath', QgsServerRequest.GetMethod, headers)
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response)
+        self.assertEqual(bytes(response.body()), b'<ServerException>Project file error</ServerException>\n')
+        self.assertEqual(response.headers(), {'Content-Length': '54', 'Content-Type': 'text/xml; charset=utf-8'})
+        self.assertEqual(response.statusCode(), 500)
+
+    def test_requestHandlerProject(self):
+        """Test request handler with none project"""
+        headers = {'header-key-1': 'header-value-1', 'header-key-2': 'header-value-2'}
+        request = QgsBufferServerRequest('http://somesite.com/somepath', QgsServerRequest.GetMethod, headers)
+        response = QgsBufferServerResponse()
+        self.server.handleRequest(request, response, None)
         self.assertEqual(bytes(response.body()), b'<ServerException>Project file error</ServerException>\n')
         self.assertEqual(response.headers(), {'Content-Length': '54', 'Content-Type': 'text/xml; charset=utf-8'})
         self.assertEqual(response.statusCode(), 500)


### PR DESCRIPTION
## Description

With this commit, it's posssible to handle a request from a QgsProject without writing it to the disk.

```python
server = QgsServer()
project = QgsProject()
vlayer = QgsVectorLayer("/path/to/shapefile/file.shp", "layer_name_you_like", "ogr")
project.addMapLayer(vlayer)

query_string = 'https://www.qgis.org/?SERVICE=WMS&VERSION=1.3&REQUEST=GetCapabilities'
request = QgsBufferServerRequest(query_string, QgsServerRequest.GetMethod, {}, data)
response = QgsBufferServerResponse()
server.handleRequest(request, response, project)
```

## Checklist
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
