### PR TITLE
Fix 'epoch' management in rpm spec

### DIFF
--- a/rpm/buildrpms.sh
+++ b/rpm/buildrpms.sh
@@ -90,7 +90,7 @@ then
     let relver+=1
     echo "relver=$relver" > version.cfg
   fi
-  timestamp=1
+  timestamp=0
 else
   relver="git$(git rev-parse --short HEAD)"
   timestamp=$(date +'%s')

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -6,6 +6,12 @@
 # - _relver
 # - _timestamp (optional)
 
+%if %{_timestamp} > 0
+%define builddate %(date -d @%{_timestamp} '+%a %b %d %Y')
+%else
+%define builddate %(date '+%a %b %d %Y')
+%endif
+
 Name:           qgis
 Version:        %{_version}
 Release:        %{_relver}%{?dist}
@@ -366,5 +372,5 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 
 
 %changelog
-* %(date -d @%{_timestamp} '+%a %b %d %Y') Daniele Viganò <daniele@vigano.me> %{_version}-%{_relver}
+* %{builddate} Daniele Viganò <daniele@vigano.me> %{_version}-%{_relver}
 - Automatic build

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -15,7 +15,7 @@ Group:          Applications/Engineering
 License:        GPLv3+ with exceptions
 URL:            http://www.qgis.org
 
-# Epoch is used when building packages from master, otherwise is set to 1
+# Epoch is used when building packages from master, otherwise is set to 0
 Epoch: %{_timestamp}
 
 Source0:        http://qgis.org/downloads/%{name}-%{version}.tar.bz2
@@ -113,7 +113,7 @@ and USGS ASCII DEM.
 %package devel
 Summary:        Development Libraries for the QGIS
 Group:          Development/Libraries
-Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description devel
 Development packages for QGIS including the C header files.
@@ -121,7 +121,7 @@ Development packages for QGIS including the C header files.
 %package grass
 Summary:        GRASS Support Libraries for QGIS
 Group:          Applications/Engineering
-Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 
 # The plug-in requires more than just the grass-libs.
 # This questions the sense of the libs package.
@@ -141,7 +141,7 @@ Provides: %{name}-python%{?_isa} = %{version}-%{release}
 Obsoletes: %{name}-python < %{version}-%{release}
 Summary:        Python integration and plug-ins for QGIS
 Group:          Applications/Engineering
-Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 Requires: gdal-python3
 Requires: python3-future
 Requires: python3-jinja2
@@ -160,7 +160,7 @@ Python integration and plug-ins for QGIS.
 %package server
 Summary:        FCGI-based OGC web map server
 Group:          Applications/Engineering
-Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 Requires:       mod_fcgid
 Provides: mapserver = %{version}-%{release}
 Obsoletes: mapserver < 2.8.1-1


### PR DESCRIPTION
## Description
This PR includes some fixes to the `rpm/buildrpms.sh` file and the spec template:

1. Default `Epoch` when not building 'unstable' packages is now `0` instead of `1` as per official documentation recommendation
2. Fixed an issue on `Depends:` in sub-packages because of `Epoch` (see error here: https://ci.services.vigano.me/#/builders/1/builds/1)
3. changelog date was invalid when `Epoch: 0`

Build tests: https://ci.services.vigano.me/#/builders/2/builds/2
Installation tests:
 - Fedora 26: https://ci.services.vigano.me/#/builders/3/builds/5
 - Fedora 27: https://ci.services.vigano.me/#/builders/4/builds/15

(buildbot sources are available here https://daniele.vigano.me/git/dani/qgis3-ci-copr)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

cc @m-kuhn 
