### PR TITLE
Cleanup temporary files in prepare-commit.sh

### DIFF
--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -68,6 +68,7 @@ astyleit() {
 	scripts/doxygen_space.pl "$modified"
 	diff "$1" "$modified" >/dev/null || mv "$modified" "$1"
 	rm -f "$modified"
+	rm -f "$modified.sortinc"
 }
 
 for f in "$@"; do

--- a/scripts/prepare-commit.sh
+++ b/scripts/prepare-commit.sh
@@ -91,10 +91,8 @@ for f in $MODIFIED; do
 
   cp $f $m
   ASTYLEPROGRESS=" [$i/$N]" astyle.sh $f
-  if diff -u $m $f >>$ASTYLEDIFF; then
-    # no difference found
-    rm $m
-  fi
+  diff -u $m $f >>$ASTYLEDIFF
+  rm $m
 done
 
 if [ -s "$ASTYLEDIFF" ]; then
@@ -102,11 +100,10 @@ if [ -s "$ASTYLEDIFF" ]; then
     # review astyle changes
     colordiff <$ASTYLEDIFF | less -r
   else
-    echo "Files changed (see $ASTYLEDIFF)"
+    echo "Files changed"
   fi
-else
-  rm $ASTYLEDIFF
 fi
+rm $ASTYLEDIFF
 
 
 # verify SIP files


### PR DESCRIPTION
QtCreator started to list all those files in the project recently. Not sure if they are left as backups or by accident, but I never really needed them in all those years.