### PR TITLE
[processing] keep column names in standard distance matrix (fix #17150)

### DIFF
--- a/python/plugins/processing/algs/qgis/PointDistance.py
+++ b/python/plugins/processing/algs/qgis/PointDistance.py
@@ -16,9 +16,6 @@
 *                                                                         *
 ***************************************************************************
 """
-from builtins import next
-from builtins import str
-from builtins import range
 
 __author__ = 'Victor Olaya'
 __date__ = 'August 2012'
@@ -207,13 +204,14 @@ class PointDistance(QgisAlgorithm):
 
     def regularMatrix(self, parameters, context, source, inField, target_source, targetField,
                       nPoints, feedback):
-
-        index = QgsSpatialIndex(target_source.getFeatures(QgsFeatureRequest().setSubsetOfAttributes([]).setDestinationCrs(source.sourceCrs())), feedback)
-        inIdx = source.fields().lookupField(inField)
-
         distArea = QgsDistanceArea()
         distArea.setSourceCrs(source.sourceCrs())
         distArea.setEllipsoid(context.project().ellipsoid())
+
+        inIdx = source.fields().lookupField(inField)
+        targetIdx = target_source.fields().lookupField(targetField)
+
+        index = QgsSpatialIndex(target_source.getFeatures(QgsFeatureRequest().setSubsetOfAttributes([]).setDestinationCrs(source.sourceCrs())), feedback)
 
         first = True
         sink = None
@@ -225,27 +223,28 @@ class PointDistance(QgisAlgorithm):
                 break
 
             inGeom = inFeat.geometry()
-            inID = str(inFeat.attributes()[inIdx])
-            featList = index.nearestNeighbor(inGeom.asPoint(), nPoints)
             if first:
+                featList = index.nearestNeighbor(inGeom.asPoint(), nPoints)
                 first = False
                 fields = QgsFields()
                 input_id_field = source.fields()[inIdx]
                 input_id_field.setName('ID')
                 fields.append(input_id_field)
-                for i in range(len(featList)):
-                    fields.append(QgsField('DIST_{0}'.format(i + 1), QVariant.Double))
+                for f in target_source.getFeatures(QgsFeatureRequest().setFilterFids(featList).setSubsetOfAttributes([targetIdx]).setDestinationCrs(source.sourceCrs())):
+                    fields.append(QgsField(str(f[targetField]), QVariant.Double))
+
                 (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                        fields, source.wkbType(), source.sourceCrs())
 
-            data = [inID]
+            data = [inFeat[inField]]
             for target in target_source.getFeatures(QgsFeatureRequest().setSubsetOfAttributes([]).setFilterFids(featList).setDestinationCrs(source.sourceCrs())):
                 if feedback.isCanceled():
                     break
                 outGeom = target.geometry()
                 dist = distArea.measureLine(inGeom.asPoint(),
                                             outGeom.asPoint())
-                data.append(float(dist))
+                data.append(dist)
+
             out_feature = QgsFeature()
             out_feature.setGeometry(inGeom)
             out_feature.setAttributes(data)

--- a/python/plugins/processing/tests/testdata/expected/linear_matrix.gml
+++ b/python/plugins/processing/tests/testdata/expected/linear_matrix.gml
@@ -1,0 +1,662 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ linear_matrix.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.0">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.1">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>7.28010988928052</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.2">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>6.32455532033676</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.3">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>3</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.4">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>6.08276253029822</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.5">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>1.4142135623731</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.6">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>4.12310562561766</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.7">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.8">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>2.82842712474619</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.9">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>5</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.10">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>6.40312423743285</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.11">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>5.65685424949238</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.12">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.13">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>8.54400374531753</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.14">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>1.4142135623731</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.15">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.16">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>2.82842712474619</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.17">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.18">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>3.60555127546399</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.19">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>6.70820393249937</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.20">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>5.8309518948453</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.21">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.22">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>7.28010988928052</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.23">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.24">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>3</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.25">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>1.4142135623731</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.26">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>1.4142135623731</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.27">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>5.8309518948453</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.28">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>4.24264068711928</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.29">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>3.60555127546399</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.30">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>1.4142135623731</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.31">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>8.60232526704263</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.32">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>3</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.33">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.34">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>4.12310562561766</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.35">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.36">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>4.47213595499958</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.37">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>4.47213595499958</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.38">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>3.60555127546399</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.39">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.40">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>7.21110255092798</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.41">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.42">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>1.4142135623731</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.43">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>3</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.44">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.45">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>4</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.46">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>8.94427190999916</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.47">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>8.06225774829855</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.48">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>7.21110255092798</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.49">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.50">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>7.28010988928052</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.51">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>8.60232526704263</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.52">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>6.08276253029822</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.53">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>8.54400374531753</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.54">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>8</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.55">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.56">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>1</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.57">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>4.47213595499958</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.58">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>8.94427190999916</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.59">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>6.70820393249937</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.60">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>4.24264068711928</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.61">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>7.28010988928052</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.62">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>6.40312423743285</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.63">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>7</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.64">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>1</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.65">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.66">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>3.60555127546399</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.67">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>8.06225774829855</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.68">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>5.8309518948453</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.69">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>3.60555127546399</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.70">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>6.32455532033676</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.71">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>5.65685424949238</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.72">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.8</ogr:TargetID>
+      <ogr:Distance>0</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.73">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>8,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.6</ogr:TargetID>
+      <ogr:Distance>8</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.74">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.7</ogr:TargetID>
+      <ogr:Distance>7</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.75">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>4,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.4</ogr:TargetID>
+      <ogr:Distance>4.47213595499958</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.76">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-5</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.5</ogr:TargetID>
+      <ogr:Distance>4</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.77">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.2</ogr:TargetID>
+      <ogr:Distance>3.60555127546399</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.78">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>5,2</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.3</ogr:TargetID>
+      <ogr:Distance>5.8309518948453</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.79">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>1,1</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.0</ogr:TargetID>
+      <ogr:Distance>2.23606797749979</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:linear_matrix fid="linear_matrix.80">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0,-1</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3,3</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:TargetID>points.1</ogr:TargetID>
+      <ogr:Distance>5</ogr:Distance>
+    </ogr:linear_matrix>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/linear_matrix.xsd
+++ b/python/plugins/processing/tests/testdata/expected/linear_matrix.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="linear_matrix" type="ogr:linear_matrix_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="linear_matrix_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:MultiPointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="InputID" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="TargetID" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Distance" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/standard_matrix.gml
+++ b/python/plugins/processing/tests/testdata/expected/standard_matrix.gml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ standard_matrix.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.0</ogr:ID>
+      <ogr:points.7>6.32455532033676</ogr:points.7>
+      <ogr:points.6>7.28010988928052</ogr:points.6>
+      <ogr:points.5>6.08276253029822</ogr:points.5>
+      <ogr:points.4>3</ogr:points.4>
+      <ogr:points.8>2.23606797749979</ogr:points.8>
+      <ogr:points.3>4.12310562561766</ogr:points.3>
+      <ogr:points.2>1.4142135623731</ogr:points.2>
+      <ogr:points.1>2.82842712474619</ogr:points.1>
+      <ogr:points.0>0</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.1</ogr:ID>
+      <ogr:points.7>5.65685424949238</ogr:points.7>
+      <ogr:points.6>6.40312423743285</ogr:points.6>
+      <ogr:points.5>8.54400374531753</ogr:points.5>
+      <ogr:points.4>2.23606797749979</ogr:points.4>
+      <ogr:points.8>5</ogr:points.8>
+      <ogr:points.3>2.23606797749979</ogr:points.3>
+      <ogr:points.2>1.4142135623731</ogr:points.2>
+      <ogr:points.1>0</ogr:points.1>
+      <ogr:points.0>2.82842712474619</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.2</ogr:ID>
+      <ogr:points.7>5.8309518948453</ogr:points.7>
+      <ogr:points.6>6.70820393249937</ogr:points.6>
+      <ogr:points.5>7.28010988928052</ogr:points.5>
+      <ogr:points.4>2.23606797749979</ogr:points.4>
+      <ogr:points.8>3.60555127546399</ogr:points.8>
+      <ogr:points.3>3</ogr:points.3>
+      <ogr:points.2>0</ogr:points.2>
+      <ogr:points.1>1.4142135623731</ogr:points.1>
+      <ogr:points.0>1.4142135623731</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.3</ogr:ID>
+      <ogr:points.7>3.60555127546399</ogr:points.7>
+      <ogr:points.6>4.24264068711928</ogr:points.6>
+      <ogr:points.5>8.60232526704263</ogr:points.5>
+      <ogr:points.4>1.4142135623731</ogr:points.4>
+      <ogr:points.8>5.8309518948453</ogr:points.8>
+      <ogr:points.3>0</ogr:points.3>
+      <ogr:points.2>3</ogr:points.2>
+      <ogr:points.1>2.23606797749979</ogr:points.1>
+      <ogr:points.0>4.12310562561766</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.4</ogr:ID>
+      <ogr:points.7>3.60555127546399</ogr:points.7>
+      <ogr:points.6>4.47213595499958</ogr:points.6>
+      <ogr:points.5>7.21110255092798</ogr:points.5>
+      <ogr:points.4>0</ogr:points.4>
+      <ogr:points.8>4.47213595499958</ogr:points.8>
+      <ogr:points.3>1.4142135623731</ogr:points.3>
+      <ogr:points.2>2.23606797749979</ogr:points.2>
+      <ogr:points.1>2.23606797749979</ogr:points.1>
+      <ogr:points.0>3</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.5</ogr:ID>
+      <ogr:points.7>8.06225774829855</ogr:points.7>
+      <ogr:points.6>8.94427190999916</ogr:points.6>
+      <ogr:points.5>0</ogr:points.5>
+      <ogr:points.4>7.21110255092798</ogr:points.4>
+      <ogr:points.8>4</ogr:points.8>
+      <ogr:points.3>8.60232526704263</ogr:points.3>
+      <ogr:points.2>7.28010988928052</ogr:points.2>
+      <ogr:points.1>8.54400374531753</ogr:points.1>
+      <ogr:points.0>6.08276253029822</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.6</ogr:ID>
+      <ogr:points.7>1</ogr:points.7>
+      <ogr:points.6>0</ogr:points.6>
+      <ogr:points.5>8.94427190999916</ogr:points.5>
+      <ogr:points.4>4.47213595499958</ogr:points.4>
+      <ogr:points.8>8</ogr:points.8>
+      <ogr:points.3>4.24264068711928</ogr:points.3>
+      <ogr:points.2>6.70820393249937</ogr:points.2>
+      <ogr:points.1>6.40312423743285</ogr:points.1>
+      <ogr:points.0>7.28010988928052</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.7</ogr:ID>
+      <ogr:points.7>0</ogr:points.7>
+      <ogr:points.6>1</ogr:points.6>
+      <ogr:points.5>8.06225774829855</ogr:points.5>
+      <ogr:points.4>3.60555127546399</ogr:points.4>
+      <ogr:points.8>7</ogr:points.8>
+      <ogr:points.3>3.60555127546399</ogr:points.3>
+      <ogr:points.2>5.8309518948453</ogr:points.2>
+      <ogr:points.1>5.65685424949238</ogr:points.1>
+      <ogr:points.0>6.32455532033676</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:standard_matrix fid="standard_matrix.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>points.8</ogr:ID>
+      <ogr:points.7>7</ogr:points.7>
+      <ogr:points.6>8</ogr:points.6>
+      <ogr:points.5>4</ogr:points.5>
+      <ogr:points.4>4.47213595499958</ogr:points.4>
+      <ogr:points.8>0</ogr:points.8>
+      <ogr:points.3>5.8309518948453</ogr:points.3>
+      <ogr:points.2>3.60555127546399</ogr:points.2>
+      <ogr:points.1>5</ogr:points.1>
+      <ogr:points.0>2.23606797749979</ogr:points.0>
+    </ogr:standard_matrix>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/standard_matrix.xsd
+++ b/python/plugins/processing/tests/testdata/expected/standard_matrix.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="standard_matrix" type="ogr:standard_matrix_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="standard_matrix_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="ID" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.7" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.6" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.5" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.4" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.8" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.3" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.1" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="points.0" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/summary_matrix.gml
+++ b/python/plugins/processing/tests/testdata/expected/summary_matrix.gml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ summary_matrix.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.0</ogr:InputID>
+      <ogr:MEAN>3.69880467001691</ogr:MEAN>
+      <ogr:STDDEV>2.30626191337</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>7.28010988928052</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.1</ogr:InputID>
+      <ogr:MEAN>3.81319543048463</ogr:MEAN>
+      <ogr:STDDEV>2.58491060409319</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>8.54400374531753</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.2</ogr:InputID>
+      <ogr:MEAN>3.49881245492613</ogr:MEAN>
+      <ogr:STDDEV>2.42268910848357</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>7.28010988928052</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.3</ogr:InputID>
+      <ogr:MEAN>3.67276180999575</ogr:MEAN>
+      <ogr:STDDEV>2.37106132315211</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>8.60232526704263</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.4</ogr:InputID>
+      <ogr:MEAN>3.18303058375153</ogr:MEAN>
+      <ogr:STDDEV>1.96680357506854</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>7.21110255092798</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.5</ogr:InputID>
+      <ogr:MEAN>6.52520373790717</ogr:MEAN>
+      <ogr:STDDEV>2.72428269069167</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>8.94427190999916</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.6</ogr:InputID>
+      <ogr:MEAN>5.22783184570342</ogr:MEAN>
+      <ogr:STDDEV>2.90646726642964</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>8.94427190999916</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.7</ogr:InputID>
+      <ogr:MEAN>4.565080195989</ogr:MEAN>
+      <ogr:STDDEV>2.56991969692314</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>8.06225774829855</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:summary_matrix fid="summary_matrix.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:InputID>points.8</ogr:InputID>
+      <ogr:MEAN>4.46052301142318</ogr:MEAN>
+      <ogr:STDDEV>2.28360363804128</ogr:STDDEV>
+      <ogr:MIN>0</ogr:MIN>
+      <ogr:MAX>8</ogr:MAX>
+    </ogr:summary_matrix>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/summary_matrix.xsd
+++ b/python/plugins/processing/tests/testdata/expected/summary_matrix.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="summary_matrix" type="ogr:summary_matrix_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="summary_matrix_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="InputID" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="MEAN" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="STDDEV" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="MIN" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="MAX" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -4299,3 +4299,73 @@ tests:
       OUTPUT:
         name: expected/transect_multi_both_2_30.gml
         type: vector
+
+  - algorithm: qgis:distancematrix
+    name: Linear (N*k x 3) distance matrix
+    params:
+      INPUT:
+        name: points.gml
+        type: vector
+      INPUT_FIELD: fid
+      MATRIX_TYPE: 0
+      NEAREST_POINTS: 0
+      TARGET:
+        name: points.gml
+        type: vector
+      TARGET_FIELD: fid
+    results:
+      OUTPUT:
+        pk:
+        - InputID
+        - TargetID
+        name: expected/linear_matrix.gml
+        type: vector
+        compare:
+          fields:
+            fid: skip
+
+
+  - algorithm: qgis:distancematrix
+    name: Standard (N x T) distance matrix
+    params:
+      INPUT:
+        name: points.gml
+        type: vector
+      INPUT_FIELD: fid
+      MATRIX_TYPE: 1
+      NEAREST_POINTS: 0
+      TARGET:
+        name: points.gml
+        type: vector
+      TARGET_FIELD: fid
+    results:
+      OUTPUT:
+        name: expected/standard_matrix.gml
+        type: vector
+        compare:
+          fields:
+            __all__:
+              precision: 7
+
+  - algorithm: qgis:distancematrix
+    name: Summary distance matrix (mean, std. dev., min, max)
+    params:
+      INPUT:
+        name: points.gml
+        type: vector
+      INPUT_FIELD: fid
+      MATRIX_TYPE: 2
+      NEAREST_POINTS: 0
+      TARGET:
+        name: points.gml
+        type: vector
+      TARGET_FIELD: fid
+    results:
+      OUTPUT:
+        name: expected/summary_matrix.gml
+        type: vector
+        compare:
+          fields:
+            __all__:
+              precision: 7
+


### PR DESCRIPTION
## Description
Use values from unique ID field as column names. Fixes https://issues.qgis.org/issues/17150.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
