### PR TITLE
Fix #17412 Fields Properties: Sorting fixed, no troubles when editing after sorting

### DIFF
--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -776,15 +776,17 @@ void QgsFieldsProperties::attributesListCellChanged( int row, int column )
   }
   else if ( column == attrNameCol && mLayer && mLayer->isEditable() )
   {
+    int idx = mIndexedWidgets.indexOf( mFieldsList->item( row, attrIdCol ) );
+
     QTableWidgetItem *nameItem = mFieldsList->item( row, column );
     if ( !nameItem ||
          nameItem->text().isEmpty() ||
-         !mLayer->fields().exists( row ) ||
-         mLayer->fields().at( row ).name() == nameItem->text() )
+         !mLayer->fields().exists( idx ) ||
+         mLayer->fields().at( idx ).name() == nameItem->text() )
       return;
 
     mLayer->beginEditCommand( tr( "Rename attribute" ) );
-    if ( mLayer->renameAttribute( row,  nameItem->text() ) )
+    if ( mLayer->renameAttribute( idx,  nameItem->text() ) )
     {
       mLayer->endEditCommand();
     }


### PR DESCRIPTION
Issue was, that in the Field-Table on Fields Properties the cellchange is triggered at re-sorting or renaming something in re-sorted table. So there was a bug that referenced to the row instead of the index. 
