### PR TITLE
[bugfix] Apply proxy configuration to OGR connections

### DIFF
--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -66,7 +66,7 @@ class QgsNetworkProxyFactory : public QNetworkProxyFactory
           return proxies;
       }
 
-      // no proxies from the proxy factor list check for excludes
+      // no proxies from the proxy factory list check for excludes
       if ( query.queryType() != QNetworkProxyQuery::UrlRequest )
         return QList<QNetworkProxy>() << nam->fallbackProxy();
 
@@ -364,16 +364,15 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache()
                  );
       proxy = QNetworkProxy( proxyType, proxyHost, proxyPort, proxyUser, proxyPassword );
     }
-  }
-
-  // Setup network proxy authentication configuration
-  QString authcfg = settings.value( QStringLiteral( "proxy/authcfg" ), "" ).toString();
-  if ( !authcfg.isEmpty( ) )
-  {
-    QgsDebugMsg( QStringLiteral( "setting proxy from stored authentication configuration %1" ).arg( authcfg ) );
-    // Never crash! Never.
-    if ( QgsApplication::authManager() )
-      QgsApplication::authManager()->updateNetworkProxy( proxy, authcfg );
+    // Setup network proxy authentication configuration
+    QString authcfg = settings.value( QStringLiteral( "proxy/authcfg" ), "" ).toString();
+    if ( !authcfg.isEmpty( ) )
+    {
+      QgsDebugMsg( QStringLiteral( "setting proxy from stored authentication configuration %1" ).arg( authcfg ) );
+      // Never crash! Never.
+      if ( QgsApplication::authManager() )
+        QgsApplication::authManager()->updateNetworkProxy( proxy, authcfg );
+    }
   }
 
   setFallbackProxyAndExcludes( proxy, excludes );

--- a/src/providers/ogr/CMakeLists.txt
+++ b/src/providers/ogr/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 SET (OGR_SRCS
     qgsogrprovider.cpp
     qgsogrdataitems.cpp
@@ -40,12 +39,14 @@ QT5_WRAP_CPP(OGR_MOC_SRCS ${OGR_MOC_HDRS})
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
+  ${CMAKE_SOURCE_DIR}/src/core/auth
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/gui
+  ${CMAKE_SOURCE_DIR}/src/gui/auth
 
   ${CMAKE_BINARY_DIR}/src/core
   ${CMAKE_BINARY_DIR}/src/gui
@@ -54,6 +55,8 @@ INCLUDE_DIRECTORIES(
 INCLUDE_DIRECTORIES(SYSTEM
   ${GDAL_INCLUDE_DIR}
   ${GEOS_INCLUDE_DIR}
+  ${QTKEYCHAIN_INCLUDE_DIR}
+  ${QCA_INCLUDE_DIR}
   ${QSCINTILLA_INCLUDE_DIR}
 )
 
@@ -86,5 +89,4 @@ ENDIF(CLANG_TIDY_EXE)
 
 INSTALL (TARGETS ogrprovider
   RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
-
+LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1983,7 +1983,7 @@ void QgsOgrProvider::setupProxy()
 {
   // Check proxy configuration, they are application level but
   // instead of adding an API and complex signal/slot connections
-  // given the limited cost of checking them on every provider instanciation
+  // given the limited cost of checking them on every provider instantiation
   // we can do it here so that new settings are applied whenever a new layer
   // is created.
   QgsSettings settings;

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -266,6 +266,11 @@ class QgsOgrProvider : public QgsVectorDataProvider
     QgsVectorDataProvider::Capabilities mCapabilities;
 
     bool doInitialActionsForEdition();
+
+#ifndef QT_NO_NETWORKPROXY
+    void setupProxy();
+#endif
+
 };
 
 /**

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -66,6 +66,8 @@ SET_TARGET_PROPERTIES(qgis_wcsprovidertest PROPERTIES
 
 ADD_QGIS_TEST(gdalprovidertest testqgsgdalprovider.cpp)
 
+ADD_QGIS_TEST(ogrprovidertest testqgsogrprovider.cpp)
+
 ADD_QGIS_TEST(wmscapabilititestest
               testqgswmscapabilities.cpp)
 TARGET_LINK_LIBRARIES(qgis_wmscapabilititestest wmsprovider_a)

--- a/tests/src/providers/testqgsogrprovider.cpp
+++ b/tests/src/providers/testqgsogrprovider.cpp
@@ -1,0 +1,124 @@
+/***************************************************************************
+  testqgsogrprovider.cpp - TestQgsOgrProvider
+
+ ---------------------
+ begin                : 10.11.2017
+ copyright            : (C) 2017 by Alessandro Pasotti
+ email                : apasotti at boundlessgeo dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+
+//qgis includes...
+#include <qgis.h>
+#include <qgssettings.h>
+#include <qgsapplication.h>
+#include <qgsproviderregistry.h>
+#include <qgsvectorlayer.h>
+#include <qgsnetworkaccessmanager.h>
+
+#include <QObject>
+
+#include <cpl_conv.h>
+
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the ogr provider
+ */
+class TestQgsOgrProvider : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {}// will be called before each testfunction is executed.
+    void cleanup() {}// will be called after every testfunction.
+
+    void setupProxy();
+
+  private:
+    QString mTestDataDir;
+    QString mReport;
+  signals:
+
+  public slots:
+};
+
+
+
+//runs before all tests
+void TestQgsOgrProvider::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  mTestDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
+  mReport = QStringLiteral( "<h1>OGR Provider Tests</h1>\n" );
+}
+
+//runs after all tests
+void TestQgsOgrProvider::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+  QString myReportFile = QDir::tempPath() + "/qgistest.html";
+  QFile myFile( myReportFile );
+  if ( myFile.open( QIODevice::WriteOnly | QIODevice::Append ) )
+  {
+    QTextStream myQTextStream( &myFile );
+    myQTextStream << mReport;
+    myFile.close();
+  }
+}
+
+void TestQgsOgrProvider::setupProxy()
+{
+
+  QgsSettings settings;
+  {
+    settings.setValue( QStringLiteral( "proxy/proxyEnabled" ), true );
+    settings.setValue( QStringLiteral( "proxy/proxyPort" ), QStringLiteral( "1234" ) );
+    settings.setValue( QStringLiteral( "proxy/proxyHost" ), QStringLiteral( "myproxyhostname.com" ) );
+    settings.setValue( QStringLiteral( "proxy/proxyUser" ), QStringLiteral( "username" ) );
+    settings.setValue( QStringLiteral( "proxy/proxyPassword" ), QStringLiteral( "password" ) );
+    settings.setValue( QStringLiteral( "proxy/proxyExcludedUrls" ), QStringLiteral( "http://www.myhost.com|http://www.myotherhost.com" ) );
+    QgsNetworkAccessManager::instance()->setupDefaultProxyAndCache();
+    QgsVectorLayer vl( mTestDataDir + '/' + QStringLiteral( "lines.shp" ), QStringLiteral( "proxy_test" ), QLatin1Literal( "ogr" ) );
+    QVERIFY( vl.isValid() );
+    const char *proxyConfig = CPLGetConfigOption( "GDAL_HTTP_PROXY", NULL );
+    QCOMPARE( proxyConfig, "myproxyhostname.com:1234" );
+    const char *proxyCredentials = CPLGetConfigOption( "GDAL_HTTP_PROXYUSERPWD", NULL );
+    QCOMPARE( proxyCredentials, "username:password" );
+  }
+
+  {
+    // Test partial config
+    settings.setValue( QStringLiteral( "proxy/proxyEnabled" ), true );
+    settings.remove( QStringLiteral( "proxy/proxyPort" ) );
+    settings.setValue( QStringLiteral( "proxy/proxyHost" ), QStringLiteral( "myproxyhostname.com" ) );
+    settings.setValue( QStringLiteral( "proxy/proxyUser" ), QStringLiteral( "username" ) );
+    settings.remove( QStringLiteral( "proxy/proxyPassword" ) );
+    QgsNetworkAccessManager::instance()->setupDefaultProxyAndCache();
+    QgsVectorLayer vl( mTestDataDir + '/' + QStringLiteral( "lines.shp" ), QStringLiteral( "proxy_test" ), QLatin1Literal( "ogr" ) );
+    QVERIFY( vl.isValid() );
+    const char *proxyConfig = CPLGetConfigOption( "GDAL_HTTP_PROXY", NULL );
+    QCOMPARE( proxyConfig, "myproxyhostname.com" );
+    const char *proxyCredentials = CPLGetConfigOption( "GDAL_HTTP_PROXYUSERPWD", NULL );
+    QCOMPARE( proxyCredentials, "username" );
+  }
+
+}
+
+
+QGSTEST_MAIN( TestQgsOgrProvider )
+#include "testqgsogrprovider.moc"


### PR DESCRIPTION
Fixes Bug report #5212 Proxy settings ignored for layers

With C++ and Python test for the new method

@rouault please have a look to the GDAL config part.