### PR TITLE
[processing] Improve api handling for provider format support

### DIFF
--- a/python/core/processing/qgsprocessingparameters.sip
+++ b/python/core/processing/qgsprocessingparameters.sip
@@ -357,7 +357,16 @@ class QgsProcessingParameterDefinition
 %Docstring
  Returns a pointer to the algorithm which owns this parameter. May be None
  for non-owned parameters.
+.. seealso:: provider()
  :rtype: QgsProcessingAlgorithm
+%End
+
+    QgsProcessingProvider *provider() const;
+%Docstring
+ Returns a pointer to the provider for the algorithm which owns this parameter. May be None
+ for non-owned parameters or algorithms.
+.. seealso:: algorithm()
+ :rtype: QgsProcessingProvider
 %End
 
   protected:

--- a/python/core/processing/qgsprocessingparameters.sip
+++ b/python/core/processing/qgsprocessingparameters.sip
@@ -353,7 +353,16 @@ class QgsProcessingParameterDefinition
  :rtype: list of str
 %End
 
+    QgsProcessingAlgorithm *algorithm() const;
+%Docstring
+ Returns a pointer to the algorithm which owns this parameter. May be None
+ for non-owned parameters.
+ :rtype: QgsProcessingAlgorithm
+%End
+
   protected:
+
+
 
 
 

--- a/python/core/processing/qgsprocessingprovider.sip
+++ b/python/core/processing/qgsprocessingprovider.sip
@@ -101,6 +101,7 @@ class QgsProcessingProvider : QObject
     virtual QStringList supportedOutputVectorLayerExtensions() const;
 %Docstring
  Returns a list of the vector format file extensions supported by this provider.
+.. seealso:: defaultVectorFileExtension()
 .. seealso:: supportedOutputRasterLayerExtensions()
 .. seealso:: supportedOutputTableExtensions()
 .. seealso:: supportsNonFileBasedOutput()
@@ -113,6 +114,35 @@ class QgsProcessingProvider : QObject
 .. seealso:: supportedOutputRasterLayerExtensions()
 .. seealso:: supportedOutputVectorLayerExtensions()
  :rtype: list of str
+%End
+
+    virtual QString defaultVectorFileExtension( bool hasGeometry = true ) const;
+%Docstring
+ Returns the default file extension to use for vector outputs created by the
+ provider.
+
+ If ``hasGeometry`` is true then the output file format must have support for
+ geometry. If ``hasGeometry`` is false then non-spatial formats can be used.
+
+ The default implementation returns the user's default Processing vector output format
+ setting.
+
+.. seealso:: supportedOutputVectorLayerExtensions()
+.. seealso:: defaultRasterFileExtension()
+ :rtype: str
+%End
+
+    virtual QString defaultRasterFileExtension() const;
+%Docstring
+ Returns the default file extension to use for raster outputs created by the
+ provider.
+
+ The default implementation returns the user's default Processing raster output format
+ setting.
+
+.. seealso:: supportedOutputRasterLayerExtensions()
+.. seealso:: defaultVectorFileExtension()
+ :rtype: str
 %End
 
     virtual bool supportsNonFileBasedOutput() const;

--- a/python/core/processing/qgsprocessingprovider.sip
+++ b/python/core/processing/qgsprocessingprovider.sip
@@ -94,7 +94,6 @@ class QgsProcessingProvider : QObject
 %Docstring
  Returns a list of the raster format file extensions supported by this provider.
 .. seealso:: supportedOutputVectorLayerExtensions()
-.. seealso:: supportedOutputTableExtensions()
  :rtype: list of str
 %End
 
@@ -103,16 +102,7 @@ class QgsProcessingProvider : QObject
  Returns a list of the vector format file extensions supported by this provider.
 .. seealso:: defaultVectorFileExtension()
 .. seealso:: supportedOutputRasterLayerExtensions()
-.. seealso:: supportedOutputTableExtensions()
 .. seealso:: supportsNonFileBasedOutput()
- :rtype: list of str
-%End
-
-    virtual QStringList supportedOutputTableExtensions() const;
-%Docstring
- Returns a list of the table format file extensions supported by this provider.
-.. seealso:: supportedOutputRasterLayerExtensions()
-.. seealso:: supportedOutputVectorLayerExtensions()
  :rtype: list of str
 %End
 
@@ -125,7 +115,8 @@ class QgsProcessingProvider : QObject
  geometry. If ``hasGeometry`` is false then non-spatial formats can be used.
 
  The default implementation returns the user's default Processing vector output format
- setting.
+ setting, if it's supported by the provider (see supportedOutputVectorLayerExtensions()).
+ Otherwise the first reported supported vector format will be used.
 
 .. seealso:: supportedOutputVectorLayerExtensions()
 .. seealso:: defaultRasterFileExtension()
@@ -138,7 +129,8 @@ class QgsProcessingProvider : QObject
  provider.
 
  The default implementation returns the user's default Processing raster output format
- setting.
+ setting, if it's supported by the provider (see supportedOutputRasterLayerExtensions()).
+ Otherwise the first reported supported raster format will be used.
 
 .. seealso:: supportedOutputRasterLayerExtensions()
 .. seealso:: defaultVectorFileExtension()

--- a/python/plugins/processing/gui/ParameterGuiUtils.py
+++ b/python/plugins/processing/gui/ParameterGuiUtils.py
@@ -63,13 +63,11 @@ def getFileFilter(param):
         for i in range(len(exts)):
             exts[i] = tr('{0} files (*.{1})', 'QgsProcessingParameterRasterDestination').format(exts[i].upper(), exts[i].lower())
         return ';;'.join(exts) + ';;' + tr('All files (*.*)')
-    elif param.type() == 'table':
-        exts = ['csv', 'dbf']
-        for i in range(len(exts)):
-            exts[i] = tr('{0} files (*.{1})', 'ParameterTable').format(exts[i].upper(), exts[i].lower())
-        return tr('All files (*.*)') + ';;' + ';;'.join(exts)
-    elif param.type() == 'sink':
-        exts = QgsVectorFileWriter.supportedFormatExtensions()
+    elif param.type() in ('sink', 'vectorDestination'):
+        if param.provider() is not None:
+            exts = param.provider().supportedOutputVectorLayerExtensions()
+        else:
+            exts = QgsVectorFileWriter.supportedFormatExtensions()
         for i in range(len(exts)):
             exts[i] = tr('{0} files (*.{1})', 'ParameterVector').format(exts[i].upper(), exts[i].lower())
         return ';;'.join(exts) + ';;' + tr('All files (*.*)')

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -242,6 +242,7 @@ bool QgsProcessingAlgorithm::addParameter( QgsProcessingParameterDefinition *def
   }
 
   mParameters << definition;
+  definition->mAlgorithm = this;
 
   if ( createOutput )
     return createAutoOutputForParameter( definition );

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -1237,6 +1237,11 @@ bool QgsProcessingParameterDefinition::fromVariantMap( const QVariantMap &map )
   return true;
 }
 
+QgsProcessingAlgorithm *QgsProcessingParameterDefinition::algorithm() const
+{
+  return mAlgorithm;
+}
+
 QgsProcessingParameterBoolean::QgsProcessingParameterBoolean( const QString &name, const QString &description, const QVariant &defaultValue, bool optional )
   : QgsProcessingParameterDefinition( name, description, defaultValue, optional )
 {}

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -16,8 +16,10 @@
  ***************************************************************************/
 
 #include "qgsprocessingparameters.h"
+#include "qgsprocessingprovider.h"
 #include "qgsprocessingcontext.h"
 #include "qgsprocessingutils.h"
+#include "qgsprocessingalgorithm.h"
 #include "qgsvectorlayerfeatureiterator.h"
 #include "qgsprocessingoutputs.h"
 #include "qgssettings.h"
@@ -1240,6 +1242,11 @@ bool QgsProcessingParameterDefinition::fromVariantMap( const QVariantMap &map )
 QgsProcessingAlgorithm *QgsProcessingParameterDefinition::algorithm() const
 {
   return mAlgorithm;
+}
+
+QgsProcessingProvider *QgsProcessingParameterDefinition::provider() const
+{
+  return mAlgorithm ? mAlgorithm->provider() : nullptr;
 }
 
 QgsProcessingParameterBoolean::QgsProcessingParameterBoolean( const QString &name, const QString &description, const QVariant &defaultValue, bool optional )
@@ -3092,14 +3099,21 @@ QgsProcessingOutputDefinition *QgsProcessingParameterFeatureSink::toOutputDefini
 
 QString QgsProcessingParameterFeatureSink::defaultFileExtension() const
 {
-  QgsSettings settings;
-  if ( hasGeometry() )
+  if ( QgsProcessingProvider *p = provider() )
   {
-    return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+    return p->defaultVectorFileExtension( hasGeometry() );
   }
   else
   {
-    return QStringLiteral( "dbf" );
+    QgsSettings settings;
+    if ( hasGeometry() )
+    {
+      return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+    }
+    else
+    {
+      return QStringLiteral( "dbf" );
+    }
   }
 }
 
@@ -3245,8 +3259,15 @@ QgsProcessingOutputDefinition *QgsProcessingParameterRasterDestination::toOutput
 
 QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
 {
-  QgsSettings settings;
-  return settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "tif" ), QgsSettings::Core ).toString();
+  if ( QgsProcessingProvider *p = provider() )
+  {
+    return p->defaultRasterFileExtension();
+  }
+  else
+  {
+    QgsSettings settings;
+    return settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "tif" ), QgsSettings::Core ).toString();
+  }
 }
 
 QgsProcessingParameterRasterDestination *QgsProcessingParameterRasterDestination::fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition )
@@ -3541,14 +3562,21 @@ QgsProcessingOutputDefinition *QgsProcessingParameterVectorDestination::toOutput
 
 QString QgsProcessingParameterVectorDestination::defaultFileExtension() const
 {
-  QgsSettings settings;
-  if ( hasGeometry() )
+  if ( QgsProcessingProvider *p = provider() )
   {
-    return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+    return p->defaultVectorFileExtension( hasGeometry() );
   }
   else
   {
-    return QStringLiteral( "dbf" );
+    QgsSettings settings;
+    if ( hasGeometry() )
+    {
+      return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+    }
+    else
+    {
+      return QStringLiteral( "dbf" );
+    }
   }
 }
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -34,6 +34,7 @@ class QgsFeatureSink;
 class QgsProcessingFeatureSource;
 class QgsProcessingOutputDefinition;
 class QgsProcessingFeedback;
+class QgsProcessingProvider;
 
 /**
  * \class QgsProcessingFeatureSourceDefinition
@@ -394,8 +395,16 @@ class CORE_EXPORT QgsProcessingParameterDefinition
     /**
      * Returns a pointer to the algorithm which owns this parameter. May be nullptr
      * for non-owned parameters.
+     * \see provider()
      */
     QgsProcessingAlgorithm *algorithm() const;
+
+    /**
+     * Returns a pointer to the provider for the algorithm which owns this parameter. May be nullptr
+     * for non-owned parameters or algorithms.
+     * \see algorithm()
+     */
+    QgsProcessingProvider *provider() const;
 
   protected:
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -391,6 +391,12 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      */
     virtual QStringList dependsOnOtherParameters() const { return QStringList(); }
 
+    /**
+     * Returns a pointer to the algorithm which owns this parameter. May be nullptr
+     * for non-owned parameters.
+     */
+    QgsProcessingAlgorithm *algorithm() const;
+
   protected:
 
     //! Parameter name
@@ -407,6 +413,12 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 
     //! Freeform metadata for parameter. Mostly used by widget wrappers to customise their appearance and behavior.
     QVariantMap mMetadata;
+
+    //! Pointer to algorithm which owns this parameter
+    QgsProcessingAlgorithm *mAlgorithm = nullptr;
+
+    // To allow access to mAlgorithm. We don't want a public setter for this!
+    friend class QgsProcessingAlgorithm;
 
 };
 

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -45,6 +45,11 @@ QString QgsProcessingProvider::longName() const
   return name();
 }
 
+QStringList QgsProcessingProvider::supportedOutputRasterLayerExtensions() const
+{
+  return QStringList() << QStringLiteral( "tif" );
+}
+
 void QgsProcessingProvider::refreshAlgorithms()
 {
   qDeleteAll( mAlgorithms );

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -18,6 +18,7 @@
 #include "qgsprocessingprovider.h"
 #include "qgsapplication.h"
 #include "qgsvectorfilewriter.h"
+#include "qgssettings.h"
 
 QgsProcessingProvider::QgsProcessingProvider( QObject *parent SIP_TRANSFERTHIS )
   : QObject( parent )
@@ -82,5 +83,24 @@ bool QgsProcessingProvider::addAlgorithm( QgsProcessingAlgorithm *algorithm )
 QStringList QgsProcessingProvider::supportedOutputVectorLayerExtensions() const
 {
   return QgsVectorFileWriter::supportedFormatExtensions();
+}
+
+QString QgsProcessingProvider::defaultVectorFileExtension( bool hasGeometry ) const
+{
+  QgsSettings settings;
+  if ( hasGeometry )
+  {
+    return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+  }
+  else
+  {
+    return QStringLiteral( "dbf" );
+  }
+}
+
+QString QgsProcessingProvider::defaultRasterFileExtension() const
+{
+  QgsSettings settings;
+  return settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "tif" ), QgsSettings::Core ).toString();
 }
 

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -93,19 +93,47 @@ QStringList QgsProcessingProvider::supportedOutputVectorLayerExtensions() const
 QString QgsProcessingProvider::defaultVectorFileExtension( bool hasGeometry ) const
 {
   QgsSettings settings;
-  if ( hasGeometry )
+  const QString defaultExtension = hasGeometry ? QStringLiteral( "shp" ) : QStringLiteral( "dbf" );
+  const QString userDefault = settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), defaultExtension, QgsSettings::Core ).toString();
+
+  const QStringList supportedExtensions = supportedOutputVectorLayerExtensions();
+  if ( supportedExtensions.contains( userDefault, Qt::CaseInsensitive ) )
   {
-    return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+    // user set default is supported by provider, use that
+    return userDefault;
+  }
+  else if ( !supportedExtensions.empty() )
+  {
+    return supportedExtensions.at( 0 );
   }
   else
   {
-    return QStringLiteral( "dbf" );
+    // who knows? provider says it has no file support at all...
+    // let's say shp. even MapInfo supports shapefiles.
+    return defaultExtension;
   }
 }
 
 QString QgsProcessingProvider::defaultRasterFileExtension() const
 {
   QgsSettings settings;
-  return settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "tif" ), QgsSettings::Core ).toString();
+  const QString defaultExtension = QStringLiteral( "tif" );
+  const QString userDefault = settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), defaultExtension, QgsSettings::Core ).toString();
+
+  const QStringList supportedExtensions = supportedOutputRasterLayerExtensions();
+  if ( supportedExtensions.contains( userDefault, Qt::CaseInsensitive ) )
+  {
+    // user set default is supported by provider, use that
+    return userDefault;
+  }
+  else if ( !supportedExtensions.empty() )
+  {
+    return supportedExtensions.at( 0 );
+  }
+  else
+  {
+    // who knows? provider says it has no file support at all...
+    return defaultExtension;
+  }
 }
 

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -106,7 +106,7 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * \see supportedOutputVectorLayerExtensions()
      * \see supportedOutputTableExtensions()
      */
-    virtual QStringList supportedOutputRasterLayerExtensions() const { return QStringList() << QStringLiteral( "tif" ); }
+    virtual QStringList supportedOutputRasterLayerExtensions() const;
 
     /**
      * Returns a list of the vector format file extensions supported by this provider.

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -104,7 +104,6 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     /**
      * Returns a list of the raster format file extensions supported by this provider.
      * \see supportedOutputVectorLayerExtensions()
-     * \see supportedOutputTableExtensions()
      */
     virtual QStringList supportedOutputRasterLayerExtensions() const;
 
@@ -112,17 +111,9 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * Returns a list of the vector format file extensions supported by this provider.
      * \see defaultVectorFileExtension()
      * \see supportedOutputRasterLayerExtensions()
-     * \see supportedOutputTableExtensions()
      * \see supportsNonFileBasedOutput()
      */
     virtual QStringList supportedOutputVectorLayerExtensions() const;
-
-    /**
-     * Returns a list of the table format file extensions supported by this provider.
-     * \see supportedOutputRasterLayerExtensions()
-     * \see supportedOutputVectorLayerExtensions()
-     */
-    virtual QStringList supportedOutputTableExtensions() const { return QStringList() << QStringLiteral( "csv" ); }
 
     /**
      * Returns the default file extension to use for vector outputs created by the
@@ -132,7 +123,8 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * geometry. If \a hasGeometry is false then non-spatial formats can be used.
      *
      * The default implementation returns the user's default Processing vector output format
-     * setting.
+     * setting, if it's supported by the provider (see supportedOutputVectorLayerExtensions()).
+     * Otherwise the first reported supported vector format will be used.
      *
      * \see supportedOutputVectorLayerExtensions()
      * \see defaultRasterFileExtension()
@@ -144,7 +136,8 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * provider.
      *
      * The default implementation returns the user's default Processing raster output format
-     * setting.
+     * setting, if it's supported by the provider (see supportedOutputRasterLayerExtensions()).
+     * Otherwise the first reported supported raster format will be used.
      *
      * \see supportedOutputRasterLayerExtensions()
      * \see defaultVectorFileExtension()

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -110,6 +110,7 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
 
     /**
      * Returns a list of the vector format file extensions supported by this provider.
+     * \see defaultVectorFileExtension()
      * \see supportedOutputRasterLayerExtensions()
      * \see supportedOutputTableExtensions()
      * \see supportsNonFileBasedOutput()
@@ -122,6 +123,33 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * \see supportedOutputVectorLayerExtensions()
      */
     virtual QStringList supportedOutputTableExtensions() const { return QStringList() << QStringLiteral( "csv" ); }
+
+    /**
+     * Returns the default file extension to use for vector outputs created by the
+     * provider.
+     *
+     * If \a hasGeometry is true then the output file format must have support for
+     * geometry. If \a hasGeometry is false then non-spatial formats can be used.
+     *
+     * The default implementation returns the user's default Processing vector output format
+     * setting.
+     *
+     * \see supportedOutputVectorLayerExtensions()
+     * \see defaultRasterFileExtension()
+     */
+    virtual QString defaultVectorFileExtension( bool hasGeometry = true ) const;
+
+    /**
+     * Returns the default file extension to use for raster outputs created by the
+     * provider.
+     *
+     * The default implementation returns the user's default Processing raster output format
+     * setting.
+     *
+     * \see supportedOutputRasterLayerExtensions()
+     * \see defaultVectorFileExtension()
+     */
+    virtual QString defaultRasterFileExtension() const;
 
     /**
      * Returns true if the provider supports non-file based outputs (such as memory layers

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -75,6 +75,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       QVERIFY( addParameter( new QgsProcessingParameterBoolean( "p1" ) ) );
       QCOMPARE( parameterDefinitions().count(), 1 );
       QCOMPARE( parameterDefinitions().at( 0 )->name(), QString( "p1" ) );
+      QCOMPARE( parameterDefinitions().at( 0 )->algorithm(), this );
 
       QVERIFY( !addParameter( nullptr ) );
       QCOMPARE( parameterDefinitions().count(), 1 );


### PR DESCRIPTION
Fixes some deficiencies in the new processing API to better support the available output formats which a provider can actually create.

This was a blocker for the SAGA provider PR.

@alexbruy I've implemented the changes we discussed. Can you let me know if this will fix the issues you ran into?