### PR TITLE
Add flags to QgsVectorFileWriter methods which return lists of drivers 

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2673,6 +2673,7 @@ for consistency with other parts of the QGIS API.
 - static `writeAsVectorFormat` calls no longer take a errorMessage argument in
   python and instead return a `(errorCode, errorMessage)` tuple.
 - ogrDriverList now returns a list of QgsVectorFileWriter.DriverDetails structs, instead of a map
+- supportedFiltersAndFormats now returns a list of QgsVectorFileWriter.FilterFormatDetails structs, instead of a map
 
 
 QgsWMSLegendNode        {#qgis_api_break_3_0_QgsWMSLegendNode}

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2672,6 +2672,7 @@ for consistency with other parts of the QGIS API.
 - The addFeature which takes a renderer argument was renamed to addFeatureWithStyle.
 - static `writeAsVectorFormat` calls no longer take a errorMessage argument in
   python and instead return a `(errorCode, errorMessage)` tuple.
+- ogrDriverList now returns a list of QgsVectorFileWriter.DriverDetails structs, instead of a map
 
 
 QgsWMSLegendNode        {#qgis_api_break_3_0_QgsWMSLegendNode}

--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -145,6 +145,14 @@ Some formats require a compulsory encoding, typically UTF-8. If no compulsory en
       SymbolLayerSymbology
     };
 
+
+    enum VectorFormatOption
+    {
+      SortRecommended,
+    };
+    typedef QFlags<QgsVectorFileWriter::VectorFormatOption> VectorFormatOptions;
+
+
     class FieldValueConverter
 {
 %Docstring
@@ -460,27 +468,41 @@ Create a new vector file writer
 
 
 
-    static QMap< QString, QString> supportedFiltersAndFormats();
+    static QList< QPair< QString, QString > > supportedFiltersAndFormats( VectorFormatOptions options = SortRecommended );
 %Docstring
- Returns a map with format filter string as key and OGR format key as value.
+ Returns a list or pairs, with format filter string as first element and OGR format key as second element.
+
+ The ``options`` argument can be used to control the sorting and filtering of
+ returned formats.
+
 .. seealso:: supportedOutputVectorLayerExtensions()
- :rtype: QMap< str, QString>
+ :rtype: list of QPair< str, QString >
 %End
 
-    static QStringList supportedFormatExtensions();
+    static QStringList supportedFormatExtensions( VectorFormatOptions options = SortRecommended );
 %Docstring
  Returns a list of file extensions for supported formats.
+
+ The ``options`` argument can be used to control the sorting and filtering of
+ returned formats.
+
 .. versionadded:: 3.0
 .. seealso:: supportedFiltersAndFormats()
  :rtype: list of str
 %End
 
-    static QMap< QString, QString> ogrDriverList();
+    static QList< QPair< QString, QString > > ogrDriverList( VectorFormatOptions options = SortRecommended );
 %Docstring
  Returns driver list that can be used for dialogs. It contains all OGR drivers
- + some additional internal QGIS driver names to distinguish between more
- supported formats of the same OGR driver
- :rtype: QMap< str, QString>
+ plus some additional internal QGIS driver names to distinguish between more
+ supported formats of the same OGR driver.
+
+ The returned list consists of pairs of driver long name (e.g. user-friendly
+ display name for the format) to internal driver short name.
+
+ The ``options`` argument can be used to control the sorting and filtering of
+ returned drivers.
+ :rtype: list of QPair< str, QString >
 %End
 
     static QString driverForExtension( const QString &extension );
@@ -492,9 +514,12 @@ Create a new vector file writer
  :rtype: str
 %End
 
-    static QString fileFilterString();
+    static QString fileFilterString( VectorFormatOptions options = SortRecommended );
 %Docstring
-Returns filter string that can be used for dialogs
+ Returns filter string that can be used for dialogs.
+
+ The ``options`` argument can be used to control the sorting and filtering of
+ returned drivers.
  :rtype: str
 %End
 
@@ -638,6 +663,8 @@ Close opened shapefile for writing
 };
 
 QFlags<QgsVectorFileWriter::EditionCapability> operator|(QgsVectorFileWriter::EditionCapability f1, QFlags<QgsVectorFileWriter::EditionCapability> f2);
+
+QFlags<QgsVectorFileWriter::VectorFormatOption> operator|(QgsVectorFileWriter::VectorFormatOption f1, QFlags<QgsVectorFileWriter::VectorFormatOption> f2);
 
 
 

--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -491,18 +491,31 @@ Create a new vector file writer
  :rtype: list of str
 %End
 
-    static QList< QPair< QString, QString > > ogrDriverList( VectorFormatOptions options = SortRecommended );
+    struct DriverDetails
+    {
+      QString longName;
 %Docstring
- Returns driver list that can be used for dialogs. It contains all OGR drivers
+Descriptive, user friendly name for the driver
+%End
+
+      QString driverName;
+%Docstring
+Unique driver name
+%End
+    };
+
+    static QList< QgsVectorFileWriter::DriverDetails > ogrDriverList( VectorFormatOptions options = SortRecommended );
+%Docstring
+ Returns the driver list that can be used for dialogs. It contains all OGR drivers
  plus some additional internal QGIS driver names to distinguish between more
  supported formats of the same OGR driver.
 
- The returned list consists of pairs of driver long name (e.g. user-friendly
- display name for the format) to internal driver short name.
+ The returned list consists of structs containing the driver long name (e.g. user-friendly
+ display name for the format) and internal driver short name.
 
  The ``options`` argument can be used to control the sorting and filtering of
  returned drivers.
- :rtype: list of QPair< str, QString >
+ :rtype: list of QgsVectorFileWriter.DriverDetails
 %End
 
     static QString driverForExtension( const QString &extension );

--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -10,8 +10,6 @@
 
 
 
-
-
 class QgsVectorFileWriter : QgsFeatureSink
 {
 %Docstring
@@ -468,7 +466,20 @@ Create a new vector file writer
 
 
 
-    static QList< QPair< QString, QString > > supportedFiltersAndFormats( VectorFormatOptions options = SortRecommended );
+    struct FilterFormatDetails
+    {
+      QString driverName;
+%Docstring
+Unique driver name
+%End
+
+      QString filterString;
+%Docstring
+Filter string for file picker dialogs
+%End
+    };
+
+    static QList< QgsVectorFileWriter::FilterFormatDetails > supportedFiltersAndFormats( VectorFormatOptions options = SortRecommended );
 %Docstring
  Returns a list or pairs, with format filter string as first element and OGR format key as second element.
 
@@ -476,7 +487,7 @@ Create a new vector file writer
  returned formats.
 
 .. seealso:: supportedOutputVectorLayerExtensions()
- :rtype: list of QPair< str, QString >
+ :rtype: list of QgsVectorFileWriter.FilterFormatDetails
 %End
 
     static QStringList supportedFormatExtensions( VectorFormatOptions options = SortRecommended );

--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -147,6 +147,7 @@ Some formats require a compulsory encoding, typically UTF-8. If no compulsory en
     enum VectorFormatOption
     {
       SortRecommended,
+      SkipNonSpatialFormats,
     };
     typedef QFlags<QgsVectorFileWriter::VectorFormatOption> VectorFormatOptions;
 

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -174,9 +174,9 @@ class GdalUtils(object):
             return 'ESRI Shapefile'
 
         formats = QgsVectorFileWriter.supportedFiltersAndFormats()
-        for k, v in list(formats.items()):
-            if ext in k:
-                return v
+        for format in formats:
+            if ext in format[0]:
+                return format[1]
         return 'ESRI Shapefile'
 
     @staticmethod

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -175,8 +175,8 @@ class GdalUtils(object):
 
         formats = QgsVectorFileWriter.supportedFiltersAndFormats()
         for format in formats:
-            if ext in format[0]:
-                return format[1]
+            if ext in format.filterString:
+                return format.driverName
         return 'ESRI Shapefile'
 
     @staticmethod

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2762,12 +2762,12 @@ QStringList QgsVectorFileWriter::supportedFormatExtensions( const VectorFormatOp
   return extensions;
 }
 
-QList< QPair< QString, QString> > QgsVectorFileWriter::ogrDriverList( const VectorFormatOptions options )
+QList< QgsVectorFileWriter::DriverDetails > QgsVectorFileWriter::ogrDriverList( const VectorFormatOptions options )
 {
-  QList< QPair< QString, QString> > resultMap;
+  QList< QgsVectorFileWriter::DriverDetails > results;
 
   QgsApplication::registerOgrDrivers();
-  int const drvCount = OGRGetDriverCount();
+  const int drvCount = OGRGetDriverCount();
 
   QStringList writableDrivers;
   for ( int i = 0; i < drvCount; ++i )
@@ -2836,10 +2836,13 @@ QList< QPair< QString, QString> > QgsVectorFileWriter::ogrDriverList( const Vect
     MetaData metadata;
     if ( driverMetadata( drvName, metadata ) && !metadata.trLongName.isEmpty() )
     {
-      resultMap << qMakePair( metadata.trLongName, drvName );
+      DriverDetails details;
+      details.driverName = drvName;
+      details.longName = metadata.trLongName;
+      results << details;
     }
   }
-  return resultMap;
+  return results;
 }
 
 QString QgsVectorFileWriter::driverForExtension( const QString &extension )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2703,7 +2703,7 @@ QList< QgsVectorFileWriter::FilterFormatDetails > QgsVectorFileWriter::supported
         {
           // skip non-spatial formats
           // TODO - use GDAL metadata to determine this, when support exists in GDAL
-          if ( drvName == QStringLiteral( "ODS" ) || drvName == QStringLiteral( "XLSX" ) || drvName == QStringLiteral( "XLS" ) )
+          if ( drvName == QLatin1String( "ODS" ) || drvName == QLatin1String( "XLSX" ) || drvName == QLatin1String( "XLS" ) )
             continue;
         }
 
@@ -2717,12 +2717,12 @@ QList< QgsVectorFileWriter::FilterFormatDetails > QgsVectorFileWriter::supported
 
         if ( options & SortRecommended )
         {
-          if ( drvName == QStringLiteral( "ESRI Shapefile" ) )
+          if ( drvName == QLatin1String( "ESRI Shapefile" ) )
           {
             shapeFormat = details;
             continue;
           }
-          else if ( drvName == QStringLiteral( "GPKG" ) )
+          else if ( drvName == QLatin1String( "GPKG" ) )
           {
             gpkgFormat = details;
             continue;
@@ -2793,7 +2793,7 @@ QList< QgsVectorFileWriter::DriverDetails > QgsVectorFileWriter::ogrDriverList( 
       {
         // skip non-spatial formats
         // TODO - use GDAL metadata to determine this, when support exists in GDAL
-        if ( drvName == QStringLiteral( "ODS" ) || drvName == QStringLiteral( "XLSX" ) || drvName == QStringLiteral( "XLS" ) )
+        if ( drvName == QLatin1String( "ODS" ) || drvName == QLatin1String( "XLSX" ) || drvName == QLatin1String( "XLS" ) )
           continue;
       }
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2894,9 +2894,11 @@ QString QgsVectorFileWriter::filterForDriver( const QString &driverName )
 {
   MetaData metadata;
   if ( !driverMetadata( driverName, metadata ) || metadata.trLongName.isEmpty() || metadata.glob.isEmpty() )
-    return QLatin1String( "" );
+    return QString();
 
-  return metadata.trLongName + " [OGR] (" + metadata.glob.toLower() + ' ' + metadata.glob.toUpper() + ')';
+  return QStringLiteral( "%1 (%2 %3)" ).arg( metadata.trLongName,
+         metadata.glob.toLower(),
+         metadata.glob.toUpper() );
 }
 
 QString QgsVectorFileWriter::convertCodecNameForEncodingOption( const QString &codecName )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2699,6 +2699,14 @@ QList< QgsVectorFileWriter::FilterFormatDetails > QgsVectorFileWriter::supported
       QString drvName = OGR_Dr_GetName( drv );
       if ( OGR_Dr_TestCapability( drv, "CreateDataSource" ) != 0 )
       {
+        if ( options & SkipNonSpatialFormats )
+        {
+          // skip non-spatial formats
+          // TODO - use GDAL metadata to determine this, when support exists in GDAL
+          if ( drvName == QStringLiteral( "ODS" ) || drvName == QStringLiteral( "XLSX" ) || drvName == QStringLiteral( "XLS" ) )
+            continue;
+        }
+
         QString filterString = filterForDriver( drvName );
         if ( filterString.isEmpty() )
           continue;
@@ -2780,6 +2788,15 @@ QList< QgsVectorFileWriter::DriverDetails > QgsVectorFileWriter::ogrDriverList( 
     if ( drv )
     {
       QString drvName = OGR_Dr_GetName( drv );
+
+      if ( options & SkipNonSpatialFormats )
+      {
+        // skip non-spatial formats
+        // TODO - use GDAL metadata to determine this, when support exists in GDAL
+        if ( drvName == QStringLiteral( "ODS" ) || drvName == QStringLiteral( "XLSX" ) || drvName == QStringLiteral( "XLS" ) )
+          continue;
+      }
+
       if ( drvName == QLatin1String( "ESRI Shapefile" ) )
       {
         writableDrivers << QStringLiteral( "DBF file" );

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2681,12 +2681,15 @@ void QgsVectorFileWriter::setSymbologyScale( double d )
   mRenderContext.setRendererScale( mSymbologyScale );
 }
 
-QMap< QString, QString> QgsVectorFileWriter::supportedFiltersAndFormats()
+QList< QPair< QString, QString > > QgsVectorFileWriter::supportedFiltersAndFormats( const VectorFormatOptions options )
 {
-  QMap<QString, QString> resultMap;
+  QList< QPair< QString, QString > > resultMap;
 
   QgsApplication::registerOgrDrivers();
   int const drvCount = OGRGetDriverCount();
+
+  QPair< QString, QString > shapeFormat;
+  QPair< QString, QString > gpkgFormat;
 
   for ( int i = 0; i < drvCount; ++i )
   {
@@ -2700,51 +2703,68 @@ QMap< QString, QString> QgsVectorFileWriter::supportedFiltersAndFormats()
         if ( filterString.isEmpty() )
           continue;
 
-        resultMap.insert( filterString, drvName );
+        if ( options & SortRecommended )
+        {
+          if ( drvName == QStringLiteral( "ESRI Shapefile" ) )
+          {
+            shapeFormat = qMakePair( filterString, drvName );
+            continue;
+          }
+          else if ( drvName == QStringLiteral( "GPKG" ) )
+          {
+            gpkgFormat = qMakePair( filterString, drvName );
+            continue;
+          }
+        }
+        resultMap << qMakePair( filterString, drvName );
       }
+    }
+  }
+
+  std::sort( resultMap.begin(), resultMap.end(), []( const QPair< QString, QString > &a, const QPair< QString, QString > &b ) -> bool
+  {
+    return a.second < b.second;
+  } );
+
+  if ( options & SortRecommended )
+  {
+    if ( !shapeFormat.first.isEmpty() )
+    {
+      resultMap.insert( 0, shapeFormat );
+    }
+    if ( !gpkgFormat.first.isEmpty() )
+    {
+      resultMap.insert( 0, gpkgFormat );
     }
   }
 
   return resultMap;
 }
 
-QStringList QgsVectorFileWriter::supportedFormatExtensions()
+QStringList QgsVectorFileWriter::supportedFormatExtensions( const VectorFormatOptions options )
 {
-  QgsStringMap formats = supportedFiltersAndFormats();
+  const auto formats = supportedFiltersAndFormats( options );
   QStringList extensions;
 
   QRegularExpression rx( QStringLiteral( "\\*\\.([a-zA-Z0-9]*)" ) );
 
-  QgsStringMap::const_iterator formatIt = formats.constBegin();
+  auto formatIt = formats.constBegin();
   for ( ; formatIt != formats.constEnd(); ++formatIt )
   {
-    QString ext = formatIt.key();
+    QString ext = formatIt->first;
     QRegularExpressionMatch match = rx.match( ext );
     if ( !match.hasMatch() )
       continue;
 
     QString matched = match.captured( 1 );
-
-    // special handling for the two main contenders for glory
-    if ( matched.compare( QStringLiteral( "gpkg" ), Qt::CaseInsensitive ) == 0 )
-      continue;
-    if ( matched.compare( QStringLiteral( "shp" ), Qt::CaseInsensitive ) == 0 )
-      continue;
-
     extensions << matched;
   }
-
-  std::sort( extensions.begin(), extensions.end() );
-
-  // Make https://twitter.com/shapefiIe a sad little fellow
-  extensions.insert( 0, QStringLiteral( "gpkg" ) );
-  extensions.insert( 1, QStringLiteral( "shp" ) );
   return extensions;
 }
 
-QMap<QString, QString> QgsVectorFileWriter::ogrDriverList()
+QList< QPair< QString, QString> > QgsVectorFileWriter::ogrDriverList( const VectorFormatOptions options )
 {
-  QMap<QString, QString> resultMap;
+  QList< QPair< QString, QString> > resultMap;
 
   QgsApplication::registerOgrDrivers();
   int const drvCount = OGRGetDriverCount();
@@ -2756,6 +2776,10 @@ QMap<QString, QString> QgsVectorFileWriter::ogrDriverList()
     if ( drv )
     {
       QString drvName = OGR_Dr_GetName( drv );
+      if ( drvName == QLatin1String( "ESRI Shapefile" ) )
+      {
+        writableDrivers << QStringLiteral( "DBF file" );
+      }
       if ( OGR_Dr_TestCapability( drv, "CreateDataSource" ) != 0 )
       {
         // Add separate format for Mapinfo MIF (MITAB is OGR default)
@@ -2786,24 +2810,35 @@ QMap<QString, QString> QgsVectorFileWriter::ogrDriverList()
           }
           CPLFree( options[0] );
         }
-        else if ( drvName == QLatin1String( "ESRI Shapefile" ) )
-        {
-          writableDrivers << QStringLiteral( "DBF file" );
-        }
         writableDrivers << drvName;
       }
     }
   }
+  std::sort( writableDrivers.begin(), writableDrivers.end() );
+  if ( options & SortRecommended )
+  {
+    // recommended order sorting, so we shift certain formats to the top
+    if ( writableDrivers.contains( QStringLiteral( "ESRI Shapefile" ) ) )
+    {
+      writableDrivers.removeAll( QStringLiteral( "ESRI Shapefile" ) );
+      writableDrivers.insert( 0, QStringLiteral( "ESRI Shapefile" ) );
+    }
+    if ( writableDrivers.contains( QStringLiteral( "GPKG" ) ) )
+    {
+      // Make https://twitter.com/shapefiIe a sad little fellow
+      writableDrivers.removeAll( QStringLiteral( "GPKG" ) );
+      writableDrivers.insert( 0, QStringLiteral( "GPKG" ) );
+    }
+  }
 
-  Q_FOREACH ( const QString &drvName, writableDrivers )
+  for ( const QString &drvName : qgis::as_const( writableDrivers ) )
   {
     MetaData metadata;
     if ( driverMetadata( drvName, metadata ) && !metadata.trLongName.isEmpty() )
     {
-      resultMap.insert( metadata.trLongName, drvName );
+      resultMap << qMakePair( metadata.trLongName, drvName );
     }
   }
-
   return resultMap;
 }
 
@@ -2841,17 +2876,16 @@ QString QgsVectorFileWriter::driverForExtension( const QString &extension )
   return QString();
 }
 
-QString QgsVectorFileWriter::fileFilterString()
+QString QgsVectorFileWriter::fileFilterString( const VectorFormatOptions options )
 {
   QString filterString;
-  QMap< QString, QString> driverFormatMap = supportedFiltersAndFormats();
-  QMap< QString, QString>::const_iterator it = driverFormatMap.constBegin();
-  for ( ; it != driverFormatMap.constEnd(); ++it )
+  const auto driverFormatMap = supportedFiltersAndFormats( options );
+  for ( auto it = driverFormatMap.constBegin(); it != driverFormatMap.constEnd(); ++it )
   {
     if ( !filterString.isEmpty() )
       filterString += QLatin1String( ";;" );
 
-    filterString += it.key();
+    filterString += it->first;
   }
   return filterString;
 }

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -528,17 +528,30 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     static QStringList supportedFormatExtensions( VectorFormatOptions options = SortRecommended );
 
     /**
-     * Returns driver list that can be used for dialogs. It contains all OGR drivers
+     * Details of available driver formats.
+     * \since QGIS 3.0
+     */
+    struct DriverDetails
+    {
+      //! Descriptive, user friendly name for the driver
+      QString longName;
+
+      //! Unique driver name
+      QString driverName;
+    };
+
+    /**
+     * Returns the driver list that can be used for dialogs. It contains all OGR drivers
      * plus some additional internal QGIS driver names to distinguish between more
      * supported formats of the same OGR driver.
      *
-     * The returned list consists of pairs of driver long name (e.g. user-friendly
-     * display name for the format) to internal driver short name.
+     * The returned list consists of structs containing the driver long name (e.g. user-friendly
+     * display name for the format) and internal driver short name.
      *
      * The \a options argument can be used to control the sorting and filtering of
      * returned drivers.
      */
-    static QList< QPair< QString, QString > > ogrDriverList( VectorFormatOptions options = SortRecommended );
+    static QList< QgsVectorFileWriter::DriverDetails > ogrDriverList( VectorFormatOptions options = SortRecommended );
 
     /**
      * Returns the OGR driver name for a specified file \a extension. E.g. the

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -29,9 +29,6 @@
 #include "qgsogrutils.h"
 #include <ogr_api.h>
 
-#include <QPair>
-
-
 class QgsSymbolLayer;
 class QTextCodec;
 class QgsFeatureIterator;
@@ -507,6 +504,19 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     QgsVectorFileWriter &operator=( const QgsVectorFileWriter &rh ) = delete;
 
     /**
+     * Details of available filters and formats.
+     * \since QGIS 3.0
+     */
+    struct FilterFormatDetails
+    {
+      //! Unique driver name
+      QString driverName;
+
+      //! Filter string for file picker dialogs
+      QString filterString;
+    };
+
+    /**
      * Returns a list or pairs, with format filter string as first element and OGR format key as second element.
      *
      * The \a options argument can be used to control the sorting and filtering of
@@ -514,7 +524,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      *
      * \see supportedOutputVectorLayerExtensions()
      */
-    static QList< QPair< QString, QString > > supportedFiltersAndFormats( VectorFormatOptions options = SortRecommended );
+    static QList< QgsVectorFileWriter::FilterFormatDetails > supportedFiltersAndFormats( VectorFormatOptions options = SortRecommended );
 
     /**
      * Returns a list of file extensions for supported formats.

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -191,6 +191,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     enum VectorFormatOption
     {
       SortRecommended = 1 << 1, //!< Use recommended sort order, with extremely commonly used formats listed first
+      SkipNonSpatialFormats = 1 << 2, //!< Filter out any formats which do not have spatial support (e.g. those which cannot save geometries)
     };
     Q_DECLARE_FLAGS( VectorFormatOptions, VectorFormatOption )
 

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -186,6 +186,17 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
       SymbolLayerSymbology //Exports one feature per symbol layer (considering symbol levels)
     };
 
+
+    /**
+     * Options for sorting and filtering vector formats.
+     * \since QGIS 3.0
+     */
+    enum VectorFormatOption
+    {
+      SortRecommended = 1 << 1, //!< Use recommended sort order, with extremely commonly used formats listed first
+    };
+    Q_DECLARE_FLAGS( VectorFormatOptions, VectorFormatOption )
+
     /**
      * \ingroup core
      * Interface to convert raw field values to their user-friendly value.
@@ -496,24 +507,38 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     QgsVectorFileWriter &operator=( const QgsVectorFileWriter &rh ) = delete;
 
     /**
-     * Returns a map with format filter string as key and OGR format key as value.
+     * Returns a list or pairs, with format filter string as first element and OGR format key as second element.
+     *
+     * The \a options argument can be used to control the sorting and filtering of
+     * returned formats.
+     *
      * \see supportedOutputVectorLayerExtensions()
      */
-    static QMap< QString, QString> supportedFiltersAndFormats();
+    static QList< QPair< QString, QString > > supportedFiltersAndFormats( VectorFormatOptions options = SortRecommended );
 
     /**
      * Returns a list of file extensions for supported formats.
+     *
+     * The \a options argument can be used to control the sorting and filtering of
+     * returned formats.
+     *
      * \since QGIS 3.0
      * \see supportedFiltersAndFormats()
      */
-    static QStringList supportedFormatExtensions();
+    static QStringList supportedFormatExtensions( VectorFormatOptions options = SortRecommended );
 
     /**
      * Returns driver list that can be used for dialogs. It contains all OGR drivers
-     * + some additional internal QGIS driver names to distinguish between more
-     * supported formats of the same OGR driver
+     * plus some additional internal QGIS driver names to distinguish between more
+     * supported formats of the same OGR driver.
+     *
+     * The returned list consists of pairs of driver long name (e.g. user-friendly
+     * display name for the format) to internal driver short name.
+     *
+     * The \a options argument can be used to control the sorting and filtering of
+     * returned drivers.
      */
-    static QMap< QString, QString> ogrDriverList();
+    static QList< QPair< QString, QString > > ogrDriverList( VectorFormatOptions options = SortRecommended );
 
     /**
      * Returns the OGR driver name for a specified file \a extension. E.g. the
@@ -523,8 +548,13 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      */
     static QString driverForExtension( const QString &extension );
 
-    //! Returns filter string that can be used for dialogs
-    static QString fileFilterString();
+    /**
+     * Returns filter string that can be used for dialogs.
+     *
+     * The \a options argument can be used to control the sorting and filtering of
+     * returned drivers.
+     */
+    static QString fileFilterString( VectorFormatOptions options = SortRecommended );
 
     //! Creates a filter for an OGR driver key
     static QString filterForDriver( const QString &driverName );
@@ -701,6 +731,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorFileWriter::EditionCapabilities )
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorFileWriter::VectorFormatOptions )
 
 // clazy:excludeall=qstring-allocations
 

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -87,11 +87,11 @@ void QgsVectorLayerSaveAsDialog::setup()
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/VectorLayerSaveAs/geometry" ) ).toByteArray() );
 
-  const QList< QPair< QString, QString > > map = QgsVectorFileWriter::ogrDriverList();
+  const QList< QgsVectorFileWriter::DriverDetails > drivers = QgsVectorFileWriter::ogrDriverList();
   mFormatComboBox->blockSignals( true );
-  for ( auto it = map.constBegin(); it != map.constEnd(); ++it )
+  for ( const QgsVectorFileWriter::DriverDetails &driver : drivers )
   {
-    mFormatComboBox->addItem( it->first, it->second );
+    mFormatComboBox->addItem( driver.longName, driver.driverName );
   }
 
   QString format = settings.value( QStringLiteral( "UI/lastVectorFormat" ), "GPKG" ).toString();

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -87,11 +87,11 @@ void QgsVectorLayerSaveAsDialog::setup()
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/VectorLayerSaveAs/geometry" ) ).toByteArray() );
 
-  QMap<QString, QString> map = QgsVectorFileWriter::ogrDriverList();
+  const QList< QPair< QString, QString > > map = QgsVectorFileWriter::ogrDriverList();
   mFormatComboBox->blockSignals( true );
-  for ( QMap< QString, QString>::const_iterator it = map.constBegin(); it != map.constEnd(); ++it )
+  for ( auto it = map.constBegin(); it != map.constEnd(); ++it )
   {
-    mFormatComboBox->addItem( it.key(), it.value() );
+    mFormatComboBox->addItem( it->first, it->second );
   }
 
   QString format = settings.value( QStringLiteral( "UI/lastVectorFormat" ), "GPKG" ).toString();

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -54,7 +54,7 @@ QgsGeometryCheckerSetupTab::QgsGeometryCheckerSetupTab( QgisInterface *iface, QD
   mAbortButton = new QPushButton( tr( "Abort" ) );
   mRunButton->setEnabled( false );
 
-  const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
+  const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats( QgsVectorFileWriter::SortRecommended | QgsVectorFileWriter::SkipNonSpatialFormats );
   for ( const QgsVectorFileWriter::FilterFormatDetails &filter : filterFormatMap )
   {
     QString driverName = filter.driverName;
@@ -216,7 +216,7 @@ void QgsGeometryCheckerSetupTab::validateInput()
 void QgsGeometryCheckerSetupTab::selectOutputDirectory()
 {
   QString filterString = QgsVectorFileWriter::filterForDriver( QStringLiteral( "GPKG" ) );
-  const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
+  const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats( QgsVectorFileWriter::SortRecommended | QgsVectorFileWriter::SkipNonSpatialFormats );
   for ( const QgsVectorFileWriter::FilterFormatDetails &filter : filterFormatMap )
   {
     QString driverName = filter.driverName;

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -54,10 +54,10 @@ QgsGeometryCheckerSetupTab::QgsGeometryCheckerSetupTab( QgisInterface *iface, QD
   mAbortButton = new QPushButton( tr( "Abort" ) );
   mRunButton->setEnabled( false );
 
-  QMap<QString, QString> filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
-  for ( const QString &filter : filterFormatMap.keys() )
+  const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
+  for ( const auto &filter : filterFormatMap )
   {
-    QString driverName = filterFormatMap.value( filter );
+    QString driverName = filter.second;
     ui.comboBoxOutputFormat->addItem( driverName );
     if ( driverName == QLatin1String( "ESRI Shapefile" ) )
     {
@@ -216,13 +216,13 @@ void QgsGeometryCheckerSetupTab::validateInput()
 void QgsGeometryCheckerSetupTab::selectOutputDirectory()
 {
   QString filterString = QgsVectorFileWriter::filterForDriver( QStringLiteral( "GPKG" ) );
-  QMap<QString, QString> filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
-  for ( const QString &filter : filterFormatMap.keys() )
+  const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
+  for ( const auto &filter : filterFormatMap )
   {
-    QString driverName = filterFormatMap.value( filter );
+    QString driverName = filter.second;
     if ( driverName != QLatin1String( "ESRI Shapefile" ) ) // Default entry, first in list (see above)
     {
-      filterString += ";;" + filter;
+      filterString += ";;" + filter.first;
     }
   }
   QString initialdir = ui.lineEditOutputDirectory->text();

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -55,9 +55,9 @@ QgsGeometryCheckerSetupTab::QgsGeometryCheckerSetupTab( QgisInterface *iface, QD
   mRunButton->setEnabled( false );
 
   const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
-  for ( const auto &filter : filterFormatMap )
+  for ( const QgsVectorFileWriter::FilterFormatDetails &filter : filterFormatMap )
   {
-    QString driverName = filter.second;
+    QString driverName = filter.driverName;
     ui.comboBoxOutputFormat->addItem( driverName );
     if ( driverName == QLatin1String( "ESRI Shapefile" ) )
     {
@@ -217,12 +217,12 @@ void QgsGeometryCheckerSetupTab::selectOutputDirectory()
 {
   QString filterString = QgsVectorFileWriter::filterForDriver( QStringLiteral( "GPKG" ) );
   const auto filterFormatMap = QgsVectorFileWriter::supportedFiltersAndFormats();
-  for ( const auto &filter : filterFormatMap )
+  for ( const QgsVectorFileWriter::FilterFormatDetails &filter : filterFormatMap )
   {
-    QString driverName = filter.second;
+    QString driverName = filter.driverName;
     if ( driverName != QLatin1String( "ESRI Shapefile" ) ) // Default entry, first in list (see above)
     {
-      filterString += ";;" + filter.first;
+      filterString += ";;" + filter.filterString;
     }
   }
   QString initialdir = ui.lineEditOutputDirectory->text();

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -737,13 +737,15 @@ class TestQgsVectorFileWriter(unittest.TestCase):
     def testOgrDriverList(self):
         # test with drivers in recommended order
         drivers = QgsVectorFileWriter.ogrDriverList(QgsVectorFileWriter.SortRecommended)
-        self.assertEqual(drivers[0], ('GeoPackage', 'GPKG'))
-        self.assertEqual(drivers[1], ('ESRI Shapefile', 'ESRI Shapefile'))
+        self.assertEqual(drivers[0].longName, 'GeoPackage')
+        self.assertEqual(drivers[0].driverName, 'GPKG')
+        self.assertEqual(drivers[1].longName, 'ESRI Shapefile')
+        self.assertEqual(drivers[1].driverName, 'ESRI Shapefile')
         # alphabetical sorting
         drivers2 = QgsVectorFileWriter.ogrDriverList(QgsVectorFileWriter.VectorFormatOptions())
-        self.assertTrue(drivers2[0][0] < drivers2[1][0])
-        self.assertCountEqual(drivers, drivers2)
-        self.assertNotEqual(drivers2[0], ('GeoPackage', 'GPKG'))
+        self.assertTrue(drivers2[0].longName < drivers2[1].longName)
+        self.assertCountEqual([d.driverName for d in drivers], [d.driverName for d in drivers2])
+        self.assertNotEqual(drivers2[0].driverName, 'GPKG')
 
     def testSupportedFormatExtensions(self):
         formats = QgsVectorFileWriter.supportedFormatExtensions()

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -726,13 +726,15 @@ class TestQgsVectorFileWriter(unittest.TestCase):
     def testSupportedFiltersAndFormat(self):
         # test with formats in recommended order
         formats = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.SortRecommended)
-        self.assertEqual(formats[0], ('GeoPackage (*.gpkg *.GPKG)', 'GPKG'))
-        self.assertEqual(formats[1], ('ESRI Shapefile (*.shp *.SHP)', 'ESRI Shapefile'))
+        self.assertEqual(formats[0].filterString, 'GeoPackage (*.gpkg *.GPKG)')
+        self.assertEqual(formats[0].driverName, 'GPKG')
+        self.assertEqual(formats[1].filterString, 'ESRI Shapefile (*.shp *.SHP)')
+        self.assertEqual(formats[1].driverName, 'ESRI Shapefile')
         # alphabetical sorting
         formats2 = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.VectorFormatOptions())
-        self.assertTrue(formats2[0][0] < formats2[1][0])
-        self.assertCountEqual(formats, formats2)
-        self.assertNotEqual(formats2[0], ('GeoPackage', 'GPKG'))
+        self.assertTrue(formats2[0].driverName < formats2[1].driverName)
+        self.assertCountEqual([f.driverName for f in formats], [f.driverName for f in formats2])
+        self.assertNotEqual(formats2[0].driverName, 'GeoPackage')
 
     def testOgrDriverList(self):
         # test with drivers in recommended order

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -723,12 +723,50 @@ class TestQgsVectorFileWriter(unittest.TestCase):
 
         gdal.Unlink(filename)
 
+    def testSupportedFiltersAndFormat(self):
+        # test with formats in recommended order
+        formats = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.SortRecommended)
+        self.assertEqual(formats[0], ('GeoPackage [OGR] (*.gpkg *.GPKG)', 'GPKG'))
+        self.assertEqual(formats[1], ('ESRI Shapefile [OGR] (*.shp *.SHP)', 'ESRI Shapefile'))
+        # alphabetical sorting
+        formats2 = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.VectorFormatOptions())
+        self.assertTrue(formats2[0][0] < formats2[1][0])
+        self.assertCountEqual(formats, formats2)
+        self.assertNotEqual(formats2[0], ('GeoPackage', 'GPKG'))
+
+    def testOgrDriverList(self):
+        # test with drivers in recommended order
+        drivers = QgsVectorFileWriter.ogrDriverList(QgsVectorFileWriter.SortRecommended)
+        self.assertEqual(drivers[0], ('GeoPackage', 'GPKG'))
+        self.assertEqual(drivers[1], ('ESRI Shapefile', 'ESRI Shapefile'))
+        # alphabetical sorting
+        drivers2 = QgsVectorFileWriter.ogrDriverList(QgsVectorFileWriter.VectorFormatOptions())
+        self.assertTrue(drivers2[0][0] < drivers2[1][0])
+        self.assertCountEqual(drivers, drivers2)
+        self.assertNotEqual(drivers2[0], ('GeoPackage', 'GPKG'))
+
     def testSupportedFormatExtensions(self):
         formats = QgsVectorFileWriter.supportedFormatExtensions()
         self.assertTrue('gpkg' in formats)
         self.assertFalse('exe' in formats)
         self.assertEqual(formats[0], 'gpkg')
         self.assertEqual(formats[1], 'shp')
+
+        # alphabetical sorting
+        formats2 = QgsVectorFileWriter.supportedFormatExtensions(QgsVectorFileWriter.VectorFormatOptions())
+        self.assertTrue(formats2[0] < formats2[1])
+        self.assertCountEqual(formats, formats2)
+        self.assertNotEqual(formats2[0], 'gpkg')
+
+    def testFileFilterString(self):
+        formats = QgsVectorFileWriter.fileFilterString()
+        self.assertTrue('gpkg' in formats)
+        self.assertTrue('shp' in formats)
+        self.assertTrue(formats.index('gpkg') < formats.index('shp'))
+
+        # alphabetical sorting
+        formats2 = QgsVectorFileWriter.fileFilterString(QgsVectorFileWriter.VectorFormatOptions())
+        self.assertNotEqual(formats.index('gpkg'), formats2.index('gpkg'))
 
     def testDriverForExtension(self):
         self.assertEqual(QgsVectorFileWriter.driverForExtension('shp'), 'ESRI Shapefile')

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -726,8 +726,8 @@ class TestQgsVectorFileWriter(unittest.TestCase):
     def testSupportedFiltersAndFormat(self):
         # test with formats in recommended order
         formats = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.SortRecommended)
-        self.assertEqual(formats[0], ('GeoPackage [OGR] (*.gpkg *.GPKG)', 'GPKG'))
-        self.assertEqual(formats[1], ('ESRI Shapefile [OGR] (*.shp *.SHP)', 'ESRI Shapefile'))
+        self.assertEqual(formats[0], ('GeoPackage (*.gpkg *.GPKG)', 'GPKG'))
+        self.assertEqual(formats[1], ('ESRI Shapefile (*.shp *.SHP)', 'ESRI Shapefile'))
         # alphabetical sorting
         formats2 = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.VectorFormatOptions())
         self.assertTrue(formats2[0][0] < formats2[1][0])

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -730,11 +730,17 @@ class TestQgsVectorFileWriter(unittest.TestCase):
         self.assertEqual(formats[0].driverName, 'GPKG')
         self.assertEqual(formats[1].filterString, 'ESRI Shapefile (*.shp *.SHP)')
         self.assertEqual(formats[1].driverName, 'ESRI Shapefile')
+        self.assertTrue('ODS' in [f.driverName for f in formats])
+
         # alphabetical sorting
         formats2 = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.VectorFormatOptions())
         self.assertTrue(formats2[0].driverName < formats2[1].driverName)
         self.assertCountEqual([f.driverName for f in formats], [f.driverName for f in formats2])
         self.assertNotEqual(formats2[0].driverName, 'GeoPackage')
+
+        # skip non-spatial
+        formats = QgsVectorFileWriter.supportedFiltersAndFormats(QgsVectorFileWriter.SkipNonSpatialFormats)
+        self.assertFalse('ODS' in [f.driverName for f in formats])
 
     def testOgrDriverList(self):
         # test with drivers in recommended order
@@ -743,11 +749,16 @@ class TestQgsVectorFileWriter(unittest.TestCase):
         self.assertEqual(drivers[0].driverName, 'GPKG')
         self.assertEqual(drivers[1].longName, 'ESRI Shapefile')
         self.assertEqual(drivers[1].driverName, 'ESRI Shapefile')
+        self.assertTrue('ODS' in [f.driverName for f in drivers])
         # alphabetical sorting
         drivers2 = QgsVectorFileWriter.ogrDriverList(QgsVectorFileWriter.VectorFormatOptions())
         self.assertTrue(drivers2[0].longName < drivers2[1].longName)
         self.assertCountEqual([d.driverName for d in drivers], [d.driverName for d in drivers2])
         self.assertNotEqual(drivers2[0].driverName, 'GPKG')
+
+        # skip non-spatial
+        formats = QgsVectorFileWriter.ogrDriverList(QgsVectorFileWriter.SkipNonSpatialFormats)
+        self.assertFalse('ODS' in [f.driverName for f in formats])
 
     def testSupportedFormatExtensions(self):
         formats = QgsVectorFileWriter.supportedFormatExtensions()
@@ -755,6 +766,7 @@ class TestQgsVectorFileWriter(unittest.TestCase):
         self.assertFalse('exe' in formats)
         self.assertEqual(formats[0], 'gpkg')
         self.assertEqual(formats[1], 'shp')
+        self.assertTrue('ods' in formats)
 
         # alphabetical sorting
         formats2 = QgsVectorFileWriter.supportedFormatExtensions(QgsVectorFileWriter.VectorFormatOptions())
@@ -762,15 +774,23 @@ class TestQgsVectorFileWriter(unittest.TestCase):
         self.assertCountEqual(formats, formats2)
         self.assertNotEqual(formats2[0], 'gpkg')
 
+        formats = QgsVectorFileWriter.supportedFormatExtensions(QgsVectorFileWriter.SkipNonSpatialFormats)
+        self.assertFalse('ods' in formats)
+
     def testFileFilterString(self):
         formats = QgsVectorFileWriter.fileFilterString()
         self.assertTrue('gpkg' in formats)
         self.assertTrue('shp' in formats)
         self.assertTrue(formats.index('gpkg') < formats.index('shp'))
+        self.assertTrue('ods' in formats)
 
         # alphabetical sorting
         formats2 = QgsVectorFileWriter.fileFilterString(QgsVectorFileWriter.VectorFormatOptions())
         self.assertNotEqual(formats.index('gpkg'), formats2.index('gpkg'))
+
+        # hide non spatial
+        formats = QgsVectorFileWriter.fileFilterString(QgsVectorFileWriter.SkipNonSpatialFormats)
+        self.assertFalse('ods' in formats)
 
     def testDriverForExtension(self):
         self.assertEqual(QgsVectorFileWriter.driverForExtension('shp'), 'ESRI Shapefile')


### PR DESCRIPTION
Initially only flag available is whether to sort drivers by recommended order. The recommended order puts GPKG first and SHP second, then leaves the rest alphabetical.

This fixes a few instances in the QGIS gui where these recommended formats are not listed first.
