### PR TITLE
[travis] Trigger libSegFault on abrt

### DIFF
--- a/.ci/travis/linux/docker-build-test.sh
+++ b/.ci/travis/linux/docker-build-test.sh
@@ -16,6 +16,7 @@ ccache -z
 # Setup the (c)test environment
 ############################
 export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+export SEGFAULT_SIGNALS="abrt segv"
 export CTEST_BUILD_COMMAND="/usr/bin/ninja"
 export CTEST_PARALLEL_LEVEL=1
 


### PR DESCRIPTION
This should trigger a stack trace on `SIGABRT` and give hints about failing tests.