### PR TITLE
fix tab clicks in plugin manager

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -38,8 +38,8 @@ const int PLUGMAN_TAB_NOT_INSTALLED = 2;
 const int PLUGMAN_TAB_UPGRADEABLE = 3;
 const int PLUGMAN_TAB_NEW = 4;
 const int PLUGMAN_TAB_INVALID = 5;
-const int PLUGMAN_TAB_INSTALL_FROM_ZIP = 7;
-const int PLUGMAN_TAB_SETTINGS = 8;
+const int PLUGMAN_TAB_INSTALL_FROM_ZIP = 6;
+const int PLUGMAN_TAB_SETTINGS = 7;
 
 /**
  * \brief Plugin manager for browsing, (un)installing and (un)loading plugins


### PR DESCRIPTION
## Description

Currently clicking on tabs in plugin manager is broken, see comments:
https://github.com/qgis/QGIS/commit/c295c92ed73be9a87d2b52bb8470b83b5eae799c#comments

Discussion IF this spacer should be there or not: 
https://github.com/qgis/qgis3_UIX_discussion/issues/24

But this at least fixes current wrong behaviour in which users cannot go to settings.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
