### PR TITLE
Value relation widget takes key again instead of value (in Attribute Form)

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -66,7 +66,7 @@ QVariant QgsValueRelationWidgetWrapper::value() const
     {
       if ( item.value == mLineEdit->text() )
       {
-        v = item.value;
+        v = item.key;
         break;
       }
     }


### PR DESCRIPTION
Corrected: Fix #17261 Value relation widget update incorrectly tries to use value instead of key

The mapped key has to be set in the return value (not the input value).
In the release-2_18 the key was returned correctly but in another structure. So this is corrected now.