### PR TITLE
Fix crash with hidden dock widget

### DIFF
--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -271,44 +271,46 @@ void QgsBrowserDockWidget::removeFavorite()
 
 void QgsBrowserDockWidget::refresh()
 {
-  if ( mModel )
-    refreshModel( QModelIndex() );
+  refreshModel( QModelIndex() );
 }
 
 void QgsBrowserDockWidget::refreshModel( const QModelIndex &index )
 {
-  QgsDataItem *item = mModel->dataItem( index );
-  if ( item )
+  if ( mModel && mProxyModel )
   {
-    QgsDebugMsg( "path = " + item->path() );
-  }
-  else
-  {
-    QgsDebugMsg( "invalid item" );
-  }
-
-  if ( item && ( item->capabilities2() & QgsDataItem::Fertile ) )
-  {
-    mModel->refresh( index );
-  }
-
-  for ( int i = 0; i < mModel->rowCount( index ); i++ )
-  {
-    QModelIndex idx = mModel->index( i, 0, index );
-    QModelIndex proxyIdx = mProxyModel->mapFromSource( idx );
-    QgsDataItem *child = mModel->dataItem( idx );
-
-    // Check also expanded descendants so that the whole expanded path does not get collapsed if one item is collapsed.
-    // Fast items (usually root items) are refreshed so that when collapsed, it is obvious they are if empty (no expand symbol).
-    if ( mBrowserView->isExpanded( proxyIdx ) || mBrowserView->hasExpandedDescendant( proxyIdx ) || ( child && child->capabilities2() & QgsDataItem::Fast ) )
+    QgsDataItem *item = mModel->dataItem( index );
+    if ( item )
     {
-      refreshModel( idx );
+      QgsDebugMsg( "path = " + item->path() );
     }
     else
     {
-      if ( child && ( child->capabilities2() & QgsDataItem::Fertile ) )
+      QgsDebugMsg( "invalid item" );
+    }
+
+    if ( item && ( item->capabilities2() & QgsDataItem::Fertile ) )
+    {
+      mModel->refresh( index );
+    }
+
+    for ( int i = 0; i < mModel->rowCount( index ); i++ )
+    {
+      QModelIndex idx = mModel->index( i, 0, index );
+      QModelIndex proxyIdx = mProxyModel->mapFromSource( idx );
+      QgsDataItem *child = mModel->dataItem( idx );
+
+      // Check also expanded descendants so that the whole expanded path does not get collapsed if one item is collapsed.
+      // Fast items (usually root items) are refreshed so that when collapsed, it is obvious they are if empty (no expand symbol).
+      if ( mBrowserView->isExpanded( proxyIdx ) || mBrowserView->hasExpandedDescendant( proxyIdx ) || ( child && child->capabilities2() & QgsDataItem::Fast ) )
       {
-        child->depopulate();
+        refreshModel( idx );
+      }
+      else
+      {
+        if ( child && ( child->capabilities2() & QgsDataItem::Fertile ) )
+        {
+          child->depopulate();
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #17357
Fixes #17279
Fixes #17317

Supersedes https://github.com/qgis/QGIS/pull/5455

Reasoning, looking at those traces I'm pretty sure, it's because QgisApp creates a browser widget, hides it and then pushes updates (`refresh()`) even when uninitialized.
Initializing happens only on `showEvent()`, so this guards discards any update event if uninitialized (i.e. no show even has occurred before, even more explicitely, if the browser dock is deactivated).