### PR TITLE
Homogenize buffer-like algorithms

### DIFF
--- a/python/plugins/processing/algs/qgis/FixedDistanceBuffer.py
+++ b/python/plugins/processing/algs/qgis/FixedDistanceBuffer.py
@@ -70,9 +70,11 @@ class FixedDistanceBuffer(QgisAlgorithm):
                                                               self.tr('Input layer')))
 
         self.addParameter(QgsProcessingParameterNumber(self.DISTANCE,
-                                                       self.tr('Distance'), defaultValue=10.0))
+                                                       self.tr('Distance'), type=QgsProcessingParameterNumber.Double,
+                                                       defaultValue=10.0))
         self.addParameter(QgsProcessingParameterNumber(self.SEGMENTS,
-                                                       self.tr('Segments'), type=QgsProcessingParameterNumber.Integer, minValue=1, defaultValue=5))
+                                                       self.tr('Segments'), type=QgsProcessingParameterNumber.Integer,
+                                                       minValue=1, defaultValue=5))
         self.addParameter(QgsProcessingParameterBoolean(self.DISSOLVE,
                                                         self.tr('Dissolve result'), defaultValue=False))
         self.end_cap_styles = [self.tr('Round'),
@@ -90,7 +92,8 @@ class FixedDistanceBuffer(QgisAlgorithm):
             self.tr('Join style'),
             options=self.join_styles, defaultValue=0))
         self.addParameter(QgsProcessingParameterNumber(self.MITER_LIMIT,
-                                                       self.tr('Miter limit'), minValue=0, defaultValue=2))
+                                                       self.tr('Miter limit'), type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0, defaultValue=2))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Buffer'), QgsProcessing.TypeVectorPolygon))
 

--- a/python/plugins/processing/algs/qgis/SingleSidedBuffer.py
+++ b/python/plugins/processing/algs/qgis/SingleSidedBuffer.py
@@ -60,7 +60,8 @@ class SingleSidedBuffer(QgisFeatureBasedAlgorithm):
 
     def initParameters(self, config=None):
         self.addParameter(QgsProcessingParameterNumber(self.DISTANCE,
-                                                       self.tr('Distance'), defaultValue=10.0))
+                                                       self.tr('Distance'), QgsProcessingParameterNumber.Double,
+                                                       defaultValue=10.0))
         self.addParameter(QgsProcessingParameterEnum(
             self.SIDE,
             self.tr('Side'),
@@ -75,7 +76,8 @@ class SingleSidedBuffer(QgisFeatureBasedAlgorithm):
             self.tr('Join style'),
             options=self.join_styles))
         self.addParameter(QgsProcessingParameterNumber(self.MITER_LIMIT,
-                                                       self.tr('Miter limit'), minValue=1, defaultValue=2))
+                                                       self.tr('Miter limit'), QgsProcessingParameterNumber.Double,
+                                                       minValue=1, defaultValue=2))
 
     def name(self):
         return 'singlesidedbuffer'
@@ -84,7 +86,7 @@ class SingleSidedBuffer(QgisFeatureBasedAlgorithm):
         return self.tr('Single sided buffer')
 
     def outputName(self):
-        return self.tr('Buffers')
+        return self.tr('Buffer')
 
     def inputLayerTypes(self):
         return [QgsProcessing.TypeVectorLine]

--- a/python/plugins/processing/algs/qgis/VariableDistanceBuffer.py
+++ b/python/plugins/processing/algs/qgis/VariableDistanceBuffer.py
@@ -90,7 +90,8 @@ class VariableDistanceBuffer(QgisAlgorithm):
             self.tr('Join style'),
             options=self.join_styles, defaultValue=0))
         self.addParameter(QgsProcessingParameterNumber(self.MITER_LIMIT,
-                                                       self.tr('Miter limit'), minValue=0, defaultValue=2))
+                                                       self.tr('Miter limit'), type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0, defaultValue=2))
 
         self.addParameter(
             QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Buffer'), QgsProcessing.TypeVectorPolygon))


### PR DESCRIPTION
It's currently impossible to use decimal values to set the distance or miter in some of buffer algorithms. This PR allows double values for distance and miter (like the "Buffer" algorithm) and also homogenize the output label.

Should the default and min values written like `10.000000` (like in Buffer alg) instead of `10.0` or `10` (to emphasize the numerical capability)?
