### PR TITLE
Fix crash when refreshing data provider list after adding, editing or deleting WMS or XYZ provider (fixes #17317)

### DIFF
--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -292,6 +292,15 @@ void QgsBrowserDockWidget::refreshModel( const QModelIndex &index )
     mModel->refresh( index );
   }
 
+  // Ensure mProxyModel instance is not nullptr.
+  // When adding, editing or deleting WMS or XYZ data provider mProxyModel is nullptr.
+  if ( !mProxyModel )
+  {
+	  mProxyModel = new QgsBrowserTreeFilterProxyModel(this);
+	  mProxyModel->setBrowserModel(mModel);
+	  mBrowserView->setModel(mProxyModel);
+  }
+
   for ( int i = 0; i < mModel->rowCount( index ); i++ )
   {
     QModelIndex idx = mModel->index( i, 0, index );


### PR DESCRIPTION
## Description
Ensure mProxyModel instance is not nullptr when refreshModel called after adding, editing or deleting WMS or XYZ provider mProxyModel is nullptr causing read access violation when calling mProxyModel->mapFromSource( idx ). [https://issues.qgis.org/issues/17317](https://issues.qgis.org/issues/17317)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
