### PR TITLE
[auth] Authmanager singleton API removal

### DIFF
--- a/python/core/auth/qgsauthmanager.sip
+++ b/python/core/auth/qgsauthmanager.sip
@@ -32,13 +32,15 @@ class QgsAuthManager : QObject
       CRITICAL
     };
 
-    static QgsAuthManager *instance();
+    bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
 %Docstring
- Enforce singleton pattern
-.. note::
-
-   To set up the manager instance and initialize everything use QgsAuthManager.instance()->init()
- :rtype: QgsAuthManager
+ init initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
+ \param pluginPath the plugin path
+ \param authDatabasePath the authentication DB path
+ :return: true on success
+.. seealso:: QgsApplication.pluginPath
+.. seealso:: QgsApplication.qgisAuthDatabaseFilePath
+ :rtype: bool
 %End
 
     ~QgsAuthManager();
@@ -61,11 +63,6 @@ Name of the authentication database table that stores server exceptions/configs
  :rtype: str
 %End
 
-    bool init( const QString &pluginPath = QString() );
-%Docstring
-Initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
- :rtype: bool
-%End
 
     bool isDisabled() const;
 %Docstring
@@ -738,6 +735,16 @@ Clear an authentication config from its associated authentication method cache
 %End
 
   protected:
+
+    static QgsAuthManager *instance();
+%Docstring
+ Enforce singleton pattern
+.. note::
+
+   To set up the manager instance and initialize everything use QgsAuthManager.instance()->init()
+ :rtype: QgsAuthManager
+%End
+
     explicit QgsAuthManager();
 
 };

--- a/python/core/auth/qgsauthmanager.sip
+++ b/python/core/auth/qgsauthmanager.sip
@@ -736,16 +736,7 @@ Clear an authentication config from its associated authentication method cache
 
   protected:
 
-    static QgsAuthManager *instance();
-%Docstring
- Enforce singleton pattern
-.. note::
 
-   To set up the manager instance and initialize everything use QgsAuthManager.instance()->init()
- :rtype: QgsAuthManager
-%End
-
-    explicit QgsAuthManager();
 
 };
 

--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -682,6 +682,17 @@ Returns path to the build output directory. Valid only when running from build d
  :rtype: QgsMessageLog
 %End
 
+    static QgsAuthManager *authManager();
+%Docstring
+ Returns the application's authentication manager instance
+.. note::
+
+   this can be a null pointer if called before initQgis
+.. seealso:: initQgis
+.. versionadded:: 3.0
+ :rtype: QgsAuthManager
+%End
+
     static QgsProcessingRegistry *processingRegistry();
 %Docstring
  Returns the application's processing registry, used for managing processing providers,

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -683,19 +683,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mTray->setIcon( QIcon( QgsApplication::appIconPath() ) );
   mTray->hide();
 
-  startProfile( QStringLiteral( "Initializing authentication" ) );
-  mSplash->showMessage( tr( "Initializing authentication" ), Qt::AlignHCenter | Qt::AlignBottom );
-  qApp->processEvents();
-  QgsAuthManager::instance()->init( QgsApplication::pluginPath() );
-  if ( !QgsAuthManager::instance()->isDisabled() )
-  {
-    masterPasswordSetup();
-  }
-  endProfile();
-
-  // Setup QgsNetworkAccessManager (this needs to happen after authentication, for proxy settings)
-  namSetup();
-
   // Create the themes folder for the user
   startProfile( QStringLiteral( "Creating theme folder" ) );
   QgsApplication::createThemeFolder();
@@ -1007,6 +994,19 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mSplash->showMessage( tr( "Checking provider plugins" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();
   QgsApplication::initQgis();
+
+  if ( !QgsApplication::authManager()->isDisabled() )
+  {
+    // Most of the auth initialization is done inside initQgis
+    startProfile( QStringLiteral( "Initializing authentication" ) );
+    mSplash->showMessage( tr( "Initializing authentication" ), Qt::AlignHCenter | Qt::AlignBottom );
+    qApp->processEvents();
+    masterPasswordSetup();
+    endProfile();
+  }
+
+  // Setup QgsNetworkAccessManager (this needs to happen after authentication, for proxy settings)
+  namSetup();
 
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsQlrDataItemProvider() );
   registerCustomDropHandler( new QgsQlrDropHandler() );
@@ -9917,7 +9917,7 @@ QgsVectorLayer *QgisApp::addVectorLayer( const QString &vectorLayerPath, const Q
     authok = false;
     if ( !QgsAuthGuiUtils::isDisabled( messageBar(), messageTimeout() ) )
     {
-      authok = QgsAuthManager::instance()->setMasterPassword( true );
+      authok = QgsApplication::authManager()->setMasterPassword( true );
     }
   }
 
@@ -12636,7 +12636,7 @@ void QgisApp::namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors
   QString digest( QgsAuthCertUtils::shaHexForCert( reply->sslConfiguration().peerCertificate() ) );
   QString dgsthostport( QStringLiteral( "%1:%2" ).arg( digest, hostport ) );
 
-  const QHash<QString, QSet<QSslError::SslError> > &errscache( QgsAuthManager::instance()->getIgnoredSslErrorCache() );
+  const QHash<QString, QSet<QSslError::SslError> > &errscache( QgsApplication::authManager()->getIgnoredSslErrorCache() );
 
   if ( errscache.contains( dgsthostport ) )
   {
@@ -12715,11 +12715,11 @@ void QgisApp::namUpdate()
 
 void QgisApp::masterPasswordSetup()
 {
-  connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+  connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
            this, &QgisApp::authMessageOut );
-  connect( QgsAuthManager::instance(), &QgsAuthManager::passwordHelperMessageOut,
+  connect( QgsApplication::authManager(), &QgsAuthManager::passwordHelperMessageOut,
            this, &QgisApp::authMessageOut );
-  connect( QgsAuthManager::instance(), &QgsAuthManager::authDatabaseEraseRequested,
+  connect( QgsApplication::authManager(), &QgsAuthManager::authDatabaseEraseRequested,
            this, &QgisApp::eraseAuthenticationDatabase );
 }
 
@@ -12737,7 +12737,7 @@ void QgisApp::eraseAuthenticationDatabase()
     if ( layertree && layertree->customProperty( QStringLiteral( "loading" ) ).toBool() )
     {
       QgsDebugMsg( "Project loading, skipping auth db erase" );
-      QgsAuthManager::instance()->setScheduledAuthDatabaseEraseRequestEmitted( false );
+      QgsApplication::authManager()->setScheduledAuthDatabaseEraseRequestEmitted( false );
       return;
     }
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -997,12 +997,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   if ( !QgsApplication::authManager()->isDisabled() )
   {
-    // Most of the auth initialization is done inside initQgis
-    startProfile( QStringLiteral( "Initializing authentication" ) );
-    mSplash->showMessage( tr( "Initializing authentication" ), Qt::AlignHCenter | Qt::AlignBottom );
-    qApp->processEvents();
+    // Most of the auth initialization is now done inside initQgis, no need to profile here
     masterPasswordSetup();
-    endProfile();
   }
 
   // Setup QgsNetworkAccessManager (this needs to happen after authentication, for proxy settings)

--- a/src/auth/basic/qgsauthbasicmethod.cpp
+++ b/src/auth/basic/qgsauthbasicmethod.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 #include <QNetworkProxy>
 #include <QMutexLocker>
@@ -182,7 +183,7 @@ QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg,
   }
 
   // else build basic bundle
-  if ( !QgsAuthManager::instance()->loadAuthenticationConfig( authcfg, mconfig, fullconfig ) )
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, fullconfig ) )
   {
     QgsDebugMsg( QString( "Retrieve config FAILED for authcfg: %1" ).arg( authcfg ) );
     return QgsAuthMethodConfig();

--- a/src/auth/identcert/qgsauthidentcertedit.cpp
+++ b/src/auth/identcert/qgsauthidentcertedit.cpp
@@ -75,7 +75,7 @@ void QgsAuthIdentCertEdit::populateIdentityComboBox()
 {
   cmbIdentityCert->addItem( tr( "Select identity..." ), "" );
 
-  QList<QSslCertificate> certs( QgsAuthManager::instance()->getCertIdentities() );
+  QList<QSslCertificate> certs( QgsApplication::authManager()->getCertIdentities() );
   if ( !certs.isEmpty() )
   {
     cmbIdentityCert->setIconSize( QSize( 26, 22 ) );

--- a/src/auth/identcert/qgsauthidentcertmethod.cpp
+++ b/src/auth/identcert/qgsauthidentcertmethod.cpp
@@ -30,6 +30,7 @@
 #include "qgsauthcertutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 static const QString AUTH_METHOD_KEY = QStringLiteral( "Identity-Cert" );
 static const QString AUTH_METHOD_DESCRIPTION = QStringLiteral( "Identity certificate authentication" );
@@ -143,7 +144,7 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
   // save CAs to temp file
   QString caFilePath = QgsAuthCertUtils::pemTextToTempFile(
                          pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                         QgsAuthManager::instance()->getTrustedCaCertsPemText() );
+                         QgsApplication::authManager()->getTrustedCaCertsPemText() );
   if ( caFilePath.isEmpty() )
   {
     return false;
@@ -238,14 +239,14 @@ QgsPkiConfigBundle *QgsAuthIdentCertMethod::getPkiConfigBundle( const QString &a
   // else build PKI bundle
   QgsAuthMethodConfig mconfig;
 
-  if ( !QgsAuthManager::instance()->loadAuthenticationConfig( authcfg, mconfig, true ) )
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, true ) )
   {
     QgsDebugMsg( QString( "PKI bundle for authcfg %1: FAILED to retrieve config" ).arg( authcfg ) );
     return bundle;
   }
 
   // get identity from database
-  QPair<QSslCertificate, QSslKey> cibundle( QgsAuthManager::instance()->getCertIdentityBundle( mconfig.config( QStringLiteral( "certid" ) ) ) );
+  QPair<QSslCertificate, QSslKey> cibundle( QgsApplication::authManager()->getCertIdentityBundle( mconfig.config( QStringLiteral( "certid" ) ) ) );
 
   // init client cert
   // Note: if this is not valid, no sense continuing

--- a/src/auth/pkipaths/qgsauthpkipathsmethod.cpp
+++ b/src/auth/pkipaths/qgsauthpkipathsmethod.cpp
@@ -30,6 +30,7 @@
 #include "qgsauthcertutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 static const QString AUTH_METHOD_KEY = QStringLiteral( "PKI-Paths" );
@@ -160,17 +161,17 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
   {
     if ( pkibundle->config().config( QStringLiteral( "addrootca" ), QStringLiteral( "false" ) ) ==  QStringLiteral( "true" ) )
     {
-      cas = QgsAuthCertUtils::casMerge( QgsAuthManager::instance()->getTrustedCaCerts(), pkibundle->caChain() );
+      cas = QgsAuthCertUtils::casMerge( QgsApplication::authManager()->getTrustedCaCerts(), pkibundle->caChain() );
     }
     else
     {
-      cas = QgsAuthCertUtils::casMerge( QgsAuthManager::instance()->getTrustedCaCerts(),
+      cas = QgsAuthCertUtils::casMerge( QgsApplication::authManager()->getTrustedCaCerts(),
                                         QgsAuthCertUtils::casRemoveSelfSigned( pkibundle->caChain() ) );
     }
   }
   else
   {
-    cas = QgsAuthManager::instance()->getTrustedCaCerts();
+    cas = QgsApplication::authManager()->getTrustedCaCerts();
   }
 
   // save CAs to temp file
@@ -274,7 +275,7 @@ QgsPkiConfigBundle *QgsAuthPkiPathsMethod::getPkiConfigBundle( const QString &au
   // else build PKI bundle
   QgsAuthMethodConfig mconfig;
 
-  if ( !QgsAuthManager::instance()->loadAuthenticationConfig( authcfg, mconfig, true ) )
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, true ) )
   {
     QgsDebugMsg( QString( "PKI bundle for authcfg %1: FAILED to retrieve config" ).arg( authcfg ) );
     return bundle;

--- a/src/auth/pkipkcs12/qgsauthpkcs12method.cpp
+++ b/src/auth/pkipkcs12/qgsauthpkcs12method.cpp
@@ -30,6 +30,7 @@
 #include "qgsauthcertutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 static const QString AUTH_METHOD_KEY = QStringLiteral( "PKI-PKCS#12" );
@@ -160,17 +161,17 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
   {
     if ( pkibundle->config().config( QStringLiteral( "addrootca" ), QStringLiteral( "false" ) ) ==  QStringLiteral( "true" ) )
     {
-      cas = QgsAuthCertUtils::casMerge( QgsAuthManager::instance()->getTrustedCaCerts(), pkibundle->caChain() );
+      cas = QgsAuthCertUtils::casMerge( QgsApplication::authManager()->getTrustedCaCerts(), pkibundle->caChain() );
     }
     else
     {
-      cas = QgsAuthCertUtils::casMerge( QgsAuthManager::instance()->getTrustedCaCerts(),
+      cas = QgsAuthCertUtils::casMerge( QgsApplication::authManager()->getTrustedCaCerts(),
                                         QgsAuthCertUtils::casRemoveSelfSigned( pkibundle->caChain() ) );
     }
   }
   else
   {
-    cas = QgsAuthManager::instance()->getTrustedCaCerts();
+    cas = QgsApplication::authManager()->getTrustedCaCerts();
   }
 
   // save CAs to temp file
@@ -273,7 +274,7 @@ QgsPkiConfigBundle *QgsAuthPkcs12Method::getPkiConfigBundle( const QString &auth
   // else build PKI bundle
   QgsAuthMethodConfig mconfig;
 
-  if ( !QgsAuthManager::instance()->loadAuthenticationConfig( authcfg, mconfig, true ) )
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, true ) )
   {
     QgsDebugMsg( QString( "PKI bundle for authcfg %1: FAILED to retrieve config" ).arg( authcfg ) );
     return bundle;

--- a/src/core/auth/qgsauthcertutils.cpp
+++ b/src/core/auth/qgsauthcertutils.cpp
@@ -25,6 +25,7 @@
 
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 QString QgsAuthCertUtils::getSslProtocolName( QSsl::SslProtocol protocol )
 {
@@ -419,7 +420,7 @@ QString QgsAuthCertUtils::getCertDistinguishedName( const QSslCertificate &qcert
     const QCA::Certificate &acert,
     bool issuer )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
     return QString();
 
   if ( acert.isNull() )
@@ -505,7 +506,7 @@ QString QgsAuthCertUtils::shaHexForCert( const QSslCertificate &cert, bool forma
 
 QCA::Certificate QgsAuthCertUtils::qtCertToQcaCert( const QSslCertificate &cert )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
     return QCA::Certificate();
 
   QCA::ConvertResult res;
@@ -521,7 +522,7 @@ QCA::Certificate QgsAuthCertUtils::qtCertToQcaCert( const QSslCertificate &cert 
 QCA::CertificateCollection QgsAuthCertUtils::qtCertsToQcaCollection( const QList<QSslCertificate> &certs )
 {
   QCA::CertificateCollection qcacoll;
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
     return qcacoll;
 
   for ( const auto &cert : certs )
@@ -690,7 +691,7 @@ QList<QgsAuthCertUtils::CertUsageType> QgsAuthCertUtils::certificateUsageTypes( 
 {
   QList<QgsAuthCertUtils::CertUsageType> usages;
 
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
     return usages;
 
   QCA::ConvertResult res;
@@ -724,9 +725,9 @@ QList<QgsAuthCertUtils::CertUsageType> QgsAuthCertUtils::certificateUsageTypes( 
 
   // ask QCA what it thinks about potential usages
   QCA::CertificateCollection trustedCAs(
-    qtCertsToQcaCollection( QgsAuthManager::instance()->getTrustedCaCertsCache() ) );
+    qtCertsToQcaCollection( QgsApplication::authManager()->getTrustedCaCertsCache() ) );
   QCA::CertificateCollection untrustedCAs(
-    qtCertsToQcaCollection( QgsAuthManager::instance()->getUntrustedCaCerts() ) );
+    qtCertsToQcaCollection( QgsApplication::authManager()->getUntrustedCaCerts() ) );
 
   QCA::Validity v_any;
   v_any = qcacert.validate( trustedCAs, untrustedCAs, QCA::UsageAny, QCA::ValidateAll );
@@ -790,7 +791,7 @@ bool QgsAuthCertUtils::certificateIsSslServer( const QSslCertificate &cert )
   //       only what it should not be able to do (cert sign, etc.). The logic here may need refined
   // see: http://security.stackexchange.com/a/26650
 
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
     return false;
 
   QCA::ConvertResult res;

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -197,7 +197,7 @@ bool QgsAuthManager::init( const QString &pluginPath, const QString &authDatabas
     return isDisabled();
   }
 
-  mAuthDbPath = authDatabasePath;
+  mAuthDbPath = QDir::cleanPath( authDatabasePath );
   QgsDebugMsg( QString( "Auth database path: %1" ).arg( authenticationDatabasePath() ) );
 
   QFileInfo dbinfo( authenticationDatabasePath() );

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -74,10 +74,14 @@ class CORE_EXPORT QgsAuthManager : public QObject
     Q_ENUM( MessageLevel );
 
     /**
-     * Enforce singleton pattern
-     * \note To set up the manager instance and initialize everything use QgsAuthManager::instance()->init()
+     * \brief init initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
+     * \param pluginPath the plugin path
+     * \param authDatabasePath the authentication DB path
+     * \return true on success
+     * \see QgsApplication::pluginPath
+     * \see QgsApplication::qgisAuthDatabaseFilePath
      */
-    static QgsAuthManager *instance();
+    bool init( const QString &pluginPath = QString(),  const QString &authDatabasePath = QString() );
 
     ~QgsAuthManager();
 
@@ -90,8 +94,6 @@ class CORE_EXPORT QgsAuthManager : public QObject
     //! Name of the authentication database table that stores server exceptions/configs
     const QString authDatabaseServersTable() const { return AUTH_SERVERS_TABLE; }
 
-    //! Initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database
-    bool init( const QString &pluginPath = QString() );
 
     //! Whether QCA has the qca-ossl plugin, which a base run-time requirement
     bool isDisabled() const;
@@ -643,6 +645,13 @@ class CORE_EXPORT QgsAuthManager : public QObject
     void tryToStartDbErase();
 
   protected:
+
+    /**
+     * Enforce singleton pattern
+     * \note To set up the manager instance and initialize everything use QgsAuthManager::instance()->init()
+     */
+    static QgsAuthManager *instance();
+
     explicit QgsAuthManager();
 
   private:
@@ -790,6 +799,8 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
     //! password helper folder in the wallets
     static const QLatin1String AUTH_PASSWORD_HELPER_FOLDER_NAME;
+
+    friend class QgsApplication;
 
 };
 

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -650,9 +650,9 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Enforce singleton pattern
      * \note To set up the manager instance and initialize everything use QgsAuthManager::instance()->init()
      */
-    static QgsAuthManager *instance();
+    static QgsAuthManager *instance() SIP_SKIP;
 
-    explicit QgsAuthManager();
+    explicit QgsAuthManager() SIP_SKIP;
 
   private:
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -876,7 +876,6 @@ void QgsApplication::initQgis()
   QgsProject::instance();
 
   // Initialize authentication manager and connect to database
-  instance()->mAuthManager = QgsAuthManager::instance();
   authManager()->init( pluginPath(), qgisAuthDatabaseFilePath() );
 
   // Make sure we have a NAM created on the main thread.
@@ -890,6 +889,10 @@ void QgsApplication::initQgis()
 
 QgsAuthManager *QgsApplication::authManager()
 {
+  if ( ! instance()->mAuthManager )
+  {
+    instance()->mAuthManager = QgsAuthManager::instance();
+  }
   return instance()->mAuthManager;
 }
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -875,16 +875,28 @@ void QgsApplication::initQgis()
   // create project instance if doesn't exist
   QgsProject::instance();
 
+  // Initialize authentication manager and connect to database
+  instance()->mAuthManager = QgsAuthManager::instance();
+  authManager()->init( pluginPath(), qgisAuthDatabaseFilePath() );
+
   // Make sure we have a NAM created on the main thread.
+  // Note that this might call QgsApplication::authManager to
+  // setup the proxy configuration that's why it needs to be
+  // called after the QgsAuthManager instance has been created
   QgsNetworkAccessManager::instance();
 
-  // initialize authentication manager and connect to database
-  QgsAuthManager::instance()->init( pluginPath() );
 }
+
+
+QgsAuthManager *QgsApplication::authManager()
+{
+  return instance()->mAuthManager;
+}
+
 
 void QgsApplication::exitQgis()
 {
-  delete QgsAuthManager::instance();
+  delete QgsApplication::authManager();
 
   //Ensure that all remaining deleteLater QObjects are actually deleted before we exit.
   //This isn't strictly necessary (since we're exiting anyway) but doing so prevents a lot of

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -44,6 +44,7 @@ class QgsUserProfile;
 class QgsUserProfileManager;
 class QgsPageSizeRegistry;
 class QgsLayoutItemRegistry;
+class QgsAuthManager;
 
 /**
  * \ingroup core
@@ -583,6 +584,14 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QgsMessageLog *messageLog();
 
     /**
+     * Returns the application's authentication manager instance
+     * \note this can be a null pointer if called before initQgis
+     * \see initQgis
+     * \since QGIS 3.0
+     */
+    static QgsAuthManager *authManager();
+
+    /**
      * Returns the application's processing registry, used for managing processing providers,
      * algorithms, and various parameters and outputs.
      * \since QGIS 3.0
@@ -740,6 +749,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     QMap<QString, QIcon> mIconCache;
 
     QgsDataItemProviderRegistry *mDataItemProviderRegistry = nullptr;
+    QgsAuthManager *mAuthManager = nullptr;
 
     struct ApplicationMembers
     {

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -20,6 +20,7 @@
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
 #include "qgswkbtypes.h"
+#include "qgsapplication.h"
 
 #include <QStringList>
 #include <QRegExp>
@@ -526,7 +527,7 @@ QString QgsDataSourceUri::connectionInfo( bool expandAuthConfig ) const
   {
     if ( expandAuthConfig )
     {
-      if ( !QgsAuthManager::instance()->updateDataSourceUriItems( connectionItems, mAuthConfigId ) )
+      if ( !QgsApplication::authManager()->updateDataSourceUriItems( connectionItems, mAuthConfigId ) )
       {
         QgsDebugMsg( QString( "Data source URI FAILED to update via loading configuration ID '%1'" ).arg( mAuthConfigId ) );
       }

--- a/src/core/qgsfiledownloader.cpp
+++ b/src/core/qgsfiledownloader.cpp
@@ -53,7 +53,7 @@ void QgsFileDownloader::startDownload()
   QNetworkRequest request( mUrl );
   if ( !mAuthCfg.isEmpty() )
   {
-    QgsAuthManager::instance()->updateNetworkRequest( request, mAuthCfg );
+    QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg );
   }
 
   if ( mReply )
@@ -68,7 +68,7 @@ void QgsFileDownloader::startDownload()
   mReply = nam->get( request );
   if ( !mAuthCfg.isEmpty() )
   {
-    QgsAuthManager::instance()->updateNetworkReply( mReply, mAuthCfg );
+    QgsApplication::authManager()->updateNetworkReply( mReply, mAuthCfg );
   }
 
   connect( mReply, &QNetworkReply::readyRead, this, &QgsFileDownloader::onReadyRead );

--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -62,7 +62,7 @@ int QgsGml::getFeatures( const QString &uri, QgsWkbTypes::Type *wkbType, QgsRect
   QNetworkRequest request( uri );
   if ( !authcfg.isEmpty() )
   {
-    if ( !QgsAuthManager::instance()->updateNetworkRequest( request, authcfg ) )
+    if ( !QgsApplication::authManager()->updateNetworkRequest( request, authcfg ) )
     {
       QgsMessageLog::logMessage(
         tr( "GML Getfeature network request update failed for authcfg %1" ).arg( authcfg ),
@@ -80,7 +80,7 @@ int QgsGml::getFeatures( const QString &uri, QgsWkbTypes::Type *wkbType, QgsRect
 
   if ( !authcfg.isEmpty() )
   {
-    if ( !QgsAuthManager::instance()->updateNetworkReply( reply, authcfg ) )
+    if ( !QgsApplication::authManager()->updateNetworkReply( reply, authcfg ) )
     {
       reply->deleteLater();
       QgsMessageLog::logMessage(

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -220,7 +220,7 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, const QgsReadWr
   // if the layer needs authentication, ensure the master password is set
   QRegExp rx( "authcfg=([a-z]|[A-Z]|[0-9]){7}" );
   if ( ( rx.indexIn( mDataSource ) != -1 )
-       && !QgsAuthManager::instance()->setMasterPassword( true ) )
+       && !QgsApplication::authManager()->setMasterPassword( true ) )
   {
     return false;
   }

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -180,17 +180,17 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
 
 #ifndef QT_NO_SSL
   bool ishttps = pReq->url().scheme().toLower() == QLatin1String( "https" );
-  if ( ishttps && !QgsAuthManager::instance()->isDisabled() )
+  if ( ishttps && !QgsApplication::authManager()->isDisabled() )
   {
     QgsDebugMsg( "Adding trusted CA certs to request" );
     QSslConfiguration sslconfig( pReq->sslConfiguration() );
     // Merge trusted CAs with any additional CAs added by the authentication methods
-    sslconfig.setCaCertificates( QgsAuthCertUtils::casMerge( QgsAuthManager::instance()->getTrustedCaCertsCache(), sslconfig.caCertificates( ) ) );
+    sslconfig.setCaCertificates( QgsAuthCertUtils::casMerge( QgsApplication::authManager()->getTrustedCaCertsCache(), sslconfig.caCertificates( ) ) );
     // check for SSL cert custom config
     QString hostport( QStringLiteral( "%1:%2" )
                       .arg( pReq->url().host().trimmed() )
                       .arg( pReq->url().port() != -1 ? pReq->url().port() : 443 ) );
-    QgsAuthConfigSslServer servconfig = QgsAuthManager::instance()->getSslCertCustomConfigByHost( hostport.trimmed() );
+    QgsAuthConfigSslServer servconfig = QgsApplication::authManager()->getSslCertCustomConfigByHost( hostport.trimmed() );
     if ( !servconfig.isNull() )
     {
       QgsDebugMsg( QString( "Adding SSL custom config to request for %1" ).arg( hostport ) );
@@ -371,7 +371,9 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache()
   if ( !authcfg.isEmpty( ) )
   {
     QgsDebugMsg( QStringLiteral( "setting proxy from stored authentication configuration %1" ).arg( authcfg ) );
-    QgsAuthManager::instance()->updateNetworkProxy( proxy, authcfg );
+    // Never crash! Never.
+    if ( QgsApplication::authManager() )
+      QgsApplication::authManager()->updateNetworkProxy( proxy, authcfg );
   }
 
   setFallbackProxyAndExcludes( proxy, excludes );

--- a/src/gui/auth/qgsauthauthoritieseditor.cpp
+++ b/src/gui/auth/qgsauthauthoritieseditor.cpp
@@ -42,12 +42,12 @@
 QgsAuthAuthoritiesEditor::QgsAuthAuthoritiesEditor( QWidget *parent )
   : QWidget( parent )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -60,10 +60,10 @@ QgsAuthAuthoritiesEditor::QgsAuthAuthoritiesEditor( QWidget *parent )
     connect( btnCaFile, &QToolButton::clicked, this, &QgsAuthAuthoritiesEditor::btnCaFile_clicked );
     connect( btnCaFileClear, &QToolButton::clicked, this, &QgsAuthAuthoritiesEditor::btnCaFileClear_clicked );
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+    connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
              this, &QgsAuthAuthoritiesEditor::authMessageOut );
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::authDatabaseChanged,
+    connect( QgsApplication::authManager(), &QgsAuthManager::authDatabaseChanged,
              this, &QgsAuthAuthoritiesEditor::refreshCaCertsView );
 
     setupCaCertsTree();
@@ -76,18 +76,18 @@ QgsAuthAuthoritiesEditor::QgsAuthAuthoritiesEditor( QWidget *parent )
 
     connect( btnViewRefresh, &QAbstractButton::clicked, this, &QgsAuthAuthoritiesEditor::refreshCaCertsView );
 
-    QVariant cafileval = QgsAuthManager::instance()->getAuthSetting( QStringLiteral( "cafile" ) );
+    QVariant cafileval = QgsApplication::authManager()->getAuthSetting( QStringLiteral( "cafile" ) );
     if ( !cafileval.isNull() )
     {
       leCaFile->setText( cafileval.toString() );
     }
 
     btnGroupByOrg->setChecked( false );
-    QVariant sortbyval = QgsAuthManager::instance()->getAuthSetting( QStringLiteral( "casortby" ), QVariant( false ) );
+    QVariant sortbyval = QgsApplication::authManager()->getAuthSetting( QStringLiteral( "casortby" ), QVariant( false ) );
     if ( !sortbyval.isNull() )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
-    mDefaultTrustPolicy = QgsAuthManager::instance()->defaultCertTrustPolicy();
+    mDefaultTrustPolicy = QgsApplication::authManager()->defaultCertTrustPolicy();
     populateCaCertsView();
     checkSelection();
 
@@ -154,7 +154,7 @@ void QgsAuthAuthoritiesEditor::populateCaCertsView()
 
 void QgsAuthAuthoritiesEditor::refreshCaCertsView()
 {
-//  QgsAuthManager::instance()->rebuildCaCertsCache();
+//  QgsApplication::authManager()->rebuildCaCertsCache();
   populateCaCertsView();
 }
 
@@ -172,7 +172,7 @@ void QgsAuthAuthoritiesEditor::populateDatabaseCaCerts()
 
   bool expanded = mDbCaSecItem->isExpanded();
   populateCaCertsSection( mDbCaSecItem,
-                          QgsAuthManager::instance()->getDatabaseCAs(),
+                          QgsApplication::authManager()->getDatabaseCAs(),
                           QgsAuthAuthoritiesEditor::DbCaCert );
   mDbCaSecItem->setExpanded( expanded );
 }
@@ -183,7 +183,7 @@ void QgsAuthAuthoritiesEditor::populateFileCaCerts()
 
   bool expanded = mFileCaSecItem->isExpanded();
   populateCaCertsSection( mFileCaSecItem,
-                          QgsAuthManager::instance()->getExtraFileCAs(),
+                          QgsApplication::authManager()->getExtraFileCAs(),
                           QgsAuthAuthoritiesEditor::FileCaCert );
   mFileCaSecItem->setExpanded( expanded );
 }
@@ -194,7 +194,7 @@ void QgsAuthAuthoritiesEditor::populateRootCaCerts()
 
   bool expanded = mRootCaSecItem->isExpanded();
   populateCaCertsSection( mRootCaSecItem,
-                          QgsAuthManager::instance()->getSystemRootCAs(),
+                          QgsApplication::authManager()->getSystemRootCAs(),
                           QgsAuthAuthoritiesEditor::RootCaCert );
   mRootCaSecItem->setExpanded( expanded );
 }
@@ -326,7 +326,7 @@ void QgsAuthAuthoritiesEditor::appendCertsToItem( const QList<QSslCertificate> &
 
 void QgsAuthAuthoritiesEditor::updateCertTrustPolicyCache()
 {
-  mCertTrustCache = QgsAuthManager::instance()->getCertTrustCache();
+  mCertTrustCache = QgsApplication::authManager()->getCertTrustCache();
 }
 
 void QgsAuthAuthoritiesEditor::populateUtilitiesMenu()
@@ -353,7 +353,7 @@ void QgsAuthAuthoritiesEditor::showCertInfo( QTreeWidgetItem *item )
   QString digest( item->data( 0, Qt::UserRole ).toString() );
 
   QMap<QString, QPair<QgsAuthCertUtils::CaCertSource, QSslCertificate> > cacertscache(
-    QgsAuthManager::instance()->getCaCertsCache() );
+    QgsApplication::authManager()->getCaCertsCache() );
 
   if ( !cacertscache.contains( digest ) )
   {
@@ -369,7 +369,7 @@ void QgsAuthAuthoritiesEditor::showCertInfo( QTreeWidgetItem *item )
   dlg->exec();
   if ( dlg->trustCacheRebuilt() )
   {
-    // QgsAuthManager::instance()->rebuildTrustedCaCertsCache() already called in dlg
+    // QgsApplication::authManager()->rebuildTrustedCaCertsCache() already called in dlg
     populateCaCertsView();
   }
   dlg->deleteLater();
@@ -442,30 +442,30 @@ void QgsAuthAuthoritiesEditor::btnAddCa_clicked()
   if ( dlg->exec() )
   {
     const QList<QSslCertificate> &certs( dlg->certificatesToImport() );
-    if ( !QgsAuthManager::instance()->storeCertAuthorities( certs ) )
+    if ( !QgsApplication::authManager()->storeCertAuthorities( certs ) )
     {
       messageBar()->pushMessage( tr( "ERROR storing CA(s) in authentication database" ),
                                  QgsMessageBar::CRITICAL );
     }
 
-    QgsAuthManager::instance()->rebuildCaCertsCache();
+    QgsApplication::authManager()->rebuildCaCertsCache();
 
     if ( dlg->certTrustPolicy() != QgsAuthCertUtils::DefaultTrust )
     {
       Q_FOREACH ( const QSslCertificate &cert, certs )
       {
-        if ( !QgsAuthManager::instance()->storeCertTrustPolicy( cert, dlg->certTrustPolicy() ) )
+        if ( !QgsApplication::authManager()->storeCertTrustPolicy( cert, dlg->certTrustPolicy() ) )
         {
           authMessageOut( QObject::tr( "Could not set trust policy for imported certificates" ),
                           QObject::tr( "Authorities Manager" ),
                           QgsAuthManager::WARNING );
         }
       }
-      QgsAuthManager::instance()->rebuildCertTrustCache();
+      QgsApplication::authManager()->rebuildCertTrustCache();
       updateCertTrustPolicyCache();
     }
 
-    QgsAuthManager::instance()->rebuildTrustedCaCertsCache();
+    QgsApplication::authManager()->rebuildTrustedCaCertsCache();
     populateDatabaseCaCerts();
     mDbCaSecItem->setExpanded( true );
   }
@@ -492,7 +492,7 @@ void QgsAuthAuthoritiesEditor::btnRemoveCa_clicked()
   }
 
   QMap<QString, QSslCertificate> mappedcerts(
-    QgsAuthManager::instance()->getMappedDatabaseCAs() );
+    QgsApplication::authManager()->getMappedDatabaseCAs() );
 
   if ( !mappedcerts.contains( digest ) )
   {
@@ -520,22 +520,22 @@ void QgsAuthAuthoritiesEditor::btnRemoveCa_clicked()
     return;
   }
 
-  if ( !QgsAuthManager::instance()->removeCertAuthority( cert ) )
+  if ( !QgsApplication::authManager()->removeCertAuthority( cert ) )
   {
     messageBar()->pushMessage( tr( "ERROR removing CA from authentication database for id %1:" ).arg( digest ),
                                QgsMessageBar::CRITICAL );
     return;
   }
 
-  if ( !QgsAuthManager::instance()->removeCertTrustPolicy( cert ) )
+  if ( !QgsApplication::authManager()->removeCertTrustPolicy( cert ) )
   {
     messageBar()->pushMessage( tr( "ERROR removing cert trust policy from authentication database for id %1:" ).arg( digest ),
                                QgsMessageBar::CRITICAL );
     return;
   }
 
-  QgsAuthManager::instance()->rebuildCaCertsCache();
-  QgsAuthManager::instance()->rebuildTrustedCaCertsCache();
+  QgsApplication::authManager()->rebuildCaCertsCache();
+  QgsApplication::authManager()->rebuildTrustedCaCertsCache();
   updateCertTrustPolicyCache();
 
   item->parent()->removeChild( item );
@@ -556,7 +556,7 @@ void QgsAuthAuthoritiesEditor::btnInfoCa_clicked()
 
 void QgsAuthAuthoritiesEditor::btnGroupByOrg_toggled( bool checked )
 {
-  if ( !QgsAuthManager::instance()->storeAuthSetting( QStringLiteral( "casortby" ), QVariant( checked ) ) )
+  if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "casortby" ), QVariant( checked ) ) )
   {
     authMessageOut( QObject::tr( "Could not store sort by preference" ),
                     QObject::tr( "Authorities Manager" ),
@@ -639,15 +639,15 @@ void QgsAuthAuthoritiesEditor::editDefaultTrustPolicy()
 
 void QgsAuthAuthoritiesEditor::defaultTrustPolicyChanged( QgsAuthCertUtils::CertTrustPolicy trustpolicy )
 {
-  if ( !QgsAuthManager::instance()->setDefaultCertTrustPolicy( trustpolicy ) )
+  if ( !QgsApplication::authManager()->setDefaultCertTrustPolicy( trustpolicy ) )
   {
     authMessageOut( QObject::tr( "Could not store default trust policy" ),
                     QObject::tr( "Authorities Manager" ),
                     QgsAuthManager::CRITICAL );
   }
   mDefaultTrustPolicy = trustpolicy;
-  QgsAuthManager::instance()->rebuildCertTrustCache();
-  QgsAuthManager::instance()->rebuildTrustedCaCertsCache();
+  QgsApplication::authManager()->rebuildCertTrustCache();
+  QgsApplication::authManager()->rebuildTrustedCaCertsCache();
   populateCaCertsView();
 }
 
@@ -669,13 +669,13 @@ void QgsAuthAuthoritiesEditor::btnCaFile_clicked()
     const QString &fn = dlg->certFileToImport();
     leCaFile->setText( fn );
 
-    if ( !QgsAuthManager::instance()->storeAuthSetting( QStringLiteral( "cafile" ), QVariant( fn ) ) )
+    if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "cafile" ), QVariant( fn ) ) )
     {
       authMessageOut( QObject::tr( "Could not store 'CA file path' in authentication database" ),
                       QObject::tr( "Authorities Manager" ),
                       QgsAuthManager::WARNING );
     }
-    if ( !QgsAuthManager::instance()->storeAuthSetting( QStringLiteral( "cafileallowinvalid" ),
+    if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "cafileallowinvalid" ),
          QVariant( dlg->allowInvalidCerts() ) ) )
     {
       authMessageOut( QObject::tr( "Could not store 'CA file allow invalids' setting in authentication database" ),
@@ -683,25 +683,25 @@ void QgsAuthAuthoritiesEditor::btnCaFile_clicked()
                       QgsAuthManager::WARNING );
     }
 
-    QgsAuthManager::instance()->rebuildCaCertsCache();
+    QgsApplication::authManager()->rebuildCaCertsCache();
 
     if ( dlg->certTrustPolicy() != QgsAuthCertUtils::DefaultTrust )
     {
-      QList<QSslCertificate> certs( QgsAuthManager::instance()->getExtraFileCAs() );
+      QList<QSslCertificate> certs( QgsApplication::authManager()->getExtraFileCAs() );
       Q_FOREACH ( const QSslCertificate &cert, certs )
       {
-        if ( !QgsAuthManager::instance()->storeCertTrustPolicy( cert, dlg->certTrustPolicy() ) )
+        if ( !QgsApplication::authManager()->storeCertTrustPolicy( cert, dlg->certTrustPolicy() ) )
         {
           authMessageOut( QObject::tr( "Could not set trust policy for imported certificates" ),
                           QObject::tr( "Authorities Manager" ),
                           QgsAuthManager::WARNING );
         }
       }
-      QgsAuthManager::instance()->rebuildCertTrustCache();
+      QgsApplication::authManager()->rebuildCertTrustCache();
       updateCertTrustPolicyCache();
     }
 
-    QgsAuthManager::instance()->rebuildTrustedCaCertsCache();
+    QgsApplication::authManager()->rebuildTrustedCaCertsCache();
 
     populateFileCaCerts();
     mFileCaSecItem->setExpanded( true );
@@ -711,14 +711,14 @@ void QgsAuthAuthoritiesEditor::btnCaFile_clicked()
 
 void QgsAuthAuthoritiesEditor::btnCaFileClear_clicked()
 {
-  if ( !QgsAuthManager::instance()->removeAuthSetting( QStringLiteral( "cafile" ) ) )
+  if ( !QgsApplication::authManager()->removeAuthSetting( QStringLiteral( "cafile" ) ) )
   {
     authMessageOut( QObject::tr( "Could not remove 'CA file path' from authentication database" ),
                     QObject::tr( "Authorities Manager" ),
                     QgsAuthManager::WARNING );
     return;
   }
-  if ( !QgsAuthManager::instance()->removeAuthSetting( QStringLiteral( "cafileallowinvalid" ) ) )
+  if ( !QgsApplication::authManager()->removeAuthSetting( QStringLiteral( "cafileallowinvalid" ) ) )
   {
     authMessageOut( QObject::tr( "Could not remove 'CA file allow invalids' setting from authentication database" ),
                     QObject::tr( "Authorities Manager" ),
@@ -726,7 +726,7 @@ void QgsAuthAuthoritiesEditor::btnCaFileClear_clicked()
     return;
   }
 
-  QgsAuthManager::instance()->rebuildCaCertsCache();
+  QgsApplication::authManager()->rebuildCaCertsCache();
 
   QString fn( leCaFile->text() );
   if ( QFile::exists( fn ) )
@@ -735,18 +735,18 @@ void QgsAuthAuthoritiesEditor::btnCaFileClear_clicked()
 
     if ( !certs.isEmpty() )
     {
-      if ( !QgsAuthManager::instance()->removeCertTrustPolicies( certs ) )
+      if ( !QgsApplication::authManager()->removeCertTrustPolicies( certs ) )
       {
         messageBar()->pushMessage( tr( "ERROR removing cert(s) trust policy from authentication database" ),
                                    QgsMessageBar::CRITICAL );
         return;
       }
-      QgsAuthManager::instance()->rebuildCertTrustCache();
+      QgsApplication::authManager()->rebuildCertTrustCache();
       updateCertTrustPolicyCache();
     }
   }
 
-  QgsAuthManager::instance()->rebuildTrustedCaCertsCache();
+  QgsApplication::authManager()->rebuildTrustedCaCertsCache();
 
   leCaFile->clear();
   populateFileCaCerts();

--- a/src/gui/auth/qgsauthcertificateinfo.cpp
+++ b/src/gui/auth/qgsauthcertificateinfo.cpp
@@ -61,11 +61,11 @@ QgsAuthCertInfo::QgsAuthCertInfo( const QSslCertificate &cert,
   , mCurrentTrustPolicy( QgsAuthCertUtils::DefaultTrust )
 
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -80,14 +80,14 @@ QgsAuthCertInfo::QgsAuthCertInfo( const QSslCertificate &cert,
     connect( treeHierarchy, &QTreeWidget::currentItemChanged,
              this, &QgsAuthCertInfo::currentCertItemChanged );
 
-    mCaCertsCache = QgsAuthManager::instance()->getCaCertsCache();
+    mCaCertsCache = QgsApplication::authManager()->getCaCertsCache();
 
     setUpCertDetailsTree();
 
     grpbxTrust->setVisible( mManageTrust );
 
     // trust policy is still queried, even if not managing the policy, so public getter will work
-    mDefaultTrustPolicy = QgsAuthManager::instance()->defaultCertTrustPolicy();
+    mDefaultTrustPolicy = QgsApplication::authManager()->defaultCertTrustPolicy();
     mCurrentTrustPolicy = QgsAuthCertUtils::DefaultTrust;
 
     bool res;
@@ -266,7 +266,7 @@ void QgsAuthCertInfo::setCertHierarchy()
       mDefaultItemForeground = item->foreground( 0 );
     }
 
-    decorateCertTreeItem( cert, QgsAuthManager::instance()->getCertificateTrustPolicy( cert ), item );
+    decorateCertTreeItem( cert, QgsApplication::authManager()->getCertificateTrustPolicy( cert ), item );
 
     item->setFirstColumnSpanned( true );
     if ( !previtem )
@@ -291,7 +291,7 @@ void QgsAuthCertInfo::updateCurrentCertInfo( int chainindx )
 
   if ( !mCurrentQCert.isNull() )
   {
-    QgsAuthCertUtils::CertTrustPolicy trustpolicy( QgsAuthManager::instance()->getCertificateTrustPolicy( mCurrentQCert ) );
+    QgsAuthCertUtils::CertTrustPolicy trustpolicy( QgsApplication::authManager()->getCertificateTrustPolicy( mCurrentQCert ) );
     mCurrentTrustPolicy = trustpolicy;
 
     cmbbxTrust->setTrustPolicy( trustpolicy );
@@ -834,7 +834,7 @@ void QgsAuthCertInfo::populateInfoPemTextSection()
 void QgsAuthCertInfo::btnSaveTrust_clicked()
 {
   QgsAuthCertUtils::CertTrustPolicy newpolicy( cmbbxTrust->trustPolicy() );
-  if ( !QgsAuthManager::instance()->storeCertTrustPolicy( mCurrentQCert, newpolicy ) )
+  if ( !QgsApplication::authManager()->storeCertTrustPolicy( mCurrentQCert, newpolicy ) )
   {
     QgsDebugMsg( "Could not set trust policy for certificate" );
   }
@@ -843,9 +843,9 @@ void QgsAuthCertInfo::btnSaveTrust_clicked()
   btnSaveTrust->setEnabled( false );
 
   // rebuild trust cache
-  QgsAuthManager::instance()->rebuildCertTrustCache();
+  QgsApplication::authManager()->rebuildCertTrustCache();
   mTrustCacheRebuilt = true;
-  QgsAuthManager::instance()->rebuildTrustedCaCertsCache();
+  QgsApplication::authManager()->rebuildTrustedCaCertsCache();
 }
 
 void QgsAuthCertInfo::currentPolicyIndexChanged( int indx )

--- a/src/gui/auth/qgsauthcerttrustpolicycombobox.cpp
+++ b/src/gui/auth/qgsauthcerttrustpolicycombobox.cpp
@@ -22,6 +22,7 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 QgsAuthCertTrustPolicyComboBox::QgsAuthCertTrustPolicyComboBox( QWidget *parent,
@@ -109,9 +110,9 @@ const QString QgsAuthCertTrustPolicyComboBox::defaultTrustText( QgsAuthCertUtils
 {
   if ( defaultpolicy == QgsAuthCertUtils::DefaultTrust )
   {
-    if ( !QgsAuthManager::instance()->isDisabled() )
+    if ( !QgsApplication::authManager()->isDisabled() )
     {
-      defaultpolicy = QgsAuthManager::instance()->defaultCertTrustPolicy();
+      defaultpolicy = QgsApplication::authManager()->defaultCertTrustPolicy();
     }
     else
     {

--- a/src/gui/auth/qgsauthconfigedit.cpp
+++ b/src/gui/auth/qgsauthconfigedit.cpp
@@ -23,6 +23,7 @@
 #include "qgsauthmanager.h"
 #include "qgsauthmethodedit.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 QgsAuthConfigEdit::QgsAuthConfigEdit( QWidget *parent, const QString &authcfg, const QString &dataprovider )
@@ -31,12 +32,12 @@ QgsAuthConfigEdit::QgsAuthConfigEdit( QWidget *parent, const QString &authcfg, c
   , mDataProvider( dataprovider )
 
 {
-  bool disabled = QgsAuthManager::instance()->isDisabled();
+  bool disabled = QgsApplication::authManager()->isDisabled();
   bool idok = true;
 
   if ( !disabled && !authcfg.isEmpty() )
   {
-    idok = QgsAuthManager::instance()->configIds().contains( authcfg );
+    idok = QgsApplication::authManager()->configIds().contains( authcfg );
   }
 
   if ( disabled || !idok )
@@ -44,7 +45,7 @@ QgsAuthConfigEdit::QgsAuthConfigEdit( QWidget *parent, const QString &authcfg, c
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
 
-    QString msg( disabled ? QgsAuthManager::instance()->disabledMessage() : QLatin1String( "" ) );
+    QString msg( disabled ? QgsApplication::authManager()->disabledMessage() : QLatin1String( "" ) );
     if ( !authcfg.isEmpty() )
     {
       msg += "\n\n" + tr( "Authentication config id not loaded: %1" ).arg( authcfg );
@@ -95,13 +96,13 @@ QgsAuthConfigEdit::QgsAuthConfigEdit( QWidget *parent, const QString &authcfg, c
 
 void QgsAuthConfigEdit::populateAuthMethods()
 {
-  QStringList authMethodKeys = QgsAuthManager::instance()->authMethodsKeys( mDataProvider );
+  QStringList authMethodKeys = QgsApplication::authManager()->authMethodsKeys( mDataProvider );
 
   // sort by auth method description attribute, then populate
   QMap<QString, QgsAuthMethod *> descmap;
   Q_FOREACH ( const QString &authMethodKey, authMethodKeys )
   {
-    QgsAuthMethod *authmethod = QgsAuthManager::instance()->authMethod( authMethodKey );
+    QgsAuthMethod *authmethod = QgsApplication::authManager()->authMethod( authMethodKey );
     if ( !authmethod )
     {
       QgsDebugMsg( QString( "Load auth method instance FAILED for auth method key (%1)" ).arg( authMethodKey ) );
@@ -114,7 +115,7 @@ void QgsAuthConfigEdit::populateAuthMethods()
   for ( it = descmap.begin(); it != descmap.end(); ++it )
   {
     QgsAuthMethodEdit *editWidget = qobject_cast<QgsAuthMethodEdit *>(
-                                      QgsAuthManager::instance()->authMethodEditWidget( it.value()->key(), this ) );
+                                      QgsApplication::authManager()->authMethodEditWidget( it.value()->key(), this ) );
     if ( !editWidget )
     {
       QgsDebugMsg( QString( "Load auth method edit widget FAILED for auth method key (%1)" ).arg( it.value()->key() ) );
@@ -137,14 +138,14 @@ void QgsAuthConfigEdit::loadConfig()
   }
 
   // edit mode requires master password to have been set and verified against auth db
-  if ( !QgsAuthManager::instance()->setMasterPassword( true ) )
+  if ( !QgsApplication::authManager()->setMasterPassword( true ) )
   {
     mAuthCfg.clear();
     return;
   }
 
   QgsAuthMethodConfig mconfig;
-  if ( !QgsAuthManager::instance()->loadAuthenticationConfig( mAuthCfg, mconfig, true ) )
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( mAuthCfg, mconfig, true ) )
   {
     QgsDebugMsg( QString( "Loading FAILED for authcfg: %1" ).arg( mAuthCfg ) );
     return;
@@ -161,7 +162,7 @@ void QgsAuthConfigEdit::loadConfig()
   leResource->setText( mconfig.uri() );
   authCfgEdit->setAuthConfigId( mconfig.id() );
 
-  QString authMethodKey = QgsAuthManager::instance()->configAuthMethodKey( mAuthCfg );
+  QString authMethodKey = QgsApplication::authManager()->configAuthMethodKey( mAuthCfg );
 
   QgsDebugMsg( QString( "Loading authcfg: %1" ).arg( mAuthCfg ) );
   QgsDebugMsg( QString( "Loading auth method: %1" ).arg( authMethodKey ) );
@@ -214,7 +215,7 @@ void QgsAuthConfigEdit::resetConfig()
 
 void QgsAuthConfigEdit::saveConfig()
 {
-  if ( !QgsAuthManager::instance()->setMasterPassword( true ) )
+  if ( !QgsApplication::authManager()->setMasterPassword( true ) )
     return;
 
   QString authMethodKey = cmbAuthMethods->currentData().toString();
@@ -226,7 +227,7 @@ void QgsAuthConfigEdit::saveConfig()
     return;
   }
 
-  QgsAuthMethod *authmethod = QgsAuthManager::instance()->authMethod( authMethodKey );
+  QgsAuthMethod *authmethod = QgsApplication::authManager()->authMethod( authMethodKey );
   if ( !authmethod )
   {
     QgsDebugMsg( QString( "Save auth config FAILED when loading auth method instance from key (%1)" ).arg( authMethodKey ) );
@@ -252,7 +253,7 @@ void QgsAuthConfigEdit::saveConfig()
     if ( authCfgId == mAuthCfg ) // update
     {
       mconfig.setId( mAuthCfg );
-      if ( QgsAuthManager::instance()->updateAuthenticationConfig( mconfig ) )
+      if ( QgsApplication::authManager()->updateAuthenticationConfig( mconfig ) )
       {
         emit authenticationConfigUpdated( mAuthCfg );
       }
@@ -264,10 +265,10 @@ void QgsAuthConfigEdit::saveConfig()
     else // store new with unique ID, then delete previous
     {
       mconfig.setId( authCfgId );
-      if ( QgsAuthManager::instance()->storeAuthenticationConfig( mconfig ) )
+      if ( QgsApplication::authManager()->storeAuthenticationConfig( mconfig ) )
       {
         emit authenticationConfigStored( authCfgId );
-        if ( !QgsAuthManager::instance()->removeAuthenticationConfig( mAuthCfg ) )
+        if ( !QgsApplication::authManager()->removeAuthenticationConfig( mAuthCfg ) )
         {
           QgsDebugMsg( QString( "Removal of older auth config FAILED" ) );
         }
@@ -283,7 +284,7 @@ void QgsAuthConfigEdit::saveConfig()
   {
     if ( authCfgId.isEmpty() ) // create new with generated ID
     {
-      if ( QgsAuthManager::instance()->storeAuthenticationConfig( mconfig ) )
+      if ( QgsApplication::authManager()->storeAuthenticationConfig( mconfig ) )
       {
         mAuthCfg = mconfig.id();
         emit authenticationConfigStored( mAuthCfg );
@@ -296,7 +297,7 @@ void QgsAuthConfigEdit::saveConfig()
     else // create new with user-created unique ID
     {
       mconfig.setId( authCfgId );
-      if ( QgsAuthManager::instance()->storeAuthenticationConfig( mconfig ) )
+      if ( QgsApplication::authManager()->storeAuthenticationConfig( mconfig ) )
       {
         mAuthCfg = authCfgId;
         emit authenticationConfigStored( mAuthCfg );

--- a/src/gui/auth/qgsauthconfigeditor.cpp
+++ b/src/gui/auth/qgsauthconfigeditor.cpp
@@ -25,17 +25,18 @@
 #include "qgsauthmanager.h"
 #include "qgsauthconfigedit.h"
 #include "qgsauthguiutils.h"
+#include "qgsapplication.h"
 
 QgsAuthConfigEditor::QgsAuthConfigEditor( QWidget *parent, bool showUtilities, bool relayMessages )
   : QWidget( parent )
   , mRelayMessages( relayMessages )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -47,8 +48,8 @@ QgsAuthConfigEditor::QgsAuthConfigEditor( QWidget *parent, bool showUtilities, b
 
     setShowUtilitiesButton( showUtilities );
 
-    mConfigModel = new QSqlTableModel( this, QgsAuthManager::instance()->authDatabaseConnection() );
-    mConfigModel->setTable( QgsAuthManager::instance()->authDatabaseConfigTable() );
+    mConfigModel = new QSqlTableModel( this, QgsApplication::authManager()->authDatabaseConnection() );
+    mConfigModel->setTable( QgsApplication::authManager()->authDatabaseConfigTable() );
     mConfigModel->select();
 
     mConfigModel->setHeaderData( 0, Qt::Horizontal, tr( "ID" ) );
@@ -79,11 +80,11 @@ QgsAuthConfigEditor::QgsAuthConfigEditor( QWidget *parent, bool showUtilities, b
 
     if ( mRelayMessages )
     {
-      connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+      connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
                this, &QgsAuthConfigEditor::authMessageOut );
     }
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::authDatabaseChanged,
+    connect( QgsApplication::authManager(), &QgsAuthManager::authDatabaseChanged,
              this, &QgsAuthConfigEditor::refreshTableView );
 
     checkSelection();
@@ -183,13 +184,13 @@ void QgsAuthConfigEditor::setRelayMessages( bool relay )
 
   if ( mRelayMessages )
   {
-    disconnect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+    disconnect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
                 this, &QgsAuthConfigEditor::authMessageOut );
     mRelayMessages = relay;
     return;
   }
 
-  connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+  connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
            this, &QgsAuthConfigEditor::authMessageOut );
   mRelayMessages = relay;
 }
@@ -216,7 +217,7 @@ void QgsAuthConfigEditor::checkSelection()
 
 void QgsAuthConfigEditor::btnAddConfig_clicked()
 {
-  if ( !QgsAuthManager::instance()->setMasterPassword( true ) )
+  if ( !QgsApplication::authManager()->setMasterPassword( true ) )
     return;
 
   QgsAuthConfigEdit *ace = new QgsAuthConfigEdit( this );
@@ -235,7 +236,7 @@ void QgsAuthConfigEditor::btnEditConfig_clicked()
   if ( authcfg.isEmpty() )
     return;
 
-  if ( !QgsAuthManager::instance()->setMasterPassword( true ) )
+  if ( !QgsApplication::authManager()->setMasterPassword( true ) )
     return;
 
   QgsAuthConfigEdit *ace = new QgsAuthConfigEdit( this, authcfg );

--- a/src/gui/auth/qgsauthconfigidedit.cpp
+++ b/src/gui/auth/qgsauthconfigidedit.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
+#include "qgsapplication.h"
 
 
 QgsAuthConfigIdEdit::QgsAuthConfigIdEdit( QWidget *parent, const QString &authcfg, bool allowEmpty )
@@ -53,9 +54,9 @@ bool QgsAuthConfigIdEdit::validate()
   bool curvalid = ( ( authcfg == mAuthCfgOrig && authcfg.size() == 7 )
                     || ( mAllowEmpty && authcfg.isEmpty() ) );
 
-  if ( !QgsAuthManager::instance()->isDisabled() && !curvalid && authcfg.size() == 7 && isAlphaNumeric( authcfg ) )
+  if ( !QgsApplication::authManager()->isDisabled() && !curvalid && authcfg.size() == 7 && isAlphaNumeric( authcfg ) )
   {
-    curvalid = QgsAuthManager::instance()->configIdUnique( authcfg );
+    curvalid = QgsApplication::authManager()->configIdUnique( authcfg );
   }
 
   if ( mValid != curvalid )

--- a/src/gui/auth/qgsauthconfigselect.cpp
+++ b/src/gui/auth/qgsauthconfigselect.cpp
@@ -33,12 +33,12 @@ QgsAuthConfigSelect::QgsAuthConfigSelect( QWidget *parent, const QString &datapr
   : QWidget( parent )
   , mDataProvider( dataprovider )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -74,7 +74,7 @@ void QgsAuthConfigSelect::setConfigId( const QString &authcfg )
 {
   if ( mDisabled && mAuthNotify )
   {
-    mAuthNotify->setText( QgsAuthManager::instance()->disabledMessage() + "\n\n" +
+    mAuthNotify->setText( QgsApplication::authManager()->disabledMessage() + "\n\n" +
                           tr( "Authentication config id not loaded: %1" ).arg( authcfg ) );
   }
   else
@@ -105,7 +105,7 @@ void QgsAuthConfigSelect::loadConfig()
   if ( !mAuthCfg.isEmpty() && mConfigs.contains( mAuthCfg ) )
   {
     QgsAuthMethodConfig config = mConfigs.value( mAuthCfg );
-    QgsAuthMethod *authmethod = QgsAuthManager::instance()->configAuthMethod( mAuthCfg );
+    QgsAuthMethod *authmethod = QgsApplication::authManager()->configAuthMethod( mAuthCfg );
     QString methoddesc = tr( "Missing authentication method description" );
     if ( authmethod )
     {
@@ -190,7 +190,7 @@ void QgsAuthConfigSelect::clearMessage()
 void QgsAuthConfigSelect::loadAvailableConfigs()
 {
   mConfigs.clear();
-  mConfigs = QgsAuthManager::instance()->availableAuthMethodConfigs( mDataProvider );
+  mConfigs = QgsApplication::authManager()->availableAuthMethodConfigs( mDataProvider );
 }
 
 void QgsAuthConfigSelect::cmbConfigSelect_currentIndexChanged( int index )
@@ -202,7 +202,7 @@ void QgsAuthConfigSelect::cmbConfigSelect_currentIndexChanged( int index )
 
 void QgsAuthConfigSelect::btnConfigAdd_clicked()
 {
-  if ( !QgsAuthManager::instance()->setMasterPassword( true ) )
+  if ( !QgsApplication::authManager()->setMasterPassword( true ) )
     return;
 
   QgsAuthConfigEdit *ace = new QgsAuthConfigEdit( this, QString(), mDataProvider );
@@ -216,7 +216,7 @@ void QgsAuthConfigSelect::btnConfigAdd_clicked()
 
 void QgsAuthConfigSelect::btnConfigEdit_clicked()
 {
-  if ( !QgsAuthManager::instance()->setMasterPassword( true ) )
+  if ( !QgsApplication::authManager()->setMasterPassword( true ) )
     return;
 
   QgsAuthConfigEdit *ace = new QgsAuthConfigEdit( this, mAuthCfg, mDataProvider );
@@ -240,7 +240,7 @@ void QgsAuthConfigSelect::btnConfigRemove_clicked()
     return;
   }
 
-  if ( QgsAuthManager::instance()->removeAuthenticationConfig( mAuthCfg ) )
+  if ( QgsApplication::authManager()->removeAuthenticationConfig( mAuthCfg ) )
   {
     emit selectedConfigIdRemoved( mAuthCfg );
     setConfigId( QString() );
@@ -260,12 +260,12 @@ void QgsAuthConfigSelect::btnConfigMsgClear_clicked()
 QgsAuthConfigUriEdit::QgsAuthConfigUriEdit( QWidget *parent, const QString &datauri, const QString &dataprovider )
   : QDialog( parent )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -329,11 +329,11 @@ QString QgsAuthConfigUriEdit::dataSourceUri()
 
 bool QgsAuthConfigUriEdit::hasConfigId( const QString &txt )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     return false;
   }
-  return QgsAuthManager::instance()->hasConfigId( txt );
+  return QgsApplication::authManager()->hasConfigId( txt );
 }
 
 void QgsAuthConfigUriEdit::saveChanges()
@@ -375,7 +375,7 @@ void QgsAuthConfigUriEdit::authCfgRemoved( const QString &authcfg )
 
 int QgsAuthConfigUriEdit::authCfgIndex()
 {
-  QRegExp rx( QgsAuthManager::instance()->configIdRegex() );
+  QRegExp rx( QgsApplication::authManager()->configIdRegex() );
   return rx.indexIn( mDataUri );
 }
 

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -26,18 +26,18 @@
 #include "qgsauthcertificatemanager.h"
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
-#include "qgsnetworkaccessmanager.h"
+#include "qgsapplication.h"
 
 
 QgsAuthMethodPlugins::QgsAuthMethodPlugins( QWidget *parent )
   : QDialog( parent )
 
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -62,7 +62,7 @@ void QgsAuthMethodPlugins::setupTable()
   tblAuthPlugins->setAlternatingRowColors( true );
   tblAuthPlugins->setColumnWidth( 0, 150 );
   tblAuthPlugins->setColumnWidth( 1, 300 );
-  tblAuthPlugins->setRowCount( QgsAuthManager::instance()->authMethodsKeys().size() );
+  tblAuthPlugins->setRowCount( QgsApplication::authManager()->authMethodsKeys().size() );
   tblAuthPlugins->verticalHeader()->setSectionResizeMode( QHeaderView::ResizeToContents );
   tblAuthPlugins->setSortingEnabled( true );
   tblAuthPlugins->setSelectionBehavior( QAbstractItemView::SelectRows );
@@ -70,7 +70,7 @@ void QgsAuthMethodPlugins::setupTable()
 
 void QgsAuthMethodPlugins::populateTable()
 {
-  QgsAuthMethodsMap authmethods( QgsAuthManager::instance()->authMethodsMap() );
+  QgsAuthMethodsMap authmethods( QgsApplication::authManager()->authMethodsMap() );
 
   int i = 0;
   for ( QgsAuthMethodsMap::const_iterator it = authmethods.constBegin(); it != authmethods.constEnd(); ++it, i++ )
@@ -105,7 +105,7 @@ QgsAuthEditorWidgets::QgsAuthEditorWidgets( QWidget *parent )
   setupUi( this );
   connect( btnCertManager, &QPushButton::clicked, this, &QgsAuthEditorWidgets::btnCertManager_clicked );
   connect( btnAuthPlugins, &QPushButton::clicked, this, &QgsAuthEditorWidgets::btnAuthPlugins_clicked );
-  if ( !QgsAuthManager::instance()->isDisabled() )
+  if ( !QgsApplication::authManager()->isDisabled() )
   {
     wdgtConfigEditor->setRelayMessages( false );
     wdgtConfigEditor->setShowUtilitiesButton( false );
@@ -137,7 +137,7 @@ void QgsAuthEditorWidgets::btnAuthPlugins_clicked()
 
 void QgsAuthEditorWidgets::setupUtilitiesMenu()
 {
-  connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+  connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
            this, &QgsAuthEditorWidgets::authMessageOut );
 
   // set up utility actions menu
@@ -162,10 +162,10 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   mActionPasswordHelperLoggingEnable = new QAction( tr( "Enable password helper debug log" ), this );
 
   mActionPasswordHelperEnable->setCheckable( true );
-  mActionPasswordHelperEnable->setChecked( QgsAuthManager::instance()->passwordHelperEnabled() );
+  mActionPasswordHelperEnable->setChecked( QgsApplication::authManager()->passwordHelperEnabled() );
 
   mActionPasswordHelperLoggingEnable->setCheckable( true );
-  mActionPasswordHelperLoggingEnable->setChecked( QgsAuthManager::instance()->passwordHelperLoggingEnabled() );
+  mActionPasswordHelperLoggingEnable->setChecked( QgsApplication::authManager()->passwordHelperLoggingEnabled() );
 
   connect( mActionSetMasterPassword, &QAction::triggered, this, &QgsAuthEditorWidgets::setMasterPassword );
   connect( mActionClearCachedMasterPassword, &QAction::triggered, this, &QgsAuthEditorWidgets::clearCachedMasterPassword );

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -27,6 +27,7 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgsapplication.h"
+#include "qgsnetworkaccessmanager.h"
 
 
 QgsAuthMethodPlugins::QgsAuthMethodPlugins( QWidget *parent )

--- a/src/gui/auth/qgsauthguiutils.cpp
+++ b/src/gui/auth/qgsauthguiutils.cpp
@@ -25,6 +25,7 @@
 #include "qgsauthmasterpassresetdialog.h"
 #include "qgslogger.h"
 #include "qgsmessagebar.h"
+#include "qgsapplication.h"
 
 
 QColor QgsAuthGuiUtils::greenColor()
@@ -64,7 +65,7 @@ QString QgsAuthGuiUtils::redTextStyleSheet( const QString &selector )
 
 bool QgsAuthGuiUtils::isDisabled( QgsMessageBar *msgbar, int timeout )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     msgbar->pushMessage( QObject::tr( "Authentication System" ),
                          QObject::tr( "DISABLED. Resources authenticating via the system can not be accessed" ),
@@ -79,14 +80,14 @@ void QgsAuthGuiUtils::setMasterPassword( QgsMessageBar *msgbar, int timeout )
   if ( QgsAuthGuiUtils::isDisabled( msgbar, timeout ) )
     return;
 
-  if ( QgsAuthManager::instance()->masterPasswordIsSet() )
+  if ( QgsApplication::authManager()->masterPasswordIsSet() )
   {
-    msgbar->pushMessage( QgsAuthManager::instance()->authManTag(),
+    msgbar->pushMessage( QgsApplication::authManager()->authManTag(),
                          QObject::tr( "Master password already set" ),
                          QgsMessageBar::INFO, timeout );
     return;
   }
-  ( void )QgsAuthManager::instance()->setMasterPassword( true );
+  ( void )QgsApplication::authManager()->setMasterPassword( true );
 }
 
 void QgsAuthGuiUtils::clearCachedMasterPassword( QgsMessageBar *msgbar, int timeout )
@@ -97,18 +98,18 @@ void QgsAuthGuiUtils::clearCachedMasterPassword( QgsMessageBar *msgbar, int time
   QString msg( QObject::tr( "Master password not cleared because it is not set" ) );
   QgsMessageBar::MessageLevel level( QgsMessageBar::INFO );
 
-  if ( QgsAuthManager::instance()->masterPasswordIsSet() )
+  if ( QgsApplication::authManager()->masterPasswordIsSet() )
   {
-    QgsAuthManager::instance()->clearMasterPassword();
+    QgsApplication::authManager()->clearMasterPassword();
     msg = QObject::tr( "Master password cleared (NOTE: network connections may be cached)" );
-    if ( QgsAuthManager::instance()->masterPasswordIsSet() )
+    if ( QgsApplication::authManager()->masterPasswordIsSet() )
     {
       msg = QObject::tr( "Master password FAILED to be cleared" );
       level = QgsMessageBar::WARNING;
     }
   }
 
-  msgbar->pushMessage( QgsAuthManager::instance()->authManTag(), msg, level, timeout );
+  msgbar->pushMessage( QgsApplication::authManager()->authManTag(), msg, level, timeout );
 }
 
 void QgsAuthGuiUtils::resetMasterPassword( QgsMessageBar *msgbar, int timeout, QWidget *parent )
@@ -120,10 +121,10 @@ void QgsAuthGuiUtils::resetMasterPassword( QgsMessageBar *msgbar, int timeout, Q
   QgsMessageBar::MessageLevel level( QgsMessageBar::INFO );
 
   // check that a master password is even set in auth db
-  if ( !QgsAuthManager::instance()->masterPasswordHashInDatabase() )
+  if ( !QgsApplication::authManager()->masterPasswordHashInDatabase() )
   {
     msg = QObject::tr( "Master password reset: NO current password hash in database" );
-    msgbar->pushMessage( QgsAuthManager::instance()->authManTag(), msg, QgsMessageBar::WARNING, 0 );
+    msgbar->pushMessage( QgsApplication::authManager()->authManTag(), msg, QgsMessageBar::WARNING, 0 );
     return;
   }
 
@@ -140,7 +141,7 @@ void QgsAuthGuiUtils::resetMasterPassword( QgsMessageBar *msgbar, int timeout, Q
   }
 
   QString backuppath;
-  if ( !QgsAuthManager::instance()->resetMasterPassword( newpass, oldpass, keepbackup, &backuppath ) )
+  if ( !QgsApplication::authManager()->resetMasterPassword( newpass, oldpass, keepbackup, &backuppath ) )
   {
     msg = QObject::tr( "Master password FAILED to be reset" );
     level = QgsMessageBar::WARNING;
@@ -152,7 +153,7 @@ void QgsAuthGuiUtils::resetMasterPassword( QgsMessageBar *msgbar, int timeout, Q
     timeout = 0; // no timeout, so user can read backup message
   }
 
-  msgbar->pushMessage( QgsAuthManager::instance()->authManTag(), msg, level, timeout );
+  msgbar->pushMessage( QgsApplication::authManager()->authManTag(), msg, level, timeout );
 }
 
 void QgsAuthGuiUtils::clearCachedAuthenticationConfigs( QgsMessageBar *msgbar, int timeout )
@@ -160,9 +161,9 @@ void QgsAuthGuiUtils::clearCachedAuthenticationConfigs( QgsMessageBar *msgbar, i
   if ( QgsAuthGuiUtils::isDisabled( msgbar, timeout ) )
     return;
 
-  QgsAuthManager::instance()->clearAllCachedConfigs();
+  QgsApplication::authManager()->clearAllCachedConfigs();
   QString msg = QObject::tr( "Cached authentication configurations for session cleared" );
-  msgbar->pushMessage( QgsAuthManager::instance()->authManTag(), msg, QgsMessageBar::INFO, timeout );
+  msgbar->pushMessage( QgsApplication::authManager()->authManTag(), msg, QgsMessageBar::INFO, timeout );
 }
 
 void QgsAuthGuiUtils::removeAuthenticationConfigs( QgsMessageBar *msgbar, int timeout, QWidget *parent )
@@ -183,13 +184,13 @@ void QgsAuthGuiUtils::removeAuthenticationConfigs( QgsMessageBar *msgbar, int ti
   QString msg( QObject::tr( "Authentication configurations removed" ) );
   QgsMessageBar::MessageLevel level( QgsMessageBar::INFO );
 
-  if ( !QgsAuthManager::instance()->removeAllAuthenticationConfigs() )
+  if ( !QgsApplication::authManager()->removeAllAuthenticationConfigs() )
   {
     msg = QObject::tr( "Authentication configurations FAILED to be removed" );
     level = QgsMessageBar::WARNING;
   }
 
-  msgbar->pushMessage( QgsAuthManager::instance()->authManTag(), msg, level, timeout );
+  msgbar->pushMessage( QgsApplication::authManager()->authManTag(), msg, level, timeout );
 }
 
 void QgsAuthGuiUtils::eraseAuthenticationDatabase( QgsMessageBar *msgbar, int timeout, QWidget *parent )
@@ -206,7 +207,7 @@ void QgsAuthGuiUtils::eraseAuthenticationDatabase( QgsMessageBar *msgbar, int ti
                                       QMessageBox::Ok | QMessageBox::Cancel,
                                       QMessageBox::Cancel );
 
-  QgsAuthManager::instance()->setScheduledAuthDatabaseErase( false );
+  QgsApplication::authManager()->setScheduledAuthDatabaseErase( false );
 
   if ( btn == QMessageBox::Cancel )
   {
@@ -217,7 +218,7 @@ void QgsAuthGuiUtils::eraseAuthenticationDatabase( QgsMessageBar *msgbar, int ti
   QgsMessageBar::MessageLevel level( QgsMessageBar::WARNING );
 
   QString backuppath;
-  if ( !QgsAuthManager::instance()->eraseAuthenticationDatabase( true, &backuppath ) )
+  if ( !QgsApplication::authManager()->eraseAuthenticationDatabase( true, &backuppath ) )
   {
     msg = QObject::tr( "Authentication database FAILED to be erased" );
     level = QgsMessageBar::WARNING;
@@ -274,9 +275,9 @@ void QgsAuthGuiUtils::passwordHelperDelete( QgsMessageBar *msgbar, int timeout, 
   }
   QString msg;
   QgsMessageBar::MessageLevel level;
-  if ( ! QgsAuthManager::instance()->passwordHelperDelete() )
+  if ( ! QgsApplication::authManager()->passwordHelperDelete() )
   {
-    msg = QgsAuthManager::instance()->passwordHelperErrorMessage();
+    msg = QgsApplication::authManager()->passwordHelperErrorMessage();
     level = QgsMessageBar::WARNING;
   }
   else
@@ -293,15 +294,15 @@ void QgsAuthGuiUtils::passwordHelperSync( QgsMessageBar *msgbar, int timeout )
 {
   QString msg;
   QgsMessageBar::MessageLevel level;
-  if ( ! QgsAuthManager::instance()->masterPasswordIsSet() )
+  if ( ! QgsApplication::authManager()->masterPasswordIsSet() )
   {
     msg = QObject::tr( "Master password is not set and cannot be stored in your %1" )
           .arg( QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME );
     level = QgsMessageBar::WARNING;
   }
-  else if ( ! QgsAuthManager::instance()->passwordHelperSync() )
+  else if ( ! QgsApplication::authManager()->passwordHelperSync() )
   {
-    msg = QgsAuthManager::instance()->passwordHelperErrorMessage();
+    msg = QgsApplication::authManager()->passwordHelperErrorMessage();
     level = QgsMessageBar::WARNING;
   }
   else
@@ -316,7 +317,7 @@ void QgsAuthGuiUtils::passwordHelperSync( QgsMessageBar *msgbar, int timeout )
 
 void QgsAuthGuiUtils::passwordHelperEnable( bool enabled, QgsMessageBar *msgbar, int timeout )
 {
-  QgsAuthManager::instance()->setPasswordHelperEnabled( enabled );
+  QgsApplication::authManager()->setPasswordHelperEnabled( enabled );
   QString msg = enabled ? QObject::tr( "Your %1 will be <b>used from now</b> on to store and retrieve the master password." )
                 .arg( QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME ) :
                 QObject::tr( "Your %1 will <b>not be used anymore</b> to store and retrieve the master password." )
@@ -328,5 +329,5 @@ void QgsAuthGuiUtils::passwordHelperLoggingEnable( bool enabled, QgsMessageBar *
 {
   Q_UNUSED( msgbar );
   Q_UNUSED( timeout );
-  QgsAuthManager::instance()->setPasswordHelperLoggingEnabled( enabled );
+  QgsApplication::authManager()->setPasswordHelperLoggingEnabled( enabled );
 }

--- a/src/gui/auth/qgsauthidentitieseditor.cpp
+++ b/src/gui/auth/qgsauthidentitieseditor.cpp
@@ -33,12 +33,12 @@
 QgsAuthIdentitiesEditor::QgsAuthIdentitiesEditor( QWidget *parent )
   : QWidget( parent )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -49,10 +49,10 @@ QgsAuthIdentitiesEditor::QgsAuthIdentitiesEditor( QWidget *parent )
     connect( btnInfoIdentity, &QToolButton::clicked, this, &QgsAuthIdentitiesEditor::btnInfoIdentity_clicked );
     connect( btnGroupByOrg, &QToolButton::toggled, this, &QgsAuthIdentitiesEditor::btnGroupByOrg_toggled );
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+    connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
              this, &QgsAuthIdentitiesEditor::authMessageOut );
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::authDatabaseChanged,
+    connect( QgsApplication::authManager(), &QgsAuthManager::authDatabaseChanged,
              this, &QgsAuthIdentitiesEditor::refreshIdentitiesView );
 
     setupIdentitiesTree();
@@ -66,7 +66,7 @@ QgsAuthIdentitiesEditor::QgsAuthIdentitiesEditor( QWidget *parent )
     connect( btnViewRefresh, &QAbstractButton::clicked, this, &QgsAuthIdentitiesEditor::refreshIdentitiesView );
 
     btnGroupByOrg->setChecked( false );
-    QVariant sortbyval = QgsAuthManager::instance()->getAuthSetting( QStringLiteral( "identitiessortby" ), QVariant( false ) );
+    QVariant sortbyval = QgsApplication::authManager()->getAuthSetting( QStringLiteral( "identitiessortby" ), QVariant( false ) );
     if ( !sortbyval.isNull() )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
@@ -117,7 +117,7 @@ void QgsAuthIdentitiesEditor::populateIdentitiesView()
   removeChildren_( mRootCertIdentItem );
 
   populateIdentitiesSection( mRootCertIdentItem,
-                             QgsAuthManager::instance()->getCertIdentities(),
+                             QgsApplication::authManager()->getCertIdentities(),
                              QgsAuthIdentitiesEditor::CertIdentity );
 }
 
@@ -224,13 +224,13 @@ void QgsAuthIdentitiesEditor::showCertInfo( QTreeWidgetItem *item )
 
   QString digest( item->data( 0, Qt::UserRole ).toString() );
 
-  if ( !QgsAuthManager::instance()->existsCertIdentity( digest ) )
+  if ( !QgsApplication::authManager()->existsCertIdentity( digest ) )
   {
     QgsDebugMsg( "Certificate identity does not exist in database" );
     return;
   }
 
-  QSslCertificate cert( QgsAuthManager::instance()->getCertIdentity( digest ) );
+  QSslCertificate cert( QgsApplication::authManager()->getCertIdentity( digest ) );
 
   QgsAuthCertInfoDialog *dlg = new QgsAuthCertInfoDialog( cert, false, this );
   dlg->setWindowModality( Qt::WindowModal );
@@ -300,7 +300,7 @@ void QgsAuthIdentitiesEditor::btnAddIdentity_clicked()
     if ( dlg->identityType() == QgsAuthImportIdentityDialog::CertIdentity )
     {
       const QPair<QSslCertificate, QSslKey> &bundle( dlg->certBundleToImport() );
-      if ( !QgsAuthManager::instance()->storeCertIdentity( bundle.first, bundle.second ) )
+      if ( !QgsApplication::authManager()->storeCertIdentity( bundle.first, bundle.second ) )
       {
         messageBar()->pushMessage( tr( "ERROR storing identity bundle in authentication database" ),
                                    QgsMessageBar::CRITICAL );
@@ -331,7 +331,7 @@ void QgsAuthIdentitiesEditor::btnRemoveIdentity_clicked()
     return;
   }
 
-  if ( !QgsAuthManager::instance()->existsCertIdentity( digest ) )
+  if ( !QgsApplication::authManager()->existsCertIdentity( digest ) )
   {
     QgsDebugMsg( "Certificate identity does not exist in database" );
     return;
@@ -348,7 +348,7 @@ void QgsAuthIdentitiesEditor::btnRemoveIdentity_clicked()
     return;
   }
 
-  if ( !QgsAuthManager::instance()->removeCertIdentity( digest ) )
+  if ( !QgsApplication::authManager()->removeCertIdentity( digest ) )
   {
     messageBar()->pushMessage( tr( "ERROR removing cert identity from authentication database for id %1:" ).arg( digest ),
                                QgsMessageBar::CRITICAL );
@@ -370,7 +370,7 @@ void QgsAuthIdentitiesEditor::btnInfoIdentity_clicked()
 
 void QgsAuthIdentitiesEditor::btnGroupByOrg_toggled( bool checked )
 {
-  if ( !QgsAuthManager::instance()->storeAuthSetting( QStringLiteral( "identitiessortby" ), QVariant( checked ) ) )
+  if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "identitiessortby" ), QVariant( checked ) ) )
   {
     authMessageOut( QObject::tr( "Could not store sort by preference" ),
                     QObject::tr( "Authentication Identities" ),

--- a/src/gui/auth/qgsauthimportcertdialog.cpp
+++ b/src/gui/auth/qgsauthimportcertdialog.cpp
@@ -27,6 +27,7 @@
 #include "qgsauthcertutils.h"
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
+#include "qgsapplication.h"
 
 
 QgsAuthImportCertDialog::QgsAuthImportCertDialog( QWidget *parent,
@@ -36,12 +37,12 @@ QgsAuthImportCertDialog::QgsAuthImportCertDialog( QWidget *parent,
   , mFilter( filter )
   , mInput( input )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else

--- a/src/gui/auth/qgsauthimportidentitydialog.cpp
+++ b/src/gui/auth/qgsauthimportidentitydialog.cpp
@@ -27,6 +27,7 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 static QByteArray fileData_( const QString &path, bool astext = false )
@@ -57,12 +58,12 @@ QgsAuthImportIdentityDialog::QgsAuthImportIdentityDialog( QgsAuthImportIdentityD
   , mDisabled( false )
 
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else

--- a/src/gui/auth/qgsauthmasterpassresetdialog.cpp
+++ b/src/gui/auth/qgsauthmasterpassresetdialog.cpp
@@ -22,16 +22,17 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 QgsMasterPasswordResetDialog::QgsMasterPasswordResetDialog( QWidget *parent )
   : QDialog( parent )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -44,7 +45,7 @@ QgsMasterPasswordResetDialog::QgsMasterPasswordResetDialog( QWidget *parent )
 
 bool QgsMasterPasswordResetDialog::requestMasterPasswordReset( QString *newpass, QString *oldpass, bool *keepbackup )
 {
-  if ( !QgsAuthManager::instance()->isDisabled() )
+  if ( !QgsApplication::authManager()->isDisabled() )
   {
     validatePasswords();
     leMasterPassCurrent->setFocus();
@@ -66,9 +67,9 @@ bool QgsMasterPasswordResetDialog::requestMasterPasswordReset( QString *newpass,
 void QgsMasterPasswordResetDialog::leMasterPassCurrent_textChanged( const QString &pass )
 {
   // since this is called on every keystroke, block signals emitted during verification of password
-  QgsAuthManager::instance()->blockSignals( true );
+  QgsApplication::authManager()->blockSignals( true );
   mPassCurOk = !pass.isEmpty();
-  QgsAuthManager::instance()->blockSignals( false );
+  QgsApplication::authManager()->blockSignals( false );
   validatePasswords();
 }
 

--- a/src/gui/auth/qgsauthserverseditor.cpp
+++ b/src/gui/auth/qgsauthserverseditor.cpp
@@ -31,12 +31,12 @@
 QgsAuthServersEditor::QgsAuthServersEditor( QWidget *parent )
   : QWidget( parent )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -47,10 +47,10 @@ QgsAuthServersEditor::QgsAuthServersEditor( QWidget *parent )
     connect( btnEditServer, &QToolButton::clicked, this, &QgsAuthServersEditor::btnEditServer_clicked );
     connect( btnGroupByOrg, &QToolButton::toggled, this, &QgsAuthServersEditor::btnGroupByOrg_toggled );
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+    connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
              this, &QgsAuthServersEditor::authMessageOut );
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::authDatabaseChanged,
+    connect( QgsApplication::authManager(), &QgsAuthManager::authDatabaseChanged,
              this, &QgsAuthServersEditor::refreshSslConfigsView );
 
     setupSslConfigsTree();
@@ -64,7 +64,7 @@ QgsAuthServersEditor::QgsAuthServersEditor( QWidget *parent )
     connect( btnViewRefresh, &QAbstractButton::clicked, this, &QgsAuthServersEditor::refreshSslConfigsView );
 
     btnGroupByOrg->setChecked( false );
-    QVariant sortbyval = QgsAuthManager::instance()->getAuthSetting( QStringLiteral( "serverssortby" ), QVariant( false ) );
+    QVariant sortbyval = QgsApplication::authManager()->getAuthSetting( QStringLiteral( "serverssortby" ), QVariant( false ) );
     if ( !sortbyval.isNull() )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
@@ -116,7 +116,7 @@ void QgsAuthServersEditor::populateSslConfigsView()
   removeChildren_( mRootSslConfigItem );
 
   populateSslConfigsSection( mRootSslConfigItem,
-                             QgsAuthManager::instance()->getSslCertCustomConfigs(),
+                             QgsApplication::authManager()->getSslCertCustomConfigs(),
                              QgsAuthServersEditor::ServerConfig );
 }
 
@@ -307,7 +307,7 @@ void QgsAuthServersEditor::btnRemoveServer_clicked()
     return;
   }
 
-  if ( !QgsAuthManager::instance()->existsSslCertCustomConfig( digest, hostport ) )
+  if ( !QgsApplication::authManager()->existsSslCertCustomConfig( digest, hostport ) )
   {
     QgsDebugMsg( QString( "SSL custom config does not exist in database for host:port, id %1:" )
                  .arg( hostport, digest ) );
@@ -325,7 +325,7 @@ void QgsAuthServersEditor::btnRemoveServer_clicked()
     return;
   }
 
-  if ( !QgsAuthManager::instance()->removeSslCertCustomConfig( digest, hostport ) )
+  if ( !QgsApplication::authManager()->removeSslCertCustomConfig( digest, hostport ) )
   {
     messageBar()->pushMessage( tr( "ERROR removing SSL custom config from authentication database for host:port, id %1:" )
                                .arg( hostport, digest ),
@@ -363,13 +363,13 @@ void QgsAuthServersEditor::btnEditServer_clicked()
     return;
   }
 
-  if ( !QgsAuthManager::instance()->existsSslCertCustomConfig( digest, hostport ) )
+  if ( !QgsApplication::authManager()->existsSslCertCustomConfig( digest, hostport ) )
   {
     QgsDebugMsg( "SSL custom config does not exist in database" );
     return;
   }
 
-  QgsAuthConfigSslServer config( QgsAuthManager::instance()->getSslCertCustomConfig( digest, hostport ) );
+  QgsAuthConfigSslServer config( QgsApplication::authManager()->getSslCertCustomConfig( digest, hostport ) );
   QSslCertificate cert( config.sslCertificate() );
 
   QgsAuthSslConfigDialog *dlg = new QgsAuthSslConfigDialog( this, cert, hostport );
@@ -385,7 +385,7 @@ void QgsAuthServersEditor::btnEditServer_clicked()
 
 void QgsAuthServersEditor::btnGroupByOrg_toggled( bool checked )
 {
-  if ( !QgsAuthManager::instance()->storeAuthSetting( QStringLiteral( "serverssortby" ), QVariant( checked ) ) )
+  if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "serverssortby" ), QVariant( checked ) ) )
   {
     authMessageOut( QObject::tr( "Could not store sort by preference" ),
                     QObject::tr( "Authentication SSL Configs" ),

--- a/src/gui/auth/qgsauthsettingswidget.cpp
+++ b/src/gui/auth/qgsauthsettingswidget.cpp
@@ -16,6 +16,7 @@
 #include "qgsauthsettingswidget.h"
 #include "qgsauthmanager.h"
 #include "qgsauthconfig.h"
+#include "qgsapplication.h"
 
 #include <QDateTime>
 
@@ -170,7 +171,7 @@ bool QgsAuthSettingsWidget::convertToEncrypted( )
   config.setName( tr( "Converted config %1" ).arg( QDateTime::currentDateTime().toString( ) ) );
   config.setConfig( QStringLiteral( "username" ), txtUserName->text() );
   config.setConfig( QStringLiteral( "password" ), txtPassword->text() );
-  if ( ! QgsAuthManager::instance()->storeAuthenticationConfig( config ) )
+  if ( ! QgsApplication::authManager()->storeAuthenticationConfig( config ) )
   {
     mAuthConfigSelect->showMessage( tr( "Couldn't create a Basic authentication configuration!" ) );
     return false;

--- a/src/gui/auth/qgsauthsslconfigwidget.cpp
+++ b/src/gui/auth/qgsauthsslconfigwidget.cpp
@@ -25,6 +25,7 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 static void setItemBold_( QTreeWidgetItem *item )
@@ -46,12 +47,12 @@ QgsAuthSslConfigWidget::QgsAuthSslConfigWidget( QWidget *parent,
   , mCert( nullptr )
   , mConnectionCAs( connectionCAs )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -249,7 +250,7 @@ void QgsAuthSslConfigWidget::setSslCertificate( const QSslCertificate &cert, con
 
   QString sha( QgsAuthCertUtils::shaHexForCert( cert ) );
   QgsAuthConfigSslServer config(
-    QgsAuthManager::instance()->getSslCertCustomConfig( sha, hostport.isEmpty() ? sslHost() : hostport ) );
+    QgsApplication::authManager()->getSslCertCustomConfig( sha, hostport.isEmpty() ? sslHost() : hostport ) );
 
   emit certFoundInAuthDatabase( !config.isNull() );
 
@@ -306,7 +307,7 @@ void QgsAuthSslConfigWidget::saveSslCertConfig()
   {
     return;
   }
-  if ( !QgsAuthManager::instance()->storeSslCertCustomConfig( sslCustomConfig() ) )
+  if ( !QgsApplication::authManager()->storeSslCertCustomConfig( sslCustomConfig() ) )
   {
     QgsDebugMsg( "SSL custom config FAILED to store in authentication database" );
   }

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -30,6 +30,7 @@
 #include "qgsauthtrustedcasdialog.h"
 #include "qgscollapsiblegroupbox.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
@@ -70,7 +71,7 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
   ignoreButton()->setDefault( false );
   abortButton()->setDefault( true );
 
-  if ( !QgsAuthManager::instance()->isDisabled() )
+  if ( !QgsApplication::authManager()->isDisabled() )
   {
     saveButton()->setEnabled( false );
 
@@ -174,7 +175,7 @@ void QgsAuthSslErrorsDialog::buttonBox_clicked( QAbstractButton *button )
   switch ( btnenum )
   {
     case QDialogButtonBox::Ignore:
-      QgsAuthManager::instance()->updateIgnoredSslErrorsCache(
+      QgsApplication::authManager()->updateIgnoredSslErrorsCache(
         QStringLiteral( "%1:%2" ).arg( mDigest, mHostPort ),
         mSslErrors );
       accept();
@@ -240,7 +241,7 @@ void QgsAuthSslErrorsDialog::btnChainCAs_clicked()
 
 void QgsAuthSslErrorsDialog::grpbxSslErrors_collapsedStateChanged( bool collapsed )
 {
-  if ( !collapsed && QgsAuthManager::instance()->isDisabled() )
+  if ( !collapsed && QgsApplication::authManager()->isDisabled() )
   {
     btnChainInfo->setVisible( false );
     btnChainCAs->setVisible( false );

--- a/src/gui/auth/qgsauthsslimportdialog.cpp
+++ b/src/gui/auth/qgsauthsslimportdialog.cpp
@@ -78,16 +78,17 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 
 QgsAuthSslImportDialog::QgsAuthSslImportDialog( QWidget *parent )
   : QDialog( parent )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -132,7 +133,7 @@ QgsAuthSslImportDialog::QgsAuthSslImportDialog( QWidget *parent )
              this, &QgsAuthSslImportDialog::widgetReadyToSaveChanged );
     wdgtSslConfig->setEnabled( false );
 
-    mTrustedCAs = QgsAuthManager::instance()->getTrustedCaCertsCache();
+    mTrustedCAs = QgsApplication::authManager()->getTrustedCaCertsCache();
   }
 }
 

--- a/src/gui/auth/qgsauthtrustedcasdialog.cpp
+++ b/src/gui/auth/qgsauthtrustedcasdialog.cpp
@@ -32,12 +32,12 @@ QgsAuthTrustedCAsDialog::QgsAuthTrustedCAsDialog( QWidget *parent,
   : QDialog( parent )
   , mTrustedCAs( trustedCAs )
 {
-  if ( QgsAuthManager::instance()->isDisabled() )
+  if ( QgsApplication::authManager()->isDisabled() )
   {
     mDisabled = true;
     mAuthNotifyLayout = new QVBoxLayout;
     this->setLayout( mAuthNotifyLayout );
-    mAuthNotify = new QLabel( QgsAuthManager::instance()->disabledMessage(), this );
+    mAuthNotify = new QLabel( QgsApplication::authManager()->disabledMessage(), this );
     mAuthNotifyLayout->addWidget( mAuthNotify );
   }
   else
@@ -46,7 +46,7 @@ QgsAuthTrustedCAsDialog::QgsAuthTrustedCAsDialog( QWidget *parent,
     connect( btnInfoCa, &QToolButton::clicked, this, &QgsAuthTrustedCAsDialog::btnInfoCa_clicked );
     connect( btnGroupByOrg, &QToolButton::toggled, this, &QgsAuthTrustedCAsDialog::btnGroupByOrg_toggled );
 
-    connect( QgsAuthManager::instance(), &QgsAuthManager::messageOut,
+    connect( QgsApplication::authManager(), &QgsAuthManager::messageOut,
              this, &QgsAuthTrustedCAsDialog::authMessageOut );
 
     setupCaCertsTree();
@@ -59,7 +59,7 @@ QgsAuthTrustedCAsDialog::QgsAuthTrustedCAsDialog( QWidget *parent,
 
 
     btnGroupByOrg->setChecked( false );
-    QVariant sortbyval = QgsAuthManager::instance()->getAuthSetting( QStringLiteral( "trustedcasortby" ), QVariant( false ) );
+    QVariant sortbyval = QgsApplication::authManager()->getAuthSetting( QStringLiteral( "trustedcasortby" ), QVariant( false ) );
     if ( !sortbyval.isNull() )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
@@ -111,7 +111,7 @@ void QgsAuthTrustedCAsDialog::populateCaCertsView()
 
   if ( mTrustedCAs.isEmpty() )
   {
-    mTrustedCAs = QgsAuthManager::instance()->getTrustedCaCerts();
+    mTrustedCAs = QgsApplication::authManager()->getTrustedCaCerts();
   }
 
   populateCaCertsSection( mRootCaSecItem, mTrustedCAs, QgsAuthTrustedCAsDialog::CaCert );
@@ -216,7 +216,7 @@ void QgsAuthTrustedCAsDialog::showCertInfo( QTreeWidgetItem *item )
   QString digest( item->data( 0, Qt::UserRole ).toString() );
 
   QMap<QString, QPair<QgsAuthCertUtils::CaCertSource, QSslCertificate> > cacertscache(
-    QgsAuthManager::instance()->getCaCertsCache() );
+    QgsApplication::authManager()->getCaCertsCache() );
 
   if ( !cacertscache.contains( digest ) )
   {
@@ -294,7 +294,7 @@ void QgsAuthTrustedCAsDialog::btnInfoCa_clicked()
 
 void QgsAuthTrustedCAsDialog::btnGroupByOrg_toggled( bool checked )
 {
-  if ( !QgsAuthManager::instance()->storeAuthSetting( QStringLiteral( "trustedcasortby" ), QVariant( checked ) ) )
+  if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "trustedcasortby" ), QVariant( checked ) ) )
   {
     authMessageOut( QObject::tr( "Could not store sort by preference" ),
                     QObject::tr( "Trusted Authorities/Issuers" ),

--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -20,6 +20,7 @@
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgsapplication.h"
 
 #include <QPushButton>
 #include <QThread>
@@ -73,7 +74,7 @@ void QgsCredentialDialog::requestCredentials( const QString &realm, QString *use
   QgsDebugMsg( "Entering." );
   stackedWidget->setCurrentIndex( 0 );
 
-  chkbxPasswordHelperEnable->setChecked( QgsAuthManager::instance()->passwordHelperEnabled() );
+  chkbxPasswordHelperEnable->setChecked( QgsApplication::authManager()->passwordHelperEnabled() );
   labelRealm->setText( realm );
   leUsername->setText( *username );
   lePassword->setText( *password );
@@ -127,7 +128,7 @@ void QgsCredentialDialog::requestCredentialsMasterPassword( QString *password, b
   QString titletxt( stored ? tr( "Enter CURRENT master authentication password" ) : tr( "Set NEW master authentication password" ) );
   lblPasswordTitle->setText( titletxt );
 
-  chkbxPasswordHelperEnable->setChecked( QgsAuthManager::instance()->passwordHelperEnabled() );
+  chkbxPasswordHelperEnable->setChecked( QgsApplication::authManager()->passwordHelperEnabled() );
 
   leMasterPassVerify->setVisible( !stored );
   lblDontForget->setVisible( !stored );
@@ -161,7 +162,7 @@ void QgsCredentialDialog::requestCredentialsMasterPassword( QString *password, b
       bool passok = !leMasterPass->text().isEmpty();
       if ( passok && stored && !chkbxEraseAuthDb->isChecked() )
       {
-        passok = QgsAuthManager::instance()->verifyMasterPassword( leMasterPass->text() );
+        passok = QgsApplication::authManager()->verifyMasterPassword( leMasterPass->text() );
       }
 
       if ( passok && !stored )
@@ -173,15 +174,15 @@ void QgsCredentialDialog::requestCredentialsMasterPassword( QString *password, b
       {
         if ( stored && chkbxEraseAuthDb->isChecked() )
         {
-          QgsAuthManager::instance()->setScheduledAuthDatabaseErase( true );
+          QgsApplication::authManager()->setScheduledAuthDatabaseErase( true );
         }
         else
         {
           *password = leMasterPass->text();
           // Let's store user's preferences to use the password helper
-          if ( chkbxPasswordHelperEnable->isChecked() != QgsAuthManager::instance()->passwordHelperEnabled() )
+          if ( chkbxPasswordHelperEnable->isChecked() != QgsApplication::authManager()->passwordHelperEnabled() )
           {
-            QgsAuthManager::instance()->setPasswordHelperEnabled( chkbxPasswordHelperEnable->isChecked() );
+            QgsApplication::authManager()->setPasswordHelperEnabled( chkbxPasswordHelperEnable->isChecked() );
           }
         }
         break;

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -1179,7 +1179,7 @@ bool QgsWcsCapabilities::setAuthorization( QNetworkRequest &request ) const
 {
   if ( mUri.hasParam( QStringLiteral( "authcfg" ) ) && !mUri.param( QStringLiteral( "authcfg" ) ).isEmpty() )
   {
-    return QgsAuthManager::instance()->updateNetworkRequest( request, mUri.param( QStringLiteral( "authcfg" ) ) );
+    return QgsApplication::authManager()->updateNetworkRequest( request, mUri.param( QStringLiteral( "authcfg" ) ) );
   }
   else if ( mUri.hasParam( QStringLiteral( "username" ) ) && mUri.hasParam( QStringLiteral( "password" ) ) )
   {
@@ -1193,7 +1193,7 @@ bool QgsWcsCapabilities::setAuthorizationReply( QNetworkReply *reply ) const
 {
   if ( mUri.hasParam( QStringLiteral( "authcfg" ) ) && !mUri.param( QStringLiteral( "authcfg" ) ).isEmpty() )
   {
-    return QgsAuthManager::instance()->updateNetworkReply( reply, mUri.param( QStringLiteral( "authcfg" ) ) );
+    return QgsApplication::authManager()->updateNetworkReply( reply, mUri.param( QStringLiteral( "authcfg" ) ) );
   }
   return true;
 }

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -30,6 +30,7 @@
 #include "qgsrectangle.h"
 #include "qgscoordinatetransform.h"
 #include "qgsogrutils.h"
+#include "qgsapplication.h"
 
 #include <QString>
 #include <QStringList>
@@ -64,7 +65,7 @@ struct QgsWcsAuthorization
   {
     if ( !mAuthCfg.isEmpty() )
     {
-      return QgsAuthManager::instance()->updateNetworkRequest( request, mAuthCfg );
+      return QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg );
     }
     else if ( !mUserName.isNull() || !mPassword.isNull() )
     {
@@ -78,7 +79,7 @@ struct QgsWcsAuthorization
   {
     if ( !mAuthCfg.isEmpty() )
     {
-      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
+      return QgsApplication::authManager()->updateNetworkReply( reply, mAuthCfg );
     }
     return true;
   }

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -19,6 +19,7 @@
 #include "qgsauthmanager.h"
 #include "qgsdatasourceuri.h"
 #include "qgsrectangle.h"
+#include "qgsapplication.h"
 
 #include <QNetworkRequest>
 #include <QString>
@@ -37,7 +38,7 @@ struct QgsWFSAuthorization
   {
     if ( !mAuthCfg.isEmpty() ) // must be non-empty value
     {
-      return QgsAuthManager::instance()->updateNetworkRequest( request, mAuthCfg );
+      return QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg );
     }
     else if ( !mUserName.isNull() || !mPassword.isNull() ) // allow empty values
     {
@@ -51,7 +52,7 @@ struct QgsWFSAuthorization
   {
     if ( !mAuthCfg.isEmpty() )
     {
-      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
+      return QgsApplication::authManager()->updateNetworkReply( reply, mAuthCfg );
     }
     return true;
   }

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -25,6 +25,7 @@
 #include "qgsraster.h"
 #include "qgsrectangle.h"
 #include "qgsrasteriterator.h"
+#include "qgsapplication.h"
 
 class QNetworkReply;
 
@@ -506,7 +507,7 @@ struct QgsWmsAuthorization
   {
     if ( !mAuthCfg.isEmpty() )
     {
-      return QgsAuthManager::instance()->updateNetworkRequest( request, mAuthCfg );
+      return QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg );
     }
     else if ( !mUserName.isEmpty() || !mPassword.isEmpty() )
     {
@@ -524,7 +525,7 @@ struct QgsWmsAuthorization
   {
     if ( !mAuthCfg.isEmpty() )
     {
-      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
+      return QgsApplication::authManager()->updateNetworkReply( reply, mAuthCfg );
     }
     return true;
   }

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -240,7 +240,7 @@ bool QgsServer::init()
 
   QgsApplication::createDatabase(); //init qgis.db (e.g. necessary for user crs)
 
-  // Instantiate authentication system
+  // Initialize the authentication system
   //   creates or uses qgis-auth.db in ~/.qgis3/ or directory defined by QGIS_AUTH_DB_DIR_PATH env variable
   //   set the master password as first line of file defined by QGIS_AUTH_PASSWORD_FILE env variable
   //   (QGIS_AUTH_PASSWORD_FILE variable removed from environment after accessing)

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -244,7 +244,7 @@ bool QgsServer::init()
   //   creates or uses qgis-auth.db in ~/.qgis3/ or directory defined by QGIS_AUTH_DB_DIR_PATH env variable
   //   set the master password as first line of file defined by QGIS_AUTH_PASSWORD_FILE env variable
   //   (QGIS_AUTH_PASSWORD_FILE variable removed from environment after accessing)
-  QgsAuthManager::instance()->init( QgsApplication::pluginPath() );
+  QgsApplication::authManager()->init( QgsApplication::pluginPath(), QgsApplication::qgisAuthDatabaseFilePath() );
 
   QString defaultConfigFilePath;
   QFileInfo projectFileInfo = defaultProjectFile(); //try to find a .qgs file in the server directory

--- a/tests/src/core/testqgsauthmanager.cpp
+++ b/tests/src/core/testqgsauthmanager.cpp
@@ -90,7 +90,7 @@ void TestQgsAuthManager::initTestCase()
   // init app and auth manager
   QgsApplication::init();
   QgsApplication::initQgis();
-  QVERIFY2( !QgsAuthManager::instance()->isDisabled(),
+  QVERIFY2( !QgsApplication::authManager()->isDisabled(),
             "Authentication system is DISABLED" );
 
   QString mySettings = QgsApplication::showSettings();
@@ -98,15 +98,15 @@ void TestQgsAuthManager::initTestCase()
   mReport += "<p>" + mySettings + "</p>\n";
 
   // verify QGIS_AUTH_DB_DIR_PATH (temp auth db path) worked
-  QString db1( QFileInfo( QgsAuthManager::instance()->authenticationDatabasePath() ).canonicalFilePath() );
+  QString db1( QFileInfo( QgsApplication::authManager()->authenticationDatabasePath() ).canonicalFilePath() );
   QString db2( QFileInfo( mTempDir + "/qgis-auth.db" ).canonicalFilePath() );
   QVERIFY2( db1 == db2, "Auth db temp path does not match db path of manager" );
 
   // verify master pass can be set manually
   // (this also creates a fresh password hash in the new temp database)
-  QVERIFY2( QgsAuthManager::instance()->setMasterPassword( mPass, true ),
+  QVERIFY2( QgsApplication::authManager()->setMasterPassword( mPass, true ),
             "Master password could not be set" );
-  QVERIFY2( QgsAuthManager::instance()->masterPasswordIsSet(),
+  QVERIFY2( QgsApplication::authManager()->masterPasswordIsSet(),
             "Auth master password not set from passed string" );
 
   // create QGIS_AUTH_PASSWORD_FILE file
@@ -126,11 +126,11 @@ void TestQgsAuthManager::initTestCase()
   // QTest::qSleep( 3000 );
   QgsApplication::init();
   QgsApplication::initQgis();
-  QVERIFY2( !QgsAuthManager::instance()->isDisabled(),
+  QVERIFY2( !QgsApplication::authManager()->isDisabled(),
             "Authentication system is DISABLED" );
 
   // verify QGIS_AUTH_PASSWORD_FILE worked, when compared against hash in db
-  QVERIFY2( QgsAuthManager::instance()->masterPasswordIsSet(),
+  QVERIFY2( QgsApplication::authManager()->masterPasswordIsSet(),
             "Auth master password not set from QGIS_AUTH_PASSWORD_FILE" );
 
   // all tests should now have a valid qgis-auth.db and stored/set master password
@@ -191,7 +191,7 @@ void TestQgsAuthManager::testMasterPassword()
 {
   // password is already stored/set in initTestCase()
   // NOTE: leave it in the same state when done with this test
-  QgsAuthManager *authm = QgsAuthManager::instance();
+  QgsAuthManager *authm = QgsApplication::authManager();
 
   QVERIFY( authm->masterPasswordIsSet() );
   QVERIFY( authm->masterPasswordHashInDatabase() );
@@ -235,7 +235,7 @@ void TestQgsAuthManager::testAuthConfigs()
   QList<QgsAuthMethodConfig> configs( registerAuthConfigs() );
   QVERIFY( !configs.isEmpty() );
 
-  QgsAuthManager *authm = QgsAuthManager::instance();
+  QgsAuthManager *authm = QgsApplication::authManager();
 
   // test storing/loading/updating
   Q_FOREACH ( QgsAuthMethodConfig config, configs )
@@ -350,7 +350,7 @@ void TestQgsAuthManager::testAuthMethods()
   QList<QgsAuthMethodConfig> configs( registerAuthConfigs() );
   QVERIFY( !configs.isEmpty() );
 
-  QgsAuthManager *authm = QgsAuthManager::instance();
+  QgsAuthManager *authm = QgsApplication::authManager();
 
   Q_FOREACH ( QgsAuthMethodConfig config, configs )
   {
@@ -419,14 +419,14 @@ QList<QgsAuthMethodConfig> TestQgsAuthManager::registerAuthConfigs()
 
 void TestQgsAuthManager::doSync()
 {
-  QgsAuthManager *authm = QgsAuthManager::instance();
+  QgsAuthManager *authm = QgsApplication::authManager();
   QVERIFY( authm->passwordHelperSync() );
 }
 
 void TestQgsAuthManager::testPasswordHelper()
 {
 
-  QgsAuthManager *authm = QgsAuthManager::instance();
+  QgsAuthManager *authm = QgsApplication::authManager();
   authm->clearMasterPassword();
 
   QgsSettings settings;

--- a/tests/src/python/test_authmanager_password_ows.py
+++ b/tests/src/python/test_authmanager_password_ows.py
@@ -36,7 +36,7 @@ from shutil import rmtree
 
 from utilities import unitTestDataPath, waitServer
 from qgis.core import (
-    QgsAuthManager,
+    QgsApplication,
     QgsAuthMethodConfig,
     QgsVectorLayer,
     QgsRasterLayer,
@@ -83,7 +83,7 @@ class TestAuthManager(unittest.TestCase):
         cls.project_path = cls.testdata_path + "test_project.qgs"
         # Enable auth
         # os.environ['QGIS_AUTH_PASSWORD_FILE'] = QGIS_AUTH_PASSWORD_FILE
-        authm = QgsAuthManager.instance()
+        authm = QgsApplication.authManager()
         assert (authm.setMasterPassword('masterpassword', True))
         cls.auth_config = QgsAuthMethodConfig('Basic')
         cls.auth_config.setName('test_auth_config')
@@ -104,7 +104,7 @@ class TestAuthManager(unittest.TestCase):
         server_path = os.path.dirname(os.path.realpath(__file__)) + \
             '/qgis_wrapped_server.py'
         cls.server = subprocess.Popen([sys.executable, server_path],
-                                      env=os.environ, stdout=subprocess.PIPE)
+                                      env=os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         line = cls.server.stdout.readline()
         cls.port = int(re.findall(b':(\d+)', line)[0])

--- a/tests/src/python/test_authmanager_pki_ows.py
+++ b/tests/src/python/test_authmanager_pki_ows.py
@@ -33,6 +33,7 @@ from shutil import rmtree
 
 from utilities import unitTestDataPath, waitServer
 from qgis.core import (
+    QgsApplication,
     QgsAuthManager,
     QgsAuthMethodConfig,
     QgsVectorLayer,
@@ -64,7 +65,7 @@ class TestAuthManager(unittest.TestCase):
     @classmethod
     def setUpAuth(cls):
         """Run before all tests and set up authentication"""
-        authm = QgsAuthManager.instance()
+        authm = QgsApplication.authManager()
         assert (authm.setMasterPassword('masterpassword', True))
         cls.sslrootcert_path = os.path.join(cls.certsdata_path, 'chains_subissuer-issuer-root_issuer2-root2.pem')
         cls.sslcert = os.path.join(cls.certsdata_path, 'gerardus_cert.pem')

--- a/tests/src/python/test_authmanager_pki_postgres.py
+++ b/tests/src/python/test_authmanager_pki_postgres.py
@@ -35,6 +35,7 @@ from shutil import rmtree
 
 from utilities import unitTestDataPath
 from qgis.core import (
+    QgsApplication,
     QgsAuthManager,
     QgsAuthMethodConfig,
     QgsVectorLayer,
@@ -97,7 +98,7 @@ class TestAuthManager(unittest.TestCase):
     @classmethod
     def setUpAuth(cls):
         """Run before all tests and set up authentication"""
-        authm = QgsAuthManager.instance()
+        authm = QgsApplication.authManager()
         assert (authm.setMasterPassword('masterpassword', True))
         cls.pg_conf = os.path.join(cls.tempfolder, 'postgresql.conf')
         cls.pg_hba = os.path.join(cls.tempfolder, 'pg_hba.conf')

--- a/tests/src/python/test_authmanager_proxy.py
+++ b/tests/src/python/test_authmanager_proxy.py
@@ -18,7 +18,7 @@ from shutil import rmtree
 import tempfile
 import random
 
-from qgis.core import QgsAuthManager, QgsAuthMethodConfig, QgsNetworkAccessManager, QgsSettings
+from qgis.core import QgsAuthManager, QgsAuthMethodConfig, QgsNetworkAccessManager, QgsSettings, QgsApplication
 from qgis.testing import start_app, unittest
 
 __author__ = 'Alessandro Pasotti'
@@ -43,7 +43,7 @@ class TestAuthManager(unittest.TestCase):
         Creates an auth configuration"""
         # Enable auth
         # os.environ['QGIS_AUTH_PASSWORD_FILE'] = QGIS_AUTH_PASSWORD_FILE
-        authm = QgsAuthManager.instance()
+        authm = QgsApplication.authManager()
         assert (authm.setMasterPassword('masterpassword', True))
         cls.auth_config = QgsAuthMethodConfig('Basic')
         cls.auth_config.setName('test_auth_config')
@@ -70,7 +70,7 @@ class TestAuthManager(unittest.TestCase):
         """
         Test that proxy is updated
         """
-        authm = QgsAuthManager.instance()
+        authm = QgsApplication.authManager()
         nam = QgsNetworkAccessManager.instance()
         proxy = nam.proxy()
         self.assertEqual(proxy.password(), '')

--- a/tests/src/python/test_authsettingswidget.py
+++ b/tests/src/python/test_authsettingswidget.py
@@ -18,7 +18,7 @@ from shutil import rmtree
 import tempfile
 import random
 
-from qgis.core import QgsAuthManager, QgsAuthMethodConfig, QgsNetworkAccessManager, QgsSettings
+from qgis.core import QgsAuthMethodConfig, QgsNetworkAccessManager, QgsSettings, QgsApplication
 from qgis.gui import QgsAuthSettingsWidget
 from qgis.testing import start_app, unittest
 
@@ -46,7 +46,7 @@ class TestAuthenticationWidget(unittest.TestCase):
         Creates an auth configuration"""
         # Enable auth
         # os.environ['QGIS_AUTH_PASSWORD_FILE'] = QGIS_AUTH_PASSWORD_FILE
-        authm = QgsAuthManager.instance()
+        authm = QgsApplication.authManager()
         assert (authm.setMasterPassword('masterpassword', True))
         cls.auth_config = QgsAuthMethodConfig('Basic')
         cls.auth_config.setName('test_auth_config')

--- a/tests/src/python/test_offline_editing_wfs.py
+++ b/tests/src/python/test_offline_editing_wfs.py
@@ -135,7 +135,7 @@ class TestWFST(unittest.TestCase, OfflineTestBase):
         self.counter += 1
         uri = ' '.join([("%s='%s'" % (k, v)) for k, v in list(parms.items())])
         wfs_layer = QgsVectorLayer(uri, layer_name, 'WFS')
-        wfs_layer.setParent(QgsAuthManager.instance())
+        wfs_layer.setParent(QgsApplication.authManager())
         assert wfs_layer.isValid()
         return wfs_layer
 
@@ -146,7 +146,7 @@ class TestWFST(unittest.TestCase, OfflineTestBase):
         """
         path = cls.testdata_path + layer_name + '.shp'
         layer = QgsVectorLayer(path, layer_name, "ogr")
-        layer.setParent(QgsAuthManager.instance())
+        layer.setParent(QgsApplication.authManager())
         assert layer.isValid()
         return layer
 

--- a/tests/src/python/test_qgsauthsystem.py
+++ b/tests/src/python/test_qgsauthsystem.py
@@ -17,7 +17,7 @@ __revision__ = '$Format:%H$'
 import os
 import tempfile
 
-from qgis.core import QgsAuthManager, QgsAuthCertUtils, QgsPkiBundle, QgsAuthMethodConfig, QgsAuthMethod, QgsAuthConfigSslServer
+from qgis.core import QgsAuthManager, QgsAuthCertUtils, QgsPkiBundle, QgsAuthMethodConfig, QgsAuthMethod, QgsAuthConfigSslServer, QgsApplication
 from qgis.gui import QgsAuthEditorWidgets
 
 
@@ -45,7 +45,7 @@ class TestQgsAuthManager(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.authm = QgsAuthManager.instance()
+        cls.authm = QgsApplication.authManager()
         assert not cls.authm.isDisabled(), cls.authm.disabledMessage()
 
         cls.mpass = 'pass'  # master password


### PR DESCRIPTION
## Description

Remove from API the possibility to create an instance of `QgsAuthManager`.
The `QgsAuthManager` singleton is now entirely managed by `QgsApplication` 
and must be accessed with `QgsApplication::authManager()`