### PR TITLE
allow pipe character in filepath in processing

### DIFF
--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -709,6 +709,21 @@ void TestQgsProcessing::mapLayers()
   QCOMPARE( l->type(), QgsMapLayer::VectorLayer );
   QCOMPARE( l->name(), QStringLiteral( "multipoint" ) );
   delete l;
+
+  // Test layers from a string with parameters
+  QString osmFilePath = testDataDir + "openstreetmap/testdata.xml";
+  QgsVectorLayer *osm = qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath ) );
+  QVERIFY( osm->isValid() );
+  QCOMPARE( osm->geometryType(), QgsWkbTypes::PointGeometry );
+
+  osm = qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3" ) );
+  QVERIFY( osm->isValid() );
+  QCOMPARE( osm->geometryType(), QgsWkbTypes::PolygonGeometry );
+
+  osm = qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3|subset=\"building\" is not null" ) );
+  QVERIFY( osm->isValid() );
+  QCOMPARE( osm->geometryType(), QgsWkbTypes::PolygonGeometry );
+  QCOMPARE( osm->subsetString(), QStringLiteral( "\"building\" is not null" ) );
 }
 
 void TestQgsProcessing::mapLayerFromStore()


### PR DESCRIPTION
## Description

* allow pipe character in filepath in processing

Useful if we have a path like:
`/path/to/file.osm|layerid=3|subset="highway" is not null`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit