### PR TITLE
Correct order of column headers in relationmanager

### DIFF
--- a/src/ui/qgsrelationmanagerdialogbase.ui
+++ b/src/ui/qgsrelationmanagerdialogbase.ui
@@ -45,12 +45,12 @@
      </column>
      <column>
       <property name="text">
-       <string>Referenced Field</string>
+       <string>Referenced Layer</string>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>Referenced Layer</string>
+       <string>Referenced Field</string>
       </property>
      </column>
      <column>


### PR DESCRIPTION
The column headers of "Referenced Field" and "Referenced Layer" were switched with respect to their content. Changed to the correct order in GUI now.

Fix #17409