### PR TITLE
[BUGFIX] Load layer from definition does not use qlr as relative path

### DIFF
--- a/python/core/qgslayerdefinition.sip
+++ b/python/core/qgslayerdefinition.sip
@@ -14,11 +14,11 @@ class QgsLayerDefinition
     /** Loads the QLR at path into QGIS.  New layers are added to rootGroup and the map layer registry*/
     static bool loadLayerDefinition( const QString & path, QgsLayerTreeGroup* rootGroup, QString &errorMessage /Out/ );
     /** Loads the QLR from the XML document.  New layers are added to rootGroup and the map layer registry */
-    static bool loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup* rootGroup, QString &errorMessage /Out/ );
+    static bool loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup* rootGroup, QString &errorMessage, const QString& relativeBasePath = QString() );
     /** Export the selected layer tree nodes to a QLR file */
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage /Out/ );
     /** Export the selected layer tree nodes to a QLR-XML document */
-    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
+    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString() );
 
     /**
      * Class used to work with layer dependencies stored in a XML project or layer definition file

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -288,6 +288,7 @@ class QgsMapLayer : QObject
 
     /** Sets state from Dom document
        @param layerElement The Dom element corresponding to ``maplayer'' tag
+       @param relativeBasePath base path for relative paths
        @note
 
        The Dom node corresponds to a Dom document project file XML element read
@@ -300,7 +301,7 @@ class QgsMapLayer : QObject
 
        @returns true if successful
      */
-    bool readLayerXML( const QDomElement& layerElement );
+    bool readLayerXML( const QDomElement& layerElement, const QString& relativeBasePath = QString() );
 
 
     /** Stores state in Dom node
@@ -319,18 +320,18 @@ class QgsMapLayer : QObject
      *
      * @returns true if successful
      */
-    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null );
+    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString() );
 
     /** Returns the given layer as a layer definition document
      *  Layer definitions store the data source as well as styling and custom properties.
      *
      *  Layer definitions can be used to load a layer and styling all from a single file.
      */
-    static QDomDocument asLayerDefinition( const QList<QgsMapLayer*>& layers, const QString& relativeBasePath = QString::null );
+    static QDomDocument asLayerDefinition( const QList<QgsMapLayer*>& layers, const QString& relativeBasePath = QString() );
 
     /** Creates a new layer from a layer defininition document
      */
-    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false );
+    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false, const QString& relativeBasePath = QString() );
     static QList<QgsMapLayer*> fromLayerDefinitionFile( const QString &qlrfile );
 
     /** Set a custom property for layer. Properties are stored in a map and saved in project file. */

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -198,10 +198,10 @@ class QgsProject : QObject
     void dumpProperties() const;
 
     /** Prepare a filename to save it to the project file */
-    QString writePath( const QString& filename, const QString& relativeBasePath = QString::null ) const;
+    QString writePath( const QString& filename, const QString& relativeBasePath = QString() ) const;
 
     /** Turn filename read from the project file to an absolute path */
-    QString readPath( QString filename ) const;
+    QString readPath( QString filename, const QString& relativeBasePath = QString() ) const;
 
     /** Return error message from previous read/write */
     QString error() const;

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -45,10 +45,10 @@ bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsLayerTreeG
   QFileInfo fileinfo( file );
   QDir::setCurrent( fileinfo.absoluteDir().path() );
 
-  return loadLayerDefinition( doc, rootGroup, errorMessage );
+  return loadLayerDefinition( doc, rootGroup, errorMessage, fileinfo.canonicalFilePath() );
 }
 
-bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup *rootGroup, QString &errorMessage )
+bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup *rootGroup, QString &errorMessage, const QString& relativeBasePath )
 {
   Q_UNUSED( errorMessage );
 
@@ -121,7 +121,7 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsLayerTreeGrou
     loadInLegend = false;
   }
 
-  QList<QgsMapLayer*> layers = QgsMapLayer::fromLayerDefinition( doc, /*addToRegistry*/ true, loadInLegend );
+  QList<QgsMapLayer*> layers = QgsMapLayer::fromLayerDefinition( doc, /*addToRegistry*/ true, loadInLegend, relativeBasePath );
 
   // Now that all layers are loaded, refresh the vectorjoins to get the joined fields
   Q_FOREACH ( QgsMapLayer* layer, layers )

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -30,11 +30,11 @@ class CORE_EXPORT QgsLayerDefinition
     /** Loads the QLR at path into QGIS.  New layers are added to rootGroup and the map layer registry*/
     static bool loadLayerDefinition( const QString & path, QgsLayerTreeGroup* rootGroup, QString &errorMessage );
     /** Loads the QLR from the XML document.  New layers are added to rootGroup and the map layer registry */
-    static bool loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup* rootGroup, QString &errorMessage );
+    static bool loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup* rootGroup, QString &errorMessage, const QString& relativeBasePath = QString() );
     /** Export the selected layer tree nodes to a QLR file */
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage );
     /** Export the selected layer tree nodes to a QLR-XML document */
-    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
+    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString() );
 
     /**
      * \ingroup core

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -310,6 +310,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** Sets state from Dom document
        @param layerElement The Dom element corresponding to ``maplayer'' tag
+       @param relativeBasePath base path for relative paths
        @note
 
        The Dom node corresponds to a Dom document project file XML element read
@@ -322,7 +323,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
        @returns true if successful
      */
-    bool readLayerXML( const QDomElement& layerElement );
+    bool readLayerXML( const QDomElement& layerElement, const QString& relativeBasePath = QString() );
 
 
     /** Stores state in Dom node
@@ -341,18 +342,18 @@ class CORE_EXPORT QgsMapLayer : public QObject
      *
      * @returns true if successful
      */
-    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null );
+    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString() );
 
     /** Returns the given layer as a layer definition document
      *  Layer definitions store the data source as well as styling and custom properties.
      *
      *  Layer definitions can be used to load a layer and styling all from a single file.
      */
-    static QDomDocument asLayerDefinition( const QList<QgsMapLayer*>& layers, const QString& relativeBasePath = QString::null );
+    static QDomDocument asLayerDefinition( const QList<QgsMapLayer*>& layers, const QString& relativeBasePath = QString() );
 
     /** Creates a new layer from a layer defininition document
      */
-    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false );
+    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false, const QString& relativeBasePath = QString() );
     static QList<QgsMapLayer*> fromLayerDefinitionFile( const QString &qlrfile );
 
     /** Set a custom property for layer. Properties are stored in a map and saved in project file. */

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1432,7 +1432,7 @@ void QgsProject::dumpProperties() const
   dump_( imp_->properties_ );
 }
 
-QString QgsProject::readPath( QString src ) const
+QString QgsProject::readPath( QString src, const QString& relativeBasePath ) const
 {
   if ( readBoolEntry( "Paths", "/Absolute", false ) )
   {
@@ -1492,6 +1492,11 @@ QString QgsProject::readPath( QString src ) const
 
   QString srcPath = src;
   QString projPath = fileName();
+
+  if ( !relativeBasePath.isNull() )
+  {
+    projPath = relativeBasePath;
+  }
 
   if ( projPath.isEmpty() )
   {

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -256,10 +256,10 @@ class CORE_EXPORT QgsProject : public QObject
     /** Prepare a filename to save it to the project file. Creates an absolute or relative path to writes
      * it to the project file.
     */
-    QString writePath( const QString& filename, const QString& relativeBasePath = QString::null ) const;
+    QString writePath( const QString& filename, const QString& relativeBasePath = QString() ) const;
 
     /** Turn filename read from the project file to an absolute path */
-    QString readPath( QString filename ) const;
+    QString readPath( QString filename, const QString& relativeBasePath = QString() ) const;
 
     /** Return error message from previous read/write */
     QString error() const;


### PR DESCRIPTION
Fixes #15656 Loading QLR file with relative path does not work correctly

Has been fixed in master but was not fixed in LTRs.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
