### PR TITLE
Update Attribute Table after field calculation: fixes #17312

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -516,7 +516,8 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer* layer, const 
     // refresh table with updated values
     // fixes https://issues.qgis.org/issues/17312
     QgsAttributeTableModel* masterModel = mMainView->masterModel();
-    masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
+    int modelColumn = masterModel->fieldCol( fieldindex );
+    masterModel->reload( masterModel->index( 0, modelColumn ), masterModel->index( masterModel->rowCount() - 1, modelColumn ) );
   }
 }
 

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -512,6 +512,11 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer* layer, const 
   }
 
   mLayer->endEditCommand();
+
+  // refresh table with updated values
+  // fixes https://issues.qgis.org/issues/17312
+  QgsAttributeTableModel* masterModel = mMainView->masterModel();
+  masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
 }
 
 void QgsAttributeTableDialog::replaceSearchWidget( QWidget* oldw, QWidget* neww )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -508,15 +508,16 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer* layer, const 
   {
     QMessageBox::critical( nullptr, tr( "Error" ), tr( "An error occurred while evaluating the calculation string:\n%1" ).arg( error ) );
     mLayer->destroyEditCommand();
-    return;
   }
+  else
+  {
+    mLayer->endEditCommand();
 
-  mLayer->endEditCommand();
-
-  // refresh table with updated values
-  // fixes https://issues.qgis.org/issues/17312
-  QgsAttributeTableModel* masterModel = mMainView->masterModel();
-  masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
+    // refresh table with updated values
+    // fixes https://issues.qgis.org/issues/17312
+    QgsAttributeTableModel* masterModel = mMainView->masterModel();
+    masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
+  }
 }
 
 void QgsAttributeTableDialog::replaceSearchWidget( QWidget* oldw, QWidget* neww )


### PR DESCRIPTION
## Description
The attribute table is not updated because listener of endEditCommand does no more reload masterModel to avoid change row postion during editing.
This patch reload masterModel explicitly as done in other part of the same code.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
