### PR TITLE
Fix 3d renderer does not work with multi-point layers

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -172,14 +172,15 @@ QList<QVector3D> Qgs3DUtils::positions( const Qgs3DMapSettings &map, QgsVectorLa
       continue;
 
     const QgsAbstractGeometry *g = f.geometry().constGet();
-    if ( const QgsPoint *pt = qgsgeometry_cast< const QgsPoint *>( g ) )
+    for ( auto it = g->vertices_begin(); it != g->vertices_end(); ++it )
     {
+      QgsPoint pt = *it;
       float geomZ = 0;
-      if ( pt->is3D() )
+      if ( pt.is3D() )
       {
-        geomZ = pt->z();
+        geomZ = pt.z();
       }
-      float terrainZ = map.terrainGenerator()->heightAt( pt->x(), pt->y(), map ) * map.terrainVerticalScale();
+      float terrainZ = map.terrainGenerator()->heightAt( pt.x(), pt.y(), map ) * map.terrainVerticalScale();
       float h;
       switch ( altClamp )
       {
@@ -193,11 +194,9 @@ QList<QVector3D> Qgs3DUtils::positions( const Qgs3DMapSettings &map, QgsVectorLa
           h = terrainZ + geomZ;
           break;
       }
-      positions.append( QVector3D( pt->x() - map.originX(), h, -( pt->y() - map.originY() ) ) );
+      positions.append( QVector3D( pt.x() - map.originX(), h, -( pt.y() - map.originY() ) ) );
       //qDebug() << positions.last();
     }
-    else
-      qDebug() << "not a point";
   }
 
   return positions;

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -75,7 +75,7 @@ class _3D_EXPORT Qgs3DUtils
     static QMatrix4x4 stringToMatrix4x4( const QString &str );
 
     /**
-     * Calculates (x,y,z) position of point in the Point vector layers
+     * Calculates (x,y,z) positions of a (multi)point in the Point vector layers
      */
     static QList<QVector3D> positions( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsFeatureRequest &req, AltitudeClamping altClamp );
 

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -23,6 +23,10 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
 {
   setupUi( this );
 
+  spinHeight->setClearValue( 0.0 );
+  spinWidth->setClearValue( 0.0 );
+  spinExtrusion->setClearValue( 0.0 );
+
   setSymbol( QgsLine3DSymbol() );
 
   connect( spinWidth, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsLine3DSymbolWidget::changed );

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -25,6 +25,16 @@ QgsPoint3DSymbolWidget::QgsPoint3DSymbolWidget( QWidget *parent )
 {
   setupUi( this );
 
+  spinTX->setClearValue( 0.0 );
+  spinTY->setClearValue( 0.0 );
+  spinTZ->setClearValue( 0.0 );
+  spinSX->setClearValue( 1.0 );
+  spinSY->setClearValue( 1.0 );
+  spinSZ->setClearValue( 1.0 );
+  spinRX->setClearValue( 0.0 );
+  spinRY->setClearValue( 0.0 );
+  spinRZ->setClearValue( 0.0 );
+
   cboShape->addItem( tr( "Sphere" ), QgsPoint3DSymbol::Sphere );
   cboShape->addItem( tr( "Cylinder" ), QgsPoint3DSymbol::Cylinder );
   cboShape->addItem( tr( "Cube" ), QgsPoint3DSymbol::Cube );

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -22,6 +22,8 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   : QWidget( parent )
 {
   setupUi( this );
+  spinHeight->setClearValue( 0.0 );
+  spinExtrusion->setClearValue( 0.0 );
 
   setSymbol( QgsPolygon3DSymbol(), nullptr );
 


### PR DESCRIPTION
The 3d renderer currently chokes on multipoint layers, refusing to create an object for these points. This commit fixes that.

I've also fixed some ui roughness with the spin boxes in 3d renderer widgets.