### PR TITLE
Expose through iface methods to copy/paste features between given layers

### DIFF
--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -767,6 +767,16 @@ Start a blank project
  :rtype: bool
 %End
 
+    virtual void copyFeatures( QgsMapLayer * ) = 0;
+%Docstring
+Copy selected features from the layer to clipboard
+%End
+
+    virtual void pasteFeatures( QgsMapLayer * ) = 0;
+%Docstring
+Paste features from clipboard to the layer
+%End
+
     virtual int addToolBarIcon( QAction *qAction ) = 0;
 %Docstring
 Add an icon to the plugins toolbar

--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -767,12 +767,12 @@ Start a blank project
  :rtype: bool
 %End
 
-    virtual void copyFeatures( QgsMapLayer * ) = 0;
+    virtual void editCopy( QgsMapLayer * ) = 0;
 %Docstring
 Copy selected features from the layer to clipboard
 %End
 
-    virtual void pasteFeatures( QgsMapLayer * ) = 0;
+    virtual void editPaste( QgsMapLayer * ) = 0;
 %Docstring
 Paste features from clipboard to the layer
 %End

--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -767,14 +767,16 @@ Start a blank project
  :rtype: bool
 %End
 
-    virtual void editCopy( QgsMapLayer * ) = 0;
+    virtual void copySelectionToClipboard( QgsMapLayer * ) = 0;
 %Docstring
-Copy selected features from the layer to clipboard
+ Copy selected features from the layer to clipboard
+.. versionadded:: 3.0
 %End
 
-    virtual void editPaste( QgsMapLayer * ) = 0;
+    virtual void pasteFromClipboard( QgsMapLayer * ) = 0;
 %Docstring
-Paste features from clipboard to the layer
+ Paste features from clipboard to the layer
+.. versionadded:: 3.0
 %End
 
     virtual int addToolBarIcon( QAction *qAction ) = 0;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1805,9 +1805,9 @@ void QgisApp::createActions()
 
   connect( mActionUndo, &QAction::triggered, mUndoWidget, &QgsUndoWidget::undo );
   connect( mActionRedo, &QAction::triggered, mUndoWidget, &QgsUndoWidget::redo );
-  connect( mActionCutFeatures, &QAction::triggered, this, [ = ] { editCut(); } );
-  connect( mActionCopyFeatures, &QAction::triggered, this, [ = ] { editCopy(); } );
-  connect( mActionPasteFeatures, &QAction::triggered, this, [ = ] { editPaste(); } );
+  connect( mActionCutFeatures, &QAction::triggered, this, [ = ] { cutSelectionToClipboard(); } );
+  connect( mActionCopyFeatures, &QAction::triggered, this, [ = ] { copySelectionToClipboard(); } );
+  connect( mActionPasteFeatures, &QAction::triggered, this, [ = ] { pasteFromClipboard(); } );
   connect( mActionPasteAsNewVector, &QAction::triggered, this, &QgisApp::pasteAsNewVector );
   connect( mActionPasteAsNewMemoryVector, &QAction::triggered, this, [ = ] { pasteAsNewMemoryVector(); } );
   connect( mActionCopyStyle, &QAction::triggered, this, [ = ] { copyStyle(); } );
@@ -8054,7 +8054,7 @@ void QgisApp::addPart()
 }
 
 
-void QgisApp::editCut( QgsMapLayer *layerContainingSelection )
+void QgisApp::cutSelectionToClipboard( QgsMapLayer *layerContainingSelection )
 {
   // Test for feature support in this layer
   QgsVectorLayer *selectionVectorLayer = qobject_cast<QgsVectorLayer *>( layerContainingSelection ? layerContainingSelection : activeLayer() );
@@ -8068,7 +8068,7 @@ void QgisApp::editCut( QgsMapLayer *layerContainingSelection )
   selectionVectorLayer->endEditCommand();
 }
 
-void QgisApp::editCopy( QgsMapLayer *layerContainingSelection )
+void QgisApp::copySelectionToClipboard( QgsMapLayer *layerContainingSelection )
 {
   QgsVectorLayer *selectionVectorLayer = qobject_cast<QgsVectorLayer *>( layerContainingSelection ? layerContainingSelection : activeLayer() );
   if ( !selectionVectorLayer )
@@ -8083,7 +8083,7 @@ void QgisApp::clipboardChanged()
   activateDeactivateLayerRelatedActions( activeLayer() );
 }
 
-void QgisApp::editPaste( QgsMapLayer *destinationLayer )
+void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
 {
   QgsVectorLayer *pasteVectorLayer = qobject_cast<QgsVectorLayer *>( destinationLayer ? destinationLayer : activeLayer() );
   if ( !pasteVectorLayer )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -745,21 +745,21 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
        \param layerContainingSelection  The layer that the selection will be taken from
                                         (defaults to the active layer on the legend)
      */
-    void editCut( QgsMapLayer *layerContainingSelection = nullptr );
+    void cutSelectionToClipboard( QgsMapLayer *layerContainingSelection = nullptr );
     //! copies selected features on the active layer to the clipboard
 
     /**
        \param layerContainingSelection  The layer that the selection will be taken from
                                         (defaults to the active layer on the legend)
      */
-    void editCopy( QgsMapLayer *layerContainingSelection = nullptr );
+    void copySelectionToClipboard( QgsMapLayer *layerContainingSelection = nullptr );
     //! copies features on the clipboard to the active layer
 
     /**
        \param destinationLayer  The layer that the clipboard will be pasted to
                                 (defaults to the active layer on the legend)
      */
-    void editPaste( QgsMapLayer *destinationLayer = nullptr );
+    void pasteFromClipboard( QgsMapLayer *destinationLayer = nullptr );
     //! copies features on the clipboard to a new vector layer
     void pasteAsNewVector();
     //! copies features on the clipboard to a new memory vector layer

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -186,6 +186,16 @@ bool QgisAppInterface::setActiveLayer( QgsMapLayer *layer )
   return qgis->setActiveLayer( layer );
 }
 
+void QgisAppInterface::copyFeatures( QgsMapLayer *layer )
+{
+  return qgis->editCopy( layer );
+}
+
+void QgisAppInterface::pasteFeatures( QgsMapLayer *layer )
+{
+  return qgis->editPaste( layer );
+}
+
 void QgisAppInterface::addPluginToMenu( const QString &name, QAction *action )
 {
   qgis->addPluginToMenu( name, action );

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -186,12 +186,12 @@ bool QgisAppInterface::setActiveLayer( QgsMapLayer *layer )
   return qgis->setActiveLayer( layer );
 }
 
-void QgisAppInterface::copyFeatures( QgsMapLayer *layer )
+void QgisAppInterface::editCopy( QgsMapLayer *layer )
 {
   return qgis->editCopy( layer );
 }
 
-void QgisAppInterface::pasteFeatures( QgsMapLayer *layer )
+void QgisAppInterface::editPaste( QgsMapLayer *layer )
 {
   return qgis->editPaste( layer );
 }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -186,14 +186,14 @@ bool QgisAppInterface::setActiveLayer( QgsMapLayer *layer )
   return qgis->setActiveLayer( layer );
 }
 
-void QgisAppInterface::editCopy( QgsMapLayer *layer )
+void QgisAppInterface::copySelectionToClipboard( QgsMapLayer *layer )
 {
-  return qgis->editCopy( layer );
+  return qgis->copySelectionToClipboard( layer );
 }
 
-void QgisAppInterface::editPaste( QgsMapLayer *layer )
+void QgisAppInterface::pasteFromClipboard( QgsMapLayer *layer )
 {
-  return qgis->editPaste( layer );
+  return qgis->pasteFromClipboard( layer );
 }
 
 void QgisAppInterface::addPluginToMenu( const QString &name, QAction *action )

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -96,11 +96,17 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     //! set the active layer (layer selected in the legend)
     bool setActiveLayer( QgsMapLayer *layer ) override;
 
-    //! Copy selected features from the layer to clipboard
-    virtual void editCopy( QgsMapLayer *layer ) override;
+    /**
+     * Copy selected features from the layer to clipboard
+     * \since QGIS 3.0
+     */
+    virtual void copySelectionToClipboard( QgsMapLayer *layer ) override;
 
-    //! Paste features from clipboard to the layer
-    virtual void editPaste( QgsMapLayer *layer ) override;
+    /**
+     * Paste features from clipboard to the layer
+     * \since QGIS 3.0
+     */
+    virtual void pasteFromClipboard( QgsMapLayer *layer ) override;
 
     //! Add an icon to the plugins toolbar
     int addToolBarIcon( QAction *qAction ) override;

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -97,10 +97,10 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     bool setActiveLayer( QgsMapLayer *layer ) override;
 
     //! Copy selected features from the layer to clipboard
-    virtual void copyFeatures( QgsMapLayer *layer ) override;
+    virtual void editCopy( QgsMapLayer *layer ) override;
 
     //! Paste features from clipboard to the layer
-    virtual void pasteFeatures( QgsMapLayer *layer ) override;
+    virtual void editPaste( QgsMapLayer *layer ) override;
 
     //! Add an icon to the plugins toolbar
     int addToolBarIcon( QAction *qAction ) override;

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -96,6 +96,12 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     //! set the active layer (layer selected in the legend)
     bool setActiveLayer( QgsMapLayer *layer ) override;
 
+    //! Copy selected features from the layer to clipboard
+    virtual void copyFeatures( QgsMapLayer *layer ) override;
+
+    //! Paste features from clipboard to the layer
+    virtual void pasteFeatures( QgsMapLayer *layer ) override;
+
     //! Add an icon to the plugins toolbar
     int addToolBarIcon( QAction *qAction ) override;
 

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -730,12 +730,12 @@ void QgsAttributeTableDialog::mActionExpressionSelect_triggered()
 
 void QgsAttributeTableDialog::mActionCopySelectedRows_triggered()
 {
-  QgisApp::instance()->editCopy( mLayer );
+  QgisApp::instance()->copySelectionToClipboard( mLayer );
 }
 
 void QgsAttributeTableDialog::mActionPasteFeatures_triggered()
 {
-  QgisApp::instance()->editPaste( mLayer );
+  QgisApp::instance()->pasteFromClipboard( mLayer );
 }
 
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -422,6 +422,12 @@ class GUI_EXPORT QgisInterface : public QObject
      */
     virtual bool setActiveLayer( QgsMapLayer * ) = 0;
 
+    //! Copy selected features from the layer to clipboard
+    virtual void copyFeatures( QgsMapLayer * ) = 0;
+
+    //! Paste features from clipboard to the layer
+    virtual void pasteFeatures( QgsMapLayer * ) = 0;
+
     //! Add an icon to the plugins toolbar
     virtual int addToolBarIcon( QAction *qAction ) = 0;
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -422,11 +422,17 @@ class GUI_EXPORT QgisInterface : public QObject
      */
     virtual bool setActiveLayer( QgsMapLayer * ) = 0;
 
-    //! Copy selected features from the layer to clipboard
-    virtual void editCopy( QgsMapLayer * ) = 0;
+    /**
+     * Copy selected features from the layer to clipboard
+     * \since QGIS 3.0
+     */
+    virtual void copySelectionToClipboard( QgsMapLayer * ) = 0;
 
-    //! Paste features from clipboard to the layer
-    virtual void editPaste( QgsMapLayer * ) = 0;
+    /**
+     * Paste features from clipboard to the layer
+     * \since QGIS 3.0
+     */
+    virtual void pasteFromClipboard( QgsMapLayer * ) = 0;
 
     //! Add an icon to the plugins toolbar
     virtual int addToolBarIcon( QAction *qAction ) = 0;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -423,10 +423,10 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual bool setActiveLayer( QgsMapLayer * ) = 0;
 
     //! Copy selected features from the layer to clipboard
-    virtual void copyFeatures( QgsMapLayer * ) = 0;
+    virtual void editCopy( QgsMapLayer * ) = 0;
 
     //! Paste features from clipboard to the layer
-    virtual void pasteFeatures( QgsMapLayer * ) = 0;
+    virtual void editPaste( QgsMapLayer * ) = 0;
 
     //! Add an icon to the plugins toolbar
     virtual int addToolBarIcon( QAction *qAction ) = 0;

--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -103,7 +103,7 @@ void TestQgisAppClipboard::copyPaste()
 
     // copy all features to clipboard
     inputLayer->selectAll();
-    mQgisApp->editCopy( inputLayer );
+    mQgisApp->copySelectionToClipboard( inputLayer );
 
     QgsFeatureList features = mQgisApp->clipboard()->copyOf();
     qDebug() << features.size() << " features copied to clipboard";


### PR DESCRIPTION
That is, no need to load layers into the layer tree nor make them active to use copy/paste functionality (such as with `iface.actionCopyFeatures().trigger()`), which means that we'll have an alternative to cover (to some extent) the missing "append to layer" functionality.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
