### PR TITLE
Rename QgsGeometry::fromPolyline as QgsGeometry::fromPolylineXY

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1283,6 +1283,9 @@ empty geometry collection)
 - isGeosEmpty() was removed. Use isEmpty() instead.
 - reshapeGeometry() expects QgsLineString as a parameter instead of a list of 2D points (so that it can support 3D geometries)
 - vertexAt() now returns a QgsPoint (previously QgsPointV2) instead of a QgsPointXY (previously QgsPoint)
+- fromPolyline() now requires a list of QgsPoint objects, instead of QgsPointXY 2d points. A new method fromPolylineXY was
+added which uses the old list of 2d QgsPointXY objects. Using the newer method with QgsPoint is greatly preferred, as it
+maintains Z or M dimensions from the input points and is more efficient.
 
 
 QgsGeometryAnalyzer        {#qgis_api_break_3_0_QgsGeometryAnalyzer}
@@ -1889,6 +1892,13 @@ plugins calling this method will need to be updated.
 - destCRS() has been renamed to destinationCrs()
 - destinationCrs() now returns a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
 plugins calling this method will need to be updated.
+
+
+QgsPolyline        {#qgis_api_break_3_0_QgsPolyline}
+-----------
+
+- QgsPolyline now consists of a list of QgsPoint, instead of 2d QgsPointXY objects. The 2d polyline variant has
+been renamed to QgsPolylineXY
 
 
 QgsProject        {#qgis_api_break_3_0_QgsProject}

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -15,7 +15,9 @@
 
 
 
-typedef QVector<QgsPointXY> QgsPolyline;
+typedef QVector<QgsPointXY> QgsPolylineXY;
+
+typedef QVector<QgsPoint> QgsPolyline;
 
 typedef QVector<QVector<QgsPointXY>> QgsPolygon;
 
@@ -122,11 +124,35 @@ Creates a new geometry from a QgsPointXY object
 Creates a new geometry from a QgsMultiPoint object
  :rtype: QgsGeometry
 %End
-    static QgsGeometry fromPolyline( const QgsPolyline &polyline );
+
+    static QgsGeometry fromPolylineXY( const QgsPolylineXY &polyline );
 %Docstring
-Creates a new geometry from a QgsPolyline object
+ Creates a new LineString geometry from a list of QgsPointXY points.
+
+ Using fromPolyline() is preferred, as fromPolyline() is more efficient
+ and will respect any Z or M dimensions present in the input points.
+
+.. note::
+
+   In QGIS 2.x this method was available as fromPolyline().
+
+.. versionadded:: 3.0
+.. seealso:: fromPolyline()
  :rtype: QgsGeometry
 %End
+
+    static QgsGeometry fromPolyline( const QgsPolyline &polyline );
+%Docstring
+ Creates a new LineString geometry from a list of QgsPoint points.
+
+ This method will respect any Z or M dimensions present in the input points.
+ E.g. if input points are PointZ type, the resultant linestring will be
+ a LineStringZ type.
+
+.. versionadded:: 3.0
+ :rtype: QgsGeometry
+%End
+
     static QgsGeometry fromMultiPolyline( const QgsMultiPolyline &multiline );
 %Docstring
 Creates a new geometry from a QgsMultiPolyline object
@@ -1065,11 +1091,11 @@ Returns an extruded version of this geometry.
  :rtype: QgsPointXY
 %End
 
-    QgsPolyline asPolyline() const;
+    QgsPolylineXY asPolyline() const;
 %Docstring
  Returns contents of the geometry as a polyline
  if wkbType is WKBLineString, otherwise an empty list
- :rtype: QgsPolyline
+ :rtype: QgsPolylineXY
 %End
 
     QgsPolygon asPolygon() const;
@@ -1343,13 +1369,13 @@ Returns an extruded version of this geometry.
  :rtype: QgsGeometry
 %End
 
-    static QgsPolyline createPolylineFromQPolygonF( const QPolygonF &polygon ) /Factory/;
+    static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) /Factory/;
 %Docstring
- Creates a QgsPolyline from a QPolygonF.
+ Creates a QgsPolylineXY from a QPolygonF.
  \param polygon source polygon
- :return: QgsPolyline
+ :return: QgsPolylineXY
 .. seealso:: createPolygonFromQPolygonF
- :rtype: QgsPolyline
+ :rtype: QgsPolylineXY
 %End
 
     static QgsPolygon createPolygonFromQPolygonF( const QPolygonF &polygon ) /Factory/;
@@ -1365,7 +1391,7 @@ Returns an extruded version of this geometry.
     static bool compare( PyObject *obj1, PyObject *obj2, double epsilon = 4 * DBL_EPSILON );
 %Docstring
  Compares two geometry objects for equality within a specified tolerance.
- The objects can be of type QgsPolyline, QgsPolygon or QgsMultiPolygon.
+ The objects can be of type QgsPolylineXY, QgsPolygon or QgsMultiPolygon.
  The 2 types should match.
  \param p1 first geometry object
  \param p2 second geometry object
@@ -1402,10 +1428,10 @@ Returns an extruded version of this geometry.
                sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
                sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
           {
-            QgsPolyline *p0;
-            QgsPolyline *p1;
-            p0 = reinterpret_cast<QgsPolyline *>( sipConvertToType( a0, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state0, &sipIsErr ) );
-            p1 = reinterpret_cast<QgsPolyline *>( sipConvertToType( a1, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state1, &sipIsErr ) );
+            QgsPolylineXY *p0;
+            QgsPolylineXY *p1;
+            p0 = reinterpret_cast<QgsPolylineXY *>( sipConvertToType( a0, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state0, &sipIsErr ) );
+            p1 = reinterpret_cast<QgsPolylineXY *>( sipConvertToType( a1, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state1, &sipIsErr ) );
             if ( sipIsErr )
             {
               sipReleaseType( p0, sipType_QVector_0100QgsPointXY, state0 );

--- a/python/plugins/processing/algs/qgis/Gridify.py
+++ b/python/plugins/processing/algs/qgis/Gridify.py
@@ -91,7 +91,7 @@ class Gridify(QgisFeatureBasedAlgorithm):
                     feedback.reportError(self.tr('Failed to gridify feature with FID {0}').format(feature.id()))
                     newGeom = None
                 else:
-                    newGeom = QgsGeometry.fromPolyline(points)
+                    newGeom = QgsGeometry.fromPolylineXY(points)
             elif geomType == QgsWkbTypes.MultiLineString:
                 polyline = []
                 for line in geom.asMultiPolyline():

--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -146,7 +146,7 @@ class HubDistanceLines(QgisAlgorithm):
             feat = QgsFeature()
             feat.setAttributes(attributes)
 
-            feat.setGeometry(QgsGeometry.fromPolyline([src, closest]))
+            feat.setGeometry(QgsGeometry.fromPolylineXY([src, closest]))
 
             sink.addFeature(feat, QgsFeatureSink.FastInsert)
             feedback.setProgress(int(current * total))

--- a/python/plugins/processing/algs/qgis/ShortestPathLayerToPoint.py
+++ b/python/plugins/processing/algs/qgis/ShortestPathLayerToPoint.py
@@ -260,7 +260,7 @@ class ShortestPathLayerToPoint(QgisAlgorithm):
             route.append(snappedPoints[i])
             route.reverse()
 
-            geom = QgsGeometry.fromPolyline(route)
+            geom = QgsGeometry.fromPolylineXY(route)
             feat.setGeometry(geom)
             feat['start'] = points[i].toString()
             feat['end'] = endPoint.toString()

--- a/python/plugins/processing/algs/qgis/ShortestPathPointToLayer.py
+++ b/python/plugins/processing/algs/qgis/ShortestPathPointToLayer.py
@@ -260,7 +260,7 @@ class ShortestPathPointToLayer(QgisAlgorithm):
             route.append(snappedPoints[0])
             route.reverse()
 
-            geom = QgsGeometry.fromPolyline(route)
+            geom = QgsGeometry.fromPolylineXY(route)
             feat.setGeometry(geom)
             feat['start'] = startPoint.toString()
             feat['end'] = points[i].toString()

--- a/python/plugins/processing/algs/qgis/ShortestPathPointToPoint.py
+++ b/python/plugins/processing/algs/qgis/ShortestPathPointToPoint.py
@@ -234,7 +234,7 @@ class ShortestPathPointToPoint(QgisAlgorithm):
         route.reverse()
 
         feedback.pushInfo(self.tr('Writing results...'))
-        geom = QgsGeometry.fromPolyline(route)
+        geom = QgsGeometry.fromPolylineXY(route)
         feat = QgsFeature()
         feat.setFields(fields)
         feat['start'] = startPoint.toString()

--- a/src/analysis/interpolation/DualEdgeTriangulation.cpp
+++ b/src/analysis/interpolation/DualEdgeTriangulation.cpp
@@ -3060,10 +3060,10 @@ bool DualEdgeTriangulation::saveTriangulation( QgsFeatureSink *sink, QgsFeedback
       //geometry
       QgsPoint *p1 = mPointVector[currentEdge->getPoint()];
       QgsPoint *p2 = mPointVector[mHalfEdge[currentEdge->getDual()]->getPoint()];
-      QgsPolyline lineGeom;
+      QgsPolylineXY lineGeom;
       lineGeom.push_back( QgsPointXY( p1->x(), p1->y() ) );
       lineGeom.push_back( QgsPointXY( p2->x(), p2->y() ) );
-      edgeLineFeature.setGeometry( QgsGeometry::fromPolyline( lineGeom ) );
+      edgeLineFeature.setGeometry( QgsGeometry::fromPolylineXY( lineGeom ) );
       edgeLineFeature.initAttributes( 1 );
 
       //attributes

--- a/src/analysis/network/qgsvectorlayerdirector.cpp
+++ b/src/analysis/network/qgsvectorlayerdirector.cpp
@@ -175,7 +175,7 @@ void QgsVectorLayerDirector::makeGraph( QgsGraphBuilderInterface *builder, const
     {
       QgsPointXY pt1, pt2;
       bool isFirstPoint = true;
-      QgsPolyline::iterator pointIt;
+      QgsPolylineXY::iterator pointIt;
       for ( pointIt = mplIt->begin(); pointIt != mplIt->end(); ++pointIt )
       {
         pt2 = ct.transform( *pointIt );
@@ -319,7 +319,7 @@ void QgsVectorLayerDirector::makeGraph( QgsGraphBuilderInterface *builder, const
       QgsPointXY pt1, pt2;
 
       bool isFirstPoint = true;
-      QgsPolyline::iterator pointIt;
+      QgsPolylineXY::iterator pointIt;
       for ( pointIt = mplIt->begin(); pointIt != mplIt->end(); ++pointIt )
       {
         pt2 = ct.transform( *pointIt );

--- a/src/app/nodetool/qgsnodetool.cpp
+++ b/src/app/nodetool/qgsnodetool.cpp
@@ -800,9 +800,9 @@ void QgsNodeTool::mouseMoveNotDragging( QgsMapMouseEvent *e )
     else
     {
       // straight edge
-      QgsPolyline points;
+      QgsPolylineXY points;
       points << p0 << p1;
-      mEdgeBand->setToGeometry( QgsGeometry::fromPolyline( points ), nullptr );
+      mEdgeBand->setToGeometry( QgsGeometry::fromPolylineXY( points ), nullptr );
     }
 
     QgsPointXY edgeCenter;
@@ -1757,9 +1757,9 @@ bool QgsNodeTool::matchEdgeCenterTest( const QgsPointLocator::Match &m, const Qg
   {
     // clip line segment to the extent so the mid-point marker is always visible
     QgsGeometry extentGeom = QgsGeometry::fromRect( visible_extent );
-    QgsGeometry lineGeom = QgsGeometry::fromPolyline( QgsPolyline() << p0 << p1 );
+    QgsGeometry lineGeom = QgsGeometry::fromPolylineXY( QgsPolylineXY() << p0 << p1 );
     lineGeom = extentGeom.intersection( lineGeom );
-    QgsPolyline polyline = lineGeom.asPolyline();
+    QgsPolylineXY polyline = lineGeom.asPolyline();
     Q_ASSERT( polyline.count() == 2 );
     p0 = polyline[0];
     p1 = polyline[1];

--- a/src/app/qgsmaptooldeletepart.cpp
+++ b/src/app/qgsmaptooldeletepart.cpp
@@ -152,7 +152,7 @@ QgsGeometry QgsMapToolDeletePart::partUnderPoint( QPoint point, QgsFeatureId &fi
           {
             fid = match.featureId();
             partNum = part;
-            return QgsGeometry::fromPolyline( mline[part] );
+            return QgsGeometry::fromPolylineXY( mline[part] );
           }
           snapVertex -= mline[part].count();
         }

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -434,7 +434,7 @@ QgsGeometry QgsMapToolOffsetCurve::linestringFromPolygon( const QgsGeometry &fea
       if ( vertex < currentVertex )
       {
         //found, return ring
-        return QgsGeometry::fromPolyline( *polyIt );
+        return QgsGeometry::fromPolylineXY( *polyIt );
       }
     }
   }
@@ -468,7 +468,7 @@ QgsGeometry QgsMapToolOffsetCurve::convertToSingleLine( const QgsGeometry &geom,
       currentVertex += it->size();
       if ( vertex < currentVertex )
       {
-        return QgsGeometry::fromPolyline( *it );
+        return QgsGeometry::fromPolylineXY( *it );
       }
     }
   }

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -185,11 +185,11 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
       QgsPolygon poly( selectGeomTrans.asPolygon() );
       if ( poly.size() == 1 && poly.at( 0 ).size() == 5 )
       {
-        const QgsPolyline &ringIn = poly.at( 0 );
+        const QgsPolylineXY &ringIn = poly.at( 0 );
 
         QgsPolygon newpoly( 1 );
         newpoly[0].resize( 41 );
-        QgsPolyline &ringOut = newpoly[0];
+        QgsPolylineXY &ringOut = newpoly[0];
 
         ringOut[ 0 ] = ringIn.at( 0 );
 

--- a/src/app/qgsmaptoolsimplify.cpp
+++ b/src/app/qgsmaptoolsimplify.cpp
@@ -142,7 +142,7 @@ int QgsMapToolSimplify::vertexCount( const QgsGeometry &g ) const
       int count = 0;
       if ( g.isMultipart() )
       {
-        Q_FOREACH ( const QgsPolyline &polyline, g.asMultiPolyline() )
+        Q_FOREACH ( const QgsPolylineXY &polyline, g.asMultiPolyline() )
           count += polyline.count();
       }
       else
@@ -155,12 +155,12 @@ int QgsMapToolSimplify::vertexCount( const QgsGeometry &g ) const
       if ( g.isMultipart() )
       {
         Q_FOREACH ( const QgsPolygon &polygon, g.asMultiPolygon() )
-          Q_FOREACH ( const QgsPolyline &ring, polygon )
+          Q_FOREACH ( const QgsPolylineXY &ring, polygon )
             count += ring.count();
       }
       else
       {
-        Q_FOREACH ( const QgsPolyline &ring, g.asPolygon() )
+        Q_FOREACH ( const QgsPolylineXY &ring, g.asPolygon() )
           count += ring.count();
       }
       return count;

--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -567,23 +567,23 @@ void QgsComposerMapGrid::calculateCrsTransformLines()
     QList< QPair< double, QPolygonF > >::const_iterator yGridIt = mTransformedYLines.constBegin();
     for ( ; yGridIt != mTransformedYLines.constEnd(); ++yGridIt )
     {
-      QgsPolyline yLine;
+      QgsPolylineXY yLine;
       for ( int i = 0; i < ( *yGridIt ).second.size(); ++i )
       {
         yLine.append( QgsPointXY( ( *yGridIt ).second.at( i ).x(), ( *yGridIt ).second.at( i ).y() ) );
       }
-      yLines << QgsGeometry::fromPolyline( yLine );
+      yLines << QgsGeometry::fromPolylineXY( yLine );
     }
     QList< QgsGeometry > xLines;
     QList< QPair< double, QPolygonF > >::const_iterator xGridIt = mTransformedXLines.constBegin();
     for ( ; xGridIt != mTransformedXLines.constEnd(); ++xGridIt )
     {
-      QgsPolyline xLine;
+      QgsPolylineXY xLine;
       for ( int i = 0; i < ( *xGridIt ).second.size(); ++i )
       {
         xLine.append( QgsPointXY( ( *xGridIt ).second.at( i ).x(), ( *xGridIt ).second.at( i ).y() ) );
       }
-      xLines << QgsGeometry::fromPolyline( xLine );
+      xLines << QgsGeometry::fromPolylineXY( xLine );
     }
 
     //now, loop through geometries and calculate intersection points

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -48,12 +48,29 @@ class QPainter;
 class QgsPolygonV2;
 class QgsLineString;
 
-//! Polyline is represented as a vector of points
-typedef QVector<QgsPointXY> QgsPolyline;
+/**
+ * Polyline as represented as a vector of two-dimensional points.
+ *
+ * This type has no support for Z/M dimensions and use of QgsPolyline is encouraged instead.
+ *
+ * \note In QGIS 2.x this type was available as QgsPolyline.
+ *
+ * \since QGIS 3.0
+ */
+typedef QVector<QgsPointXY> QgsPolylineXY;
+
+/**
+ * Polyline as represented as a vector of points.
+ *
+ * This type has full support for Z/M dimensions.
+ *
+ * \since QGIS 3.0
+ */
+typedef QVector<QgsPoint> QgsPolyline;
 
 //! Polygon: first item of the list is outer ring, inner rings (if any) start from second item
 #ifndef SIP_RUN
-typedef QVector<QgsPolyline> QgsPolygon;
+typedef QVector<QgsPolylineXY> QgsPolygon;
 #else
 typedef QVector<QVector<QgsPointXY>> QgsPolygon;
 #endif
@@ -63,7 +80,7 @@ typedef QVector<QgsPointXY> QgsMultiPoint;
 
 //! A collection of QgsPolylines that share a common collection of attributes
 #ifndef SIP_RUN
-typedef QVector<QgsPolyline> QgsMultiPolyline;
+typedef QVector<QgsPolylineXY> QgsMultiPolyline;
 #else
 typedef QVector<QVector<QgsPointXY>> QgsMultiPolyline;
 #endif
@@ -175,8 +192,31 @@ class CORE_EXPORT QgsGeometry
     static QgsGeometry fromPoint( const QgsPointXY &point );
     //! Creates a new geometry from a QgsMultiPoint object
     static QgsGeometry fromMultiPoint( const QgsMultiPoint &multipoint );
-    //! Creates a new geometry from a QgsPolyline object
+
+    /**
+     * Creates a new LineString geometry from a list of QgsPointXY points.
+     *
+     * Using fromPolyline() is preferred, as fromPolyline() is more efficient
+     * and will respect any Z or M dimensions present in the input points.
+     *
+     * \note In QGIS 2.x this method was available as fromPolyline().
+     *
+     * \since QGIS 3.0
+     * \see fromPolyline()
+     */
+    static QgsGeometry fromPolylineXY( const QgsPolylineXY &polyline );
+
+    /**
+     * Creates a new LineString geometry from a list of QgsPoint points.
+     *
+     * This method will respect any Z or M dimensions present in the input points.
+     * E.g. if input points are PointZ type, the resultant linestring will be
+     * a LineStringZ type.
+     *
+     * \since QGIS 3.0
+     */
     static QgsGeometry fromPolyline( const QgsPolyline &polyline );
+
     //! Creates a new geometry from a QgsMultiPolyline object
     static QgsGeometry fromMultiPolyline( const QgsMultiPolyline &multiline );
     //! Creates a new geometry from a QgsPolygon
@@ -1068,7 +1108,7 @@ class CORE_EXPORT QgsGeometry
      * Returns contents of the geometry as a polyline
      * if wkbType is WKBLineString, otherwise an empty list
      */
-    QgsPolyline asPolyline() const;
+    QgsPolylineXY asPolyline() const;
 
     /**
      * Returns contents of the geometry as a polygon
@@ -1328,12 +1368,12 @@ class CORE_EXPORT QgsGeometry
     static QgsGeometry fromQPolygonF( const QPolygonF &polygon );
 
     /**
-     * Creates a QgsPolyline from a QPolygonF.
+     * Creates a QgsPolylineXY from a QPolygonF.
      * \param polygon source polygon
-     * \returns QgsPolyline
+     * \returns QgsPolylineXY
      * \see createPolygonFromQPolygonF
      */
-    static QgsPolyline createPolylineFromQPolygonF( const QPolygonF &polygon ) SIP_FACTORY;
+    static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) SIP_FACTORY;
 
     /**
      * Creates a QgsPolygon from a QPolygonF.
@@ -1354,7 +1394,7 @@ class CORE_EXPORT QgsGeometry
      * points are equal within the specified tolerance
      * \since QGIS 2.9
      */
-    static bool compare( const QgsPolyline &p1, const QgsPolyline &p2,
+    static bool compare( const QgsPolylineXY &p1, const QgsPolylineXY &p2,
                          double epsilon = 4 * std::numeric_limits<double>::epsilon() );
 
     /**
@@ -1385,7 +1425,7 @@ class CORE_EXPORT QgsGeometry
 
     /**
      * Compares two geometry objects for equality within a specified tolerance.
-     * The objects can be of type QgsPolyline, QgsPolygon or QgsMultiPolygon.
+     * The objects can be of type QgsPolylineXY, QgsPolygon or QgsMultiPolygon.
      * The 2 types should match.
      * \param p1 first geometry object
      * \param p2 second geometry object
@@ -1422,10 +1462,10 @@ class CORE_EXPORT QgsGeometry
                sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
                sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
           {
-            QgsPolyline *p0;
-            QgsPolyline *p1;
-            p0 = reinterpret_cast<QgsPolyline *>( sipConvertToType( a0, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state0, &sipIsErr ) );
-            p1 = reinterpret_cast<QgsPolyline *>( sipConvertToType( a1, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state1, &sipIsErr ) );
+            QgsPolylineXY *p0;
+            QgsPolylineXY *p1;
+            p0 = reinterpret_cast<QgsPolylineXY *>( sipConvertToType( a0, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state0, &sipIsErr ) );
+            p1 = reinterpret_cast<QgsPolylineXY *>( sipConvertToType( a1, sipType_QVector_0100QgsPointXY, 0, SIP_NOT_NONE, &state1, &sipIsErr ) );
             if ( sipIsErr )
             {
               sipReleaseType( p0, sipType_QVector_0100QgsPointXY, state0 );
@@ -1566,7 +1606,7 @@ class CORE_EXPORT QgsGeometry
      */
     void reset( std::unique_ptr< QgsAbstractGeometry > newGeometry );
 
-    static void convertToPolyline( const QgsPointSequence &input, QgsPolyline &output );
+    static void convertToPolyline( const QgsPointSequence &input, QgsPolylineXY &output );
     static void convertPolygon( const QgsPolygonV2 &input, QgsPolygon &output );
 
     //! Try to convert the geometry to a point

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<QgsMultiPointV2> QgsGeometryFactory::fromMultiPoint( const QgsMu
   return mp;
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeometryFactory::fromPolyline( const QgsPolyline &polyline )
+std::unique_ptr<QgsAbstractGeometry> QgsGeometryFactory::fromPolyline( const QgsPolylineXY &polyline )
 {
   return linestringFromPolyline( polyline );
 }
@@ -197,13 +197,13 @@ std::unique_ptr< QgsMultiPolygonV2 > QgsGeometryFactory::fromMultiPolygon( const
   return mp;
 }
 
-std::unique_ptr<QgsLineString> QgsGeometryFactory::linestringFromPolyline( const QgsPolyline &polyline )
+std::unique_ptr<QgsLineString> QgsGeometryFactory::linestringFromPolyline( const QgsPolylineXY &polyline )
 {
   QVector< double > x;
   x.reserve( polyline.size() );
   QVector< double > y;
   y.reserve( polyline.size() );
-  QgsPolyline::const_iterator it = polyline.constBegin();
+  QgsPolylineXY::const_iterator it = polyline.constBegin();
   for ( ; it != polyline.constEnd(); ++it )
   {
     x << it->x();

--- a/src/core/geometry/qgsgeometryfactory.h
+++ b/src/core/geometry/qgsgeometryfactory.h
@@ -36,10 +36,10 @@ class QgsMultiPolygonV2;
 
 //compatibility with old classes
 #include "qgspointxy.h"
-typedef QVector<QgsPointXY> QgsPolyline;
-typedef QVector<QgsPolyline> QgsPolygon;
+typedef QVector<QgsPointXY> QgsPolylineXY;
+typedef QVector<QgsPolylineXY> QgsPolygon;
 typedef QVector<QgsPointXY> QgsMultiPoint;
-typedef QVector<QgsPolyline> QgsMultiPolyline;
+typedef QVector<QgsPolylineXY> QgsMultiPolyline;
 typedef QVector<QgsPolygon> QgsMultiPolygon;
 
 /**
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsGeometryFactory
     //! Construct geometry from a multipoint
     static std::unique_ptr<QgsMultiPointV2> fromMultiPoint( const QgsMultiPoint &multipoint );
     //! Construct geometry from a polyline
-    static std::unique_ptr< QgsAbstractGeometry > fromPolyline( const QgsPolyline &polyline );
+    static std::unique_ptr< QgsAbstractGeometry > fromPolyline( const QgsPolylineXY &polyline );
     //! Construct geometry from a multipolyline
     static std::unique_ptr<QgsMultiLineString> fromMultiPolyline( const QgsMultiPolyline &multiline );
     //! Construct geometry from a polygon
@@ -86,7 +86,7 @@ class CORE_EXPORT QgsGeometryFactory
     static std::unique_ptr< QgsGeometryCollection > createCollectionOfType( QgsWkbTypes::Type type );
 
   private:
-    static std::unique_ptr< QgsLineString > linestringFromPolyline( const QgsPolyline &polyline );
+    static std::unique_ptr< QgsLineString > linestringFromPolyline( const QgsPolylineXY &polyline );
 };
 
 #endif // QGSGEOMETRYFACTORY_H

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -71,7 +71,7 @@ QgsRectangle QgsRectangle::fromWkt( const QString &wkt )
   if ( poly.size() != 1 )
     return QgsRectangle();
 
-  QgsPolyline polyline = geom.asPolygon().at( 0 );
+  QgsPolylineXY polyline = geom.asPolygon().at( 0 );
   if ( polyline.size() == 5 && polyline.at( 0 ) == polyline.at( 4 ) && geom.isGeosValid() )
     return QgsRectangle( polyline.at( 0 ).x(), polyline.at( 0 ).y(), polyline.at( 2 ).x(), polyline.at( 2 ).y() );
   else

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -40,8 +40,8 @@ void QgsGeometryValidator::stop()
 }
 
 void QgsGeometryValidator::checkRingIntersections(
-  int p0, int i0, const QgsPolyline &ring0,
-  int p1, int i1, const QgsPolyline &ring1 )
+  int p0, int i0, const QgsPolylineXY &ring0,
+  int p1, int i1, const QgsPolylineXY &ring1 )
 {
   for ( int i = 0; !mStop && i < ring0.size() - 1; i++ )
   {
@@ -77,7 +77,7 @@ void QgsGeometryValidator::checkRingIntersections(
   }
 }
 
-void QgsGeometryValidator::validatePolyline( int i, QgsPolyline line, bool ring )
+void QgsGeometryValidator::validatePolyline( int i, QgsPolylineXY line, bool ring )
 {
   if ( ring )
   {
@@ -393,7 +393,7 @@ bool QgsGeometryValidator::intersectLines( const QgsPointXY &p, QgsVector v, con
   return true;
 }
 
-bool QgsGeometryValidator::pointInRing( const QgsPolyline &ring, const QgsPointXY &p )
+bool QgsGeometryValidator::pointInRing( const QgsPolylineXY &ring, const QgsPointXY &p )
 {
   bool inside = false;
   int j = ring.size() - 1;
@@ -416,7 +416,7 @@ bool QgsGeometryValidator::pointInRing( const QgsPolyline &ring, const QgsPointX
   return inside;
 }
 
-bool QgsGeometryValidator::ringInRing( const QgsPolyline &inside, const QgsPolyline &outside )
+bool QgsGeometryValidator::ringInRing( const QgsPolylineXY &inside, const QgsPolylineXY &outside )
 {
   for ( int i = 0; !mStop && i < inside.size(); i++ )
   {

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -50,13 +50,13 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
     void addError( const QgsGeometry::Error & );
 
   private:
-    void validatePolyline( int i, QgsPolyline polyline, bool ring = false );
+    void validatePolyline( int i, QgsPolylineXY polyline, bool ring = false );
     void validatePolygon( int i, const QgsPolygon &polygon );
-    void checkRingIntersections( int p0, int i0, const QgsPolyline &ring0, int p1, int i1, const QgsPolyline &ring1 );
+    void checkRingIntersections( int p0, int i0, const QgsPolylineXY &ring0, int p1, int i1, const QgsPolylineXY &ring1 );
     double distLine2Point( const QgsPointXY &p, QgsVector v, const QgsPointXY &q );
     bool intersectLines( const QgsPointXY &p, QgsVector v, const QgsPointXY &q, QgsVector w, QgsPointXY &s );
-    bool ringInRing( const QgsPolyline &inside, const QgsPolyline &outside );
-    bool pointInRing( const QgsPolyline &ring, const QgsPointXY &p );
+    bool ringInRing( const QgsPolylineXY &inside, const QgsPolylineXY &outside );
+    bool pointInRing( const QgsPolylineXY &ring, const QgsPointXY &p );
 
     QgsGeometry mGeometry;
     QList<QgsGeometry::Error> *mErrors;

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -145,7 +145,7 @@ QgsGeometry QgsOgcUtils::geometryFromGML( const QString &xmlString )
 
 QgsGeometry QgsOgcUtils::geometryFromGMLPoint( const QDomElement &geometryElement )
 {
-  QgsPolyline pointCoordinate;
+  QgsPolylineXY pointCoordinate;
 
   QDomNodeList coordList = geometryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "coordinates" ) );
   if ( !coordList.isEmpty() )
@@ -175,7 +175,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLPoint( const QDomElement &geometryElemen
     return QgsGeometry();
   }
 
-  QgsPolyline::const_iterator point_it = pointCoordinate.constBegin();
+  QgsPolylineXY::const_iterator point_it = pointCoordinate.constBegin();
   char e = htonl( 1 ) != 1;
   double x = point_it->x();
   double y = point_it->y();
@@ -200,7 +200,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLPoint( const QDomElement &geometryElemen
 
 QgsGeometry QgsOgcUtils::geometryFromGMLLineString( const QDomElement &geometryElement )
 {
-  QgsPolyline lineCoordinates;
+  QgsPolylineXY lineCoordinates;
 
   QDomNodeList coordList = geometryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "coordinates" ) );
   if ( !coordList.isEmpty() )
@@ -243,7 +243,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLLineString( const QDomElement &geometryE
   memcpy( &( wkb )[wkbPosition], &nPoints, sizeof( int ) );
   wkbPosition += sizeof( int );
 
-  QgsPolyline::const_iterator iter;
+  QgsPolylineXY::const_iterator iter;
   for ( iter = lineCoordinates.constBegin(); iter != lineCoordinates.constEnd(); ++iter )
   {
     x = iter->x();
@@ -265,7 +265,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLPolygon( const QDomElement &geometryElem
   QgsMultiPolyline ringCoordinates;
 
   //read coordinates for outer boundary
-  QgsPolyline exteriorPointList;
+  QgsPolylineXY exteriorPointList;
   QDomNodeList outerBoundaryList = geometryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "outerBoundaryIs" ) );
   if ( !outerBoundaryList.isEmpty() ) //outer ring is necessary
   {
@@ -284,7 +284,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLPolygon( const QDomElement &geometryElem
     QDomNodeList innerBoundaryList = geometryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "innerBoundaryIs" ) );
     for ( int i = 0; i < innerBoundaryList.size(); ++i )
     {
-      QgsPolyline interiorPointList;
+      QgsPolylineXY interiorPointList;
       coordinatesElement = innerBoundaryList.at( i ).firstChild().firstChild().toElement();
       if ( coordinatesElement.isNull() )
       {
@@ -320,7 +320,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLPolygon( const QDomElement &geometryElem
     QDomNodeList interiorList = geometryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "interior" ) );
     for ( int i = 0; i < interiorList.size(); ++i )
     {
-      QgsPolyline interiorPointList;
+      QgsPolylineXY interiorPointList;
       QDomElement posElement = interiorList.at( i ).firstChild().firstChild().toElement();
       if ( posElement.isNull() )
       {
@@ -368,7 +368,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLPolygon( const QDomElement &geometryElem
     memcpy( &( wkb )[wkbPosition], &nPointsInRing, sizeof( int ) );
     wkbPosition += sizeof( int );
     //iterate through the string list converting the strings to x-/y- doubles
-    QgsPolyline::const_iterator iter;
+    QgsPolylineXY::const_iterator iter;
     for ( iter = it->begin(); iter != it->end(); ++iter )
     {
       x = iter->x();
@@ -388,8 +388,8 @@ QgsGeometry QgsOgcUtils::geometryFromGMLPolygon( const QDomElement &geometryElem
 
 QgsGeometry QgsOgcUtils::geometryFromGMLMultiPoint( const QDomElement &geometryElement )
 {
-  QgsPolyline pointList;
-  QgsPolyline currentPoint;
+  QgsPolylineXY pointList;
+  QgsPolylineXY currentPoint;
   QDomNodeList pointMemberList = geometryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "pointMember" ) );
   if ( pointMemberList.size() < 1 )
   {
@@ -465,7 +465,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiPoint( const QDomElement &geometryE
   memcpy( &( wkb )[wkbPosition], &nPoints, sizeof( int ) );
   wkbPosition += sizeof( int );
   type = QgsWkbTypes::Point;
-  for ( QgsPolyline::const_iterator it = pointList.constBegin(); it != pointList.constEnd(); ++it )
+  for ( QgsPolylineXY::const_iterator it = pointList.constBegin(); it != pointList.constEnd(); ++it )
   {
     memcpy( &( wkb )[wkbPosition], &e, 1 );
     wkbPosition += 1;
@@ -495,7 +495,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
   //<gml:MultiLineString
   //<gml:LineString
 
-  QList< QgsPolyline > lineCoordinates; //first list: lines, second list: points of one line
+  QList< QgsPolylineXY > lineCoordinates; //first list: lines, second list: points of one line
   QDomElement currentLineStringElement;
   QDomNodeList currentCoordList;
   QDomNodeList currentPosList;
@@ -514,7 +514,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
       currentCoordList = currentLineStringElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "coordinates" ) );
       if ( !currentCoordList.isEmpty() )
       {
-        QgsPolyline currentPointList;
+        QgsPolylineXY currentPointList;
         if ( readGMLCoordinates( currentPointList, currentCoordList.at( 0 ).toElement() ) != 0 )
         {
           return QgsGeometry();
@@ -528,7 +528,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
         {
           return QgsGeometry();
         }
-        QgsPolyline currentPointList;
+        QgsPolylineXY currentPointList;
         if ( readGMLPositions( currentPointList, currentPosList.at( 0 ).toElement() ) != 0 )
         {
           return QgsGeometry();
@@ -548,7 +548,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
         currentCoordList = currentLineStringElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "coordinates" ) );
         if ( !currentCoordList.isEmpty() )
         {
-          QgsPolyline currentPointList;
+          QgsPolylineXY currentPointList;
           if ( readGMLCoordinates( currentPointList, currentCoordList.at( 0 ).toElement() ) != 0 )
           {
             return QgsGeometry();
@@ -563,7 +563,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
           {
             return QgsGeometry();
           }
-          QgsPolyline currentPointList;
+          QgsPolylineXY currentPointList;
           if ( readGMLPositions( currentPointList, currentPosList.at( 0 ).toElement() ) != 0 )
           {
             return QgsGeometry();
@@ -584,7 +584,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
 
   //calculate the required wkb size
   int size = ( lineCoordinates.size() + 1 ) * ( 1 + 2 * sizeof( int ) );
-  for ( QList< QgsPolyline >::const_iterator it = lineCoordinates.constBegin(); it != lineCoordinates.constEnd(); ++it )
+  for ( QList< QgsPolylineXY >::const_iterator it = lineCoordinates.constBegin(); it != lineCoordinates.constEnd(); ++it )
   {
     size += it->size() * 2 * sizeof( double );
   }
@@ -604,7 +604,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
   memcpy( &( wkb )[wkbPosition], &nLines, sizeof( int ) );
   wkbPosition += sizeof( int );
   type = QgsWkbTypes::LineString;
-  for ( QList< QgsPolyline >::const_iterator it = lineCoordinates.constBegin(); it != lineCoordinates.constEnd(); ++it )
+  for ( QList< QgsPolylineXY >::const_iterator it = lineCoordinates.constBegin(); it != lineCoordinates.constEnd(); ++it )
   {
     memcpy( &( wkb )[wkbPosition], &e, 1 );
     wkbPosition += 1;
@@ -613,7 +613,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiLineString( const QDomElement &geom
     nPoints = it->size();
     memcpy( &( wkb )[wkbPosition], &nPoints, sizeof( int ) );
     wkbPosition += sizeof( int );
-    for ( QgsPolyline::const_iterator iter = it->begin(); iter != it->end(); ++iter )
+    for ( QgsPolylineXY::const_iterator iter = it->begin(); iter != it->end(); ++iter )
     {
       x = iter->x();
       y = iter->y();
@@ -672,7 +672,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiPolygon( const QDomElement &geometr
     if ( !outerBoundaryList.isEmpty() )
     {
       currentOuterBoundaryElement = outerBoundaryList.at( 0 ).toElement();
-      QgsPolyline ringCoordinates;
+      QgsPolylineXY ringCoordinates;
 
       linearRingNodeList = currentOuterBoundaryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "LinearRing" ) );
       if ( linearRingNodeList.size() < 1 )
@@ -695,7 +695,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiPolygon( const QDomElement &geometr
       QDomNodeList innerBoundaryList = currentPolygonElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "innerBoundaryIs" ) );
       for ( int j = 0; j < innerBoundaryList.size(); ++j )
       {
-        QgsPolyline ringCoordinates;
+        QgsPolylineXY ringCoordinates;
         currentInnerBoundaryElement = innerBoundaryList.at( j ).toElement();
         linearRingNodeList = currentInnerBoundaryElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "LinearRing" ) );
         if ( linearRingNodeList.size() < 1 )
@@ -725,7 +725,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiPolygon( const QDomElement &geometr
       }
 
       currentExteriorElement = exteriorList.at( 0 ).toElement();
-      QgsPolyline ringPositions;
+      QgsPolylineXY ringPositions;
 
       linearRingNodeList = currentExteriorElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "LinearRing" ) );
       if ( linearRingNodeList.size() < 1 )
@@ -748,7 +748,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiPolygon( const QDomElement &geometr
       QDomNodeList interiorList = currentPolygonElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "interior" ) );
       for ( int j = 0; j < interiorList.size(); ++j )
       {
-        QgsPolyline ringPositions;
+        QgsPolylineXY ringPositions;
         currentInteriorElement = interiorList.at( j ).toElement();
         linearRingNodeList = currentInteriorElement.elementsByTagNameNS( GML_NAMESPACE, QStringLiteral( "LinearRing" ) );
         if ( linearRingNodeList.size() < 1 )
@@ -819,7 +819,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiPolygon( const QDomElement &geometr
       nPointsInRing = iter->size();
       memcpy( &( wkb )[wkbPosition], &nPointsInRing, sizeof( int ) );
       wkbPosition += sizeof( int );
-      for ( QgsPolyline::const_iterator iterator = iter->begin(); iterator != iter->end(); ++iterator )
+      for ( QgsPolylineXY::const_iterator iterator = iter->begin(); iterator != iter->end(); ++iterator )
       {
         x = iterator->x();
         y = iterator->y();
@@ -836,7 +836,7 @@ QgsGeometry QgsOgcUtils::geometryFromGMLMultiPolygon( const QDomElement &geometr
   return g;
 }
 
-bool QgsOgcUtils::readGMLCoordinates( QgsPolyline &coords, const QDomElement &elem )
+bool QgsOgcUtils::readGMLCoordinates( QgsPolylineXY &coords, const QDomElement &elem )
 {
   QString coordSeparator = QStringLiteral( "," );
   QString tupelSeparator = QStringLiteral( " " );
@@ -917,7 +917,7 @@ QgsRectangle QgsOgcUtils::rectangleFromGMLBox( const QDomNode &boxNode )
   return rect;
 }
 
-bool QgsOgcUtils::readGMLPositions( QgsPolyline &coords, const QDomElement &elem )
+bool QgsOgcUtils::readGMLPositions( QgsPolylineXY &coords, const QDomElement &elem )
 {
   coords.clear();
 
@@ -1506,7 +1506,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry &geometry, QDomDocumen
   return geometryToGML( geometry, doc, QStringLiteral( "GML2" ), precision );
 }
 
-QDomElement QgsOgcUtils::createGMLCoordinates( const QgsPolyline &points, QDomDocument &doc )
+QDomElement QgsOgcUtils::createGMLCoordinates( const QgsPolylineXY &points, QDomDocument &doc )
 {
   QDomElement coordElem = doc.createElement( QStringLiteral( "gml:coordinates" ) );
   coordElem.setAttribute( QStringLiteral( "cs" ), QStringLiteral( "," ) );
@@ -1530,7 +1530,7 @@ QDomElement QgsOgcUtils::createGMLCoordinates( const QgsPolyline &points, QDomDo
   return coordElem;
 }
 
-QDomElement QgsOgcUtils::createGMLPositions( const QgsPolyline &points, QDomDocument &doc )
+QDomElement QgsOgcUtils::createGMLPositions( const QgsPolylineXY &points, QDomDocument &doc )
 {
   QDomElement posElem = doc.createElement( QStringLiteral( "gml:pos" ) );
   if ( points.size() > 1 )

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -271,7 +271,7 @@ class CORE_EXPORT QgsOgcUtils
        \param coords list where the found coordinates are appended
        \param elem the \verbatim <gml:coordinates> \endverbatim element
        \returns boolean for success*/
-    static bool readGMLCoordinates( QgsPolyline &coords, const QDomElement &elem );
+    static bool readGMLCoordinates( QgsPolylineXY &coords, const QDomElement &elem );
 
     /**
      * Reads the \verbatim <gml:pos> \endverbatim or \verbatim <gml:posList> \endverbatim
@@ -280,7 +280,7 @@ class CORE_EXPORT QgsOgcUtils
        \param elem the \verbatim <gml:pos> \endverbatim or
                     \verbatim <gml:posList> \endverbatim element
        \returns boolean for success*/
-    static bool readGMLPositions( QgsPolyline &coords, const QDomElement &elem );
+    static bool readGMLPositions( QgsPolylineXY &coords, const QDomElement &elem );
 
 
     /**
@@ -288,14 +288,14 @@ class CORE_EXPORT QgsOgcUtils
       \param points list of data points
       \param doc the GML document
       \returns QDomElement */
-    static QDomElement createGMLCoordinates( const QgsPolyline &points, QDomDocument &doc );
+    static QDomElement createGMLCoordinates( const QgsPolylineXY &points, QDomDocument &doc );
 
     /**
      * Create a GML pos or posList element from a point list.
       \param points list of data points
       \param doc the GML document
       \returns QDomElement */
-    static QDomElement createGMLPositions( const QgsPolyline &points, QDomDocument &doc );
+    static QDomElement createGMLPositions( const QgsPolylineXY &points, QDomDocument &doc );
 
     //! handle a generic sub-expression
     static QgsExpressionNode *nodeFromOgcFilter( QDomElement &element, QString &errorMessage );

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -106,9 +106,9 @@ static QgsPointLocator::Match _findClosestSegmentIntersection( const QgsPointXY 
   {
     if ( m.hasEdge() )
     {
-      QgsPolyline pl( 2 );
+      QgsPolylineXY pl( 2 );
       m.edgePoints( pl[0], pl[1] );
-      geoms << QgsGeometry::fromPolyline( pl );
+      geoms << QgsGeometry::fromPolylineXY( pl );
       endpoints << pl[0] << pl[1];
     }
   }
@@ -127,7 +127,7 @@ static QgsPointLocator::Match _findClosestSegmentIntersection( const QgsPointXY 
   }
   if ( g.wkbType() == QgsWkbTypes::MultiLineString )
   {
-    Q_FOREACH ( const QgsPolyline &pl, g.asMultiPolyline() )
+    Q_FOREACH ( const QgsPolylineXY &pl, g.asMultiPolyline() )
     {
       Q_FOREACH ( const QgsPointXY &p, pl )
       {

--- a/src/core/qgstracer.cpp
+++ b/src/core/qgstracer.cpp
@@ -40,7 +40,7 @@ struct comp
 
 
 // TODO: move to geometry utils
-double distance2D( const QgsPolyline &coords )
+double distance2D( const QgsPolylineXY &coords )
 {
   int np = coords.count();
   if ( np == 0 )
@@ -62,7 +62,7 @@ double distance2D( const QgsPolyline &coords )
 
 
 // TODO: move to geometry utils
-double closestSegment( const QgsPolyline &pl, const QgsPointXY &pt, int &vertexAfter, double epsilon )
+double closestSegment( const QgsPolylineXY &pl, const QgsPointXY &pt, int &vertexAfter, double epsilon )
 {
   double sqrDist = std::numeric_limits<double>::max();
   const QgsPointXY *pldata = pl.constData();
@@ -123,13 +123,13 @@ struct QgsTracerGraph
 };
 
 
-QgsTracerGraph *makeGraph( const QVector<QgsPolyline> &edges )
+QgsTracerGraph *makeGraph( const QVector<QgsPolylineXY> &edges )
 {
   QgsTracerGraph *g = new QgsTracerGraph();
   g->joinedVertices = 0;
   QHash<QgsPointXY, int> point2vertex;
 
-  Q_FOREACH ( const QgsPolyline &line, edges )
+  Q_FOREACH ( const QgsPolylineXY &line, edges )
   {
     QgsPointXY p1( line[0] );
     QgsPointXY p2( line[line.count() - 1] );
@@ -293,7 +293,7 @@ int point2edge( const QgsTracerGraph &g, const QgsPointXY &pt, int &lineVertexAf
 }
 
 
-void splitLinestring( const QgsPolyline &points, const QgsPointXY &pt, int lineVertexAfter, QgsPolyline &pts1, QgsPolyline &pts2 )
+void splitLinestring( const QgsPolylineXY &points, const QgsPointXY &pt, int lineVertexAfter, QgsPolylineXY &pts1, QgsPolylineXY &pts2 )
 {
   int count1 = lineVertexAfter;
   int count2 = points.count() - lineVertexAfter;
@@ -325,7 +325,7 @@ int joinVertexToGraph( QgsTracerGraph &g, const QgsPointXY &pt )
   QgsTracerGraph::V &v1 = g.v[e.v1];
   QgsTracerGraph::V &v2 = g.v[e.v2];
 
-  QgsPolyline out1, out2;
+  QgsPolylineXY out1, out2;
   splitLinestring( e.coords, pt, lineVertexAfter, out1, out2 );
 
   int vIdx = g.v.count();
@@ -430,18 +430,18 @@ void extractLinework( const QgsGeometry &g, QgsMultiPolyline &mpl )
       break;
 
     case QgsWkbTypes::Polygon:
-      Q_FOREACH ( const QgsPolyline &ring, geom.asPolygon() )
+      Q_FOREACH ( const QgsPolylineXY &ring, geom.asPolygon() )
         mpl << ring;
       break;
 
     case QgsWkbTypes::MultiLineString:
-      Q_FOREACH ( const QgsPolyline &linestring, geom.asMultiPolyline() )
+      Q_FOREACH ( const QgsPolylineXY &linestring, geom.asMultiPolyline() )
         mpl << linestring;
       break;
 
     case QgsWkbTypes::MultiPolygon:
       Q_FOREACH ( const QgsPolygon &polygon, geom.asMultiPolygon() )
-        Q_FOREACH ( const QgsPolyline &ring, polygon )
+        Q_FOREACH ( const QgsPolylineXY &ring, polygon )
           mpl << ring;
       break;
 
@@ -702,7 +702,7 @@ QVector<QgsPointXY> QgsTracer::findShortestPath( const QgsPointXY &p1, const Qgs
 
   QTime t2;
   t2.start();
-  QgsPolyline points = shortestPath( *mGraph, v1, v2 );
+  QgsPolylineXY points = shortestPath( *mGraph, v1, v2 );
   int tPath = t2.elapsed();
 
   Q_UNUSED( tPrep );

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -519,8 +519,8 @@ int QgsVectorLayerEditUtils::addTopologicalPoints( const QgsGeometry &geom )
     case QgsWkbTypes::LineString25D:
     case QgsWkbTypes::LineString:
     {
-      QgsPolyline line = geom.asPolyline();
-      QgsPolyline::const_iterator line_it = line.constBegin();
+      QgsPolylineXY line = geom.asPolyline();
+      QgsPolylineXY::const_iterator line_it = line.constBegin();
       for ( ; line_it != line.constEnd(); ++line_it )
       {
         if ( addTopologicalPoints( *line_it ) != 0 )
@@ -536,11 +536,11 @@ int QgsVectorLayerEditUtils::addTopologicalPoints( const QgsGeometry &geom )
     case QgsWkbTypes::MultiLineString:
     {
       QgsMultiPolyline multiLine = geom.asMultiPolyline();
-      QgsPolyline currentPolyline;
+      QgsPolylineXY currentPolyline;
 
       for ( int i = 0; i < multiLine.size(); ++i )
       {
-        QgsPolyline::const_iterator line_it = currentPolyline.constBegin();
+        QgsPolylineXY::const_iterator line_it = currentPolyline.constBegin();
         for ( ; line_it != currentPolyline.constEnd(); ++line_it )
         {
           if ( addTopologicalPoints( *line_it ) != 0 )
@@ -557,12 +557,12 @@ int QgsVectorLayerEditUtils::addTopologicalPoints( const QgsGeometry &geom )
     case QgsWkbTypes::Polygon:
     {
       QgsPolygon polygon = geom.asPolygon();
-      QgsPolyline currentRing;
+      QgsPolylineXY currentRing;
 
       for ( int i = 0; i < polygon.size(); ++i )
       {
         currentRing = polygon.at( i );
-        QgsPolyline::const_iterator line_it = currentRing.constBegin();
+        QgsPolylineXY::const_iterator line_it = currentRing.constBegin();
         for ( ; line_it != currentRing.constEnd(); ++line_it )
         {
           if ( addTopologicalPoints( *line_it ) != 0 )
@@ -580,7 +580,7 @@ int QgsVectorLayerEditUtils::addTopologicalPoints( const QgsGeometry &geom )
     {
       QgsMultiPolygon multiPolygon = geom.asMultiPolygon();
       QgsPolygon currentPolygon;
-      QgsPolyline currentRing;
+      QgsPolylineXY currentRing;
 
       for ( int i = 0; i < multiPolygon.size(); ++i )
       {
@@ -588,7 +588,7 @@ int QgsVectorLayerEditUtils::addTopologicalPoints( const QgsGeometry &geom )
         for ( int j = 0; j < currentPolygon.size(); ++j )
         {
           currentRing = currentPolygon.at( j );
-          QgsPolyline::const_iterator line_it = currentRing.constBegin();
+          QgsPolylineXY::const_iterator line_it = currentRing.constBegin();
           for ( ; line_it != currentRing.constEnd(); ++line_it )
           {
             if ( addTopologicalPoints( *line_it ) != 0 )

--- a/src/core/symbology/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.cpp
@@ -120,7 +120,7 @@ void QgsInvertedPolygonRenderer::startRender( QgsRenderContext &context, const Q
   QRect e( context.painter()->viewport() );
   // add some space to hide borders and tend to infinity
   e.adjust( -e.width() * 5, -e.height() * 5, e.width() * 5, e.height() * 5 );
-  QgsPolyline exteriorRing;
+  QgsPolylineXY exteriorRing;
   exteriorRing << mtp.toMapCoordinates( e.topLeft() );
   exteriorRing << mtp.toMapCoordinates( e.topRight() );
   exteriorRing << mtp.toMapCoordinates( e.bottomRight() );
@@ -298,7 +298,7 @@ void QgsInvertedPolygonRenderer::stopRender( QgsRenderContext &context )
 
         for ( int i = 0; i < multi.size(); i++ )
         {
-          const QgsPolyline &exterior = multi[i][0];
+          const QgsPolylineXY &exterior = multi[i][0];
           // add the exterior ring as interior ring to the first polygon
           // make sure it satisfies at least very basic requirements of GEOS
           // (otherwise the creation of GEOS geometry will fail)

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -721,7 +721,7 @@ void QgsSymbolLayerUtils::drawStippledBackground( QPainter *painter, QRect rect 
 #include <cmath>
 #include <cfloat>
 
-static QPolygonF makeOffsetGeometry( const QgsPolyline &polyline )
+static QPolygonF makeOffsetGeometry( const QgsPolylineXY &polyline )
 {
   int i, pointCount = polyline.count();
 
@@ -756,12 +756,12 @@ QList<QPolygonF> offsetLine( QPolygonF polyline, double dist, QgsWkbTypes::Geome
 
   unsigned int i, pointCount = polyline.count();
 
-  QgsPolyline tempPolyline( pointCount );
+  QgsPolylineXY tempPolyline( pointCount );
   QPointF *tempPtr = polyline.data();
   for ( i = 0; i < pointCount; ++i, tempPtr++ )
     tempPolyline[i] = QgsPointXY( tempPtr->rx(), tempPtr->ry() );
 
-  QgsGeometry tempGeometry = geometryType == QgsWkbTypes::PolygonGeometry ? QgsGeometry::fromPolygon( QgsPolygon() << tempPolyline ) : QgsGeometry::fromPolyline( tempPolyline );
+  QgsGeometry tempGeometry = geometryType == QgsWkbTypes::PolygonGeometry ? QgsGeometry::fromPolygon( QgsPolygon() << tempPolyline ) : QgsGeometry::fromPolylineXY( tempPolyline );
   if ( !tempGeometry.isNull() )
   {
     int quadSegments = 0; // we want miter joins, not round joins
@@ -779,7 +779,7 @@ QList<QPolygonF> offsetLine( QPolygonF polyline, double dist, QgsWkbTypes::Geome
 
       if ( QgsWkbTypes::flatType( tempGeometry.wkbType() ) == QgsWkbTypes::LineString )
       {
-        QgsPolyline line = tempGeometry.asPolyline();
+        QgsPolylineXY line = tempGeometry.asPolyline();
         // Reverse the line if offset was negative, see
         // https://issues.qgis.org/issues/13811
         if ( dist < 0 ) std::reverse( line.begin(), line.end() );
@@ -3782,7 +3782,7 @@ QPointF QgsSymbolLayerUtils::polygonPointOnSurface( const QPolygonF &points )
   {
     unsigned int i, pointCount = points.count();
 
-    QgsPolyline polyline( pointCount );
+    QgsPolylineXY polyline( pointCount );
     for ( i = 0; i < pointCount; ++i ) polyline[i] = QgsPointXY( points[i].x(), points[i].y() );
 
     QgsGeometry geom = QgsGeometry::fromPolygon( QgsPolygon() << polyline );

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -209,7 +209,7 @@ void QgsHighlight::paintPoint( QPainter *p, const QgsPointXY &point )
   p->drawPolygon( r );
 }
 
-void QgsHighlight::paintLine( QPainter *p, QgsPolyline line )
+void QgsHighlight::paintLine( QPainter *p, QgsPolylineXY line )
 {
   QPolygonF polygon( line.size() );
 

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -108,7 +108,7 @@ class GUI_EXPORT QgsHighlight: public QgsMapCanvasItem
     //! Get renderer for current color mode and colors. The renderer should be freed by caller.
     QgsFeatureRenderer *getRenderer( QgsRenderContext &context, const QColor &color, const QColor &fillColor );
     void paintPoint( QPainter *p, const QgsPointXY &point );
-    void paintLine( QPainter *p, QgsPolyline line );
+    void paintLine( QPainter *p, QgsPolylineXY line );
     void paintPolygon( QPainter *p, QgsPolygon polygon );
 
     QBrush mBrush;

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -289,7 +289,7 @@ void QgsRubberBand::addGeometry( const QgsGeometry &geometry, const QgsCoordinat
     case QgsWkbTypes::LineString:
     case QgsWkbTypes::LineString25D:
     {
-      const QgsPolyline line = geom.asPolyline();
+      const QgsPolylineXY line = geom.asPolyline();
       for ( QgsPointXY pt : line )
       {
         addPoint( pt, false, idx );
@@ -302,7 +302,7 @@ void QgsRubberBand::addGeometry( const QgsGeometry &geometry, const QgsCoordinat
     {
 
       const QgsMultiPolyline mline = geom.asMultiPolyline();
-      for ( const QgsPolyline &line : mline )
+      for ( const QgsPolylineXY &line : mline )
       {
         if ( line.isEmpty() )
         {
@@ -322,7 +322,7 @@ void QgsRubberBand::addGeometry( const QgsGeometry &geometry, const QgsCoordinat
     case QgsWkbTypes::Polygon25D:
     {
       const QgsPolygon poly = geom.asPolygon();
-      const QgsPolyline line = poly.at( 0 );
+      const QgsPolylineXY line = poly.at( 0 );
       for ( QgsPointXY pt : line )
       {
         addPoint( pt, false, idx );
@@ -340,7 +340,7 @@ void QgsRubberBand::addGeometry( const QgsGeometry &geometry, const QgsCoordinat
         if ( poly.empty() )
           continue;
 
-        const QgsPolyline line = poly.at( 0 );
+        const QgsPolylineXY line = poly.at( 0 );
         for ( QgsPointXY pt : line )
         {
           addPoint( pt, false, idx );
@@ -644,7 +644,7 @@ QgsGeometry QgsRubberBand::asGeometry() const
         }
         else
         {
-          geom = QgsGeometry::fromPolyline( getPolyline( mPoints.at( 0 ) ) );
+          geom = QgsGeometry::fromPolylineXY( getPolyline( mPoints.at( 0 ) ) );
         }
       }
       break;
@@ -653,9 +653,9 @@ QgsGeometry QgsRubberBand::asGeometry() const
   return geom;
 }
 
-QgsPolyline QgsRubberBand::getPolyline( const QList<QgsPointXY> &points )
+QgsPolylineXY QgsRubberBand::getPolyline( const QList<QgsPointXY> &points )
 {
-  QgsPolyline polyline;
+  QgsPolylineXY polyline;
   QList<QgsPointXY>::const_iterator iter = points.constBegin();
   for ( ; iter != points.constEnd(); ++iter )
   {

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -348,7 +348,7 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
 
     QgsRubberBand();
 
-    static QgsPolyline getPolyline( const QList<QgsPointXY> &points );
+    static QgsPolylineXY getPolyline( const QList<QgsPointXY> &points );
 
 };
 

--- a/src/plugins/topology/topolError.cpp
+++ b/src/plugins/topology/topolError.cpp
@@ -94,11 +94,11 @@ bool TopolError::fixSnap()
 
   QgsGeometry ge = f1.geometry();
 
-  QgsPolyline line = ge.asPolyline();
-  QgsPolyline conflictLine = mConflict.asPolyline();
+  QgsPolylineXY line = ge.asPolyline();
+  QgsPolylineXY conflictLine = mConflict.asPolyline();
   line.last() = conflictLine.last();
 
-  QgsGeometry newG = QgsGeometry::fromPolyline( line );
+  QgsGeometry newG = QgsGeometry::fromPolylineXY( line );
   bool ret = fl.layer->changeGeometry( f1.id(), newG );
 
   return ret;

--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -288,7 +288,7 @@ ErrorList topolTest::checkDanglingLines( double tolerance, QgsVectorLayer *layer
       QgsMultiPolyline lines = g1.asMultiPolyline();
       for ( int m = 0; m < lines.count(); m++ )
       {
-        QgsPolyline line = lines[m];
+        QgsPolylineXY line = lines[m];
         startPoint = line[0];
         endPoint = line[line.size() - 1];
 
@@ -299,7 +299,7 @@ ErrorList topolTest::checkDanglingLines( double tolerance, QgsVectorLayer *layer
     }
     else
     {
-      QgsPolyline polyline = g1.asPolyline();
+      QgsPolylineXY polyline = g1.asPolyline();
       startPoint = polyline[0];
       endPoint = polyline[polyline.size() - 1];
       endVerticesMap.insert( std::pair<QgsPointXY, QgsFeatureId>( startPoint, it->feature.id() ) );
@@ -775,7 +775,7 @@ ErrorList topolTest::checkPseudos( double tolerance, QgsVectorLayer *layer1, Qgs
       QgsMultiPolyline lines = g1.asMultiPolyline();
       for ( int m = 0; m < lines.count(); m++ )
       {
-        QgsPolyline line = lines[m];
+        QgsPolylineXY line = lines[m];
         startPoint = line[0];
         endPoint = line[line.size() - 1];
 
@@ -786,7 +786,7 @@ ErrorList topolTest::checkPseudos( double tolerance, QgsVectorLayer *layer1, Qgs
     }
     else
     {
-      QgsPolyline polyline = g1.asPolyline();
+      QgsPolylineXY polyline = g1.asPolyline();
       startPoint = polyline[0];
       endPoint = polyline[polyline.size() - 1];
       endVerticesMap.insert( std::pair<QgsPointXY, QgsFeatureId>( startPoint, it->feature.id() ) );
@@ -983,8 +983,8 @@ ErrorList topolTest::checkSegmentLength( double tolerance, QgsVectorLayer *layer
   QgsPolygon pol;
 
   QgsMultiPolygon mpol;
-  QgsPolyline segm;
-  QgsPolyline ls;
+  QgsPolylineXY segm;
+  QgsPolylineXY ls;
   QgsMultiPolyline mls;
   QList<FeatureLayer> fls;
   TopolErrorShort *err = nullptr;
@@ -1022,7 +1022,7 @@ ErrorList topolTest::checkSegmentLength( double tolerance, QgsVectorLayer *layer
             fls << *it << *it;
             segm.clear();
             segm << ls[i - 1] << ls[i];
-            QgsGeometry conflict = QgsGeometry::fromPolyline( segm );
+            QgsGeometry conflict = QgsGeometry::fromPolylineXY( segm );
             err = new TopolErrorShort( g1.boundingBox(), conflict, fls );
             //err = new TopolErrorShort(g1->boundingBox(), QgsGeometry::fromPolyline(segm), fls);
             errorList << err;
@@ -1047,7 +1047,7 @@ ErrorList topolTest::checkSegmentLength( double tolerance, QgsVectorLayer *layer
               fls << *it << *it;
               segm.clear();
               segm << pol[i][j - 1] << pol[i][j];
-              QgsGeometry conflict = QgsGeometry::fromPolyline( segm );
+              QgsGeometry conflict = QgsGeometry::fromPolylineXY( segm );
               err = new TopolErrorShort( g1.boundingBox(), conflict, fls );
               errorList << err;
               //break on getting the first error
@@ -1064,7 +1064,7 @@ ErrorList topolTest::checkSegmentLength( double tolerance, QgsVectorLayer *layer
 
         for ( int k = 0; k < mls.size(); ++k )
         {
-          QgsPolyline &ls = mls[k];
+          QgsPolylineXY &ls = mls[k];
           for ( int i = 1; i < ls.size(); ++i )
           {
             distance = std::sqrt( ls[i - 1].sqrDist( ls[i] ) );
@@ -1074,7 +1074,7 @@ ErrorList topolTest::checkSegmentLength( double tolerance, QgsVectorLayer *layer
               fls << *it << *it;
               segm.clear();
               segm << ls[i - 1] << ls[i];
-              QgsGeometry conflict = QgsGeometry::fromPolyline( segm );
+              QgsGeometry conflict = QgsGeometry::fromPolylineXY( segm );
               err = new TopolErrorShort( g1.boundingBox(), conflict, fls );
               errorList << err;
               //break on getting the first error
@@ -1102,7 +1102,7 @@ ErrorList topolTest::checkSegmentLength( double tolerance, QgsVectorLayer *layer
                 fls << *it << *it;
                 segm.clear();
                 segm << pol[i][j - 1] << pol[i][j];
-                QgsGeometry conflict = QgsGeometry::fromPolyline( segm );
+                QgsGeometry conflict = QgsGeometry::fromPolylineXY( segm );
                 err = new TopolErrorShort( g1.boundingBox(), conflict, fls );
                 errorList << err;
                 //break on getting the first error
@@ -1252,7 +1252,7 @@ ErrorList topolTest::checkPointCoveredByLineEnds( double tolerance, QgsVectorLay
         QgsMessageLog::logMessage( tr( "Second geometry missing or GEOS import failed." ), tr( "Topology plugin" ) );
         continue;
       }
-      QgsPolyline g2Line = g2.asPolyline();
+      QgsPolylineXY g2Line = g2.asPolyline();
       QgsGeometry startPoint = QgsGeometry::fromPoint( g2Line.at( 0 ) );
       QgsGeometry endPoint = QgsGeometry::fromPoint( g2Line.last() );
       touched = g1.intersects( startPoint ) || g1.intersects( endPoint );
@@ -1315,7 +1315,7 @@ ErrorList topolTest::checkyLineEndsCoveredByPoints( double tolerance, QgsVectorL
       break;
     QgsGeometry g1 = it->feature.geometry();
 
-    QgsPolyline g1Polyline = g1.asPolyline();
+    QgsPolylineXY g1Polyline = g1.asPolyline();
     QgsGeometry startPoint = QgsGeometry::fromPoint( g1Polyline.at( 0 ) );
     QgsGeometry endPoint = QgsGeometry::fromPoint( g1Polyline.last() );
 

--- a/src/providers/grass/qgis.v.in.cpp
+++ b/src/providers/grass/qgis.v.in.cpp
@@ -52,7 +52,7 @@ void writePoint( struct Map_info *map, int type, const QgsPointXY &point, struct
   Vect_write_line( map, type, gLine, cats );
 }
 
-void writePolyline( struct Map_info *map, int type, const QgsPolyline &polyline, struct line_cats *cats )
+void writePolyline( struct Map_info *map, int type, const QgsPolylineXY &polyline, struct line_cats *cats )
 {
   Vect_reset_line( gLine );
   Q_FOREACH ( const QgsPointXY &point, polyline )
@@ -266,13 +266,13 @@ int main( int argc, char **argv )
       }
       else if ( geometryType == QgsWkbTypes::LineString )
       {
-        QgsPolyline polyline = geometry.asPolyline();
+        QgsPolylineXY polyline = geometry.asPolyline();
         writePolyline( map, GV_LINE, polyline, cats );
       }
       else if ( geometryType == QgsWkbTypes::MultiLineString )
       {
         QgsMultiPolyline multiPolyline = geometry.asMultiPolyline();
-        Q_FOREACH ( const QgsPolyline &polyline, multiPolyline )
+        Q_FOREACH ( const QgsPolylineXY &polyline, multiPolyline )
         {
           writePolyline( map, GV_LINE, polyline, cats );
         }
@@ -280,7 +280,7 @@ int main( int argc, char **argv )
       else if ( geometryType == QgsWkbTypes::Polygon )
       {
         QgsPolygon polygon = geometry.asPolygon();
-        Q_FOREACH ( const QgsPolyline &polyline, polygon )
+        Q_FOREACH ( const QgsPolylineXY &polyline, polygon )
         {
           writePolyline( map, GV_BOUNDARY, polyline, cats );
         }
@@ -290,7 +290,7 @@ int main( int argc, char **argv )
         QgsMultiPolygon multiPolygon = geometry.asMultiPolygon();
         Q_FOREACH ( const QgsPolygon &polygon, multiPolygon )
         {
-          Q_FOREACH ( const QgsPolyline &polyline, polygon )
+          Q_FOREACH ( const QgsPolylineXY &polyline, polygon )
           {
             writePolyline( map, GV_BOUNDARY, polyline, cats );
           }

--- a/src/providers/grass/qgsgrassgislib.cpp
+++ b/src/providers/grass/qgsgrassgislib.cpp
@@ -1074,7 +1074,7 @@ double GRASS_LIB_EXPORT G_area_of_cell_at_row( int row )
 
 double QgsGrassGisLib::G_area_of_polygon( const double *x, const double *y, int n )
 {
-  QgsPolyline polyline;
+  QgsPolylineXY polyline;
   for ( int i = 0; i < n; i++ )
   {
     polyline.append( QgsPointXY( x[i], y[i] ) );

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -89,9 +89,9 @@ void TestQgsAttributeTable::testFieldCalculation()
   QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
   f1.setAttribute( QStringLiteral( "pk" ), 1 );
   f1.setAttribute( QStringLiteral( "col1" ), 0.0 );
-  QgsPolyline line3111;
+  QgsPolylineXY line3111;
   line3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 );
-  QgsGeometry line3111G = QgsGeometry::fromPolyline( line3111 ) ;
+  QgsGeometry line3111G = QgsGeometry::fromPolylineXY( line3111 ) ;
   f1.setGeometry( line3111G );
   tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 );
 
@@ -137,7 +137,7 @@ void TestQgsAttributeTable::testFieldCalculationArea()
   f1.setAttribute( QStringLiteral( "pk" ), 1 );
   f1.setAttribute( QStringLiteral( "col1" ), 0.0 );
 
-  QgsPolyline polygonRing3111;
+  QgsPolylineXY polygonRing3111;
   polygonRing3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 ) << QgsPointXY( 2520109, 2397715 ) << QgsPointXY( 2520792, 2425494 ) << QgsPointXY( 2484588, 2425722 );
   QgsPolygon polygon3111;
   polygon3111 << polygonRing3111;

--- a/tests/src/app/testqgsfieldcalculator.cpp
+++ b/tests/src/app/testqgsfieldcalculator.cpp
@@ -75,9 +75,9 @@ void TestQgsFieldCalculator::testLengthCalculations()
   QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
   f1.setAttribute( QStringLiteral( "pk" ), 1 );
   f1.setAttribute( QStringLiteral( "col1" ), 0.0 );
-  QgsPolyline line3111;
+  QgsPolylineXY line3111;
   line3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 );
-  QgsGeometry line3111G = QgsGeometry::fromPolyline( line3111 ) ;
+  QgsGeometry line3111G = QgsGeometry::fromPolylineXY( line3111 ) ;
   f1.setGeometry( line3111G );
   tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 );
 
@@ -134,7 +134,7 @@ void TestQgsFieldCalculator::testAreaCalculations()
   f1.setAttribute( QStringLiteral( "pk" ), 1 );
   f1.setAttribute( QStringLiteral( "col1" ), 0.0 );
 
-  QgsPolyline polygonRing3111;
+  QgsPolylineXY polygonRing3111;
   polygonRing3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 ) << QgsPointXY( 2520109, 2397715 ) << QgsPointXY( 2520792, 2425494 ) << QgsPointXY( 2484588, 2425722 );
   QgsPolygon polygon3111;
   polygon3111 << polygonRing3111;

--- a/tests/src/app/testqgsmaptooladdfeature.cpp
+++ b/tests/src/app/testqgsmaptooladdfeature.cpp
@@ -159,10 +159,10 @@ void TestQgsMapToolAddFeature::initTestCase()
   QVERIFY( mLayerLine->isValid() );
   QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerLine );
 
-  QgsPolyline line1;
+  QgsPolylineXY line1;
   line1 << QgsPointXY( 1, 1 ) << QgsPointXY( 2, 1 ) << QgsPointXY( 3, 2 ) << QgsPointXY( 1, 2 ) << QgsPointXY( 1, 1 );
   QgsFeature lineF1;
-  lineF1.setGeometry( QgsGeometry::fromPolyline( line1 ) );
+  lineF1.setGeometry( QgsGeometry::fromPolylineXY( line1 ) );
 
   mLayerLine->startEditing();
   mLayerLine->addFeature( lineF1 );
@@ -288,7 +288,7 @@ void TestQgsMapToolAddFeature::testTracingWithOffset()
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
 
   QgsGeometry g = mLayerLine->getFeature( newFid ).geometry();
-  QgsPolyline poly = g.asPolyline();
+  QgsPolylineXY poly = g.asPolyline();
   QCOMPARE( poly.count(), 3 );
   QCOMPARE( poly[0], QgsPointXY( 2, 0.9 ) );
   QCOMPARE( poly[1], QgsPointXY( 0.9, 0.9 ) );
@@ -309,7 +309,7 @@ void TestQgsMapToolAddFeature::testTracingWithOffset()
   QgsFeatureId newFid2 = _newFeatureId( mLayerLine, oldFids );
 
   QgsGeometry g2 = mLayerLine->getFeature( newFid2 ).geometry();
-  QgsPolyline poly2 = g2.asPolyline();
+  QgsPolylineXY poly2 = g2.asPolyline();
   QCOMPARE( poly2.count(), 3 );
   QCOMPARE( poly2[0], QgsPointXY( 2, 1.1 ) );
   QCOMPARE( poly2[1], QgsPointXY( 1.1, 1.1 ) );
@@ -329,7 +329,7 @@ void TestQgsMapToolAddFeature::testTracingWithOffset()
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
   QgsGeometry g3 = mLayerLine->getFeature( newFid3 ).geometry();
-  QgsPolyline poly3 = g3.asPolyline();
+  QgsPolylineXY poly3 = g3.asPolyline();
   QCOMPARE( poly3.count(), 5 );
   QCOMPARE( poly3[0], QgsPointXY( 3, 0 ) );
   QCOMPARE( poly3[1], QgsPointXY( 2, 1.1 ) );

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -119,9 +119,9 @@ void TestQgsMapToolIdentifyAction::lengthCalculation()
   QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
   f1.setAttribute( QStringLiteral( "pk" ), 1 );
   f1.setAttribute( QStringLiteral( "col1" ), 0.0 );
-  QgsPolyline line3111;
+  QgsPolylineXY line3111;
   line3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 );
-  QgsGeometry line3111G = QgsGeometry::fromPolyline( line3111 ) ;
+  QgsGeometry line3111G = QgsGeometry::fromPolylineXY( line3111 ) ;
   f1.setGeometry( line3111G );
   tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 );
 
@@ -170,7 +170,7 @@ void TestQgsMapToolIdentifyAction::perimeterCalculation()
   QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
   f1.setAttribute( QStringLiteral( "pk" ), 1 );
   f1.setAttribute( QStringLiteral( "col1" ), 0.0 );
-  QgsPolyline polygonRing3111;
+  QgsPolylineXY polygonRing3111;
   polygonRing3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 ) << QgsPointXY( 2520109, 2397715 ) << QgsPointXY( 2520792, 2425494 ) << QgsPointXY( 2484588, 2425722 );
   QgsPolygon polygon3111;
   polygon3111 << polygonRing3111;
@@ -224,7 +224,7 @@ void TestQgsMapToolIdentifyAction::areaCalculation()
   f1.setAttribute( QStringLiteral( "pk" ), 1 );
   f1.setAttribute( QStringLiteral( "col1" ), 0.0 );
 
-  QgsPolyline polygonRing3111;
+  QgsPolylineXY polygonRing3111;
   polygonRing3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 ) << QgsPointXY( 2520109, 2397715 ) << QgsPointXY( 2520792, 2425494 ) << QgsPointXY( 2484588, 2425722 );
   QgsPolygon polygon3111;
   polygon3111 << polygonRing3111;

--- a/tests/src/app/testqgsnodetool.cpp
+++ b/tests/src/app/testqgsnodetool.cpp
@@ -149,13 +149,13 @@ void TestQgsNodeTool::initTestCase()
   QVERIFY( mLayerPoint->isValid() );
   QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerPolygon << mLayerPoint );
 
-  QgsPolyline line1;
+  QgsPolylineXY line1;
   line1 << QgsPointXY( 2, 1 ) << QgsPointXY( 1, 1 ) << QgsPointXY( 1, 3 );
   QgsFeature lineF1;
-  lineF1.setGeometry( QgsGeometry::fromPolyline( line1 ) );
+  lineF1.setGeometry( QgsGeometry::fromPolylineXY( line1 ) );
 
   QgsPolygon polygon1;
-  QgsPolyline polygon1exterior;
+  QgsPolylineXY polygon1exterior;
   polygon1exterior << QgsPointXY( 4, 1 ) << QgsPointXY( 7, 1 ) << QgsPointXY( 7, 4 ) << QgsPointXY( 4, 4 ) << QgsPointXY( 4, 1 );
   polygon1 << polygon1exterior;
   QgsFeature polygonF1;
@@ -538,10 +538,10 @@ void TestQgsNodeTool::testActiveLayerPriority()
   // create a temporary line layer that has a common vertex with existing line layer at (1, 1)
   QgsVectorLayer *layerLine2 = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:27700" ), QStringLiteral( "layer line 2" ), QStringLiteral( "memory" ) );
   QVERIFY( layerLine2->isValid() );
-  QgsPolyline line1;
+  QgsPolylineXY line1;
   line1 << QgsPointXY( 0, 1 ) << QgsPointXY( 1, 1 ) << QgsPointXY( 1, 0 );
   QgsFeature lineF1;
-  lineF1.setGeometry( QgsGeometry::fromPolyline( line1 ) );
+  lineF1.setGeometry( QgsGeometry::fromPolylineXY( line1 ) );
   layerLine2->startEditing();
   layerLine2->addFeature( lineF1 );
   QgsFeatureId fidLineF1 = lineF1.id();

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -78,7 +78,7 @@ void TestQgsCadUtils::initTestCase()
   QVERIFY( mLayerPolygon->isValid() );
 
   QgsPolygon polygon1;
-  QgsPolyline polygon1exterior;
+  QgsPolylineXY polygon1exterior;
   polygon1exterior << QgsPointXY( 10, 10 ) << QgsPointXY( 30, 10 ) << QgsPointXY( 10, 20 ) << QgsPointXY( 10, 10 );
   polygon1 << polygon1exterior;
   QgsFeature polygonF1;

--- a/tests/src/core/testqgsdistancearea.cpp
+++ b/tests/src/core/testqgsdistancearea.cpp
@@ -283,7 +283,7 @@ void TestQgsDistanceArea::measureAreaAndUnits()
   da.setEllipsoid( QStringLiteral( "NONE" ) );
   QgsCoordinateReferenceSystem daCRS;
   daCRS.createFromSrsId( da.sourceCrs().srsid() );
-  QgsPolyline ring;
+  QgsPolylineXY ring;
   ring << QgsPointXY( 0, 0 )
        << QgsPointXY( 1, 0 )
        << QgsPointXY( 1, 1 )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1821,13 +1821,13 @@ class TestQgsExpression: public QObject
       QTest::addColumn<QVariant>( "result" );
 
       QgsPointXY point( 123, 456 );
-      QgsPolyline line;
+      QgsPolylineXY line;
       line << QgsPointXY( 1, 1 ) << QgsPointXY( 4, 2 ) << QgsPointXY( 3, 1 );
 
       QTest::newRow( "geom x" ) << "$x" << QgsGeometry::fromPoint( point ) << false << QVariant( 123. );
       QTest::newRow( "geom y" ) << "$y" << QgsGeometry::fromPoint( point ) << false << QVariant( 456. );
-      QTest::newRow( "geom xat" ) << "xat(-1)" << QgsGeometry::fromPolyline( line ) << false << QVariant( 3. );
-      QTest::newRow( "geom yat" ) << "yat(1)" << QgsGeometry::fromPolyline( line ) << false << QVariant( 2. );
+      QTest::newRow( "geom xat" ) << "xat(-1)" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 3. );
+      QTest::newRow( "geom yat" ) << "yat(1)" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 2. );
       QTest::newRow( "null geometry" ) << "$geometry" << QgsGeometry() << false << QVariant( QVariant::UserType );
     }
 
@@ -1853,13 +1853,13 @@ class TestQgsExpression: public QObject
 
     void eval_geometry_calc()
     {
-      QgsPolyline polyline, polygon_ring;
+      QgsPolylineXY polyline, polygon_ring;
       polyline << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 0 );
       polygon_ring << QgsPointXY( 2, 1 ) << QgsPointXY( 10, 1 ) << QgsPointXY( 10, 6 ) << QgsPointXY( 2, 6 ) << QgsPointXY( 2, 1 );
       QgsPolygon polygon;
       polygon << polygon_ring;
       QgsFeature fPolygon, fPolyline;
-      QgsGeometry polylineGeom = QgsGeometry::fromPolyline( polyline );
+      QgsGeometry polylineGeom = QgsGeometry::fromPolylineXY( polyline );
       fPolyline.setGeometry( polylineGeom );
       QgsGeometry polygonGeom = QgsGeometry::fromPolygon( polygon );
       fPolygon.setGeometry( polygonGeom );
@@ -1987,7 +1987,7 @@ class TestQgsExpression: public QObject
       da.setEllipsoid( QStringLiteral( "WGS84" ) );
 
       QgsFeature feat;
-      QgsPolyline polygonRing3111;
+      QgsPolylineXY polygonRing3111;
       polygonRing3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 ) << QgsPointXY( 2520109, 2397715 ) << QgsPointXY( 2520792, 2425494 ) << QgsPointXY( 2484588, 2425722 );
       QgsPolygon polygon3111;
       polygon3111 << polygonRing3111;
@@ -2059,9 +2059,9 @@ class TestQgsExpression: public QObject
       QGSCOMPARENEAR( vPerimeter.toDouble(), expected, 0.001 );
 
       // test length without geomCalculator
-      QgsPolyline line3111;
+      QgsPolylineXY line3111;
       line3111 << QgsPointXY( 2484588, 2425722 ) << QgsPointXY( 2482767, 2398853 );
-      QgsGeometry line3111G =  QgsGeometry::fromPolyline( line3111 ) ;
+      QgsGeometry line3111G =  QgsGeometry::fromPolylineXY( line3111 ) ;
       feat.setGeometry( line3111G );
       context.setFeature( feat );
 
@@ -2098,7 +2098,7 @@ class TestQgsExpression: public QObject
 
     void eval_geometry_wkt()
     {
-      QgsPolyline polyline, polygon_ring;
+      QgsPolylineXY polyline, polygon_ring;
       polyline << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 0 );
       polygon_ring << QgsPointXY( 2, 1 ) << QgsPointXY( 10, 1 ) << QgsPointXY( 10, 6 ) << QgsPointXY( 2, 6 ) << QgsPointXY( 2, 1 );
 
@@ -2108,7 +2108,7 @@ class TestQgsExpression: public QObject
       QgsFeature fPoint, fPolygon, fPolyline;
       QgsGeometry fPointG = QgsGeometry::fromPoint( QgsPointXY( -1.23456789, 9.87654321 ) );
       fPoint.setGeometry( fPointG );
-      QgsGeometry fPolylineG = QgsGeometry::fromPolyline( polyline );
+      QgsGeometry fPolylineG = QgsGeometry::fromPolylineXY( polyline );
       fPolyline.setGeometry( fPolylineG );
       QgsGeometry fPolygonG = QgsGeometry::fromPolygon( polygon );
       fPolygon.setGeometry( fPolygonG );
@@ -2142,10 +2142,10 @@ class TestQgsExpression: public QObject
       QTest::addColumn<bool>( "evalError" );
 
       QgsPointXY point( 123, 456 );
-      QgsPolyline line;
+      QgsPolylineXY line;
       line << QgsPointXY( 1, 1 ) << QgsPointXY( 4, 2 ) << QgsPointXY( 3, 1 );
 
-      QgsPolyline polyline, polygon_ring;
+      QgsPolylineXY polyline, polygon_ring;
       polyline << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 0 );
       polygon_ring << QgsPointXY( 1, 1 ) << QgsPointXY( 6, 1 ) << QgsPointXY( 6, 6 ) << QgsPointXY( 1, 6 ) << QgsPointXY( 1, 1 );
       QgsPolygon polygon;
@@ -2153,10 +2153,10 @@ class TestQgsExpression: public QObject
 
       QgsGeometry sourcePoint( QgsGeometry::fromPoint( point ) );
       QTest::newRow( "geomFromWKT Point" ) << "geom_from_wkt('" + sourcePoint.exportToWkt() + "')" << QgsGeometry::fromPoint( point ) << false;
-      QgsGeometry sourceLine( QgsGeometry::fromPolyline( line ) );
-      QTest::newRow( "geomFromWKT Line" ) << "geomFromWKT('" + sourceLine.exportToWkt() + "')" << QgsGeometry::fromPolyline( line ) << false;
-      QgsGeometry sourcePolyline( QgsGeometry::fromPolyline( polyline ) );
-      QTest::newRow( "geomFromWKT Polyline" ) << "geomFromWKT('" + sourcePolyline.exportToWkt() + "')" << QgsGeometry::fromPolyline( polyline ) << false;
+      QgsGeometry sourceLine( QgsGeometry::fromPolylineXY( line ) );
+      QTest::newRow( "geomFromWKT Line" ) << "geomFromWKT('" + sourceLine.exportToWkt() + "')" << QgsGeometry::fromPolylineXY( line ) << false;
+      QgsGeometry sourcePolyline( QgsGeometry::fromPolylineXY( polyline ) );
+      QTest::newRow( "geomFromWKT Polyline" ) << "geomFromWKT('" + sourcePolyline.exportToWkt() + "')" << QgsGeometry::fromPolylineXY( polyline ) << false;
       QgsGeometry sourcePolygon( QgsGeometry::fromPolygon( polygon ) );
       QTest::newRow( "geomFromWKT Polygon" ) << "geomFromWKT('" + sourcePolygon.exportToWkt() + "')" << QgsGeometry::fromPolygon( polygon ) << false;
 
@@ -2206,18 +2206,18 @@ class TestQgsExpression: public QObject
       QTest::addColumn<bool>( "needsGeom" );
 
       QgsPointXY point( 123, 456 );
-      QgsPolyline line;
+      QgsPolylineXY line;
       line << QgsPointXY( 1, 1 ) << QgsPointXY( 4, 2 ) << QgsPointXY( 3, 1 );
 
-      QgsPolyline polyline, polygon_ring;
+      QgsPolylineXY polyline, polygon_ring;
       polyline << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 0 );
       polygon_ring << QgsPointXY( 1, 1 ) << QgsPointXY( 6, 1 ) << QgsPointXY( 6, 6 ) << QgsPointXY( 1, 6 ) << QgsPointXY( 1, 1 );
       QgsPolygon polygon;
       polygon << polygon_ring;
 
       QTest::newRow( "geometry Point" ) << "geometry( $currentfeature )" << QgsGeometry::fromPoint( point ) << false << true;
-      QTest::newRow( "geometry Line" ) << "geometry( $currentfeature )" << QgsGeometry::fromPolyline( line ) << false << true;
-      QTest::newRow( "geometry Polyline" ) << "geometry( $currentfeature )" << QgsGeometry::fromPolyline( polyline ) << false << true;
+      QTest::newRow( "geometry Line" ) << "geometry( $currentfeature )" << QgsGeometry::fromPolylineXY( line ) << false << true;
+      QTest::newRow( "geometry Polyline" ) << "geometry( $currentfeature )" << QgsGeometry::fromPolylineXY( polyline ) << false << true;
       QTest::newRow( "geometry Polygon" ) << "geometry( $currentfeature )" << QgsGeometry::fromPolygon( polygon ) << false << true;
 
       QgsCoordinateReferenceSystem s;
@@ -2226,12 +2226,12 @@ class TestQgsExpression: public QObject
       d.createFromOgcWmsCrs( QStringLiteral( "EPSG:3857" ) );
       QgsCoordinateTransform t( s, d );
 
-      QgsGeometry tLine = QgsGeometry::fromPolyline( line );
+      QgsGeometry tLine = QgsGeometry::fromPolylineXY( line );
       tLine.transform( t );
       QgsGeometry tPolygon = QgsGeometry::fromPolygon( polygon );
       tPolygon.transform( t );
 
-      QgsGeometry oLine = QgsGeometry::fromPolyline( line );
+      QgsGeometry oLine = QgsGeometry::fromPolylineXY( line );
       QgsGeometry oPolygon = QgsGeometry::fromPolygon( polygon );
       QTest::newRow( "transform Line" ) << "transform( geomFromWKT('" + oLine.exportToWkt() + "'), 'EPSG:4326', 'EPSG:3857' )" << tLine << false << false;
       QTest::newRow( "transform Polygon" ) << "transform( geomFromWKT('" + oPolygon.exportToWkt() + "'), 'EPSG:4326', 'EPSG:3857' )" << tPolygon << false << false;
@@ -2267,7 +2267,7 @@ class TestQgsExpression: public QObject
       QTest::addColumn<QVariant>( "result" );
 
       QgsPointXY point( 0, 0 );
-      QgsPolyline line, polygon_ring;
+      QgsPolylineXY line, polygon_ring;
       line << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 10 );
       polygon_ring << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 10 ) << QgsPointXY( 10, 0 ) << QgsPointXY( 0, 0 );
       QgsPolygon polygon;
@@ -2279,14 +2279,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "Disjoint" ) << "disjoint( $geometry, geomFromWKT('LINESTRING ( 2 0, 0 2 )') )" << QgsGeometry::fromPoint( point ) << false << QVariant( 1 );
 
       // OGR test
-      QTest::newRow( "OGR Intersects" ) << "intersects( $geometry, geomFromWKT('LINESTRING ( 10 0, 0 10 )') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 1 );
-      QTest::newRow( "OGR no Intersects" ) << "intersects( $geometry, geomFromWKT('POLYGON((20 20, 20 30, 30 20, 20 20))') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 0 );
-      QTest::newRow( "OGR no Disjoint" ) << "disjoint( $geometry, geomFromWKT('LINESTRING ( 10 0, 0 10 )') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 0 );
-      QTest::newRow( "OGR Disjoint" ) << "disjoint( $geometry, geomFromWKT('POLYGON((20 20, 20 30, 30 20, 20 20))') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 1 );
-      QTest::newRow( "OGR Touches" ) << "touches( $geometry, geomFromWKT('LINESTRING ( 0 0, 0 10 )') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 1 );
-      QTest::newRow( "OGR no Touches" ) << "touches( $geometry, geomFromWKT('POLYGON((20 20, 20 30, 30 20, 20 20))') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 0 );
-      QTest::newRow( "OGR Crosses" ) << "crosses( $geometry, geomFromWKT('LINESTRING ( 10 0, 0 10 )') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 1 );
-      QTest::newRow( "OGR no Crosses" ) << "crosses( $geometry, geomFromWKT('LINESTRING ( 0 0, 0 10 )') )" << QgsGeometry::fromPolyline( line ) << false << QVariant( 0 );
+      QTest::newRow( "OGR Intersects" ) << "intersects( $geometry, geomFromWKT('LINESTRING ( 10 0, 0 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "OGR no Intersects" ) << "intersects( $geometry, geomFromWKT('POLYGON((20 20, 20 30, 30 20, 20 20))') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
+      QTest::newRow( "OGR no Disjoint" ) << "disjoint( $geometry, geomFromWKT('LINESTRING ( 10 0, 0 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
+      QTest::newRow( "OGR Disjoint" ) << "disjoint( $geometry, geomFromWKT('POLYGON((20 20, 20 30, 30 20, 20 20))') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "OGR Touches" ) << "touches( $geometry, geomFromWKT('LINESTRING ( 0 0, 0 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "OGR no Touches" ) << "touches( $geometry, geomFromWKT('POLYGON((20 20, 20 30, 30 20, 20 20))') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
+      QTest::newRow( "OGR Crosses" ) << "crosses( $geometry, geomFromWKT('LINESTRING ( 10 0, 0 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "OGR no Crosses" ) << "crosses( $geometry, geomFromWKT('LINESTRING ( 0 0, 0 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
       QTest::newRow( "OGR Within" ) << "within( $geometry, geomFromWKT('POLYGON((-90 -90, -90 90, 190 -90, -90 -90))') )" << QgsGeometry::fromPolygon( polygon ) << false << QVariant( 1 );
       QTest::newRow( "OGR no Within" ) << "within( geomFromWKT('POLYGON((-90 -90, -90 90, 190 -90, -90 -90))'), $geometry )" << QgsGeometry::fromPolygon( polygon ) << false << QVariant( 0 );
       QTest::newRow( "OGR Contains" ) << "contains( geomFromWKT('POLYGON((-90 -90, -90 90, 190 -90, -90 -90))'), $geometry )" << QgsGeometry::fromPolygon( polygon ) << false << QVariant( 1 );
@@ -2324,7 +2324,7 @@ class TestQgsExpression: public QObject
       QTest::addColumn<QgsGeometry>( "result" );
 
       QgsPointXY point( 0, 0 );
-      QgsPolyline line, polygon_ring;
+      QgsPolylineXY line, polygon_ring;
       line << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 10 );
       polygon_ring << QgsPointXY( 0, 0 ) << QgsPointXY( 10, 10 ) << QgsPointXY( 10, 0 ) << QgsPointXY( 0, 0 );
       QgsPolygon polygon;
@@ -2364,7 +2364,7 @@ class TestQgsExpression: public QObject
 
       geom = QgsGeometry::fromPolygon( polygon );
       QTest::newRow( "translate" ) << "translate( $geometry, 1, 2)" << geom << false << true << QgsGeometry::fromWkt( QStringLiteral( "POLYGON ((1 2,11 12,11 2,1 2))" ) );
-      geom = QgsGeometry::fromPolyline( line );
+      geom = QgsGeometry::fromPolylineXY( line );
       QTest::newRow( "translate" ) << "translate( $geometry, -1, 2)" << geom << false << true << QgsGeometry::fromWkt( QStringLiteral( "LINESTRING (-1 2, 9 12)" ) );
       geom = QgsGeometry::fromPoint( point );
       QTest::newRow( "translate" ) << "translate( $geometry, 1, -2)" << geom << false << true << QgsGeometry::fromWkt( QStringLiteral( "POINT(1 -2)" ) );

--- a/tests/src/core/testqgsgeometryimport.cpp
+++ b/tests/src/core/testqgsgeometryimport.cpp
@@ -54,7 +54,7 @@ class TestQgsGeometryImport: public QObject
     void delimiters();
 
   private:
-    bool compareLineStrings( const QgsPolyline &polyline, QVariantList &line );
+    bool compareLineStrings( const QgsPolylineXY &polyline, QVariantList &line );
 };
 
 void TestQgsGeometryImport::initTestCase()
@@ -161,7 +161,7 @@ void TestQgsGeometryImport::linestringWkt()
   QgsGeometry geom = QgsGeometry::fromWkt( wktString );
   QCOMPARE( geom.wkbType(), QgsWkbTypes::LineString );
 
-  QgsPolyline polyLine = geom.asPolyline();
+  QgsPolylineXY polyLine = geom.asPolyline();
   QVERIFY( compareLineStrings( polyLine, line ) );
 }
 
@@ -193,7 +193,7 @@ void TestQgsGeometryImport::linestringWkb()
   geom.fromWkb( geomPtr, wkbSize );
 
   QVERIFY( geom.wkbType() == QgsWkbTypes::LineString );
-  QgsPolyline polyline = geom.asPolyline();
+  QgsPolylineXY polyline = geom.asPolyline();
   QVERIFY( compareLineStrings( polyline, line ) );
 }
 
@@ -222,12 +222,12 @@ void TestQgsGeometryImport::linestringGeos()
   geom.fromGeos( geosLine );
   QVERIFY( geom.wkbType() == QgsWkbTypes::LineString );
 
-  QgsPolyline polyline = geom.asPolyline();
+  QgsPolylineXY polyline = geom.asPolyline();
   QVERIFY( compareLineStrings( polyline, line ) );
 }
 
 
-bool TestQgsGeometryImport::compareLineStrings( const QgsPolyline &polyline, QVariantList &line )
+bool TestQgsGeometryImport::compareLineStrings( const QgsPolylineXY &polyline, QVariantList &line )
 {
   bool sizeEqual = ( polyline.size() == line.size() );
   if ( !sizeEqual )

--- a/tests/src/core/testqgsgml.cpp
+++ b/tests/src/core/testqgsgml.cpp
@@ -223,7 +223,7 @@ void TestQgsGML::testLineStringGML2()
   QCOMPARE( features.size(), 1 );
   QVERIFY( features[0].first->hasGeometry() );
   QCOMPARE( features[0].first->geometry().wkbType(), QgsWkbTypes::LineString );
-  QgsPolyline line = features[0].first->geometry().asPolyline();
+  QgsPolylineXY line = features[0].first->geometry().asPolyline();
   QCOMPARE( line.size(), 2 );
   QCOMPARE( line[0], QgsPointXY( 10, 20 ) );
   QCOMPARE( line[1], QgsPointXY( 30, 40 ) );
@@ -545,7 +545,7 @@ void TestQgsGML::testLineStringGML3()
   QCOMPARE( features.size(), 1 );
   QVERIFY( features[0].first->hasGeometry() );
   QCOMPARE( features[0].first->geometry().wkbType(), QgsWkbTypes::LineString );
-  QgsPolyline line = features[0].first->geometry().asPolyline();
+  QgsPolylineXY line = features[0].first->geometry().asPolyline();
   QCOMPARE( line.size(), 2 );
   QCOMPARE( line[0], QgsPointXY( 10, 20 ) );
   QCOMPARE( line[1], QgsPointXY( 30, 40 ) );
@@ -572,7 +572,7 @@ void TestQgsGML::testLineStringGML3_LineStringSegment()
   QCOMPARE( features.size(), 1 );
   QVERIFY( features[0].first->hasGeometry() );
   QCOMPARE( features[0].first->geometry().wkbType(), QgsWkbTypes::LineString );
-  QgsPolyline line = features[0].first->geometry().asPolyline();
+  QgsPolylineXY line = features[0].first->geometry().asPolyline();
   QCOMPARE( line.size(), 2 );
   QCOMPARE( line[0], QgsPointXY( 10, 20 ) );
   QCOMPARE( line[1], QgsPointXY( 30, 40 ) );

--- a/tests/src/core/testqgsmaprendererjob.cpp
+++ b/tests/src/core/testqgsmaprendererjob.cpp
@@ -132,7 +132,7 @@ void TestQgsMapRendererJob::initTestCase()
         //
         // Create a polygon feature
         //
-        QgsPolyline myPolyline;
+        QgsPolylineXY myPolyline;
         QgsPointXY myPoint1 = QgsPointXY( i, j );
         QgsPointXY myPoint2 = QgsPointXY( i + myInterval, j );
         QgsPointXY myPoint3 = QgsPointXY( i + myInterval, j + myInterval );

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -81,7 +81,7 @@ class TestQgsPointLocator : public QObject
       mVL = new QgsVectorLayer( QStringLiteral( "Polygon" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
       QgsFeature ff( 0 );
       QgsPolygon polygon;
-      QgsPolyline polyline;
+      QgsPolylineXY polyline;
       polyline << QgsPointXY( 0, 1 ) << QgsPointXY( 1, 0 ) << QgsPointXY( 1, 1 ) << QgsPointXY( 0, 1 );
       polygon << polyline;
       QgsGeometry ffGeom = QgsGeometry::fromPolygon( polygon );
@@ -199,7 +199,7 @@ class TestQgsPointLocator : public QObject
       // add a new feature
       QgsFeature ff( 0 );
       QgsPolygon polygon;
-      QgsPolyline polyline;
+      QgsPolylineXY polyline;
       polyline << QgsPointXY( 10, 11 ) << QgsPointXY( 11, 10 ) << QgsPointXY( 11, 11 ) << QgsPointXY( 10, 11 );
       polygon << polyline;
       QgsGeometry ffGeom = QgsGeometry::fromPolygon( polygon ) ;

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -63,7 +63,7 @@ class TestQgsSnappingUtils : public QObject
       mVL = new QgsVectorLayer( QStringLiteral( "Polygon" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
       QgsFeature ff( 0 );
       QgsPolygon polygon;
-      QgsPolyline polyline;
+      QgsPolylineXY polyline;
       polyline << QgsPointXY( 0, 1 ) << QgsPointXY( 1, 0 ) << QgsPointXY( 1, 1 ) << QgsPointXY( 0, 1 );
       polygon << polyline;
       QgsGeometry polygonGeom = QgsGeometry::fromPolygon( polygon );
@@ -191,14 +191,14 @@ class TestQgsSnappingUtils : public QObject
       //         /\    .
       // (0,0)  x  x (1,0)
       QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "LineString" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
-      QgsPolyline polyline1, polyline2;
+      QgsPolylineXY polyline1, polyline2;
       polyline1 << QgsPointXY( 0, 0 ) << QgsPointXY( 1, 1 );
       polyline2 << QgsPointXY( 1, 0 ) << QgsPointXY( 0, 1 );
       QgsFeature f1;
-      QgsGeometry f1g = QgsGeometry::fromPolyline( polyline1 ) ;
+      QgsGeometry f1g = QgsGeometry::fromPolylineXY( polyline1 ) ;
       f1.setGeometry( f1g );
       QgsFeature f2;
-      QgsGeometry f2g = QgsGeometry::fromPolyline( polyline2 );
+      QgsGeometry f2g = QgsGeometry::fromPolylineXY( polyline2 );
       f2.setGeometry( f2g );
       QgsFeatureList flist;
       flist << f1 << f2;

--- a/tests/src/core/testqgstracer.cpp
+++ b/tests/src/core/testqgstracer.cpp
@@ -121,21 +121,21 @@ void TestQgsTracer::testSimple()
   QgsTracer tracer;
   tracer.setLayers( QList<QgsVectorLayer *>() << vl );
 
-  QgsPolyline points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
+  QgsPolylineXY points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
   QCOMPARE( points1.count(), 3 );
   QCOMPARE( points1[0], QgsPointXY( 0, 0 ) );
   QCOMPARE( points1[1], QgsPointXY( 10, 0 ) );
   QCOMPARE( points1[2], QgsPointXY( 20, 10 ) );
 
   // one joined point
-  QgsPolyline points2 = tracer.findShortestPath( QgsPointXY( 5, 10 ), QgsPointXY( 0, 0 ) );
+  QgsPolylineXY points2 = tracer.findShortestPath( QgsPointXY( 5, 10 ), QgsPointXY( 0, 0 ) );
   QCOMPARE( points2.count(), 3 );
   QCOMPARE( points2[0], QgsPointXY( 5, 10 ) );
   QCOMPARE( points2[1], QgsPointXY( 0, 10 ) );
   QCOMPARE( points2[2], QgsPointXY( 0, 0 ) );
 
   // two joined points
-  QgsPolyline points3 = tracer.findShortestPath( QgsPointXY( 0, 1 ), QgsPointXY( 11, 1 ) );
+  QgsPolylineXY points3 = tracer.findShortestPath( QgsPointXY( 0, 1 ), QgsPointXY( 11, 1 ) );
   QCOMPARE( points3.count(), 4 );
   QCOMPARE( points3[0], QgsPointXY( 0, 1 ) );
   QCOMPARE( points3[1], QgsPointXY( 0, 0 ) );
@@ -143,13 +143,13 @@ void TestQgsTracer::testSimple()
   QCOMPARE( points3[3], QgsPointXY( 11, 1 ) );
 
   // two joined points on one line
-  QgsPolyline points4 = tracer.findShortestPath( QgsPointXY( 11, 1 ), QgsPointXY( 19, 9 ) );
+  QgsPolylineXY points4 = tracer.findShortestPath( QgsPointXY( 11, 1 ), QgsPointXY( 19, 9 ) );
   QCOMPARE( points4.count(), 2 );
   QCOMPARE( points4[0], QgsPointXY( 11, 1 ) );
   QCOMPARE( points4[1], QgsPointXY( 19, 9 ) );
 
   // no path to (1,1)
-  QgsPolyline points5 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 1, 1 ) );
+  QgsPolylineXY points5 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 1, 1 ) );
   QCOMPARE( points5.count(), 0 );
 
   delete vl;
@@ -168,7 +168,7 @@ void TestQgsTracer::testPolygon()
   QgsTracer tracer;
   tracer.setLayers( QList<QgsVectorLayer *>() << vl );
 
-  QgsPolyline points = tracer.findShortestPath( QgsPointXY( 1, 0 ), QgsPointXY( 0, 1 ) );
+  QgsPolylineXY points = tracer.findShortestPath( QgsPointXY( 1, 0 ), QgsPointXY( 0, 1 ) );
   QCOMPARE( points.count(), 3 );
   QCOMPARE( points[0], QgsPointXY( 1, 0 ) );
   QCOMPARE( points[1], QgsPointXY( 0, 0 ) );
@@ -197,7 +197,7 @@ void TestQgsTracer::testButterfly()
   QgsTracer tracer;
   tracer.setLayers( QList<QgsVectorLayer *>() << vl );
 
-  QgsPolyline points = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 0 ) );
+  QgsPolylineXY points = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 0 ) );
 
   QCOMPARE( points.count(), 3 );
   QCOMPARE( points[0], QgsPointXY( 0, 0 ) );
@@ -224,7 +224,7 @@ void TestQgsTracer::testLayerUpdates()
   tracer.setLayers( QList<QgsVectorLayer *>() << vl );
   tracer.init();
 
-  QgsPolyline points1 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
+  QgsPolylineXY points1 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
   QCOMPARE( points1.count(), 3 );
   QCOMPARE( points1[0], QgsPointXY( 10, 0 ) );
   QCOMPARE( points1[1], QgsPointXY( 20, 10 ) );
@@ -236,7 +236,7 @@ void TestQgsTracer::testLayerUpdates()
   QgsFeature f( make_feature( QStringLiteral( "LINESTRING(10 0, 10 10)" ) ) );
   vl->addFeature( f );
 
-  QgsPolyline points2 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
+  QgsPolylineXY points2 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
   QCOMPARE( points2.count(), 2 );
   QCOMPARE( points2[0], QgsPointXY( 10, 0 ) );
   QCOMPARE( points2[1], QgsPointXY( 10, 10 ) );
@@ -244,7 +244,7 @@ void TestQgsTracer::testLayerUpdates()
   // delete the shortcut
   vl->deleteFeature( f.id() );
 
-  QgsPolyline points3 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
+  QgsPolylineXY points3 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
   QCOMPARE( points3.count(), 3 );
   QCOMPARE( points3[0], QgsPointXY( 10, 0 ) );
   QCOMPARE( points3[1], QgsPointXY( 20, 10 ) );
@@ -254,12 +254,12 @@ void TestQgsTracer::testLayerUpdates()
   QgsGeometry g = QgsGeometry::fromWkt( QStringLiteral( "LINESTRING(10 0, 10 10)" ) );
   vl->changeGeometry( 2, g );  // change bottom line (second item in wkts)
 
-  QgsPolyline points4 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
+  QgsPolylineXY points4 = tracer.findShortestPath( QgsPointXY( 10, 0 ), QgsPointXY( 10, 10 ) );
   QCOMPARE( points4.count(), 2 );
   QCOMPARE( points4[0], QgsPointXY( 10, 0 ) );
   QCOMPARE( points4[1], QgsPointXY( 10, 10 ) );
 
-  QgsPolyline points5 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 0 ) );
+  QgsPolylineXY points5 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 0 ) );
   QCOMPARE( points5.count(), 4 );
   QCOMPARE( points5[0], QgsPointXY( 0, 0 ) );
   QCOMPARE( points5[1], QgsPointXY( 0, 10 ) );
@@ -289,12 +289,12 @@ void TestQgsTracer::testExtent()
   tracer.setExtent( QgsRectangle( 0, 0, 5, 5 ) );
   tracer.init();
 
-  QgsPolyline points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 0 ) );
+  QgsPolylineXY points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 0 ) );
   QCOMPARE( points1.count(), 2 );
   QCOMPARE( points1[0], QgsPointXY( 0, 0 ) );
   QCOMPARE( points1[1], QgsPointXY( 10, 0 ) );
 
-  QgsPolyline points2 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
+  QgsPolylineXY points2 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
   QCOMPARE( points2.count(), 0 );
 }
 
@@ -315,7 +315,7 @@ void TestQgsTracer::testReprojection()
   tracer.setDestinationCrs( dstCrs );
   tracer.init();
 
-  QgsPolyline points1 = tracer.findShortestPath( p1, p2 );
+  QgsPolylineXY points1 = tracer.findShortestPath( p1, p2 );
   QCOMPARE( points1.count(), 2 );
 }
 
@@ -335,11 +335,11 @@ void TestQgsTracer::testCurved()
   QgsTracer tracer;
   tracer.setLayers( QList<QgsVectorLayer *>() << vl );
 
-  QgsPolyline points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 10 ) );
+  QgsPolylineXY points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 10 ) );
 
   QVERIFY( points1.count() != 0 );
 
-  QgsGeometry tmpG1 = QgsGeometry::fromPolyline( points1 );
+  QgsGeometry tmpG1 = QgsGeometry::fromPolylineXY( points1 );
   double l = tmpG1.length();
 
   // fuzzy comparison as QCOMPARE is too strict for this case
@@ -374,7 +374,7 @@ void TestQgsTracer::testOffset()
 
   // curve on the right side
   tracer.setOffset( -1 );
-  QgsPolyline points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
+  QgsPolylineXY points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
   QCOMPARE( points1.count(), 3 );
   QCOMPARE( points1[0], QgsPointXY( 0, -1 ) );
   QCOMPARE( points1[1], QgsPointXY( 10 + sqrt( 2 ) - 1, -1 ) );
@@ -382,7 +382,7 @@ void TestQgsTracer::testOffset()
 
   // curve on the left side
   tracer.setOffset( 1 );
-  QgsPolyline points2 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
+  QgsPolylineXY points2 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 20, 10 ) );
   QCOMPARE( points2.count(), 3 );
   QCOMPARE( points2[0], QgsPointXY( 0, 1 ) );
   QCOMPARE( points2[1], QgsPointXY( 10 - sqrt( 2 ) + 1, 1 ) );

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -184,9 +184,9 @@ void TestQgsVectorFileWriter::createLine()
   //
   // Create a feature
   //
-  QgsPolyline myPolyline;
+  QgsPolylineXY myPolyline;
   myPolyline << mPoint1 << mPoint2 << mPoint3;
-  QgsGeometry mypLineGeometry = QgsGeometry::fromPolyline( myPolyline );
+  QgsGeometry mypLineGeometry = QgsGeometry::fromPolylineXY( myPolyline );
   QgsFeature myFeature;
   myFeature.setGeometry( mypLineGeometry );
   myFeature.initAttributes( 1 );
@@ -229,7 +229,7 @@ void TestQgsVectorFileWriter::createPolygon()
   //
   // Create a polygon feature
   //
-  QgsPolyline myPolyline;
+  QgsPolylineXY myPolyline;
   myPolyline << mPoint1 << mPoint2 << mPoint3 << mPoint1;
   QgsPolygon myPolygon;
   myPolygon << myPolyline;
@@ -282,7 +282,7 @@ void TestQgsVectorFileWriter::polygonGridTest()
       //
       // Create a polygon feature
       //
-      QgsPolyline myPolyline;
+      QgsPolylineXY myPolyline;
       QgsPointXY myPoint1 = QgsPointXY( i, j );
       QgsPointXY myPoint2 = QgsPointXY( i + myInterval, j );
       QgsPointXY myPoint3 = QgsPointXY( i + myInterval, j + myInterval );
@@ -352,7 +352,7 @@ void TestQgsVectorFileWriter::projectedPlygonGridTest()
       //
       // Create a polygon feature
       //
-      QgsPolyline myPolyline;
+      QgsPolylineXY myPolyline;
       QgsPointXY myPoint1 = QgsPointXY( i, j );
       QgsPointXY myPoint2 = QgsPointXY( i + myInterval, j );
       QgsPointXY myPoint3 = QgsPointXY( i + myInterval, j + myInterval );

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -338,10 +338,10 @@ void TestQgsVectorLayer::testAddTopologicalPoints()
   QgsVectorLayer *layerLine = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:27700" ), QStringLiteral( "layer line" ), QStringLiteral( "memory" ) );
   QVERIFY( layerLine->isValid() );
 
-  QgsPolyline line1;
+  QgsPolylineXY line1;
   line1 << QgsPointXY( 2, 1 ) << QgsPointXY( 1, 1 ) << QgsPointXY( 1, 3 );
   QgsFeature lineF1;
-  lineF1.setGeometry( QgsGeometry::fromPolyline( line1 ) );
+  lineF1.setGeometry( QgsGeometry::fromPolylineXY( line1 ) );
 
   layerLine->startEditing();
   layerLine->addFeature( lineF1 );

--- a/tests/src/python/test_qgsdistancearea.py
+++ b/tests/src/python/test_qgsdistancearea.py
@@ -47,7 +47,7 @@ class TestQgsDistanceArea(unittest.TestCase):
         #   +-+
         #   | |
         # +-+ +
-        linestring = QgsGeometry.fromPolyline(
+        linestring = QgsGeometry.fromPolylineXY(
             [QgsPointXY(0, 0), QgsPointXY(1, 0), QgsPointXY(1, 1), QgsPointXY(2, 1), QgsPointXY(2, 0), ]
         )
         da = QgsDistanceArea()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -129,7 +129,7 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(myMultiPoint.wkbType(), QgsWkbTypes.MultiPoint)
 
     def testFromLine(self):
-        myLine = QgsGeometry.fromPolyline([QgsPointXY(1, 1), QgsPointXY(2, 2)])
+        myLine = QgsGeometry.fromPolylineXY([QgsPointXY(1, 1), QgsPointXY(2, 2)])
         self.assertEqual(myLine.wkbType(), QgsWkbTypes.LineString)
 
     def testFromMultiLine(self):
@@ -241,7 +241,7 @@ class TestQgsGeometry(unittest.TestCase):
                 self.assertAlmostEqual(result, exp, 5, "Perimeter {}: mismatch Expected:\n{}\nGot:\n{}\n".format(i + 1, exp, result))
 
     def testIntersection(self):
-        myLine = QgsGeometry.fromPolyline([
+        myLine = QgsGeometry.fromPolylineXY([
             QgsPointXY(0, 0),
             QgsPointXY(1, 1),
             QgsPointXY(2, 2)])
@@ -278,7 +278,7 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertTrue(QgsGeometry.contains(myPoly, myPoint))
 
     def testTouches(self):
-        myLine = QgsGeometry.fromPolyline([
+        myLine = QgsGeometry.fromPolylineXY([
             QgsPointXY(0, 0),
             QgsPointXY(1, 1),
             QgsPointXY(2, 2)])
@@ -310,7 +310,7 @@ class TestQgsGeometry(unittest.TestCase):
         assert overlapsGeom, myMessage
 
     def testWithin(self):
-        myLine = QgsGeometry.fromPolyline([
+        myLine = QgsGeometry.fromPolylineXY([
             QgsPointXY(0.5, 0.5),
             QgsPointXY(1, 1),
             QgsPointXY(1.5, 1.5)
@@ -335,7 +335,7 @@ class TestQgsGeometry(unittest.TestCase):
         assert equalsGeom, myMessage
 
     def testCrosses(self):
-        myLine = QgsGeometry.fromPolyline([
+        myLine = QgsGeometry.fromPolylineXY([
             QgsPointXY(0, 0),
             QgsPointXY(1, 1),
             QgsPointXY(3, 3)])
@@ -395,7 +395,7 @@ class TestQgsGeometry(unittest.TestCase):
         assert myProvider is not None
 
         myFeature1 = QgsFeature()
-        myFeature1.setGeometry(QgsGeometry.fromPolyline([
+        myFeature1.setGeometry(QgsGeometry.fromPolylineXY([
             QgsPointXY(10, 10),
             QgsPointXY(20, 10),
             QgsPointXY(30, 10),
@@ -404,7 +404,7 @@ class TestQgsGeometry(unittest.TestCase):
         myFeature1.setAttributes(['Johny'])
 
         myFeature2 = QgsFeature()
-        myFeature2.setGeometry(QgsGeometry.fromPolyline([
+        myFeature2.setGeometry(QgsGeometry.fromPolylineXY([
             QgsPointXY(10, 10),
             QgsPointXY(20, 20),
             QgsPointXY(30, 30),
@@ -413,7 +413,7 @@ class TestQgsGeometry(unittest.TestCase):
         myFeature2.setAttributes(['Be'])
 
         myFeature3 = QgsFeature()
-        myFeature3.setGeometry(QgsGeometry.fromPolyline([
+        myFeature3.setGeometry(QgsGeometry.fromPolylineXY([
             QgsPointXY(10, 10),
             QgsPointXY(10, 20),
             QgsPointXY(10, 30),
@@ -488,7 +488,7 @@ class TestQgsGeometry(unittest.TestCase):
         # ! 5-+-+-+-4 !
         # |
         # 1-+-+-+-+-0 !
-        polyline = QgsGeometry.fromPolyline(
+        polyline = QgsGeometry.fromPolylineXY(
             [QgsPointXY(5, 0), QgsPointXY(0, 0), QgsPointXY(0, 4), QgsPointXY(5, 4), QgsPointXY(5, 1), QgsPointXY(1, 1), QgsPointXY(1, 3), QgsPointXY(4, 3), QgsPointXY(4, 2), QgsPointXY(2, 2)]
         )
 
@@ -632,7 +632,7 @@ class TestQgsGeometry(unittest.TestCase):
         # ! 5-+-+-+-4 !
         # |
         # 1-+-+-+-+-0 !
-        polyline = QgsGeometry.fromPolyline(
+        polyline = QgsGeometry.fromPolylineXY(
             [QgsPointXY(5, 0), QgsPointXY(0, 0), QgsPointXY(0, 4), QgsPointXY(5, 4), QgsPointXY(5, 1), QgsPointXY(1, 1), QgsPointXY(1, 3), QgsPointXY(4, 3), QgsPointXY(4, 2), QgsPointXY(2, 2)]
         )
 
@@ -772,7 +772,7 @@ class TestQgsGeometry(unittest.TestCase):
         # |
         # 1-+-+-+-+-0 !
         points = [QgsPointXY(5, 0), QgsPointXY(0, 0), QgsPointXY(0, 4), QgsPointXY(5, 4), QgsPointXY(5, 1), QgsPointXY(1, 1), QgsPointXY(1, 3), QgsPointXY(4, 3), QgsPointXY(4, 2), QgsPointXY(2, 2)]
-        polyline = QgsGeometry.fromPolyline(points)
+        polyline = QgsGeometry.fromPolylineXY(points)
 
         for i in range(0, len(points)):
             self.assertEqual(QgsPoint(points[i]), polyline.vertexAt(i), "Mismatch at %d" % i)
@@ -1223,7 +1223,7 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertTrue(g.extrude(1, 2).isNull())
 
         points = [QgsPointXY(1, 2), QgsPointXY(3, 2), QgsPointXY(4, 3)]
-        line = QgsGeometry.fromPolyline(points)
+        line = QgsGeometry.fromPolylineXY(points)
         expected = QgsGeometry.fromWkt('Polygon ((1 2, 3 2, 4 3, 5 5, 4 4, 2 4, 1 2))')
         self.assertEqual(line.extrude(1, 2).exportToWkt(), expected.exportToWkt())
 
@@ -1305,7 +1305,7 @@ class TestQgsGeometry(unittest.TestCase):
         # |
         # 1-+-+-+-+-0 !
         points = [QgsPointXY(5, 0), QgsPointXY(0, 0), QgsPointXY(0, 4), QgsPointXY(5, 4), QgsPointXY(5, 1), QgsPointXY(1, 1), QgsPointXY(1, 3), QgsPointXY(4, 3), QgsPointXY(4, 2), QgsPointXY(2, 2)]
-        polyline = QgsGeometry.fromPolyline(points)
+        polyline = QgsGeometry.fromPolylineXY(points)
         expbb = QgsRectangle(0, 0, 5, 4)
         bb = polyline.boundingBox()
         self.assertEqual(expbb, bb, "Expected:\n%s\nGot:\n%s\n" % (expbb.toString(), bb.toString()))
@@ -1368,7 +1368,7 @@ class TestQgsGeometry(unittest.TestCase):
 
         # NULL
         points = []
-        line = QgsGeometry.fromPolyline(points)
+        line = QgsGeometry.fromPolylineXY(points)
         assert line.boundingBox().isNull()
 
     def testCollectGeometry(self):
@@ -1384,7 +1384,7 @@ class TestQgsGeometry(unittest.TestCase):
             [QgsPointXY(0, 0), QgsPointXY(1, 0)],
             [QgsPointXY(2, 0), QgsPointXY(3, 0)]
         ]
-        geometries = [QgsGeometry.fromPolyline(points[0]), QgsGeometry.fromPolyline(points[1])]
+        geometries = [QgsGeometry.fromPolylineXY(points[0]), QgsGeometry.fromPolylineXY(points[1])]
         geometry = QgsGeometry.collectGeometry(geometries)
         expwkt = "MultiLineString ((0 0, 1 0), (2 0, 3 0))"
         wkt = geometry.exportToWkt()
@@ -1436,21 +1436,21 @@ class TestQgsGeometry(unittest.TestCase):
             [QgsPointXY(3, 0), QgsPointXY(3, 1), QgsPointXY(5, 1), QgsPointXY(5, 0), QgsPointXY(6, 0), ]
         ]
 
-        polyline = QgsGeometry.fromPolyline(points[0])
+        polyline = QgsGeometry.fromPolylineXY(points[0])
         self.assertEqual(polyline.addPoints(points[1][0:1]), QgsGeometry.InvalidInput, "addPoints with one point line unexpectedly succeeded.")
         self.assertEqual(polyline.addPoints(points[1][0:2]), QgsGeometry.Success, "addPoints with two point line failed.")
         expwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0), (3 0, 3 1))"
         wkt = polyline.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
-        polyline = QgsGeometry.fromPolyline(points[0])
+        polyline = QgsGeometry.fromPolylineXY(points[0])
         self.assertEqual(polyline.addPoints(points[1]), QgsGeometry.Success, "addPoints with %d point line failed." % len(points[1]))
         expwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0), (3 0, 3 1, 5 1, 5 0, 6 0))"
         wkt = polyline.exportToWkt()
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
         # test adding a part with Z values
-        polyline = QgsGeometry.fromPolyline(points[0])
+        polyline = QgsGeometry.fromPolylineXY(points[0])
         polyline.geometry().addZValue(4.0)
         points2 = [QgsPoint(p[0], p[1], 3.0, wkbType=QgsWkbTypes.PointZ) for p in points[1]]
         self.assertEqual(polyline.addPointsV2(points2), QgsGeometry.Success)
@@ -1566,7 +1566,7 @@ class TestQgsGeometry(unittest.TestCase):
         expWkt = "MultiPoint ((1 1))"
         assert compareWkt(expWkt, wkt), "convertToType failed: from point to multipoint. Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
         # LINE TO MultiPoint
-        line = QgsGeometry.fromPolyline(points[0][0])
+        line = QgsGeometry.fromPolylineXY(points[0][0])
         wkt = line.convertToType(QgsWkbTypes.PointGeometry, True).exportToWkt()
         expWkt = "MultiPoint ((0 0),(1 0),(1 1),(2 1),(2 2),(0 2),(0 0))"
         assert compareWkt(expWkt, wkt), "convertToType failed: from line to multipoint. Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
@@ -1606,7 +1606,7 @@ class TestQgsGeometry(unittest.TestCase):
         expWkt = "LineString (0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0)"
         assert compareWkt(expWkt, wkt), "convertToType failed: from multiline to line. Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
         # LINE TO MULTILINE
-        line = QgsGeometry.fromPolyline(points[0][0])
+        line = QgsGeometry.fromPolylineXY(points[0][0])
         wkt = line.convertToType(QgsWkbTypes.LineGeometry, True).exportToWkt()
         expWkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0))"
         assert compareWkt(expWkt, wkt), "convertToType failed: from line to multiline. Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
@@ -1648,18 +1648,18 @@ class TestQgsGeometry(unittest.TestCase):
         expWkt = "MultiPolygon (((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0)))"
         assert compareWkt(expWkt, wkt), "convertToType failed: from multipoint to multipolygon. Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
         # LINE TO Polygon
-        line = QgsGeometry.fromPolyline(points[0][0])
+        line = QgsGeometry.fromPolylineXY(points[0][0])
         wkt = line.convertToType(QgsWkbTypes.PolygonGeometry, False).exportToWkt()
         expWkt = "Polygon ((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0))"
         assert compareWkt(expWkt, wkt), "convertToType failed: from line to polygon. Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
         # LINE ( 3 vertices, with first = last ) TO Polygon
-        line = QgsGeometry.fromPolyline([QgsPointXY(1, 1), QgsPointXY(0, 0), QgsPointXY(1, 1)])
+        line = QgsGeometry.fromPolylineXY([QgsPointXY(1, 1), QgsPointXY(0, 0), QgsPointXY(1, 1)])
         self.assertFalse(line.convertToType(QgsWkbTypes.PolygonGeometry, False), "convertToType to polygon of a 3 vertices lines with first and last vertex identical should return a null geometry")
         # MULTILINE ( with a part of 3 vertices, with first = last ) TO MultiPolygon
         multiline = QgsGeometry.fromMultiPolyline([points[0][0], [QgsPointXY(1, 1), QgsPointXY(0, 0), QgsPointXY(1, 1)]])
         self.assertFalse(multiline.convertToType(QgsWkbTypes.PolygonGeometry, True), "convertToType to polygon of a 3 vertices lines with first and last vertex identical should return a null geometry")
         # LINE TO MultiPolygon
-        line = QgsGeometry.fromPolyline(points[0][0])
+        line = QgsGeometry.fromPolylineXY(points[0][0])
         wkt = line.convertToType(QgsWkbTypes.PolygonGeometry, True).exportToWkt()
         expWkt = "MultiPolygon (((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0)))"
         assert compareWkt(expWkt, wkt), "convertToType failed: from line to multipolygon. Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)

--- a/tests/src/python/test_qgsserver_wfst.py
+++ b/tests/src/python/test_qgsserver_wfst.py
@@ -313,9 +313,9 @@ class TestWFST(unittest.TestCase):
         feat1 = QgsFeature(wfs_layer.pendingFields())
         feat1['id'] = 11
         feat1['name'] = 'name 11'
-        feat1.setGeometry(QgsGeometry.fromPolyline([QgsPointXY(9, 45), QgsPointXY(10, 46)]))
+        feat1.setGeometry(QgsGeometry.fromPolylineXY([QgsPointXY(9, 45), QgsPointXY(10, 46)]))
         feat2 = QgsFeature(wfs_layer.pendingFields())
-        feat2.setGeometry(QgsGeometry.fromPolyline([QgsPointXY(9.5, 45.5), QgsPointXY(10.5, 46.5)]))
+        feat2.setGeometry(QgsGeometry.fromPolylineXY([QgsPointXY(9.5, 45.5), QgsPointXY(10.5, 46.5)]))
         feat2['id'] = 12
         feat2['name'] = 'name 12'
         old_features = [feat1, feat2]
@@ -323,7 +323,7 @@ class TestWFST(unittest.TestCase):
         new_feat1 = QgsFeature(wfs_layer.pendingFields())
         new_feat1['id'] = 121
         new_feat1['name'] = 'name 121'
-        new_feat1.setGeometry(QgsGeometry.fromPolyline([QgsPointXY(9.8, 45.8), QgsPointXY(10.8, 46.8)]))
+        new_feat1.setGeometry(QgsGeometry.fromPolylineXY([QgsPointXY(9.8, 45.8), QgsPointXY(10.8, 46.8)]))
         new_features = [new_feat1, feat2]
         self._testLayer(wfs_layer, layer, old_features, new_features)
 

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -58,7 +58,7 @@ def createLayerWithOneLine():
     linelayer = QgsVectorLayer("LineString?crs=epsg:4326&field=gid:int&field=name:string", "simple_line", "memory")
     one = QgsFeature(linelayer.dataProvider().fields(), 0)
     one.setAttributes([1, 'one'])
-    one.setGeometry(QgsGeometry.fromPolyline([QgsPointXY(-7, 38), QgsPointXY(-8, 42)]))
+    one.setGeometry(QgsGeometry.fromPolylineXY([QgsPointXY(-7, 38), QgsPointXY(-8, 42)]))
     linelayer.dataProvider().addFeatures([one])
     return linelayer
 

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -1669,7 +1669,7 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         self.assertTrue(temp_layer.isValid())
         f1 = QgsFeature(temp_layer.dataProvider().fields(), 1)
         f1.setAttribute("pk", 1)
-        f1.setGeometry(QgsGeometry.fromPolyline([QgsPointXY(2484588, 2425722), QgsPointXY(2482767, 2398853)]))
+        f1.setGeometry(QgsGeometry.fromPolylineXY([QgsPointXY(2484588, 2425722), QgsPointXY(2482767, 2398853)]))
         temp_layer.dataProvider().addFeatures([f1])
 
         # set project CRS and ellipsoid


### PR DESCRIPTION
...and add new QgsGeometry::fromPolyline which uses QgsPoint

We want to encourage people not to use the QgsPointXY method, as it drops Z/M values. So it's moved across to a different name to make way for a new QgsGeometry::fromPolyline which uses a QgsPoint list
instead of QgsPointXY, thus keeping Z/M values intact.

Similarly, QgsPolyline now is a list of QgsPoint (keeping z/m values) and the old 2d QgsPolyline type was renamed to QgsPolylineXY.

Making the QgsPoint method the "preferred" method and making linestrings just as easy to create from z/m dimensioned points as 2d points is important to push people to write code which does not discard
these important dimensions.

As a bonus, the QgsPoint methods are more efficient anyway, since they don't require creation of a temporary list.

ping @3nids @haubourg 