### PR TITLE
[FEATURE] Make constraint reporting less obtrusive

### DIFF
--- a/python/gui/qgsattributeformeditorwidget.sip
+++ b/python/gui/qgsattributeformeditorwidget.sip
@@ -96,6 +96,11 @@ class QgsAttributeFormEditorWidget : QWidget
  :rtype: str
 %End
 
+    void setConstraintStatus( const QString &constraint, const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result );
+%Docstring
+ Set the constraint status for this widget.
+%End
+
   public slots:
 
     void setIsMixed( bool mixed );

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -110,11 +110,11 @@ void QgsEditorWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult cons
       break;
 
     case ConstraintResultFailHard:
-      widget()->setStyleSheet( QStringLiteral( "background-color: #dd7777;" ) );
+      widget()->setStyleSheet( QStringLiteral( "background-color: #FFE0B2;" ) );
       break;
 
     case ConstraintResultFailSoft:
-      widget()->setStyleSheet( QStringLiteral( "background-color: #ffd85d;" ) );
+      widget()->setStyleSheet( QStringLiteral( "background-color: #FFECB3;" ) );
       break;
   }
 }

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -339,9 +339,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     bool currentFormFeature( QgsFeature &feature );
     bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions );
     QList<QgsEditorWidgetWrapper *> constraintDependencies( QgsEditorWidgetWrapper *w );
-    void clearInvalidConstraintsMessage();
-    void displayInvalidConstraintMessage( const QStringList &invalidFields,
-                                          const QStringList &description );
 
     QgsVectorLayer *mLayer = nullptr;
     QgsFeature mFeature;
@@ -349,8 +346,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     bool mOwnsMessageBar;
     QgsMessageBarItem *mMultiEditUnsavedMessageBarItem = nullptr;
     QgsMessageBarItem *mMultiEditMessageBarItem = nullptr;
-    QLabel *mInvalidConstraintMessage = nullptr;
-    QWidget *mTopMessageWidget = nullptr;
     QList<QgsWidgetWrapper *> mWidgets;
     QgsAttributeEditorContext mContext;
     QDialogButtonBox *mButtonBox = nullptr;
@@ -415,8 +410,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     Mode mMode;
 
-    //! Backlinks widgets to buddies.
-    QMap<QWidget *, QLabel *> mBuddyMap;
     QMap<QWidget *, QSvgWidget *> mIconMap;
 
     friend class TestQgsDualView;

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -38,6 +38,7 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
   , mIsChanged( false )
 {
   mConstraintResultLabel = new QLabel();
+  mConstraintResultLabel->setObjectName( QStringLiteral( "ConstraintStatus" ) );
   mConstraintResultLabel->setSizePolicy( QSizePolicy::Fixed, mConstraintResultLabel->sizePolicy().verticalPolicy() );
 
   mEditPage = new QWidget();

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -37,6 +37,9 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
   , mIsMixed( false )
   , mIsChanged( false )
 {
+  mConstraintResultLabel = new QLabel();
+  mConstraintResultLabel->setSizePolicy( QSizePolicy::Fixed, mConstraintResultLabel->sizePolicy().verticalPolicy() );
+
   mEditPage = new QWidget();
   QHBoxLayout *l = new QHBoxLayout();
   l->setMargin( 0 );
@@ -132,6 +135,27 @@ QWidget *QgsAttributeFormEditorWidget::searchWidgetFrame()
 QList< QgsSearchWidgetWrapper * > QgsAttributeFormEditorWidget::searchWidgetWrappers()
 {
   return mSearchWidgets;
+}
+
+void QgsAttributeFormEditorWidget::setConstraintStatus( const QString &constraint, const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result )
+{
+  switch ( result )
+  {
+    case QgsEditorWidgetWrapper::ConstraintResultFailHard:
+      mConstraintResultLabel->setText( QStringLiteral( "<font color=\"#FF9800\">✘</font>" ) );
+      mConstraintResultLabel->setToolTip( description.isEmpty() ? QStringLiteral( "<b>%1</b>: %2" ).arg( constraint, err ) : description );
+      break;
+
+    case QgsEditorWidgetWrapper::ConstraintResultFailSoft:
+      mConstraintResultLabel->setText( QStringLiteral( "<font color=\"#FFC107\">✘</font>" ) );
+      mConstraintResultLabel->setToolTip( description.isEmpty() ? QStringLiteral( "<b>%1</b>: %2" ).arg( constraint, err ) : description );
+      break;
+
+    case QgsEditorWidgetWrapper::ConstraintResultPass:
+      mConstraintResultLabel->setText( QStringLiteral( "<font color=\"#259b24\">✔</font>" ) );
+      mConstraintResultLabel->setToolTip( QString() );
+      break;
+  }
 }
 
 void QgsAttributeFormEditorWidget::setMode( QgsAttributeFormEditorWidget::Mode mode )
@@ -316,6 +340,9 @@ void QgsAttributeFormEditorWidget::updateWidgets()
     case MultiEditMode:
     {
       mStack->setCurrentWidget( mEditPage );
+
+      mEditPage->layout()->addWidget( mConstraintResultLabel );
+
       break;
     }
 

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -37,7 +37,7 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
   , mIsMixed( false )
   , mIsChanged( false )
 {
-  mConstraintResultLabel = new QLabel();
+  mConstraintResultLabel = new QLabel( this );
   mConstraintResultLabel->setObjectName( QStringLiteral( "ConstraintStatus" ) );
   mConstraintResultLabel->setSizePolicy( QSizePolicy::Fixed, mConstraintResultLabel->sizePolicy().verticalPolicy() );
 

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -209,7 +209,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
     QgsEditorWidgetWrapper *mWidget = nullptr;
     QList< QgsSearchWidgetWrapper * > mSearchWidgets;
     QgsAttributeForm *mForm = nullptr;
-    QLabel *mConstraintResultLabel;
+    QLabel *mConstraintResultLabel = nullptr;
     Mode mMode;
 
     QgsMultiEditToolButton *mMultiEditButton = nullptr;

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -23,6 +23,7 @@
 #include "qgsattributeeditorcontext.h"
 #include "qgssearchwidgetwrapper.h"
 #include "qgis_gui.h"
+#include "qgseditorwidgetwrapper.h"
 
 class QgsAttributeForm;
 class QgsEditorWidgetWrapper;
@@ -31,6 +32,7 @@ class QgsSearchWidgetToolButton;
 class QgsVectorLayer;
 class QStackedWidget;
 class QgsAttributeEditorContext;
+class QLabel;
 
 /**
  * \ingroup gui
@@ -115,6 +117,11 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
      * \since QGIS 2.16
      */
     QString currentFilterExpression() const;
+
+    /**
+     * Set the constraint status for this widget.
+     */
+    void setConstraintStatus( const QString &constraint, const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result );
 
   public slots:
 
@@ -202,6 +209,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
     QgsEditorWidgetWrapper *mWidget = nullptr;
     QList< QgsSearchWidgetWrapper * > mSearchWidgets;
     QgsAttributeForm *mForm = nullptr;
+    QLabel *mConstraintResultLabel;
     Mode mMode;
 
     QgsMultiEditToolButton *mMultiEditButton = nullptr;
@@ -210,7 +218,6 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
     bool mBlockValueUpdate;
     bool mIsMixed;
     bool mIsChanged;
-
 
     QgsVectorLayer *layer();
     void updateWidgets();

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -26,6 +26,7 @@
 #include <qgsfeature.h>
 #include <qgsvectorlayerjoininfo.h>
 #include "qgsgui.h"
+#include "qgsattributeformeditorwidget.h"
 
 class TestQgsAttributeForm : public QObject
 {
@@ -46,6 +47,13 @@ class TestQgsAttributeForm : public QObject
     void testConstraintsOnJoinedFields();
     void testEditableJoin();
     void testUpsertOnEdit();
+
+  private:
+    QLabel *constraintsLabel( QgsAttributeForm *form, QgsEditorWidgetWrapper *ww )
+    {
+      QgsAttributeFormEditorWidget *formEditorWidget = form->mFormEditorWidgets.value( ww->fieldIdx() );
+      return formEditorWidget->findChild<QLabel *>( QStringLiteral( "ConstraintStatus" ) );
+    }
 };
 
 void TestQgsAttributeForm::initTestCase()
@@ -84,9 +92,9 @@ void TestQgsAttributeForm::testFieldConstraint()
   form.setFeature( ft );
 
   // testing stuff
-  QString validLabel = QStringLiteral( "col0<font color=\"green\">✔</font>" );
-  QString invalidLabel = QStringLiteral( "col0<font color=\"red\">✘</font>" );
-  QString warningLabel = QStringLiteral( "col0<font color=\"orange\">✘</font>" );
+  QString validLabel = QStringLiteral( "<font color=\"#259b24\">\u2714</font>" );
+  QString invalidLabel = QStringLiteral( "<font color=\"#FF9800\">\u2718</font>" );
+  QString warningLabel = QStringLiteral( "<font color=\"#FFC107\">\u2718</font>" );
 
   // set constraint
   layer->setConstraintExpression( 0, QString() );
@@ -95,9 +103,8 @@ void TestQgsAttributeForm::testFieldConstraint()
   QgsEditorWidgetWrapper *ww = nullptr;
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[0] );
 
-  // no constraint so we expect a label with just the field name
-  QLabel *label = form.mBuddyMap.value( ww->widget() );
-  QCOMPARE( label->text(), QString( "col0" ) );
+  // no constraint so we expect an empty label
+  QCOMPARE( constraintsLabel( &form, ww )->text(), QString() );
 
   // set a not null constraint
   layer->setConstraintExpression( 0, QStringLiteral( "col0 is not null" ) );
@@ -106,24 +113,23 @@ void TestQgsAttributeForm::testFieldConstraint()
   form2.setFeature( ft );
   QSignalSpy spy( &form2, SIGNAL( attributeChanged( QString, QVariant ) ) );
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[0] );
-  label = form2.mBuddyMap.value( ww->widget() );
 
   // set value to 1
   ww->setValue( 1 );
   QCOMPARE( spy.count(), 2 );
-  QCOMPARE( label->text(), validLabel );
+  QCOMPARE( constraintsLabel( &form2, ww )->text(), validLabel );
 
   // set value to null
   spy.clear();
   ww->setValue( QVariant() );
   QCOMPARE( spy.count(), 2 );
-  QCOMPARE( label->text(), invalidLabel );
+  QCOMPARE( constraintsLabel( &form2, ww )->text(), invalidLabel );
 
   // set value to 1
   spy.clear();
   ww->setValue( 1 );
   QCOMPARE( spy.count(), 2 );
-  QCOMPARE( label->text(), validLabel );
+  QCOMPARE( constraintsLabel( &form2, ww )->text(), validLabel );
 
   // set a soft constraint
   layer->setConstraintExpression( 0, QStringLiteral( "col0 is not null" ) );
@@ -132,19 +138,18 @@ void TestQgsAttributeForm::testFieldConstraint()
   QgsAttributeForm form3( layer );
   form3.setFeature( ft );
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form3.mWidgets[0] );
-  label = form3.mBuddyMap.value( ww->widget() );
 
   // set value to 1
   ww->setValue( 1 );
-  QCOMPARE( label->text(), validLabel );
+  QCOMPARE( constraintsLabel( &form3, ww )->text(), validLabel );
 
   // set value to null
   ww->setValue( QVariant() );
-  QCOMPARE( label->text(), warningLabel );
+  QCOMPARE( constraintsLabel( &form3, ww )->text(), warningLabel );
 
   // set value to 1
   ww->setValue( 1 );
-  QCOMPARE( label->text(), validLabel );
+  QCOMPARE( constraintsLabel( &form3, ww )->text(), validLabel );
 }
 
 void TestQgsAttributeForm::testFieldMultiConstraints()
@@ -172,8 +177,8 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
 
   // testing stuff
   QSignalSpy spy( &form, SIGNAL( attributeChanged( QString, QVariant ) ) );
-  QString val = QStringLiteral( "<font color=\"green\">✔</font>" );
-  QString inv = QStringLiteral( "<font color=\"red\">✘</font>" );
+  QString val = QStringLiteral( "<font color=\"#259b24\">\u2714</font>" );
+  QString inv = QStringLiteral( "<font color=\"#FF9800\">\u2718</font>" );
 
   // get wrappers for each widget
   QgsEditorWidgetWrapper *ww0, *ww1, *ww2, *ww3;
@@ -182,17 +187,11 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   ww2 = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[2] );
   ww3 = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[3] );
 
-  // get label for wrappers
-  QLabel *label0 = form.mBuddyMap.value( ww0->widget() );
-  QLabel *label1 = form.mBuddyMap.value( ww1->widget() );
-  QLabel *label2 = form.mBuddyMap.value( ww2->widget() );
-  QLabel *label3 = form.mBuddyMap.value( ww3->widget() );
-
-  // no constraint so we expect a label with just the field name
-  QCOMPARE( label0->text(), QString( "col0" ) );
-  QCOMPARE( label1->text(), QString( "col1" ) );
-  QCOMPARE( label2->text(), QString( "col2" ) );
-  QCOMPARE( label3->text(), QString( "col3" ) );
+  // no constraint so we expect an empty label
+  Q_ASSERT( constraintsLabel( &form, ww0 )->text().isEmpty() );
+  Q_ASSERT( constraintsLabel( &form, ww1 )->text().isEmpty() );
+  Q_ASSERT( constraintsLabel( &form, ww2 )->text().isEmpty() );
+  Q_ASSERT( constraintsLabel( &form, ww3 )->text().isEmpty() );
 
   // update constraint
   layer->setConstraintExpression( 0, QStringLiteral( "col0 < (col1 * col2)" ) );
@@ -206,30 +205,26 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   ww1 = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[1] );
   ww2 = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[2] );
   ww3 = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[3] );
-  label0 = form2.mBuddyMap.value( ww0->widget() );
-  label1 = form2.mBuddyMap.value( ww1->widget() );
-  label2 = form2.mBuddyMap.value( ww2->widget() );
-  label3 = form2.mBuddyMap.value( ww3->widget() );
   QSignalSpy spy2( &form2, SIGNAL( attributeChanged( QString, QVariant ) ) );
 
   // change value
   ww0->setValue( 2 ); // update col0
   QCOMPARE( spy2.count(), 2 );
 
-  QCOMPARE( label0->text(), QString( "col0" + inv ) ); // 2 < ( 1 + 2 )
-  QCOMPARE( label1->text(), QString( "col1" ) );
-  QCOMPARE( label2->text(), QString( "col2" ) );
-  QCOMPARE( label3->text(), QString( "col3" + val ) ); // 2 = 2
+  QCOMPARE( constraintsLabel( &form2, ww0 )->text(), inv ); // 2 < ( 1 + 2 )
+  QCOMPARE( constraintsLabel( &form2, ww1 )->text(), QString() );
+  QCOMPARE( constraintsLabel( &form2, ww2 )->text(), QString() );
+  QCOMPARE( constraintsLabel( &form2, ww3 )->text(), val ); // 2 = 2
 
   // change value
   spy2.clear();
   ww0->setValue( 1 ); // update col0
   QCOMPARE( spy2.count(), 2 );
 
-  QCOMPARE( label0->text(), QString( "col0" + val ) ); // 1 < ( 1 + 2 )
-  QCOMPARE( label1->text(), QString( "col1" ) );
-  QCOMPARE( label2->text(), QString( "col2" ) );
-  QCOMPARE( label3->text(), QString( "col3" + inv ) ); // 2 = 1
+  QCOMPARE( constraintsLabel( &form2, ww0 )->text(), val ); // 1 < ( 1 + 2 )
+  QCOMPARE( constraintsLabel( &form2, ww1 )->text(), QString() );
+  QCOMPARE( constraintsLabel( &form2, ww2 )->text(), QString() );
+  QCOMPARE( constraintsLabel( &form2, ww3 )->text(), inv ); // 2 = 1
 }
 
 void TestQgsAttributeForm::testOKButtonStatus()
@@ -445,8 +440,8 @@ void TestQgsAttributeForm::testDynamicForm()
 
 void TestQgsAttributeForm::testConstraintsOnJoinedFields()
 {
-  QString validLabel = QStringLiteral( "col0<font color=\"green\">✔</font>" );
-  QString warningLabel = QStringLiteral( "col0<font color=\"orange\">✘</font>" );
+  QString validLabel = QStringLiteral( "<font color=\"#259b24\">\u2714</font>" );
+  QString warningLabel = QStringLiteral( "<font color=\"#FFC107\">\u2718</font>" );
 
   // make temporary layers
   QString defA = QStringLiteral( "Point?field=id_a:integer" );
@@ -501,16 +496,14 @@ void TestQgsAttributeForm::testConstraintsOnJoinedFields()
   // compare
   QgsEditorWidgetWrapper *ww = nullptr;
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[1] );
-  QLabel *label = form.mBuddyMap.value( ww->widget() );
-  QCOMPARE( label->text(), "layerB_" + validLabel );
+  QCOMPARE( constraintsLabel( &form, ww )->text(), validLabel );
 
   // change layerA join id field
   form.changeAttribute( QStringLiteral( "id_a" ), QVariant( 31 ) );
 
   // compare
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[1] );
-  label = form.mBuddyMap.value( ww->widget() );
-  QCOMPARE( label->text(), "layerB_" + warningLabel );
+  QCOMPARE( constraintsLabel( &form, ww )->text(), warningLabel );
 }
 
 void TestQgsAttributeForm::testEditableJoin()


### PR DESCRIPTION
A new and polished look and feel for the constraints. They are now only shown inline and the top widget showing up to three constraints has been removed. The constraint text is reported as a tooltip.

Do we need a list of all constraints still somewhere?
We could add a button at the bottom "constraint report" that would open up such a dialog, but I'm not sure that's actually required.

![unobtrusiveconstraints](https://user-images.githubusercontent.com/588407/32067494-c03778a4-ba83-11e7-856c-0652512267c0.png)