### PR TITLE
[GDAL provider] in create(), use newly create dataset handle to instanciate the provider (fix #17103)

### DIFF
--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -63,11 +63,12 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     /**
      * Constructor for the provider.
      *
-     * \param   uri   HTTP URL of the Web Server.  If needed a proxy will be used
-     *                otherwise we contact the host directly.
+     * \param   uri         file name
+     * \param   update      whether to open in update mode
+     * \param   newDataset  handle of newly created dataset.
      *
      */
-    QgsGdalProvider( QString const &uri = QString(), bool update = false );
+    QgsGdalProvider( QString const &uri = QString(), bool update = false, GDALDatasetH newDataset = nullptr );
 
     //! Create invalid provider with error
     QgsGdalProvider( QString const &uri, const QgsError &error );


### PR DESCRIPTION
Previously we created an empty file, close it and re-opened it immediately in open mode.
However for GeoPackage, if you create for example a 1 band or 3 band dataset, upon reopening
you get a 4 band RGBA dataset, due to the fact that GeoPackage doesn't explicitly store the
number of bands. Thus the 4th band (alpha) was never written by the QgsRasterFileWriter logic.
