### PR TITLE
[bugfix] Fixes #16798 FilterFid feature requests with virtual layers

### DIFF
--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -163,7 +163,7 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
       {
         if ( request.filterType() == QgsFeatureRequest::FilterFid )
         {
-          columns = QStringLiteral( "%1" ).arg( request.filterFid() );
+          columns = QString::number( request.filterFid() );
         }
         else
         {

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -110,7 +110,10 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
     {
       if ( request.filterType() == QgsFeatureRequest::FilterFid )
       {
-        offset = QStringLiteral( " LIMIT 1 OFFSET %1" ).arg( request.filterFid() );
+        if ( request.filterFid() >= 0 )
+          offset = QStringLiteral( " LIMIT 1 OFFSET %1" ).arg( request.filterFid() );
+        else // never return a feature if the id is negative
+          offset = QStringLiteral( " LIMIT 0" );
       }
     }
 

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -253,17 +253,11 @@ bool QgsVirtualLayerFeatureIterator::fetchFeature( QgsFeature &feature )
 
   feature.setFields( mSource->mFields, /* init */ true );
 
-  if ( mSource->mDefinition.uid().isNull() )
+  if ( mSource->mDefinition.uid().isNull() &&
+       mRequest.filterType() != QgsFeatureRequest::FilterFid )
   {
-    if ( mRequest.filterType() == QgsFeatureRequest::FilterFid )
-    {
-      feature.setId( mQuery->columnInt64( 0 ) );
-    }
-    else
-    {
-      // no id column => autoincrement
-      feature.setId( mFid++ );
-    }
+    // no id column => autoincrement
+    feature.setId( mFid++ );
   }
   else
   {

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -86,11 +86,11 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         pass
 
     def test_filterfid_crossjoin(self):
-        l0 = QgsVectorLayer(os.path.join(self.testDataDir, "france_parts.shp"), "france_parts", "ogr", False)
+        l0 = QgsVectorLayer(os.path.join(self.testDataDir, "france_parts.shp"), "france_parts", "ogr")
         self.assertTrue(l0.isValid())
         QgsProject.instance().addMapLayer(l0)
 
-        l1 = QgsVectorLayer(os.path.join(self.testDataDir, "points.shp"), "points", "ogr", False)
+        l1 = QgsVectorLayer(os.path.join(self.testDataDir, "points.shp"), "points", "ogr")
         self.assertTrue(l1.isValid())
         QgsProject.instance().addMapLayer(l1)
 

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -85,6 +85,46 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         """Run after each test."""
         pass
 
+    def test_filterfid_crossjoin(self):
+        l0 = QgsVectorLayer(os.path.join(self.testDataDir, "france_parts.shp"), "france_parts", "ogr", False)
+        self.assertTrue(l0.isValid())
+        QgsProject.instance().addMapLayer(l0)
+
+        l1 = QgsVectorLayer(os.path.join(self.testDataDir, "points.shp"), "points", "ogr", False)
+        self.assertTrue(l1.isValid())
+        QgsProject.instance().addMapLayer(l1)
+
+        # cross join
+        query = toPercent("SELECT * FROM france_parts,points")
+        vl = QgsVectorLayer("?query=%s" % query, "tt", "virtual")
+
+        self.assertEqual(vl.featureCount(), l0.featureCount() * l1.featureCount())
+
+        # test with FilterFid requests
+        f = next(vl.getFeatures(QgsFeatureRequest().setFilterFid(0)))
+        idx = f.fields().indexOf('Class')
+        self.assertEqual(f.id(), 0)
+        self.assertEqual(f.attributes()[idx], 'Jet')
+
+        f = next(vl.getFeatures(QgsFeatureRequest().setFilterFid(5)))
+        self.assertEqual(f.id(), 5)
+        self.assertEqual(f.attributes()[idx], 'Biplane')
+
+        # test with FilterFid requests
+        fit = vl.getFeatures(QgsFeatureRequest().setFilterFids([0, 3, 5]))
+
+        f = next(fit)
+        self.assertEqual(f.id(), 0)
+        self.assertEqual(f.attributes()[idx], 'Jet')
+
+        f = next(fit)
+        self.assertEqual(f.id(), 3)
+        self.assertEqual(f.attributes()[idx], 'Jet')
+
+        f = next(fit)
+        self.assertEqual(f.id(), 5)
+        self.assertEqual(f.attributes()[idx], 'Biplane')
+
     def test_CsvNoGeometry(self):
         l1 = QgsVectorLayer(QUrl.fromLocalFile(os.path.join(self.testDataDir, "delimitedtext/test.csv")).toString() + "?type=csv&geomType=none&subsetIndex=no&watchFile=no", "test", "delimitedtext", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l1.isValid(), True)


### PR DESCRIPTION
## Description

This PR fixes https://issues.qgis.org/issues/16798. 

Now, `FilterFid` feature requests work well when there's no uid used in layer definition.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
