### PR TITLE
[north arrow] prevent crash if project CRS is not defined

### DIFF
--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -123,7 +123,15 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
       // called when the projection or map extent changes
       if ( mAutomatic )
       {
-        mRotationInt = QgsBearingUtils:: bearingTrueNorth( mapSettings.destinationCrs(), context.extent().center() );
+        try
+        {
+          mRotationInt = QgsBearingUtils:: bearingTrueNorth( mapSettings.destinationCrs(), context.extent().center() );
+        }
+        catch ( QgsException &e )
+        {
+          mRotationInt = 0.0;
+          //QgsDebugMsg( "Can not get direction to true north. Probably project CRS is not defined." );
+        }
         mRotationInt += mapSettings.rotation();
       }
 
@@ -210,5 +218,4 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
       context.painter()->drawText( 10, 20, tr( "North arrow pixmap not found" ) );
     }
   }
-
 }


### PR DESCRIPTION
## Description
Prevents QGIS crash from North Arrow decoration if project CRS is not defined and automatic arrow rotation is used. Fixes https://issues.qgis.org/issues/16874

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit