### PR TITLE
Fix issues with custom CRS dialog

### DIFF
--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -185,13 +185,15 @@ QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::Windo
   populateList();
   if ( !mCustomCRSnames.empty() )
   {
-    leName->setText( mCustomCRSnames[0] );
-    teParameters->setPlainText( mCustomCRSparameters[0] );
+    whileBlocking( leName )->setText( mCustomCRSnames[0] );
+    whileBlocking( teParameters )->setPlainText( mCustomCRSparameters[0] );
     leNameList->setCurrentItem( leNameList->topLevelItem( 0 ) );
   }
 
   leNameList->hideColumn( QgisCrsIdColumn );
 
+  connect( leName, &QLineEdit::textChanged, this, &QgsCustomProjectionDialog::updateListFromCurrentItem );
+  connect( teParameters, &QPlainTextEdit::textChanged, this, &QgsCustomProjectionDialog::updateListFromCurrentItem );
 }
 
 QgsCustomProjectionDialog::~QgsCustomProjectionDialog()
@@ -451,8 +453,8 @@ void QgsCustomProjectionDialog::leNameList_currentItemChanged( QTreeWidgetItem *
   if ( current )
   {
     currentIndex = leNameList->indexOfTopLevelItem( current );
-    leName->setText( mCustomCRSnames[currentIndex] );
-    teParameters->setPlainText( current->text( QgisCrsParametersColumn ) );
+    whileBlocking( leName )->setText( mCustomCRSnames[currentIndex] );
+    whileBlocking( teParameters )->setPlainText( current->text( QgisCrsParametersColumn ) );
   }
   else
   {
@@ -539,6 +541,22 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
   {
     accept();
   }
+}
+
+void QgsCustomProjectionDialog::updateListFromCurrentItem()
+{
+  QTreeWidgetItem *item = leNameList->currentItem();
+  if ( !item )
+    return;
+
+  int currentIndex = leNameList->indexOfTopLevelItem( item );
+  if ( currentIndex < 0 )
+    return;
+
+  mCustomCRSnames[currentIndex] = leName->text();
+  mCustomCRSparameters[currentIndex] = teParameters->toPlainText();
+  item->setText( QgisCrsNameColumn, leName->text() );
+  item->setText( QgisCrsParametersColumn, teParameters->toPlainText() );
 }
 
 void QgsCustomProjectionDialog::pbnCalculate_clicked()

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -581,7 +581,7 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
   // Get the WGS84 coordinates
   bool okN, okE;
   double northing = northWGS84->text().toDouble( &okN ) * DEG_TO_RAD;
-  double easthing = eastWGS84->text().toDouble( &okE )  * DEG_TO_RAD;
+  double easting = eastWGS84->text().toDouble( &okE )  * DEG_TO_RAD;
 
   if ( !okN || !okE )
   {
@@ -609,7 +609,7 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
 
   double z = 0.0;
 
-  int projResult = pj_transform( wgs84Proj, proj, 1, 0, &easthing, &northing, &z );
+  int projResult = pj_transform( wgs84Proj, proj, 1, 0, &easting, &northing, &z );
   if ( projResult != 0 )
   {
     projectedX->setText( tr( "Error" ) );
@@ -620,9 +620,18 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
   {
     QString tmp;
 
-    tmp = QLocale::system().toString( northing, 'f', 4 );
+    int precision = 4;
+
+    if ( pj_is_latlong( proj ) )
+    {
+      northing *= RAD_TO_DEG;
+      easting *= RAD_TO_DEG;
+      precision = 7;
+    }
+
+    tmp = QLocale::system().toString( northing, 'f', precision );
     projectedX->setText( tmp );
-    tmp = QLocale::system().toString( easthing, 'f', 4 );
+    tmp = QLocale::system().toString( easting, 'f', precision );
     projectedY->setText( tmp );
   }
 

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -339,8 +339,9 @@ void  QgsCustomProjectionDialog::insertProjection( const QString &projectionAcro
   }
 }
 
-bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem parameters, const QString &name, QString id, bool newEntry )
+bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem parameters, const QString &name, const QString &existingId, bool newEntry )
 {
+  QString id = existingId;
   QString sql;
   int returnId;
   QString projectionAcronym = parameters.projectionAcronym();
@@ -504,23 +505,23 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
     }
   }
   //Modify the CRS changed:
-  bool save_success = true;
+  bool saveSuccess = true;
   for ( int i = 0; i < mCustomCRSids.size(); ++i )
   {
     CRS.createFromProj4( mCustomCRSparameters[i] );
     //Test if we just added this CRS (if it has no existing ID)
-    if ( !mCustomCRSids[i].isEmpty() )
+    if ( mCustomCRSids[i].isEmpty() )
     {
-      save_success &= saveCrs( CRS, mCustomCRSnames[i], QLatin1String( "" ), true );
+      saveSuccess &= saveCrs( CRS, mCustomCRSnames[i], QString(), true );
     }
     else
     {
       if ( mExistingCRSnames[mCustomCRSids[i]] != mCustomCRSnames[i] || mExistingCRSparameters[mCustomCRSids[i]] != mCustomCRSparameters[i] )
       {
-        save_success &= saveCrs( CRS, mCustomCRSnames[i], mCustomCRSids[i], false );
+        saveSuccess &= saveCrs( CRS, mCustomCRSnames[i], mCustomCRSids[i], false );
       }
     }
-    if ( ! save_success )
+    if ( ! saveSuccess )
     {
       QgsDebugMsg( QString( "Error when saving CRS '%1'" ).arg( mCustomCRSnames[i] ) );
     }
@@ -528,13 +529,13 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
   QgsDebugMsg( "We remove the deleted CRS." );
   for ( int i = 0; i < mDeletedCRSs.size(); ++i )
   {
-    save_success &= deleteCrs( mDeletedCRSs[i] );
-    if ( ! save_success )
+    saveSuccess &= deleteCrs( mDeletedCRSs[i] );
+    if ( ! saveSuccess )
     {
       QgsDebugMsg( QString( "Problem for layer '%1'" ).arg( mCustomCRSparameters[i] ) );
     }
   }
-  if ( save_success )
+  if ( saveSuccess )
   {
     accept();
   }

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -107,20 +107,18 @@ void QgsCustomProjectionDialog::populateList()
   // XXX Need to free memory from the error msg if one is set
   if ( result == SQLITE_OK )
   {
-    QTreeWidgetItem *newItem = nullptr;
-    QString id, name, parameters;
     QgsCoordinateReferenceSystem crs;
     while ( sqlite3_step( preparedStatement ) == SQLITE_ROW )
     {
-      id = QString::fromUtf8( ( char * ) sqlite3_column_text( preparedStatement, 0 ) );
-      name = QString::fromUtf8( ( char * ) sqlite3_column_text( preparedStatement, 1 ) );
-      parameters = QString::fromUtf8( ( char * ) sqlite3_column_text( preparedStatement, 2 ) );
+      QString id = QString::fromUtf8( ( char * ) sqlite3_column_text( preparedStatement, 0 ) );
+      QString name = QString::fromUtf8( ( char * ) sqlite3_column_text( preparedStatement, 1 ) );
+      QString parameters = QString::fromUtf8( ( char * ) sqlite3_column_text( preparedStatement, 2 ) );
 
       crs.createFromProj4( parameters );
       mExistingCRSnames[id] = name;
       mExistingCRSparameters[id] = crs.toProj4();
 
-      newItem = new QTreeWidgetItem( leNameList, QStringList() );
+      QTreeWidgetItem *newItem = new QTreeWidgetItem( leNameList, QStringList() );
       newItem->setText( QgisCrsNameColumn, name );
       newItem->setText( QgisCrsIdColumn, id );
       newItem->setText( QgisCrsParametersColumn, crs.toProj4() );
@@ -332,8 +330,7 @@ void QgsCustomProjectionDialog::pbnRemove_clicked()
   {
     return;
   }
-  QTreeWidgetItem *item = leNameList->takeTopLevelItem( i );
-  delete item;
+  delete leNameList->takeTopLevelItem( i );
   if ( !mCustomCRSids[i].isEmpty() )
   {
     mDeletedCRSs.push_back( mCustomCRSids[i] );
@@ -372,7 +369,7 @@ void QgsCustomProjectionDialog::leNameList_currentItemChanged( QTreeWidgetItem *
 
 void QgsCustomProjectionDialog::pbnCopyCRS_clicked()
 {
-  QgsProjectionSelectionDialog *selector = new QgsProjectionSelectionDialog( this );
+  std::unique_ptr< QgsProjectionSelectionDialog > selector = qgis::make_unique< QgsProjectionSelectionDialog >( this );
   if ( selector->exec() )
   {
     QgsCoordinateReferenceSystem srs = selector->crs();
@@ -385,7 +382,6 @@ void QgsCustomProjectionDialog::pbnCopyCRS_clicked()
     leNameList->currentItem()->setText( QgisCrsParametersColumn, srs.toProj4() );
 
   }
-  delete selector;
 }
 
 void QgsCustomProjectionDialog::buttonBox_accepted()

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -419,6 +419,8 @@ void QgsCustomProjectionDialog::pbnAdd_clicked()
   mCustomCRSids.push_back( id );
   mCustomCRSparameters.push_back( parameters.toProj4() );
   leNameList->setCurrentItem( newItem );
+  leName->selectAll();
+  leName->setFocus();
 }
 
 void QgsCustomProjectionDialog::pbnRemove_clicked()

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -89,12 +89,11 @@ QgsCustomProjectionDialog::~QgsCustomProjectionDialog()
 void QgsCustomProjectionDialog::populateList()
 {
   //Setup connection to the existing custom CRS database:
-  sqlite3      *myDatabase = nullptr;
-  const char   *myTail = nullptr;
+  sqlite3 *myDatabase = nullptr;
+  const char *myTail = nullptr;
   sqlite3_stmt *myPreparedStatement = nullptr;
-  int           myResult;
   //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::qgisUserDatabaseFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
+  int myResult = sqlite3_open_v2( QgsApplication::qgisUserDatabaseFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, nullptr );
   if ( myResult != SQLITE_OK )
   {
     QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
@@ -149,15 +148,14 @@ void QgsCustomProjectionDialog::populateList()
 
 bool  QgsCustomProjectionDialog::deleteCrs( const QString &id )
 {
-  sqlite3      *myDatabase = nullptr;
-  const char   *myTail = nullptr;
+  sqlite3 *myDatabase = nullptr;
+  const char *myTail = nullptr;
   sqlite3_stmt *myPreparedStatement = nullptr;
-  int           myResult;
 
   QString mySql = "delete from tbl_srs where srs_id=" + quotedValue( id );
   QgsDebugMsg( mySql );
   //check the db is available
-  myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
+  int myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
   if ( myResult != SQLITE_OK )
   {
     QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDatabaseFilePath() ) );
@@ -181,13 +179,13 @@ bool  QgsCustomProjectionDialog::deleteCrs( const QString &id )
 
 void  QgsCustomProjectionDialog::insertProjection( const QString &myProjectionAcronym )
 {
-  sqlite3      *myDatabase = nullptr;
+  sqlite3 *myDatabase = nullptr;
   sqlite3_stmt *myPreparedStatement = nullptr;
-  sqlite3      *srsDatabase = nullptr;
+  sqlite3 *srsDatabase = nullptr;
   QString mySql;
-  const char   *myTail = nullptr;
+  const char *myTail = nullptr;
   //check the db is available
-  int           myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
+  int myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
   if ( myResult != SQLITE_OK )
   {
     QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDatabaseFilePath() ) );
@@ -205,7 +203,7 @@ void  QgsCustomProjectionDialog::insertProjection( const QString &myProjectionAc
     // Set up the query to retrieve the projection information needed to populate the PROJECTION list
     QString srsSql = "select acronym,name,notes,parameters from tbl_projection where acronym=" + quotedValue( myProjectionAcronym );
 
-    const char   *srsTail = nullptr;
+    const char *srsTail = nullptr;
     sqlite3_stmt *srsPreparedStatement = nullptr;
     srsResult = sqlite3_prepare( srsDatabase, srsSql.toUtf8(), srsSql.length(), &srsPreparedStatement, &srsTail );
     // XXX Need to free memory from the error msg if one is set
@@ -247,17 +245,17 @@ void  QgsCustomProjectionDialog::insertProjection( const QString &myProjectionAc
 bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem myCRS, const QString &myName, QString myId, bool newEntry )
 {
   QString mySql;
-  int return_id;
-  QString myProjectionAcronym  = myCRS.projectionAcronym();
-  QString myEllipsoidAcronym   = myCRS.ellipsoidAcronym();
+  int returnId;
+  QString myProjectionAcronym = myCRS.projectionAcronym();
+  QString myEllipsoidAcronym = myCRS.ellipsoidAcronym();
   QgsDebugMsg( QString( "Saving a CRS:%1, %2, %3" ).arg( myName, myCRS.toProj4() ).arg( newEntry ) );
   if ( newEntry )
   {
-    return_id = myCRS.saveAsUserCrs( myName );
-    if ( return_id == -1 )
+    returnId = myCRS.saveAsUserCrs( myName );
+    if ( returnId == -1 )
       return false;
     else
-      myId = QString::number( return_id );
+      myId = QString::number( returnId );
   }
   else
   {
@@ -270,12 +268,11 @@ bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem myCRS, con
             + " where srs_id=" + quotedValue( myId )
             ;
     QgsDebugMsg( mySql );
-    sqlite3      *myDatabase = nullptr;
-    const char   *myTail = nullptr;
+    sqlite3 *myDatabase = nullptr;
+    const char *myTail = nullptr;
     sqlite3_stmt *myPreparedStatement = nullptr;
-    int           myResult;
     //check if the db is available
-    myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
+    int myResult = sqlite3_open( QgsApplication::qgisUserDatabaseFilePath().toUtf8(), &myDatabase );
     if ( myResult != SQLITE_OK )
     {
       QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ), QgsApplication::qgisUserDatabaseFilePath() ) );
@@ -454,11 +451,7 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
 
 void QgsCustomProjectionDialog::pbnCalculate_clicked()
 {
-
-
-  //
   // We must check the prj def is valid!
-  //
   projCtx pContext = pj_ctx_alloc();
   projPJ myProj = pj_init_plus_ctx( pContext, teParameters->toPlainText().toLocal8Bit().data() );
 
@@ -523,13 +516,10 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
     projectedY->setText( tmp );
   }
 
-  //
   pj_free( myProj );
   pj_free( wgs84Proj );
   pj_ctx_free( pContext );
-
 }
-
 
 QString QgsCustomProjectionDialog::quotedValue( QString value )
 {

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -49,7 +49,7 @@ class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCust
     void populateList();
     QString quotedValue( QString value );
     bool deleteCrs( const QString &id );
-    bool saveCrs( QgsCoordinateReferenceSystem parameters, const QString &name, QString id, bool newEntry );
+    bool saveCrs( QgsCoordinateReferenceSystem parameters, const QString &name, const QString &id, bool newEntry );
     void insertProjection( const QString &projectionAcronym );
     void showHelp();
 

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -49,8 +49,8 @@ class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCust
     void populateList();
     QString quotedValue( QString value );
     bool deleteCrs( const QString &id );
-    bool saveCrs( QgsCoordinateReferenceSystem myParameters, const QString &myName, QString myId, bool newEntry );
-    void insertProjection( const QString &myProjectionAcronym );
+    bool saveCrs( QgsCoordinateReferenceSystem parameters, const QString &name, QString id, bool newEntry );
+    void insertProjection( const QString &projectionAcronym );
     void showHelp();
 
     //These two QMap store the values as they are on the database when loading

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -43,6 +43,10 @@ class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCust
     void leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *prev );
     void buttonBox_accepted();
 
+  private slots:
+
+    void updateListFromCurrentItem();
+
   private:
 
     //helper functions

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -54,16 +54,16 @@ class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCust
     void showHelp();
 
     //These two QMap store the values as they are on the database when loading
-    QMap <QString, QString> existingCRSparameters;
-    QMap <QString, QString> existingCRSnames;
+    QMap <QString, QString> mExistingCRSparameters;
+    QMap <QString, QString> mExistingCRSnames;
 
     //These three list store the value updated with the current modifications
-    QStringList customCRSnames;
-    QStringList customCRSids;
-    QStringList customCRSparameters;
+    QStringList mCustomCRSnames;
+    QStringList mCustomCRSids;
+    QStringList mCustomCRSparameters;
 
     //vector saving the CRS to be deleted
-    QStringList deletedCRSs;
+    QStringList mDeletedCRSs;
 
     //Columns in the tree widget
     enum Columns { QgisCrsNameColumn, QgisCrsIdColumn, QgisCrsParametersColumn };

--- a/src/ui/qgscustomprojectiondialogbase.ui
+++ b/src/ui/qgscustomprojectiondialogbase.ui
@@ -56,17 +56,14 @@
           <string>Define</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="label">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>You can define your own custom Coordinate Reference System (CRS) here. The definition must conform to the proj4 format for specifying a CRS.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
+             <string>Parameters</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
+          <item row="1" column="0" colspan="3">
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
              <widget class="QTreeWidget" name="leNameList">
@@ -145,21 +142,41 @@
                 </property>
                </spacer>
               </item>
-              <item>
-               <widget class="QPushButton" name="pbnCopyCRS">
-                <property name="toolTip">
-                 <string>Copy existing CRS</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../images/images.qrc">
-                  <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
-                </property>
-               </widget>
-              </item>
              </layout>
+            </item>
+           </layout>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QPlainTextEdit" name="teParameters">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>70</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pbnCopyCRS">
+              <property name="toolTip">
+               <string>Copy parameters from existing CRS</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -170,31 +187,18 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="0" colspan="3">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>You can define your own custom Coordinate Reference System (CRS) here. The definition must conform to the proj4 format for specifying a CRS.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
            <widget class="QLineEdit" name="leName"/>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Parameters</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QPlainTextEdit" name="teParameters">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>70</height>
-             </size>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>
@@ -323,14 +327,12 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>groupBox</tabstop>
   <tabstop>leNameList</tabstop>
   <tabstop>pbnAdd</tabstop>
   <tabstop>pbnRemove</tabstop>
-  <tabstop>pbnCopyCRS</tabstop>
   <tabstop>leName</tabstop>
   <tabstop>teParameters</tabstop>
-  <tabstop>groupBox_2</tabstop>
+  <tabstop>pbnCopyCRS</tabstop>
   <tabstop>northWGS84</tabstop>
   <tabstop>eastWGS84</tabstop>
   <tabstop>pbnCalculate</tabstop>


### PR DESCRIPTION
Also clean up and modernize the code in this dialog a lot.

I'd love to use the new sqlite3 unique_ptrs introduced here elsewhere, as we have a lot of messy code sitting around trying to cleanly handle sqlite3 errors and cleanups. So I'd love a review on that part before it gets moved out of the dialog cpp file to core and re-used elsewhere.