### PR TITLE
QgsTriangle Fix draw (as polygon)

### DIFF
--- a/python/core/geometry/qgstriangle.sip
+++ b/python/core/geometry/qgstriangle.sip
@@ -69,6 +69,9 @@ class QgsTriangle : QgsPolygonV2
 
 
 
+    virtual void draw( QPainter &p ) const;
+
+
     virtual QgsPolygonV2 *surfaceToPolygon() const /Factory/;
 
 

--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -224,6 +224,14 @@ bool QgsTriangle::fromWkt( const QString &wkt )
   return true;
 }
 
+void QgsTriangle::draw( QPainter &p ) const
+{
+  if ( !mExteriorRing )
+    return;
+
+  mExteriorRing->drawAsPolygon( p );
+}
+
 QgsPolygonV2 *QgsTriangle::surfaceToPolygon() const
 {
   return toPolygon();

--- a/src/core/geometry/qgstriangle.h
+++ b/src/core/geometry/qgstriangle.h
@@ -78,6 +78,8 @@ class CORE_EXPORT QgsTriangle : public QgsPolygonV2
     // inherited: QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const;
     // inherited: QString asJSON( int precision = 17 ) const;
 
+    void draw( QPainter &p ) const override;
+
     QgsPolygonV2 *surfaceToPolygon() const override SIP_FACTORY;
 
     QgsCurvePolygon *toCurveType() const override SIP_FACTORY;


### PR DESCRIPTION
## Description
Triangle wasn't drawn (using make_triangle). It's now fixed for polygon. Do you think that we have to add a draw method for linestring?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
