### PR TITLE
[Bugfix] Enable adding color in Options->Color tab

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -806,8 +806,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   //
   // Color palette
   //
-  connect( mButtonCopyColors, &QAbstractButton::clicked, mTreeCustomColors, &QgsColorSchemeList::copyColors );
+  connect( mButtonAddColor, &QAbstractButton::clicked, this, &QgsOptions::addColor );
   connect( mButtonRemoveColor, &QAbstractButton::clicked, mTreeCustomColors, &QgsColorSchemeList::removeSelection );
+  connect( mButtonCopyColors, &QAbstractButton::clicked, mTreeCustomColors, &QgsColorSchemeList::copyColors );
   connect( mButtonPasteColors, &QAbstractButton::clicked, mTreeCustomColors, &QgsColorSchemeList::pasteColors );
   connect( mButtonImportColors, &QAbstractButton::clicked, mTreeCustomColors, &QgsColorSchemeList::showImportColorsDialog );
   connect( mButtonExportColors, &QAbstractButton::clicked, mTreeCustomColors, &QgsColorSchemeList::showExportColorsDialog );


### PR DESCRIPTION
It's currently impossible to add a new color in the Settings --> Options --> Colors tab