### PR TITLE
Hide symbology export options when not compatible

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -57,6 +57,7 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, i
     mLayerExtent = layer->extent();
   }
   setup();
+
   if ( !( options & Symbology ) )
   {
     mSymbologyExportLabel->hide();
@@ -360,13 +361,29 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
   const QString sFormat( format() );
   if ( sFormat == QLatin1String( "DXF" ) || sFormat == QLatin1String( "DGN" ) )
   {
-    mAttributesSelection->setEnabled( false );
+    mAttributesSelection->setVisible( false );
     selectAllFields = false;
   }
   else
   {
-    mAttributesSelection->setEnabled( true );
+    mAttributesSelection->setVisible( true );
     fieldsAsDisplayedValues = ( sFormat == QLatin1String( "CSV" ) || sFormat == QLatin1String( "XLS" ) || sFormat == QLatin1String( "XLSX" ) || sFormat == QLatin1String( "ODS" ) );
+  }
+
+  // Show symbology options only for some formats
+  if ( sFormat == QLatin1String( "DXF" ) || sFormat == QLatin1String( "KML" ) || sFormat == QLatin1String( "MapInfo File" ) || sFormat == QLatin1String( "MapInfo MIF" ) )
+  {
+    mSymbologyExportLabel->setVisible( true );
+    mSymbologyExportComboBox->setVisible( true );
+    mScaleLabel->setVisible( true );
+    mScaleWidget->setVisible( true );
+  }
+  else
+  {
+    mSymbologyExportLabel->hide();
+    mSymbologyExportComboBox->hide();
+    mScaleLabel->hide();
+    mScaleWidget->hide();
   }
 
   leLayername->setEnabled( sFormat == QLatin1String( "KML" ) ||


### PR DESCRIPTION
In the vector layer "Save As..." dialog there are options to export features/layer with a symbology. From [what i understood](http://docs.qgis.org/testing/en/docs/user_manual/managing_data_source/create_layers.html#vector-specific-parameters) it has to do with OGR styles and apply to only some formats. But these options were always shown whatever the selected format.
The PR also hides the "select fields..." frame instead of simply disable it.

![image](https://user-images.githubusercontent.com/7983394/32082862-c2ddb38a-babe-11e7-80ee-d562c5d824c2.png)


