### PR TITLE
set feature when starting action on attribute edit form

### DIFF
--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -89,6 +89,7 @@ void QgsActionMenu::triggerAction()
   {
     // define custom substitutions: layer id and clicked coords
     QgsExpressionContext context = mLayer->createExpressionContext();
+    context.setFeature( mFeature );
 
     QgsExpressionContextScope *actionScope = new QgsExpressionContextScope();
     actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "action_scope" ), mActionScope, true ) );


### PR DESCRIPTION
Because when there is started an action for a feature from the feature-editor, like it's done f.e. in the canvas, we need the feature-information in the Python command.