### PR TITLE
Make some QgsOptionsDialogBase's slots virtual

### DIFF
--- a/python/gui/qgsoptionsdialogbase.sip
+++ b/python/gui/qgsoptionsdialogbase.sip
@@ -127,9 +127,10 @@ class QgsOptionsDialogBase : QDialog
 %End
 
   protected slots:
-    void updateOptionsListVerticalTabs();
-    void optionsStackedWidget_CurrentChanged( int indx );
-    void optionsStackedWidget_WidgetRemoved( int indx );
+    virtual void updateOptionsListVerticalTabs();
+    virtual void optionsStackedWidget_CurrentChanged( int indx );
+    virtual void optionsStackedWidget_WidgetRemoved( int indx );
+
     void warnAboutMissingObjects();
 
   protected:

--- a/python/gui/qgsoptionsdialogbase.sip
+++ b/python/gui/qgsoptionsdialogbase.sip
@@ -128,8 +128,8 @@ class QgsOptionsDialogBase : QDialog
 
   protected slots:
     virtual void updateOptionsListVerticalTabs();
-    virtual void optionsStackedWidget_CurrentChanged( int indx );
-    virtual void optionsStackedWidget_WidgetRemoved( int indx );
+    virtual void optionsStackedWidget_CurrentChanged( int index );
+    virtual void optionsStackedWidget_WidgetRemoved( int index );
 
     void warnAboutMissingObjects();
 

--- a/python/gui/qgsoptionsdialogbase.sip
+++ b/python/gui/qgsoptionsdialogbase.sip
@@ -128,8 +128,17 @@ class QgsOptionsDialogBase : QDialog
 
   protected slots:
     virtual void updateOptionsListVerticalTabs();
+%Docstring
+Update tabs on the splitter move
+%End
     virtual void optionsStackedWidget_CurrentChanged( int index );
+%Docstring
+Select relevant tab on current page change
+%End
     virtual void optionsStackedWidget_WidgetRemoved( int index );
+%Docstring
+Remove tab and unregister widgets on page remove
+%End
 
     void warnAboutMissingObjects();
 

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -172,7 +172,7 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     void showHelp();
 
     //! Reimplement QgsOptionsDialogBase method to prevent modifying the tab list by signals from the stacked widget
-    void optionsStackedWidget_CurrentChanged( int indx ) { Q_UNUSED( indx ) }
+    void optionsStackedWidget_CurrentChanged( int indx ) override { Q_UNUSED( indx ) };
 
     //! Only show plugins from selected repository (e.g. for inspection)
     void setRepositoryFilter();

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -172,7 +172,7 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     void showHelp();
 
     //! Reimplement QgsOptionsDialogBase method to prevent modifying the tab list by signals from the stacked widget
-    void optionsStackedWidget_CurrentChanged( int indx ) override { Q_UNUSED( indx ) };
+    void optionsStackedWidget_CurrentChanged( int index ) override { Q_UNUSED( index ) };
 
     //! Only show plugins from selected repository (e.g. for inspection)
     void setRepositoryFilter();

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -95,7 +95,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   connect( mProxyTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsOptions::mProxyTypeComboBox_currentIndexChanged );
   connect( mCustomVariablesChkBx, &QCheckBox::toggled, this, &QgsOptions::mCustomVariablesChkBx_toggled );
   connect( mCurrentVariablesQGISChxBx, &QCheckBox::toggled, this, &QgsOptions::mCurrentVariablesQGISChxBx_toggled );
-  connect( mOptionsStackedWidget, &QStackedWidget::currentChanged, this, &QgsOptions::mOptionsStackedWidget_currentChanged );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsOptions::showHelp );
 
   // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
@@ -1998,9 +1997,11 @@ void QgsOptions::clearAccessCache()
   QMessageBox::information( this, tr( "Cache cleared" ), tr( "Connection authentication cache has been cleared" ) );
 }
 
-void QgsOptions::mOptionsStackedWidget_currentChanged( int indx )
+void QgsOptions::optionsStackedWidget_CurrentChanged( int index )
 {
-  Q_UNUSED( indx );
+  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
+
+  Q_UNUSED( index );
   // load gdal driver list when gdal tab is first opened
   if ( mOptionsStackedWidget->currentWidget()->objectName() == QLatin1String( "mOptionsPageGDAL" )
        && ! mLoadedGdalDriverList )

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -216,7 +216,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void exportScales();
 
     //! Auto slot executed when the active page in the option section widget is changed
-    void mOptionsStackedWidget_currentChanged( int indx );
+    void optionsStackedWidget_CurrentChanged( int index ) override;
 
     //! A scale in the list of predefined scales changed
     void scaleItemChanged( QListWidgetItem *changedScaleItem );

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -122,8 +122,6 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
 
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsRasterLayerProperties::apply );
 
-  connect( mOptionsStackedWidget, &QStackedWidget::currentChanged, this, &QgsRasterLayerProperties::mOptionsStackedWidget_CurrentChanged );
-
   // brightness/contrast controls
   connect( mSliderBrightness, &QAbstractSlider::valueChanged, mBrightnessSpinBox, &QSpinBox::setValue );
   connect( mBrightnessSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), mSliderBrightness, &QAbstractSlider::setValue );
@@ -1483,21 +1481,23 @@ void QgsRasterLayerProperties::setTransparencyToEdited( int row )
   mTransparencyToEdited[row] = true;
 }
 
-void QgsRasterLayerProperties::mOptionsStackedWidget_CurrentChanged( int indx )
+void QgsRasterLayerProperties::optionsStackedWidget_CurrentChanged( int index )
 {
+  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
+
   if ( !mHistogramWidget )
     return;
 
-  if ( indx == 5 )
+  if ( index == 5 )
   {
-    mHistogramWidget->setActive( true );
+    mHistogramWidget->setActive( false );
   }
   else
   {
     mHistogramWidget->setActive( false );
   }
 
-  if ( indx == mOptStackedWidget->indexOf( mOptsPage_Information ) || !mMetadataFilled )
+  if ( index == mOptStackedWidget->indexOf( mOptsPage_Information ) || !mMetadataFilled )
     //set the metadata contents (which can be expensive)
     teMetadataViewer->clear();
   teMetadataViewer->setHtml( mRasterLayer->htmlMetadata() );

--- a/src/app/qgsrasterlayerproperties.h
+++ b/src/app/qgsrasterlayerproperties.h
@@ -79,7 +79,7 @@ class APP_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //! \brief slot executed when user wishes to export transparency values
     void pbnExportTransparentPixelValues_clicked();
     //! \brief auto slot executed when the active page in the main widget stack is changed
-    void mOptionsStackedWidget_CurrentChanged( int indx );
+    void optionsStackedWidget_CurrentChanged( int index ) override;
     //! \brief slow executed when user wishes to import transparency values
     void pbnImportTransparentPixelValues_clicked();
     //! \brief slot executed when user presses "Remove Selected Row" button on the transparency page

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -122,8 +122,6 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   connect( this, &QDialog::accepted, this, &QgsVectorLayerProperties::apply );
   connect( this, &QDialog::rejected, this, &QgsVectorLayerProperties::onCancel );
 
-  connect( mOptionsStackedWidget, &QStackedWidget::currentChanged, this, &QgsVectorLayerProperties::mOptionsStackedWidget_CurrentChanged );
-
   mContext << QgsExpressionContextUtils::globalScope()
            << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
            << QgsExpressionContextUtils::atlasScope( nullptr )
@@ -1447,9 +1445,11 @@ void QgsVectorLayerProperties::pbnUpdateExtents_clicked()
   mMetadataFilled = false;
 }
 
-void QgsVectorLayerProperties::mOptionsStackedWidget_CurrentChanged( int indx )
+void QgsVectorLayerProperties::optionsStackedWidget_CurrentChanged( int index )
 {
-  if ( indx != mOptStackedWidget->indexOf( mOptsPage_Information ) || mMetadataFilled )
+  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
+
+  if ( index != mOptStackedWidget->indexOf( mOptsPage_Information ) || mMetadataFilled )
     return;
 
   //set the metadata contents (which can be expensive)

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -116,7 +116,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void saveDefaultStyle_clicked();
     void loadStyle_clicked();
     void saveStyleAs_clicked();
-    void mOptionsStackedWidget_CurrentChanged( int indx );
+    void optionsStackedWidget_CurrentChanged( int index ) override;
     void pbnUpdateExtents_clicked();
 
     void mButtonAddJoin_clicked();

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -356,24 +356,24 @@ void QgsOptionsDialogBase::updateOptionsListVerticalTabs()
     mOptListWidget->setWordWrap( true );
 }
 
-void QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( int indx )
+void QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( int index )
 {
   mOptListWidget->blockSignals( true );
-  mOptListWidget->setCurrentRow( indx );
+  mOptListWidget->setCurrentRow( index );
   mOptListWidget->blockSignals( false );
 
   updateWindowTitle();
 }
 
-void QgsOptionsDialogBase::optionsStackedWidget_WidgetRemoved( int indx )
+void QgsOptionsDialogBase::optionsStackedWidget_WidgetRemoved( int index )
 {
   // will need to take item first, if widgets are set for item in future
-  delete mOptListWidget->item( indx );
+  delete mOptListWidget->item( index );
 
   QList<QPair< QgsSearchHighlightOptionWidget *, int > >::iterator it = mRegisteredSearchWidgets.begin();
   while ( it != mRegisteredSearchWidgets.end() )
   {
-    if ( ( *it ).second == indx )
+    if ( ( *it ).second == index )
       it = mRegisteredSearchWidgets.erase( it );
     else
       ++it;

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -159,8 +159,8 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
 
   protected slots:
     virtual void updateOptionsListVerticalTabs();
-    virtual void optionsStackedWidget_CurrentChanged( int indx );
-    virtual void optionsStackedWidget_WidgetRemoved( int indx );
+    virtual void optionsStackedWidget_CurrentChanged( int index );
+    virtual void optionsStackedWidget_WidgetRemoved( int index );
 
     void warnAboutMissingObjects();
 

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -158,8 +158,11 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
     void searchText( const QString &text );
 
   protected slots:
+    //! Update tabs on the splitter move
     virtual void updateOptionsListVerticalTabs();
+    //! Select relevant tab on current page change
     virtual void optionsStackedWidget_CurrentChanged( int index );
+    //! Remove tab and unregister widgets on page remove
     virtual void optionsStackedWidget_WidgetRemoved( int index );
 
     void warnAboutMissingObjects();

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -158,9 +158,10 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
     void searchText( const QString &text );
 
   protected slots:
-    void updateOptionsListVerticalTabs();
-    void optionsStackedWidget_CurrentChanged( int indx );
-    void optionsStackedWidget_WidgetRemoved( int indx );
+    virtual void updateOptionsListVerticalTabs();
+    virtual void optionsStackedWidget_CurrentChanged( int indx );
+    virtual void optionsStackedWidget_WidgetRemoved( int indx );
+
     void warnAboutMissingObjects();
 
   protected:


### PR DESCRIPTION
...for overriding in derived clases with non-standard tabs. 

One of the three changed slots was necessary for fixing insane tab behaviour in Plugin manager.

Two other are currently not overriden, but having them virtual looks more consistent to me (it allows to detach the tabs from pages completely - also if pages are inserted dynamically etc).

Supersedes #5545