### PR TITLE
[server][bugfix] Fix OGC test recommendations

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1732,26 +1732,21 @@ namespace QgsWms
       keywordsElem.appendChild( keywordElem );
       parent.appendChild( keywordsElem );
       QStringList keywords = QgsServerProjectUtils::owsServiceKeywords( *project );
-      if ( !keywords.isEmpty() )
+      for ( const QString &keyword : qgis::as_const( keywords ) )
       {
-        for ( int i = 0; i < keywords.size(); ++i )
+        if ( !keyword.isEmpty() )
         {
-          QString keyword = keywords.at( i );
-          if ( !keyword.isEmpty() )
+          keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
+          keywordText = doc.createTextNode( keyword );
+          keywordElem.appendChild( keywordText );
+          if ( sia2045 )
           {
-            keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
-            keywordText = doc.createTextNode( keyword );
-            keywordElem.appendChild( keywordText );
-            if ( sia2045 )
-            {
-              keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
-            }
-            keywordsElem.appendChild( keywordElem );
+            keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
           }
+          keywordsElem.appendChild( keywordElem );
         }
-
-        parent.appendChild( keywordsElem );
       }
+      parent.appendChild( keywordsElem );
     }
   }
 

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -84,6 +84,7 @@ namespace QgsWms
                                     const QgsLayerTreeGroup *layerTreeGroup,
                                     bool projectSettings );
 
+    void addKeywordListElement( const QgsProject *project, QDomDocument &doc, QDomElement &parent );
   }
 
   void writeGetCapabilities( QgsServerInterface *serverIface, const QgsProject *project,
@@ -225,8 +226,6 @@ namespace QgsWms
   QDomElement getServiceElement( QDomDocument &doc, const QgsProject *project, const QString &version,
                                  const QgsServerRequest &request )
   {
-    bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
-
     //Service element
     QDomElement serviceElem = doc.createElement( QStringLiteral( "Service" ) );
 
@@ -254,34 +253,7 @@ namespace QgsWms
       serviceElem.appendChild( abstractElem );
     }
 
-    QDomElement keywordsElem = doc.createElement( QStringLiteral( "KeywordList" ) );
-    //add default keyword
-    QDomElement keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
-    keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "ISO" ) );
-    QDomText keywordText = doc.createTextNode( QStringLiteral( "infoMapAccessService" ) );
-    keywordElem.appendChild( keywordText );
-    keywordsElem.appendChild( keywordElem );
-    serviceElem.appendChild( keywordsElem );
-    QStringList keywords = QgsServerProjectUtils::owsServiceKeywords( *project );
-    if ( !keywords.isEmpty() )
-    {
-      for ( int i = 0; i < keywords.size(); ++i )
-      {
-        QString keyword = keywords.at( i );
-        if ( !keyword.isEmpty() )
-        {
-          keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
-          keywordText = doc.createTextNode( keyword );
-          keywordElem.appendChild( keywordText );
-          if ( sia2045 )
-          {
-            keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
-          }
-          keywordsElem.appendChild( keywordElem );
-        }
-      }
-      serviceElem.appendChild( keywordsElem );
-    }
+    addKeywordListElement( project, doc, serviceElem );
 
     QString onlineResource = QgsServerProjectUtils::owsServiceOnlineResource( *project );
     if ( onlineResource.isEmpty() )
@@ -781,6 +753,28 @@ namespace QgsWms
     QDomText layerParentAbstText = doc.createTextNode( project->title() );
     layerParentAbstElem.appendChild( layerParentAbstText );
     layerParentElem.appendChild( layerParentAbstElem );
+
+    // Root Layer name
+    QDomElement layerParentNameElem = doc.createElement( QStringLiteral( "Name" ) );
+    QString rootName = QgsServerProjectUtils::wmsRootName( *project );
+    if ( rootName.isEmpty() )
+    {
+      QDomText layerParentNameText = doc.createTextNode( project->title() );
+      layerParentNameElem.appendChild( layerParentNameText );
+    }
+    else
+    {
+      QDomText layerParentNameText = doc.createTextNode( rootName );
+      layerParentNameElem.appendChild( layerParentNameText );
+    }
+    layerParentElem.appendChild( layerParentNameElem );
+
+    // Keyword list
+    addKeywordListElement( project, doc, layerParentElem );
+
+    // Metadata (empty but needed for OGC tests RECOMMENDATIONS)
+    QDomElement metaUrlElem = doc.createElement( QStringLiteral( "MetadataURL" ) );
+    layerParentElem.appendChild( metaUrlElem );
 
     // Root Layer tree name
     if ( projectSettings )
@@ -1725,6 +1719,40 @@ namespace QgsWms
       }
     }
 
+    void addKeywordListElement( const QgsProject *project, QDomDocument &doc, QDomElement &parent )
+    {
+      bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
+
+      QDomElement keywordsElem = doc.createElement( QStringLiteral( "KeywordList" ) );
+      //add default keyword
+      QDomElement keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
+      keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "ISO" ) );
+      QDomText keywordText = doc.createTextNode( QStringLiteral( "infoMapAccessService" ) );
+      keywordElem.appendChild( keywordText );
+      keywordsElem.appendChild( keywordElem );
+      parent.appendChild( keywordsElem );
+      QStringList keywords = QgsServerProjectUtils::owsServiceKeywords( *project );
+      if ( !keywords.isEmpty() )
+      {
+        for ( int i = 0; i < keywords.size(); ++i )
+        {
+          QString keyword = keywords.at( i );
+          if ( !keyword.isEmpty() )
+          {
+            keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
+            keywordText = doc.createTextNode( keyword );
+            keywordElem.appendChild( keywordText );
+            if ( sia2045 )
+            {
+              keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
+            }
+            keywordsElem.appendChild( keywordElem );
+          }
+        }
+
+        parent.appendChild( keywordsElem );
+      }
+    }
   }
 
 

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -770,26 +770,17 @@ namespace QgsWms
 
     QDomElement layerParentElem = doc.createElement( QStringLiteral( "Layer" ) );
 
-    // Root Layer name
-    QDomElement layerParentNameElem = doc.createElement( QStringLiteral( "Name" ) );
-    QString rootName = QgsServerProjectUtils::wmsRootName( *project );
-    if ( rootName.isEmpty() )
-    {
-      QDomText layerParentNameText = doc.createTextNode( project->title() );
-      layerParentNameElem.appendChild( layerParentNameText );
-    }
-    else
-    {
-      QDomText layerParentNameText = doc.createTextNode( rootName );
-      layerParentNameElem.appendChild( layerParentNameText );
-    }
-    layerParentElem.appendChild( layerParentNameElem );
-
     // Root Layer title
     QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
     QDomText layerParentTitleText = doc.createTextNode( project->title() );
     layerParentTitleElem.appendChild( layerParentTitleText );
     layerParentElem.appendChild( layerParentTitleElem );
+
+    // Root Layer abstract
+    QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );
+    QDomText layerParentAbstText = doc.createTextNode( project->title() );
+    layerParentAbstElem.appendChild( layerParentAbstText );
+    layerParentElem.appendChild( layerParentAbstElem );
 
     // Root Layer tree name
     if ( projectSettings )

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -98,8 +98,8 @@ Content-Type: text/xml; charset=utf-8
    <Format>XML</Format>
   </Exception>
   <Layer>
-   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
+   <Abstract>QGIS Test Project</Abstract>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -111,6 +111,11 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5.60604e+06" maxx="913283" miny="5.60599e+06" CRS="EPSG:3857" minx="913171"/>
    <BoundingBox maxy="8.20416" maxx="44.9016" miny="8.20315" CRS="EPSG:4326" minx="44.9012"/>
+   <Name>QGIS Test Project</Name>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
+   <MetadataURL/>
    <Layer queryable="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -133,6 +133,11 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5.60604e+06" maxx="913283" miny="5.60599e+06" CRS="EPSG:3857" minx="913171"/>
    <BoundingBox maxy="8.20416" maxx="44.9016" miny="8.20315" CRS="EPSG:4326" minx="44.9012"/>
+   <Name>QGIS Test Project</Name>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
+   <MetadataURL/>
    <Layer queryable="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -120,8 +120,8 @@ Content-Type: text/xml; charset=utf-8
    </inspire_common:ResponseLanguage>
   </inspire_vs:ExtendedCapabilities>
   <Layer>
-   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
+   <Abstract>QGIS Test Project</Abstract>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -114,8 +114,8 @@ Content-Type: text/xml; charset=utf-8
    <WFSLayer name="testlayer èé"/>
   </WFSLayers>
   <Layer>
-   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
+   <Abstract>QGIS Test Project</Abstract>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -127,6 +127,11 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5.60604e+06" maxx="913283" miny="5.60599e+06" CRS="EPSG:3857" minx="913171"/>
    <BoundingBox maxy="8.20416" maxx="44.9016" miny="8.20315" CRS="EPSG:4326" minx="44.9012"/>
+   <Name>QGIS Test Project</Name>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
+   <MetadataURL/>
    <TreeName>QGIS Test Project</TreeName>
    <Layer geometryType="Point" queryable="1" displayField="name" visible="1">
     <Name>testlayer èé</Name>


### PR DESCRIPTION
## Description

This PR fixes the OGC test recommendations (abstracts, keywordlists and metadataurls) which is currently failing: http://test.qgis.org/ogc_cite/2017_11_08_18_00_wms_1_3_0.html#fa4d94ab-1902-41e8-b5d9-738d7c52eac0/d1e17382_1

I took a look on `GetCapabilities` response from geoserver (http://cite.demo.opengeo.org:8080/geoserver_wms13/wms?service=wms&request=getcapabilities&version=1.3.0) and it seems that the root layer has `<Title/>` and `<Abstract/>` fields. But in QGIS Server, we currently have `<Name/>` and `<Title/>` instead. 

By replacing `<Name/>` field with `<Abstract/>` for the root layer, OGC tests are green.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
