### PR TITLE
Enable 3D support in RPM

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,6 +12,15 @@
 %define builddate %(date '+%a %b %d %Y')
 %endif
 
+# Qt53D support
+# Fedora 26 provides Qt 5.7 which is not supported at the moment.
+# This check may be removed when https://bodhi.fedoraproject.org/updates/FEDORA-2017-c133443edc
+# is pushed to stable
+%if 0%{?fedora} > 26
+%global configure_with_3d -D WITH_3D:BOOL=TRUE
+BuildRequires: qt5-qt3d-devel
+%endif
+
 Name:           qgis
 Version:        %{_version}
 Release:        %{_relver}%{?dist}
@@ -96,8 +105,6 @@ BuildRequires: qt5-qtwebkit-devel
 BuildRequires: qt5-qtxmlpatterns-devel
 BuildRequires: qtkeychain-qt5-devel
 BuildRequires: qextserialport-devel
-# Qt53D support
-BuildRequires: qt5-qt3d-devel
 
 # Qwt stuff
 BuildRequires: qwt-devel
@@ -213,7 +220,7 @@ gzip ChangeLog
       -D ENABLE_TESTS:BOOL=FALSE \
       -D WITH_QSPATIALITE:BOOL=TRUE \
       -D WITH_SERVER:BOOL=TRUE \
-      -D WITH_3D:BOOL=TRUE \
+      %{configure_with_3d} \
       .
 
       # Using external QEXTSERIALPORT causes segfaults

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -111,6 +111,8 @@ BuildRequires: qwt-devel
 BuildRequires: qwt-qt5-devel
 BuildRequires: qwt-qt5-devel
 
+# Installation of QCA plugins must be explicit
+Requires:       qca-qt5-ossl
 Requires:       gpsbabel
 
 # We don't want to provide private Python extension libs

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -96,6 +96,8 @@ BuildRequires: qt5-qtwebkit-devel
 BuildRequires: qt5-qtxmlpatterns-devel
 BuildRequires: qtkeychain-qt5-devel
 BuildRequires: qextserialport-devel
+# Qt53D support
+BuildRequires: qt5-qt3d-devel
 
 # Qwt stuff
 BuildRequires: qwt-devel
@@ -211,6 +213,7 @@ gzip ChangeLog
       -D ENABLE_TESTS:BOOL=FALSE \
       -D WITH_QSPATIALITE:BOOL=TRUE \
       -D WITH_SERVER:BOOL=TRUE \
+      -D WITH_3D:BOOL=TRUE \
       .
 
       # Using external QEXTSERIALPORT causes segfaults


### PR DESCRIPTION
## Description
Set `WITH_3D=TRUE` in RPM spec file. This is currently supported only in Fedora > 26.
Fedora 26 provides Qt 5.7; Qt 5.9 may be pushed to F26 stable in the near future anyway: see https://bodhi.fedoraproject.org/updates/FEDORA-2017-c133443edc

Being built here: https://ci.services.vigano.me/#/builders/2/builds/4

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
