### PR TITLE
[bug fix][need backport]Circular string (and new derived map tools) doesn't honor rubberband line width of digitizing settings.

### DIFF
--- a/src/gui/qgsmaptooledit.cpp
+++ b/src/gui/qgsmaptooledit.cpp
@@ -131,6 +131,7 @@ QgsGeometryRubberBand *QgsMapToolEdit::createGeometryRubberBand( QgsWkbTypes::Ge
   color.setAlphaF( myAlpha );
   rb->setStrokeColor( color );
   rb->setFillColor( color );
+  rb->setStrokeWidth( digitizingStrokeWidth() );
   rb->show();
   return rb;
 }


### PR DESCRIPTION
## Description
Circular string (and new derived map tools) doesn't honor rubberband line width of digitizing settings.
This PR fix issue [17355](https://issues.qgis.org/issues/17355).

Only add this line
`  rb->setStrokeWidth( digitizingStrokeWidth() );`

I think it was an omission rather than a wish.

Need to be backported

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
