### PR TITLE
[server][bugfix]  Fixes #17401 by replacing '+' symbol by space 

### DIFF
--- a/src/server/qgsserverrequest.cpp
+++ b/src/server/qgsserverrequest.cpp
@@ -79,7 +79,11 @@ QMap<QString, QString> QgsServerRequest::parameters() const
     QList<pair_t> items = query.queryItems( QUrl::FullyDecoded );
     Q_FOREACH ( const pair_t &pair, items )
     {
-      mParams.insert( pair.first.toUpper(), pair.second );
+      // prepare the value
+      QString value = pair.second;
+      value.replace( "+", " " );
+
+      mParams.insert( pair.first.toUpper(), value );
     }
     mDecoded = true;
   }

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -207,6 +207,16 @@ class TestQgsServerWMS(QgsServerTestBase):
                                  'FEATURE_COUNT=10&FILTER_GEOM=POLYGON((8.2035381 44.901459,8.2035562 44.901459,8.2035562 44.901418,8.2035381 44.901418,8.2035381 44.901459))',
                                  'wms_getfeatureinfo_invalid_query_layers')
 
+        # Test feature info request with '+' instead of ' ' in layers and
+        # query_layers parameters
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer+%C3%A8%C3%A9&styles=&' +
+                                 'info_format=text%2Fxml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer+%C3%A8%C3%A9&X=190&Y=320',
+                                 'wms_getfeatureinfo-text-xml')
+
     def test_describelayer(self):
         # Test DescribeLayer
         self.wms_request_compare('DescribeLayer',


### PR DESCRIPTION
## Description

During its tests with QWC2, @elemoine reported another minor issue: https://issues.qgis.org/issues/17401. 

With QGIS Server 2.18, it's possible to use `+` symbol instead of space for parameters' values. This way, these kind of requests are valid for the layer named `my layer`:

```
http://localhost/qgisserver?
SERVICE=WMS&
REQUEST=GetFeatureInfo&
QUERY_LAYERS=my+layer&
...
```

However, it's not possible anymore with QGIS Server from master. This PR fixes this issue and add a test.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
