### PR TITLE
Snap indicators improvements

### DIFF
--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -14,6 +14,7 @@
 %Include qgsmapmouseevent.sip
 %Include qgsmaptip.sip
 %Include qgsrubberband.sip
+%Include qgssnapindicator.sip
 %Include qgstablewidgetitem.sip
 %Include qgsuserinputdockwidget.sip
 %Include qgsbrowserdockwidget.sip
@@ -188,7 +189,6 @@
 %Include qgssearchquerybuilder.sip
 %Include qgsshortcutsmanager.sip
 %Include qgsslider.sip
-%Include qgssnapindicator.sip
 %Include qgsstatusbar.sip
 %Include qgssublayersdialog.sip
 %Include qgssubstitutionlistwidget.sip

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -188,6 +188,7 @@
 %Include qgssearchquerybuilder.sip
 %Include qgsshortcutsmanager.sip
 %Include qgsslider.sip
+%Include qgssnapindicator.sip
 %Include qgsstatusbar.sip
 %Include qgssublayersdialog.sip
 %Include qgssubstitutionlistwidget.sip

--- a/python/gui/qgssnapindicator.sip
+++ b/python/gui/qgssnapindicator.sip
@@ -48,6 +48,12 @@ Returns whether the snapping indicator is visible
  :rtype: bool
 %End
 
+  private:
+    QgsSnapIndicator( const QgsSnapIndicator &rh );
+    QgsSnapIndicator &operator=( const QgsSnapIndicator & );
+%Docstring
+ :rtype: QgsSnapIndicator
+%End
 };
 
 /************************************************************************

--- a/python/gui/qgssnapindicator.sip
+++ b/python/gui/qgssnapindicator.sip
@@ -1,0 +1,59 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssnapindicator.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsSnapIndicator
+{
+%Docstring
+ Class that shows snapping marker on map canvas for the current snapping match.
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgssnapindicator.h"
+%End
+  public:
+    QgsSnapIndicator( QgsMapCanvas *canvas );
+%Docstring
+Constructs an indicator for the given map canvas
+%End
+    ~QgsSnapIndicator();
+
+    void setMatch( const QgsPointLocator::Match &match );
+%Docstring
+Sets snapping match that should be displayed in map canvas. Invalid match hides the indicator
+%End
+    QgsPointLocator::Match match() const;
+%Docstring
+Returns currently displayed snapping match
+ :rtype: QgsPointLocator.Match
+%End
+
+    void setVisible( bool visible = true );
+%Docstring
+Sets whether the snapping indicator is visible
+%End
+    bool isVisible() const;
+%Docstring
+Returns whether the snapping indicator is visible
+ :rtype: bool
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssnapindicator.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgsvertexmarker.sip
+++ b/python/gui/qgsvertexmarker.sip
@@ -37,7 +37,8 @@ class QgsVertexMarker : QgsMapCanvasItem
       ICON_CROSS,
       ICON_X,
       ICON_BOX,
-      ICON_CIRCLE
+      ICON_CIRCLE,
+      ICON_DOUBLE_TRIANGLE,
     };
 
     QgsVertexMarker( QgsMapCanvas *mapCanvas /TransferThis/ );

--- a/src/app/nodetool/qgsnodetool.h
+++ b/src/app/nodetool/qgsnodetool.h
@@ -27,6 +27,7 @@ class QRubberBand;
 class QgsGeometryValidator;
 class QgsNodeEditor;
 class QgsSelectedFeature;
+class QgsSnapIndicator;
 class QgsVertexMarker;
 
 //! helper structure for a vertex being dragged
@@ -202,7 +203,7 @@ class APP_EXPORT QgsNodeTool : public QgsMapToolAdvancedDigitizing
     // members used for temporary highlight of stuff
 
     //! marker of a snap match (if any) when dragging a vertex
-    QgsVertexMarker *mSnapMarker = nullptr;
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
     /**
      * marker in the middle of an edge while pointer is close to a vertex and not dragging anything

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -941,6 +941,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   }
   mSearchRadiusVertexEditComboBox->setCurrentIndex( index );
 
+  mSnappingMarkerColorButton->setColor( mSettings->value( QStringLiteral( "/qgis/digitizing/snap_color" ), QColor( Qt::magenta ) ).value<QColor>() );
+  mSnappingTooltipsCheckbox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/snap_tooltip" ), false ).toBool() );
+
   //vertex marker
   mMarkersOnlyForSelectedCheckBox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/marker_only_for_selected" ), true ).toBool() );
 
@@ -1458,6 +1461,9 @@ void QgsOptions::saveOptions()
                        ( mDefaultSnappingToleranceComboBox->currentIndex() == 0 ? QgsTolerance::ProjectUnits : QgsTolerance::Pixels ) );
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/search_radius_vertex_edit_unit" ),
                        ( mSearchRadiusVertexEditComboBox->currentIndex()  == 0 ? QgsTolerance::ProjectUnits : QgsTolerance::Pixels ) );
+
+  mSettings->setValue( QStringLiteral( "/qgis/digitizing/snap_color" ), mSnappingMarkerColorButton->color() );
+  mSettings->setValue( QStringLiteral( "/qgis/digitizing/snap_tooltip" ), mSnappingTooltipsCheckbox->isChecked() );
 
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/marker_only_for_selected" ), mMarkersOnlyForSelectedCheckBox->isChecked() );
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -333,6 +333,7 @@ SET(QGIS_GUI_SRCS
   qgssearchquerybuilder.cpp
   qgsshortcutsmanager.cpp
   qgsslider.cpp
+  qgssnapindicator.cpp
   qgssublayersdialog.cpp
   qgssubstitutionlistwidget.cpp
   qgssqlcomposerdialog.cpp
@@ -710,6 +711,7 @@ SET(QGIS_GUI_HDRS
   qgsmapmouseevent.h
   qgsmaptip.h
   qgsrubberband.h
+  qgssnapindicator.h
   qgssqlcomposerdialog.h
   qgstablewidgetitem.h
   qgsuserinputdockwidget.h

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -26,6 +26,7 @@
 #include "qgis_gui.h"
 
 class QgsRubberBand;
+class QgsSnapIndicator;
 class QgsVertexMarker;
 class QgsMapLayer;
 class QgsGeometryValidator;
@@ -248,7 +249,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
     bool mCaptureModeFromLayer;
 
-    QgsVertexMarker *mSnappingMarker = nullptr;
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
     /**
      * Keeps point (in map units) snapped to a segment where we most recently finished tracing,

--- a/src/gui/qgssnapindicator.cpp
+++ b/src/gui/qgssnapindicator.cpp
@@ -57,13 +57,13 @@ void QgsSnapIndicator::setMatch( const QgsPointLocator::Match &match )
     if ( match.hasVertex() )
     {
       if ( match.layer() )
-        iconType = QgsVertexMarker::ICON_CROSS;  // vertex snap
+        iconType = QgsVertexMarker::ICON_BOX;  // vertex snap
       else
         iconType = QgsVertexMarker::ICON_X;  // intersection snap
     }
     else  // must be segment snap
     {
-      iconType = QgsVertexMarker::ICON_BOX;
+      iconType = QgsVertexMarker::ICON_DOUBLE_TRIANGLE;
     }
     mSnappingMarker->setIconType( iconType );
 

--- a/src/gui/qgssnapindicator.cpp
+++ b/src/gui/qgssnapindicator.cpp
@@ -1,0 +1,59 @@
+/***************************************************************************
+  qgssnapindicator.cpp
+  --------------------------------------
+  Date                 : October 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssnapindicator.h"
+
+#include "qgsvertexmarker.h"
+
+
+QgsSnapIndicator::QgsSnapIndicator( QgsMapCanvas *canvas )
+  : mCanvas( canvas )
+{
+}
+
+QgsSnapIndicator::~QgsSnapIndicator()
+{
+}
+
+void QgsSnapIndicator::setMatch( const QgsPointLocator::Match &match )
+{
+  mMatch = match;
+
+  if ( !mMatch.isValid() )
+  {
+    mSnappingMarker.reset();
+  }
+  else
+  {
+    if ( !mSnappingMarker )
+    {
+      mSnappingMarker.reset( new QgsVertexMarker( mCanvas ) );
+      mSnappingMarker->setIconType( QgsVertexMarker::ICON_CROSS );
+      mSnappingMarker->setColor( Qt::magenta );
+      mSnappingMarker->setPenWidth( 3 );
+    }
+    mSnappingMarker->setCenter( match.point() );
+  }
+}
+
+void QgsSnapIndicator::setVisible( bool visible )
+{
+  mSnappingMarker->setVisible( visible );
+}
+
+bool QgsSnapIndicator::isVisible() const
+{
+  return mSnappingMarker->isVisible();
+}

--- a/src/gui/qgssnapindicator.cpp
+++ b/src/gui/qgssnapindicator.cpp
@@ -28,9 +28,8 @@ QgsSnapIndicator::QgsSnapIndicator( QgsMapCanvas *canvas )
 {
 }
 
-QgsSnapIndicator::~QgsSnapIndicator()
-{
-}
+QgsSnapIndicator::~QgsSnapIndicator() = default;
+
 
 void QgsSnapIndicator::setMatch( const QgsPointLocator::Match &match )
 {

--- a/src/gui/qgssnapindicator.h
+++ b/src/gui/qgssnapindicator.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+  qgssnapindicator.h
+  --------------------------------------
+  Date                 : October 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSNAPINDICATOR_H
+#define QGSSNAPINDICATOR_H
+
+#include "qgspointlocator.h"
+
+#include "qgis_gui.h"
+
+class QgsMapCanvas;
+class QgsVertexMarker;
+
+
+/**
+ * \ingroup gui
+ * Class that shows snapping marker on map canvas for the current snapping match.
+ * \since QGIS 3.0
+ */
+class GUI_EXPORT QgsSnapIndicator
+{
+  public:
+    //! Constructs an indicator for the given map canvas
+    QgsSnapIndicator( QgsMapCanvas *canvas );
+    ~QgsSnapIndicator();
+
+    //! Sets snapping match that should be displayed in map canvas. Invalid match hides the indicator
+    void setMatch( const QgsPointLocator::Match &match );
+    //! Returns currently displayed snapping match
+    QgsPointLocator::Match match() const { return mMatch; }
+
+    //! Sets whether the snapping indicator is visible
+    void setVisible( bool visible = true );
+    //! Returns whether the snapping indicator is visible
+    bool isVisible() const;
+
+  private:
+    QgsMapCanvas *mCanvas;
+    QgsPointLocator::Match mMatch;
+    std::unique_ptr<QgsVertexMarker> mSnappingMarker;
+};
+
+#endif // QGSSNAPINDICATOR_H

--- a/src/gui/qgssnapindicator.h
+++ b/src/gui/qgssnapindicator.h
@@ -47,6 +47,13 @@ class GUI_EXPORT QgsSnapIndicator
     bool isVisible() const;
 
   private:
+    Q_DISABLE_COPY( QgsSnapIndicator )
+
+#ifdef SIP_RUN
+    QgsSnapIndicator( const QgsSnapIndicator &rh );
+    QgsSnapIndicator &operator=( const QgsSnapIndicator & );
+#endif
+
     QgsMapCanvas *mCanvas;
     QgsPointLocator::Match mMatch;
     std::unique_ptr<QgsVertexMarker> mSnappingMarker;

--- a/src/gui/qgsvertexmarker.cpp
+++ b/src/gui/qgsvertexmarker.cpp
@@ -91,6 +91,13 @@ void QgsVertexMarker::paint( QPainter *p )
     case ICON_CIRCLE:
       p->drawEllipse( QPointF( 0, 0 ), s, s );
       break;
+
+    case ICON_DOUBLE_TRIANGLE:
+      p->drawLine( QLineF( -s, -s,  s, -s ) );
+      p->drawLine( QLineF( -s,  s,  s,  s ) );
+      p->drawLine( QLineF( -s, -s,  s,  s ) );
+      p->drawLine( QLineF( s, -s, -s,  s ) );
+      break;
   }
 }
 

--- a/src/gui/qgsvertexmarker.h
+++ b/src/gui/qgsvertexmarker.h
@@ -53,7 +53,8 @@ class GUI_EXPORT QgsVertexMarker : public QgsMapCanvasItem
       ICON_CROSS,
       ICON_X,
       ICON_BOX,
-      ICON_CIRCLE
+      ICON_CIRCLE,
+      ICON_DOUBLE_TRIANGLE,    //!< Added in QGIS 3.0
     };
 
     QgsVertexMarker( QgsMapCanvas *mapCanvas SIP_TRANSFERTHIS );

--- a/src/plugins/georeferencer/qgsmapcoordsdialog.h
+++ b/src/plugins/georeferencer/qgsmapcoordsdialog.h
@@ -16,9 +16,9 @@
 #include <QMouseEvent>
 
 #include "qgsmaptoolemitpoint.h"
+#include "qgssnapindicator.h"
 #include "qgssnappingutils.h"
 #include "qgspointxy.h"
-#include "qgsvertexmarker.h"
 #include "qgsmapcanvas.h"
 
 #include "ui_qgsmapcoordsdialogbase.h"
@@ -33,40 +33,22 @@ class QgsGeorefMapToolEmitPoint : public QgsMapTool
     explicit QgsGeorefMapToolEmitPoint( QgsMapCanvas *canvas )
       : QgsMapTool( canvas )
     {
+      mSnapIndicator.reset( new QgsSnapIndicator( canvas ) );
     }
 
     virtual ~QgsGeorefMapToolEmitPoint()
     {
-      delete mSnappingMarker;
-      mSnappingMarker = nullptr;
     }
 
     void canvasMoveEvent( QgsMapMouseEvent *e ) override
     {
-      MappedPoint mapped = mapPoint( e );
-
-      if ( !mapped.snapped )
-      {
-        delete mSnappingMarker;
-        mSnappingMarker = nullptr;
-      }
-      else
-      {
-        if ( !mSnappingMarker )
-        {
-          mSnappingMarker = new QgsVertexMarker( mCanvas );
-          mSnappingMarker->setIconType( QgsVertexMarker::ICON_CROSS );
-          mSnappingMarker->setColor( Qt::magenta );
-          mSnappingMarker->setPenWidth( 3 );
-        }
-        mSnappingMarker->setCenter( mapped.point );
-      }
+      mSnapIndicator->setMatch( mapPointMatch( e ) );
     }
 
     void canvasPressEvent( QgsMapMouseEvent *e ) override
     {
-      MappedPoint mapped = mapPoint( e );
-      emit canvasClicked( mapped.point, e->button() );
+      QgsPointLocator::Match m = mapPointMatch( e );
+      emit canvasClicked( m.isValid() ? m.point() : toMapCoordinates( e->pos() ), e->button() );
     }
 
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override
@@ -77,8 +59,7 @@ class QgsGeorefMapToolEmitPoint : public QgsMapTool
 
     void deactivate() override
     {
-      delete mSnappingMarker;
-      mSnappingMarker = 0;
+      mSnapIndicator->setMatch( QgsPointLocator::Match() );
 
       QgsMapTool::deactivate();
     }
@@ -88,26 +69,14 @@ class QgsGeorefMapToolEmitPoint : public QgsMapTool
     void mouseReleased();
 
   private:
-    struct MappedPoint
-    {
-      MappedPoint() {}
-      QgsPointXY point;
-      bool snapped = false;
-    };
 
-    MappedPoint mapPoint( QMouseEvent *e )
+    QgsPointLocator::Match mapPointMatch( QMouseEvent *e )
     {
       QgsPointXY pnt = toMapCoordinates( e->pos() );
-      QgsSnappingUtils *snappingUtils = canvas()->snappingUtils();
-      QgsPointLocator::Match match = snappingUtils->snapToMap( pnt );
-
-      MappedPoint ret;
-      ret.snapped = match.isValid();
-      ret.point = ret.snapped ? match.point() : pnt;
-      return ret;
+      return canvas()->snappingUtils()->snapToMap( pnt );
     }
 
-    QgsVertexMarker *mSnappingMarker = nullptr;
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 };
 
 class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -4112,6 +4112,9 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   <string>Snapping</string>
                  </property>
                  <layout class="QGridLayout" name="_10">
+                  <item row="6" column="5">
+                   <widget class="QgsColorButton" name="mSnappingMarkerColorButton"/>
+                  </item>
                   <item row="1" column="1" colspan="6">
                    <widget class="QCheckBox" name="mSnappingEnabledDefault">
                     <property name="text">
@@ -4123,6 +4126,13 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    <widget class="QLabel" name="label_49">
                     <property name="text">
                      <string>Display main dialog as (restart required)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="1">
+                   <widget class="QLabel" name="label_2">
+                    <property name="text">
+                     <string>Snapping marker color</string>
                     </property>
                    </widget>
                   </item>
@@ -4189,6 +4199,20 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </property>
                    </widget>
                   </item>
+                  <item row="4" column="6">
+                   <widget class="QComboBox" name="mSearchRadiusVertexEditComboBox">
+                    <item>
+                     <property name="text">
+                      <string>map units</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>pixels</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
                   <item row="4" column="5">
                    <widget class="QDoubleSpinBox" name="mSearchRadiusVertexEditSpinBox">
                     <property name="decimals">
@@ -4222,19 +4246,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </property>
                    </spacer>
                   </item>
-                  <item row="4" column="6">
-                   <widget class="QComboBox" name="mSearchRadiusVertexEditComboBox">
-                    <item>
-                     <property name="text">
-                      <string>map units</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>pixels</string>
-                     </property>
-                    </item>
-                   </widget>
+                  <item row="5" column="5" colspan="2">
+                   <widget class="QComboBox" name="mSnappingMainDialogComboBox"/>
                   </item>
                   <item row="4" column="1" colspan="3">
                    <widget class="QLabel" name="mVertexSearchRadiusVertexEditLabel">
@@ -4243,13 +4256,17 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="5" colspan="2">
-                   <widget class="QComboBox" name="mSnappingMainDialogComboBox"/>
-                  </item>
                   <item row="3" column="1" colspan="2">
                    <widget class="QLabel" name="mDefaultSnappingToleranceTextLabel">
                     <property name="text">
                      <string>Default snapping tolerance</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="1" colspan="6">
+                   <widget class="QCheckBox" name="mSnappingTooltipsCheckbox">
+                    <property name="text">
+                     <string>Show snapping tooltips</string>
                     </property>
                    </widget>
                   </item>
@@ -4829,7 +4846,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                 <x>0</x>
                 <y>0</y>
                 <width>866</width>
-                <height>822</height>
+                <height>930</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">


### PR DESCRIPTION
- tooltips with name of the layer that has been snapped
- different markers for different snap types (cross for vertex, X for intersection, box for edge)
- snapping marker color can be customized in options (default: magenta - as before)
- whether to show tooltips can be customized in options (default: off)
- API: new QgsSnapIndicator class to handle snapping markers
