### PR TITLE
Fix crashes when no QgsApplication instance is available

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -111,8 +111,6 @@ const char *QgsApplication::QGIS_ORGANIZATION_DOMAIN = "qgis.org";
 const char *QgsApplication::QGIS_APPLICATION_NAME = "QGIS3";
 
 QgsApplication::ApplicationMembers *QgsApplication::sApplicationMembers = nullptr;
-QgsAuthManager *QgsApplication::sAuthManager = nullptr;
-QgsDataItemProviderRegistry *QgsApplication::sDataItemProviderRegistry = nullptr;
 
 QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const QString &profileFolder, const QString &platformName )
   : QApplication( argc, argv, GUIenabled )
@@ -903,6 +901,7 @@ QgsAuthManager *QgsApplication::authManager()
   else
   {
     // no QgsApplication instance
+    static QgsAuthManager *sAuthManager = nullptr;
     if ( !sAuthManager )
       sAuthManager = QgsAuthManager::instance();
     return sAuthManager;
@@ -1572,6 +1571,7 @@ QgsDataItemProviderRegistry *QgsApplication::dataItemProviderRegistry()
   else
   {
     // no QgsApplication instance
+    static QgsDataItemProviderRegistry *sDataItemProviderRegistry = nullptr;
     if ( !sDataItemProviderRegistry )
       sDataItemProviderRegistry = new QgsDataItemProviderRegistry();
     return sDataItemProviderRegistry;

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -111,6 +111,7 @@ const char *QgsApplication::QGIS_ORGANIZATION_DOMAIN = "qgis.org";
 const char *QgsApplication::QGIS_APPLICATION_NAME = "QGIS3";
 
 QgsApplication::ApplicationMembers *QgsApplication::sApplicationMembers = nullptr;
+QgsAuthManager *QgsApplication::sAuthManager = nullptr;
 
 QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const QString &profileFolder, const QString &platformName )
   : QApplication( argc, argv, GUIenabled )
@@ -889,11 +890,21 @@ void QgsApplication::initQgis()
 
 QgsAuthManager *QgsApplication::authManager()
 {
-  if ( ! instance()->mAuthManager )
+  if ( instance() )
   {
-    instance()->mAuthManager = QgsAuthManager::instance();
+    if ( !instance()->mAuthManager )
+    {
+      instance()->mAuthManager = QgsAuthManager::instance();
+    }
+    return instance()->mAuthManager;
   }
-  return instance()->mAuthManager;
+  else
+  {
+    // no QgsApplication instance
+    if ( !sAuthManager )
+      sAuthManager = QgsAuthManager::instance();
+    return sAuthManager;
+  }
 }
 
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -112,6 +112,7 @@ const char *QgsApplication::QGIS_APPLICATION_NAME = "QGIS3";
 
 QgsApplication::ApplicationMembers *QgsApplication::sApplicationMembers = nullptr;
 QgsAuthManager *QgsApplication::sAuthManager = nullptr;
+QgsDataItemProviderRegistry *QgsApplication::sDataItemProviderRegistry = nullptr;
 
 QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const QString &profileFolder, const QString &platformName )
   : QApplication( argc, argv, GUIenabled )
@@ -871,7 +872,8 @@ void QgsApplication::initQgis()
   // set the provider plugin path (this creates provider registry)
   QgsProviderRegistry::instance( pluginPath() );
 
-  instance()->mDataItemProviderRegistry = new QgsDataItemProviderRegistry();
+  // create data item provider registry
+  ( void )QgsApplication::dataItemProviderRegistry();
 
   // create project instance if doesn't exist
   QgsProject::instance();
@@ -1559,7 +1561,21 @@ QgsRasterRendererRegistry *QgsApplication::rasterRendererRegistry()
 
 QgsDataItemProviderRegistry *QgsApplication::dataItemProviderRegistry()
 {
-  return instance()->mDataItemProviderRegistry;
+  if ( instance() )
+  {
+    if ( !instance()->mDataItemProviderRegistry )
+    {
+      instance()->mDataItemProviderRegistry = new QgsDataItemProviderRegistry();
+    }
+    return instance()->mDataItemProviderRegistry;
+  }
+  else
+  {
+    // no QgsApplication instance
+    if ( !sDataItemProviderRegistry )
+      sDataItemProviderRegistry = new QgsDataItemProviderRegistry();
+    return sDataItemProviderRegistry;
+  }
 }
 
 QgsSvgCache *QgsApplication::svgCache()

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -749,7 +749,10 @@ class CORE_EXPORT QgsApplication : public QApplication
     QMap<QString, QIcon> mIconCache;
 
     QgsDataItemProviderRegistry *mDataItemProviderRegistry = nullptr;
+
     QgsAuthManager *mAuthManager = nullptr;
+    // ... but in case QgsApplication is never instantiated (eg with custom designer widgets), we fall back to static instance
+    static QgsAuthManager *sAuthManager;
 
     struct ApplicationMembers
     {

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -749,12 +749,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     QMap<QString, QIcon> mIconCache;
 
     QgsDataItemProviderRegistry *mDataItemProviderRegistry = nullptr;
-    // ... but in case QgsApplication is never instantiated (eg with custom designer widgets), we fall back to static instance
-    static QgsDataItemProviderRegistry *sDataItemProviderRegistry;
-
     QgsAuthManager *mAuthManager = nullptr;
-    // ... but in case QgsApplication is never instantiated (eg with custom designer widgets), we fall back to static instance
-    static QgsAuthManager *sAuthManager;
 
     struct ApplicationMembers
     {

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -749,6 +749,8 @@ class CORE_EXPORT QgsApplication : public QApplication
     QMap<QString, QIcon> mIconCache;
 
     QgsDataItemProviderRegistry *mDataItemProviderRegistry = nullptr;
+    // ... but in case QgsApplication is never instantiated (eg with custom designer widgets), we fall back to static instance
+    static QgsDataItemProviderRegistry *sDataItemProviderRegistry;
 
     QgsAuthManager *mAuthManager = nullptr;
     // ... but in case QgsApplication is never instantiated (eg with custom designer widgets), we fall back to static instance

--- a/tests/src/python/test_qgsnoapplication.py
+++ b/tests/src/python/test_qgsnoapplication.py
@@ -56,6 +56,15 @@ class TestQgsNoApplication(unittest.TestCase):
     def testAuthManager(self):
         self.assertTrue(QgsApplication.authManager())
 
+    def testDataItemProviderRegistry(self):
+        self.assertTrue(QgsApplication.dataItemProviderRegistry())
+
+    def testInit(self):
+        """
+        Test calling QgsApplication.initQgis() without QgsApplication instance
+        """
+        QgsApplication.initQgis()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsnoapplication.py
+++ b/tests/src/python/test_qgsnoapplication.py
@@ -53,6 +53,9 @@ class TestQgsNoApplication(unittest.TestCase):
         QgsApplication.setNullRepresentation(nr)
         self.assertEqual(QgsApplication.nullRepresentation(), nr)
 
+    def testAuthManager(self):
+        self.assertTrue(QgsApplication.authManager())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsnoapplication.py
+++ b/tests/src/python/test_qgsnoapplication.py
@@ -13,7 +13,8 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
-
+import sys
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (QgsApplication)
 from qgis.testing import unittest
 
@@ -27,6 +28,8 @@ falls back to static members, which this test is designed to check.
 So don't add start_app here or anything else which creates a
 QgsApplication instance!
 """
+
+app = QCoreApplication(sys.argv)
 
 
 class TestQgsNoApplication(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a number of crashes encountered when using the QGIS libraries with a QgsApplication instance (e.g. with custom designer widgets, 3rd party apps built off qgis libraries).

Basically when no QgsApplication instance is available, we fall back to using static instances for certain member variables.