### PR TITLE
[postgres] Distinguish empty and NULL values

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2050,7 +2050,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       if ( i == flist.size() )
       {
-        if ( v == defVal )
+        if ( v == defVal && defVal.isNull() == v.isNull() )
         {
           if ( defVal.isNull() )
           {

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -329,15 +329,6 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(f['val'], feature['val'])
         self.assertEqual(f['name'], feature['name'])
 
-        f = QgsFeature(vl.fields())
-        f['gid'] = 101
-        f['val'] = NULL
-        f['name'] = NULL
-        vl.addFeature(f)
-        feature = next(vl.getFeatures('"gid" = 101'))
-        self.assertEqual(f['val'], feature['val'])
-        self.assertEqual(f['name'], feature['name'])
-
     def testNestedInsert(self):
         tg = QgsTransactionGroup()
         tg.addLayer(self.vl)


### PR DESCRIPTION
Right now adding a feature with an empty string attribute to postgres will add a feature with a NULL value, if constraints are in place for this attribute.

This is especially painful when we have a string field with a `NOT NULL` constraint. Leaving the line edit on the form empty, it will be reported as valid with a green tick, the database will complain about the value being invalid on insert.