### PR TITLE
Move plugin installer's settings to the [app] section

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -98,9 +98,8 @@ mPlugins = dict of dicts {id : {
 
 translatableAttributes = ["name", "description", "about", "tags"]
 
-reposGroup = "/Qgis/plugin-repos"
-settingsGroup = "/Qgis/plugin-installer"
-seenPluginGroup = "/Qgis/plugin-seen"
+settingsGroup = "app/plugin_installer"
+reposGroup = "app/plugin_repositories"
 
 officialRepo = (QCoreApplication.translate("QgsPluginInstaller", "QGIS Official Plugin Repository"), "https://plugins.qgis.org/plugins/plugins.xml")
 
@@ -790,7 +789,7 @@ class Plugins(QObject):
     def markNews(self):
         """ mark all new plugins as new """
         settings = QgsSettings()
-        seenPlugins = settings.value(seenPluginGroup, list(self.mPlugins.keys()), type=str)
+        seenPlugins = settings.value(settingsGroup + '/seen_plugins', list(self.mPlugins.keys()), type=str)
         if len(seenPlugins) > 0:
             for i in list(self.mPlugins.keys()):
                 if seenPlugins.count(i) == 0 and self.mPlugins[i]["status"] == "not installed":
@@ -800,11 +799,11 @@ class Plugins(QObject):
     def updateSeenPluginsList(self):
         """ update the list of all seen plugins """
         settings = QgsSettings()
-        seenPlugins = settings.value(seenPluginGroup, list(self.mPlugins.keys()), type=str)
+        seenPlugins = settings.value(settingsGroup + '/seen_plugins', list(self.mPlugins.keys()), type=str)
         for i in list(self.mPlugins.keys()):
             if seenPlugins.count(i) == 0:
                 seenPlugins += [i]
-        settings.setValue(seenPluginGroup, seenPlugins)
+        settings.setValue(settingsGroup + '/seen_plugins', seenPlugins)
 
     # ----------------------------------------- #
     def isThereAnythingNew(self):

--- a/resources/2to3migration.txt
+++ b/resources/2to3migration.txt
@@ -1,4 +1,4 @@
-# version=1
+# version=2
 # If you update this file make sure you bump the above version number it must be higher then the last run.
 #oldkey;newkey
 
@@ -17,3 +17,6 @@ Qgis/compileExpressions;*
 variables/names;*
 variables/values;*
 
+#Plugin installer
+Qgis/plugin-installer/*;app/plugin_installer/*
+Qgis/plugin-repos/*;app/plugin_repositories/*


### PR DESCRIPTION
@elpaso @NathanW2, so how do you like moving all the installer stuff to two groups within [app] section?

`app/plugin_installer/`
`app/plugin_repositories/`

It seems it's the first use of this section. I'll soft-code it using the QgsSettings.Section.App when this bug is fixed: https://issues.qgis.org/issues/17376   

Note the second group can't be put inside the first one because of settings migration capabilities: https://issues.qgis.org/issues/17378 