### PR TITLE
[Geometry Checker] Better handling of the geometry checker dialog

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.ui
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.ui
@@ -41,9 +41,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-265</y>
-        <width>626</width>
-        <height>1016</height>
+        <y>0</y>
+        <width>656</width>
+        <height>960</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_4">
@@ -110,11 +110,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBoxGeometryTypes">
-            <property name="title">
+           <widget class="QgsCollapsibleGroupBox" name="groupBoxGeometryTypes" native="true">
+            <property name="title" stdset="0">
              <string>Allowed geometry types</string>
             </property>
-            <property name="flat">
+            <property name="flat" stdset="0">
              <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout">
@@ -179,11 +179,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBox_2">
-            <property name="title">
+           <widget class="QgsCollapsibleGroupBox" name="groupBox_2" native="true">
+            <property name="title" stdset="0">
              <string>Geometry validity</string>
             </property>
-            <property name="flat">
+            <property name="flat" stdset="0">
              <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_8">
@@ -243,11 +243,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBoxGeometryProperties">
-            <property name="title">
+           <widget class="QgsCollapsibleGroupBox" name="groupBoxGeometryProperties" native="true">
+            <property name="title" stdset="0">
              <string>Geometry properties</string>
             </property>
-            <property name="flat">
+            <property name="flat" stdset="0">
              <bool>true</bool>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -291,11 +291,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBoxGeometryConditions">
-            <property name="title">
+           <widget class="QgsCollapsibleGroupBox" name="groupBoxGeometryConditions" native="true">
+            <property name="title" stdset="0">
              <string>Geometry conditions</string>
             </property>
-            <property name="flat">
+            <property name="flat" stdset="0">
              <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_2">
@@ -462,11 +462,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBoxTopology">
-            <property name="title">
+           <widget class="QgsCollapsibleGroupBox" name="groupBoxTopology" native="true">
+            <property name="title" stdset="0">
              <string>Topology checks</string>
             </property>
-            <property name="flat">
+            <property name="flat" stdset="0">
              <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
@@ -519,7 +519,7 @@
              <item row="3" column="0">
               <widget class="QCheckBox" name="checkBoxGaps">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -563,7 +563,7 @@
              <item row="2" column="0">
               <widget class="QCheckBox" name="checkBoxOverlaps">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -731,14 +731,14 @@
                 <item row="0" column="0">
                  <widget class="QLabel" name="labelOutputFormat">
                   <property name="text">
-                   <string>Format:</string>
+                   <string>Format</string>
                   </property>
                  </widget>
                 </item>
                 <item row="1" column="0">
                  <widget class="QLabel" name="labelOutputDirectory">
                   <property name="text">
-                   <string>Output directory:</string>
+                   <string>Output directory</string>
                   </property>
                  </widget>
                 </item>
@@ -762,7 +762,7 @@
                 <item row="2" column="0">
                  <widget class="QLabel" name="labelFilenamePrefix">
                   <property name="text">
-                   <string>Filename prefix:</string>
+                   <string>Filename prefix</string>
                   </property>
                  </widget>
                 </item>
@@ -834,6 +834,19 @@
          </layout>
         </widget>
        </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -847,20 +860,30 @@
    <header>qgsvscrollarea.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QWidget</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
+  <tabstop>listWidgetInputLayers</tabstop>
   <tabstop>checkBoxInputSelectedOnly</tabstop>
-  <tabstop>checkBoxSelfIntersections</tabstop>
-  <tabstop>checkBoxDuplicateNodes</tabstop>
   <tabstop>checkBoxPoint</tabstop>
   <tabstop>checkBoxMultipoint</tabstop>
   <tabstop>checkBoxLine</tabstop>
   <tabstop>checkBoxMultiline</tabstop>
   <tabstop>checkBoxPolygon</tabstop>
   <tabstop>checkBoxMultipolygon</tabstop>
+  <tabstop>checkBoxSelfIntersections</tabstop>
+  <tabstop>checkBoxDuplicateNodes</tabstop>
+  <tabstop>checkBoxSelfContacts</tabstop>
+  <tabstop>checkBoxDegeneratePolygon</tabstop>
   <tabstop>checkBoxNoHoles</tabstop>
   <tabstop>checkBoxMultipart</tabstop>
+  <tabstop>checkBoxDangle</tabstop>
   <tabstop>checkBoxSegmentLength</tabstop>
   <tabstop>doubleSpinBoxSegmentLength</tabstop>
   <tabstop>checkBoxAngle</tabstop>
@@ -877,9 +900,20 @@
   <tabstop>doubleSpinBoxOverlapArea</tabstop>
   <tabstop>checkBoxGaps</tabstop>
   <tabstop>doubleSpinBoxGapArea</tabstop>
+  <tabstop>checkPointCoveredByLine</tabstop>
+  <tabstop>checkPointInPolygon</tabstop>
+  <tabstop>checkLineIntersection</tabstop>
+  <tabstop>checkLineLayerIntersection</tabstop>
+  <tabstop>comboLineLayerIntersection</tabstop>
+  <tabstop>checkBoxFollowBoundaries</tabstop>
+  <tabstop>comboBoxFollowBoundaries</tabstop>
   <tabstop>spinBoxTolerance</tabstop>
   <tabstop>radioButtonOutputModifyInput</tabstop>
   <tabstop>radioButtonOutputNew</tabstop>
+  <tabstop>comboBoxOutputFormat</tabstop>
+  <tabstop>lineEditOutputDirectory</tabstop>
+  <tabstop>pushButtonOutputDirectory</tabstop>
+  <tabstop>lineEditFilenamePrefix</tabstop>
  </tabstops>
  <resources>
   <include location="pluginres.qrc"/>


### PR DESCRIPTION
On a 17" laptop, the whole dialog is too high to be visible and the input layers are not easy to pick.
By using collapsible group boxes (reducing height of dialog) but keeping the input and output sections always visible, i think it gives a better UI.
Also fix widget tab ordering and align widgets.

![image](https://user-images.githubusercontent.com/7983394/32405710-b1872820-c16a-11e7-9d29-e46591eb2d73.png)