### PR TITLE
[needs-docs] Make maptip and geometry attribute optional in featureinfo response

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -462,6 +462,20 @@ namespace QgsWms
                                QVariant()
                              };
     save( pGridY );
+
+    const Parameter pWithGeometry = { ParameterName::WITH_GEOMETRY,
+                                      QVariant::Bool,
+                                      QVariant( false ),
+                                      QVariant()
+                                    };
+    save( pWithGeometry );
+
+    const Parameter pWithMapTip = { ParameterName::WITH_MAPTIP,
+                                    QVariant::Bool,
+                                    QVariant( false ),
+                                    QVariant()
+                                  };
+    save( pWithMapTip );
   }
 
   QgsWmsParameters::QgsWmsParameters( const QgsServerRequest::Parameters &parameters )
@@ -1906,6 +1920,16 @@ namespace QgsWms
       wmsUri.setParam( paramIt.key().toLower(), paramIt.value() );
     }
     return wmsUri.encodedUri();
+  }
+
+  bool QgsWmsParameters::withGeometry() const
+  {
+    return toBool( ParameterName::WITH_GEOMETRY );
+  }
+
+  bool QgsWmsParameters::withMapTip() const
+  {
+    return toBool( ParameterName::WITH_MAPTIP );
   }
 
   QString QgsWmsParameters::name( ParameterName name ) const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -919,14 +919,14 @@ namespace QgsWms
       QString externalWMSUri( const QString &id ) const;
 
       /**
-       * @brief Returns if the client wants the feature info response with geometry information
-       * @return true if geometry information is requested for feature info response
+       * \brief Returns if the client wants the feature info response with geometry information
+       * \returns true if geometry information is requested for feature info response
        */
       bool withGeometry() const;
 
       /**
-       * @brief withMapTip
-       * @return true if maptip information is requested for feature info response
+       * \brief withMapTip
+       * \returns true if maptip information is requested for feature info response
        */
       bool withMapTip() const;
 

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -141,7 +141,9 @@ namespace QgsWms
         EXTENT,
         ROTATION,
         GRID_INTERVAL_X,
-        GRID_INTERVAL_Y
+        GRID_INTERVAL_Y,
+        WITH_GEOMETRY,
+        WITH_MAPTIP
       };
       Q_ENUM( ParameterName )
 
@@ -915,6 +917,18 @@ namespace QgsWms
        * @return uri string or an empty string if the external wms id does not exist
        */
       QString externalWMSUri( const QString &id ) const;
+
+      /**
+       * @brief Returns if the client wants the feature info response with geometry information
+       * @return true if geometry information is requested for feature info response
+       */
+      bool withGeometry() const;
+
+      /**
+       * @brief withMapTip
+       * @return true if maptip information is requested for feature info response
+       */
+      bool withMapTip() const;
 
     private:
       QString name( ParameterName name ) const;

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1426,7 +1426,7 @@ namespace QgsWms
     int featureCounter = 0;
     layer->updateFields();
     const QgsFields &fields = layer->pendingFields();
-    bool addWktGeometry = QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( *mProject );
+    bool addWktGeometry = ( QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( *mProject ) && mWmsParameters.withGeometry() );
     bool segmentizeWktGeometry = QgsServerProjectUtils::wmsFeatureInfoSegmentizeWktGeometry( *mProject );
     const QSet<QString> &excludedAttributes = layer->excludeAttributesWms();
 
@@ -1578,7 +1578,7 @@ namespace QgsWms
 
         //add maptip attribute based on html/expression (in case there is no maptip attribute)
         QString mapTip = layer->mapTipTemplate();
-        if ( !mapTip.isEmpty() )
+        if ( !mapTip.isEmpty() && mWmsParameters.withMapTip() )
         {
           QDomElement maptipElem = infoDocument.createElement( QStringLiteral( "Attribute" ) );
           maptipElem.setAttribute( QStringLiteral( "name" ), QStringLiteral( "maptip" ) );
@@ -2226,7 +2226,7 @@ namespace QgsWms
     {
       QString mapTip = layer->mapTipTemplate();
 
-      if ( !mapTip.isEmpty() )
+      if ( !mapTip.isEmpty() && mWmsParameters.withMapTip() )
       {
         QString fieldTextString = QgsExpression::replaceExpressionText( mapTip, &expressionContext );
         QDomElement fieldElem = doc.createElement( QStringLiteral( "qgs:maptip" ) );

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -92,7 +92,7 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
                                  'wms_getfeatureinfo-text-html')
-                                 
+
         #Test getfeatureinfo response html with geometry
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
@@ -100,7 +100,7 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
-                                 'with_geometry=true', 
+                                 'with_geometry=true',
                                  'wms_getfeatureinfo-text-html-geometry')
 
         # Test getfeatureinfo response text

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -92,6 +92,16 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
                                  'wms_getfeatureinfo-text-html')
+                                 
+        #Test getfeatureinfo response html with geometry
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=text%2Fhtml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
+                                 'with_geometry=true', 
+                                 'wms_getfeatureinfo-text-html-geometry')
 
         # Test getfeatureinfo response text
         self.wms_request_compare('GetFeatureInfo',

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -103,6 +103,16 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'with_geometry=true',
                                  'wms_getfeatureinfo-text-html-geometry')
 
+        #Test getfeatureinfo response html with maptip
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=text%2Fhtml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
+                                 'with_maptip=true',
+                                 'wms_getfeatureinfo-text-html-maptip')
+
         # Test getfeatureinfo response text
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +

--- a/tests/testdata/qgis_server/test_project.qgs
+++ b/tests/testdata/qgis_server/test_project.qgs
@@ -356,6 +356,7 @@
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
+      <mapTip>[% 'Name: ' ||  "name" %]</mapTip>
     </maplayer>
   </projectlayers>
   <properties>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-geometry.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-geometry.txt
@@ -1,0 +1,21 @@
+Content-Length: 512
+Content-Type: text/html; charset=utf-8
+
+<HEAD>
+<TITLE> GetFeatureInfo results </TITLE>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+</HEAD>
+<BODY>
+<TABLE border=1 width=100%>
+<TR><TH width=25%>Layer</TH><TD>testlayer èé</TD></TR>
+</BR><TABLE border=1 width=100%>
+<TR><TH>Feature</TH><TD>2</TD></TR>
+<TR><TH>id</TH><TD>3</TD></TR>
+<TR><TH>name</TH><TD>three</TD></TR>
+<TR><TH>utf8nameè</TH><TD>three èé↓</TD></TR>
+<TR><TH>geometry</TH><TD>Point (913204.9128 5606011.4565)</TD></TR>
+</TABLE>
+</BR>
+</TABLE>
+<BR></BR>
+</BODY>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html-maptip.txt
@@ -1,0 +1,21 @@
+Content-Length: 512
+Content-Type: text/html; charset=utf-8
+
+<HEAD>
+<TITLE> GetFeatureInfo results </TITLE>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+</HEAD>
+<BODY>
+<TABLE border=1 width=100%>
+<TR><TH width=25%>Layer</TH><TD>testlayer èé</TD></TR>
+</BR><TABLE border=1 width=100%>
+<TR><TH>Feature</TH><TD>2</TD></TR>
+<TR><TH>id</TH><TD>3</TD></TR>
+<TR><TH>name</TH><TD>three</TD></TR>
+<TR><TH>utf8nameè</TH><TD>three èé↓</TD></TR>
+<TR><TH>maptip</TH><TD>Name: three</TD></TR>
+</TABLE>
+</BR>
+</TABLE>
+<BR></BR>
+</BODY>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-html.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-html.txt
@@ -13,7 +13,6 @@ Content-Type: text/html; charset=utf-8
 <TR><TH>id</TH><TD>3</TD></TR>
 <TR><TH>name</TH><TD>three</TD></TR>
 <TR><TH>utf8nameè</TH><TD>three èé↓</TD></TR>
-<TR><TH>geometry</TH><TD>Point (913204.9128 5606011.4565)</TD></TR>
 </TABLE>
 </BR>
 </TABLE>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-plain.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-plain.txt
@@ -8,5 +8,4 @@ Feature 2
 id = '3'
 name = 'three'
 utf8nameè = 'three èé↓'
-geometry = 'Point (913204.9128 5606011.4565)'
 

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
@@ -7,8 +7,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
-   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
-   <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
@@ -10,7 +10,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="two àò" name="utf8nameè"/>
    <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
-   <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
@@ -10,7 +10,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="two àò" name="utf8nameè"/>
    <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
-   <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="2">
    <Attribute value="3" name="id"/>
@@ -18,7 +17,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="three èé↓" name="utf8nameè"/>
    <Attribute value="2" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
-   <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
@@ -10,7 +10,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="two àò" name="utf8nameè"/>
    <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
-   <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="2">
    <Attribute value="3" name="id"/>
@@ -18,7 +17,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="three èé↓" name="utf8nameè"/>
    <Attribute value="2" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
-   <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter.txt
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute name="name" value="two"/>
    <Attribute name="utf8nameè" value="two àò"/>
    <BoundingBox CRS="EPSG:3857" minx="913214.6741" maxx="913214.6741" miny="5606017.8743" maxy="5606017.8743"/>
-   <Attribute name="geometry" value="Point (913214.6741 5606017.8743)" type="derived"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>


### PR DESCRIPTION
In the QGIS Server GetFeatureInfo response, there is the maptip attribute and the geometry attribute (if enabled in the project). This pull request changes the behaviour to only include these attributes if requested by the client (new parameters WITH_GEOMETRY and WITH_MAPTIP).  Some wms clients always display popups and they can get quite large if the geometry wkt is contained in the response.