### PR TITLE
Trigger layer repaint when adding field-less features (fixes #17426)

### DIFF
--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -217,9 +217,14 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
     mFeatureSaved = mLayer->addFeature( *mFeature );
 
     if ( mFeatureSaved )
+    {
       mLayer->endEditCommand();
+      mLayer->triggerRepaint();
+    }
     else
+    {
       mLayer->destroyEditCommand();
+    }
   }
   else
   {


### PR DESCRIPTION
## Description
This PR fixes a regression (introduced in commit 7dbae64cc7e9882c7833c3a887c2ed80f46a4fca) whereas adding field-less features fail to trigger a canvas repaint.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
