### PR TITLE
[Plugin manager] Fix insane tabs

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -89,6 +89,10 @@ QgsPluginManager::QgsPluginManager( QWidget *parent, bool pluginsAreEnabled, Qt:
   // and connecting QDialogButtonBox's accepted/rejected signals to dialog's accept/reject slots
   initOptionsBase( true );
 
+  // QgsOptionsDialogBase::initOptionsBase() connected a signal from mOptionsStackedWidget to mOptionsListWidget
+  // for mutual synchronization. Revert it now, because tab indexes and page indexes don't match in QgsPluginManager.
+  disconnect( mOptionsStackedWidget, &QStackedWidget::currentChanged, this, &QgsPluginManager::optionsStackedWidget_CurrentChanged );
+
   // Don't let QgsOptionsDialogBase to narrow the vertical tab list widget
   mOptListWidget->setMaximumWidth( 16777215 );
 

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -171,9 +171,6 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     //! Open help browser
     void showHelp();
 
-    //! Reimplement QgsOptionsDialogBase method to prevent modifying the tab list by signals from the stacked widget
-    void optionsStackedWidget_CurrentChanged( int indx ) { Q_UNUSED( indx ) }
-
     //! Only show plugins from selected repository (e.g. for inspection)
     void setRepositoryFilter();
 


### PR DESCRIPTION
In QgsOptionsDialogBase, the mOptionsStackedWidget is connected back to mOptionsListWidget, so changing pages updates the tabs. It must be disabled in PluginManager, because there is a few tabs pointing to the same page.

Previously the related slot was reimplemented, but now it's protected, so my only idea (except reimplementing the whole initOptionsBase() method) is to disconnect the signal right after connecting. A bit tricky, but simple.

Are there any objections of doing that?