### PR TITLE
[Plugin manager] [needs-doc] Don't preload all plugins for a test

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -307,7 +307,7 @@ class QgsPluginInstaller(QObject):
             updateAvailablePlugins()
             # try to load the plugin
             loadPlugin(plugin["id"])
-            plugins.getAllInstalled(testLoad=True)
+            plugins.getAllInstalled()
             plugins.rebuild()
             plugin = plugins.all()[key]
             if not plugin["error"]:
@@ -565,7 +565,7 @@ class QgsPluginInstaller(QObject):
         if infoString is None:
             updateAvailablePlugins()
             loadPlugin(pluginName)
-            plugins.getAllInstalled(testLoad=True)
+            plugins.getAllInstalled()
             plugins.rebuild()
 
             if settings.contains('/PythonPlugins/' + pluginName):

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -548,7 +548,7 @@ class Plugins(QObject):
             del self.repoCache[repo]
 
     # ----------------------------------------- #
-    def getInstalledPlugin(self, key, path, readOnly, testLoad=True):
+    def getInstalledPlugin(self, key, path, readOnly, testLoad=False):
         """ get the metadata of an installed plugin """
         def metadataParser(fct):
             """ plugin metadata parser reimplemented from qgis.utils
@@ -683,8 +683,11 @@ class Plugins(QObject):
         return plugin
 
     # ----------------------------------------- #
-    def getAllInstalled(self, testLoad=True):
-        """ Build the localCache """
+    def getAllInstalled(self, testLoad=False):
+        """ Build the localCache
+            Note: Currently testLoad is always disabled in order to speed up QGIS startup.
+                  The related code will be probably removed.
+        """
         self.localCache = {}
 
         # reversed list of the plugin paths: first system plugins -> then user plugins -> finally custom path(s)


### PR DESCRIPTION
The test loading of all plugins slowed down QGIS start, so this PR removes that function.
First, we have the watchdog now.
Second, if an enabled plugin fails to load, in QGIS 3.2 we can store details and show the status/reason/traceback/whatever in the manager rather than load twice.
 
See the discussion https://github.com/qgis/qgis3.0_api/issues/43