### PR TITLE
Fixing messages displayed in GUI

### DIFF
--- a/python/plugins/MetaSearch/dialogs/manageconnectionsdialog.py
+++ b/python/plugins/MetaSearch/dialogs/manageconnectionsdialog.py
@@ -72,11 +72,11 @@ class ManageConnectionsDialog(QDialog, BASE_CLASS):
         label = self.tr('eXtensible Markup Language (*.xml *.XML)')
 
         if self.mode == 0:
-            slabel = self.tr('Save connections')
+            slabel = self.tr('Save Connections')
             self.filename, filter = QFileDialog.getSaveFileName(self, slabel,
                                                                 '.', label)
         else:
-            slabel = self.tr('Load connections')
+            slabel = self.tr('Load Connections')
             self.filename, selected_filter = QFileDialog.getOpenFileName(self, slabel,
                                                                          '.', label)
 

--- a/python/plugins/MetaSearch/dialogs/manageconnectionsdialog.py
+++ b/python/plugins/MetaSearch/dialogs/manageconnectionsdialog.py
@@ -134,7 +134,7 @@ class ManageConnectionsDialog(QDialog, BASE_CLASS):
         with open(self.filename, 'w') as fileobj:
             fileobj.write(prettify_xml(etree.tostring(doc)))
         QMessageBox.information(self, self.tr('Save Connections'),
-                                self.tr('Saved to {0}').format(self.filename))
+                                self.tr('Saved to {0}.').format(self.filename))
         self.reject()
 
     def load(self, items):

--- a/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
+++ b/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
@@ -59,13 +59,13 @@ class NewConnectionDialog(QDialog, BASE_CLASS):
         conn_password = self.lePassword.text().strip()
 
         if any([conn_name == '', conn_url == '']):
-            QMessageBox.warning(self, self.tr('Save connection'),
-                                self.tr('Both Name and URL must be provided'))
+            QMessageBox.warning(self, self.tr('Save Connection'),
+                                self.tr('Both Name and URL must be provided.'))
             return
 
         if '/' in conn_name:
-            QMessageBox.warning(self, self.tr('Save connection'),
-                                self.tr('Name cannot contain \'/\''))
+            QMessageBox.warning(self, self.tr('Save Connection'),
+                                self.tr('Name cannot contain \'/\'.'))
             return
 
         if conn_name is not None:
@@ -76,7 +76,7 @@ class NewConnectionDialog(QDialog, BASE_CLASS):
             # warn if entry was renamed to an existing connection
             if all([self.conn_name_orig != conn_name,
                     self.settings.contains(keyurl)]):
-                res = QMessageBox.warning(self, self.tr('Save connection'),
+                res = QMessageBox.warning(self, self.tr('Save Connection'),
                                           self.tr('Overwrite {0}?').format(conn_name),
                                           QMessageBox.Ok | QMessageBox.Cancel)
                 if res == QMessageBox.Cancel:

--- a/python/plugins/db_manager/dlg_table_properties.py
+++ b/python/plugins/db_manager/dlg_table_properties.py
@@ -167,7 +167,8 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         m = self.viewFields.model()
         fld = m.getObject(index)
 
-        res = QMessageBox.question(self, self.tr("Are you sure"), self.tr("Really delete column '{0}'?").format(fld.name),
+        res = QMessageBox.question(self, self.tr("Delete Column"),
+                                   self.tr("Are you sure you want to delete column '{0}'?").format(fld.name),
                                    QMessageBox.Yes | QMessageBox.No)
         if res != QMessageBox.Yes:
             return
@@ -218,8 +219,8 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         m = self.viewConstraints.model()
         constr = m.getObject(index)
 
-        res = QMessageBox.question(self, self.tr("Are you sure"),
-                                   self.tr("Really delete constraint '{0}'?").format(constr.name),
+        res = QMessageBox.question(self, self.tr("Delete Constraint"),
+                                   self.tr("Are you sure you want to delete constraint '{0}'?").format(constr.name),
                                    QMessageBox.Yes | QMessageBox.No)
         if res != QMessageBox.Yes:
             return
@@ -274,7 +275,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
             QMessageBox.information(self, self.tr("DB Manager"), self.tr("The selected table has no geometry"))
             return
 
-        res = QMessageBox.question(self, self.tr("Create?"),
+        res = QMessageBox.question(self, self.tr("Create Spatial Index"),
                                    self.tr("Create spatial index for field {0}?").format(self.table.geomColumn),
                                    QMessageBox.Yes | QMessageBox.No)
         if res != QMessageBox.Yes:
@@ -308,7 +309,8 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         m = self.viewIndexes.model()
         idx = m.getObject(index)
 
-        res = QMessageBox.question(self, self.tr("Are you sure"), self.tr("Really delete index '{0}'?").format(idx.name),
+        res = QMessageBox.question(self, self.tr("Delete Index"),
+                                   self.tr("Are you sure you want to delete index '{0}'?").format(idx.name),
                                    QMessageBox.Yes | QMessageBox.No)
         if res != QMessageBox.Yes:
             return

--- a/python/plugins/db_manager/dlg_table_properties.py
+++ b/python/plugins/db_manager/dlg_table_properties.py
@@ -272,7 +272,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
     def createSpatialIndex(self):
         """ create spatial index for the geometry column """
         if self.table.type != self.table.VectorType:
-            QMessageBox.information(self, self.tr("DB Manager"), self.tr("The selected table has no geometry"))
+            QMessageBox.information(self, self.tr("DB Manager"), self.tr("The selected table has no geometry."))
             return
 
         res = QMessageBox.question(self, self.tr("Create Spatial Index"),

--- a/python/plugins/db_manager/ui/DlgDbError.ui
+++ b/python/plugins/db_manager/ui/DlgDbError.ui
@@ -27,7 +27,7 @@
        <item>
         <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>An error occurred:</string>
+          <string>An error occurred</string>
          </property>
         </widget>
        </item>
@@ -51,7 +51,7 @@
        <item>
         <widget class="QLabel" name="label">
          <property name="text">
-          <string>An error occurred when executing a query:</string>
+          <string>An error occurred when executing a query</string>
          </property>
         </widget>
        </item>
@@ -68,7 +68,7 @@
        <item>
         <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Query:</string>
+          <string>Query</string>
          </property>
         </widget>
        </item>

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -142,7 +142,7 @@ class BatchPanel(BASE, WIDGET):
 
     def load(self):
         filename, selected_filter = QFileDialog.getOpenFileName(self,
-                                                                self.tr('Open batch'), None,
+                                                                self.tr('Open Batch'), None,
                                                                 self.tr('JSON files (*.json)'))
         if filename:
             with open(filename) as f:
@@ -216,7 +216,7 @@ class BatchPanel(BASE, WIDGET):
             toSave.append({self.PARAMETERS: algParams, self.OUTPUTS: algOutputs})
 
         filename, __ = QFileDialog.getSaveFileName(self,
-                                                   self.tr('Save batch'),
+                                                   self.tr('Save Batch'),
                                                    None,
                                                    self.tr('JSON files (*.json)'))
         if filename:

--- a/python/pyplugin_installer/qgsplugininstallerfetchingbase.ui
+++ b/python/pyplugin_installer/qgsplugininstallerfetchingbase.ui
@@ -33,7 +33,7 @@
    <item row="2" column="0" >
     <widget class="QLabel" name="label1" >
      <property name="text" >
-      <string>Overall progress:</string>
+      <string>Overall progress</string>
      </property>
     </widget>
    </item>

--- a/src/app/dwg/qgsdwgimporter.cpp
+++ b/src/app/dwg/qgsdwgimporter.cpp
@@ -101,7 +101,7 @@ bool QgsDwgImporter::exec( const QString &sql, bool logError )
 
   if ( logError )
   {
-    LOG( QObject::tr( "SQL statement failed\nDatabase:%1\nSQL:%2\nError:%3" )
+    LOG( QObject::tr( "SQL statement failed\nDatabase: %1\nSQL: %2\nError: %3" )
          .arg( mDatabase, sql, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
   }
   return false;
@@ -127,7 +127,7 @@ OGRLayerH QgsDwgImporter::query( const QString &sql )
   if ( CPLGetLastErrorType() == CE_None )
     return layer;
 
-  LOG( QObject::tr( "SQL statement failed\nDatabase:%1\nSQL:%2\nError:%3" )
+  LOG( QObject::tr( "SQL statement failed\nDatabase: %1\nSQL: %2\nError: %3" )
        .arg( mDatabase, sql, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
 
   OGR_DS_ReleaseResultSet( mDs.get(), layer );
@@ -143,7 +143,7 @@ void QgsDwgImporter::startTransaction()
   mInTransaction = GDALDatasetStartTransaction( mDs.get(), 0 ) == OGRERR_NONE;
   if ( !mInTransaction )
   {
-    LOG( QObject::tr( "Could not start transaction\nDatabase:%1\nError:%2" )
+    LOG( QObject::tr( "Could not start transaction\nDatabase: %1\nError: %2" )
          .arg( mDatabase, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
   }
 }
@@ -154,7 +154,7 @@ void QgsDwgImporter::commitTransaction()
 
   if ( mInTransaction && GDALDatasetCommitTransaction( mDs.get() ) != OGRERR_NONE )
   {
-    LOG( QObject::tr( "Could not commit transaction\nDatabase:%1\nError:%2" )
+    LOG( QObject::tr( "Could not commit transaction\nDatabase: %1\nError: %2" )
          .arg( mDatabase, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
   }
   mInTransaction = false;
@@ -2672,7 +2672,7 @@ bool QgsDwgImporter::expandInserts( QString &error )
         {
           if ( errors < 1000 )
           {
-            QgsMessageLog::logMessage( QObject::tr( "Could not copy feature of block %2 from layer %1 [Errors:%3]" )
+            QgsMessageLog::logMessage( QObject::tr( "Could not copy feature of block %2 from layer %1 [Errors: %3]" )
                                        .arg( name ).arg( handle ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ),
                                        QObject::tr( "DWG/DXF import" ) );
           }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -300,7 +300,7 @@ void qgisCrash( int signal )
 #endif
     if ( len < 0 )
     {
-      myPrint( "Could not read link (%d:%s)\n", errno, strerror( errno ) );
+      myPrint( "Could not read link (%d: %s)\n", errno, strerror( errno ) );
     }
     else
     {
@@ -325,7 +325,7 @@ void qgisCrash( int signal )
       }
       else
       {
-        myPrint( "Cannot fork (%d:%s)\n", errno, strerror( errno ) );
+        myPrint( "Cannot fork (%d: %s)\n", errno, strerror( errno ) );
         dumpBacktrace( 256 );
       }
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4027,7 +4027,7 @@ void QgisApp::about()
 #ifdef HAVE_POSTGRESQL
     versionString += PG_VERSION;
 #else
-    versionString += tr( "No support." );
+    versionString += tr( "No support" );
 #endif
     versionString += QLatin1String( "</td>" );
 
@@ -4185,14 +4185,14 @@ bool QgisApp::addVectorLayers( const QStringList &layerQStringList, const QStrin
       }
       else
       {
-        QString msg = tr( "%1 doesn't have any layers" ).arg( src );
+        QString msg = tr( "%1 doesn't have any layers." ).arg( src );
         messageBar()->pushMessage( tr( "Invalid Data Source" ), msg, QgsMessageBar::CRITICAL, messageTimeout() );
         delete layer;
       }
     }
     else
     {
-      QString msg = tr( "%1 is not a valid or recognized data source" ).arg( src );
+      QString msg = tr( "%1 is not a valid or recognized data source." ).arg( src );
       messageBar()->pushMessage( tr( "Invalid Data Source" ), msg, QgsMessageBar::CRITICAL, messageTimeout() );
 
       // since the layer is bad, stomp on it
@@ -7581,7 +7581,7 @@ void QgisApp::mergeAttributesOfSelectedFeatures()
   {
     messageBar()->pushMessage(
       tr( "Not enough features selected" ),
-      tr( "The merge tool requires at least two selected features" ),
+      tr( "The merge tool requires at least two selected features." ),
       QgsMessageBar::WARNING );
     return;
   }
@@ -7736,7 +7736,7 @@ void QgisApp::mergeSelectedFeatures()
     {
       messageBar()->pushMessage(
         tr( "Merge failed" ),
-        tr( "An error occurred during the merge operation" ),
+        tr( "An error occurred during the merge operation." ),
         QgsMessageBar::CRITICAL );
     }
     return;
@@ -7772,7 +7772,7 @@ void QgisApp::mergeSelectedFeatures()
       {
         messageBar()->pushMessage(
           tr( "Merge failed" ),
-          tr( "An error occurred during the merge operation" ),
+          tr( "An error occurred during the merge operation." ),
           QgsMessageBar::CRITICAL );
       }
       return;
@@ -7798,7 +7798,7 @@ void QgisApp::mergeSelectedFeatures()
     {
       messageBar()->pushMessage(
         tr( "Invalid result" ),
-        tr( "Could not store value '%1' in field of type %2" ).arg( attrs.at( i ).toString(), vl->fields().at( i ).typeName() ),
+        tr( "Could not store value '%1' in field of type %2." ).arg( attrs.at( i ).toString(), vl->fields().at( i ).typeName() ),
         QgsMessageBar::WARNING );
     }
     attrs[i] = val;
@@ -7928,7 +7928,7 @@ void QgisApp::selectAll()
   {
     messageBar()->pushMessage(
       tr( "No active vector layer" ),
-      tr( "To select all, choose a vector layer in the legend" ),
+      tr( "To select all, choose a vector layer in the legend." ),
       QgsMessageBar::INFO,
       messageTimeout() );
     return;
@@ -7952,7 +7952,7 @@ void QgisApp::selectByExpression()
   {
     messageBar()->pushMessage(
       tr( "No active vector layer" ),
-      tr( "To select features, choose a vector layer in the legend" ),
+      tr( "To select features, choose a vector layer in the legend." ),
       QgsMessageBar::INFO,
       messageTimeout() );
     return;
@@ -7972,7 +7972,7 @@ void QgisApp::selectByForm()
   {
     messageBar()->pushMessage(
       tr( "No active vector layer" ),
-      tr( "To select features, choose a vector layer in the legend" ),
+      tr( "To select features, choose a vector layer in the legend." ),
       QgsMessageBar::INFO,
       messageTimeout() );
     return;

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -194,7 +194,7 @@ void QgsBookmarks::deleteClicked()
     return;
 
   // make sure the user really wants to delete these bookmarks
-  if ( QMessageBox::Cancel == QMessageBox::information( this, tr( "Really Delete?" ),
+  if ( QMessageBox::Cancel == QMessageBox::information( this, tr( "Delete Bookmarks" ),
        tr( "Are you sure you want to delete %n bookmark(s)?", "number of rows", rows.size() ),
        QMessageBox::Ok | QMessageBox::Cancel ) )
     return;
@@ -236,7 +236,7 @@ void QgsBookmarks::zoomToBookmark()
     rect = ct.transform( rect );
     if ( rect.isEmpty() )
     {
-      QMessageBox::warning( this, tr( "Empty extent" ), tr( "Reprojected extent is empty." ) );
+      QMessageBox::warning( this, tr( "Empty Extent" ), tr( "Reprojected extent is empty." ) );
       return;
     }
   }
@@ -326,7 +326,7 @@ void QgsBookmarks::exportToXml()
   QgsSettings settings;
 
   QString lastUsedDir = settings.value( QStringLiteral( "Windows/Bookmarks/LastUsedDirectory" ), QDir::homePath() ).toString();
-  QString fileName = QFileDialog::getSaveFileName( this, tr( "Export bookmarks" ), lastUsedDir,
+  QString fileName = QFileDialog::getSaveFileName( this, tr( "Export Bookmarks" ), lastUsedDir,
                      tr( "XML files (*.xml *.XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -173,7 +173,7 @@ void QgsBookmarks::addClicked()
   }
   else
   {
-    QMessageBox::warning( this, tr( "Error" ), tr( "Unable to create the bookmark.\nDriver:%1\nDatabase:%2" )
+    QMessageBox::warning( this, tr( "Error" ), tr( "Unable to create the bookmark.\nDriver: %1\nDatabase: %2" )
                           .arg( query.lastError().driverText(),
                                 query.lastError().databaseText() ) );
   }

--- a/src/app/qgsloadstylefromdbdialog.cpp
+++ b/src/app/qgsloadstylefromdbdialog.cpp
@@ -166,7 +166,7 @@ void QgsLoadStyleFromDBDialog::deleteStyleFromDB()
   QString msgError;
   QString opInfo = QObject::tr( "Delete style %1 from %2" ).arg( mSelectedStyleName, mLayer->providerType() );
 
-  if ( QMessageBox::question( nullptr, QObject::tr( "Delete style" ),
+  if ( QMessageBox::question( nullptr, QObject::tr( "Delete Style" ),
                               QObject::tr( "Are you sure you want to delete the style %1?" ).arg( mSelectedStyleName ),
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;

--- a/src/app/qgsloadstylefromdbdialog.cpp
+++ b/src/app/qgsloadstylefromdbdialog.cpp
@@ -192,7 +192,7 @@ void QgsLoadStyleFromDBDialog::deleteStyleFromDB()
     int sectionLimit = mLayer->listStylesInDatabase( ids, names, descriptions, errorMsg );
     if ( !errorMsg.isNull() )
     {
-      QgisApp::instance()->messageBar()->pushMessage( tr( "Error occurred retrieving styles from database" ), errorMsg, QgsMessageBar::WARNING, QgisApp::instance()->messageTimeout() );
+      QgisApp::instance()->messageBar()->pushMessage( tr( "Error occurred while retrieving styles from database" ), errorMsg, QgsMessageBar::WARNING, QgisApp::instance()->messageTimeout() );
     }
     else
     {

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -110,7 +110,7 @@ void QgsMapThemes::addPreset()
   dlg.setWindowTitle( tr( "Map Themes" ) );
   dlg.setHintString( tr( "Name of the new theme" ) );
   dlg.setOverwriteEnabled( false );
-  dlg.setConflictingNameWarning( tr( "A theme with this name already exists" ) );
+  dlg.setConflictingNameWarning( tr( "A theme with this name already exists." ) );
   if ( dlg.exec() != QDialog::Accepted || dlg.name().isEmpty() )
     return;
 

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -133,7 +133,7 @@ void QgsMapThemes::replaceTriggered()
   if ( !actionPreset )
     return;
 
-  int res = QMessageBox::question( mMenu, tr( "Replace theme" ),
+  int res = QMessageBox::question( mMenu, tr( "Replace Theme" ),
                                    trUtf8( "Are you sure you want to replace the existing theme “%1”?" ).arg( actionPreset->text() ),
                                    QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
   if ( res != QMessageBox::Yes )

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -65,7 +65,7 @@ void QgsMapToolAddRing::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     else if ( error == 2 )
     {
       //problem with coordinate transformation
-      emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system" ), QgsMessageBar::WARNING );
+      emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system." ), QgsMessageBar::WARNING );
       return;
     }
 
@@ -126,7 +126,7 @@ void QgsMapToolAddRing::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       {
         errorMessage = tr( "an unknown error occurred" );
       }
-      emit messageEmitted( tr( "could not add ring since %1." ).arg( errorMessage ), QgsMessageBar::CRITICAL );
+      emit messageEmitted( tr( "Could not add ring since %1." ).arg( errorMessage ), QgsMessageBar::CRITICAL );
       vlayer->destroyEditCommand();
     }
     else

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1732,7 +1732,7 @@ QStringList QgsOptions::i18nList()
 void QgsOptions::restoreDefaultWindowState()
 {
   // richard
-  if ( QMessageBox::warning( this, tr( "Restore UI defaults" ), tr( "Are you sure to reset the UI to default (needs restart)?" ), QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
+  if ( QMessageBox::warning( this, tr( "Restore UI Defaults" ), tr( "Are you sure to reset the UI to default (needs restart)?" ), QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
     return;
   mSettings->setValue( QStringLiteral( "/qgis/restoreDefaultWindowState" ), true );
 }

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1581,9 +1581,9 @@ void QgsVectorLayerProperties::onAuxiliaryLayerClear()
   if ( !alayer )
     return;
 
-  const QString msg = tr( "Are you sure you want to clear auxiliary data for %1" ).arg( mLayer->name() );
+  const QString msg = tr( "Are you sure you want to clear auxiliary data for %1?" ).arg( mLayer->name() );
   QMessageBox::StandardButton reply;
-  reply = QMessageBox::question( this, "Clear auxiliary data", msg, QMessageBox::Yes | QMessageBox::No );
+  reply = QMessageBox::question( this, "Clear Auxiliary Data", msg, QMessageBox::Yes | QMessageBox::No );
 
   if ( reply == QMessageBox::Yes )
   {
@@ -1601,9 +1601,9 @@ void QgsVectorLayerProperties::onAuxiliaryLayerDelete()
   if ( !alayer )
     return;
 
-  const QString msg = tr( "Are you sure you want to delete auxiliary storage for %1" ).arg( mLayer->name() );
+  const QString msg = tr( "Are you sure you want to delete auxiliary storage for %1?" ).arg( mLayer->name() );
   QMessageBox::StandardButton reply;
-  reply = QMessageBox::question( this, "Delete auxiliary storage", msg, QMessageBox::Yes | QMessageBox::No );
+  reply = QMessageBox::question( this, "Delete Auxiliary Storage", msg, QMessageBox::Yes | QMessageBox::No );
 
   if ( reply == QMessageBox::Yes )
   {
@@ -1662,10 +1662,10 @@ void QgsVectorLayerProperties::onAuxiliaryLayerDeleteField()
     return;
 
   // should be only 1 field
-  const QString msg = tr( "Are you sure you want to delete auxiliary field %1 for %2" ).arg( item->text( 1 ), item->text( 0 ) );
+  const QString msg = tr( "Are you sure you want to delete auxiliary field %1 for %2?" ).arg( item->text( 1 ), item->text( 0 ) );
 
   QMessageBox::StandardButton reply;
-  reply = QMessageBox::question( this, "Delete auxiliary field", msg, QMessageBox::Yes | QMessageBox::No );
+  reply = QMessageBox::question( this, "Delete Auxiliary Field", msg, QMessageBox::Yes | QMessageBox::No );
 
   if ( reply == QMessageBox::Yes )
   {

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1128,7 +1128,7 @@ void QgsVectorLayerProperties::showListOfStylesFromDatabase()
   int sectionLimit = mLayer->listStylesInDatabase( ids, names, descriptions, errorMsg );
   if ( !errorMsg.isNull() )
   {
-    QMessageBox::warning( this, tr( "Error occurred retrieving styles from database" ), errorMsg );
+    QMessageBox::warning( this, tr( "Error occurred while retrieving styles from database" ), errorMsg );
     return;
   }
 
@@ -1143,7 +1143,7 @@ void QgsVectorLayerProperties::showListOfStylesFromDatabase()
     QString qmlStyle = mLayer->getStyleFromDatabase( selectedStyleId, errorMsg );
     if ( !errorMsg.isNull() )
     {
-      QMessageBox::warning( this, tr( "Error occurred retrieving styles from database" ), errorMsg );
+      QMessageBox::warning( this, tr( "Error occurred while retrieving styles from database" ), errorMsg );
       return;
     }
 
@@ -1156,7 +1156,7 @@ void QgsVectorLayerProperties::showListOfStylesFromDatabase()
     }
     else
     {
-      QMessageBox::warning( this, tr( "Error occurred retrieving styles from database" ),
+      QMessageBox::warning( this, tr( "Error occurred while retrieving styles from database" ),
                             tr( "The retrieved style is not a valid named style. Error message: %1" )
                             .arg( errorMsg ) );
     }

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -1114,7 +1114,7 @@ QString QgsExpressionNodeLiteral::dump() const
     case QVariant::Bool:
       return mValue.toBool() ? QStringLiteral( "TRUE" ) : QStringLiteral( "FALSE" );
     default:
-      return tr( "[unsupported type;%1; value:%2]" ).arg( mValue.typeName(), mValue.toString() );
+      return tr( "[unsupported type: %1; value: %2]" ).arg( mValue.typeName(), mValue.toString() );
   }
 }
 

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -235,7 +235,7 @@ void QgsGeoNodeRequest::replyFinished()
 
         if ( mHttpGeoNodeResponse.isEmpty() )
         {
-          mError = tr( "empty of capabilities: %1" ).arg( mGeoNodeReply->errorString() );
+          mError = tr( "Empty of capabilities: %1" ).arg( mGeoNodeReply->errorString() );
         }
       }
     }

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -513,7 +513,7 @@ QString QgsProcessingUtils::formatHelpMapAsHtml( const QVariantMap &map, const Q
     return QString();
   };
 
-  QString s = QObject::tr( "<html><body><h2>Algorithm description</h2>\n " );
+  QString s = QObject::tr( "<html><body><h2>Algorithm description</h2>\n" );
   s += QStringLiteral( "<p>" ) + getText( QStringLiteral( "ALG_DESC" ) ) + QStringLiteral( "</p>\n" );
   s += QObject::tr( "<h2>Input parameters</h2>\n" );
 

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -222,7 +222,7 @@ void QgsGeometryValidator::run()
       GEOSContextHandle_t handle = QgsGeometry::getGEOSHandler();
       if ( !g0 )
       {
-        emit errorFound( QgsGeometry::Error( QObject::tr( "GEOS error:could not produce geometry for GEOS (check log window)" ) ) );
+        emit errorFound( QgsGeometry::Error( QObject::tr( "GEOS error: could not produce geometry for GEOS (check log window)" ) ) );
       }
       else
       {
@@ -240,7 +240,7 @@ void QgsGeometryValidator::run()
               double x, y;
               GEOSCoordSeq_getX_r( handle, cs, 0, &x );
               GEOSCoordSeq_getY_r( handle, cs, 0, &y );
-              emit errorFound( QgsGeometry::Error( QObject::tr( "GEOS error:%1" ).arg( r ), QgsPointXY( x, y ) ) );
+              emit errorFound( QgsGeometry::Error( QObject::tr( "GEOS error: %1" ).arg( r ), QgsPointXY( x, y ) ) );
               mErrorCount++;
             }
 
@@ -248,7 +248,7 @@ void QgsGeometryValidator::run()
           }
           else
           {
-            emit errorFound( QgsGeometry::Error( QObject::tr( "GEOS error:%1" ).arg( r ) ) );
+            emit errorFound( QgsGeometry::Error( QObject::tr( "GEOS error: %1" ).arg( r ) ) );
             mErrorCount++;
           }
 

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -462,7 +462,7 @@ QString QgsSQLStatement::NodeLiteral::dump() const
     case QVariant::Bool:
       return mValue.toBool() ? "TRUE" : "FALSE";
     default:
-      return tr( "[unsupported type;%1; value:%2]" ).arg( mValue.typeName(), mValue.toString() );
+      return tr( "[unsupported type: %1; value: %2]" ).arg( mValue.typeName(), mValue.toString() );
   }
 }
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -281,10 +281,10 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   {
     mError = ErrCreateDataSource;
     if ( action == CreateOrOverwriteFile )
-      mErrorMessage = QObject::tr( "creation of data source failed (OGR error:%1)" )
+      mErrorMessage = QObject::tr( "Creation of data source failed (OGR error: %1)" )
                       .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
     else
-      mErrorMessage = QObject::tr( "opening of data source in update mode failed (OGR error:%1)" )
+      mErrorMessage = QObject::tr( "Opening of data source in update mode failed (OGR error: %1)" )
                       .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
     return;
   }
@@ -304,7 +304,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
         if ( OGR_DS_DeleteLayer( mDS.get(), i ) != OGRERR_NONE )
         {
           mError = ErrCreateLayer;
-          mErrorMessage = QObject::tr( "overwriting of existing layer failed (OGR error:%1)" )
+          mErrorMessage = QObject::tr( "Overwriting of existing layer failed (OGR error: %1)" )
                           .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
           return;
         }
@@ -420,10 +420,10 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   if ( !mLayer )
   {
     if ( action == CreateOrOverwriteFile || action == CreateOrOverwriteLayer )
-      mErrorMessage = QObject::tr( "creation of layer failed (OGR error:%1)" )
+      mErrorMessage = QObject::tr( "Creation of layer failed (OGR error: %1)" )
                       .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
     else
-      mErrorMessage = QObject::tr( "opening of layer failed (OGR error:%1)" )
+      mErrorMessage = QObject::tr( "Opening of layer failed (OGR error: %1)" )
                       .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
     mError = ErrCreateLayer;
     return;
@@ -690,7 +690,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   datasetOptions.insert( QStringLiteral( "NB_IDS" ), new SetOption(
                            QObject::tr( "BNA records may contain from 2 to 4 identifiers per record. "
                                         "Some software packages only support a precise number of identifiers. "
-                                        "You can override the default value (2) by a precise value" ),
+                                        "You can override the default value (2) by a precise value." ),
                            QStringList()
                            << QStringLiteral( "2" )
                            << QStringLiteral( "3" )
@@ -962,7 +962,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   datasetOptions.insert( QStringLiteral( "HEADER" ), new StringOption(
                            QObject::tr( "XML content that will be put between the <channel> element and the "
                                         "first <item> element for a RSS document, or between the xml tag and "
-                                        "the first <entry> element for an Atom document. " ),
+                                        "the first <entry> element for an Atom document." ),
                            QLatin1String( "" )  // Default value
                          ) );
 
@@ -1068,9 +1068,9 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                          ) );
 
   datasetOptions.insert( QStringLiteral( "GML3_LONGSRS" ), new BoolOption(
-                           QObject::tr( "only valid when FORMAT=GML3/GML3Degree/GML3.2) Default to YES. "
+                           QObject::tr( "Only valid when FORMAT=GML3/GML3Degree/GML3.2. Default to YES. "
                                         "If YES, SRS with EPSG authority will be written with the "
-                                        "'urn:ogc:def:crs:EPSG::' prefix. In the case, if the SRS is a "
+                                        "'urn:ogc:def:crs:EPSG::' prefix. In the case the SRS is a "
                                         "geographic SRS without explicit AXIS order, but that the same "
                                         "SRS authority code imported with ImportFromEPSGA() should be "
                                         "treated as lat/long, then the function will take care of coordinate "
@@ -1260,7 +1260,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( QStringLiteral( "NameField" ), new StringOption(
-                           QObject::tr( "Allows you to specify the field to use for the KML <name> element. " ),
+                           QObject::tr( "Allows you to specify the field to use for the KML <name> element." ),
                            QStringLiteral( "Name" )  // Default value
                          ) );
 
@@ -1423,7 +1423,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( QStringLiteral( "UPDATES" ), new SetOption(
-                           QObject::tr( "Should update files be incorporated into the base data on the fly. " ),
+                           QObject::tr( "Should update files be incorporated into the base data on the fly." ),
                            QStringList()
                            << QStringLiteral( "APPLY" )
                            << QStringLiteral( "IGNORE" ),
@@ -1622,7 +1622,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.insert( QStringLiteral( "COMPRESS_GEOM" ), new BoolOption(
                          QObject::tr( "If the format of the geometry BLOB is of the SpatiaLite flavor, "
                                       "this option can be used to control if the compressed format for "
-                                      "geometries (LINESTRINGs, POLYGONs) must be used" ),
+                                      "geometries (LINESTRINGs, POLYGONs) must be used." ),
                          false  // Default value
                        ) );
 
@@ -1700,14 +1700,14 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                          ) );
 
   datasetOptions.insert( QStringLiteral( "CONFIG" ), new StringOption(
-                           QObject::tr( "path to the GCT : the GCT file describe the GeoConcept types definitions: "
+                           QObject::tr( "Path to the GCT: the GCT file describes the GeoConcept types definitions: "
                                         "In this file, every line must start with //# followed by a keyword. "
                                         "Lines starting with // are comments." ),
                            QLatin1String( "" )  // Default value
                          ) );
 
   datasetOptions.insert( QStringLiteral( "FEATURETYPE" ), new StringOption(
-                           QObject::tr( "defines the feature to be created. The TYPE corresponds to one of the Name "
+                           QObject::tr( "Defines the feature to be created. The TYPE corresponds to one of the Name "
                                         "found in the GCT file for a type section. The SUBTYPE corresponds to one of "
                                         "the Name found in the GCT file for a sub-type section within the previous "
                                         "type section." ),
@@ -1774,7 +1774,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.insert( QStringLiteral( "OGR_XLSX_HEADERS" ), new SetOption(
                          QObject::tr( "By default, the driver will read the first lines of each sheet to detect "
                                       "if the first line might be the name of columns. If set to FORCE, the driver "
-                                      "will consider the first line will be taken as the header line. If set to "
+                                      "will consider the first line as the header line. If set to "
                                       "DISABLE, it will be considered as the first feature. Otherwise "
                                       "auto-detection will occur." ),
                          QStringList()
@@ -1814,7 +1814,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.insert( QStringLiteral( "OGR_ODS_HEADERS" ), new SetOption(
                          QObject::tr( "By default, the driver will read the first lines of each sheet to detect "
                                       "if the first line might be the name of columns. If set to FORCE, the driver "
-                                      "will consider the first line will be taken as the header line. If set to "
+                                      "will consider the first line as the header line. If set to "
                                       "DISABLE, it will be considered as the first feature. Otherwise "
                                       "auto-detection will occur." ),
                          QStringList()

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -530,7 +530,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
       default:
         //assert(0 && "invalid variant type!");
-        mErrorMessage = QObject::tr( "unsupported type for field %1" )
+        mErrorMessage = QObject::tr( "Unsupported type for field %1" )
                         .arg( attrField.name() );
         mError = ErrAttributeTypeUnsupported;
         return;
@@ -553,7 +553,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
       if ( i == 10 )
       {
-        mErrorMessage = QObject::tr( "no available replacement for internal fieldname ogc_fid found" ).arg( attrField.name() );
+        mErrorMessage = QObject::tr( "No available replacement for internal fieldname ogc_fid found" ).arg( attrField.name() );
         mError = ErrAttributeCreationFailed;
         return;
       }
@@ -581,7 +581,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     if ( OGR_L_CreateField( mLayer, fld.get(), true ) != OGRERR_NONE )
     {
       QgsDebugMsg( "error creating field " + attrField.name() );
-      mErrorMessage = QObject::tr( "creation of field %1 failed (OGR error: %2)" )
+      mErrorMessage = QObject::tr( "Creation of field %1 failed (OGR error: %2)" )
                       .arg( attrField.name(),
                             QString::fromUtf8( CPLGetLastErrorMsg() ) );
       mError = ErrAttributeCreationFailed;
@@ -598,7 +598,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
       if ( ogrIdx < 0 )
       {
         QgsDebugMsg( "error creating field " + attrField.name() );
-        mErrorMessage = QObject::tr( "created field %1 not found (OGR error: %2)" )
+        mErrorMessage = QObject::tr( "Created field %1 not found (OGR error: %2)" )
                         .arg( attrField.name(),
                               QString::fromUtf8( CPLGetLastErrorMsg() ) );
         mError = ErrAttributeCreationFailed;
@@ -837,7 +837,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   // as we set encoding for shapefiles based on "fileEncoding" parameter passed to the writer
 #if 0
   layerOptions.insert( "ENCODING", new SetOption(
-                         QObject::tr( "set the encoding value in the DBF file. "
+                         QObject::tr( "Set the encoding value in the DBF file. "
                                       "The default value is LDID/87. It is not clear "
                                       "what other values may be appropriate." ),
                          QStringList()
@@ -1068,7 +1068,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                          ) );
 
   datasetOptions.insert( QStringLiteral( "GML3_LONGSRS" ), new BoolOption(
-                           QObject::tr( "Only valid when FORMAT=GML3/GML3Degree/GML3.2. Default to YES. "
+                           QObject::tr( "Only valid when FORMAT=GML3/GML3Degree/GML3.2. Default to YES. " //needs review here
                                         "If YES, SRS with EPSG authority will be written with the "
                                         "'urn:ogc:def:crs:EPSG::' prefix. In the case the SRS is a "
                                         "geographic SRS without explicit AXIS order, but that the same "
@@ -1440,7 +1440,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
 
   datasetOptions.insert( QStringLiteral( "ADD_SOUNDG_DEPTH" ), new BoolOption(
                            QObject::tr( "Should a DEPTH attribute be added on SOUNDG features and assign the depth "
-                                        "of the sounding. This should only be enabled with SPLIT_MULTIPOINT is "
+                                        "of the sounding. This should only be enabled when SPLIT_MULTIPOINT is "
                                         "also enabled." ),
                            false  // Default value
                          ) );

--- a/src/gui/auth/qgsauthauthoritieseditor.cpp
+++ b/src/gui/auth/qgsauthauthoritieseditor.cpp
@@ -641,7 +641,7 @@ void QgsAuthAuthoritiesEditor::defaultTrustPolicyChanged( QgsAuthCertUtils::Cert
 {
   if ( !QgsApplication::authManager()->setDefaultCertTrustPolicy( trustpolicy ) )
   {
-    authMessageOut( QObject::tr( "Could not store default trust policy" ),
+    authMessageOut( QObject::tr( "Could not store default trust policy." ),
                     QObject::tr( "Authorities Manager" ),
                     QgsAuthManager::CRITICAL );
   }
@@ -671,14 +671,14 @@ void QgsAuthAuthoritiesEditor::btnCaFile_clicked()
 
     if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "cafile" ), QVariant( fn ) ) )
     {
-      authMessageOut( QObject::tr( "Could not store 'CA file path' in authentication database" ),
+      authMessageOut( QObject::tr( "Could not store 'CA file path' in authentication database." ),
                       QObject::tr( "Authorities Manager" ),
                       QgsAuthManager::WARNING );
     }
     if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "cafileallowinvalid" ),
          QVariant( dlg->allowInvalidCerts() ) ) )
     {
-      authMessageOut( QObject::tr( "Could not store 'CA file allow invalids' setting in authentication database" ),
+      authMessageOut( QObject::tr( "Could not store 'CA file allow invalids' setting in authentication database." ),
                       QObject::tr( "Authorities Manager" ),
                       QgsAuthManager::WARNING );
     }
@@ -692,7 +692,7 @@ void QgsAuthAuthoritiesEditor::btnCaFile_clicked()
       {
         if ( !QgsApplication::authManager()->storeCertTrustPolicy( cert, dlg->certTrustPolicy() ) )
         {
-          authMessageOut( QObject::tr( "Could not set trust policy for imported certificates" ),
+          authMessageOut( QObject::tr( "Could not set trust policy for imported certificates." ),
                           QObject::tr( "Authorities Manager" ),
                           QgsAuthManager::WARNING );
         }
@@ -713,14 +713,14 @@ void QgsAuthAuthoritiesEditor::btnCaFileClear_clicked()
 {
   if ( !QgsApplication::authManager()->removeAuthSetting( QStringLiteral( "cafile" ) ) )
   {
-    authMessageOut( QObject::tr( "Could not remove 'CA file path' from authentication database" ),
+    authMessageOut( QObject::tr( "Could not remove 'CA file path' from authentication database." ),
                     QObject::tr( "Authorities Manager" ),
                     QgsAuthManager::WARNING );
     return;
   }
   if ( !QgsApplication::authManager()->removeAuthSetting( QStringLiteral( "cafileallowinvalid" ) ) )
   {
-    authMessageOut( QObject::tr( "Could not remove 'CA file allow invalids' setting from authentication database" ),
+    authMessageOut( QObject::tr( "Could not remove 'CA file allow invalids' setting from authentication database." ),
                     QObject::tr( "Authorities Manager" ),
                     QgsAuthManager::WARNING );
     return;
@@ -737,7 +737,7 @@ void QgsAuthAuthoritiesEditor::btnCaFileClear_clicked()
     {
       if ( !QgsApplication::authManager()->removeCertTrustPolicies( certs ) )
       {
-        messageBar()->pushMessage( tr( "ERROR removing cert(s) trust policy from authentication database" ),
+        messageBar()->pushMessage( tr( "ERROR removing cert(s) trust policy from authentication database." ),
                                    QgsMessageBar::CRITICAL );
         return;
       }

--- a/src/gui/auth/qgsauthauthoritieseditor.cpp
+++ b/src/gui/auth/qgsauthauthoritieseditor.cpp
@@ -515,7 +515,7 @@ void QgsAuthAuthoritiesEditor::btnRemoveCa_clicked()
 
   if ( cert.isNull() )
   {
-    messageBar()->pushMessage( tr( "Certificate could not found in database for id %1:" ).arg( digest ),
+    messageBar()->pushMessage( tr( "Certificate could not be found in database for id %1:" ).arg( digest ),
                                QgsMessageBar::WARNING );
     return;
   }

--- a/src/gui/auth/qgsauthguiutils.cpp
+++ b/src/gui/auth/qgsauthguiutils.cpp
@@ -83,7 +83,7 @@ void QgsAuthGuiUtils::setMasterPassword( QgsMessageBar *msgbar, int timeout )
   if ( QgsApplication::authManager()->masterPasswordIsSet() )
   {
     msgbar->pushMessage( QgsApplication::authManager()->authManTag(),
-                         QObject::tr( "Master password already set" ),
+                         QObject::tr( "Master password already set." ),
                          QgsMessageBar::INFO, timeout );
     return;
   }
@@ -95,16 +95,16 @@ void QgsAuthGuiUtils::clearCachedMasterPassword( QgsMessageBar *msgbar, int time
   if ( QgsAuthGuiUtils::isDisabled( msgbar, timeout ) )
     return;
 
-  QString msg( QObject::tr( "Master password not cleared because it is not set" ) );
+  QString msg( QObject::tr( "Master password not cleared because it is not set." ) );
   QgsMessageBar::MessageLevel level( QgsMessageBar::INFO );
 
   if ( QgsApplication::authManager()->masterPasswordIsSet() )
   {
     QgsApplication::authManager()->clearMasterPassword();
-    msg = QObject::tr( "Master password cleared (NOTE: network connections may be cached)" );
+    msg = QObject::tr( "Master password cleared (NOTE: network connections may be cached)." );
     if ( QgsApplication::authManager()->masterPasswordIsSet() )
     {
-      msg = QObject::tr( "Master password FAILED to be cleared" );
+      msg = QObject::tr( "Master password FAILED to be cleared." );
       level = QgsMessageBar::WARNING;
     }
   }
@@ -181,12 +181,12 @@ void QgsAuthGuiUtils::removeAuthenticationConfigs( QgsMessageBar *msgbar, int ti
     return;
   }
 
-  QString msg( QObject::tr( "Authentication configurations removed" ) );
+  QString msg( QObject::tr( "Authentication configurations removed." ) );
   QgsMessageBar::MessageLevel level( QgsMessageBar::INFO );
 
   if ( !QgsApplication::authManager()->removeAllAuthenticationConfigs() )
   {
-    msg = QObject::tr( "Authentication configurations FAILED to be removed" );
+    msg = QObject::tr( "Authentication configurations FAILED to be removed." );
     level = QgsMessageBar::WARNING;
   }
 
@@ -214,13 +214,13 @@ void QgsAuthGuiUtils::eraseAuthenticationDatabase( QgsMessageBar *msgbar, int ti
     return;
   }
 
-  QString msg( QObject::tr( "Active authentication database erased" ) );
+  QString msg( QObject::tr( "Active authentication database erased." ) );
   QgsMessageBar::MessageLevel level( QgsMessageBar::WARNING );
 
   QString backuppath;
   if ( !QgsApplication::authManager()->eraseAuthenticationDatabase( true, &backuppath ) )
   {
-    msg = QObject::tr( "Authentication database FAILED to be erased" );
+    msg = QObject::tr( "Authentication database FAILED to be erased." );
     level = QgsMessageBar::WARNING;
   }
   else
@@ -296,7 +296,7 @@ void QgsAuthGuiUtils::passwordHelperSync( QgsMessageBar *msgbar, int timeout )
   QgsMessageBar::MessageLevel level;
   if ( ! QgsApplication::authManager()->masterPasswordIsSet() )
   {
-    msg = QObject::tr( "Master password is not set and cannot be stored in your %1" )
+    msg = QObject::tr( "Master password is not set and cannot be stored in your %1." )
           .arg( QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME );
     level = QgsMessageBar::WARNING;
   }
@@ -307,7 +307,7 @@ void QgsAuthGuiUtils::passwordHelperSync( QgsMessageBar *msgbar, int timeout )
   }
   else
   {
-    msg = QObject::tr( "Master password has been successfully stored in your %1" )
+    msg = QObject::tr( "Master password has been successfully stored in your %1." )
           .arg( QgsAuthManager::AUTH_PASSWORD_HELPER_DISPLAY_NAME );
 
     level = QgsMessageBar::INFO;

--- a/src/gui/auth/qgsauthidentitieseditor.cpp
+++ b/src/gui/auth/qgsauthidentitieseditor.cpp
@@ -302,7 +302,7 @@ void QgsAuthIdentitiesEditor::btnAddIdentity_clicked()
       const QPair<QSslCertificate, QSslKey> &bundle( dlg->certBundleToImport() );
       if ( !QgsApplication::authManager()->storeCertIdentity( bundle.first, bundle.second ) )
       {
-        messageBar()->pushMessage( tr( "ERROR storing identity bundle in authentication database" ),
+        messageBar()->pushMessage( tr( "ERROR storing identity bundle in authentication database." ),
                                    QgsMessageBar::CRITICAL );
       }
       populateIdentitiesView();
@@ -326,7 +326,7 @@ void QgsAuthIdentitiesEditor::btnRemoveIdentity_clicked()
 
   if ( digest.isEmpty() )
   {
-    messageBar()->pushMessage( tr( "Certificate id missing" ),
+    messageBar()->pushMessage( tr( "Certificate id missing." ),
                                QgsMessageBar::WARNING );
     return;
   }
@@ -372,7 +372,7 @@ void QgsAuthIdentitiesEditor::btnGroupByOrg_toggled( bool checked )
 {
   if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "identitiessortby" ), QVariant( checked ) ) )
   {
-    authMessageOut( QObject::tr( "Could not store sort by preference" ),
+    authMessageOut( QObject::tr( "Could not store sort by preference." ),
                     QObject::tr( "Authentication Identities" ),
                     QgsAuthManager::WARNING );
   }

--- a/src/gui/auth/qgsauthserverseditor.cpp
+++ b/src/gui/auth/qgsauthserverseditor.cpp
@@ -352,13 +352,13 @@ void QgsAuthServersEditor::btnEditServer_clicked()
 
   if ( digest.isEmpty() )
   {
-    messageBar()->pushMessage( tr( "SSL custom config id missing" ),
+    messageBar()->pushMessage( tr( "SSL custom config id missing." ),
                                QgsMessageBar::WARNING );
     return;
   }
   if ( hostport.isEmpty() )
   {
-    messageBar()->pushMessage( tr( "SSL custom config host:port missing" ),
+    messageBar()->pushMessage( tr( "SSL custom config host:port missing." ),
                                QgsMessageBar::WARNING );
     return;
   }
@@ -387,7 +387,7 @@ void QgsAuthServersEditor::btnGroupByOrg_toggled( bool checked )
 {
   if ( !QgsApplication::authManager()->storeAuthSetting( QStringLiteral( "serverssortby" ), QVariant( checked ) ) )
   {
-    authMessageOut( QObject::tr( "Could not store sort by preference" ),
+    authMessageOut( QObject::tr( "Could not store sort by preference." ),
                     QObject::tr( "Authentication SSL Configs" ),
                     QgsAuthManager::WARNING );
   }

--- a/src/gui/auth/qgsauthsslimportdialog.cpp
+++ b/src/gui/auth/qgsauthsslimportdialog.cpp
@@ -159,7 +159,7 @@ void QgsAuthSslImportDialog::updateEnabledState()
   bool connected = mSocket && mSocket->state() == QAbstractSocket::ConnectedState;
   if ( connected && !mSocket->peerName().isEmpty() )
   {
-    appendString( tr( "Connected to %1:%2" ).arg( mSocket->peerName() ).arg( mSocket->peerPort() ) );
+    appendString( tr( "Connected to %1: %2" ).arg( mSocket->peerName() ).arg( mSocket->peerPort() ) );
   }
 }
 

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -201,7 +201,7 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
   {
     QMessageBox::information( nullptr,
                               tr( "Error" ),
-                              tr( "Could not open file %1\nError was:%2" ).arg( fileName, f.errorString() ),
+                              tr( "Could not open file %1\nError was: %2" ).arg( fileName, f.errorString() ),
                               QMessageBox::Cancel );
     return;
   }

--- a/src/gui/ogr/qgsnewogrconnection.cpp
+++ b/src/gui/ogr/qgsnewogrconnection.cpp
@@ -116,7 +116,7 @@ void QgsNewOgrConnection::accept()
   if ( ( mOriginalConnName.isNull() || mOriginalConnName != txtName->text() ) &&
        settings.contains( baseKey + txtName->text() + "/host" ) &&
        QMessageBox::question( this,
-                              tr( "Save connection" ),
+                              tr( "Save Connection" ),
                               tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -77,7 +77,7 @@ void QgsManageConnectionsDialog::doExportImport()
   QList<QListWidgetItem *> selection = listConnections->selectedItems();
   if ( selection.isEmpty() )
   {
-    QMessageBox::warning( this, tr( "Export/import error" ),
+    QMessageBox::warning( this, tr( "Export/Import Error" ),
                           tr( "You should select at least one connection from list." ) );
     return;
   }
@@ -91,7 +91,7 @@ void QgsManageConnectionsDialog::doExportImport()
 
   if ( mDialogMode == Export )
   {
-    QString fileName = QFileDialog::getSaveFileName( this, tr( "Save connections" ), QDir::homePath(),
+    QString fileName = QFileDialog::getSaveFileName( this, tr( "Save Connections" ), QDir::homePath(),
                        tr( "XML files (*.xml *.XML)" ) );
     if ( fileName.isEmpty() )
     {
@@ -138,7 +138,7 @@ void QgsManageConnectionsDialog::doExportImport()
     QFile file( mFileName );
     if ( !file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
     {
-      QMessageBox::warning( this, tr( "Saving connections" ),
+      QMessageBox::warning( this, tr( "Saving Connections" ),
                             tr( "Cannot write file %1:\n%2." )
                             .arg( mFileName,
                                   file.errorString() ) );
@@ -153,7 +153,7 @@ void QgsManageConnectionsDialog::doExportImport()
     QFile file( mFileName );
     if ( !file.open( QIODevice::ReadOnly | QIODevice::Text ) )
     {
-      QMessageBox::warning( this, tr( "Loading connections" ),
+      QMessageBox::warning( this, tr( "Loading Connections" ),
                             tr( "Cannot read file %1:\n%2." )
                             .arg( mFileName,
                                   file.errorString() ) );
@@ -167,7 +167,7 @@ void QgsManageConnectionsDialog::doExportImport()
 
     if ( !doc.setContent( &file, true, &errorStr, &errorLine, &errorColumn ) )
     {
-      QMessageBox::warning( this, tr( "Loading connections" ),
+      QMessageBox::warning( this, tr( "Loading Connections" ),
                             tr( "Parse error at line %1, column %2:\n%3" )
                             .arg( errorLine )
                             .arg( errorColumn )
@@ -260,7 +260,7 @@ bool QgsManageConnectionsDialog::populateConnections()
     QFile file( mFileName );
     if ( !file.open( QIODevice::ReadOnly | QIODevice::Text ) )
     {
-      QMessageBox::warning( this, tr( "Loading connections" ),
+      QMessageBox::warning( this, tr( "Loading Connections" ),
                             tr( "Cannot read file %1:\n%2." )
                             .arg( mFileName,
                                   file.errorString() ) );
@@ -274,7 +274,7 @@ bool QgsManageConnectionsDialog::populateConnections()
 
     if ( !doc.setContent( &file, true, &errorStr, &errorLine, &errorColumn ) )
     {
-      QMessageBox::warning( this, tr( "Loading connections" ),
+      QMessageBox::warning( this, tr( "Loading Connections" ),
                             tr( "Parse error at line %1, column %2:\n%3" )
                             .arg( errorLine )
                             .arg( errorColumn )
@@ -288,7 +288,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case WMS:
         if ( root.tagName() != QLatin1String( "qgsWMSConnections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not a WMS connections exchange file." ) );
           return false;
         }
@@ -297,7 +297,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case WFS:
         if ( root.tagName() != QLatin1String( "qgsWFSConnections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Cnnections" ),
                                     tr( "The file is not a WFS connections exchange file." ) );
           return false;
         }
@@ -306,7 +306,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case WCS:
         if ( root.tagName() != QLatin1String( "qgsWCSConnections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not a WCS connections exchange file." ) );
           return false;
         }
@@ -315,7 +315,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case PostGIS:
         if ( root.tagName() != QLatin1String( "qgsPgConnections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not a PostGIS connections exchange file." ) );
           return false;
         }
@@ -324,7 +324,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case MSSQL:
         if ( root.tagName() != QLatin1String( "qgsMssqlConnections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not a MSSQL connections exchange file." ) );
           return false;
         }
@@ -332,7 +332,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case Oracle:
         if ( root.tagName() != QLatin1String( "qgsOracleConnections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not an Oracle connections exchange file." ) );
           return false;
         }
@@ -340,7 +340,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case DB2:
         if ( root.tagName() != QLatin1String( "qgsDb2Connections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not a DB2 connections exchange file." ) );
           return false;
         }
@@ -348,7 +348,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case GeoNode:
         if ( root.tagName() != QLatin1String( "qgsGeoNodeConnections" ) )
         {
-          QMessageBox::information( this, tr( "Loading connections" ),
+          QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not a GeoNode connections exchange file." ) );
           return false;
         }
@@ -627,7 +627,7 @@ void QgsManageConnectionsDialog::loadOWSConnections( const QDomDocument &doc, co
   QDomElement root = doc.documentElement();
   if ( root.tagName() != "qgs" + service.toUpper() + "Connections" )
   {
-    QMessageBox::information( this, tr( "Loading connections" ),
+    QMessageBox::information( this, tr( "Loading Connections" ),
                               tr( "The file is not a %1 connections exchange file." ).arg( service ) );
     return;
   }
@@ -654,7 +654,7 @@ void QgsManageConnectionsDialog::loadOWSConnections( const QDomDocument &doc, co
     if ( keys.contains( connectionName ) && prompt )
     {
       int res = QMessageBox::warning( this,
-                                      tr( "Loading connections" ),
+                                      tr( "Loading Connections" ),
                                       tr( "Connection with name '%1' already exists. Overwrite?" )
                                       .arg( connectionName ),
                                       QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
@@ -714,7 +714,7 @@ void QgsManageConnectionsDialog::loadWfsConnections( const QDomDocument &doc, co
   QDomElement root = doc.documentElement();
   if ( root.tagName() != QLatin1String( "qgsWFSConnections" ) )
   {
-    QMessageBox::information( this, tr( "Loading connections" ),
+    QMessageBox::information( this, tr( "Loading Connections" ),
                               tr( "The file is not a WFS connections exchange file." ) );
     return;
   }
@@ -741,7 +741,7 @@ void QgsManageConnectionsDialog::loadWfsConnections( const QDomDocument &doc, co
     if ( keys.contains( connectionName ) && prompt )
     {
       int res = QMessageBox::warning( this,
-                                      tr( "Loading connections" ),
+                                      tr( "Loading Connections" ),
                                       tr( "Connection with name '%1' already exists. Overwrite?" )
                                       .arg( connectionName ),
                                       QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
@@ -796,7 +796,7 @@ void QgsManageConnectionsDialog::loadPgConnections( const QDomDocument &doc, con
   if ( root.tagName() != QLatin1String( "qgsPgConnections" ) )
   {
     QMessageBox::information( this,
-                              tr( "Loading connections" ),
+                              tr( "Loading Connections" ),
                               tr( "The file is not a PostGIS connections exchange file." ) );
     return;
   }
@@ -823,7 +823,7 @@ void QgsManageConnectionsDialog::loadPgConnections( const QDomDocument &doc, con
     if ( keys.contains( connectionName ) && prompt )
     {
       int res = QMessageBox::warning( this,
-                                      tr( "Loading connections" ),
+                                      tr( "Loading Connections" ),
                                       tr( "Connection with name '%1' already exists. Overwrite?" )
                                       .arg( connectionName ),
                                       QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
@@ -886,7 +886,7 @@ void QgsManageConnectionsDialog::loadMssqlConnections( const QDomDocument &doc, 
   if ( root.tagName() != QLatin1String( "qgsMssqlConnections" ) )
   {
     QMessageBox::information( this,
-                              tr( "Loading connections" ),
+                              tr( "Loading Connections" ),
                               tr( "The file is not a MSSQL connections exchange file." ) );
     return;
   }
@@ -913,7 +913,7 @@ void QgsManageConnectionsDialog::loadMssqlConnections( const QDomDocument &doc, 
     if ( keys.contains( connectionName ) && prompt )
     {
       int res = QMessageBox::warning( this,
-                                      tr( "Loading connections" ),
+                                      tr( "Loading Connections" ),
                                       tr( "Connection with name '%1' already exists. Overwrite?" )
                                       .arg( connectionName ),
                                       QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
@@ -976,7 +976,7 @@ void QgsManageConnectionsDialog::loadOracleConnections( const QDomDocument &doc,
   if ( root.tagName() != QLatin1String( "qgsOracleConnections" ) )
   {
     QMessageBox::information( this,
-                              tr( "Loading connections" ),
+                              tr( "Loading Connections" ),
                               tr( "The file is not an Oracle connections exchange file." ) );
     return;
   }
@@ -1003,7 +1003,7 @@ void QgsManageConnectionsDialog::loadOracleConnections( const QDomDocument &doc,
     if ( keys.contains( connectionName ) && prompt )
     {
       int res = QMessageBox::warning( this,
-                                      tr( "Loading connections" ),
+                                      tr( "Loading Connections" ),
                                       tr( "Connection with name '%1' already exists. Overwrite?" )
                                       .arg( connectionName ),
                                       QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
@@ -1062,7 +1062,7 @@ void QgsManageConnectionsDialog::loadDb2Connections( const QDomDocument &doc, co
   if ( root.tagName() != QLatin1String( "qgsDb2Connections" ) )
   {
     QMessageBox::information( this,
-                              tr( "Loading connections" ),
+                              tr( "Loading Connections" ),
                               tr( "The file is not a DB2 connections exchange file." ) );
     return;
   }
@@ -1089,7 +1089,7 @@ void QgsManageConnectionsDialog::loadDb2Connections( const QDomDocument &doc, co
     if ( keys.contains( connectionName ) && prompt )
     {
       int res = QMessageBox::warning( this,
-                                      tr( "Loading connections" ),
+                                      tr( "Loading Connections" ),
                                       tr( "Connection with name '%1' already exists. Overwrite?" )
                                       .arg( connectionName ),
                                       QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
@@ -1151,7 +1151,7 @@ void QgsManageConnectionsDialog::loadGeonodeConnections( const QDomDocument &doc
   QDomElement root = doc.documentElement();
   if ( root.tagName() != QLatin1String( "qgsGeoNodeConnections" ) )
   {
-    QMessageBox::information( this, tr( "Loading connections" ),
+    QMessageBox::information( this, tr( "Loading Connections" ),
                               tr( "The file is not a GeoNode connections exchange file." ) );
     return;
   }
@@ -1178,7 +1178,7 @@ void QgsManageConnectionsDialog::loadGeonodeConnections( const QDomDocument &doc
     if ( keys.contains( connectionName ) && prompt )
     {
       int res = QMessageBox::warning( this,
-                                      tr( "Loading connections" ),
+                                      tr( "Loading Connections" ),
                                       tr( "Connection with name '%1' already exists. Overwrite?" )
                                       .arg( connectionName ),
                                       QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -304,7 +304,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
     hDS.reset( OGR_Dr_CreateDataSource( hGpkgDriver, fileName.toUtf8().constData(), nullptr ) );
     if ( !hDS )
     {
-      QString msg( tr( "Creation of database failed (OGR error:%1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+      QString msg( tr( "Creation of database failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
       if ( !property( "hideDialogs" ).toBool() )
         QMessageBox::critical( this, tr( "Layer creation failed" ), msg );
       return false;
@@ -316,7 +316,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
     hDS.reset( OGROpen( fileName.toUtf8().constData(), true, &hDriver ) );
     if ( !hDS )
     {
-      QString msg( tr( "Opening of database failed (OGR error:%1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+      QString msg( tr( "Opening of database failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
       if ( !property( "hideDialogs" ).toBool() )
         QMessageBox::critical( this, tr( "Layer creation failed" ), msg );
       return false;
@@ -401,7 +401,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
     OSRRelease( hSRS );
   if ( !hLayer )
   {
-    QString msg( tr( "Creation of layer failed (OGR error:%1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+    QString msg( tr( "Creation of layer failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
     if ( !property( "hideDialogs" ).toBool() )
       QMessageBox::critical( this, tr( "Layer creation failed" ), msg );
     return false;
@@ -453,7 +453,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
   OGR_L_ResetReading( hLayer );
   if ( CPLGetLastErrorType() != CE_None )
   {
-    QString msg( tr( "Creation of layer failed (OGR error:%1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+    QString msg( tr( "Creation of layer failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
     if ( !property( "hideDialogs" ).toBool() )
       QMessageBox::critical( this, tr( "Layer creation failed" ), msg );
     return false;

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -173,7 +173,7 @@ bool QgsNewHttpConnection::validate()
   if ( ( mOriginalConnName.isNull() || mOriginalConnName.compare( txtName->text(), Qt::CaseInsensitive ) != 0 ) &&
        settings.contains( key + "/url" ) &&
        QMessageBox::question( this,
-                              tr( "Save connection" ),
+                              tr( "Save Connection" ),
                               tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
@@ -182,7 +182,7 @@ bool QgsNewHttpConnection::validate()
 
   if ( ! mAuthSettings->password().isEmpty() &&
        QMessageBox::question( this,
-                              tr( "Saving passwords" ),
+                              tr( "Saving Passwords" ),
                               trUtf8( "WARNING: You have entered a password. It will be stored in unsecured plain text in your project files and your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't provide a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -307,7 +307,7 @@ void QgsOWSSourceSelect::mSaveButton_clicked()
 
 void QgsOWSSourceSelect::mLoadButton_clicked()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), QDir::homePath(),
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QDir::homePath(),
                      tr( "XML files (*.xml *XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/gui/qgssqlcomposerdialog.cpp
+++ b/src/gui/qgssqlcomposerdialog.cpp
@@ -212,13 +212,13 @@ void QgsSQLComposerDialog::accept()
     if ( !mSQLValidatorCallback->isValid( sql(), errorMsg, warningMsg ) )
     {
       if ( errorMsg.isEmpty() )
-        errorMsg = tr( "An error occurred during evaluation of the SQL statement" );
-      QMessageBox::critical( this, tr( "SQL error" ), errorMsg );
+        errorMsg = tr( "An error occurred during evaluation of the SQL statement." );
+      QMessageBox::critical( this, tr( "SQL Error" ), errorMsg );
       return;
     }
     if ( !warningMsg.isEmpty() )
     {
-      QMessageBox::warning( this, tr( "SQL warning" ), warningMsg );
+      QMessageBox::warning( this, tr( "SQL Warning" ), warningMsg );
     }
   }
   QDialog::accept();

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -875,12 +875,12 @@ void QgsCategorizedSymbolRendererWidget::matchToSymbolsFromLibrary()
   int matched = matchToSymbols( QgsStyle::defaultStyle() );
   if ( matched > 0 )
   {
-    QMessageBox::information( this, tr( "Matched symbols" ),
+    QMessageBox::information( this, tr( "Matched Symbols" ),
                               tr( "Matched %1 categories to symbols." ).arg( matched ) );
   }
   else
   {
-    QMessageBox::warning( this, tr( "Matched symbols" ),
+    QMessageBox::warning( this, tr( "Matched Symbols" ),
                           tr( "No categories could be matched to symbols in library." ) );
   }
 }
@@ -926,20 +926,20 @@ void QgsCategorizedSymbolRendererWidget::matchToSymbolsFromXml()
   QgsStyle importedStyle;
   if ( !importedStyle.importXml( fileName ) )
   {
-    QMessageBox::warning( this, tr( "Matching error" ),
-                          tr( "An error occurred reading file:\n%1" ).arg( importedStyle.errorString() ) );
+    QMessageBox::warning( this, tr( "Matching Error" ),
+                          tr( "An error occurred while reading file:\n%1" ).arg( importedStyle.errorString() ) );
     return;
   }
 
   int matched = matchToSymbols( &importedStyle );
   if ( matched > 0 )
   {
-    QMessageBox::information( this, tr( "Matched symbols" ),
+    QMessageBox::information( this, tr( "Matched Symbols" ),
                               tr( "Matched %1 categories to symbols from file." ).arg( matched ) );
   }
   else
   {
-    QMessageBox::warning( this, tr( "Matched symbols" ),
+    QMessageBox::warning( this, tr( "Matched Symbols" ),
                           tr( "No categories could be matched to symbols in file." ) );
   }
 }

--- a/src/gui/symbology/qgssmartgroupeditordialog.cpp
+++ b/src/gui/symbology/qgssmartgroupeditordialog.cpp
@@ -194,7 +194,7 @@ void QgsSmartGroupEditorDialog::buttonBox_accepted()
 {
   if ( mNameLineEdit->text().isEmpty() )
   {
-    QMessageBox::critical( this, tr( "Invalid name" ), tr( "The smart group name field is empty. Kindly provide a name" ) );
+    QMessageBox::critical( this, tr( "Invalid name" ), tr( "The smart group name field is empty. Kindly provide a name." ) );
     return;
   }
   accept();

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -180,7 +180,7 @@ bool QgsStyleExportImportDialog::populateStyles( QgsStyle *style )
     // NOTE mTempStyle is style here
     if ( !style->importXml( mFileName ) )
     {
-      QMessageBox::warning( this, tr( "Import error" ),
+      QMessageBox::warning( this, tr( "Import Error" ),
                             tr( "An error occurred during import:\n%1" ).arg( style->errorString() ) );
       return false;
     }
@@ -278,7 +278,7 @@ void QgsStyleExportImportDialog::moveStyles( QModelIndexList *selection, QgsStyl
     {
       if ( dst->symbolNames().contains( symbolName ) && prompt )
       {
-        int res = QMessageBox::warning( this, tr( "Duplicate names" ),
+        int res = QMessageBox::warning( this, tr( "Duplicate Names" ),
                                         tr( "Symbol with name '%1' already exists.\nOverwrite?" )
                                         .arg( symbolName ),
                                         QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
@@ -322,7 +322,7 @@ void QgsStyleExportImportDialog::moveStyles( QModelIndexList *selection, QgsStyl
     {
       if ( dst->colorRampNames().contains( symbolName ) && prompt )
       {
-        int res = QMessageBox::warning( this, tr( "Duplicate names" ),
+        int res = QMessageBox::warning( this, tr( "Duplicate Names" ),
                                         tr( "Color ramp with name '%1' already exists.\nOverwrite?" )
                                         .arg( symbolName ),
                                         QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );

--- a/src/plugins/gps_importer/qgsgpsdevicedialog.cpp
+++ b/src/plugins/gps_importer/qgsgpsdevicedialog.cpp
@@ -53,7 +53,7 @@ void QgsGPSDeviceDialog::pbnNewDevice_clicked()
 
 void QgsGPSDeviceDialog::pbnDeleteDevice_clicked()
 {
-  if ( QMessageBox::warning( this, tr( "Are you sure?" ),
+  if ( QMessageBox::warning( this, tr( "Delete Device" ),
                              tr( "Are you sure that you want to delete this device?" ),
                              QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Ok )
   {

--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -82,7 +82,7 @@ void QgsDb2NewConnection::accept()
   QgsDebugMsg( QString( "hasAuthConfigID: %1" ).arg( hasAuthConfigID ) );
   if ( !hasAuthConfigID && mAuthSettings->storePasswordIsChecked( ) &&
        QMessageBox::question( this,
-                              tr( "Saving passwords" ),
+                              tr( "Saving Passwords" ),
                               tr( "WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory on Unix-like systems, or in your user profile on Windows. If you do not want this to happen, please press the Cancel button.\n" ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
@@ -94,7 +94,7 @@ void QgsDb2NewConnection::accept()
        ( settings.contains( baseKey + txtName->text() + "/service" ) ||
          settings.contains( baseKey + txtName->text() + "/host" ) ) &&
        QMessageBox::question( this,
-                              tr( "Save connection" ),
+                              tr( "Save Connection" ),
                               tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {

--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -176,7 +176,7 @@ bool QgsDb2NewConnection::testConnection()
   if ( errMsg.isEmpty() )
   {
     QgsDebugMsg( "connection open succeeded " + connInfo );
-    bar->pushMessage( tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ),
+    bar->pushMessage( tr( "Connection to %1 was successful." ).arg( txtDatabase->text() ),
                       QgsMessageBar::INFO );
     return true;
   }

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -262,7 +262,7 @@ void QgsDb2SourceSelect::btnSave_clicked()
 
 void QgsDb2SourceSelect::btnLoad_clicked()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), QStringLiteral( "." ),
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QStringLiteral( "." ),
                      tr( "XML files (*.xml *XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -755,9 +755,8 @@ void QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &extent, int pi
   if ( !myWarpOptions->pTransformerArg )
   {
     QMessageBox::warning( 0, QObject::tr( "Warning" ),
-                          QObject::tr( "Cannot GDALCreateGenImgProjTransformer: " )
-                          + QString::fromUtf8( CPLGetLastErrorMsg() ) );
-    return;
+                          QObject::tr( "Cannot GDALCreateGenImgProjTransformer: %1" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ); // missing word?
+                          return;
 
   }
 
@@ -786,9 +785,8 @@ void QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &extent, int pi
   if ( myOperation.Initialize( myWarpOptions ) != CE_None )
   {
     QMessageBox::warning( 0, QObject::tr( "Warning" ),
-                          QObject::tr( "Cannot inittialize GDALWarpOperation : " )
-                          + QString::fromUtf8( CPLGetLastErrorMsg() ) );
-    return;
+                          QObject::tr( "Cannot initialize GDAL Warp operation : %1" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
+                          return;
 
   }
   CPLErrorReset();
@@ -797,7 +795,7 @@ void QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &extent, int pi
   if ( myErr != CPLE_None )
   {
     QMessageBox::warning( 0, QObject::tr( "Warning" ),
-                          QObject::tr( "Cannot ChunkAndWarpImage: %1" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+                          QObject::tr( "Cannot chunk and warp image: %1" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
     return;
   }
 

--- a/src/providers/geonode/qgsgeonodesourceselect.cpp
+++ b/src/providers/geonode/qgsgeonodesourceselect.cpp
@@ -272,7 +272,7 @@ void QgsGeoNodeSourceSelect::connectToGeonodeConnection()
 
     else
     {
-      QMessageBox::critical( this, tr( "Connect to GeoNode" ), tr( "Cannot get any feature services" ) );
+      QMessageBox::critical( this, tr( "Connect to GeoNode" ), tr( "Cannot get any feature services." ) );
     }
 
     treeView->resizeColumnToContents( MODEL_IDX_TITLE );

--- a/src/providers/geonode/qgsgeonodesourceselect.cpp
+++ b/src/providers/geonode/qgsgeonodesourceselect.cpp
@@ -91,7 +91,7 @@ void QgsGeoNodeSourceSelect::addConnectionsEntryList()
 void QgsGeoNodeSourceSelect::modifyConnectionsEntryList()
 {
   QgsGeoNodeNewConnection nc( this, cmbConnections->currentText() );
-  nc.setWindowTitle( tr( "Modify GeoNode connection" ) );
+  nc.setWindowTitle( tr( "Modify GeoNode Connection" ) );
 
   if ( nc.exec() )
   {
@@ -300,7 +300,7 @@ void QgsGeoNodeSourceSelect::saveGeonodeConnection()
 
 void QgsGeoNodeSourceSelect::loadGeonodeConnection()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), QDir::homePath(),
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QDir::homePath(),
                      tr( "XML files (*.xml *.XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -2258,7 +2258,7 @@ QMap<QString, QString> QgsGrass::query( const QString &gisdbase, const QString &
   }
   catch ( QgsGrass::Exception &e )
   {
-    warning( tr( "Cannot query raster " ) + "\n" + e.what() );
+    warning( tr( "Cannot query raster\n%1" ).arg( e.what() ) );
   }
   return result;
 }
@@ -2321,7 +2321,7 @@ bool QgsGrass::deleteObject( const QgsGrassObject &object )
   }
   catch ( QgsGrass::Exception &e )
   {
-    warning( tr( "Cannot delete" ) + " " + object.elementName() + " " + object.name() + ": " + e.what() );
+    warning( tr( "Cannot delete %1 %2: %3" ).arg( object.elementName(), object.name(), e.what() ) );
     return false;
   }
   return true;
@@ -2412,7 +2412,7 @@ void QgsGrass::createTable( dbDriver *driver, const QString &tableName, const Qg
   db_free_string( &dbstr );
   if ( result != DB_OK )
   {
-    throw QgsGrass::Exception( QObject::tr( "Cannot create table" ) + ": " + QString::fromLatin1( db_get_error_msg() ) );
+    throw QgsGrass::Exception( QObject::tr( "Cannot create table: %1" ).arg( QString::fromLatin1( db_get_error_msg() ) ) );
   }
 }
 

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -82,7 +82,7 @@ void QgsMssqlNewConnection::accept()
        ( settings.contains( baseKey + txtName->text() + "/service" ) ||
          settings.contains( baseKey + txtName->text() + "/host" ) ) &&
        QMessageBox::question( this,
-                              tr( "Save connection" ),
+                              tr( "Save Connection" ),
                               tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -155,7 +155,7 @@ bool QgsMssqlNewConnection::testConnection( const QString &testDatabase )
   if ( txtService->text().isEmpty() && txtHost->text().isEmpty() )
   {
     bar->clearWidgets();
-    bar->pushWarning( tr( "Connection Failed" ), tr( "Host name hasn't been specified" ) );
+    bar->pushWarning( tr( "Connection Failed" ), tr( "Host name hasn't been specified." ) );
     return false;
   }
 

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -265,7 +265,7 @@ void QgsMssqlSourceSelect::btnSave_clicked()
 
 void QgsMssqlSourceSelect::btnLoad_clicked()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), QDir::homePath(),
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QDir::homePath(),
                      tr( "XML files (*.xml *XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -226,7 +226,7 @@ QStringList QgsOracleConn::pkCandidates( QString ownerName, QString viewName )
   if ( !exec( qry, QString( "SELECT column_name FROM all_tab_columns WHERE owner=? AND table_name=? ORDER BY column_id" ),
               QVariantList() << ownerName << viewName ) )
   {
-    QgsMessageLog::logMessage( tr( "SQL:%1 [owner:%2 table_name:%3]\nerror:%4\n" ).arg( qry.lastQuery(), qry.lastError().text(), ownerName, viewName ), tr( "Oracle" ) );
+    QgsMessageLog::logMessage( tr( "SQL: %1 [owner: %2 table_name: %3]\nerror: %4\n" ).arg( qry.lastQuery(), qry.lastError().text(), ownerName, viewName ), tr( "Oracle" ) );
     return cols;
   }
 
@@ -275,7 +275,7 @@ bool QgsOracleConn::tableInfo( bool geometryColumnsOnly, bool userTablesOnly, bo
   QSqlQuery qry( mDatabase );
   if ( !exec( qry, sql, QVariantList() ) )
   {
-    QgsMessageLog::logMessage( tr( "Querying available tables failed.\nSQL:%1\nerror:%2\n" ).arg( qry.lastQuery() ).arg( qry.lastError().text() ), tr( "Oracle" ) );
+    QgsMessageLog::logMessage( tr( "Querying available tables failed.\nSQL: %1\nerror: %2\n" ).arg( qry.lastQuery() ).arg( qry.lastError().text() ), tr( "Oracle" ) );
     return false;
   }
 
@@ -484,7 +484,7 @@ void QgsOracleConn::retrieveLayerTypes( QgsOracleLayerProperty &layerProperty, b
               .arg( table )
               .arg( where.isEmpty() ? "" : QString( " AND (%1)" ).arg( where ) ), QVariantList() ) )
   {
-    QgsMessageLog::logMessage( tr( "SQL:%1\nerror:%2\n" )
+    QgsMessageLog::logMessage( tr( "SQL: %1\nerror: %2\n" )
                                .arg( qry.lastQuery() )
                                .arg( qry.lastError().text() ),
                                tr( "Oracle" ) );

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -264,7 +264,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
       mRewind = false;
       if ( !QgsOracleProvider::exec( mQry, mSql, mArgs ) )
       {
-        QgsMessageLog::logMessage( QObject::tr( "Fetching features failed.\nSQL:%1\nError: %2" )
+        QgsMessageLog::logMessage( QObject::tr( "Fetching features failed.\nSQL: %1\nError: %2" )
                                    .arg( mQry.lastQuery() )
                                    .arg( mQry.lastError().text() ),
                                    QObject::tr( "Oracle" ) );
@@ -498,7 +498,7 @@ bool QgsOracleFeatureIterator::openQuery( QString whereClause, QVariantList args
     {
       if ( showLog )
       {
-        QgsMessageLog::logMessage( QObject::tr( "Fetching features failed.\nSQL:%1\nError: %2" )
+        QgsMessageLog::logMessage( QObject::tr( "Fetching features failed.\nSQL: %1\nError: %2" )
                                    .arg( mQry.lastQuery() )
                                    .arg( mQry.lastError().text() ),
                                    QObject::tr( "Oracle" ) );

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -152,7 +152,7 @@ void QgsOracleNewConnection::on_btnConnect_clicked()
   if ( conn )
   {
     // Database successfully opened; we can now issue SQL commands.
-    bar->pushMessage( tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ),
+    bar->pushMessage( tr( "Connection to %1 was successful." ).arg( txtDatabase->text() ),
                       QgsMessageBar::INFO );
     // free connection resources
     QgsOracleConnPool::instance()->releaseConnection( conn );

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -92,7 +92,7 @@ void QgsOracleNewConnection::accept()
 
   if ( chkStorePassword->isChecked() &&
        QMessageBox::question( this,
-                              tr( "Saving passwords" ),
+                              tr( "Saving Passwords" ),
                               tr( "WARNING: You have opted to save your password. It will be stored in plain text in your project files and in your home directory on Unix-like systems, or in your user profile on Windows. If you do not want this to happen, please press the Cancel button.\n" ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
@@ -104,7 +104,7 @@ void QgsOracleNewConnection::accept()
        ( settings.contains( baseKey + txtName->text() + "/service" ) ||
          settings.contains( baseKey + txtName->text() + "/host" ) ) &&
        QMessageBox::question( this,
-                              tr( "Save connection" ),
+                              tr( "Save Connection" ),
                               tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2508,7 +2508,7 @@ bool QgsOracleProvider::createSpatialIndex()
                 .arg( quotedIdentifier( mTableName ) )
                 .arg( quotedIdentifier( mGeometryColumn ) ), QVariantList() ) )
     {
-      QgsMessageLog::logMessage( tr( "Creation of spatial index failed.\nSQL: %1\nError: %2" )
+      QgsMessageLog::logMessage( tr( "Creation spatial index failed.\nSQL: %1\nError: %2" )
                                  .arg( qry.lastQuery() )
                                  .arg( qry.lastError().text() ),
                                  tr( "Oracle" ) );

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2459,7 +2459,7 @@ bool QgsOracleProvider::createSpatialIndex()
                 QVariantList() << r.xMinimum() << r.xMaximum() << r.yMinimum() << r.yMaximum() << mTableName << mGeometryColumn )
        )
     {
-      QgsMessageLog::logMessage( tr( "Could not update metadata for %1.%2.\nSQL:%3\nError: %4" )
+      QgsMessageLog::logMessage( tr( "Could not update metadata for %1.%2.\nSQL: %3\nError: %4" )
                                  .arg( mTableName )
                                  .arg( mGeometryColumn )
                                  .arg( qry.lastQuery() )
@@ -2478,7 +2478,7 @@ bool QgsOracleProvider::createSpatialIndex()
                   << r.xMinimum() << r.xMaximum() << r.yMinimum() << r.yMaximum() )
          )
       {
-        QgsMessageLog::logMessage( tr( "Could not insert metadata for %1.%2.\nSQL:%3\nError: %4" )
+        QgsMessageLog::logMessage( tr( "Could not insert metadata for %1.%2.\nSQL: %3\nError: %4" )
                                    .arg( quotedValue( mTableName ) )
                                    .arg( quotedValue( mGeometryColumn ) )
                                    .arg( qry.lastQuery() )
@@ -2508,7 +2508,7 @@ bool QgsOracleProvider::createSpatialIndex()
                 .arg( quotedIdentifier( mTableName ) )
                 .arg( quotedIdentifier( mGeometryColumn ) ), QVariantList() ) )
     {
-      QgsMessageLog::logMessage( tr( "Creation spatial index failed.\nSQL:%1\nError: %2" )
+      QgsMessageLog::logMessage( tr( "Creation of spatial index failed.\nSQL: %1\nError: %2" )
                                  .arg( qry.lastQuery() )
                                  .arg( qry.lastError().text() ),
                                  tr( "Oracle" ) );
@@ -2521,7 +2521,7 @@ bool QgsOracleProvider::createSpatialIndex()
   {
     if ( !exec( qry, QString( "ALTER INDEX %1 REBUILD" ).arg( mSpatialIndexName ), QVariantList() ) )
     {
-      QgsMessageLog::logMessage( tr( "Rebuild of spatial index failed.\nSQL:%1\nError: %2" )
+      QgsMessageLog::logMessage( tr( "Rebuild of spatial index failed.\nSQL: %1\nError: %2" )
                                  .arg( qry.lastQuery() )
                                  .arg( qry.lastError().text() ),
                                  tr( "Oracle" ) );
@@ -2819,7 +2819,7 @@ QgsVectorLayerExporter::ExportError QgsOracleProvider::createEmptyLayer(
     {
       if ( !exec( qry, QString( "DROP TABLE %1" ).arg( ownerTableName ), QVariantList() ) )
       {
-        QgsMessageLog::logMessage( tr( "Drop created table %1 failed.\nSQL:%2\nError: %3" )
+        QgsMessageLog::logMessage( tr( "Drop created table %1 failed.\nSQL: %2\nError: %3" )
                                    .arg( qry.lastQuery() )
                                    .arg( qry.lastError().text() ), tr( "Oracle" ) );
       }
@@ -2985,7 +2985,7 @@ QgsCoordinateReferenceSystem QgsOracleProvider::crs() const
   }
   else
   {
-    QgsMessageLog::logMessage( tr( "Lookup of Oracle SRID %1 failed.\nSQL:%2\nError:%3" )
+    QgsMessageLog::logMessage( tr( "Lookup of Oracle SRID %1 failed.\nSQL: %2\nError: %3" )
                                .arg( mSrid )
                                .arg( qry.lastQuery() )
                                .arg( qry.lastError().text() ),

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -285,7 +285,7 @@ void QgsOracleSourceSelect::on_btnSave_clicked()
 
 void QgsOracleSourceSelect::on_btnLoad_clicked()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), ".",
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), ".",
                      tr( "XML files (*.xml *XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -114,7 +114,7 @@ void QgsPgNewConnection::accept()
 
   if ( !hasAuthConfigID && mAuthSettings->storePasswordIsChecked( ) &&
        QMessageBox::question( this,
-                              tr( "Saving passwords" ),
+                              tr( "Saving Passwords" ),
                               trUtf8( "WARNING: You have opted to save your password. It will be stored in unsecured plain text in your project files and in your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't save a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
@@ -126,7 +126,7 @@ void QgsPgNewConnection::accept()
        ( settings.contains( baseKey + txtName->text() + "/service" ) ||
          settings.contains( baseKey + txtName->text() + "/host" ) ) &&
        QMessageBox::question( this,
-                              tr( "Save connection" ),
+                              tr( "Save Connection" ),
                               tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -201,7 +201,7 @@ void QgsPgNewConnection::testConnection()
   if ( conn )
   {
     // Database successfully opened; we can now issue SQL commands.
-    bar->pushMessage( tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ),
+    bar->pushMessage( tr( "Connection to %1 was successful." ).arg( txtDatabase->text() ),
                       QgsMessageBar::INFO );
 
     // free pg connection resources

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -320,7 +320,7 @@ void QgsPgSourceSelect::btnSave_clicked()
 
 void QgsPgSourceSelect::btnLoad_clicked()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), QDir::homePath(),
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QDir::homePath(),
                      tr( "XML files (*.xml *XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -382,7 +382,7 @@ void QgsPostgresConn::addColumnInfo( QgsPostgresLayerProperty &layerProperty, co
   }
   else
   {
-    QgsMessageLog::logMessage( tr( "SQL:%1\nresult:%2\nerror:%3\n" ).arg( sql ).arg( colRes.PQresultStatus() ).arg( colRes.PQresultErrorMessage() ), tr( "PostGIS" ) );
+    QgsMessageLog::logMessage( tr( "SQL: %1\nresult: %2\nerror: %3\n" ).arg( sql ).arg( colRes.PQresultStatus() ).arg( colRes.PQresultErrorMessage() ), tr( "PostGIS" ) );
   }
 
 }
@@ -1868,7 +1868,7 @@ QString QgsPostgresConn::currentDatabase() const
   }
   else
   {
-    QgsMessageLog::logMessage( tr( "SQL:%1\nresult:%2\nerror:%3\n" ).arg( sql ).arg( res.PQresultStatus() ).arg( res.PQresultErrorMessage() ), tr( "PostGIS" ) );
+    QgsMessageLog::logMessage( tr( "SQL: %1\nresult: %2\nerror: %3\n" ).arg( sql ).arg( res.PQresultStatus() ).arg( res.PQresultErrorMessage() ), tr( "PostGIS" ) );
   }
 
   return database;

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -148,7 +148,7 @@ void QgsSpatiaLiteSourceSelect::updateStatistics()
     subKey.truncate( idx );
 
   QString msg = tr( "Are you sure you want to update the internal statistics for DB: %1?\n\n"
-                    "This could take a long time (depending on the DB size),\n"
+                    "This could take a long time (depending on the DB size), "
                     "but implies better performance thereafter." ).arg( subKey );
   QMessageBox::StandardButton result =
     QMessageBox::information( this, tr( "Confirm Update Statistics" ), msg, QMessageBox::Ok | QMessageBox::Cancel );
@@ -463,11 +463,11 @@ void QgsSpatiaLiteSourceSelect::btnConnect_clicked()
         break;
       case QgsSpatiaLiteConnection::FailedToCheckMetadata:
         QMessageBox::critical( this, tr( "SpatiaLite metadata check failed" ),
-                               tr( "Failure getting table metadata ... is this really a SpatialLite database? %1\n\n%2" ).arg( mSqlitePath, errCause ) );
+                               tr( "Failure getting table metadata... is %1 really a SpatiaLite database?\n\n%2" ).arg( mSqlitePath, errCause ) );
         break;
       default:
         QMessageBox::critical( this, tr( "SpatiaLite Error" ),
-                               tr( "Unexpected error when working with: %1\n\n%2" ).arg( mSqlitePath, errCause ) );
+                               tr( "Unexpected error when working with %1\n\n%2" ).arg( mSqlitePath, errCause ) );
     }
     mSqlitePath = QString();
     return;

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -468,7 +468,7 @@ bool QgsWcsCapabilities::parseCapabilitiesDom( QByteArray const &xml, QgsWcsCapa
     {
       mErrorTitle = tr( "Dom Exception" );
       mErrorFormat = QStringLiteral( "text/plain" );
-      mError = tr( "Could not get WCS capabilities in the expected format (DTD): no %1 found.\nThis might be due to an incorrect WCS Server URL.\nTag:%3\nResponse was:\n%4" )
+      mError = tr( "Could not get WCS capabilities in the expected format (DTD): no %1 found.\nThis might be due to an incorrect WCS Server URL.\nTag: %3\nResponse was:\n%4" )
                .arg( QStringLiteral( "Capabilities" ),
                      docElem.tagName(),
                      QString( xml ) );
@@ -774,7 +774,7 @@ bool QgsWcsCapabilities::parseDescribeCoverageDom10( QByteArray const &xml, QgsW
   {
     mErrorTitle = tr( "Dom Exception" );
     mErrorFormat = QStringLiteral( "text/plain" );
-    mError = tr( "Could not get WCS capabilities in the expected format (DTD): no %1 found.\nThis might be due to an incorrect WCS Server URL.\nTag:%3\nResponse was:\n%4" )
+    mError = tr( "Could not get WCS capabilities in the expected format (DTD): no %1 found.\nThis might be due to an incorrect WCS Server URL.\nTag: %3\nResponse was:\n%4" )
              .arg( QStringLiteral( "CoverageDescription" ),
                    docElem.tagName(),
                    QString( xml ) );
@@ -930,7 +930,7 @@ bool QgsWcsCapabilities::parseDescribeCoverageDom11( QByteArray const &xml, QgsW
   {
     mErrorTitle = tr( "Dom Exception" );
     mErrorFormat = QStringLiteral( "text/plain" );
-    mError = tr( "Could not get WCS capabilities in the expected format (DTD): no %1 found.\nThis might be due to an incorrect WCS Server URL.\nTag:%3\nResponse was:\n%4" )
+    mError = tr( "Could not get WCS capabilities in the expected format (DTD): no %1 found.\nThis might be due to an incorrect WCS Server URL.\nTag: %3\nResponse was:\n%4" )
              .arg( QStringLiteral( "CoverageDescriptions" ),
                    docElem.tagName(),
                    QString( xml ) );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1704,7 +1704,7 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
     {
       QVariant phrase = mCacheReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
 
-      QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Reason phrase: %2; URL:%3)" )
+      QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Reason phrase: %2; URL: %3)" )
                                  .arg( status.toInt() )
                                  .arg( phrase.toString(),
                                        mCacheReply->url().toString() ), tr( "WCS" ) );
@@ -1742,7 +1742,7 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
       }
       else
       {
-        QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Response: %2; URL:%3)" )
+        QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Response: %2; URL: %3)" )
                                    .arg( status.toInt() )
                                    .arg( QString::fromUtf8( text ),
                                          mCacheReply->url().toString() ), tr( "WCS" ) );
@@ -1798,13 +1798,13 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
         QString errorTitle, errorText;
         if ( QgsWcsProvider::parseServiceExceptionReportDom( body, mWcsVersion, errorTitle, errorText ) )
         {
-          QgsMessageLog::logMessage( tr( "Map request error (Title:%1; Error:%2; URL: %3)" )
+          QgsMessageLog::logMessage( tr( "Map request error (Title: %1; Error: %2; URL: %3)" )
                                      .arg( errorTitle, errorText,
                                            mCacheReply->url().toString() ), tr( "WCS" ) );
         }
         else
         {
-          QgsMessageLog::logMessage( tr( "Map request error (Response: %1; URL:%2)" )
+          QgsMessageLog::logMessage( tr( "Map request error (Response: %1; URL: %2)" )
                                      .arg( QString::fromUtf8( body ),
                                            mCacheReply->url().toString() ), tr( "WCS" ) );
         }
@@ -1877,7 +1877,7 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
       sErrors++;
       if ( sErrors < 100 )
       {
-        QgsMessageLog::logMessage( tr( "Map request failed [error:%1 url:%2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WCS" ) );
+        QgsMessageLog::logMessage( tr( "Map request failed [error: %1 url: %2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WCS" ) );
       }
       else if ( sErrors == 100 )
       {

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -621,7 +621,7 @@ bool QgsWFSProvider::processSQL( const QString &sqlString, QString &errorMsg, QS
       }
       if ( mapFieldNameToSrcLayerNameFieldName.contains( fieldName ) )
       {
-        errorMsg = tr( "Field '%1': a field with the same name already exists" ).arg( column->dump() );
+        errorMsg = tr( "Field '%1': a field with the same name already exists." ).arg( column->dump() );
         return false;
       }
 

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -512,7 +512,7 @@ bool QgsWFSProvider::processSQL( const QString &sqlString, QString &errorMsg, QS
     QgsSQLStatement::Node *column = selectedcolumn->column();
     if ( column->nodeType() != QgsSQLStatement::ntColumnRef )
     {
-      errorMsg = tr( "Column '%1' is not a direct reference to a table column" ).arg( column->dump() );
+      errorMsg = tr( "Column '%1' is not a direct reference to a table column." ).arg( column->dump() );
       return false;
     }
     QgsSQLStatement::NodeColumnRef *columnRef = dynamic_cast<QgsSQLStatement::NodeColumnRef *>( column );
@@ -551,7 +551,7 @@ bool QgsWFSProvider::processSQL( const QString &sqlString, QString &errorMsg, QS
           field.setName( fieldName );
           if ( mapFieldNameToSrcLayerNameFieldName.contains( fieldName ) )
           {
-            errorMsg = tr( "Field '%1': a field with the same name already exists" ).arg( field.name() );
+            errorMsg = tr( "Field '%1': a field with the same name already exists." ).arg( field.name() );
             return false;
           }
 
@@ -592,7 +592,7 @@ bool QgsWFSProvider::processSQL( const QString &sqlString, QString &errorMsg, QS
     {
       if ( columnTableTypename != mShared->mURI.typeName() )
       {
-        warningMsg = tr( "The geometry field of a typename that is not the main typename is ignored in the selected fields" );
+        warningMsg = tr( "The geometry field of a typename that is not the main typename is ignored in the selected fields." );
         QgsDebugMsg( warningMsg );
       }
     }
@@ -1263,7 +1263,7 @@ bool QgsWFSProvider::readAttributesFromSchema( QDomDocument &schemaDoc,
     }
     if ( foundImport && onlyIncludeOrImport )
     {
-      errorMsg = tr( "it is probably a schema for Complex Features" );
+      errorMsg = tr( "It is probably a schema for Complex Features." );
     }
     else
     {
@@ -1645,19 +1645,19 @@ void QgsWFSProvider::handleException( const QDomDocument &serverResponse )
   QDomElement exceptionElem = serverResponse.documentElement();
   if ( exceptionElem.isNull() )
   {
-    pushError( tr( "empty response" ) );
+    pushError( tr( "Empty response" ) );
     return;
   }
 
   if ( exceptionElem.tagName() == QLatin1String( "ServiceExceptionReport" ) )
   {
-    pushError( tr( "WFS service exception:%1" ).arg( exceptionElem.firstChildElement( QStringLiteral( "ServiceException" ) ).text() ) );
+    pushError( tr( "WFS service exception: %1" ).arg( exceptionElem.firstChildElement( QStringLiteral( "ServiceException" ) ).text() ) );
     return;
   }
 
   if ( exceptionElem.tagName() == QLatin1String( "WFS_TransactionResponse" ) )
   {
-    pushError( tr( "unsuccessful service response: %1" ).arg( exceptionElem.firstChildElement( QStringLiteral( "TransactionResult" ) ).firstChildElement( QStringLiteral( "Message" ) ).text() ) );
+    pushError( tr( "Unsuccessful service response: %1" ).arg( exceptionElem.firstChildElement( QStringLiteral( "TransactionResult" ) ).firstChildElement( QStringLiteral( "Message" ) ).text() ) );
     return;
   }
 
@@ -1671,7 +1671,7 @@ void QgsWFSProvider::handleException( const QDomDocument &serverResponse )
     return;
   }
 
-  pushError( tr( "unhandled response: %1" ).arg( exceptionElem.tagName() ) );
+  pushError( tr( "Unhandled response: %1" ).arg( exceptionElem.tagName() ) );
 }
 
 QGISEXTERN QgsWFSProvider *classFactory( const QString *uri )

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -708,7 +708,7 @@ void QgsWFSSourceSelect::btnSave_clicked()
 
 void QgsWFSSourceSelect::btnLoad_clicked()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), QDir::homePath(),
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QDir::homePath(),
                      tr( "XML files (*.xml *XML)" ) );
   if ( fileName.isEmpty() )
   {

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -284,7 +284,7 @@ bool QgsWmsCapabilities::parseCapabilitiesDom( QByteArray const &xml, QgsWmsCapa
   {
     mErrorCaption = QObject::tr( "Dom Exception" );
     mErrorFormat = QStringLiteral( "text/plain" );
-    mError = QObject::tr( "Could not get WMS capabilities in the expected format (DTD): no %1 or %2 found.\nThis might be due to an incorrect WMS Server URL.\nTag:%3\nResponse was:\n%4" )
+    mError = QObject::tr( "Could not get WMS capabilities in the expected format (DTD): no %1 or %2 found.\nThis might be due to an incorrect WMS Server URL.\nTag: %3\nResponse was:\n%4" )
              .arg( QStringLiteral( "WMS_Capabilities" ),
                    QStringLiteral( "WMT_MS_Capabilities" ),
                    docElem.tagName(),

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2739,7 +2739,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
 
         if ( isXml && parseServiceExceptionReportDom( body, mErrorCaption, mError ) )
         {
-          QgsMessageLog::logMessage( tr( "Get feature info request error (Title:%1; Error:%2; URL: %3)" )
+          QgsMessageLog::logMessage( tr( "Get feature info request error (Title: %1; Error: %2; URL: %3)" )
                                      .arg( mErrorCaption, mError,
                                            requestUrl.toString() ), tr( "WMS" ) );
           continue;
@@ -3601,7 +3601,7 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
     {
       QVariant phrase = mCacheReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
 
-      QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Reason phrase: %2; URL:%3)" )
+      QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Reason phrase: %2; URL: %3)" )
                                  .arg( status.toInt() )
                                  .arg( phrase.toString(),
                                        mCacheReply->url().toString() ), tr( "WMS" ) );
@@ -3625,7 +3625,7 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
     else if ( contentType.startsWith( QLatin1String( "image/" ), Qt::CaseInsensitive ) ||
               contentType.compare( QLatin1String( "application/octet-stream" ), Qt::CaseInsensitive ) == 0 )
     {
-      QgsMessageLog::logMessage( tr( "Returned image is flawed [Content-Type:%1; URL:%2]" )
+      QgsMessageLog::logMessage( tr( "Returned image is flawed [Content-Type: %1; URL: %2]" )
                                  .arg( contentType, mCacheReply->url().toString() ), tr( "WMS" ) );
     }
     else
@@ -3633,13 +3633,13 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
       QString errorTitle, errorText;
       if ( contentType.toLower() == QLatin1String( "text/xml" ) && QgsWmsProvider::parseServiceExceptionReportDom( text, errorTitle, errorText ) )
       {
-        QgsMessageLog::logMessage( tr( "Map request error (Title:%1; Error:%2; URL: %3)" )
+        QgsMessageLog::logMessage( tr( "Map request error (Title: %1; Error: %2; URL: %3)" )
                                    .arg( errorTitle, errorText,
                                          mCacheReply->url().toString() ), tr( "WMS" ) );
       }
       else
       {
-        QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Response: %2; Content-Type: %3; URL:%4)" )
+        QgsMessageLog::logMessage( tr( "Map request error (Status: %1; Response: %2; Content-Type: %3; URL: %4)" )
                                    .arg( status.toInt() )
                                    .arg( QString::fromUtf8( text ),
                                          contentType,
@@ -3668,7 +3668,7 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
       stat.errors++;
       if ( stat.errors < 100 )
       {
-        QgsMessageLog::logMessage( tr( "Map request failed [error:%1 url:%2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WMS" ) );
+        QgsMessageLog::logMessage( tr( "Map request failed [error: %1 url: %2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WMS" ) );
       }
       else if ( stat.errors == 100 )
       {
@@ -3869,13 +3869,13 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
       QString errorTitle, errorText;
       if ( contentType.toLower() == QLatin1String( "text/xml" ) && QgsWmsProvider::parseServiceExceptionReportDom( text, errorTitle, errorText ) )
       {
-        QgsMessageLog::logMessage( tr( "Tile request error (Title:%1; Error:%2; URL: %3)" )
+        QgsMessageLog::logMessage( tr( "Tile request error (Title: %1; Error: %2; URL: %3)" )
                                    .arg( errorTitle, errorText,
                                          reply->url().toString() ), tr( "WMS" ) );
       }
       else
       {
-        QgsMessageLog::logMessage( tr( "Tile request error (Status:%1; Content-Type:%2; Length:%3; URL: %4)" )
+        QgsMessageLog::logMessage( tr( "Tile request error (Status: %1; Content-Type: %2; Length: %3; URL: %4)" )
                                    .arg( status.toString(),
                                          contentType )
                                    .arg( text.size() )
@@ -3936,7 +3936,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
       }
       else
       {
-        QgsMessageLog::logMessage( tr( "Returned image is flawed [Content-Type:%1; URL: %2]" )
+        QgsMessageLog::logMessage( tr( "Returned image is flawed [Content-Type: %1; URL: %2]" )
                                    .arg( contentType, reply->url().toString() ), tr( "WMS" ) );
       }
     }

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -220,7 +220,7 @@ void QgsWMSSourceSelect::btnSave_clicked()
 
 void QgsWMSSourceSelect::btnLoad_clicked()
 {
-  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load connections" ), QDir::homePath(),
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Load Connections" ), QDir::homePath(),
                      tr( "XML files (*.xml *XML)" ) );
   if ( fileName.isEmpty() )
   {
@@ -402,7 +402,7 @@ bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabiliti
               {
                 QTableWidgetItem *item = lstTilesets->item( row, i );
                 item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
-                item->setToolTip( tr( "encoding %1 not supported." ).arg( format ) );
+                item->setToolTip( tr( "Encoding %1 not supported." ).arg( format ) );
               }
             }
 

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -942,7 +942,7 @@
                <string>Geometry is read as a well known text string from the selected fields</string>
               </property>
               <property name="text">
-               <string>Well known text (WKT) </string>
+               <string>Well known text (WKT)</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
At the beginning, i was trying to fix some translations in Qt Linguist and I found some inconsistencies in the texts (no full stop at the end of full sentence, no capital letter at the beginning of a sentence, unneeded trailing space, missing spacing...)
This PR also fixes some issues related to [Bad message box titles](https://github.com/qgis/qgis3_UIX_discussion/issues/44) and [inconsistent capitalisation in dialogs](https://github.com/qgis/qgis3_UIX_discussion/issues/43).

I'd have loved to catch them all but it's a bit time consuming and I think there's a room for improvement. Eg What could be nice is to normalize text and reduce translator workload ( eg `save connection` vs `save connections` - not fixed here). if someone else want to pick the remaining.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
