### PR TITLE
Implement scoped pointers for gdal handled objects

### DIFF
--- a/python/analysis/raster/qgsalignraster.sip
+++ b/python/analysis/raster/qgsalignraster.sip
@@ -37,7 +37,6 @@ class QgsAlignRaster
 %Docstring
 Construct raster info with a path to a raster file
 %End
-        ~RasterInfo();
 
 
         bool isValid() const;

--- a/python/analysis/raster/qgskde.sip
+++ b/python/analysis/raster/qgskde.sip
@@ -96,6 +96,7 @@ Type of output value
  to generate the surface. The output path and file format are also required.
 %End
 
+
     Result run();
 %Docstring
  Runs the KDE calculation across the whole layer at once. Either call this method, or manually
@@ -128,6 +129,8 @@ Type of output value
  :rtype: Result
 %End
 
+  private:
+    QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other );
 };
 
 

--- a/python/analysis/raster/qgsninecellfilter.sip
+++ b/python/analysis/raster/qgsninecellfilter.sip
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsNineCellFilter
 {
 %Docstring

--- a/src/analysis/raster/qgsalignraster.cpp
+++ b/src/analysis/raster/qgsalignraster.cpp
@@ -426,7 +426,7 @@ bool QgsAlignRaster::createAndWarp( const Item &raster )
   }
 
   // Open the source file.
-  GDALDatasetH hSrcDS = GDALOpen( raster.inputFilename.toLocal8Bit().constData(), GA_ReadOnly );
+  gdal::dataset_unique_ptr hSrcDS( GDALOpen( raster.inputFilename.toLocal8Bit().constData(), GA_ReadOnly ) );
   if ( !hSrcDS )
   {
     mErrorMessage = QObject::tr( "Unable to open input file: %1" ).arg( raster.inputFilename );
@@ -435,37 +435,35 @@ bool QgsAlignRaster::createAndWarp( const Item &raster )
 
   // Create output with same datatype as first input band.
 
-  int bandCount = GDALGetRasterCount( hSrcDS );
-  GDALDataType eDT = GDALGetRasterDataType( GDALGetRasterBand( hSrcDS, 1 ) );
+  int bandCount = GDALGetRasterCount( hSrcDS.get() );
+  GDALDataType eDT = GDALGetRasterDataType( GDALGetRasterBand( hSrcDS.get(), 1 ) );
 
   // Create the output file.
-  GDALDatasetH hDstDS;
-  hDstDS = GDALCreate( hDriver, raster.outputFilename.toLocal8Bit().constData(), mXSize, mYSize,
-                       bandCount, eDT, nullptr );
+  gdal::dataset_unique_ptr hDstDS( GDALCreate( hDriver, raster.outputFilename.toLocal8Bit().constData(), mXSize, mYSize,
+                                   bandCount, eDT, nullptr ) );
   if ( !hDstDS )
   {
-    GDALClose( hSrcDS );
     mErrorMessage = QObject::tr( "Unable to create output file: %1" ).arg( raster.outputFilename );
     return false;
   }
 
   // Write out the projection definition.
-  GDALSetProjection( hDstDS, mCrsWkt.toLatin1().constData() );
-  GDALSetGeoTransform( hDstDS, mGeoTransform );
+  GDALSetProjection( hDstDS.get(), mCrsWkt.toLatin1().constData() );
+  GDALSetGeoTransform( hDstDS.get(), mGeoTransform );
 
   // Copy the color table, if required.
-  GDALColorTableH hCT = GDALGetRasterColorTable( GDALGetRasterBand( hSrcDS, 1 ) );
+  GDALColorTableH hCT = GDALGetRasterColorTable( GDALGetRasterBand( hSrcDS.get(), 1 ) );
   if ( hCT )
-    GDALSetRasterColorTable( GDALGetRasterBand( hDstDS, 1 ), hCT );
+    GDALSetRasterColorTable( GDALGetRasterBand( hDstDS.get(), 1 ), hCT );
 
   // -----------------------------------------------------------------------
 
   // Setup warp options.
-  GDALWarpOptions *psWarpOptions = GDALCreateWarpOptions();
-  psWarpOptions->hSrcDS = hSrcDS;
-  psWarpOptions->hDstDS = hDstDS;
+  gdal::warp_options_unique_ptr psWarpOptions( GDALCreateWarpOptions() );
+  psWarpOptions->hSrcDS = hSrcDS.get();
+  psWarpOptions->hDstDS = hDstDS.get();
 
-  psWarpOptions->nBandCount = GDALGetRasterCount( hSrcDS );
+  psWarpOptions->nBandCount = GDALGetRasterCount( hSrcDS.get() );
   psWarpOptions->panSrcBands = ( int * ) CPLMalloc( sizeof( int ) * psWarpOptions->nBandCount );
   psWarpOptions->panDstBands = ( int * ) CPLMalloc( sizeof( int ) * psWarpOptions->nBandCount );
   for ( int i = 0; i < psWarpOptions->nBandCount; ++i )
@@ -482,8 +480,8 @@ bool QgsAlignRaster::createAndWarp( const Item &raster )
 
   // Establish reprojection transformer.
   psWarpOptions->pTransformerArg =
-    GDALCreateGenImgProjTransformer( hSrcDS, GDALGetProjectionRef( hSrcDS ),
-                                     hDstDS, GDALGetProjectionRef( hDstDS ),
+    GDALCreateGenImgProjTransformer( hSrcDS.get(), GDALGetProjectionRef( hSrcDS.get() ),
+                                     hDstDS.get(), GDALGetProjectionRef( hDstDS.get() ),
                                      FALSE, 0.0, 1 );
   psWarpOptions->pfnTransformer = GDALGenImgProjTransform;
 
@@ -502,14 +500,10 @@ bool QgsAlignRaster::createAndWarp( const Item &raster )
 
   // Initialize and execute the warp operation.
   GDALWarpOperation oOperation;
-  oOperation.Initialize( psWarpOptions );
+  oOperation.Initialize( psWarpOptions.get() );
   oOperation.ChunkAndWarpImage( 0, 0, mXSize, mYSize );
 
   GDALDestroyGenImgProjTransformer( psWarpOptions->pTransformerArg );
-  GDALDestroyWarpOptions( psWarpOptions );
-
-  GDALClose( hDstDS );
-  GDALClose( hSrcDS );
   return true;
 }
 
@@ -519,7 +513,7 @@ bool QgsAlignRaster::suggestedWarpOutput( const QgsAlignRaster::RasterInfo &info
   // to destination georeferenced coordinates (not destination
   // pixel line).  We do that by omitting the destination dataset
   // handle (setting it to nullptr).
-  void *hTransformArg = GDALCreateGenImgProjTransformer( info.mDataset, info.mCrsWkt.toLatin1().constData(), nullptr, destWkt.toLatin1().constData(), FALSE, 0, 1 );
+  void *hTransformArg = GDALCreateGenImgProjTransformer( info.mDataset.get(), info.mCrsWkt.toLatin1().constData(), nullptr, destWkt.toLatin1().constData(), FALSE, 0, 1 );
   if ( !hTransformArg )
     return false;
 
@@ -528,7 +522,7 @@ bool QgsAlignRaster::suggestedWarpOutput( const QgsAlignRaster::RasterInfo &info
   double extents[4];
   int nPixels = 0, nLines = 0;
   CPLErr eErr;
-  eErr = GDALSuggestedWarpOutput2( info.mDataset,
+  eErr = GDALSuggestedWarpOutput2( info.mDataset.get(),
                                    GDALGenImgProjTransform, hTransformArg,
                                    adfDstGeoTransform, &nPixels, &nLines, extents, 0 );
   GDALDestroyGenImgProjTransformer( hTransformArg );
@@ -553,29 +547,20 @@ bool QgsAlignRaster::suggestedWarpOutput( const QgsAlignRaster::RasterInfo &info
 
 
 QgsAlignRaster::RasterInfo::RasterInfo( const QString &layerpath )
-  : mXSize( 0 )
-  , mYSize( 0 )
-  , mBandCnt( 0 )
 {
-  mDataset = GDALOpen( layerpath.toLocal8Bit().constData(), GA_ReadOnly );
+  mDataset.reset( GDALOpen( layerpath.toLocal8Bit().constData(), GA_ReadOnly ) );
   if ( !mDataset )
     return;
 
-  mXSize = GDALGetRasterXSize( mDataset );
-  mYSize = GDALGetRasterYSize( mDataset );
+  mXSize = GDALGetRasterXSize( mDataset.get() );
+  mYSize = GDALGetRasterYSize( mDataset.get() );
 
-  ( void ) GDALGetGeoTransform( mDataset, mGeoTransform );
+  ( void ) GDALGetGeoTransform( mDataset.get(), mGeoTransform );
 
   // TODO: may be null or empty string
-  mCrsWkt = QString::fromLatin1( GDALGetProjectionRef( mDataset ) );
+  mCrsWkt = QString::fromLatin1( GDALGetProjectionRef( mDataset.get() ) );
 
-  mBandCnt = GDALGetBandNumber( mDataset );
-}
-
-QgsAlignRaster::RasterInfo::~RasterInfo()
-{
-  if ( mDataset )
-    GDALClose( mDataset );
+  mBandCnt = GDALGetBandNumber( mDataset.get() );
 }
 
 QSizeF QgsAlignRaster::RasterInfo::cellSize() const
@@ -616,7 +601,7 @@ void QgsAlignRaster::RasterInfo::dump() const
 
 double QgsAlignRaster::RasterInfo::identify( double mx, double my )
 {
-  GDALRasterBandH hBand = GDALGetRasterBand( mDataset, 1 );
+  GDALRasterBandH hBand = GDALGetRasterBand( mDataset.get(), 1 );
 
   // must not be rotated in order for this to work
   int px = int( ( mx - mGeoTransform[0] ) / mGeoTransform[1] );

--- a/src/analysis/raster/qgsalignraster.h
+++ b/src/analysis/raster/qgsalignraster.h
@@ -23,6 +23,7 @@
 #include <gdal_version.h>
 #include "qgis_analysis.h"
 #include "qgis.h"
+#include "qgsogrutils.h"
 
 class QgsRectangle;
 
@@ -54,7 +55,6 @@ class ANALYSIS_EXPORT QgsAlignRaster
       public:
         //! Construct raster info with a path to a raster file
         RasterInfo( const QString &layerpath );
-        ~RasterInfo();
 
         RasterInfo( const RasterInfo &rh ) = delete;
         RasterInfo &operator=( const RasterInfo &rh ) = delete;
@@ -85,15 +85,17 @@ class ANALYSIS_EXPORT QgsAlignRaster
 
       protected:
         //! handle to open GDAL dataset
-        GDALDatasetH mDataset;
+        gdal::dataset_unique_ptr mDataset;
         //! CRS stored in WKT format
         QString mCrsWkt;
         //! geotransform coefficients
         double mGeoTransform[6];
-        //! raster grid size
-        int mXSize, mYSize;
+        //! raster grid size X
+        int mXSize = 0;
+        //! raster grid size Y
+        int mYSize = 0;
         //! number of raster's bands
-        int mBandCnt;
+        int mBandCnt = 0;
 
       private:
 #ifdef SIP_RUN

--- a/src/analysis/raster/qgskde.cpp
+++ b/src/analysis/raster/qgskde.cpp
@@ -90,10 +90,10 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::prepare()
     return FileCreationError;
 
   // open the raster in GA_Update mode
-  mDatasetH = GDALOpen( mOutputFile.toUtf8().constData(), GA_Update );
+  mDatasetH.reset( GDALOpen( mOutputFile.toUtf8().constData(), GA_Update ) );
   if ( !mDatasetH )
     return FileCreationError;
-  mRasterBandH = GDALGetRasterBand( mDatasetH, 1 );
+  mRasterBandH = GDALGetRasterBand( mDatasetH.get(), 1 );
   if ( !mRasterBandH )
     return FileCreationError;
 
@@ -207,8 +207,7 @@ QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::addFeature( const
 
 QgsKernelDensityEstimation::Result QgsKernelDensityEstimation::finalise()
 {
-  GDALClose( ( GDALDatasetH ) mDatasetH );
-  mDatasetH = nullptr;
+  mDatasetH.reset();
   mRasterBandH = nullptr;
   return Success;
 }
@@ -226,18 +225,18 @@ int QgsKernelDensityEstimation::radiusSizeInPixels( double radius ) const
 bool QgsKernelDensityEstimation::createEmptyLayer( GDALDriverH driver, const QgsRectangle &bounds, int rows, int columns ) const
 {
   double geoTransform[6] = { bounds.xMinimum(), mPixelSize, 0, bounds.yMaximum(), 0, -mPixelSize };
-  GDALDatasetH emptyDataset = GDALCreate( driver, mOutputFile.toUtf8(), columns, rows, 1, GDT_Float32, nullptr );
+  gdal::dataset_unique_ptr emptyDataset( GDALCreate( driver, mOutputFile.toUtf8(), columns, rows, 1, GDT_Float32, nullptr ) );
   if ( !emptyDataset )
     return false;
 
-  if ( GDALSetGeoTransform( emptyDataset, geoTransform ) != CE_None )
+  if ( GDALSetGeoTransform( emptyDataset.get(), geoTransform ) != CE_None )
     return false;
 
   // Set the projection on the raster destination to match the input layer
-  if ( GDALSetProjection( emptyDataset, mSource->sourceCrs().toWkt().toLocal8Bit().data() ) != CE_None )
+  if ( GDALSetProjection( emptyDataset.get(), mSource->sourceCrs().toWkt().toLocal8Bit().data() ) != CE_None )
     return false;
 
-  GDALRasterBandH poBand = GDALGetRasterBand( emptyDataset, 1 );
+  GDALRasterBandH poBand = GDALGetRasterBand( emptyDataset.get(), 1 );
   if ( !poBand )
     return false;
 
@@ -259,8 +258,6 @@ bool QgsKernelDensityEstimation::createEmptyLayer( GDALDriverH driver, const Qgs
   }
 
   CPLFree( line );
-  //close the dataset
-  GDALClose( emptyDataset );
   return true;
 }
 

--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -101,7 +101,9 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
      */
     QgsKernelDensityEstimation( const Parameters &parameters, const QString &outputFile, const QString &outputFormat );
 
+    //! QgsKernelDensityEstimation cannot be copied.
     QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other ) = delete;
+    //! QgsKernelDensityEstimation cannot be copied.
     QgsKernelDensityEstimation &operator=( const QgsKernelDensityEstimation &other ) = delete;
 
     /**

--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -17,6 +17,7 @@
 #define QGSKDE_H
 
 #include "qgsrectangle.h"
+#include "qgsogrutils.h"
 #include <QString>
 
 // GDAL includes
@@ -100,6 +101,9 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
      */
     QgsKernelDensityEstimation( const Parameters &parameters, const QString &outputFile, const QString &outputFormat );
 
+    QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other ) = delete;
+    QgsKernelDensityEstimation &operator=( const QgsKernelDensityEstimation &other ) = delete;
+
     /**
      * Runs the KDE calculation across the whole layer at once. Either call this method, or manually
      * call run(), addFeature() and finalise() separately.
@@ -162,12 +166,16 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
 
     int mBufferSize;
 
-    GDALDatasetH mDatasetH;
+    gdal::dataset_unique_ptr mDatasetH;
     GDALRasterBandH mRasterBandH;
 
     //! Creates a new raster layer and initializes it to the no data value
     bool createEmptyLayer( GDALDriverH driver, const QgsRectangle &bounds, int rows, int columns ) const;
     int radiusSizeInPixels( double radius ) const;
+
+#ifdef SIP_RUN
+    QgsKernelDensityEstimation( const QgsKernelDensityEstimation &other );
+#endif
 };
 
 

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "cpl_string.h"
 #include "qgsfeedback.h"
+#include "qgsogrutils.h"
 #include <QFile>
 
 QgsNineCellFilter::QgsNineCellFilter( const QString &inputFile, const QString &outputFile, const QString &outputFormat )
@@ -35,7 +36,7 @@ int QgsNineCellFilter::processRaster( QgsFeedback *feedback )
 
   //open input file
   int xSize, ySize;
-  GDALDatasetH  inputDataset = openInputFile( xSize, ySize );
+  gdal::dataset_unique_ptr inputDataset( openInputFile( xSize, ySize ) );
   if ( !inputDataset )
   {
     return 1; //opening of input file failed
@@ -48,27 +49,23 @@ int QgsNineCellFilter::processRaster( QgsFeedback *feedback )
     return 2;
   }
 
-  GDALDatasetH outputDataset = openOutputFile( inputDataset, outputDriver );
+  gdal::dataset_unique_ptr outputDataset( openOutputFile( inputDataset.get(), outputDriver ) );
   if ( !outputDataset )
   {
     return 3; //create operation on output file failed
   }
 
   //open first raster band for reading (operation is only for single band raster)
-  GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset, 1 );
+  GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !rasterBand )
   {
-    GDALClose( inputDataset );
-    GDALClose( outputDataset );
     return 4;
   }
   mInputNodataValue = GDALGetRasterNoDataValue( rasterBand, nullptr );
 
-  GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset, 1 );
+  GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
   if ( !outputRasterBand )
   {
-    GDALClose( inputDataset );
-    GDALClose( outputDataset );
     return 5;
   }
   //try to set -9999 as nodata value
@@ -77,8 +74,6 @@ int QgsNineCellFilter::processRaster( QgsFeedback *feedback )
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {
-    GDALClose( inputDataset );
-    GDALClose( outputDataset );
     return 6;
   }
 
@@ -168,31 +163,27 @@ int QgsNineCellFilter::processRaster( QgsFeedback *feedback )
   CPLFree( scanLine2 );
   CPLFree( scanLine3 );
 
-  GDALClose( inputDataset );
-
   if ( feedback && feedback->isCanceled() )
   {
     //delete the dataset without closing (because it is faster)
+    ( void )outputDataset.release();
     GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
     return 7;
   }
-  GDALClose( outputDataset );
-
   return 0;
 }
 
-GDALDatasetH QgsNineCellFilter::openInputFile( int &nCellsX, int &nCellsY )
+gdal::dataset_unique_ptr QgsNineCellFilter::openInputFile( int &nCellsX, int &nCellsY )
 {
-  GDALDatasetH inputDataset = GDALOpen( mInputFile.toUtf8().constData(), GA_ReadOnly );
+  gdal::dataset_unique_ptr inputDataset( GDALOpen( mInputFile.toUtf8().constData(), GA_ReadOnly ) );
   if ( inputDataset )
   {
-    nCellsX = GDALGetRasterXSize( inputDataset );
-    nCellsY = GDALGetRasterYSize( inputDataset );
+    nCellsX = GDALGetRasterXSize( inputDataset.get() );
+    nCellsY = GDALGetRasterYSize( inputDataset.get() );
 
     //we need at least one band
-    if ( GDALGetRasterCount( inputDataset ) < 1 )
+    if ( GDALGetRasterCount( inputDataset.get() ) < 1 )
     {
-      GDALClose( inputDataset );
       return nullptr;
     }
   }
@@ -220,7 +211,7 @@ GDALDriverH QgsNineCellFilter::openOutputDriver()
   return outputDriver;
 }
 
-GDALDatasetH QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver )
+gdal::dataset_unique_ptr QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver )
 {
   if ( !inputDataset )
   {
@@ -232,7 +223,7 @@ GDALDatasetH QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALD
 
   //open output file
   char **papszOptions = nullptr;
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 1, GDT_Float32, papszOptions );
+  gdal::dataset_unique_ptr outputDataset( GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 1, GDT_Float32, papszOptions ) );
   if ( !outputDataset )
   {
     return outputDataset;
@@ -242,10 +233,9 @@ GDALDatasetH QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALD
   double geotransform[6];
   if ( GDALGetGeoTransform( inputDataset, geotransform ) != CE_None )
   {
-    GDALClose( outputDataset );
     return nullptr;
   }
-  GDALSetGeoTransform( outputDataset, geotransform );
+  GDALSetGeoTransform( outputDataset.get(), geotransform );
 
   //make sure mCellSizeX and mCellSizeY are always > 0
   mCellSizeX = geotransform[1];
@@ -260,7 +250,7 @@ GDALDatasetH QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALD
   }
 
   const char *projection = GDALGetProjectionRef( inputDataset );
-  GDALSetProjection( outputDataset, projection );
+  GDALSetProjection( outputDataset.get(), projection );
 
   return outputDataset;
 }

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -166,8 +166,7 @@ int QgsNineCellFilter::processRaster( QgsFeedback *feedback )
   if ( feedback && feedback->isCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    ( void )outputDataset.release();
-    GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
+    gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
     return 7;
   }
   return 0;

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -21,7 +21,7 @@
 #include <QString>
 #include "gdal.h"
 #include "qgis_analysis.h"
-
+#include "qgsogrutils.h"
 class QgsFeedback;
 
 /**
@@ -68,7 +68,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     QgsNineCellFilter() = delete;
 
     //! Opens the input file and returns the dataset handle and the number of pixels in x-/y- direction
-    GDALDatasetH openInputFile( int &nCellsX, int &nCellsY );
+    gdal::dataset_unique_ptr openInputFile( int &nCellsX, int &nCellsY );
 
     /**
      * Opens the output driver and tests if it supports the creation of a new dataset
@@ -78,7 +78,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     /**
      * Opens the output file and sets the same geotransform and CRS as the input data
       \returns the output dataset or nullptr in case of error*/
-    GDALDatasetH openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver );
+    gdal::dataset_unique_ptr openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver );
 
   protected:
 

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -23,6 +23,7 @@
 #include "qgsrastermatrix.h"
 #include "qgsrasterprojector.h"
 #include "qgsfeedback.h"
+#include "qgsogrutils.h"
 
 #include <QFile>
 
@@ -110,9 +111,9 @@ int QgsRasterCalculator::processCalculation( QgsFeedback *feedback )
     return static_cast< int >( CreateOutputError );
   }
 
-  GDALDatasetH outputDataset = openOutputFile( outputDriver );
-  GDALSetProjection( outputDataset, mOutputCrs.toWkt().toLocal8Bit().data() );
-  GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset, 1 );
+  gdal::dataset_unique_ptr outputDataset( openOutputFile( outputDriver ) );
+  GDALSetProjection( outputDataset.get(), mOutputCrs.toWkt().toLocal8Bit().data() );
+  GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
 
   float outputNodataValue = -FLT_MAX;
   GDALSetRasterNoDataValue( outputRasterBand, outputNodataValue );
@@ -170,8 +171,6 @@ int QgsRasterCalculator::processCalculation( QgsFeedback *feedback )
     GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
     return static_cast< int >( Canceled );
   }
-  GDALClose( outputDataset );
-
   return static_cast< int >( Success );
 }
 
@@ -196,20 +195,20 @@ GDALDriverH QgsRasterCalculator::openOutputDriver()
   return outputDriver;
 }
 
-GDALDatasetH QgsRasterCalculator::openOutputFile( GDALDriverH outputDriver )
+gdal::dataset_unique_ptr QgsRasterCalculator::openOutputFile( GDALDriverH outputDriver )
 {
   //open output file
   char **papszOptions = nullptr;
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), mNumOutputColumns, mNumOutputRows, 1, GDT_Float32, papszOptions );
+  gdal::dataset_unique_ptr outputDataset( GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), mNumOutputColumns, mNumOutputRows, 1, GDT_Float32, papszOptions ) );
   if ( !outputDataset )
   {
-    return outputDataset;
+    return nullptr;
   }
 
   //assign georef information
   double geotransform[6];
   outputGeoTransform( geotransform );
-  GDALSetGeoTransform( outputDataset, geotransform );
+  GDALSetGeoTransform( outputDataset.get(), geotransform );
 
   return outputDataset;
 }

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -168,7 +168,7 @@ int QgsRasterCalculator::processCalculation( QgsFeedback *feedback )
   if ( feedback && feedback->isCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
+    gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
     return static_cast< int >( Canceled );
   }
   return static_cast< int >( Success );

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -24,6 +24,7 @@
 #include <QVector>
 #include "gdal.h"
 #include "qgis_analysis.h"
+#include "qgsogrutils.h"
 
 class QgsRasterLayer;
 class QgsFeedback;
@@ -109,7 +110,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
     /**
      * Opens the output file and sets the same geotransform and CRS as the input data
       \returns the output dataset or nullptr in case of error*/
-    GDALDatasetH openOutputFile( GDALDriverH outputDriver );
+    gdal::dataset_unique_ptr openOutputFile( GDALDriverH outputDriver );
 
     /**
      * Sets gdal 6 parameters array from mOutputRectangle, mNumOutputColumns, mNumOutputRows

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -276,8 +276,7 @@ int QgsRelief::processRaster( QgsFeedback *feedback )
   if ( feedback && feedback->isCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    ( void )outputDataset.release();
-    GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
+    gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
     return 7;
   }
 

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -23,6 +23,7 @@
 #include "qgsfeedback.h"
 #include "qgis.h"
 #include "cpl_string.h"
+#include "qgsogrutils.h"
 #include <cfloat>
 
 #include <QVector>
@@ -84,7 +85,7 @@ int QgsRelief::processRaster( QgsFeedback *feedback )
 {
   //open input file
   int xSize, ySize;
-  GDALDatasetH  inputDataset = openInputFile( xSize, ySize );
+  gdal::dataset_unique_ptr inputDataset = openInputFile( xSize, ySize );
   if ( !inputDataset )
   {
     return 1; //opening of input file failed
@@ -97,7 +98,7 @@ int QgsRelief::processRaster( QgsFeedback *feedback )
     return 2;
   }
 
-  GDALDatasetH outputDataset = openOutputFile( inputDataset, outputDriver );
+  gdal::dataset_unique_ptr outputDataset = openOutputFile( inputDataset.get(), outputDriver );
   if ( !outputDataset )
   {
     return 3; //create operation on output file failed
@@ -121,11 +122,9 @@ int QgsRelief::processRaster( QgsFeedback *feedback )
   mAspectFilter->setZFactor( mZFactor );
 
   //open first raster band for reading (operation is only for single band raster)
-  GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset, 1 );
+  GDALRasterBandH rasterBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !rasterBand )
   {
-    GDALClose( inputDataset );
-    GDALClose( outputDataset );
     return 4;
   }
   mInputNodataValue = GDALGetRasterNoDataValue( rasterBand, nullptr );
@@ -135,14 +134,12 @@ int QgsRelief::processRaster( QgsFeedback *feedback )
   mHillshadeFilter300->setInputNodataValue( mInputNodataValue );
   mHillshadeFilter315->setInputNodataValue( mInputNodataValue );
 
-  GDALRasterBandH outputRedBand = GDALGetRasterBand( outputDataset, 1 );
-  GDALRasterBandH outputGreenBand = GDALGetRasterBand( outputDataset, 2 );
-  GDALRasterBandH outputBlueBand = GDALGetRasterBand( outputDataset, 3 );
+  GDALRasterBandH outputRedBand = GDALGetRasterBand( outputDataset.get(), 1 );
+  GDALRasterBandH outputGreenBand = GDALGetRasterBand( outputDataset.get(), 2 );
+  GDALRasterBandH outputBlueBand = GDALGetRasterBand( outputDataset.get(), 3 );
 
   if ( !outputRedBand || !outputGreenBand || !outputBlueBand )
   {
-    GDALClose( inputDataset );
-    GDALClose( outputDataset );
     return 5;
   }
   //try to set -9999 as nodata value
@@ -158,8 +155,6 @@ int QgsRelief::processRaster( QgsFeedback *feedback )
 
   if ( ySize < 3 ) //we require at least three rows (should be true for most datasets)
   {
-    GDALClose( inputDataset );
-    GDALClose( outputDataset );
     return 6;
   }
 
@@ -278,15 +273,13 @@ int QgsRelief::processRaster( QgsFeedback *feedback )
   CPLFree( scanLine2 );
   CPLFree( scanLine3 );
 
-  GDALClose( inputDataset );
-
   if ( feedback && feedback->isCanceled() )
   {
     //delete the dataset without closing (because it is faster)
+    ( void )outputDataset.release();
     GDALDeleteDataset( outputDriver, mOutputFile.toUtf8().constData() );
     return 7;
   }
-  GDALClose( outputDataset );
 
   return 0;
 }
@@ -404,18 +397,17 @@ bool QgsRelief::setElevationColor( double elevation, int *red, int *green, int *
 }
 
 //duplicated from QgsNineCellFilter. Todo: make common base class
-GDALDatasetH QgsRelief::openInputFile( int &nCellsX, int &nCellsY )
+gdal::dataset_unique_ptr QgsRelief::openInputFile( int &nCellsX, int &nCellsY )
 {
-  GDALDatasetH inputDataset = GDALOpen( mInputFile.toUtf8().constData(), GA_ReadOnly );
+  gdal::dataset_unique_ptr inputDataset( GDALOpen( mInputFile.toUtf8().constData(), GA_ReadOnly ) );
   if ( inputDataset )
   {
-    nCellsX = GDALGetRasterXSize( inputDataset );
-    nCellsY = GDALGetRasterYSize( inputDataset );
+    nCellsX = GDALGetRasterXSize( inputDataset.get() );
+    nCellsY = GDALGetRasterYSize( inputDataset.get() );
 
     //we need at least one band
-    if ( GDALGetRasterCount( inputDataset ) < 1 )
+    if ( GDALGetRasterCount( inputDataset.get() ) < 1 )
     {
-      GDALClose( inputDataset );
       return nullptr;
     }
   }
@@ -443,7 +435,7 @@ GDALDriverH QgsRelief::openOutputDriver()
   return outputDriver;
 }
 
-GDALDatasetH QgsRelief::openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver )
+gdal::dataset_unique_ptr QgsRelief::openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver )
 {
   if ( !inputDataset )
   {
@@ -460,20 +452,19 @@ GDALDatasetH QgsRelief::openOutputFile( GDALDatasetH inputDataset, GDALDriverH o
   papszOptions = CSLSetNameValue( papszOptions, "COMPRESS", "PACKBITS" );
 
   //create three band raster (reg, green, blue)
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 3, GDT_Byte, papszOptions );
+  gdal::dataset_unique_ptr outputDataset( GDALCreate( outputDriver, mOutputFile.toUtf8().constData(), xSize, ySize, 3, GDT_Byte, papszOptions ) );
   if ( !outputDataset )
   {
-    return outputDataset;
+    return nullptr;
   }
 
   //get geotransform from inputDataset
   double geotransform[6];
   if ( GDALGetGeoTransform( inputDataset, geotransform ) != CE_None )
   {
-    GDALClose( outputDataset );
     return nullptr;
   }
-  GDALSetGeoTransform( outputDataset, geotransform );
+  GDALSetGeoTransform( outputDataset.get(), geotransform );
 
   //make sure mCellSizeX and mCellSizeY are always > 0
   mCellSizeX = geotransform[1];
@@ -488,7 +479,7 @@ GDALDatasetH QgsRelief::openOutputFile( GDALDatasetH inputDataset, GDALDriverH o
   }
 
   const char *projection = GDALGetProjectionRef( inputDataset );
-  GDALSetProjection( outputDataset, projection );
+  GDALSetProjection( outputDataset.get(), projection );
 
   return outputDataset;
 }
@@ -497,17 +488,16 @@ GDALDatasetH QgsRelief::openOutputFile( GDALDatasetH inputDataset, GDALDriverH o
 bool QgsRelief::exportFrequencyDistributionToCsv( const QString &file )
 {
   int nCellsX, nCellsY;
-  GDALDatasetH inputDataset = openInputFile( nCellsX, nCellsY );
+  gdal::dataset_unique_ptr inputDataset = openInputFile( nCellsX, nCellsY );
   if ( !inputDataset )
   {
     return false;
   }
 
   //open first raster band for reading (elevation raster is always single band)
-  GDALRasterBandH elevationBand = GDALGetRasterBand( inputDataset, 1 );
+  GDALRasterBandH elevationBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !elevationBand )
   {
-    GDALClose( inputDataset );
     return false;
   }
 
@@ -584,17 +574,16 @@ QList< QgsRelief::ReliefColor > QgsRelief::calculateOptimizedReliefClasses()
   QList< QgsRelief::ReliefColor > resultList;
 
   int nCellsX, nCellsY;
-  GDALDatasetH inputDataset = openInputFile( nCellsX, nCellsY );
+  gdal::dataset_unique_ptr inputDataset = openInputFile( nCellsX, nCellsY );
   if ( !inputDataset )
   {
     return resultList;
   }
 
   //open first raster band for reading (elevation raster is always single band)
-  GDALRasterBandH elevationBand = GDALGetRasterBand( inputDataset, 1 );
+  GDALRasterBandH elevationBand = GDALGetRasterBand( inputDataset.get(), 1 );
   if ( !elevationBand )
   {
-    GDALClose( inputDataset );
     return resultList;
   }
 

--- a/src/analysis/raster/qgsrelief.h
+++ b/src/analysis/raster/qgsrelief.h
@@ -23,6 +23,7 @@
 #include <QPair>
 #include <QString>
 #include "gdal.h"
+#include "qgsogrutils.h"
 #include "qgis_analysis.h"
 
 class QgsAspectFilter;
@@ -105,7 +106,7 @@ class ANALYSIS_EXPORT QgsRelief
                                 unsigned char *red, unsigned char *green, unsigned char *blue );
 
     //! Opens the input file and returns the dataset handle and the number of pixels in x-/y- direction
-    GDALDatasetH openInputFile( int &nCellsX, int &nCellsY );
+    gdal::dataset_unique_ptr openInputFile( int &nCellsX, int &nCellsY );
 
     /**
      * Opens the output driver and tests if it supports the creation of a new dataset
@@ -115,7 +116,7 @@ class ANALYSIS_EXPORT QgsRelief
     /**
      * Opens the output file and sets the same geotransform and CRS as the input data
       \returns the output dataset or nullptr in case of error*/
-    GDALDatasetH openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver );
+    gdal::dataset_unique_ptr openOutputFile( GDALDatasetH inputDataset, GDALDriverH outputDriver );
 
     //! Set elevation color
     bool setElevationColor( double elevation, int *red, int *green, int *blue );

--- a/src/app/dwg/qgsdwgimporter.cpp
+++ b/src/app/dwg/qgsdwgimporter.cpp
@@ -50,8 +50,11 @@
 #define ONCE( x ) { static bool show=true; if( show ) LOG( x ); show=false; }
 #define NYI( x ) { static bool show=true; if( show ) LOG( QObject::tr("Not yet implemented %1").arg( x ) ); show=false; }
 #define SETSTRING(a)  setString(dfn, f, #a, data.a)
+#define SETSTRINGPTR(a)  setString(dfn, f.get(), #a, data.a)
 #define SETDOUBLE(a)  setDouble(dfn, f, #a, data.a)
+#define SETDOUBLEPTR(a)  setDouble(dfn, f.get(), #a, data.a)
 #define SETINTEGER(a) setInteger(dfn, f, #a, data.a)
+#define SETINTEGERPTR(a) setInteger(dfn, f.get(), #a, data.a)
 
 #ifdef _MSC_VER
 #define strcasecmp(a,b) stricmp(a,b)
@@ -85,11 +88,11 @@ bool QgsDwgImporter::exec( const QString &sql, bool logError )
 
   CPLErrorReset();
 
-  OGRLayerH layer = OGR_DS_ExecuteSQL( mDs, sql.toUtf8().constData(), nullptr, nullptr );
+  OGRLayerH layer = OGR_DS_ExecuteSQL( mDs.get(), sql.toUtf8().constData(), nullptr, nullptr );
   if ( layer )
   {
     QgsDebugMsg( "Unexpected result set" );
-    OGR_DS_ReleaseResultSet( mDs, layer );
+    OGR_DS_ReleaseResultSet( mDs.get(), layer );
     return false;
   }
 
@@ -114,7 +117,7 @@ OGRLayerH QgsDwgImporter::query( const QString &sql )
 
   CPLErrorReset();
 
-  OGRLayerH layer = OGR_DS_ExecuteSQL( mDs, sql.toUtf8().constData(), nullptr, nullptr );
+  OGRLayerH layer = OGR_DS_ExecuteSQL( mDs.get(), sql.toUtf8().constData(), nullptr, nullptr );
   if ( !layer )
   {
     QgsDebugMsg( "Result expected" );
@@ -127,7 +130,7 @@ OGRLayerH QgsDwgImporter::query( const QString &sql )
   LOG( QObject::tr( "SQL statement failed\nDatabase:%1\nSQL:%2\nError:%3" )
        .arg( mDatabase, sql, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
 
-  OGR_DS_ReleaseResultSet( mDs, layer );
+  OGR_DS_ReleaseResultSet( mDs.get(), layer );
 
   return nullptr;
 }
@@ -137,7 +140,7 @@ void QgsDwgImporter::startTransaction()
 {
   Q_ASSERT( mDs );
 
-  mInTransaction = GDALDatasetStartTransaction( mDs, 0 ) == OGRERR_NONE;
+  mInTransaction = GDALDatasetStartTransaction( mDs.get(), 0 ) == OGRERR_NONE;
   if ( !mInTransaction )
   {
     LOG( QObject::tr( "Could not start transaction\nDatabase:%1\nError:%2" )
@@ -149,7 +152,7 @@ void QgsDwgImporter::commitTransaction()
 {
   Q_ASSERT( mDs );
 
-  if ( mInTransaction && GDALDatasetCommitTransaction( mDs ) != OGRERR_NONE )
+  if ( mInTransaction && GDALDatasetCommitTransaction( mDs.get() ) != OGRERR_NONE )
   {
     LOG( QObject::tr( "Could not commit transaction\nDatabase:%1\nError:%2" )
          .arg( mDatabase, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
@@ -164,9 +167,6 @@ QgsDwgImporter::~QgsDwgImporter()
   if ( mDs )
   {
     commitTransaction();
-
-    OGR_DS_Destroy( mDs );
-    mDs = nullptr;
   }
 }
 
@@ -197,7 +197,7 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
 
   if ( QFileInfo::exists( mDatabase ) )
   {
-    mDs = OGROpen( mDatabase.toUtf8().constData(), true, nullptr );
+    mDs.reset( OGROpen( mDatabase.toUtf8().constData(), true, nullptr ) );
     if ( !mDs )
     {
       LOG( QObject::tr( "Could not open database [%1]" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
@@ -205,12 +205,11 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
     }
 
     // Check whether database is uptodate
-    OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "drawing" );
+    OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(), "drawing" );
     if ( !layer )
     {
       LOG( QObject::tr( "Query for drawing %1 failed." ).arg( drawing ) );
-      OGR_DS_Destroy( mDs );
-      mDs = nullptr;
+      mDs.reset();
       return false;
     }
 
@@ -220,22 +219,19 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
 
     OGR_L_ResetReading( layer );
 
-    OGRFeatureH f = OGR_L_GetNextFeature( layer );
+    gdal::ogr_feature_unique_ptr f( OGR_L_GetNextFeature( layer ) );
     if ( !f )
     {
       LOG( QObject::tr( "Could not retrieve drawing name from database [%1]" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
-      OGR_DS_Destroy( mDs );
-      mDs = nullptr;
+      mDs.reset();
       return false;
     }
 
     int year, month, day, hour, minute, second, tzf;
-    if ( !OGR_F_GetFieldAsDateTime( f, lastmodifiedIdx, &year, &month, &day, &hour, &minute, &second, &tzf ) )
+    if ( !OGR_F_GetFieldAsDateTime( f.get(), lastmodifiedIdx, &year, &month, &day, &hour, &minute, &second, &tzf ) )
     {
       LOG( QObject::tr( "Recorded last modification date unreadable [%1]" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
-      OGR_F_Destroy( f );
-      OGR_DS_Destroy( mDs );
-      mDs = nullptr;
+      mDs.reset();
       return false;
     }
 
@@ -251,8 +247,7 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
     }
 #endif
 
-    OGR_DS_Destroy( mDs );
-    mDs = nullptr;
+    mDs.reset();
 
     QFile::remove( mDatabase );
   }
@@ -491,7 +486,7 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
   }
 
   // create database
-  mDs = OGR_Dr_CreateDataSource( driver, mDatabase.toUtf8().constData(), nullptr );
+  mDs.reset( OGR_Dr_CreateDataSource( driver, mDatabase.toUtf8().constData(), nullptr ) );
   if ( !mDs )
   {
     LOG( QObject::tr( "Creation of datasource failed [%1]" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
@@ -510,7 +505,7 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
       options = CSLSetNameValue( options, "SPATIAL_INDEX", "NO" );
     }
 
-    OGRLayerH layer = OGR_DS_CreateLayer( mDs, t.mName.toUtf8().constData(), ( t.mWkbType != wkbNone && mCrs > 0 ) ? mCrsH : nullptr, t.mWkbType, options );
+    OGRLayerH layer = OGR_DS_CreateLayer( mDs.get(),  t.mName.toUtf8().constData(), ( t.mWkbType != wkbNone && mCrs > 0 ) ? mCrsH : nullptr, t.mWkbType, options );
 
     CSLDestroy( options );
     options = nullptr;
@@ -518,35 +513,31 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
     if ( !layer )
     {
       LOG( QObject::tr( "Creation of drawing layer %1 failed [%2]" ).arg( t.mName, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
-      OGR_DS_Destroy( mDs );
-      mDs = nullptr;
+      mDs.reset();
       return false;
     }
 
     Q_FOREACH ( const field &f, t.mFields )
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( f.mName.toUtf8().constData(), f.mOgrType );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( f.mName.toUtf8().constData(), f.mOgrType ) );
       if ( !fld )
       {
         LOG( QObject::tr( "Creation of field definition for %1.%2 failed [%3]" ).arg( t.mName, f.mName, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
-        OGR_DS_Destroy( mDs );
-        mDs = nullptr;
+        mDs.reset();
         return false;
       }
 
       if ( f.mWidth >= 0 )
-        OGR_Fld_SetWidth( fld, f.mWidth );
+        OGR_Fld_SetWidth( fld.get(), f.mWidth );
       if ( f.mPrecision >= 0 )
-        OGR_Fld_SetPrecision( fld, f.mPrecision );
+        OGR_Fld_SetPrecision( fld.get(), f.mPrecision );
 
-      OGRErr res = OGR_L_CreateField( layer, fld, true );
-      OGR_Fld_Destroy( fld );
+      OGRErr res = OGR_L_CreateField( layer, fld.get(), true );
 
       if ( res != OGRERR_NONE )
       {
         LOG( QObject::tr( "Creation of field %1.%2 failed [%3]" ).arg( t.mName, f.mName, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
-        OGR_DS_Destroy( mDs );
-        mDs = nullptr;
+        mDs.reset();
         return false;
       }
     }
@@ -554,7 +545,7 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
 
   commitTransaction();
 
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "drawing" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "drawing" );
   Q_ASSERT( layer );
 
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
@@ -563,13 +554,13 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
   int lastmodifiedIdx = OGR_FD_GetFieldIndex( dfn, "lastmodified" );
   int crsIdx = OGR_FD_GetFieldIndex( dfn, "crs" );
 
-  OGRFeatureH f = OGR_F_Create( dfn );
+  gdal::ogr_feature_unique_ptr f( OGR_F_Create( dfn ) );
   Q_ASSERT( f );
 
-  OGR_F_SetFieldString( f, pathIdx, fi.canonicalFilePath().toUtf8().constData() );
+  OGR_F_SetFieldString( f.get(), pathIdx, fi.canonicalFilePath().toUtf8().constData() );
 
   QDateTime d( fi.lastModified() );
-  OGR_F_SetFieldDateTime( f, lastmodifiedIdx,
+  OGR_F_SetFieldDateTime( f.get(), lastmodifiedIdx,
                           d.date().year(),
                           d.date().month(),
                           d.date().day(),
@@ -580,7 +571,7 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
                         );
 
   d = QDateTime::currentDateTime();
-  OGR_F_SetFieldDateTime( f, importdatIdx,
+  OGR_F_SetFieldDateTime( f.get(), importdatIdx,
                           d.date().year(),
                           d.date().month(),
                           d.date().day(),
@@ -590,16 +581,13 @@ bool QgsDwgImporter::import( const QString &drawing, QString &error, bool doExpa
                           0
                         );
 
-  OGR_F_SetFieldInteger( f, crsIdx, mCrs );
+  OGR_F_SetFieldInteger( f.get(), crsIdx, mCrs );
 
-  if ( OGR_L_CreateFeature( layer, f ) != OGRERR_NONE )
+  if ( OGR_L_CreateFeature( layer, f.get() ) != OGRERR_NONE )
   {
     LOG( QObject::tr( "Could not update drawing record [%1]" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
-    OGR_F_Destroy( f );
     return false;
   }
-
-  OGR_F_Destroy( f );
 
   LOG( QObject::tr( "Updating database from %1 [%2]." ).arg( drawing, fi.lastModified().toString() ) );
 
@@ -690,37 +678,34 @@ void QgsDwgImporter::addHeader( const DRW_Header *data )
 
   if ( !data->getComments().empty() )
   {
-    OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "drawing" );
+    OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "drawing" );
     OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
     int importdatIdx = OGR_FD_GetFieldIndex( dfn, "comments" );
 
     OGR_L_ResetReading( layer );
-    OGRFeatureH f = OGR_L_GetNextFeature( layer );
+    gdal::ogr_feature_unique_ptr f( OGR_L_GetNextFeature( layer ) );
     Q_ASSERT( f );
 
-    OGR_F_SetFieldString( f, importdatIdx, data->getComments().c_str() );
+    OGR_F_SetFieldString( f.get(), importdatIdx, data->getComments().c_str() );
 
-    if ( OGR_L_SetFeature( layer, f ) != OGRERR_NONE )
+    if ( OGR_L_SetFeature( layer, f.get() ) != OGRERR_NONE )
     {
       LOG( QObject::tr( "Could not update comment in drawing record [%1]" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
-      OGR_F_Destroy( f );
       return;
     }
-
-    OGR_F_Destroy( f );
   }
 
   if ( data->vars.empty() )
     return;
 
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "headers" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "headers" );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   int kIdx = OGR_FD_GetFieldIndex( dfn, "k" );
   int vIdx = OGR_FD_GetFieldIndex( dfn, "v" );
 
   for ( std::map<std::string, DRW_Variant *>::const_iterator it = data->vars.begin(); it != data->vars.end(); ++it )
   {
-    OGRFeatureH f = OGR_F_Create( dfn );
+    gdal::ogr_feature_unique_ptr f( OGR_F_Create( dfn ) );
 
     QString k = it->first.c_str();
 
@@ -754,10 +739,10 @@ void QgsDwgImporter::addHeader( const DRW_Header *data )
         break;
     }
 
-    OGR_F_SetFieldString( f, kIdx, k.toUtf8().constData() );
-    OGR_F_SetFieldString( f, vIdx, v.toUtf8().constData() );
+    OGR_F_SetFieldString( f.get(), kIdx, k.toUtf8().constData() );
+    OGR_F_SetFieldString( f.get(), vIdx, v.toUtf8().constData() );
 
-    if ( OGR_L_CreateFeature( layer, f ) != OGRERR_NONE )
+    if ( OGR_L_CreateFeature( layer, f.get() ) != OGRERR_NONE )
     {
       LOG( QObject::tr( "Could not add %3 %1 [%2]" )
            .arg( k,
@@ -765,25 +750,23 @@ void QgsDwgImporter::addHeader( const DRW_Header *data )
                  QObject::tr( "header record" ) )
          );
     }
-
-    OGR_F_Destroy( f );
   }
 }
 
 void QgsDwgImporter::addLType( const DRW_LType &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "linetypes" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "linetypes" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
 
-  OGRFeatureH f = OGR_F_Create( dfn );
+  gdal::ogr_feature_unique_ptr f( OGR_F_Create( dfn ) );
   Q_ASSERT( f );
 
-  SETSTRING( name );
-  SETSTRING( desc );
+  SETSTRINGPTR( name );
+  SETSTRINGPTR( desc );
 
   QVector<double> path( QVector<double>::fromStdVector( data.path ) );
-  OGR_F_SetFieldDoubleList( f, OGR_FD_GetFieldIndex( dfn, "path" ), path.size(), path.data() );
+  OGR_F_SetFieldDoubleList( f.get(), OGR_FD_GetFieldIndex( dfn, "path" ), path.size(), path.data() );
 
   QVector<double> upath;
   for ( int i = 0; i < path.size(); i++ )
@@ -829,7 +812,7 @@ void QgsDwgImporter::addLType( const DRW_LType &data )
   }
   mLinetype.insert( typeName.toLower(), dash );
 
-  if ( OGR_L_CreateFeature( layer, f ) != OGRERR_NONE )
+  if ( OGR_L_CreateFeature( layer, f.get() ) != OGRERR_NONE )
   {
     LOG( QObject::tr( "Could not add %3 %1 [%2]" )
          .arg( data.name.c_str(),
@@ -837,8 +820,6 @@ void QgsDwgImporter::addLType( const DRW_LType &data )
                QObject::tr( "line type" ) )
        );
   }
-
-  OGR_F_Destroy( f );
 }
 
 QString QgsDwgImporter::colorString( int color, int color24, int transparency, const std::string &layer ) const
@@ -892,16 +873,16 @@ QString QgsDwgImporter::linetypeString( const std::string &olinetype, const std:
 
 void QgsDwgImporter::addLayer( const DRW_Layer &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "layers" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "layers" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
-  OGRFeatureH f = OGR_F_Create( dfn );
+  gdal::ogr_feature_unique_ptr f( OGR_F_Create( dfn ) );
   Q_ASSERT( f );
 
-  SETSTRING( name );
-  SETSTRING( lineType );
-  SETINTEGER( flags );
+  SETSTRINGPTR( name );
+  SETSTRINGPTR( lineType );
+  SETINTEGERPTR( flags );
 
   QString color = colorString( data.color, data.color24, data.transparency, "" );
   mLayerColor.insert( data.name.c_str(), color );
@@ -912,14 +893,14 @@ void QgsDwgImporter::addLayer( const DRW_Layer &data )
   mLayerLinewidth.insert( data.name.c_str(), linewidth );
   mLayerLinetype.insert( data.name.c_str(), linetypeString( data.lineType, "" ) );
 
-  setInteger( dfn, f, QStringLiteral( "ocolor" ), data.color );
-  SETINTEGER( color24 );
-  SETINTEGER( transparency );
-  setString( dfn, f, QStringLiteral( "color" ), color.toUtf8().constData() );
-  setInteger( dfn, f, QStringLiteral( "lweight" ), DRW_LW_Conv::lineWidth2dxfInt( data.lWeight ) );
-  setInteger( dfn, f, QStringLiteral( "linewidth" ), linewidth );
+  setInteger( dfn, f.get(), QStringLiteral( "ocolor" ), data.color );
+  SETINTEGERPTR( color24 );
+  SETINTEGERPTR( transparency );
+  setString( dfn, f.get(), QStringLiteral( "color" ), color.toUtf8().constData() );
+  setInteger( dfn, f.get(), QStringLiteral( "lweight" ), DRW_LW_Conv::lineWidth2dxfInt( data.lWeight ) );
+  setInteger( dfn, f.get(), QStringLiteral( "linewidth" ), linewidth );
 
-  if ( OGR_L_CreateFeature( layer, f ) != OGRERR_NONE )
+  if ( OGR_L_CreateFeature( layer, f.get() ) != OGRERR_NONE )
   {
     LOG( QObject::tr( "Could not add %3 %1 [%2]" )
          .arg( data.name.c_str() )
@@ -927,8 +908,6 @@ void QgsDwgImporter::addLayer( const DRW_Layer &data )
          .arg( QObject::tr( "layer" ) )
        );
   }
-
-  OGR_F_Destroy( f );
 }
 
 void QgsDwgImporter::setString( OGRFeatureDefnH dfn, OGRFeatureH f, const QString &field, const std::string &value ) const
@@ -1046,84 +1025,84 @@ double QgsDwgImporter::lineWidth( int lWeight, const std::string &layer ) const
 
 void QgsDwgImporter::addDimStyle( const DRW_Dimstyle &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "dimstyles" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "dimstyles" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
-  OGRFeatureH f = OGR_F_Create( dfn );
+  gdal::ogr_feature_unique_ptr f( OGR_F_Create( dfn ) );
   Q_ASSERT( f );
 
-  SETSTRING( name );
-  SETSTRING( dimpost );
-  SETSTRING( dimapost );
-  SETSTRING( dimblk );
-  SETSTRING( dimblk1 );
-  SETSTRING( dimblk2 );
-  SETDOUBLE( dimscale );
-  SETDOUBLE( dimasz );
-  SETDOUBLE( dimexo );
-  SETDOUBLE( dimdli );
-  SETDOUBLE( dimexe );
-  SETDOUBLE( dimrnd );
-  SETDOUBLE( dimdle );
-  SETDOUBLE( dimtp );
-  SETDOUBLE( dimtm );
-  SETDOUBLE( dimfxl );
-  SETDOUBLE( dimtxt );
-  SETDOUBLE( dimcen );
-  SETDOUBLE( dimtsz );
-  SETDOUBLE( dimaltf );
-  SETDOUBLE( dimlfac );
-  SETDOUBLE( dimtvp );
-  SETDOUBLE( dimtfac );
-  SETDOUBLE( dimgap );
-  SETDOUBLE( dimaltrnd );
-  SETINTEGER( dimtol );
-  SETINTEGER( dimlim );
-  SETINTEGER( dimtih );
-  SETINTEGER( dimtoh );
-  SETINTEGER( dimse1 );
-  SETINTEGER( dimse2 );
-  SETINTEGER( dimtad );
-  SETINTEGER( dimzin );
-  SETINTEGER( dimazin );
-  SETINTEGER( dimalt );
-  SETINTEGER( dimaltd );
-  SETINTEGER( dimtofl );
-  SETINTEGER( dimsah );
-  SETINTEGER( dimtix );
-  SETINTEGER( dimsoxd );
-  SETINTEGER( dimclrd );
-  SETINTEGER( dimclre );
-  SETINTEGER( dimclrt );
-  SETINTEGER( dimadec );
-  SETINTEGER( dimunit );
-  SETINTEGER( dimdec );
-  SETINTEGER( dimtdec );
-  SETINTEGER( dimaltu );
-  SETINTEGER( dimalttd );
-  SETINTEGER( dimaunit );
-  SETINTEGER( dimfrac );
-  SETINTEGER( dimlunit );
-  SETINTEGER( dimdsep );
-  SETINTEGER( dimtmove );
-  SETINTEGER( dimjust );
-  SETINTEGER( dimsd1 );
-  SETINTEGER( dimsd2 );
-  SETINTEGER( dimtolj );
-  SETINTEGER( dimtzin );
-  SETINTEGER( dimaltz );
-  SETINTEGER( dimaltttz );
-  SETINTEGER( dimfit );
-  SETINTEGER( dimupt );
-  SETINTEGER( dimatfit );
-  SETINTEGER( dimfxlon );
-  SETSTRING( dimtxsty );
-  SETSTRING( dimldrblk );
-  SETINTEGER( dimlwd );
-  SETINTEGER( dimlwe );
+  SETSTRINGPTR( name );
+  SETSTRINGPTR( dimpost );
+  SETSTRINGPTR( dimapost );
+  SETSTRINGPTR( dimblk );
+  SETSTRINGPTR( dimblk1 );
+  SETSTRINGPTR( dimblk2 );
+  SETDOUBLEPTR( dimscale );
+  SETDOUBLEPTR( dimasz );
+  SETDOUBLEPTR( dimexo );
+  SETDOUBLEPTR( dimdli );
+  SETDOUBLEPTR( dimexe );
+  SETDOUBLEPTR( dimrnd );
+  SETDOUBLEPTR( dimdle );
+  SETDOUBLEPTR( dimtp );
+  SETDOUBLEPTR( dimtm );
+  SETDOUBLEPTR( dimfxl );
+  SETDOUBLEPTR( dimtxt );
+  SETDOUBLEPTR( dimcen );
+  SETDOUBLEPTR( dimtsz );
+  SETDOUBLEPTR( dimaltf );
+  SETDOUBLEPTR( dimlfac );
+  SETDOUBLEPTR( dimtvp );
+  SETDOUBLEPTR( dimtfac );
+  SETDOUBLEPTR( dimgap );
+  SETDOUBLEPTR( dimaltrnd );
+  SETINTEGERPTR( dimtol );
+  SETINTEGERPTR( dimlim );
+  SETINTEGERPTR( dimtih );
+  SETINTEGERPTR( dimtoh );
+  SETINTEGERPTR( dimse1 );
+  SETINTEGERPTR( dimse2 );
+  SETINTEGERPTR( dimtad );
+  SETINTEGERPTR( dimzin );
+  SETINTEGERPTR( dimazin );
+  SETINTEGERPTR( dimalt );
+  SETINTEGERPTR( dimaltd );
+  SETINTEGERPTR( dimtofl );
+  SETINTEGERPTR( dimsah );
+  SETINTEGERPTR( dimtix );
+  SETINTEGERPTR( dimsoxd );
+  SETINTEGERPTR( dimclrd );
+  SETINTEGERPTR( dimclre );
+  SETINTEGERPTR( dimclrt );
+  SETINTEGERPTR( dimadec );
+  SETINTEGERPTR( dimunit );
+  SETINTEGERPTR( dimdec );
+  SETINTEGERPTR( dimtdec );
+  SETINTEGERPTR( dimaltu );
+  SETINTEGERPTR( dimalttd );
+  SETINTEGERPTR( dimaunit );
+  SETINTEGERPTR( dimfrac );
+  SETINTEGERPTR( dimlunit );
+  SETINTEGERPTR( dimdsep );
+  SETINTEGERPTR( dimtmove );
+  SETINTEGERPTR( dimjust );
+  SETINTEGERPTR( dimsd1 );
+  SETINTEGERPTR( dimsd2 );
+  SETINTEGERPTR( dimtolj );
+  SETINTEGERPTR( dimtzin );
+  SETINTEGERPTR( dimaltz );
+  SETINTEGERPTR( dimaltttz );
+  SETINTEGERPTR( dimfit );
+  SETINTEGERPTR( dimupt );
+  SETINTEGERPTR( dimatfit );
+  SETINTEGERPTR( dimfxlon );
+  SETSTRINGPTR( dimtxsty );
+  SETSTRINGPTR( dimldrblk );
+  SETINTEGERPTR( dimlwd );
+  SETINTEGERPTR( dimlwe );
 
-  if ( OGR_L_CreateFeature( layer, f ) != OGRERR_NONE )
+  if ( OGR_L_CreateFeature( layer, f.get() ) != OGRERR_NONE )
   {
     LOG( QObject::tr( "Could not add %3 %1 [%2]" )
          .arg( data.name.c_str() )
@@ -1131,8 +1110,6 @@ void QgsDwgImporter::addDimStyle( const DRW_Dimstyle &data )
          .arg( QObject::tr( "dimension style" ) )
        );
   }
-
-  OGR_F_Destroy( f );
 }
 
 void QgsDwgImporter::addVport( const DRW_Vport &data )
@@ -1142,24 +1119,24 @@ void QgsDwgImporter::addVport( const DRW_Vport &data )
 
 void QgsDwgImporter::addTextStyle( const DRW_Textstyle &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "textstyles" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "textstyles" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
-  OGRFeatureH f = OGR_F_Create( dfn );
+  gdal::ogr_feature_unique_ptr f( OGR_F_Create( dfn ) );
   Q_ASSERT( f );
 
-  SETSTRING( name );
-  SETDOUBLE( height );
-  SETDOUBLE( width );
-  SETDOUBLE( oblique );
-  SETINTEGER( genFlag );
-  SETDOUBLE( lastHeight );
-  SETSTRING( font );
-  SETSTRING( bigFont );
-  SETINTEGER( fontFamily );
+  SETSTRINGPTR( name );
+  SETDOUBLEPTR( height );
+  SETDOUBLEPTR( width );
+  SETDOUBLEPTR( oblique );
+  SETINTEGERPTR( genFlag );
+  SETDOUBLEPTR( lastHeight );
+  SETSTRINGPTR( font );
+  SETSTRINGPTR( bigFont );
+  SETINTEGERPTR( fontFamily );
 
-  if ( OGR_L_CreateFeature( layer, f ) != OGRERR_NONE )
+  if ( OGR_L_CreateFeature( layer, f.get() ) != OGRERR_NONE )
   {
     LOG( QObject::tr( "Could not add %3 %1 [%2]" )
          .arg( data.name.c_str() )
@@ -1167,8 +1144,6 @@ void QgsDwgImporter::addTextStyle( const DRW_Textstyle &data )
          .arg( QObject::tr( "text style" ) )
        );
   }
-
-  OGR_F_Destroy( f );
 }
 
 void QgsDwgImporter::addAppId( const DRW_AppId &data )
@@ -1210,21 +1185,21 @@ void QgsDwgImporter::addBlock( const DRW_Block &data )
   mBlockHandle = data.handle;
   QgsDebugMsgLevel( QString( "block %1/0x%2 starts" ).arg( data.name.c_str() ).arg( mBlockHandle, 0, 16 ), 5 );
 
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "blocks" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "blocks" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
-  OGRFeatureH f = OGR_F_Create( dfn );
+  gdal::ogr_feature_unique_ptr f( OGR_F_Create( dfn ) );
   Q_ASSERT( f );
 
-  addEntity( dfn, f, data );
+  addEntity( dfn, f.get(), data );
 
-  SETSTRING( name );
-  SETINTEGER( flags );
+  SETSTRINGPTR( name );
+  SETINTEGERPTR( flags );
 
   QgsPoint p( QgsWkbTypes::PointZ, data.basePoint.x, data.basePoint.y, data.basePoint.z );
 
-  if ( !createFeature( layer, f, p ) )
+  if ( !createFeature( layer, f.get(), p ) )
   {
     LOG( QObject::tr( "Could not add %2 [%1]" )
          .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) )
@@ -1271,7 +1246,7 @@ void QgsDwgImporter::addEntity( OGRFeatureDefnH dfn, OGRFeatureH f, const DRW_En
 
 void QgsDwgImporter::addPoint( const DRW_Point &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "points" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "points" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -1308,7 +1283,7 @@ void QgsDwgImporter::addXline( const DRW_Xline &data )
 
 void QgsDwgImporter::addArc( const DRW_Arc &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "lines" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "lines" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -1350,7 +1325,7 @@ void QgsDwgImporter::addArc( const DRW_Arc &data )
 
 void QgsDwgImporter::addCircle( const DRW_Circle &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "lines" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "lines" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -1508,7 +1483,7 @@ void QgsDwgImporter::addLWPolyline( const DRW_LWPolyline &data )
       if ( width != staWidth || width != endWidth )
       {
         // write out entity
-        OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "polylines" );
+        OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "polylines" );
         Q_ASSERT( layer );
         OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
         Q_ASSERT( dfn );
@@ -1562,7 +1537,7 @@ void QgsDwgImporter::addLWPolyline( const DRW_LWPolyline &data )
     }
     else
     {
-      OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "hatches" );
+      OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "hatches" );
       Q_ASSERT( layer );
       OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
       Q_ASSERT( dfn );
@@ -1625,7 +1600,7 @@ void QgsDwgImporter::addLWPolyline( const DRW_LWPolyline &data )
   if ( cc.nCurves() > 0 )
   {
     // write out entity
-    OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "polylines" );
+    OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "polylines" );
     Q_ASSERT( layer );
     OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
     Q_ASSERT( dfn );
@@ -1707,7 +1682,7 @@ void QgsDwgImporter::addPolyline( const DRW_Polyline &data )
       if ( width != staWidth || width != endWidth )
       {
         // write out entity
-        OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "polylines" );
+        OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "polylines" );
         Q_ASSERT( layer );
         OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
         Q_ASSERT( dfn );
@@ -1764,7 +1739,7 @@ void QgsDwgImporter::addPolyline( const DRW_Polyline &data )
     }
     else
     {
-      OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "hatches" );
+      OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "hatches" );
       Q_ASSERT( layer );
       OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
       Q_ASSERT( dfn );
@@ -1831,7 +1806,7 @@ void QgsDwgImporter::addPolyline( const DRW_Polyline &data )
   if ( cc.nCurves() > 0 )
   {
     // write out entity
-    OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "polylines" );
+    OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "polylines" );
     Q_ASSERT( layer );
     OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
     Q_ASSERT( dfn );
@@ -2074,7 +2049,7 @@ void QgsDwgImporter::addSpline( const DRW_Spline *data )
     rbspline( *data, npts, k, p1, cps, h, p );
   }
 
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "polylines" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "polylines" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -2106,7 +2081,7 @@ void QgsDwgImporter::addKnot( const DRW_Entity &data )
 
 void QgsDwgImporter::addInsert( const DRW_Insert &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "inserts" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "inserts" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -2154,7 +2129,7 @@ void QgsDwgImporter::add3dFace( const DRW_3Dface &data )
 
 void QgsDwgImporter::addSolid( const DRW_Solid &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "hatches" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "hatches" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -2194,7 +2169,7 @@ void QgsDwgImporter::addSolid( const DRW_Solid &data )
 
 void QgsDwgImporter::addMText( const DRW_MText &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "texts" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "texts" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -2230,7 +2205,7 @@ void QgsDwgImporter::addMText( const DRW_MText &data )
 
 void QgsDwgImporter::addText( const DRW_Text &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "texts" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "texts" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -2320,7 +2295,7 @@ void QgsDwgImporter::addHatch( const DRW_Hatch *pdata )
   Q_ASSERT( pdata );
   const DRW_Hatch &data = *pdata;
 
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "hatches" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "hatches" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -2402,7 +2377,7 @@ void QgsDwgImporter::addHatch( const DRW_Hatch *pdata )
 
 void QgsDwgImporter::addLine( const DRW_Line &data )
 {
-  OGRLayerH layer = OGR_DS_GetLayerByName( mDs, "lines" );
+  OGRLayerH layer = OGR_DS_GetLayerByName( mDs.get(),  "lines" );
   Q_ASSERT( layer );
   OGRFeatureDefnH dfn = OGR_L_GetLayerDefn( layer );
   Q_ASSERT( dfn );
@@ -2469,7 +2444,7 @@ bool QgsDwgImporter::expandInserts( QString &error )
 {
   QgsDebugCall;
 
-  OGRLayerH blocks = OGR_DS_GetLayerByName( mDs, "blocks" );
+  OGRLayerH blocks = OGR_DS_GetLayerByName( mDs.get(),  "blocks" );
   if ( !blocks )
   {
     QgsDebugMsg( "could not open layer 'blocks'" );
@@ -2491,21 +2466,19 @@ bool QgsDwgImporter::expandInserts( QString &error )
 
   OGR_L_ResetReading( blocks );
 
-  OGRFeatureH f;
+  gdal::ogr_feature_unique_ptr f;
   for ( ;; )
   {
-    f = OGR_L_GetNextFeature( blocks );
+    f.reset( OGR_L_GetNextFeature( blocks ) );
     if ( !f )
       break;
 
-    QString name = QString::fromUtf8( OGR_F_GetFieldAsString( f, nameIdx ) );
-    int handle = OGR_F_GetFieldAsInteger( f, handleIdx );
+    QString name = QString::fromUtf8( OGR_F_GetFieldAsString( f.get(), nameIdx ) );
+    int handle = OGR_F_GetFieldAsInteger( f.get(), handleIdx );
     blockhandle.insert( name, handle );
-
-    OGR_F_Destroy( f );
   }
 
-  OGRLayerH inserts = OGR_DS_GetLayerByName( mDs, "inserts" );
+  OGRLayerH inserts = OGR_DS_GetLayerByName( mDs.get(),  "inserts" );
   if ( !inserts )
   {
     QgsDebugMsg( "could not open layer 'inserts'" );
@@ -2543,7 +2516,7 @@ bool QgsDwgImporter::expandInserts( QString &error )
 
   OGR_L_ResetReading( inserts );
 
-  OGRFeatureH insert = nullptr;
+  gdal::ogr_feature_unique_ptr insert;
   int i = 0, errors = 0;
   for ( int i = 0; true; ++i )
   {
@@ -2552,43 +2525,38 @@ bool QgsDwgImporter::expandInserts( QString &error )
       QgsDebugMsg( QString( "Expanding inserts %1/%2..." ).arg( i ).arg( n ) );
     }
 
-    if ( insert )
-    {
-      OGR_F_Destroy( insert );
-    }
-
-    insert = OGR_L_GetNextFeature( inserts );
+    insert.reset( OGR_L_GetNextFeature( inserts ) );
     if ( !insert )
       break;
 
-    OGRGeometryH ogrG = OGR_F_GetGeometryRef( insert );
+    OGRGeometryH ogrG = OGR_F_GetGeometryRef( insert.get() );
     if ( !ogrG )
     {
-      QgsDebugMsg( QString( "%1: insert without geometry" ).arg( OGR_F_GetFID( insert ) ) );
+      QgsDebugMsg( QString( "%1: insert without geometry" ).arg( OGR_F_GetFID( insert.get() ) ) );
       continue;
     }
 
     QgsGeometry g( QgsOgrUtils::ogrGeometryToQgsGeometry( ogrG ) );
     if ( g.isNull() )
     {
-      QgsDebugMsg( QString( "%1: could not copy geometry" ).arg( OGR_F_GetFID( insert ) ) );
+      QgsDebugMsg( QString( "%1: could not copy geometry" ).arg( OGR_F_GetFID( insert.get() ) ) );
       continue;
     }
 
     QgsPointXY p( g.asPoint() );
 
-    QString name = QString::fromUtf8( OGR_F_GetFieldAsString( insert, nameIdx ) );
-    double xscale = OGR_F_GetFieldAsDouble( insert, xscaleIdx );
-    double yscale = OGR_F_GetFieldAsDouble( insert, yscaleIdx );
-    double angle = OGR_F_GetFieldAsDouble( insert, angleIdx );
-    QString blockLayer = QString::fromUtf8( OGR_F_GetFieldAsString( insert, layerIdx ) );
-    QString blockColor = QString::fromUtf8( OGR_F_GetFieldAsString( insert, colorIdx ) );
-    QString blockLinetype = QString::fromUtf8( OGR_F_GetFieldAsString( insert, linetypeIdx ) );
+    QString name = QString::fromUtf8( OGR_F_GetFieldAsString( insert.get(), nameIdx ) );
+    double xscale = OGR_F_GetFieldAsDouble( insert.get(), xscaleIdx );
+    double yscale = OGR_F_GetFieldAsDouble( insert.get(), yscaleIdx );
+    double angle = OGR_F_GetFieldAsDouble( insert.get(), angleIdx );
+    QString blockLayer = QString::fromUtf8( OGR_F_GetFieldAsString( insert.get(), layerIdx ) );
+    QString blockColor = QString::fromUtf8( OGR_F_GetFieldAsString( insert.get(), colorIdx ) );
+    QString blockLinetype = QString::fromUtf8( OGR_F_GetFieldAsString( insert.get(), linetypeIdx ) );
     if ( blockLinetype == QLatin1String( "1" ) )
     {
       QgsDebugMsg( "blockLinetype == 1" );
     }
-    double blockLinewidth = OGR_F_GetFieldAsDouble( insert, linewidthIdx );
+    double blockLinewidth = OGR_F_GetFieldAsDouble( insert.get(), linewidthIdx );
 
     int handle = blockhandle.value( name, -1 );
     if ( handle < 0 )
@@ -2607,14 +2575,14 @@ bool QgsDwgImporter::expandInserts( QString &error )
 
     Q_FOREACH ( const QString &name, QStringList() << "hatches" << "lines" << "polylines" << "texts" << "points" )
     {
-      OGRLayerH src = OGR_DS_ExecuteSQL( mDs, QStringLiteral( "SELECT * FROM %1 WHERE block=%2" ).arg( name ).arg( handle ).toUtf8().constData(), nullptr, nullptr );
+      OGRLayerH src = OGR_DS_ExecuteSQL( mDs.get(),  QStringLiteral( "SELECT * FROM %1 WHERE block=%2" ).arg( name ).arg( handle ).toUtf8().constData(), nullptr, nullptr );
       if ( !src )
       {
         QgsDebugMsg( QString( "%1: could not execute query for block %2" ).arg( name ).arg( handle ) );
         continue;
       }
 
-      OGRLayerH dst = OGR_DS_GetLayerByName( mDs, name.toUtf8().constData() );
+      OGRLayerH dst = OGR_DS_GetLayerByName( mDs.get(),  name.toUtf8().constData() );
       Q_ASSERT( dst );
 
       dfn = OGR_L_GetLayerDefn( src );
@@ -2628,7 +2596,7 @@ bool QgsDwgImporter::expandInserts( QString &error )
         QgsDebugMsg( QString( "%1: fields not found (blockIdx=%2, layerIdx=%3 colorIdx=%4)" )
                      .arg( name ).arg( blockIdx ).arg( layerIdx ).arg( colorIdx )
                    );
-        OGR_DS_ReleaseResultSet( mDs, src );
+        OGR_DS_ReleaseResultSet( mDs.get(),  src );
         continue;
       }
 
@@ -2638,21 +2606,18 @@ bool QgsDwgImporter::expandInserts( QString &error )
 
       OGR_L_ResetReading( src );
 
-      OGRFeatureH f = nullptr;
+      gdal::ogr_feature_unique_ptr f;
       int j = 0;
       for ( ;; )
       {
-        if ( f )
-          OGR_F_Destroy( f );
-
-        f = OGR_L_GetNextFeature( src );
+        f.reset( OGR_L_GetNextFeature( src ) );
         if ( !f )
           break;
 
-        GIntBig fid = OGR_F_GetFID( f );
+        GIntBig fid = OGR_F_GetFID( f.get() );
         Q_UNUSED( fid );
 
-        ogrG = OGR_F_GetGeometryRef( f );
+        ogrG = OGR_F_GetGeometryRef( f.get() );
         if ( !ogrG )
         {
           QgsDebugMsg( QString( "%1/%2: geometryless feature skipped" ).arg( name ).arg( fid ) );
@@ -2679,31 +2644,31 @@ bool QgsDwgImporter::expandInserts( QString &error )
           continue;
         }
 
-        if ( OGR_F_SetGeometryDirectly( f, ogrG ) != OGRERR_NONE )
+        if ( OGR_F_SetGeometryDirectly( f.get(), ogrG ) != OGRERR_NONE )
         {
           QgsDebugMsg( QString( "%1/%2: could not assign geometry" ).arg( name ).arg( fid ) );
           continue;
         }
 
-        OGR_F_SetFID( f, OGRNullFID );
-        OGR_F_SetFieldInteger( f, blockIdx, -1 );
+        OGR_F_SetFID( f.get(), OGRNullFID );
+        OGR_F_SetFieldInteger( f.get(), blockIdx, -1 );
 
-        if ( strcasecmp( OGR_F_GetFieldAsString( f, layerIdx ), "byblock" ) == 0 )
-          OGR_F_SetFieldString( f, layerIdx, blockLayer.toUtf8().constData() );
+        if ( strcasecmp( OGR_F_GetFieldAsString( f.get(), layerIdx ), "byblock" ) == 0 )
+          OGR_F_SetFieldString( f.get(), layerIdx, blockLayer.toUtf8().constData() );
 
-        if ( strcasecmp( OGR_F_GetFieldAsString( f, colorIdx ), "byblock" ) == 0 )
-          OGR_F_SetFieldString( f, colorIdx, blockColor.toUtf8().constData() );
+        if ( strcasecmp( OGR_F_GetFieldAsString( f.get(), colorIdx ), "byblock" ) == 0 )
+          OGR_F_SetFieldString( f.get(), colorIdx, blockColor.toUtf8().constData() );
 
         if ( angleIdx >= 0 )
-          OGR_F_SetFieldDouble( f, angleIdx, OGR_F_GetFieldAsDouble( f, angleIdx ) + angle );
+          OGR_F_SetFieldDouble( f.get(), angleIdx, OGR_F_GetFieldAsDouble( f.get(), angleIdx ) + angle );
 
-        if ( linetypeIdx >= 0 && strcasecmp( OGR_F_GetFieldAsString( f, linetypeIdx ), "byblock" ) == 0 )
-          OGR_F_SetFieldString( f, linetypeIdx, blockLinetype.toUtf8().constData() );
+        if ( linetypeIdx >= 0 && strcasecmp( OGR_F_GetFieldAsString( f.get(), linetypeIdx ), "byblock" ) == 0 )
+          OGR_F_SetFieldString( f.get(), linetypeIdx, blockLinetype.toUtf8().constData() );
 
-        if ( linewidthIdx >= 0 && OGR_F_GetFieldAsDouble( f, linewidthIdx ) < 0.0 )
-          OGR_F_SetFieldDouble( f, linewidthIdx, blockLinewidth );
+        if ( linewidthIdx >= 0 && OGR_F_GetFieldAsDouble( f.get(), linewidthIdx ) < 0.0 )
+          OGR_F_SetFieldDouble( f.get(), linewidthIdx, blockLinewidth );
 
-        if ( OGR_L_CreateFeature( dst, f ) != OGRERR_NONE )
+        if ( OGR_L_CreateFeature( dst, f.get() ) != OGRERR_NONE )
         {
           if ( errors < 1000 )
           {
@@ -2723,7 +2688,7 @@ bool QgsDwgImporter::expandInserts( QString &error )
         ++j;
       }
 
-      OGR_DS_ReleaseResultSet( mDs, src );
+      OGR_DS_ReleaseResultSet( mDs.get(),  src );
 
       QgsDebugMsgLevel( QString( "%1: %2 features copied" ).arg( name ).arg( j ), 5 );
     }

--- a/src/app/dwg/qgsdwgimporter.h
+++ b/src/app/dwg/qgsdwgimporter.h
@@ -21,6 +21,7 @@
 #include <ogr_api.h>
 
 #include "qgsabstractgeometry.h"
+#include "qgsogrutils.h"
 
 class QgsCompoundCurve;
 class QgsQgsCoordinateReferenceSystem;
@@ -186,7 +187,7 @@ class QgsDwgImporter : public DRW_Interface
 
     bool createFeature( OGRLayerH layer, OGRFeatureH f, const QgsAbstractGeometry &g ) const;
 
-    OGRDataSourceH mDs;
+    gdal::ogr_datasource_unique_ptr mDs;
     QString mDatabase;
     bool mInTransaction;
     int mSplineSegs;

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -49,6 +49,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgsogrutils.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -2760,16 +2761,15 @@ void QgsComposition::georeferenceOutput( const QString &file, QgsComposerMap *ma
   // important - we need to manually specify the DPI in advance, as GDAL will otherwise
   // assume a DPI of 150
   CPLSetConfigOption( "GDAL_PDF_DPI", QString::number( dpi ).toLocal8Bit().constData() );
-  GDALDatasetH outputDS = GDALOpen( file.toLocal8Bit().constData(), GA_Update );
+  gdal::dataset_unique_ptr outputDS( GDALOpen( file.toLocal8Bit().constData(), GA_Update ) );
   if ( outputDS )
   {
-    GDALSetGeoTransform( outputDS, t );
+    GDALSetGeoTransform( outputDS.get(), t );
 #if 0
     //TODO - metadata can be set here, e.g.:
     GDALSetMetadataItem( outputDS, "AUTHOR", "me", nullptr );
 #endif
-    GDALSetProjection( outputDS, map->crs().toWkt().toLocal8Bit().constData() );
-    GDALClose( outputDS );
+    GDALSetProjection( outputDS.get(), map->crs().toWkt().toLocal8Bit().constData() );
   }
   CPLSetConfigOption( "GDAL_PDF_DPI", nullptr );
   delete[] t;

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -51,6 +51,16 @@ void gdal::OGRFeatureDeleter::operator()( void *feature )
   OGR_F_Destroy( feature );
 }
 
+void gdal::GDALDatasetCloser::operator()( void *dataset )
+{
+  GDALClose( dataset );
+}
+
+void gdal::GDALWarpOptionsDeleter::operator()( GDALWarpOptions *options )
+{
+  GDALDestroyWarpOptions( options );
+}
+
 QgsFeature QgsOgrUtils::readOgrFeature( OGRFeatureH ogrFet, const QgsFields &fields, QTextCodec *encoding )
 {
   QgsFeature feature;

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -22,6 +22,8 @@
 #include "qgsfeature.h"
 
 #include <ogr_api.h>
+#include <gdal.h>
+#include <gdalwarper.h>
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
@@ -81,6 +83,32 @@ namespace gdal
   };
 
   /**
+   * Closes and cleanups GDAL dataset.
+   */
+  struct GDALDatasetCloser
+  {
+
+    /**
+     * Destroys an gdal \a dataset, using the correct gdal calls.
+     */
+    void CORE_EXPORT operator()( void *dataset );
+
+  };
+
+  /**
+   * Closes and cleanups GDAL warp options.
+   */
+  struct GDALWarpOptionsDeleter
+  {
+
+    /**
+     * Destroys GDAL warp \a options, using the correct gdal calls.
+     */
+    void CORE_EXPORT operator()( GDALWarpOptions *options );
+
+  };
+
+  /**
    * Scoped OGR data source.
    */
   using ogr_datasource_unique_ptr = std::unique_ptr< void, OGRDataSourceDeleter>;
@@ -99,6 +127,16 @@ namespace gdal
    * Scoped OGR feature.
    */
   using ogr_feature_unique_ptr = std::unique_ptr< void, OGRFeatureDeleter >;
+
+  /**
+   * Scoped GDAL dataset.
+   */
+  using dataset_unique_ptr = std::unique_ptr< void, GDALDatasetCloser >;
+
+  /**
+   * Scoped GDAL warp options.
+   */
+  using warp_options_unique_ptr = std::unique_ptr< GDALWarpOptions, GDALWarpOptionsDeleter >;
 }
 
 /**

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -138,7 +138,7 @@ namespace gdal
    * data store. Use when the resultant dataset is no longer required, e.g. as a result
    * of user cancelation of an operation.
    *
-   * Requires a gdal \a dataset pointer, the corresponding gdal \driver and underlying
+   * Requires a gdal \a dataset pointer, the corresponding gdal \a driver and underlying
    * dataset file \a path.
    */
   void CORE_EXPORT fast_delete_and_close( dataset_unique_ptr &dataset, GDALDriverH driver, const QString &path );

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -134,6 +134,16 @@ namespace gdal
   using dataset_unique_ptr = std::unique_ptr< void, GDALDatasetCloser >;
 
   /**
+   * Performs a fast close of an unwanted GDAL dataset handle by deleting the underlying
+   * data store. Use when the resultant dataset is no longer required, e.g. as a result
+   * of user cancelation of an operation.
+   *
+   * Requires a gdal \a dataset pointer, the corresponding gdal \driver and underlying
+   * dataset file \a path.
+   */
+  void CORE_EXPORT fast_delete_and_close( dataset_unique_ptr &dataset, GDALDriverH driver, const QString &path );
+
+  /**
    * Scoped GDAL warp options.
    */
   using warp_options_unique_ptr = std::unique_ptr< GDALWarpOptions, GDALWarpOptionsDeleter >;

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -25,6 +25,82 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
+namespace gdal
+{
+
+  /**
+   * Destroys OGR data sources.
+   */
+  struct OGRDataSourceDeleter
+  {
+
+    /**
+     * Destroys an OGR data \a source, using the correct gdal calls.
+     */
+    void CORE_EXPORT operator()( void *source );
+
+  };
+
+  /**
+   * Destroys OGR geometries.
+   */
+  struct OGRGeometryDeleter
+  {
+
+    /**
+     * Destroys an OGR \a geometry, using the correct gdal calls.
+     */
+    void CORE_EXPORT operator()( void *geometry );
+
+  };
+
+  /**
+   * Destroys OGR field definition.
+   */
+  struct OGRFldDeleter
+  {
+
+    /**
+     * Destroys an OGR field \a definition, using the correct gdal calls.
+     */
+    void CORE_EXPORT operator()( void *definition );
+
+  };
+
+  /**
+   * Destroys OGR feature.
+   */
+  struct OGRFeatureDeleter
+  {
+
+    /**
+     * Destroys an OGR \a feature, using the correct gdal calls.
+     */
+    void CORE_EXPORT operator()( void *feature );
+
+  };
+
+  /**
+   * Scoped OGR data source.
+   */
+  using ogr_datasource_unique_ptr = std::unique_ptr< void, OGRDataSourceDeleter>;
+
+  /**
+   * Scoped OGR geometry.
+   */
+  using ogr_geometry_unique_ptr = std::unique_ptr< void, OGRGeometryDeleter>;
+
+  /**
+   * Scoped OGR field definition.
+   */
+  using ogr_field_def_unique_ptr = std::unique_ptr< void, OGRFldDeleter >;
+
+  /**
+   * Scoped OGR feature.
+   */
+  using ogr_feature_unique_ptr = std::unique_ptr< void, OGRFeatureDeleter >;
+}
+
 /**
  * \ingroup core
  * \class QgsOgrUtils

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2019,7 +2019,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
 // field to not be present at all in the output, and thus on reading to
 // have disappeared. #16812
 #ifdef OGRNullMarker
-      OGR_F_SetFieldNull( poFeature, ogrField );
+      OGR_F_SetFieldNull( poFeature.get(), ogrField );
 #endif
       continue;
     }

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -26,6 +26,7 @@
 #include "qgssymbol.h"
 #include "qgstaskmanager.h"
 #include "qgsvectorlayer.h"
+#include "qgsogrutils.h"
 #include <ogr_api.h>
 
 #include <QPair>
@@ -630,7 +631,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     //! \note not available in Python bindings
     OGRGeometryH createEmptyGeometry( QgsWkbTypes::Type wkbType ) SIP_SKIP;
 
-    OGRDataSourceH mDS = nullptr;
+    gdal::ogr_datasource_unique_ptr mDS;
     OGRLayerH mLayer = nullptr;
     OGRSpatialReferenceH mOgrRef = nullptr;
 
@@ -680,7 +681,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 
     static QMap<QString, MetaData> initMetaData();
     void createSymbolLayerTable( QgsVectorLayer *vl, const QgsCoordinateTransform &ct, OGRDataSourceH ds );
-    OGRFeatureH createFeature( const QgsFeature &feature );
+    gdal::ogr_feature_unique_ptr createFeature( const QgsFeature &feature );
     bool writeFeature( OGRLayerH layer, OGRFeatureH feature );
 
     //! Writes features considering symbol level order

--- a/src/plugins/georeferencer/qgsimagewarper.cpp
+++ b/src/plugins/georeferencer/qgsimagewarper.cpp
@@ -28,6 +28,7 @@
 #include "qgsimagewarper.h"
 #include "qgsgeoreftransform.h"
 #include "qgslogger.h"
+#include "qgsogrutils.h"
 
 bool QgsImageWarper::sWarpCanceled = false;
 
@@ -38,18 +39,18 @@ QgsImageWarper::QgsImageWarper( QWidget *parent )
 
 bool QgsImageWarper::openSrcDSAndGetWarpOpt( const QString &input, ResamplingMethod resampling,
     const GDALTransformerFunc &pfnTransform,
-    GDALDatasetH &hSrcDS, GDALWarpOptions *&psWarpOptions )
+    gdal::dataset_unique_ptr &hSrcDS, gdal::warp_options_unique_ptr &psWarpOptions )
 {
   // Open input file
   GDALAllRegister();
-  hSrcDS = GDALOpen( input.toUtf8().constData(), GA_ReadOnly );
+  hSrcDS.reset( GDALOpen( input.toUtf8().constData(), GA_ReadOnly ) );
   if ( !hSrcDS )
     return false;
 
   // Setup warp options.
-  psWarpOptions = GDALCreateWarpOptions();
-  psWarpOptions->hSrcDS = hSrcDS;
-  psWarpOptions->nBandCount = GDALGetRasterCount( hSrcDS );
+  psWarpOptions.reset( GDALCreateWarpOptions() );
+  psWarpOptions->hSrcDS = hSrcDS.get();
+  psWarpOptions->nBandCount = GDALGetRasterCount( hSrcDS.get() );
   psWarpOptions->panSrcBands =
     ( int * ) CPLMalloc( sizeof( int ) * psWarpOptions->nBandCount );
   psWarpOptions->panDstBands =
@@ -66,7 +67,7 @@ bool QgsImageWarper::openSrcDSAndGetWarpOpt( const QString &input, ResamplingMet
   return true;
 }
 
-bool QgsImageWarper::createDestinationDataset( const QString &outputName, GDALDatasetH hSrcDS, GDALDatasetH &hDstDS,
+bool QgsImageWarper::createDestinationDataset( const QString &outputName, GDALDatasetH hSrcDS, gdal::dataset_unique_ptr &hDstDS,
     uint resX, uint resY, double *adfGeoTransform, bool useZeroAsTrans,
     const QString &compression, const QgsCoordinateReferenceSystem &crs )
 {
@@ -78,17 +79,17 @@ bool QgsImageWarper::createDestinationDataset( const QString &outputName, GDALDa
   }
   char **papszOptions = nullptr;
   papszOptions = CSLSetNameValue( papszOptions, "COMPRESS", compression.toLatin1() );
-  hDstDS = GDALCreate( driver,
-                       outputName.toUtf8().constData(), resX, resY,
-                       GDALGetRasterCount( hSrcDS ),
-                       GDALGetRasterDataType( GDALGetRasterBand( hSrcDS, 1 ) ),
-                       papszOptions );
+  hDstDS.reset( GDALCreate( driver,
+                            outputName.toUtf8().constData(), resX, resY,
+                            GDALGetRasterCount( hSrcDS ),
+                            GDALGetRasterDataType( GDALGetRasterBand( hSrcDS, 1 ) ),
+                            papszOptions ) );
   if ( !hDstDS )
   {
     return false;
   }
 
-  if ( CE_None != GDALSetGeoTransform( hDstDS, adfGeoTransform ) )
+  if ( CE_None != GDALSetGeoTransform( hDstDS.get(), adfGeoTransform ) )
   {
     return false;
   }
@@ -100,7 +101,7 @@ bool QgsImageWarper::createDestinationDataset( const QString &outputName, GDALDa
 
     char *wkt = nullptr;
     OGRErr err = oTargetSRS.exportToWkt( &wkt );
-    if ( err != CE_None || GDALSetProjection( hDstDS, wkt ) != CE_None )
+    if ( err != CE_None || GDALSetProjection( hDstDS.get(), wkt ) != CE_None )
     {
       CPLFree( wkt );
       return false;
@@ -111,7 +112,7 @@ bool QgsImageWarper::createDestinationDataset( const QString &outputName, GDALDa
   for ( int i = 0; i < GDALGetRasterCount( hSrcDS ); ++i )
   {
     GDALRasterBandH hSrcBand = GDALGetRasterBand( hSrcDS, i + 1 );
-    GDALRasterBandH hDstBand = GDALGetRasterBand( hDstDS, i + 1 );
+    GDALRasterBandH hDstBand = GDALGetRasterBand( hDstDS.get(), i + 1 );
     GDALColorTableH cTable = GDALGetRasterColorTable( hSrcBand );
     GDALSetRasterColorInterpretation( hDstBand, GDALGetRasterColorInterpretation( hSrcBand ) );
     if ( cTable )
@@ -147,8 +148,9 @@ int QgsImageWarper::warpFile( const QString &input,
     return false;
 
   CPLErr eErr;
-  GDALDatasetH hSrcDS, hDstDS;
-  GDALWarpOptions *psWarpOptions = nullptr;
+  gdal::dataset_unique_ptr hSrcDS;
+  gdal::dataset_unique_ptr hDstDS;
+  gdal::warp_options_unique_ptr psWarpOptions;
   if ( !openSrcDSAndGetWarpOpt( input, resampling, georefTransform.GDALTransformer(), hSrcDS, psWarpOptions ) )
   {
     // TODO: be verbose about failures
@@ -157,13 +159,11 @@ int QgsImageWarper::warpFile( const QString &input,
 
   double adfGeoTransform[6];
   int destPixels, destLines;
-  eErr = GDALSuggestedWarpOutput( hSrcDS, georefTransform.GDALTransformer(),
+  eErr = GDALSuggestedWarpOutput( hSrcDS.get(), georefTransform.GDALTransformer(),
                                   georefTransform.GDALTransformerArgs(),
                                   adfGeoTransform, &destPixels, &destLines );
   if ( eErr != CE_None )
   {
-    GDALClose( hSrcDS );
-    GDALDestroyWarpOptions( psWarpOptions );
     return false;
   }
 
@@ -204,12 +204,10 @@ int QgsImageWarper::warpFile( const QString &input,
     adfGeoTransform[5] = destResY;
   }
 
-  if ( !createDestinationDataset( output, hSrcDS, hDstDS, destPixels, destLines,
+  if ( !createDestinationDataset( output, hSrcDS.get(), hDstDS, destPixels, destLines,
                                   adfGeoTransform, useZeroAsTrans, compression,
                                   crs ) )
   {
-    GDALClose( hSrcDS );
-    GDALDestroyWarpOptions( psWarpOptions );
     return false;
   }
 
@@ -225,8 +223,8 @@ int QgsImageWarper::warpFile( const QString &input,
   psWarpOptions->pProgressArg = createWarpProgressArg( progressDialog );
   psWarpOptions->pfnProgress  = updateWarpProgress;
 
-  psWarpOptions->hSrcDS = hSrcDS;
-  psWarpOptions->hDstDS = hDstDS;
+  psWarpOptions->hSrcDS = hSrcDS.get();
+  psWarpOptions->hDstDS = hDstDS.get();
 
   // Create a transformer which transforms from source to destination pixels (and vice versa)
   psWarpOptions->pfnTransformer  = GeoToPixelTransform;
@@ -236,7 +234,7 @@ int QgsImageWarper::warpFile( const QString &input,
 
   // Initialize and execute the warp operation.
   GDALWarpOperation oOperation;
-  oOperation.Initialize( psWarpOptions );
+  oOperation.Initialize( psWarpOptions.get() );
 
   progressDialog->show();
   progressDialog->raise();
@@ -246,12 +244,7 @@ int QgsImageWarper::warpFile( const QString &input,
 //  eErr = oOperation.ChunkAndWarpMulti(0, 0, destPixels, destLines);
 
   destroyGeoToPixelTransform( psWarpOptions->pTransformerArg );
-  GDALDestroyWarpOptions( psWarpOptions );
   delete progressDialog;
-
-  GDALClose( hSrcDS );
-  GDALClose( hDstDS );
-
   return sWarpCanceled ? -1 : eErr == CE_None ? 1 : 0;
 }
 

--- a/src/plugins/georeferencer/qgsimagewarper.h
+++ b/src/plugins/georeferencer/qgsimagewarper.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include "qgspointxy.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsogrutils.h"
 
 class QgsGeorefTransform;
 class QProgressDialog;
@@ -84,10 +85,10 @@ class QgsImageWarper
     void destroyGeoToPixelTransform( void *GeoToPixelTransfomArg ) const;
 
     bool openSrcDSAndGetWarpOpt( const QString &input, ResamplingMethod resampling,
-                                 const GDALTransformerFunc &pfnTransform, GDALDatasetH &hSrcDS,
-                                 GDALWarpOptions *&psWarpOptions );
+                                 const GDALTransformerFunc &pfnTransform, gdal::dataset_unique_ptr &hSrcDS,
+                                 gdal::warp_options_unique_ptr &psWarpOptions );
 
-    bool createDestinationDataset( const QString &outputName, GDALDatasetH hSrcDS, GDALDatasetH &hDstDS, uint resX, uint resY,
+    bool createDestinationDataset( const QString &outputName, GDALDatasetH hSrcDS, gdal::dataset_unique_ptr &hDstDS, uint resX, uint resY,
                                    double *adfGeoTransform, bool useZeroAsTrans, const QString &compression, const QgsCoordinateReferenceSystem &crs );
 
     QWidget *mParent = nullptr;

--- a/src/plugins/georeferencer/qgsrasterchangecoords.cpp
+++ b/src/plugins/georeferencer/qgsrasterchangecoords.cpp
@@ -16,6 +16,8 @@
 #include "qgsrasterchangecoords.h"
 
 #include "qgspoint.h"
+#include "qgsogrutils.h"
+
 #include <gdal.h>
 
 #include <QFile>
@@ -23,9 +25,9 @@
 void QgsRasterChangeCoords::setRaster( const QString &fileRaster )
 {
   GDALAllRegister();
-  GDALDatasetH hDS = GDALOpen( fileRaster.toUtf8().constData(), GA_ReadOnly );
+  gdal::dataset_unique_ptr hDS( GDALOpen( fileRaster.toUtf8().constData(), GA_ReadOnly ) );
   double adfGeoTransform[6];
-  if ( GDALGetProjectionRef( hDS ) && GDALGetGeoTransform( hDS, adfGeoTransform ) == CE_None )
+  if ( GDALGetProjectionRef( hDS.get() ) && GDALGetGeoTransform( hDS.get(), adfGeoTransform ) == CE_None )
     //if ( false )
   {
     mHasCrs = true;
@@ -38,7 +40,6 @@ void QgsRasterChangeCoords::setRaster( const QString &fileRaster )
   {
     mHasCrs = false;
   }
-  GDALClose( hDS );
 }
 
 QVector<QgsPointXY> QgsRasterChangeCoords::getPixelCoords( const QVector<QgsPointXY> &mapCoords )

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -311,6 +311,7 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   }
 
   QStringList sublayers = QgsGdalProvider::subLayers( hDS.get() );
+  hDS.reset();
 
   QgsDebugMsgLevel( "GdalDataset opened " + path, 2 );
 

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -2739,6 +2739,7 @@ QGISEXTERN QgsGdalProvider *create(
 
   GDALSetGeoTransform( dataset.get(), geoTransform );
   GDALSetProjection( dataset.get(), crs.toWkt().toLocal8Bit().data() );
+  dataset.reset();
 
   return new QgsGdalProvider( uri, true );
 }

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -34,6 +34,7 @@
 #include "qgsrasterpyramid.h"
 #include "qgspointxy.h"
 #include "qgssettings.h"
+#include "qgsogrutils.h"
 
 #ifdef HAVE_GUI
 #include "qgssourceselectprovider.h"
@@ -2136,7 +2137,7 @@ void buildSupportedRasterFileFilterAndExtensions( QString &fileFiltersString, QS
 
 QGISEXTERN bool isValidRasterFileName( QString const &fileNameQString, QString &retErrMsg )
 {
-  GDALDatasetH myDataset;
+  gdal::dataset_unique_ptr myDataset;
 
   QgsGdalProviderBase::registerGdalDrivers();
 
@@ -2156,18 +2157,16 @@ QGISEXTERN bool isValidRasterFileName( QString const &fileNameQString, QString &
 
   //open the file using gdal making sure we have handled locale properly
   //myDataset = GDALOpen( QFile::encodeName( fileNameQString ).constData(), GA_ReadOnly );
-  myDataset = QgsGdalProviderBase::gdalOpen( fileName.toUtf8().constData(), GA_ReadOnly );
+  myDataset.reset( QgsGdalProviderBase::gdalOpen( fileName.toUtf8().constData(), GA_ReadOnly ) );
   if ( !myDataset )
   {
     if ( CPLGetLastErrorNo() != CPLE_OpenFailed )
       retErrMsg = QString::fromUtf8( CPLGetLastErrorMsg() );
     return false;
   }
-  else if ( GDALGetRasterCount( myDataset ) == 0 )
+  else if ( GDALGetRasterCount( myDataset.get() ) == 0 )
   {
-    QStringList layers = QgsGdalProvider::subLayers( myDataset );
-    GDALClose( myDataset );
-    myDataset = nullptr;
+    QStringList layers = QgsGdalProvider::subLayers( myDataset.get() );
     if ( layers.isEmpty() )
     {
       retErrMsg = QObject::tr( "This raster file has no bands and is invalid as a raster layer." );
@@ -2177,7 +2176,6 @@ QGISEXTERN bool isValidRasterFileName( QString const &fileNameQString, QString &
   }
   else
   {
-    GDALClose( myDataset );
     return true;
   }
 }
@@ -2730,7 +2728,7 @@ QGISEXTERN QgsGdalProvider *create(
   //create dataset
   CPLErrorReset();
   char **papszOptions = papszFromStringList( createOptions );
-  GDALDatasetH dataset = GDALCreate( driver, uri.toUtf8().constData(), width, height, nBands, ( GDALDataType )type, papszOptions );
+  gdal::dataset_unique_ptr dataset( GDALCreate( driver, uri.toUtf8().constData(), width, height, nBands, ( GDALDataType )type, papszOptions ) );
   CSLDestroy( papszOptions );
   if ( !dataset )
   {
@@ -2739,9 +2737,8 @@ QGISEXTERN QgsGdalProvider *create(
     return new QgsGdalProvider( uri, error );
   }
 
-  GDALSetGeoTransform( dataset, geoTransform );
-  GDALSetProjection( dataset, crs.toWkt().toLocal8Bit().data() );
-  GDALClose( dataset );
+  GDALSetGeoTransform( dataset.get(), geoTransform );
+  GDALSetProjection( dataset.get(), crs.toWkt().toLocal8Bit().data() );
 
   return new QgsGdalProvider( uri, true );
 }

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -260,6 +260,7 @@ QList<QgsOgrDbLayerInfo *> QgsOgrLayerItem::subLayers( const QString &path, cons
     {
       QString uri( QStringLiteral( "%1:%2" ).arg( driver, path ) );
       QString name = GDALGetMetadataItem( hDS.get(), "IDENTIFIER", NULL );
+      hDS.reset();
       // Fallback: will not be able to delete the table
       if ( name.isEmpty() )
       {

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -66,7 +66,7 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
 
   private:
 
-    bool readFeature( OGRFeatureH fet, QgsFeature &feature ) const;
+    bool readFeature( gdal::ogr_feature_unique_ptr fet, QgsFeature &feature ) const;
 
     //! Get an attribute associated with a feature
     void getFeatureAttribute( OGRFeatureH ogrFet, QgsFeature &f, int attindex ) const;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1321,7 +1321,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
 // field to not be present at all in the output, and thus on reading to
 // have disappeared. #16812
 #ifdef OGRNullMarker
-      OGR_F_SetFieldNull( feature, ogrAttId );
+      OGR_F_SetFieldNull( feature.get(), ogrAttId );
 #else
       OGR_F_UnsetField( feature.get(), ogrAttId );
 #endif
@@ -1719,7 +1719,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
 // field to not be present at all in the output, and thus on reading to
 // have disappeared. #16812
 #ifdef OGRNullMarker
-        OGR_F_SetFieldNull( of, f );
+        OGR_F_SetFieldNull( of.get(), f );
 #else
         OGR_F_UnsetField( of.get(), f );
 #endif

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -731,16 +731,15 @@ void QgsOgrProvider::addSubLayerDetailsToSubLayerList( int i, QgsOgrLayer *layer
     // TODO: avoid reading attributes, setRelevantFields cannot be called here because it is not constant
 
     layer->ResetReading();
-    OGRFeatureH fet;
-    while ( ( fet = layer->GetNextFeature() ) )
+    gdal::ogr_feature_unique_ptr fet;
+    while ( fet.reset( layer->GetNextFeature() ), fet )
     {
-      OGRGeometryH geom = OGR_F_GetGeometryRef( fet );
+      OGRGeometryH geom = OGR_F_GetGeometryRef( fet.get() );
       if ( geom )
       {
         OGRwkbGeometryType gType = ogrWkbSingleFlatten( OGR_G_GetGeometryType( geom ) );
         fCount[gType] = fCount.value( gType ) + 1;
       }
-      OGR_F_Destroy( fet );
     }
     layer->ResetReading();
     // it may happen that there are no features in the layer, in that case add unknown type
@@ -867,16 +866,15 @@ OGRwkbGeometryType QgsOgrProvider::getOgrGeomType( OGRLayerH ogrLayer )
       OGR_L_ResetReading( ogrLayer );
       for ( int i = 0; i < 10; i++ )
       {
-        OGRFeatureH nextFeature = OGR_L_GetNextFeature( ogrLayer );
+        gdal::ogr_feature_unique_ptr nextFeature( OGR_L_GetNextFeature( ogrLayer ) );
         if ( !nextFeature )
           break;
 
-        OGRGeometryH geometry = OGR_F_GetGeometryRef( nextFeature );
+        OGRGeometryH geometry = OGR_F_GetGeometryRef( nextFeature.get() );
         if ( geometry )
         {
           geomType = OGR_G_GetGeometryType( geometry );
         }
-        OGR_F_Destroy( nextFeature );
         if ( geomType != wkbNone )
           break;
       }
@@ -1108,12 +1106,12 @@ QgsRectangle QgsOgrProvider::extent() const
       mExtent->MaxX = -std::numeric_limits<double>::max();
       mExtent->MaxY = -std::numeric_limits<double>::max();
 
-      OGRFeatureH f;
+      gdal::ogr_feature_unique_ptr f;
 
       mOgrLayer->ResetReading();
-      while ( ( f = mOgrLayer->GetNextFeature() ) )
+      while ( f.reset( mOgrLayer->GetNextFeature() ), f )
       {
-        OGRGeometryH g = OGR_F_GetGeometryRef( f );
+        OGRGeometryH g = OGR_F_GetGeometryRef( f.get() );
         if ( g )
         {
           OGREnvelope env;
@@ -1124,8 +1122,6 @@ QgsRectangle QgsOgrProvider::extent() const
           mExtent->MaxX = std::max( mExtent->MaxX, env.MaxX );
           mExtent->MaxY = std::max( mExtent->MaxY, env.MaxY );
         }
-
-        OGR_F_Destroy( f );
       }
       mOgrLayer->ResetReading();
     }
@@ -1260,7 +1256,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
 {
   bool returnValue = true;
   QgsOgrFeatureDefn &fdef = mOgrLayer->GetLayerDefn();
-  OGRFeatureH feature = fdef.CreateFeature();
+  gdal::ogr_feature_unique_ptr feature( fdef.CreateFeature() );
 
   if ( f.hasGeometry() )
   {
@@ -1277,7 +1273,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
 
       geom = ConvertGeometryIfNecessary( geom );
 
-      OGR_F_SetGeometryDirectly( feature, geom );
+      OGR_F_SetGeometryDirectly( feature.get(), geom );
     }
   }
 
@@ -1296,7 +1292,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
       qlonglong id = attrFid.toLongLong( &ok );
       if ( ok )
       {
-        OGR_F_SetFID( feature, static_cast<GIntBig>( id ) );
+        OGR_F_SetFID( feature.get(), static_cast<GIntBig>( id ) );
       }
     }
   }
@@ -1327,7 +1323,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
 #ifdef OGRNullMarker
       OGR_F_SetFieldNull( feature, ogrAttId );
 #else
-      OGR_F_UnsetField( feature, ogrAttId );
+      OGR_F_UnsetField( feature.get(), ogrAttId );
 #endif
     }
     else
@@ -1335,20 +1331,20 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
       switch ( type )
       {
         case OFTInteger:
-          OGR_F_SetFieldInteger( feature, ogrAttId, attrVal.toInt() );
+          OGR_F_SetFieldInteger( feature.get(), ogrAttId, attrVal.toInt() );
           break;
 
 
         case OFTInteger64:
-          OGR_F_SetFieldInteger64( feature, ogrAttId, attrVal.toLongLong() );
+          OGR_F_SetFieldInteger64( feature.get(), ogrAttId, attrVal.toLongLong() );
           break;
 
         case OFTReal:
-          OGR_F_SetFieldDouble( feature, ogrAttId, attrVal.toDouble() );
+          OGR_F_SetFieldDouble( feature.get(), ogrAttId, attrVal.toDouble() );
           break;
 
         case OFTDate:
-          OGR_F_SetFieldDateTime( feature, ogrAttId,
+          OGR_F_SetFieldDateTime( feature.get(), ogrAttId,
                                   attrVal.toDate().year(),
                                   attrVal.toDate().month(),
                                   attrVal.toDate().day(),
@@ -1357,7 +1353,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
           break;
 
         case OFTTime:
-          OGR_F_SetFieldDateTime( feature, ogrAttId,
+          OGR_F_SetFieldDateTime( feature.get(), ogrAttId,
                                   0, 0, 0,
                                   attrVal.toTime().hour(),
                                   attrVal.toTime().minute(),
@@ -1366,7 +1362,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
           break;
 
         case OFTDateTime:
-          OGR_F_SetFieldDateTime( feature, ogrAttId,
+          OGR_F_SetFieldDateTime( feature.get(), ogrAttId,
                                   attrVal.toDateTime().date().year(),
                                   attrVal.toDateTime().date().month(),
                                   attrVal.toDateTime().date().day(),
@@ -1381,7 +1377,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
                        .arg( qgisAttId )
                        .arg( attrVal.toString(),
                              textEncoding()->name().data() ) );
-          OGR_F_SetFieldString( feature, ogrAttId, textEncoding()->fromUnicode( attrVal.toString() ).constData() );
+          OGR_F_SetFieldString( feature.get(), ogrAttId, textEncoding()->fromUnicode( attrVal.toString() ).constData() );
           break;
 
         default:
@@ -1391,14 +1387,14 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
     }
   }
 
-  if ( mOgrLayer->CreateFeature( feature ) != OGRERR_NONE )
+  if ( mOgrLayer->CreateFeature( feature.get() ) != OGRERR_NONE )
   {
     pushError( tr( "OGR error creating feature %1: %2" ).arg( f.id() ).arg( CPLGetLastErrorMsg() ) );
     returnValue = false;
   }
   else if ( !( flags & QgsFeatureSink::FastInsert ) )
   {
-    QgsFeatureId id = static_cast<QgsFeatureId>( OGR_F_GetFID( feature ) );
+    QgsFeatureId id = static_cast<QgsFeatureId>( OGR_F_GetFID( feature.get() ) );
     if ( id >= 0 )
     {
       f.setId( id );
@@ -1409,7 +1405,6 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
       }
     }
   }
-  OGR_F_Destroy( feature );
 
   return returnValue;
 }
@@ -1510,19 +1505,18 @@ bool QgsOgrProvider::addAttributes( const QList<QgsField> &attributes )
         continue;
     }
 
-    OGRFieldDefnH fielddefn = OGR_Fld_Create( textEncoding()->fromUnicode( iter->name() ).constData(), type );
+    gdal::ogr_field_def_unique_ptr fielddefn( OGR_Fld_Create( textEncoding()->fromUnicode( iter->name() ).constData(), type ) );
     int width = iter->length();
     if ( iter->precision() )
       width += 1;
-    OGR_Fld_SetWidth( fielddefn, width );
-    OGR_Fld_SetPrecision( fielddefn, iter->precision() );
+    OGR_Fld_SetWidth( fielddefn.get(), width );
+    OGR_Fld_SetPrecision( fielddefn.get(), iter->precision() );
 
-    if ( mOgrLayer->CreateField( fielddefn, true ) != OGRERR_NONE )
+    if ( mOgrLayer->CreateField( fielddefn.get(), true ) != OGRERR_NONE )
     {
       pushError( tr( "OGR error creating field %1: %2" ).arg( iter->name(), CPLGetLastErrorMsg() ) );
       returnvalue = false;
     }
-    OGR_Fld_Destroy( fielddefn );
   }
   loadFields();
 
@@ -1618,13 +1612,12 @@ bool QgsOgrProvider::renameAttributes( const QgsFieldNameMap &renamedAttributes 
     }
 
     //type does not matter, it will not be used
-    OGRFieldDefnH fld = OGR_Fld_Create( textEncoding()->fromUnicode( renameIt.value() ), OFTReal );
-    if ( mOgrLayer->AlterFieldDefn( ogrFieldIndex, fld, ALTER_NAME_FLAG ) != OGRERR_NONE )
+    gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( textEncoding()->fromUnicode( renameIt.value() ), OFTReal ) );
+    if ( mOgrLayer->AlterFieldDefn( ogrFieldIndex, fld.get(), ALTER_NAME_FLAG ) != OGRERR_NONE )
     {
       pushError( tr( "OGR error renaming field %1: %2" ).arg( fieldIndex ).arg( CPLGetLastErrorMsg() ) );
       result = false;
     }
-    OGR_Fld_Destroy( fld );
   }
   loadFields();
   return result;
@@ -1678,7 +1671,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
     if ( attr.isEmpty() )
       continue;
 
-    OGRFeatureH of = mOgrLayer->GetFeature( FID_TO_NUMBER( fid ) );
+    gdal::ogr_feature_unique_ptr of( mOgrLayer->GetFeature( FID_TO_NUMBER( fid ) ) );
     if ( !of )
     {
       pushError( tr( "Feature %1 for attribute update not found." ).arg( fid ) );
@@ -1707,7 +1700,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
         }
       }
 
-      OGRFieldDefnH fd = OGR_F_GetFieldDefnRef( of, f );
+      OGRFieldDefnH fd = OGR_F_GetFieldDefnRef( of.get(), f );
       if ( !fd )
       {
         pushError( tr( "Field %1 of feature %2 doesn't exist." ).arg( f ).arg( fid ) );
@@ -1728,7 +1721,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
 #ifdef OGRNullMarker
         OGR_F_SetFieldNull( of, f );
 #else
-        OGR_F_UnsetField( of, f );
+        OGR_F_UnsetField( of.get(), f );
 #endif
       }
       else
@@ -1737,16 +1730,16 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
         switch ( type )
         {
           case OFTInteger:
-            OGR_F_SetFieldInteger( of, f, it2->toInt() );
+            OGR_F_SetFieldInteger( of.get(), f, it2->toInt() );
             break;
           case OFTInteger64:
-            OGR_F_SetFieldInteger64( of, f, it2->toLongLong() );
+            OGR_F_SetFieldInteger64( of.get(), f, it2->toLongLong() );
             break;
           case OFTReal:
-            OGR_F_SetFieldDouble( of, f, it2->toDouble() );
+            OGR_F_SetFieldDouble( of.get(), f, it2->toDouble() );
             break;
           case OFTDate:
-            OGR_F_SetFieldDateTime( of, f,
+            OGR_F_SetFieldDateTime( of.get(), f,
                                     it2->toDate().year(),
                                     it2->toDate().month(),
                                     it2->toDate().day(),
@@ -1754,7 +1747,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
                                     0 );
             break;
           case OFTTime:
-            OGR_F_SetFieldDateTime( of, f,
+            OGR_F_SetFieldDateTime( of.get(), f,
                                     0, 0, 0,
                                     it2->toTime().hour(),
                                     it2->toTime().minute(),
@@ -1762,7 +1755,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
                                     0 );
             break;
           case OFTDateTime:
-            OGR_F_SetFieldDateTime( of, f,
+            OGR_F_SetFieldDateTime( of.get(), f,
                                     it2->toDateTime().date().year(),
                                     it2->toDateTime().date().month(),
                                     it2->toDateTime().date().day(),
@@ -1772,7 +1765,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
                                     0 );
             break;
           case OFTString:
-            OGR_F_SetFieldString( of, f, textEncoding()->fromUnicode( it2->toString() ).constData() );
+            OGR_F_SetFieldString( of.get(), f, textEncoding()->fromUnicode( it2->toString() ).constData() );
             break;
           default:
             pushError( tr( "Type %1 of attribute %2 of feature %3 unknown." ).arg( type ).arg( fid ).arg( f ) );
@@ -1781,12 +1774,10 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
       }
     }
 
-    if ( mOgrLayer->SetFeature( of ) != OGRERR_NONE )
+    if ( mOgrLayer->SetFeature( of.get() ) != OGRERR_NONE )
     {
       pushError( tr( "OGR error setting feature %1: %2" ).arg( fid ).arg( CPLGetLastErrorMsg() ) );
     }
-
-    OGR_F_Destroy( of );
   }
 
   if ( inTransaction )
@@ -1813,7 +1804,7 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
 
   for ( QgsGeometryMap::const_iterator it = geometry_map.constBegin(); it != geometry_map.constEnd(); ++it )
   {
-    OGRFeatureH theOGRFeature = mOgrLayer->GetFeature( static_cast<long>( FID_TO_NUMBER( it.key() ) ) );
+    gdal::ogr_feature_unique_ptr theOGRFeature( mOgrLayer->GetFeature( static_cast<long>( FID_TO_NUMBER( it.key() ) ) ) );
     if ( !theOGRFeature )
     {
       pushError( tr( "OGR error changing geometry: feature %1 not found" ).arg( it.key() ) );
@@ -1836,14 +1827,12 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
         pushError( tr( "OGR error creating geometry for feature %1: %2" ).arg( it.key() ).arg( CPLGetLastErrorMsg() ) );
         OGR_G_DestroyGeometry( newGeometry );
         newGeometry = nullptr;
-        OGR_F_Destroy( theOGRFeature );
         continue;
       }
 
       if ( !newGeometry )
       {
         pushError( tr( "OGR error in feature %1: geometry is null" ).arg( it.key() ) );
-        OGR_F_Destroy( theOGRFeature );
         continue;
       }
 
@@ -1851,28 +1840,24 @@ bool QgsOgrProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
     }
 
     //set the new geometry
-    if ( OGR_F_SetGeometryDirectly( theOGRFeature, newGeometry ) != OGRERR_NONE )
+    if ( OGR_F_SetGeometryDirectly( theOGRFeature.get(), newGeometry ) != OGRERR_NONE )
     {
       pushError( tr( "OGR error setting geometry of feature %1: %2" ).arg( it.key() ).arg( CPLGetLastErrorMsg() ) );
       // Shouldn't happen normally. If it happens, ownership of the geometry
       // may be not really well defined, so better not destroy it, but just
       // the feature.
-      OGR_F_Destroy( theOGRFeature );
       continue;
     }
 
 
-    if ( mOgrLayer->SetFeature( theOGRFeature ) != OGRERR_NONE )
+    if ( mOgrLayer->SetFeature( theOGRFeature.get() ) != OGRERR_NONE )
     {
       pushError( tr( "OGR error setting feature %1: %2" ).arg( it.key() ).arg( CPLGetLastErrorMsg() ) );
-      OGR_F_Destroy( theOGRFeature );
       continue;
     }
     mShapefileMayBeCorrupted = true;
 
     invalidateCachedExtent( true );
-
-    OGR_F_Destroy( theOGRFeature );
   }
 
   if ( inTransaction )
@@ -3030,11 +3015,10 @@ QSet<QVariant> QgsOgrProvider::uniqueValues( int index, int limit ) const
     return QgsVectorDataProvider::uniqueValues( index, limit );
   }
 
-  OGRFeatureH f;
-  while ( ( f = l->GetNextFeature() ) )
+  gdal::ogr_feature_unique_ptr f;
+  while ( f.reset( l->GetNextFeature() ), f )
   {
-    uniqueValues << ( OGR_F_IsFieldSetAndNotNull( f, 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f, 0 ) ) ) : QVariant( fld.type() ) );
-    OGR_F_Destroy( f );
+    uniqueValues << ( OGR_F_IsFieldSetAndNotNull( f.get(), 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f.get(), 0 ) ) ) : QVariant( fld.type() ) );
 
     if ( limit >= 0 && uniqueValues.size() >= limit )
       break;
@@ -3077,12 +3061,11 @@ QStringList QgsOgrProvider::uniqueStringsMatching( int index, const QString &sub
     return QgsVectorDataProvider::uniqueStringsMatching( index, substring, limit, feedback );
   }
 
-  OGRFeatureH f;
-  while ( ( f = l->GetNextFeature() ) )
+  gdal::ogr_feature_unique_ptr f;
+  while ( f.reset( l->GetNextFeature() ), f )
   {
-    if ( OGR_F_IsFieldSetAndNotNull( f, 0 ) )
-      results << textEncoding()->toUnicode( OGR_F_GetFieldAsString( f, 0 ) );
-    OGR_F_Destroy( f );
+    if ( OGR_F_IsFieldSetAndNotNull( f.get(), 0 ) )
+      results << textEncoding()->toUnicode( OGR_F_GetFieldAsString( f.get(), 0 ) );
 
     if ( ( limit >= 0 && results.size() >= limit ) || ( feedback && feedback->isCanceled() ) )
       break;
@@ -3116,15 +3099,14 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
     return QgsVectorDataProvider::minimumValue( index );
   }
 
-  OGRFeatureH f = l->GetNextFeature();
+  gdal::ogr_feature_unique_ptr f( l->GetNextFeature() );
   if ( !f )
   {
     QgsOgrProviderUtils::release( l );
     return QVariant();
   }
 
-  QVariant value = OGR_F_IsFieldSetAndNotNull( f, 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f, 0 ) ) ) : QVariant( fld.type() );
-  OGR_F_Destroy( f );
+  QVariant value = OGR_F_IsFieldSetAndNotNull( f.get(), 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f.get(), 0 ) ) ) : QVariant( fld.type() );
 
   QgsOgrProviderUtils::release( l );
 
@@ -3155,15 +3137,14 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
     return QgsVectorDataProvider::maximumValue( index );
   }
 
-  OGRFeatureH f = l->GetNextFeature();
+  gdal::ogr_feature_unique_ptr f( l->GetNextFeature() );
   if ( !f )
   {
     QgsOgrProviderUtils::release( l );
     return QVariant();
   }
 
-  QVariant value = OGR_F_IsFieldSetAndNotNull( f, 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f, 0 ) ) ) : QVariant( fld.type() );
-  OGR_F_Destroy( f );
+  QVariant value = OGR_F_IsFieldSetAndNotNull( f.get(), 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f.get(), 0 ) ) ) : QVariant( fld.type() );
 
   QgsOgrProviderUtils::release( l );
 
@@ -3346,13 +3327,12 @@ void QgsOgrProviderUtils::GDALCloseWrapper( GDALDatasetH hDS )
                             nullptr, nullptr );
         if ( hSqlLyr )
         {
-          OGRFeatureH hFeat = OGR_L_GetNextFeature( hSqlLyr );
+          gdal::ogr_feature_unique_ptr hFeat( OGR_L_GetNextFeature( hSqlLyr ) );
           if ( hFeat )
           {
-            const char *pszRet = OGR_F_GetFieldAsString( hFeat, 0 );
+            const char *pszRet = OGR_F_GetFieldAsString( hFeat.get(), 0 );
             bSuccess = EQUAL( pszRet, "delete" );
             QgsDebugMsg( QString( "Return: %1" ).arg( pszRet ) );
-            OGR_F_Destroy( hFeat );
           }
         }
         else if ( CPLGetLastErrorType() != CE_None )
@@ -3385,12 +3365,11 @@ void QgsOgrProviderUtils::GDALCloseWrapper( GDALDatasetH hDS )
           CPLPopErrorHandler();
           if ( hSqlLyr != NULL )
           {
-            OGRFeatureH hFeat = OGR_L_GetNextFeature( hSqlLyr );
+            gdal::ogr_feature_unique_ptr hFeat( OGR_L_GetNextFeature( hSqlLyr ) );
             if ( hFeat != NULL )
             {
-              const char *pszRet = OGR_F_GetFieldAsString( hFeat, 0 );
+              const char *pszRet = OGR_F_GetFieldAsString( hFeat.get(), 0 );
               QgsDebugMsg( QString( "Return: %1" ).arg( pszRet ) );
-              OGR_F_Destroy( hFeat );
             }
             GDALDatasetReleaseResultSet( hDS, hSqlLyr );
           }
@@ -3536,19 +3515,18 @@ void QgsOgrProvider::recalculateFeatureCount()
     mOgrLayer->ResetReading();
     setRelevantFields( true, QgsAttributeList() );
     mOgrLayer->ResetReading();
-    OGRFeatureH fet;
+    gdal::ogr_feature_unique_ptr fet;
     const OGRwkbGeometryType flattenGeomTypeFilter =
       QgsOgrProvider::ogrWkbSingleFlatten( mOgrGeometryTypeFilter );
-    while ( ( fet = mOgrLayer->GetNextFeature() ) )
+    while ( fet.reset( mOgrLayer->GetNextFeature() ), fet )
     {
-      OGRGeometryH geom = OGR_F_GetGeometryRef( fet );
+      OGRGeometryH geom = OGR_F_GetGeometryRef( fet.get() );
       if ( geom )
       {
         OGRwkbGeometryType gType = OGR_G_GetGeometryType( geom );
         gType = QgsOgrProvider::ogrWkbSingleFlatten( gType );
         if ( gType == flattenGeomTypeFilter ) mFeaturesCounted++;
       }
-      OGR_F_Destroy( fet );
     }
     mOgrLayer->ResetReading();
 
@@ -4737,73 +4715,61 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
     }
     bool ok = true;
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "f_table_catalog", OFTString );
-      OGR_Fld_SetWidth( fld, 256 );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "f_table_catalog", OFTString ) );
+      OGR_Fld_SetWidth( fld.get(), 256 );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "f_table_schema", OFTString );
-      OGR_Fld_SetWidth( fld, 256 );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "f_table_schema", OFTString ) );
+      OGR_Fld_SetWidth( fld.get(), 256 );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "f_table_name", OFTString );
-      OGR_Fld_SetWidth( fld, 256 );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "f_table_name", OFTString ) );
+      OGR_Fld_SetWidth( fld.get(), 256 );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "f_geometry_column", OFTString );
-      OGR_Fld_SetWidth( fld, 256 );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "f_geometry_column", OFTString ) );
+      OGR_Fld_SetWidth( fld.get(), 256 );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "styleName", OFTString );
-      OGR_Fld_SetWidth( fld, 30 );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "styleName", OFTString ) );
+      OGR_Fld_SetWidth( fld.get(), 30 );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "styleQML", OFTString );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "styleQML", OFTString ) );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "styleSLD", OFTString );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "styleSLD", OFTString ) );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "useAsDefault", OFTInteger );
-      OGR_Fld_SetSubType( fld, OFSTBoolean );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "useAsDefault", OFTInteger ) );
+      OGR_Fld_SetSubType( fld.get(), OFSTBoolean );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "description", OFTString );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "description", OFTString ) );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "owner", OFTString );
-      OGR_Fld_SetWidth( fld, 30 );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "owner", OFTString ) );
+      OGR_Fld_SetWidth( fld.get(), 30 );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "ui", OFTString );
-      OGR_Fld_SetWidth( fld, 30 );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "ui", OFTString ) );
+      OGR_Fld_SetWidth( fld.get(), 30 );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     {
-      OGRFieldDefnH fld = OGR_Fld_Create( "update_time", OFTDateTime );
-      OGR_Fld_SetDefault( fld, "CURRENT_TIMESTAMP" );
-      ok &= OGR_L_CreateField( hLayer, fld, true ) == OGRERR_NONE;
-      OGR_Fld_Destroy( fld );
+      gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( "update_time", OFTDateTime ) );
+      OGR_Fld_SetDefault( fld.get(), "CURRENT_TIMESTAMP" );
+      ok &= OGR_L_CreateField( hLayer, fld.get(), true ) == OGRERR_NONE;
     }
     if ( !ok )
     {
@@ -4827,14 +4793,13 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
                               .arg( QgsOgrProviderUtils::quotedValue( QString( OGR_L_GetName( hUserLayer ) ) ) )
                               .arg( QgsOgrProviderUtils::quotedValue( QString( OGR_L_GetGeometryColumn( hUserLayer ) ) ) );
     OGR_L_SetAttributeFilter( hLayer, oldDefaultQuery.toUtf8().constData() );
-    OGRFeatureH hFeature = OGR_L_GetNextFeature( hLayer );
+    gdal::ogr_feature_unique_ptr hFeature( OGR_L_GetNextFeature( hLayer ) );
     if ( hFeature )
     {
-      OGR_F_SetFieldInteger( hFeature,
+      OGR_F_SetFieldInteger( hFeature.get(),
                              OGR_FD_GetFieldIndex( hLayerDefn, "useAsDefault" ),
                              0 );
-      bool ok = OGR_L_SetFeature( hLayer, hFeature ) == 0;
-      OGR_F_Destroy( hFeature );
+      bool ok = OGR_L_SetFeature( hLayer, hFeature.get() ) == 0;
       if ( !ok )
       {
         QgsDebugMsg( "Could not unset previous useAsDefault style" );
@@ -4851,7 +4816,7 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
                        .arg( QgsOgrProviderUtils::quotedValue( realStyleName ) );
   OGR_L_SetAttributeFilter( hLayer, checkQuery.toUtf8().constData() );
   OGR_L_ResetReading( hLayer );
-  OGRFeatureH hFeature = OGR_L_GetNextFeature( hLayer );
+  gdal::ogr_feature_unique_ptr hFeature( OGR_L_GetNextFeature( hLayer ) );
   bool bNew = true;
 
   if ( hFeature )
@@ -4867,7 +4832,6 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
                                   QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No ) )
     {
       errCause = QObject::tr( "Operation aborted" );
-      OGR_F_Destroy( hFeature );
       mutex->unlock();
       QgsOgrProviderUtils::release( userLayer );
       return false;
@@ -4876,52 +4840,50 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
   }
   else
   {
-    hFeature = OGR_F_Create( hLayerDefn );
-    OGR_F_SetFieldString( hFeature,
+    hFeature.reset( OGR_F_Create( hLayerDefn ) );
+    OGR_F_SetFieldString( hFeature.get(),
                           OGR_FD_GetFieldIndex( hLayerDefn, "f_table_catalog" ),
                           "" );
-    OGR_F_SetFieldString( hFeature,
+    OGR_F_SetFieldString( hFeature.get(),
                           OGR_FD_GetFieldIndex( hLayerDefn, "f_table_schema" ),
                           "" );
-    OGR_F_SetFieldString( hFeature,
+    OGR_F_SetFieldString( hFeature.get(),
                           OGR_FD_GetFieldIndex( hLayerDefn, "f_table_name" ),
                           OGR_L_GetName( hUserLayer ) );
-    OGR_F_SetFieldString( hFeature,
+    OGR_F_SetFieldString( hFeature.get(),
                           OGR_FD_GetFieldIndex( hLayerDefn, "f_geometry_column" ),
                           OGR_L_GetGeometryColumn( hUserLayer ) );
-    OGR_F_SetFieldString( hFeature,
+    OGR_F_SetFieldString( hFeature.get(),
                           OGR_FD_GetFieldIndex( hLayerDefn, "styleName" ),
                           realStyleName.toUtf8().constData() );
     if ( !uiFileContent.isEmpty() )
     {
-      OGR_F_SetFieldString( hFeature,
+      OGR_F_SetFieldString( hFeature.get(),
                             OGR_FD_GetFieldIndex( hLayerDefn, "ui" ),
                             uiFileContent.toUtf8().constData() );
     }
   }
-  OGR_F_SetFieldString( hFeature,
+  OGR_F_SetFieldString( hFeature.get(),
                         OGR_FD_GetFieldIndex( hLayerDefn, "styleQML" ),
                         qmlStyle.toUtf8().constData() );
-  OGR_F_SetFieldString( hFeature,
+  OGR_F_SetFieldString( hFeature.get(),
                         OGR_FD_GetFieldIndex( hLayerDefn, "styleSLD" ),
                         sldStyle.toUtf8().constData() );
-  OGR_F_SetFieldInteger( hFeature,
+  OGR_F_SetFieldInteger( hFeature.get(),
                          OGR_FD_GetFieldIndex( hLayerDefn, "useAsDefault" ),
                          useAsDefault ? 1 : 0 );
-  OGR_F_SetFieldString( hFeature,
+  OGR_F_SetFieldString( hFeature.get(),
                         OGR_FD_GetFieldIndex( hLayerDefn, "description" ),
                         ( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ).toUtf8().constData() );
-  OGR_F_SetFieldString( hFeature,
+  OGR_F_SetFieldString( hFeature.get(),
                         OGR_FD_GetFieldIndex( hLayerDefn, "owner" ),
                         "" );
 
   bool bFeatureOK;
   if ( bNew )
-    bFeatureOK = OGR_L_CreateFeature( hLayer, hFeature ) == OGRERR_NONE;
+    bFeatureOK = OGR_L_CreateFeature( hLayer, hFeature.get() ) == OGRERR_NONE;
   else
-    bFeatureOK = OGR_L_SetFeature( hLayer, hFeature ) == OGRERR_NONE;
-
-  OGR_F_Destroy( hFeature );
+    bFeatureOK = OGR_L_SetFeature( hLayer, hFeature.get() ) == OGRERR_NONE;
 
   mutex->unlock();
   QgsOgrProviderUtils::release( userLayer );
@@ -5010,19 +4972,18 @@ QGISEXTERN QString loadStyle( const QString &uri, QString &errCause )
   qlonglong moreRecentTimestamp = 0;
   while ( true )
   {
-    OGRFeatureH hFeat = OGR_L_GetNextFeature( hLayer );
+    gdal::ogr_feature_unique_ptr hFeat( OGR_L_GetNextFeature( hLayer ) );
     if ( !hFeat )
       break;
-    if ( OGR_F_GetFieldAsInteger( hFeat, OGR_FD_GetFieldIndex( hLayerDefn, "useAsDefault" ) ) )
+    if ( OGR_F_GetFieldAsInteger( hFeat.get(), OGR_FD_GetFieldIndex( hLayerDefn, "useAsDefault" ) ) )
     {
       styleQML = QString::fromUtf8(
-                   OGR_F_GetFieldAsString( hFeat, OGR_FD_GetFieldIndex( hLayerDefn, "styleQML" ) ) );
-      OGR_F_Destroy( hFeat );
+                   OGR_F_GetFieldAsString( hFeat.get(), OGR_FD_GetFieldIndex( hLayerDefn, "styleQML" ) ) );
       break;
     }
 
     int  year, month, day, hour, minute, second, TZ;
-    OGR_F_GetFieldAsDateTime( hFeat, OGR_FD_GetFieldIndex( hLayerDefn, "update_time" ),
+    OGR_F_GetFieldAsDateTime( hFeat.get(), OGR_FD_GetFieldIndex( hLayerDefn, "update_time" ),
                               &year, &month, &day, &hour, &minute, &second, &TZ );
     qlonglong ts = second + minute * 60 + hour * 3600 + day * 24 * 3600 +
                    ( qlonglong )month * 31 * 24 * 3600 + ( qlonglong )year * 12 * 31 * 24 * 3600;
@@ -5030,10 +4991,9 @@ QGISEXTERN QString loadStyle( const QString &uri, QString &errCause )
     {
       moreRecentTimestamp = ts;
       styleQML = QString::fromUtf8(
-                   OGR_F_GetFieldAsString( hFeat, OGR_FD_GetFieldIndex( hLayerDefn, "styleQML" ) ) );
+                   OGR_F_GetFieldAsString( hFeat.get(), OGR_FD_GetFieldIndex( hLayerDefn, "styleQML" ) ) );
 
     }
-    OGR_F_Destroy( hFeat );
   }
 
   mutex1->unlock();
@@ -5112,23 +5072,23 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   int numberOfRelatedStyles = 0;
   while ( true )
   {
-    OGRFeatureH hFeature = OGR_L_GetNextFeature( hLayer );
+    gdal::ogr_feature_unique_ptr hFeature( OGR_L_GetNextFeature( hLayer ) );
     if ( !hFeature )
       break;
 
     QString tableName( QString::fromUtf8(
-                         OGR_F_GetFieldAsString( hFeature,
+                         OGR_F_GetFieldAsString( hFeature.get(),
                              OGR_FD_GetFieldIndex( hLayerDefn, "f_table_name" ) ) ) );
     QString geometryColumn( QString::fromUtf8(
-                              OGR_F_GetFieldAsString( hFeature,
+                              OGR_F_GetFieldAsString( hFeature.get(),
                                   OGR_FD_GetFieldIndex( hLayerDefn, "f_geometry_column" ) ) ) );
     QString styleName( QString::fromUtf8(
-                         OGR_F_GetFieldAsString( hFeature,
+                         OGR_F_GetFieldAsString( hFeature.get(),
                              OGR_FD_GetFieldIndex( hLayerDefn, "styleName" ) ) ) );
     QString description( QString::fromUtf8(
-                           OGR_F_GetFieldAsString( hFeature,
+                           OGR_F_GetFieldAsString( hFeature.get(),
                                OGR_FD_GetFieldIndex( hLayerDefn, "description" ) ) ) );
-    int fid = static_cast<int>( OGR_F_GetFID( hFeature ) );
+    int fid = static_cast<int>( OGR_F_GetFID( hFeature.get() ) );
     if ( tableName == QString::fromUtf8( OGR_L_GetName( hUserLayer ) ) &&
          geometryColumn == QString::fromUtf8( OGR_L_GetGeometryColumn( hUserLayer ) ) )
     {
@@ -5142,7 +5102,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
     else
     {
       int  year, month, day, hour, minute, second, TZ;
-      OGR_F_GetFieldAsDateTime( hFeature, OGR_FD_GetFieldIndex( hLayerDefn, "update_time" ),
+      OGR_F_GetFieldAsDateTime( hFeature.get(), OGR_FD_GetFieldIndex( hLayerDefn, "update_time" ),
                                 &year, &month, &day, &hour, &minute, &second, &TZ );
       qlonglong ts = second + minute * 60 + hour * 3600 + day * 24 * 3600 +
                      ( qlonglong )month * 31 * 24 * 3600 + ( qlonglong )year * 12 * 31 * 24 * 3600;
@@ -5152,8 +5112,6 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
       mapIdToDescription[fid] = styleName;
       mapTimestampToId[ts].append( fid );
     }
-
-    OGR_F_Destroy( hFeature );
   }
 
   std::sort( listTimestamp.begin(), listTimestamp.end() );
@@ -5203,7 +5161,7 @@ QGISEXTERN QString getStyleById( const QString &uri, QString styleId, QString &e
     return QLatin1String( "" );
   }
 
-  OGRFeatureH hFeature = OGR_L_GetFeature( hLayer, id );
+  gdal::ogr_feature_unique_ptr hFeature( OGR_L_GetFeature( hLayer, id ) );
   if ( !hFeature )
   {
     errCause = QObject::tr( "No style corresponding to style identifier" );
@@ -5215,10 +5173,8 @@ QGISEXTERN QString getStyleById( const QString &uri, QString styleId, QString &e
 
   OGRFeatureDefnH hLayerDefn = OGR_L_GetLayerDefn( hLayer );
   QString styleQML( QString::fromUtf8(
-                      OGR_F_GetFieldAsString( hFeature,
+                      OGR_F_GetFieldAsString( hFeature.get(),
                           OGR_FD_GetFieldIndex( hLayerDefn, "styleQML" ) ) ) );
-
-  OGR_F_Destroy( hFeature );
 
   mutex1->unlock();
   QgsOgrProviderUtils::release( layerStyles );

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -29,6 +29,7 @@
 #include "qgsgdalproviderbase.h"
 #include "qgsrectangle.h"
 #include "qgscoordinatetransform.h"
+#include "qgsogrutils.h"
 
 #include <QString>
 #include <QStringList>
@@ -330,7 +331,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     mutable VSILFILE *mCachedMemFile = nullptr;
 
     //! Pointer to cached GDAL dataset
-    mutable GDALDatasetH mCachedGdalDataset = nullptr;
+    mutable gdal::dataset_unique_ptr mCachedGdalDataset;
 
     //! Current cache error last getCache() error.
     mutable QgsError mCachedError;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -46,7 +46,7 @@
 #include "qgswmscapabilities.h"
 #include "qgsexception.h"
 #include "qgssettings.h"
-
+#include "qgsogrutils.h"
 
 #ifdef HAVE_GUI
 #include "qgswmssourceselect.h"
@@ -3045,13 +3045,12 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
               QScriptValue geom = json_stringify.call( QScriptValue(), QScriptValueList() << f.property( QStringLiteral( "geometry" ) ) );
               if ( geom.isString() )
               {
-                OGRGeometryH ogrGeom = OGR_G_CreateGeometryFromJson( geom.toString().toUtf8() );
+                gdal::ogr_geometry_unique_ptr ogrGeom( OGR_G_CreateGeometryFromJson( geom.toString().toUtf8() ) );
                 if ( ogrGeom )
                 {
-                  int wkbSize = OGR_G_WkbSize( ogrGeom );
+                  int wkbSize = OGR_G_WkbSize( ogrGeom.get() );
                   unsigned char *wkb = new unsigned char[ wkbSize ];
-                  OGR_G_ExportToWkb( ogrGeom, ( OGRwkbByteOrder ) QgsApplication::endian(), wkb );
-                  OGR_G_DestroyGeometry( ogrGeom );
+                  OGR_G_ExportToWkb( ogrGeom.get(), ( OGRwkbByteOrder ) QgsApplication::endian(), wkb );
 
                   QgsGeometry g;
                   g.fromWkb( wkb, wkbSize );


### PR DESCRIPTION
Implements a c++11 unique_ptr with custom deleter for storing/automatic clean up of some gdal object types.

This fixes at least 2 leaks I noticed while implementing this, and I suspect it has the potential to save many more...