### PR TITLE
Two offset curve map tool fixes

### DIFF
--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -33,7 +33,6 @@
 
 QgsMapToolOffsetCurve::QgsMapToolOffsetCurve( QgsMapCanvas *canvas )
   : QgsMapToolEdit( canvas )
-  , mOriginalGeometry( nullptr )
   , mModifiedFeature( -1 )
   , mGeometryModified( false )
   , mForceCopy( false )
@@ -350,6 +349,7 @@ void QgsMapToolOffsetCurve::deleteDistanceWidget()
 
 void QgsMapToolOffsetCurve::deleteRubberBandAndGeometry()
 {
+  mOriginalGeometry.set( nullptr );
   delete mRubberBand;
   mRubberBand = nullptr;
 }

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -88,6 +88,7 @@ void QgsMapToolOffsetCurve::canvasReleaseEvent( QgsMapMouseEvent *e )
     QgsSnappingConfig config = snapping->config();
     // setup new settings (temporary)
     QgsSettings settings;
+    config.setEnabled( true );
     config.setMode( QgsSnappingConfig::AllLayers );
     config.setType( QgsSnappingConfig::Segment );
     config.setTolerance( settings.value( QStringLiteral( "qgis/digitizing/search_radius_vertex_edit" ), 10 ).toDouble() );


### PR DESCRIPTION
## Description
Simple fixes to make this map tool a/ work at all (if snapping is defaulted to off), and b/ work more than once 😄 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
