### PR TITLE
[FEATURE] Search widget for relations using aggregates

### DIFF
--- a/python/core/qgsaggregatecalculator.sip
+++ b/python/core/qgsaggregatecalculator.sip
@@ -147,6 +147,9 @@ class QgsAggregateCalculator
 
     static QList< QgsAggregateCalculator::AggregateInfo > aggregates();
 %Docstring
+ Structured information for available aggregates.
+
+.. versionadded:: 3.2
  :rtype: list of QgsAggregateCalculator.AggregateInfo
 %End
 

--- a/python/core/qgsaggregatecalculator.sip
+++ b/python/core/qgsaggregatecalculator.sip
@@ -28,9 +28,9 @@ class QgsAggregateCalculator
 
     struct AggregateInfo
     {
-      QString function;
-      QString name;
-      QSet<QVariant::Type> supportedTypes;
+      QString function; //!< The expression function
+      QString name; //!< A translated, human readable name
+      QSet<QVariant::Type> supportedTypes; //!< This aggregate function can only be used with these datatypes
     };
 
     enum Aggregate

--- a/python/core/qgsaggregatecalculator.sip
+++ b/python/core/qgsaggregatecalculator.sip
@@ -26,6 +26,13 @@ class QgsAggregateCalculator
 %End
   public:
 
+    struct AggregateInfo
+    {
+      QString function;
+      QString name;
+      QSet<QVariant::Type> supportedTypes;
+    };
+
     enum Aggregate
     {
       Count,
@@ -136,6 +143,11 @@ class QgsAggregateCalculator
  \param ok if specified, will be set to true if conversion was successful
  :return: aggregate type
  :rtype: Aggregate
+%End
+
+    static QList< QgsAggregateCalculator::AggregateInfo > aggregates();
+%Docstring
+ :rtype: list of QgsAggregateCalculator.AggregateInfo
 %End
 
 };

--- a/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
@@ -169,6 +169,25 @@ class QgsSearchWidgetWrapper : QgsWidgetWrapper
  :rtype: str
 %End
 
+    QString createFieldIdentifier() const;
+%Docstring
+ :rtype: str
+%End
+
+
+
+    QString aggregate() const;
+%Docstring
+ :rtype: str
+%End
+    void setAggregate( const QString &aggregate );
+
+    QgsRelation aggregateRelation() const;
+%Docstring
+ :rtype: QgsRelation
+%End
+    void setAggregateRelation( const QgsRelation &aggregateRelation );
+
   public slots:
 
     virtual void clearWidget();

--- a/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
@@ -60,14 +60,8 @@
 class QgsSearchWidgetWrapper : QgsWidgetWrapper
 {
 %Docstring
- Manages an editor widget
- Widget and wrapper share the same parent
 
- A wrapper controls one attribute editor widget and is able to create a default
- widget or use a pre-existent widget. It is able to set the widget to the value implied
- by a field of a vector layer, or return the value it currently holds. Every time it is changed
- it has to emit a valueChanged signal. If it fails to do so, there is no guarantee that the
- changed status of the widget will be saved.
+ Shows a search widget on a filter form.
 %End
 
 %TypeHeaderCode
@@ -171,22 +165,30 @@ class QgsSearchWidgetWrapper : QgsWidgetWrapper
 
     QString createFieldIdentifier() const;
 %Docstring
+ Get a field name or expression to use as field comparison.
+ If in SearchMode returns a quoted field identifier.
+ If in AggregateSearchMode returns an appropriate aggregate expression.
+
+.. versionadded:: 3.2
  :rtype: str
 %End
-
-
 
     QString aggregate() const;
 %Docstring
+ If in AggregateSearch mode, which aggregate should be used to construct
+ the filter expression. Is a Null String if none.
+
+.. versionadded:: 3.2
  :rtype: str
 %End
-    void setAggregate( const QString &aggregate );
 
-    QgsRelation aggregateRelation() const;
+    void setAggregate( const QString &aggregate );
 %Docstring
- :rtype: QgsRelation
+ If in AggregateSearch mode, which aggregate should be used to construct
+ the filter expression. Is a Null String if none.
+
+.. versionadded:: 3.2
 %End
-    void setAggregateRelation( const QgsRelation &aggregateRelation );
 
   public slots:
 

--- a/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
@@ -169,7 +169,7 @@ class QgsSearchWidgetWrapper : QgsWidgetWrapper
  If in SearchMode returns a quoted field identifier.
  If in AggregateSearchMode returns an appropriate aggregate expression.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
  :rtype: str
 %End
 
@@ -178,7 +178,7 @@ class QgsSearchWidgetWrapper : QgsWidgetWrapper
  If in AggregateSearch mode, which aggregate should be used to construct
  the filter expression. Is a Null String if none.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
  :rtype: str
 %End
 
@@ -187,7 +187,7 @@ class QgsSearchWidgetWrapper : QgsWidgetWrapper
  If in AggregateSearch mode, which aggregate should be used to construct
  the filter expression. Is a Null String if none.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
 %End
 
   public slots:

--- a/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
@@ -1,0 +1,53 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsRelationAggregateSearchWidgetWrapper : QgsSearchWidgetWrapper
+{
+%Docstring
+*************************************************************************
+qgsrelationaggregatesearchwidget.h
+-----------------------------
+Date                 : Nov 2017
+Copyright            : (C) 2017 Matthias Kuhn
+Email                : matthias@opengis.ch
+**************************************************************************
+                                                                         *
+   This program is free software; you can redistribute it and/or modify  *
+   it under the terms of the GNU General Public License as published by  *
+   the Free Software Foundation; either version 2 of the License, or     *
+   (at your option) any later version.                                   *
+                                                                         *
+**************************************************************************
+%End
+
+%TypeHeaderCode
+#include "qgsrelationaggregatesearchwidgetwrapper.h"
+%End
+  public:
+    explicit QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *vl, QgsRelationWidgetWrapper *wrapper, QWidget *parent /TransferThis/ = 0 );
+
+    virtual QString expression() const;
+
+    virtual bool valid() const;
+    virtual QWidget *createWidget( QWidget *parent );
+    virtual bool applyDirectly();
+    virtual void setExpression( const QString &value );
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
@@ -13,27 +13,23 @@
 class QgsRelationAggregateSearchWidgetWrapper : QgsSearchWidgetWrapper
 {
 %Docstring
-*************************************************************************
-qgsrelationaggregatesearchwidget.h
------------------------------
-Date                 : Nov 2017
-Copyright            : (C) 2017 Matthias Kuhn
-Email                : matthias@opengis.ch
-**************************************************************************
-                                                                         *
-   This program is free software; you can redistribute it and/or modify  *
-   it under the terms of the GNU General Public License as published by  *
-   the Free Software Foundation; either version 2 of the License, or     *
-   (at your option) any later version.                                   *
-                                                                         *
-**************************************************************************
+
+ Search widget for the children of a relation.
+ For each attribute of the child, an additional QgsAggregateToolButton will be shown
+ to determine how the values should be aggregated for searching.
+
+.. versionadded:: 3.2
 %End
 
 %TypeHeaderCode
 #include "qgsrelationaggregatesearchwidgetwrapper.h"
 %End
   public:
-    explicit QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *vl, QgsRelationWidgetWrapper *wrapper, QWidget *parent /TransferThis/ = 0 );
+
+    explicit QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *layer, QgsRelationWidgetWrapper *wrapper, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+ Constructor
+%End
 
     virtual QString expression() const;
 

--- a/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
@@ -18,7 +18,7 @@ class QgsRelationAggregateSearchWidgetWrapper : QgsSearchWidgetWrapper
  For each attribute of the child, an additional QgsAggregateToolButton will be shown
  to determine how the values should be aggregated for searching.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode

--- a/python/gui/editorwidgets/qgsrelationwidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationwidgetwrapper.sip
@@ -71,6 +71,11 @@ class QgsRelationWidgetWrapper : QgsWidgetWrapper
 .. versionadded:: 2.18
 %End
 
+    QgsRelation relation() const;
+%Docstring
+ :rtype: QgsRelation
+%End
+
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 

--- a/python/gui/editorwidgets/qgsrelationwidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationwidgetwrapper.sip
@@ -73,6 +73,9 @@ class QgsRelationWidgetWrapper : QgsWidgetWrapper
 
     QgsRelation relation() const;
 %Docstring
+ The relation for which this wrapper is created.
+
+.. versionadded:: 3.2
  :rtype: QgsRelation
 %End
 

--- a/python/gui/editorwidgets/qgsrelationwidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationwidgetwrapper.sip
@@ -75,7 +75,7 @@ class QgsRelationWidgetWrapper : QgsWidgetWrapper
 %Docstring
  The relation for which this wrapper is created.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
  :rtype: QgsRelation
 %End
 

--- a/python/gui/editorwidgets/qgssearchwidgettoolbutton.sip
+++ b/python/gui/editorwidgets/qgssearchwidgettoolbutton.sip
@@ -8,6 +8,10 @@
 
 
 
+%ModuleHeaderCode
+#include "qgssearchwidgettoolbutton.h"
+%End
+
 class QgsSearchWidgetToolButton : QToolButton
 {
 %Docstring
@@ -19,6 +23,12 @@ class QgsSearchWidgetToolButton : QToolButton
 
 %TypeHeaderCode
 #include "qgssearchwidgettoolbutton.h"
+%End
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsSearchWidgetToolButton *>( sipCpp ) )
+      sipType = sipType_QgsSearchWidgetToolButton;
+    else
+      sipType = nullptr;
 %End
   public:
 

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -52,9 +52,11 @@
 %Include qgisinterface.sip
 %Include qgsactionmenu.sip
 %Include qgsadvanceddigitizingdockwidget.sip
+%Include qgsaggregatetoolbutton.sip
 %Include qgsattributedialog.sip
 %Include qgsattributeform.sip
 %Include qgsattributeformeditorwidget.sip
+%Include qgsattributeformrelationeditorwidget.sip
 %Include qgsattributeformwidget.sip
 %Include qgsattributetypeloaddialog.sip
 %Include qgsblendmodecombobox.sip
@@ -279,6 +281,7 @@
 %Include editorwidgets/qgsrelationreferencewidget.sip
 %Include editorwidgets/qgsrelationreferencewidgetwrapper.sip
 %Include editorwidgets/qgsrelationwidgetwrapper.sip
+%Include editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip
 %Include editorwidgets/qgssearchwidgettoolbutton.sip
 %Include editorwidgets/qgsspinbox.sip
 %Include editorwidgets/qgsvaluemapsearchwidgetwrapper.sip

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -55,6 +55,7 @@
 %Include qgsattributedialog.sip
 %Include qgsattributeform.sip
 %Include qgsattributeformeditorwidget.sip
+%Include qgsattributeformwidget.sip
 %Include qgsattributetypeloaddialog.sip
 %Include qgsblendmodecombobox.sip
 %Include qgsbrowsertreeview.sip

--- a/python/gui/qgsaggregatetoolbutton.sip
+++ b/python/gui/qgsaggregatetoolbutton.sip
@@ -1,0 +1,68 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsaggregatetoolbutton.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsAggregateToolButton : QToolButton
+{
+%Docstring
+*************************************************************************
+qgsaggregatetoolbutton.h
+--------------------------------------
+Date                 : Nov 2017
+Copyright            : (C) 2017 Matthias Kuhn
+Email                : matthias@opengis.ch
+**************************************************************************
+                                                                         *
+   This program is free software; you can redistribute it and/or modify  *
+   it under the terms of the GNU General Public License as published by  *
+   the Free Software Foundation; either version 2 of the License, or     *
+   (at your option) any later version.                                   *
+                                                                         *
+**************************************************************************
+%End
+
+%TypeHeaderCode
+#include "qgsaggregatetoolbutton.h"
+%End
+  public:
+    QgsAggregateToolButton();
+
+    void setType( QVariant::Type type );
+
+    QVariant::Type type() const;
+%Docstring
+ :rtype: QVariant.Type
+%End
+
+    void setActive( bool active );
+    bool active() const;
+%Docstring
+ :rtype: bool
+%End
+
+    QString aggregate() const;
+%Docstring
+ :rtype: str
+%End
+    void setAggregate( const QString &aggregate );
+
+  signals:
+    void aggregateChanged();
+    void activeChanged();
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsaggregatetoolbutton.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgsaggregatetoolbutton.sip
+++ b/python/gui/qgsaggregatetoolbutton.sip
@@ -71,7 +71,7 @@ class QgsAggregateToolButton : QToolButton
 
     void activeChanged();
 %Docstring
- A function has been selected or unselected.
+ A function has been selected or deselected.
 %End
 
 };

--- a/python/gui/qgsaggregatetoolbutton.sip
+++ b/python/gui/qgsaggregatetoolbutton.sip
@@ -12,50 +12,67 @@
 class QgsAggregateToolButton : QToolButton
 {
 %Docstring
-*************************************************************************
-qgsaggregatetoolbutton.h
---------------------------------------
-Date                 : Nov 2017
-Copyright            : (C) 2017 Matthias Kuhn
-Email                : matthias@opengis.ch
-**************************************************************************
-                                                                         *
-   This program is free software; you can redistribute it and/or modify  *
-   it under the terms of the GNU General Public License as published by  *
-   the Free Software Foundation; either version 2 of the License, or     *
-   (at your option) any later version.                                   *
-                                                                         *
-**************************************************************************
+
+ Offers a toolbutton to choose between different aggregate functions.
+ Functions are filtered based on the type.
+
+.. versionadded:: 3.2
 %End
 
 %TypeHeaderCode
 #include "qgsaggregatetoolbutton.h"
 %End
   public:
+
     QgsAggregateToolButton();
+%Docstring
+ Constructor
+%End
 
     void setType( QVariant::Type type );
+%Docstring
+ Based on the ``type`` of underlying data, some aggregates will be available or not.
+%End
 
     QVariant::Type type() const;
 %Docstring
+ Based on the ``type`` of underlying data, some aggregates will be available or not.
  :rtype: QVariant.Type
 %End
 
     void setActive( bool active );
+%Docstring
+ When this flag is false, the aggregate will be deactivated. I.e. no aggregate is chosen.
+%End
+
     bool active() const;
 %Docstring
+ When this flag is false, the aggregate will be deactivated. I.e. no aggregate is chosen.
  :rtype: bool
 %End
 
     QString aggregate() const;
 %Docstring
+ The function name of the selected aggregate or a Null String if none is chosen.
  :rtype: str
 %End
+
     void setAggregate( const QString &aggregate );
+%Docstring
+ The function name of the selected aggregate or a Null String if none is chosen.
+%End
 
   signals:
+
     void aggregateChanged();
+%Docstring
+ The function name of the selected aggregate has changed.
+%End
+
     void activeChanged();
+%Docstring
+ A function has been selected or unselected.
+%End
 
 };
 

--- a/python/gui/qgsaggregatetoolbutton.sip
+++ b/python/gui/qgsaggregatetoolbutton.sip
@@ -16,7 +16,7 @@ class QgsAggregateToolButton : QToolButton
  Offers a toolbutton to choose between different aggregate functions.
  Functions are filtered based on the type.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode

--- a/python/gui/qgsattributeform.sip
+++ b/python/gui/qgsattributeform.sip
@@ -126,6 +126,11 @@ class QgsAttributeForm : QWidget
 
     QString aggregateFilter() const;
 %Docstring
+ The aggregate filter is only useful if the form is in AggregateFilter mode.
+ In this case it will return a combined expression according to the chosen filters
+ on all attribute widgets.
+
+.. versionadded:: 3.2
  :rtype: str
 %End
 

--- a/python/gui/qgsattributeform.sip
+++ b/python/gui/qgsattributeform.sip
@@ -130,7 +130,7 @@ class QgsAttributeForm : QWidget
  In this case it will return a combined expression according to the chosen filters
  on all attribute widgets.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
  :rtype: str
 %End
 

--- a/python/gui/qgsattributeform.sip
+++ b/python/gui/qgsattributeform.sip
@@ -25,6 +25,7 @@ class QgsAttributeForm : QWidget
       AddFeatureMode,
       MultiEditMode,
       SearchMode,
+      AggregateSearchMode,
     };
 
     enum FilterType
@@ -121,6 +122,11 @@ class QgsAttributeForm : QWidget
  mode to display the count of selected features.
  \param messageBar target message bar
 .. versionadded:: 2.16
+%End
+
+    QString aggregateFilter() const;
+%Docstring
+ :rtype: str
 %End
 
   signals:

--- a/python/gui/qgsattributeformeditorwidget.sip
+++ b/python/gui/qgsattributeformeditorwidget.sip
@@ -56,15 +56,6 @@ class QgsAttributeFormEditorWidget : QgsAttributeFormWidget
  :rtype: QVariant
 %End
 
-    virtual QString currentFilterExpression() const;
-
-%Docstring
- Creates an expression matching the current search filter value and
- search properties represented in the widget.
-.. versionadded:: 2.16
- :rtype: str
-%End
-
     void setConstraintStatus( const QString &constraint, const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result );
 %Docstring
  Set the constraint status for this widget.
@@ -88,66 +79,12 @@ class QgsAttributeFormEditorWidget : QgsAttributeFormWidget
  Called when field values have been committed;
 %End
 
-    void resetSearch();
-%Docstring
- Resets the search/filter value of the widget.
-%End
-
   signals:
 
     void valueChanged( const QVariant &value );
 %Docstring
  Emitted when the widget's value changes
  \param value new widget value
-%End
-
-  protected:
-
-    QgsSearchWidgetToolButton *searchWidgetToolButton();
-%Docstring
- Returns a pointer to the search widget tool button in the widget.
-.. note::
-
-   this method is in place for unit testing only, and is not considered
- stable API
- :rtype: QgsSearchWidgetToolButton
-%End
-
-    void setSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
-%Docstring
- Sets the search widget wrapper for the widget used when the form is in
- search mode.
- \param wrapper search widget wrapper.
-.. note::
-
-   the search widget wrapper should be created using searchWidgetFrame()
- as its parent
-.. note::
-
-   this method is in place for unit testing only, and is not considered
- stable API
-%End
-
-    QWidget *searchWidgetFrame();
-%Docstring
- Returns the widget which should be used as a parent during construction
- of the search widget wrapper.
-.. note::
-
-   this method is in place for unit testing only, and is not considered
- stable AP
- :rtype: QWidget
-%End
-
-    QList< QgsSearchWidgetWrapper * > searchWidgetWrappers();
-%Docstring
- Returns the search widget wrapper used in this widget. The wrapper must
- first be created using createSearchWidgetWrapper()
-.. note::
-
-   this method is in place for unit testing only, and is not considered
- stable API
- :rtype: list of QgsSearchWidgetWrapper
 %End
 
 };

--- a/python/gui/qgsattributeformeditorwidget.sip
+++ b/python/gui/qgsattributeformeditorwidget.sip
@@ -29,6 +29,8 @@ class QgsAttributeFormEditorWidget : QgsAttributeFormWidget
 %Docstring
  Constructor for QgsAttributeFormEditorWidget.
  \param editorWidget associated editor widget wrapper (for default/edit modes)
+ \param widgetType the type identifier of the widget passed in the
+        wrapper
  \param form parent attribute form
 %End
 

--- a/python/gui/qgsattributeformeditorwidget.sip
+++ b/python/gui/qgsattributeformeditorwidget.sip
@@ -9,7 +9,7 @@
 
 
 
-class QgsAttributeFormEditorWidget : QWidget
+class QgsAttributeFormEditorWidget : QgsAttributeFormWidget
 {
 %Docstring
  A widget consisting of both an editor widget and additional widgets for controlling the behavior
@@ -24,15 +24,8 @@ class QgsAttributeFormEditorWidget : QWidget
 %End
   public:
 
-    enum Mode
-    {
-      DefaultMode,
-      MultiEditMode,
-      SearchMode,
-    };
-
-    explicit QgsAttributeFormEditorWidget( QgsEditorWidgetWrapper *editorWidget,
-                                           QgsAttributeForm *form /TransferThis/ );
+    explicit QgsAttributeFormEditorWidget( QgsEditorWidgetWrapper *editorWidget, const QString &widgetType,
+                                           QgsAttributeForm *form  /TransferThis/ );
 %Docstring
  Constructor for QgsAttributeFormEditorWidget.
  \param editorWidget associated editor widget wrapper (for default/edit modes)
@@ -41,32 +34,7 @@ class QgsAttributeFormEditorWidget : QWidget
 
     ~QgsAttributeFormEditorWidget();
 
-    void createSearchWidgetWrappers( const QString &widgetId, int fieldIdx,
-                                     const QVariantMap &config );
-
-%Docstring
- Creates the search widget wrappers for the widget used when the form is in
- search mode.
- \param widgetId id of the widget type to create a search wrapper for
- \param fieldIdx index of field associated with widget
- \param config configuration which should be used for the widget creation
- \param context editor context (not available in Python bindings)
-%End
-
-    void setMode( Mode mode );
-%Docstring
- Sets the current mode for the widget. The widget will adapt its state and visible widgets to
- reflect the updated mode. For example, showing multi edit tool buttons if the mode is set to MultiEditMode.
- \param mode widget mode
-.. seealso:: mode()
-%End
-
-    Mode mode() const;
-%Docstring
- Returns the current mode for the widget.
-.. seealso:: setMode()
- :rtype: Mode
-%End
+    virtual void createSearchWidgetWrappers();
 
     void initialize( const QVariant &initialValue, bool mixedValues = false );
 %Docstring
@@ -88,7 +56,8 @@ class QgsAttributeFormEditorWidget : QWidget
  :rtype: QVariant
 %End
 
-    QString currentFilterExpression() const;
+    virtual QString currentFilterExpression() const;
+
 %Docstring
  Creates an expression matching the current search filter value and
  search properties represented in the widget.
@@ -156,7 +125,7 @@ class QgsAttributeFormEditorWidget : QWidget
 .. note::
 
    this method is in place for unit testing only, and is not considered
- stable AP
+ stable API
 %End
 
     QWidget *searchWidgetFrame();
@@ -177,7 +146,7 @@ class QgsAttributeFormEditorWidget : QWidget
 .. note::
 
    this method is in place for unit testing only, and is not considered
- stable AP
+ stable API
  :rtype: list of QgsSearchWidgetWrapper
 %End
 

--- a/python/gui/qgsattributeformrelationeditorwidget.sip
+++ b/python/gui/qgsattributeformrelationeditorwidget.sip
@@ -1,0 +1,48 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsattributeformrelationeditorwidget.h                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsAttributeFormRelationEditorWidget : QgsAttributeFormWidget
+{
+%Docstring
+*************************************************************************
+qgsattributeformrelationeditorwidget.h
+--------------------------------------
+Date                 : Nov 2017
+Copyright            : (C) 2017 Matthias Kuhn
+Email                : matthias@opengis.ch
+**************************************************************************
+                                                                         *
+   This program is free software; you can redistribute it and/or modify  *
+   it under the terms of the GNU General Public License as published by  *
+   the Free Software Foundation; either version 2 of the License, or     *
+   (at your option) any later version.                                   *
+                                                                         *
+**************************************************************************
+%End
+
+%TypeHeaderCode
+#include "qgsattributeformrelationeditorwidget.h"
+%End
+  public:
+    explicit QgsAttributeFormRelationEditorWidget( QgsRelationWidgetWrapper *wrapper, QgsAttributeForm *form );
+
+    virtual void createSearchWidgetWrappers();
+    virtual QString currentFilterExpression() const;
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsattributeformrelationeditorwidget.h                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgsattributeformrelationeditorwidget.sip
+++ b/python/gui/qgsattributeformrelationeditorwidget.sip
@@ -9,30 +9,25 @@
 
 
 
+
 class QgsAttributeFormRelationEditorWidget : QgsAttributeFormWidget
 {
 %Docstring
-*************************************************************************
-qgsattributeformrelationeditorwidget.h
---------------------------------------
-Date                 : Nov 2017
-Copyright            : (C) 2017 Matthias Kuhn
-Email                : matthias@opengis.ch
-**************************************************************************
-                                                                         *
-   This program is free software; you can redistribute it and/or modify  *
-   it under the terms of the GNU General Public License as published by  *
-   the Free Software Foundation; either version 2 of the License, or     *
-   (at your option) any later version.                                   *
-                                                                         *
-**************************************************************************
+
+ Widget to show for child relations on an attribute form.
+
+.. versionadded:: 3.2
 %End
 
 %TypeHeaderCode
 #include "qgsattributeformrelationeditorwidget.h"
 %End
   public:
+
     explicit QgsAttributeFormRelationEditorWidget( QgsRelationWidgetWrapper *wrapper, QgsAttributeForm *form );
+%Docstring
+ Constructor
+%End
 
     virtual void createSearchWidgetWrappers();
     virtual QString currentFilterExpression() const;

--- a/python/gui/qgsattributeformrelationeditorwidget.sip
+++ b/python/gui/qgsattributeformrelationeditorwidget.sip
@@ -16,7 +16,7 @@ class QgsAttributeFormRelationEditorWidget : QgsAttributeFormWidget
 
  Widget to show for child relations on an attribute form.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -11,6 +11,13 @@
 
 class QgsAttributeFormWidget : QWidget /Abstract/
 {
+%Docstring
+
+ Base class for all widgets shown on a QgsAttributeForm.
+ Consists of the widget which is visible in edit mode as well as the widget visible in search mode.
+
+.. versionadded:: 3.2
+%End
 
 %TypeHeaderCode
 #include "qgsattributeformwidget.h"
@@ -61,11 +68,13 @@ class QgsAttributeFormWidget : QWidget /Abstract/
 
     QgsVectorLayer *layer();
 %Docstring
+ The layer for which this widget and its form is shown.
  :rtype: QgsVectorLayer
 %End
 
     QgsAttributeForm *form() const;
 %Docstring
+ The form on which this widget is shown.
  :rtype: QgsAttributeForm
 %End
 
@@ -108,15 +117,7 @@ class QgsAttributeFormWidget : QWidget /Abstract/
 
 
 
-    QgsSearchWidgetToolButton *searchWidgetToolButton();
-%Docstring
- Returns a pointer to the search widget tool button in the widget.
-.. note::
 
-   this method is in place for unit testing only, and is not considered
- stable API
- :rtype: QgsSearchWidgetToolButton
-%End
 
 };
 

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -1,0 +1,79 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsattributeformwidget.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsAttributeFormWidget : QWidget /Abstract/
+{
+
+%TypeHeaderCode
+#include "qgsattributeformwidget.h"
+%End
+  public:
+
+    enum Mode
+    {
+      DefaultMode,
+      MultiEditMode,
+      SearchMode,
+    };
+
+    explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
+
+    virtual void createSearchWidgetWrappers() = 0;
+%Docstring
+ Creates the search widget wrappers for the widget used when the form is in
+ search mode.
+
+ \param context editor context (not available in Python bindings)
+%End
+
+    virtual QString currentFilterExpression() const = 0;
+%Docstring
+ Creates an expression matching the current search filter value and
+ search properties represented in the widget.
+.. versionadded:: 2.16
+ :rtype: str
+%End
+
+
+    void setMode( Mode mode );
+%Docstring
+ Sets the current mode for the widget. The widget will adapt its state and visible widgets to
+ reflect the updated mode. For example, showing multi edit tool buttons if the mode is set to MultiEditMode.
+ \param mode widget mode
+.. seealso:: mode()
+%End
+
+    Mode mode() const;
+%Docstring
+ Returns the current mode for the widget.
+.. seealso:: setMode()
+ :rtype: Mode
+%End
+
+    QgsVectorLayer *layer();
+%Docstring
+ :rtype: QgsVectorLayer
+%End
+
+    QgsAttributeForm *form() const;
+%Docstring
+ :rtype: QgsAttributeForm
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsattributeformwidget.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -125,7 +125,6 @@ class QgsAttributeFormWidget : QWidget /Abstract/
 
 
 
-
 };
 
 /************************************************************************

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -120,6 +120,12 @@ class QgsAttributeFormWidget : QWidget /Abstract/
  Resets the search/filter value of the widget.
 %End
 
+    bool searchWidgetToolButtonVisible() const;
+%Docstring
+ :rtype: bool
+%End
+    void setSearchWidgetToolButtonVisible( bool searchWidgetToolButtonVisible );
+
   protected:
 
 

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -16,7 +16,7 @@ class QgsAttributeFormWidget : QWidget /Abstract/
  Base class for all widgets shown on a QgsAttributeForm.
  Consists of the widget which is visible in edit mode as well as the widget visible in search mode.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -22,6 +22,7 @@ class QgsAttributeFormWidget : QWidget /Abstract/
       DefaultMode,
       MultiEditMode,
       SearchMode,
+      AggregateSearchMode,
     };
 
     explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
@@ -34,7 +35,7 @@ class QgsAttributeFormWidget : QWidget /Abstract/
  \param context editor context (not available in Python bindings)
 %End
 
-    virtual QString currentFilterExpression() const = 0;
+    virtual QString currentFilterExpression() const;
 %Docstring
  Creates an expression matching the current search filter value and
  search properties represented in the widget.
@@ -66,6 +67,55 @@ class QgsAttributeFormWidget : QWidget /Abstract/
     QgsAttributeForm *form() const;
 %Docstring
  :rtype: QgsAttributeForm
+%End
+
+
+
+    void setSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
+%Docstring
+ Sets the search widget wrapper for the widget used when the form is in
+ search mode.
+ \param wrapper search widget wrapper.
+.. note::
+
+   the search widget wrapper should be created using searchWidgetFrame()
+ as its parent
+.. note::
+
+   this method is in place for unit testing only, and is not considered
+ stable API
+%End
+
+    void addAdditionalSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
+
+    QList< QgsSearchWidgetWrapper * > searchWidgetWrappers();
+%Docstring
+ Returns the search widget wrapper used in this widget. The wrapper must
+ first be created using createSearchWidgetWrapper()
+.. note::
+
+   this method is in place for unit testing only, and is not considered
+ stable API
+ :rtype: list of QgsSearchWidgetWrapper
+%End
+
+    void resetSearch();
+%Docstring
+ Resets the search/filter value of the widget.
+%End
+
+  protected:
+
+
+
+    QgsSearchWidgetToolButton *searchWidgetToolButton();
+%Docstring
+ Returns a pointer to the search widget tool button in the widget.
+.. note::
+
+   this method is in place for unit testing only, and is not considered
+ stable API
+ :rtype: QgsSearchWidgetToolButton
 %End
 
 };

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -33,6 +33,9 @@ class QgsAttributeFormWidget : QWidget /Abstract/
     };
 
     explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
+%Docstring
+ A new form widget for the wrapper ``widget`` on ``form``.
+%End
 
     virtual void createSearchWidgetWrappers() = 0;
 %Docstring
@@ -96,6 +99,10 @@ class QgsAttributeFormWidget : QWidget /Abstract/
 %End
 
     void addAdditionalSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
+%Docstring
+ Adds an additional search widget wrapper.
+ Used to register a secondary search widget as used for "between" searches.
+%End
 
     QList< QgsSearchWidgetWrapper * > searchWidgetWrappers();
 %Docstring

--- a/python/gui/qgsattributeformwidget.sip
+++ b/python/gui/qgsattributeformwidget.sip
@@ -122,9 +122,16 @@ class QgsAttributeFormWidget : QWidget /Abstract/
 
     bool searchWidgetToolButtonVisible() const;
 %Docstring
+ The visibility of the search widget tool button, that allows (de)activating
+ this search widgte or defines the comparison operator to use.
  :rtype: bool
 %End
+
     void setSearchWidgetToolButtonVisible( bool searchWidgetToolButtonVisible );
+%Docstring
+ The visibility of the search widget tool button, that allows (de)activating
+ this search widgte or defines the comparison operator to use.
+%End
 
   protected:
 

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -227,6 +227,7 @@ QList<QgsAggregateCalculator::AggregateInfo> QgsAggregateCalculator::aggregates(
         << QVariant::UInt
         << QVariant::LongLong
         << QVariant::ULongLong
+        << QVariant::Double
         << QVariant::String
   }
       << AggregateInfo
@@ -240,6 +241,7 @@ QList<QgsAggregateCalculator::AggregateInfo> QgsAggregateCalculator::aggregates(
         << QVariant::UInt
         << QVariant::LongLong
         << QVariant::ULongLong
+        << QVariant::Double
         << QVariant::String
   }
       << AggregateInfo

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -174,6 +174,232 @@ QgsAggregateCalculator::Aggregate QgsAggregateCalculator::stringToAggregate( con
   return Count;
 }
 
+QList<QgsAggregateCalculator::AggregateInfo> QgsAggregateCalculator::aggregates()
+{
+  QList< AggregateInfo > aggregates;
+  aggregates
+      << AggregateInfo
+  {
+    QStringLiteral( "count" ),
+    QCoreApplication::tr( "Count" ),
+    QSet<QVariant::Type>()
+        << QVariant::DateTime
+        << QVariant::Date
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "count_distinct" ),
+    QCoreApplication::tr( "Count Distinct" ),
+    QSet<QVariant::Type>()
+        << QVariant::DateTime
+        << QVariant::Date
+        << QVariant::UInt
+        << QVariant::Int
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "count_missing" ),
+    QCoreApplication::tr( "Count Missing" ),
+    QSet<QVariant::Type>()
+        << QVariant::DateTime
+        << QVariant::Date
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "min" ),
+    QCoreApplication::tr( "Min" ),
+    QSet<QVariant::Type>()
+        << QVariant::DateTime
+        << QVariant::Date
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "max" ),
+    QCoreApplication::tr( "Max" ),
+    QSet<QVariant::Type>()
+        << QVariant::DateTime
+        << QVariant::Date
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "sum" ),
+    QCoreApplication::tr( "Sum" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "mean" ),
+    QCoreApplication::tr( "Mean" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "median" ),
+    QCoreApplication::tr( "Median" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "stdev" ),
+    QCoreApplication::tr( "Stdev" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "stdevsample" ),
+    QCoreApplication::tr( "Stdev Sample" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "range" ),
+    QCoreApplication::tr( "Range" ),
+    QSet<QVariant::Type>()
+        << QVariant::Date
+        << QVariant::DateTime
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "minority" ),
+    QCoreApplication::tr( "Minority" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "majority" ),
+    QCoreApplication::tr( "Majority" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "q1" ),
+    QCoreApplication::tr( "Q1" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "q3" ),
+    QCoreApplication::tr( "Q3" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "iqr" ),
+    QCoreApplication::tr( "InterQuartileRange" ),
+    QSet<QVariant::Type>()
+        << QVariant::Int
+        << QVariant::UInt
+        << QVariant::LongLong
+        << QVariant::ULongLong
+        << QVariant::Double
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "min_length" ),
+    QCoreApplication::tr( "Min Length" ),
+    QSet<QVariant::Type>()
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "max_length" ),
+    QCoreApplication::tr( "Max Length" ),
+    QSet<QVariant::Type>()
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "concatenate" ),
+    QCoreApplication::tr( "Concatenate" ),
+    QSet<QVariant::Type>()
+        << QVariant::String
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "collect" ),
+    QCoreApplication::tr( "Collect" ),
+    QSet<QVariant::Type>()
+  }
+      << AggregateInfo
+  {
+    QStringLiteral( "array_agg" ),
+    QCoreApplication::tr( "Array Aggregate" ),
+    QSet<QVariant::Type>()
+  };
+
+  return aggregates;
+}
+
 QVariant QgsAggregateCalculator::calculate( QgsAggregateCalculator::Aggregate aggregate, QgsFeatureIterator &fit, QVariant::Type resultType,
     int attr, QgsExpression *expression, const QString &delimiter, QgsExpressionContext *context, bool *ok )
 {

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -167,6 +167,11 @@ class CORE_EXPORT QgsAggregateCalculator
      */
     static Aggregate stringToAggregate( const QString &string, bool *ok = nullptr );
 
+    /**
+     * Structured information for available aggregates.
+     *
+     * \since QGIS 3.2
+     */
     static QList< QgsAggregateCalculator::AggregateInfo > aggregates();
 
   private:

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -43,11 +43,16 @@ class CORE_EXPORT QgsAggregateCalculator
 {
   public:
 
+    /**
+     * Structured information about the available aggregates.
+     *
+     * \since QGIS 3.0
+     */
     struct AggregateInfo
     {
-      QString function;
-      QString name;
-      QSet<QVariant::Type> supportedTypes;
+      QString function; //!< The expression function
+      QString name; //!< A translated, human readable name
+      QSet<QVariant::Type> supportedTypes; //!< This aggregate function can only be used with these datatypes
     };
 
     /**

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsAggregateCalculator
     /**
      * Structured information about the available aggregates.
      *
-     * \since QGIS 3.0
+     * \since QGIS 3.2
      */
     struct AggregateInfo
     {

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -43,6 +43,13 @@ class CORE_EXPORT QgsAggregateCalculator
 {
   public:
 
+    struct AggregateInfo
+    {
+      QString function;
+      QString name;
+      QSet<QVariant::Type> supportedTypes;
+    };
+
     /**
      * Available aggregates to calculate. Not all aggregates are available for all field
      * types.
@@ -154,6 +161,8 @@ class CORE_EXPORT QgsAggregateCalculator
      * \returns aggregate type
      */
     static Aggregate stringToAggregate( const QString &string, bool *ok = nullptr );
+
+    static QList< QgsAggregateCalculator::AggregateInfo > aggregates();
 
   private:
 

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsAggregateCalculator
     /**
      * Structured information about the available aggregates.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.0
      */
     struct AggregateInfo
     {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -197,6 +197,7 @@ SET(QGIS_GUI_SRCS
   qgsattributeforminterface.cpp
   qgsattributeformlegacyinterface.cpp
   qgsattributetypeloaddialog.cpp
+  qgsattributeformwidget.cpp
   qgsblendmodecombobox.cpp
   qgsbrowsertreeview.cpp
   qgsbrowserdockwidget.cpp
@@ -370,6 +371,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsattributedialog.h
   qgsattributeform.h
   qgsattributeformeditorwidget.h
+  qgsattributeformwidget.h
   qgsattributetypeloaddialog.h
   qgsblendmodecombobox.h
   qgsbrowsertreeview.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -125,6 +125,7 @@ SET(QGIS_GUI_SRCS
   editorwidgets/qgsrangeconfigdlg.cpp
   editorwidgets/qgsrangewidgetwrapper.cpp
   editorwidgets/qgsrangewidgetfactory.cpp
+  editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
   editorwidgets/qgssearchwidgettoolbutton.cpp
   editorwidgets/qgsspinbox.cpp
   editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -191,6 +192,7 @@ SET(QGIS_GUI_SRCS
   qgsactionmenu.cpp
   qgsadvanceddigitizingcanvasitem.cpp
   qgsadvanceddigitizingdockwidget.cpp
+  qgsaggregatetoolbutton.cpp
   qgsattributedialog.cpp
   qgsattributeform.cpp
   qgsattributeformeditorwidget.cpp
@@ -198,6 +200,7 @@ SET(QGIS_GUI_SRCS
   qgsattributeformlegacyinterface.cpp
   qgsattributetypeloaddialog.cpp
   qgsattributeformwidget.cpp
+  qgsattributeformrelationeditorwidget.cpp
   qgsblendmodecombobox.cpp
   qgsbrowsertreeview.cpp
   qgsbrowserdockwidget.cpp
@@ -368,9 +371,11 @@ SET(QGIS_GUI_MOC_HDRS
   qgisinterface.h
   qgsactionmenu.h
   qgsadvanceddigitizingdockwidget.h
+  qgsaggregatetoolbutton.h
   qgsattributedialog.h
   qgsattributeform.h
   qgsattributeformeditorwidget.h
+  qgsattributeformrelationeditorwidget.h
   qgsattributeformwidget.h
   qgsattributetypeloaddialog.h
   qgsblendmodecombobox.h
@@ -647,6 +652,7 @@ SET(QGIS_GUI_MOC_HDRS
   editorwidgets/qgsrelationreferencewidget.h
   editorwidgets/qgsrelationreferencewidgetwrapper.h
   editorwidgets/qgsrelationwidgetwrapper.h
+  editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
   editorwidgets/qgssearchwidgettoolbutton.h
   editorwidgets/qgsspinbox.h
   editorwidgets/qgstexteditconfigdlg.h

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -38,8 +38,9 @@ int QgsEditorWidgetWrapper::fieldIdx() const
 
 QgsField QgsEditorWidgetWrapper::field() const
 {
-  if ( mFieldIdx < layer()->fields().count() )
-    return layer()->fields().at( mFieldIdx );
+  QgsVectorLayer *vl = layer();
+  if ( vl && mFieldIdx < vl->fields().count() )
+    return vl->fields().at( mFieldIdx );
   else
     return QgsField();
 }

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
@@ -100,6 +100,15 @@ QgsSearchWidgetWrapper::FilterFlags QgsSearchWidgetWrapper::defaultFlags() const
   return FilterFlags();
 }
 
+QString QgsSearchWidgetWrapper::createFieldIdentifier() const
+{
+  QString field = QgsExpression::quotedColumnRef( layer()->fields().at( mFieldIdx ).name() );
+  if ( mAggregate.isEmpty() )
+    return field;
+  else
+    return QStringLiteral( "relation_aggregate('%1','%2',%3)" ).arg( context().relation().id(), mAggregate, field );
+}
+
 void QgsSearchWidgetWrapper::setFeature( const QgsFeature &feature )
 {
   Q_UNUSED( feature )
@@ -108,5 +117,25 @@ void QgsSearchWidgetWrapper::setFeature( const QgsFeature &feature )
 void QgsSearchWidgetWrapper::clearExpression()
 {
   mExpression = QStringLiteral( "TRUE" );
+}
+
+QgsRelation QgsSearchWidgetWrapper::aggregateRelation() const
+{
+  return mAggregateRelation;
+}
+
+void QgsSearchWidgetWrapper::setAggregateRelation( const QgsRelation &aggregateRelation )
+{
+  mAggregateRelation = aggregateRelation;
+}
+
+QString QgsSearchWidgetWrapper::aggregate() const
+{
+  return mAggregate;
+}
+
+void QgsSearchWidgetWrapper::setAggregate( const QString &aggregate )
+{
+  mAggregate = aggregate;
 }
 

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
@@ -119,16 +119,6 @@ void QgsSearchWidgetWrapper::clearExpression()
   mExpression = QStringLiteral( "TRUE" );
 }
 
-QgsRelation QgsSearchWidgetWrapper::aggregateRelation() const
-{
-  return mAggregateRelation;
-}
-
-void QgsSearchWidgetWrapper::setAggregateRelation( const QgsRelation &aggregateRelation )
-{
-  mAggregateRelation = aggregateRelation;
-}
-
 QString QgsSearchWidgetWrapper::aggregate() const
 {
   return mAggregate;

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
@@ -187,7 +187,7 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
      * If in SearchMode returns a quoted field identifier.
      * If in AggregateSearchMode returns an appropriate aggregate expression.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.0
      */
     QString createFieldIdentifier() const;
 
@@ -195,7 +195,7 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
      * If in AggregateSearch mode, which aggregate should be used to construct
      * the filter expression. Is a Null String if none.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.0
      */
     QString aggregate() const;
 
@@ -203,7 +203,7 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
      * If in AggregateSearch mode, which aggregate should be used to construct
      * the filter expression. Is a Null String if none.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.0
      */
     void setAggregate( const QString &aggregate );
 

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
@@ -79,14 +79,8 @@ class QgsField;
 
 /**
  * \ingroup gui
- * Manages an editor widget
- * Widget and wrapper share the same parent
  *
- * A wrapper controls one attribute editor widget and is able to create a default
- * widget or use a pre-existent widget. It is able to set the widget to the value implied
- * by a field of a vector layer, or return the value it currently holds. Every time it is changed
- * it has to emit a valueChanged signal. If it fails to do so, there is no guarantee that the
- * changed status of the widget will be saved.
+ * Shows a search widget on a filter form.
  */
 class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
 {
@@ -188,15 +182,30 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
     // TODO QGIS 3.0 - make pure virtual
     virtual QString createExpression( FilterFlags flags ) const { Q_UNUSED( flags ); return QStringLiteral( "TRUE" ); }
 
+    /**
+     * Get a field name or expression to use as field comparison.
+     * If in SearchMode returns a quoted field identifier.
+     * If in AggregateSearchMode returns an appropriate aggregate expression.
+     *
+     * \since QGIS 3.2
+     */
     QString createFieldIdentifier() const;
 
-
-
+    /**
+     * If in AggregateSearch mode, which aggregate should be used to construct
+     * the filter expression. Is a Null String if none.
+     *
+     * \since QGIS 3.2
+     */
     QString aggregate() const;
-    void setAggregate( const QString &aggregate );
 
-    QgsRelation aggregateRelation() const;
-    void setAggregateRelation( const QgsRelation &aggregateRelation );
+    /**
+     * If in AggregateSearch mode, which aggregate should be used to construct
+     * the filter expression. Is a Null String if none.
+     *
+     * \since QGIS 3.2
+     */
+    void setAggregate( const QString &aggregate );
 
   public slots:
 

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
@@ -188,6 +188,16 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
     // TODO QGIS 3.0 - make pure virtual
     virtual QString createExpression( FilterFlags flags ) const { Q_UNUSED( flags ); return QStringLiteral( "TRUE" ); }
 
+    QString createFieldIdentifier() const;
+
+
+
+    QString aggregate() const;
+    void setAggregate( const QString &aggregate );
+
+    QgsRelation aggregateRelation() const;
+    void setAggregateRelation( const QgsRelation &aggregateRelation );
+
   public slots:
 
     /**
@@ -239,6 +249,9 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
     QString mExpression;
     int mFieldIdx;
 
+  private:
+    QString mAggregate;
+    QgsRelation mAggregateRelation;
 };
 // We'll use this class inside a QVariant in the widgets properties
 Q_DECLARE_METATYPE( QgsSearchWidgetWrapper * )

--- a/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.cpp
@@ -61,7 +61,7 @@ QgsSearchWidgetWrapper::FilterFlags QgsCheckboxSearchWidgetWrapper::defaultFlags
 QString QgsCheckboxSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const
 {
   QVariant::Type fldType = layer()->fields().at( mFieldIdx ).type();
-  QString fieldName = QgsExpression::quotedColumnRef( layer()->fields().at( mFieldIdx ).name() );
+  QString fieldName = createFieldIdentifier();
 
   //clear any unsupported flags
   flags &= supportedFlags();

--- a/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.cpp
@@ -62,7 +62,7 @@ QgsSearchWidgetWrapper::FilterFlags QgsDateTimeSearchWidgetWrapper::defaultFlags
 
 QString QgsDateTimeSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const
 {
-  QString fieldName = QgsExpression::quotedColumnRef( layer()->fields().at( mFieldIdx ).name() );
+  QString fieldName = createFieldIdentifier();
 
   //clear any unsupported flags
   flags &= supportedFlags();

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -148,7 +148,7 @@ QString QgsDefaultSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper:
   flags &= supportedFlags();
 
   QVariant::Type fldType = layer()->fields().at( mFieldIdx ).type();
-  QString fieldName = QgsExpression::quotedColumnRef( layer()->fields().at( mFieldIdx ).name() );
+  QString fieldName = createFieldIdentifier();
 
   if ( flags & IsNull )
     return fieldName + " IS NULL";

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
@@ -1,0 +1,61 @@
+/***************************************************************************
+     qgsrelationaggregatesearchwidget.cpp
+     -----------------------------
+    Date                 : Nov 2017
+    Copyright            : (C) 2017 Matthias Kuhn
+    Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgsrelationaggregatesearchwidgetwrapper.h"
+#include "qgsattributeform.h"
+#include "qgsrelationwidgetwrapper.h"
+
+#include <QLabel>
+
+QgsRelationAggregateSearchWidgetWrapper::QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *vl, QgsRelationWidgetWrapper *wrapper, QWidget *parent )
+  : QgsSearchWidgetWrapper( vl, -1, parent )
+  , mWrapper( wrapper )
+{
+  setContext( mWrapper->context() );
+}
+
+QString QgsRelationAggregateSearchWidgetWrapper::expression() const
+{
+  QString aggregateFilter = mAttributeForm->aggregateFilter();
+
+  if ( aggregateFilter.isEmpty() )
+    return QStringLiteral( "TRUE" );
+  else
+    return aggregateFilter;
+}
+
+bool QgsRelationAggregateSearchWidgetWrapper::valid() const
+{
+  return true;
+}
+
+QWidget *QgsRelationAggregateSearchWidgetWrapper::createWidget( QWidget *parent )
+{
+  QgsAttributeEditorContext subContext = QgsAttributeEditorContext( context(), mWrapper->relation(), QgsAttributeEditorContext::Multiple, QgsAttributeEditorContext::Embed );
+  mAttributeForm = new QgsAttributeForm( mWrapper->relation().referencingLayer(), QgsFeature(), subContext, parent );
+  mAttributeForm->setMode( QgsAttributeForm::AggregateSearchMode );
+  return mAttributeForm;
+}
+
+bool QgsRelationAggregateSearchWidgetWrapper::applyDirectly()
+{
+  return true;
+}
+
+void QgsRelationAggregateSearchWidgetWrapper::setExpression( const QString &value )
+{
+
+}

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
@@ -18,8 +18,10 @@
 #include "qgsattributeform.h"
 #include "qgsrelationwidgetwrapper.h"
 #include "qgslogger.h"
+#include "qgscollapsiblegroupbox.h"
 
 #include <QLabel>
+#include <QGridLayout>
 
 QgsRelationAggregateSearchWidgetWrapper::QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *vl, QgsRelationWidgetWrapper *wrapper, QWidget *parent )
   : QgsSearchWidgetWrapper( vl, -1, parent )
@@ -51,6 +53,8 @@ QWidget *QgsRelationAggregateSearchWidgetWrapper::createWidget( QWidget *parent 
   QWidget *widget;
   QgsRelation relation = mWrapper->relation();
 
+  QgsCollapsibleGroupBox *groupBox = new QgsCollapsibleGroupBox( relation.name() );
+
   if ( !relation.isValid() )
   {
     widget = new QLabel( tr( "Relation not valid" ) );
@@ -63,7 +67,10 @@ QWidget *QgsRelationAggregateSearchWidgetWrapper::createWidget( QWidget *parent 
     widget = mAttributeForm;
   }
 
-  return widget;
+  groupBox->setLayout( new QGridLayout() );
+  groupBox->layout()->addWidget( widget );
+
+  return groupBox;
 }
 
 bool QgsRelationAggregateSearchWidgetWrapper::applyDirectly()

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
@@ -30,7 +30,10 @@ QgsRelationAggregateSearchWidgetWrapper::QgsRelationAggregateSearchWidgetWrapper
 
 QString QgsRelationAggregateSearchWidgetWrapper::expression() const
 {
-  QString aggregateFilter = mAttributeForm->aggregateFilter();
+  QString aggregateFilter;
+
+  if ( mAttributeForm )
+    aggregateFilter = mAttributeForm->aggregateFilter();
 
   if ( aggregateFilter.isEmpty() )
     return QStringLiteral( "TRUE" );
@@ -45,10 +48,22 @@ bool QgsRelationAggregateSearchWidgetWrapper::valid() const
 
 QWidget *QgsRelationAggregateSearchWidgetWrapper::createWidget( QWidget *parent )
 {
-  QgsAttributeEditorContext subContext = QgsAttributeEditorContext( context(), mWrapper->relation(), QgsAttributeEditorContext::Multiple, QgsAttributeEditorContext::Embed );
-  mAttributeForm = new QgsAttributeForm( mWrapper->relation().referencingLayer(), QgsFeature(), subContext, parent );
-  mAttributeForm->setMode( QgsAttributeForm::AggregateSearchMode );
-  return mAttributeForm;
+  QWidget *widget;
+  QgsRelation relation = mWrapper->relation();
+
+  if ( !relation.isValid() )
+  {
+    widget = new QLabel( tr( "Relation not valid" ) );
+  }
+  else
+  {
+    QgsAttributeEditorContext subContext = QgsAttributeEditorContext( context(), mWrapper->relation(), QgsAttributeEditorContext::Multiple, QgsAttributeEditorContext::Embed );
+    mAttributeForm = new QgsAttributeForm( mWrapper->relation().referencingLayer(), QgsFeature(), subContext, parent );
+    mAttributeForm->setMode( QgsAttributeForm::AggregateSearchMode );
+    widget = mAttributeForm;
+  }
+
+  return widget;
 }
 
 bool QgsRelationAggregateSearchWidgetWrapper::applyDirectly()

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
@@ -17,6 +17,7 @@
 #include "qgsrelationaggregatesearchwidgetwrapper.h"
 #include "qgsattributeform.h"
 #include "qgsrelationwidgetwrapper.h"
+#include "qgslogger.h"
 
 #include <QLabel>
 
@@ -57,5 +58,6 @@ bool QgsRelationAggregateSearchWidgetWrapper::applyDirectly()
 
 void QgsRelationAggregateSearchWidgetWrapper::setExpression( const QString &value )
 {
-
+  Q_UNUSED( value )
+  QgsDebugMsg( "Not supported" );
 }

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
@@ -51,10 +51,8 @@ class GUI_EXPORT QgsRelationAggregateSearchWidgetWrapper : public QgsSearchWidge
     virtual void setExpression( const QString &value ) override;
 
   private:
-    QgsRelationWidgetWrapper *mWrapper;
-    QgsAttributeForm *mAttributeForm;
-
-
+    QgsRelationWidgetWrapper *mWrapper = nullptr;
+    QgsAttributeForm *mAttributeForm = nullptr;
 };
 
 #endif // QGSRELATIONAGGREGATESEARCHWIDGETWRAPPER_H

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+     qgsrelationaggregatesearchwidget.h
+     -----------------------------
+    Date                 : Nov 2017
+    Copyright            : (C) 2017 Matthias Kuhn
+    Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSRELATIONAGGREGATESEARCHWIDGETWRAPPER_H
+#define QGSRELATIONAGGREGATESEARCHWIDGETWRAPPER_H
+
+#include "qgis_gui.h"
+#include "qgssearchwidgetwrapper.h"
+#include "qgsattributeform.h"
+
+class QgsRelationWidgetWrapper;
+
+class GUI_EXPORT QgsRelationAggregateSearchWidgetWrapper : public QgsSearchWidgetWrapper
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *vl, QgsRelationWidgetWrapper *wrapper, QWidget *parent SIP_TRANSFERTHIS = 0 );
+
+    virtual QString expression() const override;
+
+    virtual bool valid() const override;
+    virtual QWidget *createWidget( QWidget *parent ) override;
+    virtual bool applyDirectly() override;
+    virtual void setExpression( const QString &value ) override;
+
+  private:
+    QgsRelationWidgetWrapper *mWrapper;
+    QgsAttributeForm *mAttributeForm;
+
+
+};
+
+#endif // QGSRELATIONAGGREGATESEARCHWIDGETWRAPPER_H

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
@@ -30,7 +30,7 @@ class QgsRelationWidgetWrapper;
  * For each attribute of the child, an additional QgsAggregateToolButton will be shown
  * to determine how the values should be aggregated for searching.
  *
- * \since QGIS 3.2
+ * \since QGIS 3.0
  */
 class GUI_EXPORT QgsRelationAggregateSearchWidgetWrapper : public QgsSearchWidgetWrapper
 {

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
@@ -23,12 +23,25 @@
 
 class QgsRelationWidgetWrapper;
 
+/**
+ * \ingroup gui
+ *
+ * Search widget for the children of a relation.
+ * For each attribute of the child, an additional QgsAggregateToolButton will be shown
+ * to determine how the values should be aggregated for searching.
+ *
+ * \since QGIS 3.2
+ */
 class GUI_EXPORT QgsRelationAggregateSearchWidgetWrapper : public QgsSearchWidgetWrapper
 {
     Q_OBJECT
 
   public:
-    explicit QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *vl, QgsRelationWidgetWrapper *wrapper, QWidget *parent SIP_TRANSFERTHIS = 0 );
+
+    /**
+     * Constructor
+     */
+    explicit QgsRelationAggregateSearchWidgetWrapper( QgsVectorLayer *layer, QgsRelationWidgetWrapper *wrapper, QWidget *parent SIP_TRANSFERTHIS = 0 );
 
     virtual QString expression() const override;
 

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -63,7 +63,7 @@ QgsSearchWidgetWrapper::FilterFlags QgsRelationReferenceSearchWidgetWrapper::def
 
 QString QgsRelationReferenceSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const
 {
-  QString fieldName = QgsExpression::quotedColumnRef( layer()->fields().at( mFieldIdx ).name() );
+  QString fieldName = createFieldIdentifier();
 
   //clear any unsupported flags
   flags &= supportedFlags();

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -46,6 +46,11 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
     mWidget->setVisible( visible );
 }
 
+QgsRelation QgsRelationWidgetWrapper::relation() const
+{
+  return mRelation;
+}
+
 bool QgsRelationWidgetWrapper::showUnlinkButton() const
 {
   return mWidget->showUnlinkButton();

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -79,6 +79,11 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      */
     void setShowUnlinkButton( bool showUnlinkButton );
 
+    /**
+     * The relation for which this wrapper is created.
+     *
+     * \since QGIS 3.2
+     */
     QgsRelation relation() const;
 
   protected:

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -79,6 +79,8 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      */
     void setShowUnlinkButton( bool showUnlinkButton );
 
+    QgsRelation relation() const;
+
   protected:
     QWidget *createWidget( QWidget *parent ) override;
     void initWidget( QWidget *editor ) override;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -82,7 +82,7 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
     /**
      * The relation for which this wrapper is created.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.0
      */
     QgsRelation relation() const;
 

--- a/src/gui/editorwidgets/qgssearchwidgettoolbutton.h
+++ b/src/gui/editorwidgets/qgssearchwidgettoolbutton.h
@@ -21,6 +21,12 @@
 #include <QToolButton>
 #include "qgis_gui.h"
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+#include "qgssearchwidgettoolbutton.h"
+% End
+#endif
+
 /**
  * \ingroup gui
  * \class QgsSearchWidgetToolButton
@@ -31,6 +37,16 @@
  */
 class GUI_EXPORT QgsSearchWidgetToolButton : public QToolButton
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsSearchWidgetToolButton *>( sipCpp ) )
+      sipType = sipType_QgsSearchWidgetToolButton;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
+
     Q_OBJECT
 
   public:

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -88,7 +88,7 @@ QString QgsValueMapSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper
   flags &= supportedFlags();
 
   QVariant::Type fldType = layer()->fields().at( mFieldIdx ).type();
-  QString fieldName = QgsExpression::quotedColumnRef( layer()->fields().at( mFieldIdx ).name() );
+  QString fieldName = createFieldIdentifier();
 
   if ( flags & IsNull )
     return fieldName + " IS NULL";

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -94,7 +94,7 @@ QgsSearchWidgetWrapper::FilterFlags QgsValueRelationSearchWidgetWrapper::default
 
 QString QgsValueRelationSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const
 {
-  QString fieldName = QgsExpression::quotedColumnRef( layer()->fields().at( mFieldIdx ).name() );
+  QString fieldName = createFieldIdentifier();
 
   //clear any unsupported flags
   flags &= supportedFlags();

--- a/src/gui/qgsaggregatetoolbutton.cpp
+++ b/src/gui/qgsaggregatetoolbutton.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+    qgsaggregatetoolbutton.cpp
+     --------------------------------------
+    Date                 : Nov 2017
+    Copyright            : (C) 2017 Matthias Kuhn
+    Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsaggregatetoolbutton.h"
+#include "qgsaggregatecalculator.h"
+
+#include <QMenu>
+
+QgsAggregateToolButton::QgsAggregateToolButton()
+{
+  setFocusPolicy( Qt::StrongFocus );
+  setPopupMode( QToolButton::InstantPopup );
+
+  mMenu = new QMenu( this );
+  connect( mMenu, &QMenu::aboutToShow, this, &QgsAggregateToolButton::aboutToShowMenu );
+  setMenu( mMenu );
+
+  setText( tr( "Exclude" ) );
+}
+
+void QgsAggregateToolButton::setType( QVariant::Type type )
+{
+  if ( mType == type )
+    return;
+
+  mType = type;
+  updateAvailableAggregates();
+}
+
+void QgsAggregateToolButton::aboutToShowMenu()
+{
+  mMenu->clear();
+
+  for ( const auto &aggregate : qgis::as_const( mAvailableAggregates ) )
+  {
+    mMenu->addAction( aggregate.name, this, [ this, aggregate ]
+    {
+      setText( aggregate.name );
+      setAggregate( aggregate.function );
+    } );
+  }
+}
+
+void QgsAggregateToolButton::updateAvailableAggregates()
+{
+  QList<QgsAggregateCalculator::AggregateInfo> aggregates = QgsAggregateCalculator::aggregates();
+
+  for ( const auto &aggregate : aggregates )
+  {
+    if ( aggregate.supportedTypes.contains( mType ) )
+    {
+      mAvailableAggregates.append( aggregate );
+    }
+  }
+}
+
+void QgsAggregateToolButton::setActive( bool active )
+{
+  if ( active == mActive )
+    return;
+
+  mActive = active;
+
+  if ( !active )
+    setText( tr( "Exclude" ) );
+  emit activeChanged();
+}
+
+QString QgsAggregateToolButton::aggregate() const
+{
+  return mAggregate;
+}
+
+void QgsAggregateToolButton::setAggregate( const QString &aggregate )
+{
+  if ( aggregate == mAggregate )
+    return;
+
+  mAggregate = QString();
+
+  for ( const auto &agg : qgis::as_const( mAvailableAggregates ) )
+  {
+    if ( agg.function == aggregate )
+    {
+      mAggregate = aggregate;
+      break;
+    }
+  }
+
+  setActive( !mAggregate.isEmpty() );
+
+  emit aggregateChanged();
+}
+
+bool QgsAggregateToolButton::active() const
+{
+  return mActive;
+}
+
+QVariant::Type QgsAggregateToolButton::type() const
+{
+  return mType;
+}

--- a/src/gui/qgsaggregatetoolbutton.cpp
+++ b/src/gui/qgsaggregatetoolbutton.cpp
@@ -43,9 +43,16 @@ void QgsAggregateToolButton::aboutToShowMenu()
 {
   mMenu->clear();
 
+  QAction *action = mMenu->addAction( tr( "Exclude" ) );
+  connect( action, &QAction::triggered, [ this ]
+  {
+    setActive( false );
+  } );
+
   for ( const auto &aggregate : qgis::as_const( mAvailableAggregates ) )
   {
-    mMenu->addAction( aggregate.name, this, [ this, aggregate ]
+    QAction *action = mMenu->addAction( aggregate.name );
+    connect( action, &QAction::triggered, [ this, aggregate ]
     {
       setText( aggregate.name );
       setAggregate( aggregate.function );
@@ -95,6 +102,7 @@ void QgsAggregateToolButton::setAggregate( const QString &aggregate )
     if ( agg.function == aggregate )
     {
       mAggregate = aggregate;
+      setText( agg.name );
       break;
     }
   }

--- a/src/gui/qgsaggregatetoolbutton.h
+++ b/src/gui/qgsaggregatetoolbutton.h
@@ -22,25 +22,65 @@
 #include "qgsaggregatecalculator.h"
 #include "qgis_gui.h"
 
+/**
+ * \ingroup gui
+ *
+ * Offers a toolbutton to choose between different aggregate functions.
+ * Functions are filtered based on the type.
+ *
+ * \since QGIS 3.2
+ */
 class GUI_EXPORT QgsAggregateToolButton : public QToolButton
 {
     Q_OBJECT
 
   public:
+
+    /**
+     * Constructor
+     */
     QgsAggregateToolButton();
 
+    /**
+     * Based on the \a type of underlying data, some aggregates will be available or not.
+     */
     void setType( QVariant::Type type );
 
+    /**
+     * Based on the \a type of underlying data, some aggregates will be available or not.
+     */
     QVariant::Type type() const;
 
+    /**
+     * When this flag is false, the aggregate will be deactivated. I.e. no aggregate is chosen.
+     */
     void setActive( bool active );
+
+    /**
+     * When this flag is false, the aggregate will be deactivated. I.e. no aggregate is chosen.
+     */
     bool active() const;
 
+    /**
+     * The function name of the selected aggregate or a Null String if none is chosen.
+     */
     QString aggregate() const;
+
+    /**
+     * The function name of the selected aggregate or a Null String if none is chosen.
+     */
     void setAggregate( const QString &aggregate );
 
   signals:
+
+    /**
+     * The function name of the selected aggregate has changed.
+     */
     void aggregateChanged();
+
+    /**
+     * A function has been selected or unselected.
+     */
     void activeChanged();
 
   private slots:

--- a/src/gui/qgsaggregatetoolbutton.h
+++ b/src/gui/qgsaggregatetoolbutton.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+    qgsaggregatetoolbutton.h
+     --------------------------------------
+    Date                 : Nov 2017
+    Copyright            : (C) 2017 Matthias Kuhn
+    Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAGGREGATETOOLBUTTON_H
+#define QGSAGGREGATETOOLBUTTON_H
+
+#include <QToolButton>
+#include <QVariant>
+
+#include "qgsaggregatecalculator.h"
+#include "qgis_gui.h"
+
+class GUI_EXPORT QgsAggregateToolButton : public QToolButton
+{
+    Q_OBJECT
+
+  public:
+    QgsAggregateToolButton();
+
+    void setType( QVariant::Type type );
+
+    QVariant::Type type() const;
+
+    void setActive( bool active );
+    bool active() const;
+
+    QString aggregate() const;
+    void setAggregate( const QString &aggregate );
+
+  signals:
+    void aggregateChanged();
+    void activeChanged();
+
+  private slots:
+    void aboutToShowMenu();
+
+  private:
+    void updateAvailableAggregates();
+    QMenu *mMenu = nullptr;
+    QVariant::Type mType;
+    bool mActive = false;
+    QString mAggregate;
+    QList<QgsAggregateCalculator::AggregateInfo> mAvailableAggregates;
+};
+
+#endif // QGSAGGREGATETOOLBUTTON_H

--- a/src/gui/qgsaggregatetoolbutton.h
+++ b/src/gui/qgsaggregatetoolbutton.h
@@ -79,7 +79,7 @@ class GUI_EXPORT QgsAggregateToolButton : public QToolButton
     void aggregateChanged();
 
     /**
-     * A function has been selected or unselected.
+     * A function has been selected or deselected.
      */
     void activeChanged();
 

--- a/src/gui/qgsaggregatetoolbutton.h
+++ b/src/gui/qgsaggregatetoolbutton.h
@@ -28,7 +28,7 @@
  * Offers a toolbutton to choose between different aggregate functions.
  * Functions are filtered based on the type.
  *
- * \since QGIS 3.2
+ * \since QGIS 3.0
  */
 class GUI_EXPORT QgsAggregateToolButton : public QToolButton
 {

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -151,24 +151,24 @@ void QgsAttributeForm::setMode( QgsAttributeForm::Mode mode )
   }
 
   //update all form editor widget modes to match
-  Q_FOREACH ( QgsAttributeFormEditorWidget *w, findChildren<  QgsAttributeFormEditorWidget * >() )
+  for ( QgsAttributeFormWidget *w : findChildren<  QgsAttributeFormWidget * >() )
   {
     switch ( mode )
     {
       case QgsAttributeForm::SingleEditMode:
-        w->setMode( QgsAttributeFormEditorWidget::DefaultMode );
+        w->setMode( QgsAttributeFormWidget::DefaultMode );
         break;
 
       case QgsAttributeForm::AddFeatureMode:
-        w->setMode( QgsAttributeFormEditorWidget::DefaultMode );
+        w->setMode( QgsAttributeFormWidget::DefaultMode );
         break;
 
       case QgsAttributeForm::MultiEditMode:
-        w->setMode( QgsAttributeFormEditorWidget::MultiEditMode );
+        w->setMode( QgsAttributeFormWidget::MultiEditMode );
         break;
 
       case QgsAttributeForm::SearchMode:
-        w->setMode( QgsAttributeFormEditorWidget::SearchMode );
+        w->setMode( QgsAttributeFormWidget::SearchMode );
         break;
     }
   }
@@ -1221,10 +1221,10 @@ void QgsAttributeForm::init()
       QWidget *w = nullptr;
       if ( eww )
       {
-        QgsAttributeFormEditorWidget *formWidget = new QgsAttributeFormEditorWidget( eww, this );
+        QgsAttributeFormEditorWidget *formWidget = new QgsAttributeFormEditorWidget( eww, widgetSetup.type(), this );
         w = formWidget;
         mFormEditorWidgets.insert( idx, formWidget );
-        formWidget->createSearchWidgetWrappers( widgetSetup.type(), idx, widgetSetup.config(), mContext );
+        formWidget->createSearchWidgetWrappers( mContext );
 
         l->setBuddy( eww->widget() );
       }
@@ -1523,10 +1523,10 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
         const QgsEditorWidgetSetup widgetSetup = QgsGui::editorWidgetRegistry()->findBest( mLayer, fieldDef->name() );
 
         QgsEditorWidgetWrapper *eww = QgsGui::editorWidgetRegistry()->create( widgetSetup.type(), mLayer, fldIdx, widgetSetup.config(), nullptr, this, mContext );
-        QgsAttributeFormEditorWidget *w = new QgsAttributeFormEditorWidget( eww, this );
+        QgsAttributeFormEditorWidget *w = new QgsAttributeFormEditorWidget( eww, widgetSetup.type(), this );
         mFormEditorWidgets.insert( fldIdx, w );
 
-        w->createSearchWidgetWrappers( widgetSetup.type(), fldIdx, widgetSetup.config(), mContext );
+        w->createSearchWidgetWrappers( mContext );
 
         newWidgetInfo.widget = w;
         addWidgetWrapper( eww );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
       will add a new feature when the form is accepted. */
       MultiEditMode, //!< Multi edit mode, for editing fields of multiple features at once
       SearchMode, //!< Form values are used for searching/filtering the layer
-      AggregateSearchMode, //!< Form is in aggregate search mode, show each widget in this mode \since QGIS 3.2
+      AggregateSearchMode, //!< Form is in aggregate search mode, show each widget in this mode \since QGIS 3.0
     };
 
     //! Filter types
@@ -166,7 +166,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      * In this case it will return a combined expression according to the chosen filters
      * on all attribute widgets.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.0
      */
     QString aggregateFilter() const;
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -54,6 +54,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
       will add a new feature when the form is accepted. */
       MultiEditMode, //!< Multi edit mode, for editing fields of multiple features at once
       SearchMode, //!< Form values are used for searching/filtering the layer
+      AggregateSearchMode,
     };
 
     //! Filter types
@@ -159,6 +160,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      * \since QGIS 2.16
      */
     void setMessageBar( QgsMessageBar *messageBar );
+
+    QString aggregateFilter() const;
 
   signals:
 
@@ -351,6 +354,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QWidget *mSearchButtonBox = nullptr;
     QList<QgsAttributeFormInterface *> mInterfaces;
     QMap< int, QgsAttributeFormEditorWidget * > mFormEditorWidgets;
+    QList< QgsAttributeFormWidget *> mFormWidgets;
     QgsExpressionContext mExpressionContext;
     QMap<const QgsVectorLayerJoinInfo *, QgsFeature> mJoinedFeatures;
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -34,6 +34,7 @@ class QgsMessageBar;
 class QgsMessageBarItem;
 class QgsWidgetWrapper;
 class QgsTabWidget;
+class QgsAttributeFormWidget;
 
 /**
  * \ingroup gui

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
       will add a new feature when the form is accepted. */
       MultiEditMode, //!< Multi edit mode, for editing fields of multiple features at once
       SearchMode, //!< Form values are used for searching/filtering the layer
-      AggregateSearchMode,
+      AggregateSearchMode, //!< Form is in aggregate search mode, show each widget in this mode \since QGIS 3.2
     };
 
     //! Filter types
@@ -161,6 +161,13 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void setMessageBar( QgsMessageBar *messageBar );
 
+    /**
+     * The aggregate filter is only useful if the form is in AggregateFilter mode.
+     * In this case it will return a combined expression according to the chosen filters
+     * on all attribute widgets.
+     *
+     * \since QGIS 3.2
+     */
     QString aggregateFilter() const;
 
   signals:

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -48,6 +48,8 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     /**
      * Constructor for QgsAttributeFormEditorWidget.
      * \param editorWidget associated editor widget wrapper (for default/edit modes)
+     * \param widgetType the type identifier of the widget passed in the
+     *        wrapper
      * \param form parent attribute form
      */
     explicit QgsAttributeFormEditorWidget( QgsEditorWidgetWrapper *editorWidget, const QString &widgetType,

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -28,6 +28,7 @@ class QgsVectorLayer;
 class QStackedWidget;
 class QgsAttributeEditorContext;
 class QLabel;
+class QgsAggregateToolButton;
 
 /**
  * \ingroup gui
@@ -75,13 +76,6 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     QVariant currentValue() const;
 
     /**
-     * Creates an expression matching the current search filter value and
-     * search properties represented in the widget.
-     * \since QGIS 2.16
-     */
-    QString currentFilterExpression() const override;
-
-    /**
      * Set the constraint status for this widget.
      */
     void setConstraintStatus( const QString &constraint, const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result );
@@ -104,11 +98,6 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
      */
     void changesCommitted();
 
-    /**
-     * Resets the search/filter value of the widget.
-     */
-    void resetSearch();
-
   signals:
 
     /**
@@ -128,60 +117,16 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     //! Triggered when the multi edit tool button "set field value" action is selected
     void setFieldTriggered();
 
-    //! Triggered when search button flags are changed
-    void searchWidgetFlagsChanged( QgsSearchWidgetWrapper::FilterFlags flags );
-
-  protected:
-
-    /**
-     * Returns a pointer to the search widget tool button in the widget.
-     * \note this method is in place for unit testing only, and is not considered
-     * stable API
-     */
-    QgsSearchWidgetToolButton *searchWidgetToolButton();
-
-    /**
-     * Sets the search widget wrapper for the widget used when the form is in
-     * search mode.
-     * \param wrapper search widget wrapper.
-     * \note the search widget wrapper should be created using searchWidgetFrame()
-     * as its parent
-     * \note this method is in place for unit testing only, and is not considered
-     * stable API
-     */
-    void setSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
-
-    /**
-     * Returns the widget which should be used as a parent during construction
-     * of the search widget wrapper.
-     * \note this method is in place for unit testing only, and is not considered
-     * stable AP
-     */
-    QWidget *searchWidgetFrame();
-
-    /**
-     * Returns the search widget wrapper used in this widget. The wrapper must
-     * first be created using createSearchWidgetWrapper()
-     * \note this method is in place for unit testing only, and is not considered
-     * stable API
-     */
-    QList< QgsSearchWidgetWrapper * > searchWidgetWrappers();
+    void onAggregateChanged();
 
   private:
-
-    QWidget *mEditPage = nullptr;
-    QWidget *mSearchPage = nullptr;
-    QStackedWidget *mStack = nullptr;
-    QWidget *mSearchFrame = nullptr;
-
     QString mWidgetType;
     QgsEditorWidgetWrapper *mWidget = nullptr;
-    QList< QgsSearchWidgetWrapper * > mSearchWidgets;
     QgsAttributeForm *mForm = nullptr;
     QLabel *mConstraintResultLabel = nullptr;
 
     QgsMultiEditToolButton *mMultiEditButton = nullptr;
-    QgsSearchWidgetToolButton *mSearchWidgetToolButton = nullptr;
+    QgsAggregateToolButton *mAggregateButton = nullptr;
     QVariant mPreviousValue;
     bool mBlockValueUpdate;
     bool mIsMixed;

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -16,16 +16,11 @@
 #ifndef QGSATTRIBUTEFORMEDITORWIDGET_H
 #define QGSATTRIBUTEFORMEDITORWIDGET_H
 
-#include <QWidget>
 #include "qgis_sip.h"
-#include "qgis.h"
-#include <QVariant>
-#include "qgsattributeeditorcontext.h"
-#include "qgssearchwidgetwrapper.h"
 #include "qgis_gui.h"
 #include "qgseditorwidgetwrapper.h"
+#include "qgsattributeformwidget.h"
 
-class QgsAttributeForm;
 class QgsEditorWidgetWrapper;
 class QgsMultiEditToolButton;
 class QgsSearchWidgetToolButton;
@@ -43,55 +38,23 @@ class QLabel;
  * controlling the multi edit results.
  * \since QGIS 2.16
  */
-class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
+class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
 {
     Q_OBJECT
 
   public:
-
-    //! Widget modes
-    enum Mode
-    {
-      DefaultMode, //!< Default mode, only the editor widget is shown
-      MultiEditMode, //!< Multi edit mode, both the editor widget and a QgsMultiEditToolButton is shown
-      SearchMode, //!< Layer search/filter mode
-    };
 
     /**
      * Constructor for QgsAttributeFormEditorWidget.
      * \param editorWidget associated editor widget wrapper (for default/edit modes)
      * \param form parent attribute form
      */
-    explicit QgsAttributeFormEditorWidget( QgsEditorWidgetWrapper *editorWidget,
-                                           QgsAttributeForm *form SIP_TRANSFERTHIS );
+    explicit QgsAttributeFormEditorWidget( QgsEditorWidgetWrapper *editorWidget, const QString &widgetType,
+                                           QgsAttributeForm *form  SIP_TRANSFERTHIS );
 
     ~QgsAttributeFormEditorWidget();
 
-    /**
-     * Creates the search widget wrappers for the widget used when the form is in
-     * search mode.
-     * \param widgetId id of the widget type to create a search wrapper for
-     * \param fieldIdx index of field associated with widget
-     * \param config configuration which should be used for the widget creation
-     * \param context editor context (not available in Python bindings)
-     */
-    void createSearchWidgetWrappers( const QString &widgetId, int fieldIdx,
-                                     const QVariantMap &config,
-                                     const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() );
-
-    /**
-     * Sets the current mode for the widget. The widget will adapt its state and visible widgets to
-     * reflect the updated mode. For example, showing multi edit tool buttons if the mode is set to MultiEditMode.
-     * \param mode widget mode
-     * \see mode()
-     */
-    void setMode( Mode mode );
-
-    /**
-     * Returns the current mode for the widget.
-     * \see setMode()
-     */
-    Mode mode() const { return mMode; }
+    virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) override;
 
     /**
      * Resets the widget to an initial value.
@@ -116,7 +79,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
      * search properties represented in the widget.
      * \since QGIS 2.16
      */
-    QString currentFilterExpression() const;
+    QString currentFilterExpression() const override;
 
     /**
      * Set the constraint status for this widget.
@@ -184,7 +147,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
      * \note the search widget wrapper should be created using searchWidgetFrame()
      * as its parent
      * \note this method is in place for unit testing only, and is not considered
-     * stable AP
+     * stable API
      */
     void setSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
 
@@ -200,7 +163,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
      * Returns the search widget wrapper used in this widget. The wrapper must
      * first be created using createSearchWidgetWrapper()
      * \note this method is in place for unit testing only, and is not considered
-     * stable AP
+     * stable API
      */
     QList< QgsSearchWidgetWrapper * > searchWidgetWrappers();
 
@@ -211,11 +174,11 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
     QStackedWidget *mStack = nullptr;
     QWidget *mSearchFrame = nullptr;
 
+    QString mWidgetType;
     QgsEditorWidgetWrapper *mWidget = nullptr;
     QList< QgsSearchWidgetWrapper * > mSearchWidgets;
     QgsAttributeForm *mForm = nullptr;
     QLabel *mConstraintResultLabel = nullptr;
-    Mode mMode;
 
     QgsMultiEditToolButton *mMultiEditButton = nullptr;
     QgsSearchWidgetToolButton *mSearchWidgetToolButton = nullptr;
@@ -224,8 +187,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
     bool mIsMixed;
     bool mIsChanged;
 
-    QgsVectorLayer *layer();
-    void updateWidgets();
+    void updateWidgets() override;
 };
 
 #endif // QGSATTRIBUTEFORMEDITORWIDGET_H

--- a/src/gui/qgsattributeformrelationeditorwidget.cpp
+++ b/src/gui/qgsattributeformrelationeditorwidget.cpp
@@ -23,6 +23,7 @@ QgsAttributeFormRelationEditorWidget::QgsAttributeFormRelationEditorWidget( QgsR
   : QgsAttributeFormWidget( wrapper, form )
   , mWrapper( wrapper )
 {
+  setSearchWidgetToolButtonVisible( false );
 }
 
 void QgsAttributeFormRelationEditorWidget::createSearchWidgetWrappers( const QgsAttributeEditorContext &context )

--- a/src/gui/qgsattributeformrelationeditorwidget.cpp
+++ b/src/gui/qgsattributeformrelationeditorwidget.cpp
@@ -27,6 +27,7 @@ QgsAttributeFormRelationEditorWidget::QgsAttributeFormRelationEditorWidget( QgsR
 
 void QgsAttributeFormRelationEditorWidget::createSearchWidgetWrappers( const QgsAttributeEditorContext &context )
 {
+  Q_UNUSED( context )
   mSearchWidget = new QgsRelationAggregateSearchWidgetWrapper( layer(), mWrapper, form() );
 
   setSearchWidgetWrapper( mSearchWidget );

--- a/src/gui/qgsattributeformrelationeditorwidget.cpp
+++ b/src/gui/qgsattributeformrelationeditorwidget.cpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+    qgsattributeformrelationeditorwidget.cpp
+     --------------------------------------
+    Date                 : Nov 2017
+    Copyright            : (C) 2017 Matthias Kuhn
+    Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsattributeformrelationeditorwidget.h"
+#include "qgsrelationaggregatesearchwidgetwrapper.h"
+#include "qgsattributeform.h"
+
+#include "qgsrelationwidgetwrapper.h"
+
+QgsAttributeFormRelationEditorWidget::QgsAttributeFormRelationEditorWidget( QgsRelationWidgetWrapper *wrapper, QgsAttributeForm *form )
+  : QgsAttributeFormWidget( wrapper, form )
+  , mWrapper( wrapper )
+{
+}
+
+void QgsAttributeFormRelationEditorWidget::createSearchWidgetWrappers( const QgsAttributeEditorContext &context )
+{
+  mSearchWidget = new QgsRelationAggregateSearchWidgetWrapper( layer(), mWrapper, form() );
+
+  setSearchWidgetWrapper( mSearchWidget );
+}
+
+QString QgsAttributeFormRelationEditorWidget::currentFilterExpression() const
+{
+  return mSearchWidget->expression();
+}

--- a/src/gui/qgsattributeformrelationeditorwidget.h
+++ b/src/gui/qgsattributeformrelationeditorwidget.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+    qgsattributeformrelationeditorwidget.h
+     --------------------------------------
+    Date                 : Nov 2017
+    Copyright            : (C) 2017 Matthias Kuhn
+    Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSATTRIBUTEFORMRELATIONEDITORWIDGET_H
+#define QGSATTRIBUTEFORMRELATIONEDITORWIDGET_H
+
+#include "qgis_gui.h"
+#include "qgsattributeformwidget.h"
+
+class QgsRelationWidgetWrapper;
+class QgsRelationAggregateSearchWidgetWrapper;
+
+class GUI_EXPORT QgsAttributeFormRelationEditorWidget : public QgsAttributeFormWidget
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsAttributeFormRelationEditorWidget( QgsRelationWidgetWrapper *wrapper, QgsAttributeForm *form );
+
+    virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) override;
+    virtual QString currentFilterExpression() const override;
+
+  private:
+    QgsRelationAggregateSearchWidgetWrapper *mSearchWidget;
+    QgsRelationWidgetWrapper *mWrapper;
+};
+
+#endif // QGSATTRIBUTEFORMRELATIONEDITORWIDGET_H

--- a/src/gui/qgsattributeformrelationeditorwidget.h
+++ b/src/gui/qgsattributeformrelationeditorwidget.h
@@ -22,11 +22,23 @@
 class QgsRelationWidgetWrapper;
 class QgsRelationAggregateSearchWidgetWrapper;
 
+
+/**
+ * \ingroup gui
+ *
+ * Widget to show for child relations on an attribute form.
+ *
+ * \since QGIS 3.2
+ */
 class GUI_EXPORT QgsAttributeFormRelationEditorWidget : public QgsAttributeFormWidget
 {
     Q_OBJECT
 
   public:
+
+    /**
+     * Constructor
+     */
     explicit QgsAttributeFormRelationEditorWidget( QgsRelationWidgetWrapper *wrapper, QgsAttributeForm *form );
 
     virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) override;

--- a/src/gui/qgsattributeformrelationeditorwidget.h
+++ b/src/gui/qgsattributeformrelationeditorwidget.h
@@ -28,7 +28,7 @@ class QgsRelationAggregateSearchWidgetWrapper;
  *
  * Widget to show for child relations on an attribute form.
  *
- * \since QGIS 3.2
+ * \since QGIS 3.0
  */
 class GUI_EXPORT QgsAttributeFormRelationEditorWidget : public QgsAttributeFormWidget
 {

--- a/src/gui/qgsattributeformwidget.cpp
+++ b/src/gui/qgsattributeformwidget.cpp
@@ -30,6 +30,7 @@ QgsAttributeFormWidget::QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAtt
   mSearchPage->setLayout( l );
   l->addWidget( mSearchFrame, 1 );
   mSearchWidgetToolButton = new QgsSearchWidgetToolButton();
+  mSearchWidgetToolButton->setObjectName( QStringLiteral( "SearchWidgetToolButton" ) );
   connect( mSearchWidgetToolButton, &QgsSearchWidgetToolButton::activeFlagsChanged,
            this, &QgsAttributeFormWidget::searchWidgetFlagsChanged );
   l->addWidget( mSearchWidgetToolButton, 0 );
@@ -129,15 +130,9 @@ void QgsAttributeFormWidget::resetSearch()
   }
 }
 
-QgsSearchWidgetToolButton *QgsAttributeFormWidget::searchWidgetToolButton() SIP_SKIP
-{
-  return mSearchWidgetToolButton;
-}
-
 QgsVectorLayer *QgsAttributeFormWidget::layer()
 {
-  QgsAttributeForm *aform = form();
-  return aform ? aform->layer() : nullptr;
+  return mWidget->layer();
 }
 
 void QgsAttributeFormWidget::searchWidgetFlagsChanged( QgsSearchWidgetWrapper::FilterFlags flags )

--- a/src/gui/qgsattributeformwidget.cpp
+++ b/src/gui/qgsattributeformwidget.cpp
@@ -1,0 +1,28 @@
+#include "qgsattributeformwidget.h"
+
+#include "qgsattributeform.h"
+
+QgsAttributeFormWidget::QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form )
+  : QWidget( form )
+  , mMode( DefaultMode )
+  , mForm( form )
+{
+
+}
+
+void QgsAttributeFormWidget::setMode( QgsAttributeFormWidget::Mode mode )
+{
+  mMode = mode;
+  updateWidgets();
+}
+
+QgsAttributeForm *QgsAttributeFormWidget::form() const
+{
+  return mForm;
+}
+
+QgsVectorLayer *QgsAttributeFormWidget::layer()
+{
+  QgsAttributeForm *aform = form();
+  return aform ? aform->layer() : nullptr;
+}

--- a/src/gui/qgsattributeformwidget.cpp
+++ b/src/gui/qgsattributeformwidget.cpp
@@ -173,6 +173,16 @@ void QgsAttributeFormWidget::updateWidgets()
 
 }
 
+bool QgsAttributeFormWidget::searchWidgetToolButtonVisible() const
+{
+  return mSearchWidgetToolButton->isVisible();
+}
+
+void QgsAttributeFormWidget::setSearchWidgetToolButtonVisible( bool searchWidgetToolButtonVisible )
+{
+  return mSearchWidgetToolButton->setVisible( searchWidgetToolButtonVisible );
+}
+
 QWidget *QgsAttributeFormWidget::searchPage() const
 {
   return mSearchPage;

--- a/src/gui/qgsattributeformwidget.cpp
+++ b/src/gui/qgsattributeformwidget.cpp
@@ -1,13 +1,56 @@
 #include "qgsattributeformwidget.h"
+#include <QHBoxLayout>
+#include <QStackedWidget>
 
 #include "qgsattributeform.h"
+#include "qgssearchwidgettoolbutton.h"
 
 QgsAttributeFormWidget::QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form )
   : QWidget( form )
   , mMode( DefaultMode )
   , mForm( form )
+  , mWidget( widget )
 {
+  mEditPage = new QWidget();
+  QHBoxLayout *l = new QHBoxLayout();
+  l->setMargin( 0 );
+  l->setContentsMargins( 0, 0, 0, 0 );
+  mEditPage->setLayout( l );
 
+  l = new QHBoxLayout();
+  l->setMargin( 0 );
+  l->setContentsMargins( 0, 0, 0, 0 );
+  mSearchFrame = new QWidget();
+  mSearchFrame->setLayout( l );
+
+  mSearchPage = new QWidget();
+  l = new QHBoxLayout();
+  l->setMargin( 0 );
+  l->setContentsMargins( 0, 0, 0, 0 );
+  mSearchPage->setLayout( l );
+  l->addWidget( mSearchFrame, 1 );
+  mSearchWidgetToolButton = new QgsSearchWidgetToolButton();
+  connect( mSearchWidgetToolButton, &QgsSearchWidgetToolButton::activeFlagsChanged,
+           this, &QgsAttributeFormWidget::searchWidgetFlagsChanged );
+  l->addWidget( mSearchWidgetToolButton, 0 );
+
+
+  mStack = new QStackedWidget;
+  mStack->addWidget( mEditPage );
+  mStack->addWidget( mSearchPage );
+
+  l = new QHBoxLayout();
+  l->setMargin( 0 );
+  l->setContentsMargins( 0, 0, 0, 0 );
+  setLayout( l );
+  l->addWidget( mStack );
+
+  if ( !mWidget || !mForm )
+    return;
+
+  mEditPage->layout()->addWidget( mWidget->widget() );
+
+  updateWidgets();
 }
 
 void QgsAttributeFormWidget::setMode( QgsAttributeFormWidget::Mode mode )
@@ -21,8 +64,131 @@ QgsAttributeForm *QgsAttributeFormWidget::form() const
   return mForm;
 }
 
+QWidget *QgsAttributeFormWidget::searchWidgetFrame()
+{
+  return mSearchFrame;
+}
+
+void QgsAttributeFormWidget::setSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper ) SIP_SKIP
+{
+  mSearchWidgets.clear();
+  mSearchWidgets << wrapper;
+  mSearchFrame->layout()->addWidget( wrapper->widget() );
+  mSearchWidgetToolButton->setAvailableFlags( wrapper->supportedFlags() );
+  mSearchWidgetToolButton->setActiveFlags( QgsSearchWidgetWrapper::FilterFlags() );
+  mSearchWidgetToolButton->setDefaultFlags( wrapper->defaultFlags() );
+  connect( wrapper, &QgsSearchWidgetWrapper::valueChanged, mSearchWidgetToolButton, &QgsSearchWidgetToolButton::setActive );
+  connect( wrapper, &QgsSearchWidgetWrapper::valueCleared, mSearchWidgetToolButton, &QgsSearchWidgetToolButton::setInactive );
+}
+
+void QgsAttributeFormWidget::addAdditionalSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper )
+{
+  mSearchWidgets << wrapper;
+
+  mSearchFrame->layout()->addWidget( wrapper->widget() );
+  wrapper->widget()->hide();
+}
+
+QList<QgsSearchWidgetWrapper *> QgsAttributeFormWidget::searchWidgetWrappers() SIP_SKIP
+{
+  return mSearchWidgets;
+}
+
+QString QgsAttributeFormWidget::currentFilterExpression() const
+{
+  if ( mSearchWidgets.isEmpty() )
+    return QString();
+
+  if ( !mSearchWidgetToolButton->isActive() )
+    return QString();
+
+  if ( mSearchWidgetToolButton->activeFlags() & QgsSearchWidgetWrapper::Between )
+  {
+    // special case: Between search
+    QString filter1 = mSearchWidgets.at( 0 )->createExpression( QgsSearchWidgetWrapper::GreaterThanOrEqualTo );
+    QString filter2 = mSearchWidgets.at( 1 )->createExpression( QgsSearchWidgetWrapper::LessThanOrEqualTo );
+    return QStringLiteral( "%1 AND %2" ).arg( filter1, filter2 );
+  }
+  else if ( mSearchWidgetToolButton->activeFlags() & QgsSearchWidgetWrapper::IsNotBetween )
+  {
+    // special case: Is Not Between search
+    QString filter1 = mSearchWidgets.at( 0 )->createExpression( QgsSearchWidgetWrapper::LessThan );
+    QString filter2 = mSearchWidgets.at( 1 )->createExpression( QgsSearchWidgetWrapper::GreaterThan );
+    return QStringLiteral( "%1 OR %2" ).arg( filter1, filter2 );
+  }
+
+  return mSearchWidgets.at( 0 )->createExpression( mSearchWidgetToolButton->activeFlags() );
+}
+
+void QgsAttributeFormWidget::resetSearch()
+{
+  mSearchWidgetToolButton->setInactive();
+  Q_FOREACH ( QgsSearchWidgetWrapper *widget, mSearchWidgets )
+  {
+    widget->clearWidget();
+  }
+}
+
+QgsSearchWidgetToolButton *QgsAttributeFormWidget::searchWidgetToolButton() SIP_SKIP
+{
+  return mSearchWidgetToolButton;
+}
+
 QgsVectorLayer *QgsAttributeFormWidget::layer()
 {
   QgsAttributeForm *aform = form();
   return aform ? aform->layer() : nullptr;
+}
+
+void QgsAttributeFormWidget::searchWidgetFlagsChanged( QgsSearchWidgetWrapper::FilterFlags flags )
+{
+  Q_FOREACH ( QgsSearchWidgetWrapper *widget, mSearchWidgets )
+  {
+    widget->setEnabled( !( flags & QgsSearchWidgetWrapper::IsNull )
+                        && !( flags & QgsSearchWidgetWrapper::IsNotNull ) );
+    if ( !mSearchWidgetToolButton->isActive() )
+    {
+      widget->clearWidget();
+    }
+  }
+
+  if ( mSearchWidgets.count() >= 2 )
+  {
+    mSearchWidgets.at( 1 )->widget()->setVisible( flags & QgsSearchWidgetWrapper::Between ||
+        flags & QgsSearchWidgetWrapper::IsNotBetween );
+  }
+}
+
+void QgsAttributeFormWidget::updateWidgets()
+{
+  switch ( mMode )
+  {
+    case DefaultMode:
+    case MultiEditMode:
+      mStack->setCurrentWidget( mEditPage );
+      break;
+
+    case SearchMode:
+    case AggregateSearchMode:
+    {
+      mStack->setCurrentWidget( mSearchPage );
+      break;
+    }
+  }
+
+}
+
+QWidget *QgsAttributeFormWidget::searchPage() const
+{
+  return mSearchPage;
+}
+
+QStackedWidget *QgsAttributeFormWidget::stack() const
+{
+  return mStack;
+}
+
+QWidget *QgsAttributeFormWidget::editPage() const
+{
+  return mEditPage;
 }

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -146,13 +146,6 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      */
     QWidget *searchPage() const SIP_SKIP;
 
-    /**
-     * Returns a pointer to the search widget tool button in the widget.
-     * \note this method is in place for unit testing only, and is not considered
-     * stable API
-     */
-    QgsSearchWidgetToolButton *searchWidgetToolButton() SIP_SKIP;
-
   private slots:
 
     //! Triggered when search button flags are changed

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -13,6 +13,14 @@ class QgsAttributeForm;
 class QStackedWidget;
 class QgsSearchWidgetToolButton;
 
+/**
+ * \ingroup gui
+ *
+ * Base class for all widgets shown on a QgsAttributeForm.
+ * Consists of the widget which is visible in edit mode as well as the widget visible in search mode.
+ *
+ * \since QGIS 3.2
+ */
 class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
 {
     Q_OBJECT
@@ -25,7 +33,7 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
       DefaultMode, //!< Default mode, only the editor widget is shown
       MultiEditMode, //!< Multi edit mode, both the editor widget and a QgsMultiEditToolButton is shown
       SearchMode, //!< Layer search/filter mode
-      AggregateSearchMode,
+      AggregateSearchMode, //!< Embedded in a search form, show additional aggregate function toolbutton
     };
 
     explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
@@ -60,8 +68,14 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      */
     Mode mode() const { return mMode; }
 
+    /**
+     * The layer for which this widget and its form is shown.
+     */
     QgsVectorLayer *layer();
 
+    /**
+     * The form on which this widget is shown.
+     */
     QgsAttributeForm *form() const;
 
     /**
@@ -100,10 +114,29 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
     void resetSearch();
 
   protected:
+
+    /**
+     * Returns a pointer to the EDIT page widget.
+     * \note this method is in place for unit testing only, and is not considered
+     * stable API
+     * \note not available in Python bindings
+     */
     QWidget *editPage() const SIP_SKIP;
 
+    /**
+     * Returns a pointer to the stacked widget managing edit and search page.
+     * \note this method is in place for unit testing only, and is not considered
+     * stable API
+     * \note not available in Python bindings
+     */
     QStackedWidget *stack() const SIP_SKIP;
 
+    /**
+     * Returns a pointer to the search page widget.
+     * \note this method is in place for unit testing only, and is not considered
+     * stable API
+     * \note not available in Python bindings
+     */
     QWidget *searchPage() const SIP_SKIP;
 
     /**
@@ -111,7 +144,7 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      * \note this method is in place for unit testing only, and is not considered
      * stable API
      */
-    QgsSearchWidgetToolButton *searchWidgetToolButton();
+    QgsSearchWidgetToolButton *searchWidgetToolButton() SIP_SKIP;
 
   private slots:
 

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -36,6 +36,9 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
       AggregateSearchMode, //!< Embedded in a search form, show additional aggregate function toolbutton
     };
 
+    /**
+     * A new form widget for the wrapper \a widget on \a form.
+     */
     explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
 
     /**
@@ -98,6 +101,10 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      */
     void setSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
 
+    /**
+     * Adds an additional search widget wrapper.
+     * Used to register a secondary search widget as used for "between" searches.
+     */
     void addAdditionalSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
 
     /**

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -120,7 +120,16 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      */
     void resetSearch();
 
+    /**
+     * The visibility of the search widget tool button, that allows (de)activating
+     * this search widgte or defines the comparison operator to use.
+     */
     bool searchWidgetToolButtonVisible() const;
+
+    /**
+     * The visibility of the search widget tool button, that allows (de)activating
+     * this search widgte or defines the comparison operator to use.
+     */
     void setSearchWidgetToolButtonVisible( bool searchWidgetToolButtonVisible );
 
   protected:

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -120,6 +120,9 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      */
     void resetSearch();
 
+    bool searchWidgetToolButtonVisible() const;
+    void setSearchWidgetToolButtonVisible( bool searchWidgetToolButtonVisible );
+
   protected:
 
     /**
@@ -153,7 +156,6 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
 
   private:
     virtual void updateWidgets();
-
     QgsAttributeFormWidget::Mode mMode = DefaultMode;
     QgsSearchWidgetToolButton *mSearchWidgetToolButton = nullptr;
     QWidget *mEditPage = nullptr;

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -10,6 +10,8 @@
 #include <QVariant>
 
 class QgsAttributeForm;
+class QStackedWidget;
+class QgsSearchWidgetToolButton;
 
 class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
 {
@@ -23,6 +25,7 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
       DefaultMode, //!< Default mode, only the editor widget is shown
       MultiEditMode, //!< Multi edit mode, both the editor widget and a QgsMultiEditToolButton is shown
       SearchMode, //!< Layer search/filter mode
+      AggregateSearchMode,
     };
 
     explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
@@ -40,7 +43,7 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
      * search properties represented in the widget.
      * \since QGIS 2.16
      */
-    virtual QString currentFilterExpression() const = 0;
+    virtual QString currentFilterExpression() const;
 
 
     /**
@@ -61,10 +64,72 @@ class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
 
     QgsAttributeForm *form() const;
 
+    /**
+     * Returns the widget which should be used as a parent during construction
+     * of the search widget wrapper.
+     * \note this method is in place for unit testing only, and is not considered
+     * stable API
+     */
+    QWidget *searchWidgetFrame() SIP_SKIP;
+
+
+    /**
+     * Sets the search widget wrapper for the widget used when the form is in
+     * search mode.
+     * \param wrapper search widget wrapper.
+     * \note the search widget wrapper should be created using searchWidgetFrame()
+     * as its parent
+     * \note this method is in place for unit testing only, and is not considered
+     * stable API
+     */
+    void setSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
+
+    void addAdditionalSearchWidgetWrapper( QgsSearchWidgetWrapper *wrapper );
+
+    /**
+     * Returns the search widget wrapper used in this widget. The wrapper must
+     * first be created using createSearchWidgetWrapper()
+     * \note this method is in place for unit testing only, and is not considered
+     * stable API
+     */
+    QList< QgsSearchWidgetWrapper * > searchWidgetWrappers();
+
+    /**
+     * Resets the search/filter value of the widget.
+     */
+    void resetSearch();
+
+  protected:
+    QWidget *editPage() const SIP_SKIP;
+
+    QStackedWidget *stack() const SIP_SKIP;
+
+    QWidget *searchPage() const SIP_SKIP;
+
+    /**
+     * Returns a pointer to the search widget tool button in the widget.
+     * \note this method is in place for unit testing only, and is not considered
+     * stable API
+     */
+    QgsSearchWidgetToolButton *searchWidgetToolButton();
+
+  private slots:
+
+    //! Triggered when search button flags are changed
+    void searchWidgetFlagsChanged( QgsSearchWidgetWrapper::FilterFlags flags );
+
   private:
+    virtual void updateWidgets();
+
     QgsAttributeFormWidget::Mode mMode = DefaultMode;
-    virtual void updateWidgets() = 0;
+    QgsSearchWidgetToolButton *mSearchWidgetToolButton = nullptr;
+    QWidget *mEditPage = nullptr;
+    QWidget *mSearchPage = nullptr;
+    QStackedWidget *mStack = nullptr;
+    QWidget *mSearchFrame = nullptr;
     QgsAttributeForm *mForm = nullptr;
+    QList< QgsSearchWidgetWrapper * > mSearchWidgets;
+    QgsWidgetWrapper *mWidget = nullptr;
 };
 
 #endif // QGSATTRIBUTEFORMWIDGET_H

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -19,7 +19,7 @@ class QgsSearchWidgetToolButton;
  * Base class for all widgets shown on a QgsAttributeForm.
  * Consists of the widget which is visible in edit mode as well as the widget visible in search mode.
  *
- * \since QGIS 3.2
+ * \since QGIS 3.0
  */
 class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
 {

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -1,0 +1,70 @@
+#ifndef QGSATTRIBUTEFORMWIDGET_H
+#define QGSATTRIBUTEFORMWIDGET_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "qgsattributeeditorcontext.h"
+#include "qgssearchwidgetwrapper.h"
+
+#include <QWidget>
+#include <QVariant>
+
+class QgsAttributeForm;
+
+class GUI_EXPORT QgsAttributeFormWidget : public QWidget // SIP_ABSTRACT
+{
+    Q_OBJECT
+
+  public:
+
+    //! Widget modes
+    enum Mode
+    {
+      DefaultMode, //!< Default mode, only the editor widget is shown
+      MultiEditMode, //!< Multi edit mode, both the editor widget and a QgsMultiEditToolButton is shown
+      SearchMode, //!< Layer search/filter mode
+    };
+
+    explicit QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAttributeForm *form );
+
+    /**
+     * Creates the search widget wrappers for the widget used when the form is in
+     * search mode.
+     *
+     * \param context editor context (not available in Python bindings)
+     */
+    virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) = 0;
+
+    /**
+     * Creates an expression matching the current search filter value and
+     * search properties represented in the widget.
+     * \since QGIS 2.16
+     */
+    virtual QString currentFilterExpression() const = 0;
+
+
+    /**
+     * Sets the current mode for the widget. The widget will adapt its state and visible widgets to
+     * reflect the updated mode. For example, showing multi edit tool buttons if the mode is set to MultiEditMode.
+     * \param mode widget mode
+     * \see mode()
+     */
+    void setMode( Mode mode );
+
+    /**
+     * Returns the current mode for the widget.
+     * \see setMode()
+     */
+    Mode mode() const { return mMode; }
+
+    QgsVectorLayer *layer();
+
+    QgsAttributeForm *form() const;
+
+  private:
+    QgsAttributeFormWidget::Mode mMode = DefaultMode;
+    virtual void updateWidgets() = 0;
+    QgsAttributeForm *mForm = nullptr;
+};
+
+#endif // QGSATTRIBUTEFORMWIDGET_H

--- a/tests/src/python/test_qgsattributeformeditorwidget.py
+++ b/tests/src/python/test_qgsattributeformeditorwidget.py
@@ -18,6 +18,7 @@ from qgis.gui import (QgsSearchWidgetWrapper,
                       QgsAttributeFormEditorWidget,
                       QgsDefaultSearchWidgetWrapper,
                       QgsAttributeForm,
+                      QgsSearchWidgetToolButton,
                       QgsGui
                       )
 from qgis.core import (QgsVectorLayer)
@@ -37,14 +38,17 @@ class PyQgsAttributeFormEditorWidget(unittest.TestCase):
         layer = QgsVectorLayer("Point?field=fldint:integer", "test", "memory")
         parent = QWidget()
         w = QgsDefaultSearchWidgetWrapper(layer, 0, parent)
-        af = QgsAttributeFormEditorWidget(None, None)
+        setup = QgsGui.editorWidgetRegistry().findBest(layer, "fldint")
+        wrapper = QgsGui.editorWidgetRegistry().create(layer, 0, None, parent)
+        af = QgsAttributeFormEditorWidget(wrapper, setup.type(), None)
         af.setSearchWidgetWrapper(w)
 
         # test that filter combines both current value in search widget wrapper and flags from search tool button
         w.lineEdit().setText('5.5')
-        af.searchWidgetToolButton().setActiveFlags(QgsSearchWidgetWrapper.EqualTo)
+        sb = af.findChild(QWidget, "SearchWidgetToolButton")
+        sb.setActiveFlags(QgsSearchWidgetWrapper.EqualTo)
         self.assertEqual(af.currentFilterExpression(), '"fldint"=5.5')
-        af.searchWidgetToolButton().setActiveFlags(QgsSearchWidgetWrapper.NotEqualTo)
+        sb.setActiveFlags(QgsSearchWidgetWrapper.NotEqualTo)
         self.assertEqual(af.currentFilterExpression(), '"fldint"<>5.5')
 
     def testSetActive(self):
@@ -53,10 +57,12 @@ class PyQgsAttributeFormEditorWidget(unittest.TestCase):
         layer = QgsVectorLayer("Point?field=fldtext:string&field=fldint:integer", "test", "memory")
         parent = QWidget()
         w = QgsDefaultSearchWidgetWrapper(layer, 0, parent)
-        af = QgsAttributeFormEditorWidget(None, None)
+        setup = QgsGui.editorWidgetRegistry().findBest(layer, "fldint")
+        wrapper = QgsGui.editorWidgetRegistry().create(layer, 0, None, parent)
+        af = QgsAttributeFormEditorWidget(wrapper, setup.type(), None)
         af.setSearchWidgetWrapper(w)
 
-        sb = af.searchWidgetToolButton()
+        sb = af.findChild(QWidget, "SearchWidgetToolButton")
         # start with inactive
         sb.setActiveFlags(QgsSearchWidgetWrapper.FilterFlags())
         # set to inactive
@@ -78,17 +84,19 @@ class PyQgsAttributeFormEditorWidget(unittest.TestCase):
         """ Test creating a between type filter """
         layer = QgsVectorLayer("Point?field=fldtext:string&field=fldint:integer", "test", "memory")
         form = QgsAttributeForm(layer)
-        af = QgsAttributeFormEditorWidget(None, form)
-        af.createSearchWidgetWrappers("DateTime", 0, {})
+        wrapper = QgsGui.editorWidgetRegistry().create(layer, 0, None, form)
+        af = QgsAttributeFormEditorWidget(wrapper, 'DateTime', None)
+        af.createSearchWidgetWrappers()
 
         d1 = af.findChildren(QDateTimeEdit)[0]
         d2 = af.findChildren(QDateTimeEdit)[1]
         d1.setDateTime(QDateTime(QDate(2013, 5, 6), QTime()))
         d2.setDateTime(QDateTime(QDate(2013, 5, 16), QTime()))
 
-        af.searchWidgetToolButton().setActiveFlags(QgsSearchWidgetWrapper.Between)
+        sb = af.findChild(QWidget, "SearchWidgetToolButton")
+        sb.setActiveFlags(QgsSearchWidgetWrapper.Between)
         self.assertEqual(af.currentFilterExpression(), '"fldtext">=\'2013-05-06\' AND "fldtext"<=\'2013-05-16\'')
-        af.searchWidgetToolButton().setActiveFlags(QgsSearchWidgetWrapper.IsNotBetween)
+        sb.setActiveFlags(QgsSearchWidgetWrapper.IsNotBetween)
         self.assertEqual(af.currentFilterExpression(), '"fldtext"<\'2013-05-06\' OR "fldtext">\'2013-05-16\'')
 
 

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -29,7 +29,8 @@ from qgis.core import (
 from qgis.gui import (
     QgsGui,
     QgsRelationWidgetWrapper,
-    QgsAttributeEditorContext
+    QgsAttributeEditorContext,
+    QgsMapCanvas
 )
 
 from qgis.PyQt.QtCore import QTimer
@@ -47,7 +48,8 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         Setup the involved layers and relations for a n:m relation
         :return:
         """
-        QgsGui.editorWidgetRegistry().initEditors()
+        cls.mapCanvas = QgsMapCanvas()
+        QgsGui.editorWidgetRegistry().initEditors(cls.mapCanvas)
         cls.dbconn = 'service=\'qgis_test\''
         if 'QGIS_PGTEST_DB' in os.environ:
             cls.dbconn = os.environ['QGIS_PGTEST_DB']


### PR DESCRIPTION
For each child relations, the subform is visible.

Each attribute of the children has a tool button option to define to which
aggregate the specified value should be compared. This allows for searching
things like

 * Each city where the highest building is more than 300 m
 * Each sensor where the median value is lower than 50 ppm
 * Each feature with a child with a missing value
 * ...

Find all *wastewater structures* with where the mean level (m.a.s.l.) of all associated covers is lower than 395 meters

![screenshot from 2017-11-02 16-52-13](https://user-images.githubusercontent.com/588407/32335898-321cfe2a-bfee-11e7-8378-d7a668c21dae.png)

Note: performance is an issue on big datasets since it's using expression relation functionality.