### PR TITLE
adding WITH_CLANG_TIDY as advanced, so you can build without it even …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,18 +735,22 @@ ENDIF (WITH_CORE)
 
 ####################################################
 # clang-tidy
+SET (WITH_CLANG_TIDY FALSE CACHE BOOL "Use Clang tidy")
+MARK_AS_ADVANCED(WITH_CORE)
 IF (WITH_CORE)
-  FIND_PROGRAM(
-    CLANG_TIDY_EXE
-    NAMES "clang-tidy"
-    DOC "Path to clang-tidy executable"
-    )
-  IF(NOT CLANG_TIDY_EXE)
-    MESSAGE(STATUS "clang-tidy not found.")
-  ELSE(NOT CLANG_TIDY_EXE)
-    MESSAGE(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-    SET(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-checks=*,-clang-analyzer-alpha.*,-cppcoreguidelines*,-readability-implicit-bool-cast,-llvm-include-order,-cert-err58-cpp,-modernize-pass-by-value,-google-readability-braces-around-statements,-modernize-use-auto,-modernize-loop-convert,-readability-else-after-return,-readability-braces-around-statements,-google-runtime-references,-readability-named-parameter,-google-default-arguments,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-cert-flp30-c,-google-readability-casting,-clang-analyzer-security.FloatLoopCounter,-google-runtime-int,-modernize-use-using,-google-explicit-constructor,-google-build-using-namespace,-cert-err34-c,-clang-analyzer-core.CallAndMessage,-google-readability-function-size,-modernize-make-shared,-modernize-use-nullptr,-clang-analyzer-cplusplus.NewDeleteLeaks,-clang-analyzer-core.NonNullParamChecker,performance-unnecessary-copy-initialization,-readability-simplify-boolean-expr,-modernize-raw-string-literal,-performance-unnecessary-copy-initialization")
-  ENDIF(NOT CLANG_TIDY_EXE)
+  IF(WITH_CLANG_TIDY)
+    FIND_PROGRAM(
+      CLANG_TIDY_EXE
+      NAMES "clang-tidy"
+      DOC "Path to clang-tidy executable"
+      )
+    IF(NOT CLANG_TIDY_EXE)
+      MESSAGE(STATUS "clang-tidy not found.")
+    ELSE(NOT CLANG_TIDY_EXE)
+      MESSAGE(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+      SET(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-checks=*,-clang-analyzer-alpha.*,-cppcoreguidelines*,-readability-implicit-bool-cast,-llvm-include-order,-cert-err58-cpp,-modernize-pass-by-value,-google-readability-braces-around-statements,-modernize-use-auto,-modernize-loop-convert,-readability-else-after-return,-readability-braces-around-statements,-google-runtime-references,-readability-named-parameter,-google-default-arguments,-google-readability-todo,-readability-inconsistent-declaration-parameter-name,-cert-flp30-c,-google-readability-casting,-clang-analyzer-security.FloatLoopCounter,-google-runtime-int,-modernize-use-using,-google-explicit-constructor,-google-build-using-namespace,-cert-err34-c,-clang-analyzer-core.CallAndMessage,-google-readability-function-size,-modernize-make-shared,-modernize-use-nullptr,-clang-analyzer-cplusplus.NewDeleteLeaks,-clang-analyzer-core.NonNullParamChecker,performance-unnecessary-copy-initialization,-readability-simplify-boolean-expr,-modernize-raw-string-literal,-performance-unnecessary-copy-initialization")
+    ENDIF(NOT CLANG_TIDY_EXE)
+  ENDIF(WITH_CLANG_TIDY)
 ENDIF (WITH_CORE)
 
 #############################################################


### PR DESCRIPTION

## Description

As soon as you have clang-tidy installed, your build will become MUCH much slower, and you will have a lot of warnings like:

'''
[ 4%] Building CXX object src/core/CMakeFiles/qgis_core.dir/composer/qgscomposermapitem.cpp.o /usr/lib/gcc/x86_64-linux-gnu/7.2.0/../../../../include/c++/7.2.0/bits/std_abs.h:102:3: error: support for type '__float128' is not yet implemented [clang-diagnostic-error] abs(__float128 __x) ^ /usr/lib/gcc/x86_64-linux-gnu/7.2.0/../../../../include/c++/7.2.0/bits/std_abs.h:102:18: error: support for type '__float128' is not yet implemented [clang-diagnostic-error] abs(__float128 __x)
'''

So: there is no way to speed up your build then uninstalling clang-tidy again.

This flag WITH_CLANG_TIDY defaults to False so you can choose to build with or without it.

Messed up an earlier branch, see https://github.com/qgis/QGIS/pull/5457
For some discussion there. This commit makes the WITH_CLANG_TIDY an advanced property.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
