### PR TITLE
Fix QgsGeometry::angleAtVertex returned wrong angle for start/end of closed linestrings

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -368,31 +368,7 @@ double QgsGeometry::angleAtVertex( int vertex ) const
     return 0;
   }
 
-  QgsVertexId v1;
-  QgsVertexId v3;
-  QgsGeometryUtils::adjacentVertices( *d->geometry, v2, v1, v3 );
-  if ( v1.isValid() && v3.isValid() )
-  {
-    QgsPoint p1 = d->geometry->vertexAt( v1 );
-    QgsPoint p2 = d->geometry->vertexAt( v2 );
-    QgsPoint p3 = d->geometry->vertexAt( v3 );
-    double angle1 = QgsGeometryUtils::lineAngle( p1.x(), p1.y(), p2.x(), p2.y() );
-    double angle2 = QgsGeometryUtils::lineAngle( p2.x(), p2.y(), p3.x(), p3.y() );
-    return QgsGeometryUtils::averageAngle( angle1, angle2 );
-  }
-  else if ( v3.isValid() )
-  {
-    QgsPoint p1 = d->geometry->vertexAt( v2 );
-    QgsPoint p2 = d->geometry->vertexAt( v3 );
-    return QgsGeometryUtils::lineAngle( p1.x(), p1.y(), p2.x(), p2.y() );
-  }
-  else if ( v1.isValid() )
-  {
-    QgsPoint p1 = d->geometry->vertexAt( v1 );
-    QgsPoint p2 = d->geometry->vertexAt( v2 );
-    return QgsGeometryUtils::lineAngle( p1.x(), p1.y(), p2.x(), p2.y() );
-  }
-  return 0.0;
+  return d->geometry->vertexAngle( v2 );
 }
 
 void QgsGeometry::adjacentVertices( int atVertex, int &beforeVertex, int &afterVertex ) const

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -3618,6 +3618,11 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertAlmostEqual(linestring.angleAtVertex(0), math.radians(270), places=3)
         self.assertAlmostEqual(linestring.angleAtVertex(2), math.radians(180), places=3)
 
+        # closed linestring - angle at first/last vertex should be average angle
+        linestring = QgsGeometry.fromWkt('LineString (-1007697 1334641, -1007697 1334643, -1007695 1334643, -1007695 1334641, -1007696 1334641, -1007697 1334641)')
+        self.assertAlmostEqual(linestring.angleAtVertex(0), math.radians(315), places=3)
+        self.assertAlmostEqual(linestring.angleAtVertex(5), math.radians(315), places=3)
+
         # polygon
         polygon = QgsGeometry.fromWkt('Polygon((0 0, 10 0, 10 10, 0 10, 0 0))')
         self.assertAlmostEqual(polygon.angleAtVertex(0), math.radians(135.0), places=3)


### PR DESCRIPTION
The average angle of adjacent segments should be used in this case

Refs discussion in https://github.com/qgis/QGIS/pull/5404#issuecomment-338418824