### PR TITLE
Load SpatiaLite extension for sqlite3 (on Windows)

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -599,7 +599,7 @@ using the "mod_spatialite" extension (python3)"""
         # SpatiaLite >= 4.2 and Sqlite >= 3.7.17, should work on all platforms
         ("mod_spatialite", "sqlite3_modspatialite_init"),
         # SpatiaLite >= 4.2 (windows)
-        ("spatialite4.dll", "sqlite3_modspatialite_init"),
+        ("spatialite", "spatialite_init_ex"),
         # SpatiaLite >= 4.2 and Sqlite < 3.7.17 (Travis)
         ("mod_spatialite.so", "sqlite3_modspatialite_init"),
         # SpatiaLite < 4.2 (linux)


### PR DESCRIPTION
Current module and process are failing to load. I've tested these new ones.

Can anybody confirm on a Windows machine? 
In QGIS Python console this is currently failing:

```
con = qgis.utils.spatialite_connect(":memory:") # Shouldn't throw any exception now!
cur = con.cursor()
res = cur.execute("SELECT spatialite_version();")
print(res.fetchone())
```

This PR  fixes it, making db_manager able to read SpatiaLite DBs again.


- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
