### PR TITLE
Don't use thread_local on mingw or OpenBSD builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,24 @@ IF(WITH_CORE)
     ENDIF (OSGEARTHQT_LIBRARY)
   ENDIF (WITH_GLOBE)
 
+  SET (WITH_THREAD_LOCAL TRUE CACHE BOOL "Determines whether std::thread_local should be used")
+  MARK_AS_ADVANCED(WITH_THREAD_LOCAL)
+
+  IF (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+    # MingW has broken support for thread_local, so force disabling it
+    # see
+    # https://sourceforge.net/p/mingw-w64/bugs/445/
+    # https://sourceforge.net/p/mingw-w64/bugs/527/
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80816
+
+    # also OpenBSD has no thread_local support, see https://issues.qgis.org/issues/17351
+
+  ELSE (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+    IF (WITH_THREAD_LOCAL)
+      SET (USE_THREAD_LOCAL TRUE)  # used in qgsconfig.h
+    ENDIF (WITH_THREAD_LOCAL)
+  ENDIF (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+
   # Compile flag. Make it possible to turn it off.
   SET (PEDANTIC TRUE CACHE BOOL "Determines if we should compile in pedantic mode.")
 
@@ -736,7 +754,7 @@ ENDIF (WITH_CORE)
 ####################################################
 # clang-tidy
 SET (WITH_CLANG_TIDY FALSE CACHE BOOL "Use Clang tidy")
-MARK_AS_ADVANCED(WITH_CORE)
+MARK_AS_ADVANCED(WITH_CLANG_TIDY)
 IF (WITH_CORE)
   IF(WITH_CLANG_TIDY)
     FIND_PROGRAM(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ IF(WITH_CORE)
   SET (WITH_THREAD_LOCAL TRUE CACHE BOOL "Determines whether std::thread_local should be used")
   MARK_AS_ADVANCED(WITH_THREAD_LOCAL)
 
-  IF (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+  IF (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     # MingW has broken support for thread_local, so force disabling it
     # see
     # https://sourceforge.net/p/mingw-w64/bugs/445/
@@ -154,11 +154,11 @@ IF(WITH_CORE)
 
     # also OpenBSD has no thread_local support, see https://issues.qgis.org/issues/17351
 
-  ELSE (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+  ELSE (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     IF (WITH_THREAD_LOCAL)
       SET (USE_THREAD_LOCAL TRUE)  # used in qgsconfig.h
     ENDIF (WITH_THREAD_LOCAL)
-  ENDIF (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+  ENDIF (MINGW OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 
   # Compile flag. Make it possible to turn it off.
   SET (PEDANTIC TRUE CACHE BOOL "Determines if we should compile in pedantic mode.")

--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -60,5 +60,7 @@
 
 #cmakedefine HAVE_3D
 
+#cmakedefine USE_THREAD_LOCAL
+
 #endif
 

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -18,6 +18,7 @@
 #define QGSCOORDINATETRANSFORMPRIVATE_H
 
 #define SIP_NO_FILE
+#include "qgsconfig.h"
 
 /// @cond PRIVATE
 
@@ -31,6 +32,11 @@
 //
 
 #include <QSharedData>
+
+#ifndef USE_THREAD_LOCAL
+#include <QThreadStorage>
+#endif
+
 #include "qgscoordinatereferencesystem.h"
 
 typedef void *projPJ;
@@ -100,7 +106,11 @@ class QgsCoordinateTransformPrivate : public QSharedData
      * Thread local proj context storage. A new proj context will be created
      * for every thread.
      */
+#ifdef USE_THREAD_LOCAL
     static thread_local QgsProjContextStore mProjContext;
+#else
+    static QThreadStorage< QgsProjContextStore * > mProjContext;
+#endif
 
     QReadWriteLock mProjLock;
     QMap < uintptr_t, QPair< projPJ, projPJ > > mProjProjections;


### PR DESCRIPTION
MingW has broken support for thread_local, so force disabling it. See:
https://sourceforge.net/p/mingw-w64/bugs/445/
https://sourceforge.net/p/mingw-w64/bugs/527/
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80816

Also OpenBSD has no thread_local support, see https://issues.qgis.org/issues/17351

So on these platforms we fall back to using QThreadStorage.

Fixes #17351

Supersedes #5504