### PR TITLE
[auth][needs-docs][feature] Clear access cache

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -377,6 +377,15 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   connect( mBrowseCacheDirectory, &QAbstractButton::clicked, this, &QgsOptions::browseCacheDirectory );
   connect( mClearCache, &QAbstractButton::clicked, this, &QgsOptions::clearCache );
 
+  // Access (auth) cache settings
+  mAutoClearAccessCache->setChecked( mSettings->value( QStringLiteral( "clear_auth_cache_on_errors" ), true, QgsSettings::Section::Auth ).toBool( ) );
+  connect( mClearAccessCache, &QAbstractButton::clicked, this, &QgsOptions::clearAccessCache );
+
+  connect( mAutoClearAccessCache, &QCheckBox::clicked, this, [ = ]( bool checked )
+  {
+    mSettings->setValue( QStringLiteral( "clear_auth_cache_on_errors" ), checked, QgsSettings::Section::Auth );
+  } );
+
   //wms search server
   leWmsSearch->setText( mSettings->value( QStringLiteral( "/qgis/WMSSearchUrl" ), "http://geopole.org/wms/search?search=%1&type=rss" ).toString() );
 
@@ -1978,6 +1987,13 @@ void QgsOptions::browseCacheDirectory()
 void QgsOptions::clearCache()
 {
   QgsNetworkAccessManager::instance()->cache()->clear();
+  QMessageBox::information( this, tr( "Cache cleared" ), tr( "Content cache has been cleared" ) );
+}
+
+void QgsOptions::clearAccessCache()
+{
+  QgsNetworkAccessManager::instance()->clearAccessCache();
+  QMessageBox::information( this, tr( "Cache cleared" ), tr( "Connection authentication cache has been cleared" ) );
 }
 
 void QgsOptions::mOptionsStackedWidget_currentChanged( int indx )

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -187,6 +187,12 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void clearCache();
 
     /**
+     * \brief clearAuthenticationConnectionCache clears the QNetworkAccessManager
+     * authentication connection cache
+     */
+    void clearAccessCache();
+
+    /**
      * Let the user add a scale to the list of scales
      * used in scale combobox
      */

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -141,15 +141,15 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
            this, &QgsAuthEditorWidgets::authMessageOut );
 
   // set up utility actions menu
-  mActionSetMasterPassword = new QAction( QStringLiteral( "Input master password" ), this );
-  mActionClearCachedMasterPassword = new QAction( QStringLiteral( "Clear cached master password" ), this );
-  mActionResetMasterPassword = new QAction( QStringLiteral( "Reset master password" ), this );
-  mActionClearCachedAuthConfigs = new QAction( QStringLiteral( "Clear cached authentication configurations" ), this );
-  mActionRemoveAuthConfigs = new QAction( QStringLiteral( "Remove all authentication configurations" ), this );
-  mActionEraseAuthDatabase = new QAction( QStringLiteral( "Erase authentication database" ), this );
+  mActionSetMasterPassword = new QAction( tr( "Input master password" ), this );
+  mActionClearCachedMasterPassword = new QAction( tr( "Clear cached master password" ), this );
+  mActionResetMasterPassword = new QAction( tr( "Reset master password" ), this );
+  mActionClearCachedAuthConfigs = new QAction( tr( "Clear cached authentication configurations" ), this );
+  mActionRemoveAuthConfigs = new QAction( tr( "Remove all authentication configurations" ), this );
+  mActionEraseAuthDatabase = new QAction( tr( "Erase authentication database" ), this );
 
-  mActionClearAccessCacheNow = new QAction( QStringLiteral( "Clear network authentication access cache" ), this );
-  mActionAutoClearAccessCache = new QAction( QStringLiteral( "Automatically clear network authentication access cache on SSL errors" ), this );
+  mActionClearAccessCacheNow = new QAction( tr( "Clear network authentication access cache" ), this );
+  mActionAutoClearAccessCache = new QAction( tr( "Automatically clear network authentication access cache on SSL errors" ), this );
   mActionAutoClearAccessCache->setCheckable( true );
   mActionAutoClearAccessCache->setChecked( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ), true, QgsSettings::Section::Auth ).toBool( ) );
 

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -151,7 +151,7 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   mActionClearAccessCacheNow = new QAction( QStringLiteral( "Clear network authentication access cache" ), this );
   mActionAutoClearAccessCache = new QAction( QStringLiteral( "Automatically clear network authentication access cache on SSL errors" ), this );
   mActionAutoClearAccessCache->setCheckable( true );
-  mActionAutoClearAccessCache->setChecked( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ), false, QgsSettings::Section::Auth ).toBool( ) );
+  mActionAutoClearAccessCache->setChecked( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ), true, QgsSettings::Section::Auth ).toBool( ) );
 
   mActionPasswordHelperSync = new QAction( tr( "Store/update the master password in your %1" )
       .arg( QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME ), this );

--- a/src/gui/auth/qgsautheditorwidgets.h
+++ b/src/gui/auth/qgsautheditorwidgets.h
@@ -120,6 +120,8 @@ class GUI_EXPORT QgsAuthEditorWidgets : public QWidget, private Ui::QgsAuthEdito
     QAction *mActionPasswordHelperSync = nullptr;
     QAction *mActionPasswordHelperEnable = nullptr;
     QAction *mActionPasswordHelperLoggingEnable = nullptr;
+    QAction *mActionClearAccessCacheNow = nullptr;
+    QAction *mActionAutoClearAccessCache = nullptr;
 };
 
 #endif // QGSAUTHEDITORWIDGETS_H

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -56,11 +56,6 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
   }
 
   setupUi( this );
-  cbClearAuthCacheOnErrors->setChecked( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ), false, QgsSettings::Section::Auth ).toBool( ) );
-  connect( cbClearAuthCacheOnErrors, &QCheckBox::clicked, this, [ ]( bool checked )
-  {
-    QgsSettings().setValue( QStringLiteral( "clear_auth_cache_on_errors" ), checked, QgsSettings::Section::Auth );
-  } );
   connect( buttonBox, &QDialogButtonBox::clicked, this, &QgsAuthSslErrorsDialog::buttonBox_clicked );
   connect( btnChainInfo, &QToolButton::clicked, this, &QgsAuthSslErrorsDialog::btnChainInfo_clicked );
   connect( btnChainCAs, &QToolButton::clicked, this, &QgsAuthSslErrorsDialog::btnChainCAs_clicked );
@@ -194,9 +189,11 @@ void QgsAuthSslErrorsDialog::buttonBox_clicked( QAbstractButton *button )
       reject();
       break;
   }
-  // Clear access cache
-  if ( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ),
-                            false,
+  // Clear access cache if the user choose ignore and the
+  // setting allows it
+  if ( btnenum == QDialogButtonBox::Abort &&
+       QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ),
+                            true,
                             QgsSettings::Section::Auth ).toBool( ) )
   {
     QgsNetworkAccessManager::instance()->clearAccessCache();

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -189,7 +189,7 @@ void QgsAuthSslErrorsDialog::buttonBox_clicked( QAbstractButton *button )
       reject();
       break;
   }
-  // Clear access cache if the user choose ignore and the
+  // Clear access cache if the user choose abort and the
   // setting allows it
   if ( btnenum == QDialogButtonBox::Abort &&
        QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ),

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -25,6 +25,7 @@
 #include <QToolButton>
 
 #include "qgsauthmanager.h"
+#include "qgsnetworkaccessmanager.h"
 #include "qgsauthcertutils.h"
 #include "qgsauthtrustedcasdialog.h"
 #include "qgscollapsiblegroupbox.h"
@@ -55,6 +56,11 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
   }
 
   setupUi( this );
+  cbClearAuthCacheOnErrors->setChecked( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ), false, QgsSettings::Section::Auth ).toBool( ) );
+  connect( cbClearAuthCacheOnErrors, &QCheckBox::clicked, this, [ ]( bool checked )
+  {
+    QgsSettings().setValue( QStringLiteral( "clear_auth_cache_on_errors" ), checked, QgsSettings::Section::Auth );
+  } );
   connect( buttonBox, &QDialogButtonBox::clicked, this, &QgsAuthSslErrorsDialog::buttonBox_clicked );
   connect( btnChainInfo, &QToolButton::clicked, this, &QgsAuthSslErrorsDialog::btnChainInfo_clicked );
   connect( btnChainCAs, &QToolButton::clicked, this, &QgsAuthSslErrorsDialog::btnChainCAs_clicked );
@@ -187,6 +193,13 @@ void QgsAuthSslErrorsDialog::buttonBox_clicked( QAbstractButton *button )
     default:
       reject();
       break;
+  }
+  // Clear access cache
+  if ( QgsSettings().value( QStringLiteral( "clear_auth_cache_on_errors" ),
+                            false,
+                            QgsSettings::Section::Auth ).toBool( ) )
+  {
+    QgsNetworkAccessManager::instance()->clearAccessCache();
   }
 }
 

--- a/src/ui/auth/qgsauthsslerrorsdialog.ui
+++ b/src/ui/auth/qgsauthsslerrorsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>617</width>
-    <height>710</height>
+    <width>568</width>
+    <height>550</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -169,7 +169,7 @@
        </sizepolicy>
       </property>
       <property name="title">
-       <string>Save SSL server exception</string>
+       <string>Save SSL server e&amp;xception</string>
       </property>
       <property name="checkable">
        <bool>true</bool>
@@ -219,14 +219,28 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Abort|QDialogButtonBox::Ignore|QDialogButtonBox::Save</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QCheckBox" name="cbClearAuthCacheOnErrors">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The authentication cache stores all connections even when the connection fails. &lt;/p&gt;&lt;p&gt;If you make any change to the authentication configuration or to the CAs you should clear the authentication cache or restart QGIS. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;When this option is checked, it will clear the authentication cache when this dialog is closed.&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Clear authentication cache</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Abort|QDialogButtonBox::Ignore|QDialogButtonBox::Save</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/ui/auth/qgsauthsslerrorsdialog.ui
+++ b/src/ui/auth/qgsauthsslerrorsdialog.ui
@@ -6,9 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>568</width>
-    <height>550</height>
+    <width>493</width>
+    <height>430</height>
    </rect>
+  </property>
+  <property name="contextMenuPolicy">
+   <enum>Qt::PreventContextMenu</enum>
   </property>
   <property name="windowTitle">
    <string>Custom Certificate Configuration</string>
@@ -220,16 +223,6 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="cbClearAuthCacheOnErrors">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The authentication cache stores all connections even when the connection fails. &lt;/p&gt;&lt;p&gt;If you make any change to the authentication configuration or to the CAs you should clear the authentication cache or restart QGIS. &lt;/p&gt;&lt;p&gt;&lt;br/&gt;When this option is checked, it will clear the authentication cache when this dialog is closed.&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Clear authentication cache</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -308,7 +308,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>12</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -337,15 +337,15 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>580</width>
-                <height>672</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="grpLocale">
                  <property name="title">
-                  <string>O&amp;verride system locale</string>
+                  <string>Override system &amp;locale</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -1032,7 +1032,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>537</width>
+                <width>846</width>
                 <height>1128</height>
                </rect>
               </property>
@@ -1562,8 +1562,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>499</width>
-                <height>754</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1930,7 +1930,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>672</width>
+                <width>846</width>
                 <height>1043</height>
                </rect>
               </property>
@@ -2681,8 +2681,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>130</width>
-                <height>322</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -2832,8 +2832,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>500</width>
-                <height>340</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3175,8 +3175,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>623</width>
-                <height>734</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3619,8 +3619,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>491</width>
-                <height>610</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -3888,8 +3888,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>548</width>
-                <height>785</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4466,8 +4466,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>431</width>
-                <height>376</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4605,8 +4605,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>418</width>
-                <height>544</height>
+                <width>866</width>
+                <height>822</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -4755,7 +4755,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   <item row="3" column="0">
                    <widget class="QRadioButton" name="radUseGlobalProjection">
                     <property name="text">
-                     <string>Use a default CRS</string>
+                     <string>&amp;Use a default CRS</string>
                     </property>
                    </widget>
                   </item>
@@ -4947,53 +4947,88 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <property name="title">
                   <string>Cache settings</string>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_2">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_10">
-                    <property name="text">
-                     <string>Directory</string>
+                 <layout class="QVBoxLayout" name="verticalLayout_19">
+                  <item>
+                   <widget class="QTabWidget" name="tabContentCache">
+                    <property name="currentIndex">
+                     <number>0</number>
                     </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="mCacheDirectory"/>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QToolButton" name="mBrowseCacheDirectory">
-                    <property name="toolTip">
-                     <string>Select folder</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_11">
-                    <property name="text">
-                     <string>Size [KiB]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QSpinBox" name="mCacheSize"/>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QToolButton" name="mClearCache">
-                    <property name="toolTip">
-                     <string>Clear</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
-                    </property>
+                    <widget class="QWidget" name="tab">
+                     <attribute name="title">
+                      <string>Content</string>
+                     </attribute>
+                     <layout class="QGridLayout" name="gridLayout_2">
+                      <item row="4" column="0">
+                       <widget class="QLabel" name="label_11">
+                        <property name="text">
+                         <string>Size [KiB]</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_10">
+                        <property name="text">
+                         <string>Directory</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="1">
+                       <widget class="QLineEdit" name="mCacheDirectory"/>
+                      </item>
+                      <item row="4" column="1">
+                       <widget class="QSpinBox" name="mCacheSize"/>
+                      </item>
+                      <item row="0" column="2">
+                       <widget class="QToolButton" name="mBrowseCacheDirectory">
+                        <property name="toolTip">
+                         <string>Select folder</string>
+                        </property>
+                        <property name="text">
+                         <string/>
+                        </property>
+                        <property name="icon">
+                         <iconset resource="../../images/images.qrc">
+                          <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="4" column="2">
+                       <widget class="QToolButton" name="mClearCache">
+                        <property name="toolTip">
+                         <string>Clear cache</string>
+                        </property>
+                        <property name="text">
+                         <string/>
+                        </property>
+                        <property name="icon">
+                         <iconset resource="../../images/images.qrc">
+                          <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                    <widget class="QWidget" name="tab_2">
+                     <attribute name="title">
+                      <string>Authentication</string>
+                     </attribute>
+                     <layout class="QGridLayout" name="gridLayout_5">
+                      <item row="0" column="0">
+                       <widget class="QCheckBox" name="mAutoClearAccessCache">
+                        <property name="text">
+                         <string>Automatically clear the connection authentication cache on SSL errors</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="0">
+                       <widget class="QPushButton" name="mClearAccessCache">
+                        <property name="text">
+                         <string>Clear authentication connection cache</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
                    </widget>
                   </item>
                  </layout>
@@ -5610,9 +5645,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
   <tabstop>mDefaultTileMaxRetrySpinBox</tabstop>
   <tabstop>leUserAgent</tabstop>
   <tabstop>mCacheDirectory</tabstop>
-  <tabstop>mBrowseCacheDirectory</tabstop>
   <tabstop>mCacheSize</tabstop>
-  <tabstop>mClearCache</tabstop>
   <tabstop>grpProxy</tabstop>
   <tabstop>mProxyTypeComboBox</tabstop>
   <tabstop>leProxyHost</tabstop>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -5016,7 +5016,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                       <item row="0" column="0">
                        <widget class="QCheckBox" name="mAutoClearAccessCache">
                         <property name="toolTip">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The connection cache stores all authentication connections data even when the connection fails.&lt;br/&gt;If you make any change to the authentication configurations or to the certification authorities, you should clear the authentication cache or&lt;br/&gt;restart QGIS. &lt;br/&gt;When this option is checked, it will clear the authentication cache every time an SSL error occurs and you choose tole abort the connection.&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The connection cache stores all authentication connections data even when the connection fails.&lt;br/&gt;If you make any change to the authentication configurations or to the certification authorities, you should clear the authentication cache or&lt;br/&gt;restart QGIS. &lt;br/&gt;When this option is checked, the authentication cache will be automatically cleared every time an SSL error occurs and you choose to abort the connection.&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                         </property>
                         <property name="text">
                          <string>Automatically clear the connection authentication cache on SSL errors (recommended)</string>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -337,8 +337,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>580</width>
+                <height>804</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1032,7 +1032,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>846</width>
+                <width>537</width>
                 <height>1128</height>
                </rect>
               </property>
@@ -1562,8 +1562,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>499</width>
+                <height>754</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1930,7 +1930,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>846</width>
+                <width>672</width>
                 <height>1043</height>
                </rect>
               </property>
@@ -2681,8 +2681,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>130</width>
+                <height>322</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -2832,8 +2832,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>500</width>
+                <height>340</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3175,8 +3175,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>623</width>
+                <height>734</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3619,8 +3619,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>491</width>
+                <height>610</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -3888,8 +3888,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>548</width>
+                <height>785</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4466,8 +4466,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>431</width>
+                <height>376</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4605,8 +4605,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>866</width>
-                <height>822</height>
+                <width>418</width>
+                <height>544</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -5015,8 +5015,11 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <layout class="QGridLayout" name="gridLayout_5">
                       <item row="0" column="0">
                        <widget class="QCheckBox" name="mAutoClearAccessCache">
+                        <property name="toolTip">
+                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The connection cache stores all authentication connections data even when the connection fails.&lt;br/&gt;If you make any change to the authentication configurations or to the certification authorities, you should clear the authentication cache or&lt;br/&gt;restart QGIS. &lt;br/&gt;When this option is checked, it will clear the authentication cache every time an SSL error occurs and you choose tole abort the connection.&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        </property>
                         <property name="text">
-                         <string>Automatically clear the connection authentication cache on SSL errors</string>
+                         <string>Automatically clear the connection authentication cache on SSL errors (recommended)</string>
                         </property>
                        </widget>
                       </item>


### PR DESCRIPTION
## Description
This fixes a bug that required to restart
QGIS after a connection failed due to SSL
errors (the connection auth was cached).

## Snapshots

![options-cache-2](https://user-images.githubusercontent.com/142164/31902623-c221f9a6-b825-11e7-84d4-cbbe36d00efa.png)
![options-cache-1](https://user-images.githubusercontent.com/142164/31902624-c2466548-b825-11e7-89bd-d31f3dde2d51.png)
![options-cache-3](https://user-images.githubusercontent.com/142164/31902622-c1ed792e-b825-11e7-8059-66fb081b511d.png)

## Also

- added a tab for content and connection
  auth cache configuration
- user feedback on (both) caches cleared
- changed icon for content cache clear to
  a trash bin (after users enquiries about
  what was that "back/undo" icon for)