### PR TITLE
[FEATURE][Plugin manager] Only install non-trusted plugins if user explicitly agreed.

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -744,6 +744,7 @@ class Plugins(QObject):
         for i in list(self.localCache.keys()):
             self.mPlugins[i] = self.localCache[i].copy()
         settings = QgsSettings()
+        allowThirdParty = settings.value(settingsGroup + "/allowThirdParty", False, type=bool)
         allowExperimental = settings.value(settingsGroup + "/allowExperimental", False, type=bool)
         allowDeprecated = settings.value(settingsGroup + "/allowDeprecated", False, type=bool)
         for i in list(self.repoCache.values()):
@@ -751,7 +752,8 @@ class Plugins(QObject):
                 plugin = j.copy()  # do not update repoCache elements!
                 key = plugin["id"]
                 # check if the plugin is allowed and if there isn't any better one added already.
-                if (allowExperimental or not plugin["experimental"]) \
+                if (allowThirdParty or plugin["trusted"]) \
+                   and (allowExperimental or not plugin["experimental"]) \
                    and (allowDeprecated or not plugin["deprecated"]) \
                    and not (key in self.mPlugins and self.mPlugins[key]["version_available"] and compareVersions(self.mPlugins[key]["version_available"], plugin["version_available"]) < 2):
                     # The mPlugins dict contains now locally installed plugins.

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -80,6 +80,7 @@ QgsPluginManager::QgsPluginManager( QWidget *parent, bool pluginsAreEnabled, Qt:
   connect( buttonEditRep, &QPushButton::clicked, this, &QgsPluginManager::buttonEditRep_clicked );
   connect( buttonDeleteRep, &QPushButton::clicked, this, &QgsPluginManager::buttonDeleteRep_clicked );
   connect( buttonRefreshRepos, &QPushButton::clicked, this, &QgsPluginManager::buttonRefreshRepos_clicked );
+  connect( ckbThirdParty, &QgsCollapsibleGroupBox::toggled, this, &QgsPluginManager::ckbThirdParty_toggled );
   connect( ckbExperimental, &QgsCollapsibleGroupBox::toggled, this, &QgsPluginManager::ckbExperimental_toggled );
   connect( ckbDeprecated, &QgsCollapsibleGroupBox::toggled, this, &QgsPluginManager::ckbDeprecated_toggled );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPluginManager::showHelp );
@@ -1424,6 +1425,15 @@ void QgsPluginManager::buttonDeleteRep_clicked()
 }
 
 
+void QgsPluginManager::ckbThirdParty_toggled( bool state )
+{
+  QString settingsGroup;
+  QgsPythonRunner::eval( QStringLiteral( "pyplugin_installer.instance().exportSettingsGroup()" ), settingsGroup );
+  QgsSettings settings;
+  settings.setValue( settingsGroup + "/allowThirdParty", QVariant( state ) );
+  QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.installer_data.plugins.rebuild()" ) );
+  QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.instance().exportPluginsToManager()" ) );
+}
 
 void QgsPluginManager::ckbExperimental_toggled( bool state )
 {

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -162,6 +162,9 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     //! Reload all repositories
     void buttonRefreshRepos_clicked();
 
+    //! Reload plugin metadata registry after allowing/disallowing third party plugins
+    void ckbThirdParty_toggled( bool state );
+
     //! Reload plugin metadata registry after allowing/disallowing experimental plugins
     void ckbExperimental_toggled( bool state );
 

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -804,7 +804,7 @@
                    <x>0</x>
                    <y>0</y>
                    <width>646</width>
-                   <height>638</height>
+                   <height>861</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -892,6 +892,62 @@
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; If this function is enabled, QGIS will inform you whenever a new plugin or plugin update is available. Otherwise, fetching repositories will be performed during opening of the Plugin Manager window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QgsCollapsibleGroupBox" name="ckbThirdParty">
+                    <property name="title">
+                     <string>Show also third party plugins</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <property name="collapsed" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <property name="saveCheckedState" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <property name="saveCollapsedState" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_15">
+                     <item>
+                      <widget class="QLabel" name="lblThirdParty">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>0</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-weight:600;&quot;&gt;Please Note:&lt;/span&gt;&lt;span style=&quot; font-family:'DejaVu Sans';&quot;&gt;: Whilst the QGIS project provides a platform for creating and sharing plugins, we make not assertions as to the quality and security of these plugins. Plugins in the repository are developed by third parties and may have bugs, be non-functional or even contain malicious code. We recommend that you carefully review which plugins you install. You should understand that the use of contributed plugins is entirely at your own risk. If you wish to report an issue with any plugin that you believe may be a security issue, or that creates a poor experience for users in other ways, please contact the plugin creators directly. If you do not receive a response from the plugin author or you do not believe the author intends to correctly address a serious issue, please contact us at &lt;/span&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-style:italic;&quot;&gt;plugins@qgis.org&lt;/span&gt;&lt;span style=&quot; font-family:'DejaVu Sans';&quot;&gt; and we will consider delisting the plugins if needed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::RichText</enum>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>


### PR DESCRIPTION
**EDIT: Ah, now I see this PR was late for 3 hours after the feature freeze (it was always at the midnight, wasn't it?). I'm ok to postpone it for 4.0  ;-)**

There was a discussion we agreed users should be warned before installing non-trusted plugins, and also there should be an option to only install trusted/featured plugins. See https://issues.qgis.org/issues/14914 for details.

Rather than opt-out "Only trusted plugins", I used opt-in "Show also third party plugins", as it's consistent with existing checkboxes. Better wording welcome. 

A big side-effect is the default plugin set will be very limited as most of the plugins is disabled. I believe such change should be made for 3.0 or wait for 4.0, to not change rules during the 3.x lifetime.

![untrusted](https://user-images.githubusercontent.com/1000043/32114559-2ccf5822-bb44-11e7-8edf-857422c6b324.png)

@timlinux @pcav @DelazJ @gioman 