### PR TITLE
Deal with failure to create savepoint

### DIFF
--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -24,6 +24,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgsexpression.h"
+#include "qgsmessagelog.h"
 #include <QUuid>
 
 typedef QgsTransaction *createTransaction_t( const QString &connString );
@@ -195,7 +196,10 @@ QString QgsTransaction::createSavepoint( QString &error SIP_OUT )
   const QString name( QUuid::createUuid().toString() );
 
   if ( !executeSql( QStringLiteral( "SAVEPOINT %1" ).arg( QgsExpression::quotedColumnRef( name ) ), error ) )
+  {
+    QgsMessageLog::logMessage( tr( "Could not create savepoint (%1)" ).arg( error ) );
     return QString();
+  }
 
   mSavepoints.push( name );
   mLastSavePointIsDirty = false;
@@ -208,7 +212,10 @@ QString QgsTransaction::createSavepoint( const QString &savePointId, QString &er
     return QString();
 
   if ( !executeSql( QStringLiteral( "SAVEPOINT %1" ).arg( QgsExpression::quotedColumnRef( savePointId ) ), error ) )
+  {
+    QgsMessageLog::logMessage( tr( "Could not create savepoint (%1)" ).arg( error ) );
     return QString();
+  }
 
   mSavepoints.push( savePointId );
   mLastSavePointIsDirty = false;

--- a/src/core/qgsvectorlayerundopassthroughcommand.cpp
+++ b/src/core/qgsvectorlayerundopassthroughcommand.cpp
@@ -31,7 +31,8 @@
 
 QgsVectorLayerUndoPassthroughCommand::QgsVectorLayerUndoPassthroughCommand( QgsVectorLayerEditBuffer *buffer, const QString &text, bool autocreate )
   : QgsVectorLayerUndoCommand( buffer )
-  , mSavePointId( mBuffer->L->isEditCommandActive() || !autocreate
+  , mSavePointId( mBuffer->L->isEditCommandActive() && !mBuffer->L->dataProvider()->transaction()->savePoints().isEmpty()
+                  || !autocreate
                   ? mBuffer->L->dataProvider()->transaction()->savePoints().last()
                   : mBuffer->L->dataProvider()->transaction()->createSavepoint( mError ) )
   , mHasError( !mError.isEmpty() )


### PR DESCRIPTION
I just ran into  a situation when no savepoint could be created. I am not completely sure how this happened, but the debug output said something like "savepoints can only be created in transaction context" (and it's a transactional project).

This pull request will put the information into the message log (where it's more accessible to deal with similar issues and iron out the sources of this in the future)
Plus it will not crash, by trying to access an inexistent savepoint.