### PR TITLE
[bugfix] Issue #17387: MSSQL provider fails to load UNIQUEIDENTIFIER fields

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -417,7 +417,9 @@ void QgsMssqlProvider::loadFields()
         }
         if ( sqlType == QVariant::String )
         {
-          int length = query.value( ( sqlTypeName == "uniqueidentifier" ) ? 6 : 7 ).toInt();
+          // Field length in chars is column 7 ("Length") of the sp_columns output,
+          // except for uniqueidentifiers which must use column 6 ("Precision").
+          int length = query.value( sqlTypeName.startsWith( QLatin1String( "uniqueidentifier" ), Qt::CaseInsensitive ) ? 6 : 7 ).toInt();
           if ( sqlTypeName.startsWith( QLatin1String( "n" ) ) )
           {
             length = length / 2;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -417,7 +417,7 @@ void QgsMssqlProvider::loadFields()
         }
         if ( sqlType == QVariant::String )
         {
-          int length = query.value( 7 ).toInt();
+          int length = query.value( ( sqlTypeName == "uniqueidentifier" ) ? 6 : 7 ).toInt();
           if ( sqlTypeName.startsWith( QLatin1String( "n" ) ) )
           {
             length = length / 2;


### PR DESCRIPTION
## Description
This PR is an attempt at a fix for [issue #17387](https://issues.qgis.org/issues/17387). I can't compile QGIS locally so it is untested.

Running the prepare-commit script fails for me with `astyle.sh not found`.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
