### PR TITLE
Fix represent value

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3454,7 +3454,7 @@ static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressi
 
     if ( index == -1 )
     {
-      parent->setEvalErrorString( QStringLiteral( "%1: Field not found %2" ).arg( QStringLiteral( "represent_value" ), fieldName ) );
+      parent->setEvalErrorString( QCoreApplication::translate( "expression", "%1: Field not found %2" ).arg( QStringLiteral( "represent_value" ), fieldName ) );
     }
     else
     {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3435,15 +3435,13 @@ static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressi
 {
   QVariant result;
   QString fieldName;
-  if ( values.size() == 1 )
+  if ( !values.isEmpty() )
   {
     QgsExpressionNodeColumnRef *col = dynamic_cast<QgsExpressionNodeColumnRef *>( node->args()->at( 0 ) );
-    if ( col )
+    if ( col && ( values.size() == 1 || !values.at( 1 ).isValid() ) )
       fieldName = col->name();
-  }
-  else
-  {
-    fieldName = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
+    else if ( values.size() == 2 )
+      fieldName = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   }
   QVariant value = values.at( 0 );
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -420,9 +420,12 @@ class TestQgsExpression: public QObject
       if ( expression3.hasEvalError() )
         qDebug() << expression3.evalErrorString();
       Q_ASSERT( !expression3.hasEvalError() );
-      expression3.prepare( &context );
+
       mPointsLayer->getFeatures( QgsFeatureRequest().setFilterExpression( "Pilots = 1" ) ).nextFeature( feature );
       context.setFeature( feature );
+
+      QCOMPARE( expression.evaluate( &context ).toString(), QStringLiteral( "one" ) );
+      expression3.prepare( &context );
       QCOMPARE( expression.evaluate( &context ).toString(), QStringLiteral( "one" ) );
 
 


### PR DESCRIPTION
When executing represent_value in its single-parameter version in an unprepared state.

Fixes https://issues.qgis.org/issues/17407