### PR TITLE
[postgres] Fix default value check if evaluated server side

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1846,7 +1846,7 @@ bool QgsPostgresProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstrain
 {
   if ( providerProperty( EvaluateDefaultValues, false ).toBool() )
   {
-    return mDefaultValues.contains( fieldIndex );
+    return !mDefaultValues.value( fieldIndex ).isEmpty();
   }
   else
   {


### PR DESCRIPTION
Fixes an issue where (server side, hard) NOT NULL constraints are completely ignored when default values are evaluated server side.