### PR TITLE
Python editor window size in attributeformproperties

### DIFF
--- a/src/ui/qgsattributesforminitcode.ui
+++ b/src/ui/qgsattributesforminitcode.ui
@@ -14,6 +14,28 @@
    <string>Python Init Code Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <widget class="QWidget" name="mBelow" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QgsCodeEditorPython" name="mInitCodeEditorPython" native="true">
+        <property name="baseSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QWidget" name="mInitFunctionContainer" native="true">
      <property name="sizePolicy">
@@ -88,7 +110,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="maximumSize">
       <size>
@@ -103,9 +125,6 @@
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QgsCodeEditorPython" name="mInitCodeEditorPython" native="true"/>
    </item>
    <item row="0" column="0">
     <widget class="QWidget" name="mInitCodeSourceContainter" native="true">
@@ -163,19 +182,6 @@ Reference in function name: my_form_open
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Used an expanding widget to contain the python editor. So if the editor is not visible, the layout of the combobox on top is still contstant.

Fix #17428
