### PR TITLE
[server][bugfix] Fixes #17399 WIDTH and HEIGHT parameters are not mandatory for GetPrint

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -292,7 +292,7 @@ namespace QgsWms
     QList<QgsWmsParametersLayer> params = mWmsParameters.layersParameters();
 
     // create the output image
-    std::unique_ptr<QImage> image( createImage() );
+    std::unique_ptr<QImage> image( new QImage() );
 
     // configure map settings (background, DPI, ...)
     QgsMapSettings mapSettings;

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -1189,8 +1189,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1206,8 +1204,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1224,8 +1220,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
             "LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1243,8 +1237,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country_Labels",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1263,8 +1255,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country_Labels",
             "map0:STYLES": "custom",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1281,8 +1271,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "LAYERS": "Country_Labels",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1300,8 +1288,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "LAYERS": "Country_Labels",
             "STYLES": "custom",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1319,8 +1305,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country_Labels",
             "LAYERS": "Country_Labels",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1339,8 +1323,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:LAYERS": "Country_Labels",
             "map0:STYLES": "custom",
             "LAYERS": "Country_Labels",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1357,8 +1339,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1375,8 +1355,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-309.015,-133.011,312.179,133.949",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:4326"
         }.items())])
 
@@ -1394,8 +1372,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
             "map0:SCALE": "36293562",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1414,8 +1390,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:LAYERS": "Country,Hello",
             "map0:GRID_INTERVAL_X": "1000000",
             "map0:GRID_INTERVAL_Y": "2000000",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1433,8 +1407,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
             "map0:ROTATION": "45",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1451,8 +1423,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857",
             "SELECTION": "Country: 4"
         }.items())])
@@ -1470,8 +1440,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857",
             "SELECTION": "Country: 4",
             "LAYERS": "Country,Hello",
@@ -1490,8 +1458,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857",
             "SELECTION": "Country: 4",
             "LAYERS": "Country,Hello",
@@ -1519,8 +1485,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "map0:HIGHLIGHT_LABELCOLOR": "%2300FF0000",
             "map0:HIGHLIGHT_LABELBUFFERCOLOR": "%232300FF00",
             "map0:HIGHLIGHT_LABELBUFFERSIZE": "1.5",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857"
         }.items())])
 
@@ -1538,8 +1502,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857",
             "IDTEXTBOX": "Updated QGIS composer label"
         }.items())])
@@ -1556,8 +1518,6 @@ class TestQgsServerWMS(QgsServerTestBase):
             "FORMAT": "png",
             "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
-            "HEIGHT": "500",
-            "WIDTH": "500",
             "CRS": "EPSG:3857",
             "IDTEXTBOX": ""
         }.items())])


### PR DESCRIPTION
## Description

@elemoine reported an issue for the `GetPrint` request by playing with QWC2: https://issues.qgis.org/issues/17399. 

In fact, `WIDTH` and `HEIGHT` parameters are now mandatory but it should not.

I updated tests accordingly.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
