### PR TITLE
Constrain the Help button placement (blocked at left)

### DIFF
--- a/src/ui/qgsexpressionselectiondialogbase.ui
+++ b/src/ui/qgsexpressionselectiondialogbase.ui
@@ -68,6 +68,12 @@
    </item>
    <item row="1" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Help</set>
      </property>


### PR DESCRIPTION
and avoid it move like below

![image](https://user-images.githubusercontent.com/7983394/32603898-bc260b18-c54b-11e7-99a5-630aee3d77d1.png)