### PR TITLE
[server][bugfix] Consider QUERY_LAYERS as valid layers in GetFeatureInfo 

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -956,6 +956,16 @@ namespace QgsWms
     else
       layers = stylizedLayers( params );
 
+    // add QUERY_LAYERS to list of available layers for more flexibility
+    for ( const QString &queryLayer : queryLayers )
+    {
+      if ( mNicknameLayers.contains( queryLayer )
+           && !layers.contains( mNicknameLayers[queryLayer] ) )
+      {
+        layers.append( mNicknameLayers[queryLayer] );
+      }
+    }
+
     // create the mapSettings and the output image
     QgsMapSettings mapSettings;
     std::unique_ptr<QImage> outputImage( createImage() );

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -84,6 +84,14 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
                                  'wms_getfeatureinfo-text-xml')
 
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=&styles=&' +
+                                 'info_format=text%2Fxml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
+                                 'wms_getfeatureinfo-text-xml')
+
         # Test getfeatureinfo response html
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +


### PR DESCRIPTION
## Description

Another regression raised by @elemoine during its tests with QWC2 is about the `GetFeatureInfo` request and the behavior of LAYERS/QUERY_LAYERS parameters.

With QGIS Server 2.X, these kind of request were allowed:

```
http://localhost/qgisserver?
REQUEST=GetFeatureInfo&
LAYERS=&
QUERY_LAYERS=countries
```

or

```
http://localhost/qgisserver?
REQUEST=GetFeatureInfo&
LAYERS=world&
QUERY_LAYERS=countries
```

Actually, layers in a QUERY_LAYERS didn't have to be indicated in LAYERS. But now with QGIS Server on master, these kind of requests are not allowed anymore and it leads to some issues with QWC2.

This PR allows the server to consider QUERY_LAYERS as valid layers for more flexibility.

And by the way, I tested this PR with Teamengine and it doesn't break OGC tests.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
