### PR TITLE
[FEATURE] Show comments as tooltips on form

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1192,6 +1192,7 @@ void QgsAttributeForm::init()
         tabWidget = nullptr;
         WidgetInfo widgetInfo = createWidgetFromDef( widgDef, container, mLayer, mContext );
         QLabel *label = new QLabel( widgetInfo.labelText );
+        label->setToolTip( QStringLiteral( "<b>%1</b><p>%2</p>" ).arg( widgetInfo.labelText, widgetInfo.hint ) );
         if ( columnCount > 1 && !widgetInfo.labelOnTop )
         {
           label->setAlignment( Qt::AlignRight | Qt::AlignVCenter );
@@ -1277,6 +1278,7 @@ void QgsAttributeForm::init()
 
       // This will also create the widget
       QLabel *l = new QLabel( fieldName );
+      l->setToolTip( QStringLiteral( "<b>%1</b><p>%2</p>" ).arg( fieldName, field.comment() ) );
       QSvgWidget *i = new QSvgWidget();
       i->setFixedSize( 18, 18 );
 
@@ -1599,6 +1601,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
       newWidgetInfo.labelOnTop = mLayer->editFormConfig().labelOnTop( fieldDef->idx() );
       newWidgetInfo.labelText = mLayer->attributeDisplayName( fieldDef->idx() );
+      newWidgetInfo.hint = mLayer->fields().at( fieldDef->idx() ).comment();
       newWidgetInfo.showLabel = widgetDef->showLabel();
 
       break;
@@ -1687,6 +1690,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
         else
         {
           QLabel *mypLabel = new QLabel( widgetInfo.labelText );
+          mypLabel->setToolTip( QStringLiteral( "<b>%1</b><p>%2</p>" ).arg( widgetInfo.labelText, widgetInfo.hint ) );
           if ( columnCount > 1 && !widgetInfo.labelOnTop )
           {
             mypLabel->setAlignment( Qt::AlignRight | Qt::AlignVCenter );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -304,6 +304,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
       QWidget *widget = nullptr;
       QString labelText;
+      QString hint;
       bool labelOnTop = false;
       bool labelAlignRight = false;
       bool showLabel = true;


### PR DESCRIPTION
Let's face it, where we need the information is not in the layer
properties configuration, it's when we enter the data.

![commentsonform](https://user-images.githubusercontent.com/588407/32069281-f3137304-ba88-11e7-9065-8528dfb1c80d.png)
