### PR TITLE
Developers Map: show more descriptive info

### DIFF
--- a/doc/contributors.json
+++ b/doc/contributors.json
@@ -8,7 +8,7 @@
         "Committer": "Yes",
         "First Commit Message": "Initial revision",
         "First Commit Date": "06-07-2002",
-        "GIT Nickname": "gsherman"
+        "GIT Nickname": "g-sherman"
       },
       "geometry": {
         "type": "Point",
@@ -141,7 +141,7 @@
         "Committer": "Yes",
         "First Commit Message": "some dutch translations for git testing",
         "First Commit Date": "4-9-2011",
-        "GIT Nickname": "duiv"
+        "GIT Nickname": "rduivenvoorde"
       },
       "geometry": {
         "type": "Point",
@@ -277,7 +277,7 @@
         "Committer": "Yes",
         "First Commit Message": "some bugfixes",
         "First Commit Date": "07-04-2004",
-        "GIT Nickname": "rabla,rblazek,blazek"
+        "GIT Nickname": "blazek"
       },
       "geometry": {
         "type": "Point",
@@ -334,7 +334,7 @@
         "type": "Point",
         "coordinates": [
           104.9110,
-          11.5582          
+          11.5582
         ]
       }
     },
@@ -627,7 +627,7 @@
         "Committer": "Yes",
         "First Commit Message": "Patch to allow setting extents from cli on startup",
         "First Commit Date": "03-06-2005",
-        "GIT Nickname": "wonder"
+        "GIT Nickname": "wonder-sk"
       },
       "geometry": {
         "type": "Point",

--- a/doc/developersmap.html
+++ b/doc/developersmap.html
@@ -21,10 +21,18 @@
   });
 
   $.getJSON($('link[rel="points"]').attr("href"), function(data) {
+    var nameString = '';
     var geojson = L.geoJson(data, {
       onEachFeature: function (feature, layer) {
-        layer.bindPopup("<b>Name:</b> " + feature.properties.Name +
-                        "<br><b>Status:</b> " + (feature.properties.Committer == "Yes" ?
+        if (feature.properties['GIT Nickname'] !== undefined){
+          nameString = "<a href='https://github.com/" +
+                       feature.properties['GIT Nickname'] + "' target='_blank' >" +
+                       feature.properties.Name + "</a>";
+        } else {
+          nameString = feature.properties.Name;
+        }
+        layer.bindPopup("<b>Name:</b> " + nameString + "<br><b>Status:</b> " +
+                        (feature.properties.Committer == "Yes" ?
                         "Core committer" : "Core contributor" ));
       }
     });

--- a/doc/developersmap.html
+++ b/doc/developersmap.html
@@ -31,7 +31,7 @@
         } else {
           nameString = feature.properties.Name;
         }
-        layer.bindPopup("<b>Name:</b> " + nameString + "<br><b>Status:</b> " +
+        layer.bindPopup(nameString + "<br>" +
                         (feature.properties.Committer == "Yes" ?
                         "Core committer" : "Core contributor" ));
       }

--- a/doc/developersmap.html
+++ b/doc/developersmap.html
@@ -17,14 +17,15 @@
   <script>
   var developersMapTiles = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
     maxZooom: 18,
-    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'  
+    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
   });
 
   $.getJSON($('link[rel="points"]').attr("href"), function(data) {
     var geojson = L.geoJson(data, {
       onEachFeature: function (feature, layer) {
         layer.bindPopup("<b>Name:</b> " + feature.properties.Name +
-			"<br><b>Committer:</b> " + feature.properties.Committer);
+                        "<br><b>Status:</b> " + (feature.properties.Committer == "Yes" ?
+                        "Core committer" : "Core contributor" ));
       }
     });
     var map = L.map('developers-map').fitBounds(geojson.getBounds());


### PR DESCRIPTION
As a follow-up to the "Trusted Plugin/Trusted Author" [discussion](http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-Reword-quot-Trusted-Plugin-quot-gt-quot-Trusted-Plugin-Author-quot-td5334047.html) and [PR](https://github.com/qgis/QGIS/pull/5272), the `Committer: No` in the developers map seems a bit selective for me, I don't know if other contributors feel the same.

What I propose is to change 

```
Commiter: Yes  -->   Status: Core committer
Commiter: No   -->   Status: Core contributor
```
![committers](https://user-images.githubusercontent.com/652785/32377758-ab88d21a-c076-11e7-842c-6738ae9715f2.png)


This is to avoid excluding people from a group and instead acknowledging (and letting others know) what a person means for the project.

Additionally, since the contributors.json file has a `GIT Nickname` property, this PR adds a link to each dev's GIT account.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
