### PR TITLE
Postgres testing, QgsProject::instance() dependencies, travis build times

### DIFF
--- a/.ci/travis/linux/docker-build-test.sh
+++ b/.ci/travis/linux/docker-build-test.sh
@@ -6,7 +6,7 @@ set -e
 # Setup ccache
 ##############
 export CCACHE_TEMPDIR=/tmp
-ccache -M 500M
+ccache -M 1G
 
 # Temporarily uncomment to debug ccache issues
 # export CCACHE_LOGFILE=/tmp/cache.debug

--- a/.ci/travis/linux/docker-build-test.sh
+++ b/.ci/travis/linux/docker-build-test.sh
@@ -7,6 +7,9 @@ set -e
 ##############
 export CCACHE_TEMPDIR=/tmp
 ccache -M 500M
+
+# Temporarily uncomment to debug ccache issues
+# export CCACHE_LOGFILE=/tmp/cache.debug
 ccache -z
 
 ############################
@@ -57,6 +60,11 @@ echo "travis_fold:start:ninja-build.1"
 echo "${bold}Building QGIS...${endbold}"
 ${CTEST_BUILD_COMMAND}
 echo "travis_fold:end:ninja-build.1"
+
+# Temporarily uncomment to debug ccache issues
+# echo "travis_fold:start:ccache-debug"
+# cat /tmp/cache.debug
+# echo "travis_fold:end:ccache-debug"
 
 ############################
 # Restore postgres test data

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2426,6 +2426,11 @@ QgsTracer        {#qgis_api_break_3_0_QgsTracer}
 
 - hasCrsTransformEnabled() and setCrsTransformEnabled() were removed. CRS transformation is now always enabled when required.
 
+QgsTransaction        {#qgis_api_break_3_0_QgsTransaction}
+--------------
+
+- `createTransaction()` takes a set of map layers instead of a layer ids
+
 
 QgsTreeWidgetItem        {#qgis_api_break_3_0_QgsTreeWidgetItem}
 -----------------

--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -23,7 +23,7 @@ class QgsTransaction : QObject /Abstract/
  and all layers need to be in read-only mode for a transaction to be committed
  or rolled back.
 
- Layers cannot only be included in one transaction at a time.
+ Layers can only be included in one transaction at a time.
 
  When editing layers which are part of a transaction group, all changes are
  sent directly to the data provider (bypassing the undo/redo stack), and the
@@ -105,7 +105,7 @@ class QgsTransaction : QObject /Abstract/
 
     static bool supportsTransaction( const QgsVectorLayer *layer );
 %Docstring
- Checks if a the provider of a given ``layer`` supports transactions.
+ Checks if the provider of a given ``layer`` supports transactions.
  :rtype: bool
 %End
 

--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsTransaction : QObject /Abstract/
 {
 %Docstring
@@ -47,23 +48,15 @@ class QgsTransaction : QObject /Abstract/
  :rtype: QgsTransaction
 %End
 
-    static QgsTransaction *create( const QStringList &layerIds ) /Factory/;
+    static QgsTransaction *create( const QSet<QgsVectorLayer *> &layers ) /Factory/;
 %Docstring
- Create a transaction which includes the layers specified with
- ``layerIds``.
+ Create a transaction which includes the ``layers``.
  All layers are expected to have the same connection string and data
  provider.
  :rtype: QgsTransaction
 %End
 
     virtual ~QgsTransaction();
-
-    bool addLayer( const QString &layerId );
-%Docstring
- Add the layer with ``layerId`` to the transaction. The layer must not be
- in edit mode and the connection string must match.
- :rtype: bool
-%End
 
     bool addLayer( QgsVectorLayer *layer );
 %Docstring

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -20,7 +20,6 @@
 #include "qgstransaction.h"
 #include "qgslogger.h"
 #include "qgsdatasourceuri.h"
-#include "qgsproject.h"
 #include "qgsproviderregistry.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -52,6 +52,7 @@ class QgsVectorLayer;
  *
  * Edits on features can get rejected if another conflicting transaction is active.
  */
+
 class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
 {
     Q_OBJECT
@@ -65,20 +66,13 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     static QgsTransaction *create( const QString &connString, const QString &providerKey ) SIP_FACTORY;
 
     /**
-     * Create a transaction which includes the layers specified with
-     * \a layerIds.
+     * Create a transaction which includes the \a layers.
      * All layers are expected to have the same connection string and data
      * provider.
      */
-    static QgsTransaction *create( const QStringList &layerIds ) SIP_FACTORY;
+    static QgsTransaction *create( const QSet<QgsVectorLayer *> &layers ) SIP_FACTORY;
 
     virtual ~QgsTransaction();
-
-    /**
-     * Add the layer with \a layerId to the transaction. The layer must not be
-     * in edit mode and the connection string must match.
-     */
-    bool addLayer( const QString &layerId );
 
     /**
      * Add the \a layer to the transaction. The layer must not be
@@ -182,7 +176,7 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     QString mConnString;
 
   private slots:
-    void onLayersDeleted( const QStringList &layerids );
+    void onLayerDeleted();
 
   private:
 

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -40,7 +40,7 @@ class QgsVectorLayer;
  * and all layers need to be in read-only mode for a transaction to be committed
  * or rolled back.
  *
- * Layers cannot only be included in one transaction at a time.
+ * Layers can only be included in one transaction at a time.
  *
  * When editing layers which are part of a transaction group, all changes are
  * sent directly to the data provider (bypassing the undo/redo stack), and the
@@ -115,7 +115,7 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     virtual bool executeSql( const QString &sql, QString &error SIP_OUT, bool isDirty = false ) = 0;
 
     /**
-     * Checks if a the provider of a given \a layer supports transactions.
+     * Checks if the provider of a given \a layer supports transactions.
      */
     static bool supportsTransaction( const QgsVectorLayer *layer );
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -339,6 +339,18 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.vl.addFeature(f)  # Should not deadlock during an active iteration
         f = next(it)
 
+    def testTimeout(self):
+        """
+        Asserts that we will not deadlock if more iterators are opened in parallel than
+        available in the connection pool
+        """
+        request = QgsFeatureRequest()
+        request.setConnectionTimeout(1)
+
+        iterators = list()
+        for i in range(100):
+            iterators.append(self.vl.getFeatures(request))
+
     def testTransactionNotDirty(self):
         # create a vector ayer based on postgres
         vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'pk\' srid=4326 type=POLYGON table="qgis_test"."some_poly_data" (geom) sql=', 'test', 'postgres')

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -233,7 +233,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         """
         lyrs = [self.vl_a, self.vl_b, self.vl_link]
 
-        self.transaction = QgsTransaction.create([l.id() for l in lyrs])
+        self.transaction = QgsTransaction.create(lyrs)
         self.transaction.begin()
         for l in lyrs:
             l.startEditing()


### PR DESCRIPTION
* Adds a test for the connectionTimeout flag in QgsFeatureRequest
* Decouples QgsTransaction from QgsProject (less QgsProject.instance() dependencies)
* Brings back nice 15 minutes build times on travis