### PR TITLE
Fix QgsVectorFileWriter use of transactions while writing

### DIFF
--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -676,6 +676,8 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 
     QgsRenderContext mRenderContext;
 
+    bool mUsingTransaction = false;
+
     static QMap<QString, MetaData> initMetaData();
     void createSymbolLayerTable( QgsVectorLayer *vl, const QgsCoordinateTransform &ct, OGRDataSourceH ds );
     OGRFeatureH createFeature( const QgsFeature &feature );

--- a/tests/src/core/testqgsmaprendererjob.cpp
+++ b/tests/src/core/testqgsmaprendererjob.cpp
@@ -109,7 +109,7 @@ void TestQgsMapRendererJob::initTestCase()
   QString myDataDir( TEST_DATA_DIR ); //defined in CmakeLists.txt
   QString myTestDataDir = myDataDir + '/';
   QString myTmpDir = QDir::tempPath() + '/';
-  QString myFileName = myTmpDir +  "maprender_testdata.shp";
+  QString myFileName = myTmpDir +  "maprender_testdata.gpkg";
   //copy over the default qml for our generated layer
   QString myQmlFileName = myTestDataDir +  "maprender_testdata.qml";
   QFile::remove( myTmpDir + "maprender_testdata.qml" );


### PR DESCRIPTION
Previously the writer was only using transactions in some cases (when calling the static writeAsVectorFormat method).

This changes the writer to always use a transaction when possible.

Fixes the map renderer job test using gpkg from timing out after taking forever to running twice the speed of the shapefile version. Similar benefits across other parts of qgis, which are writing files without using the static method, e.g. processing.
