### PR TITLE
[GDAL/OGR providers] Improve list of extensions, remove duplicates, support netCDF vector (fixes #17000)

### DIFF
--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -256,8 +256,10 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
   // return item without testing if:
   // scanExtSetting
   // or zipfile and scan zip == "Basic scan"
-  if ( scanExtSetting ||
-       ( ( is_vsizip || is_vsitar ) && scanZipSetting == QLatin1String( "basic" ) ) )
+  // netCDF files can be both raster or vector, so fallback to opening
+  if ( ( scanExtSetting ||
+         ( ( is_vsizip || is_vsitar ) && scanZipSetting == QLatin1String( "basic" ) ) ) &&
+       suffix != QLatin1String( "nc" ) )
   {
     // Skip this layer if it's handled by ogr:
     if ( ogrSupportedDbLayersExtensions.contains( suffix ) )

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -598,8 +598,10 @@ QGISEXTERN QgsDataItem *dataItem( QString path, QgsDataItem *parentItem )
 
   // Fast track: return item without testing if:
   // scanExtSetting or zipfile and scan zip == "Basic scan"
-  if ( scanExtSetting ||
-       ( ( is_vsizip || is_vsitar ) && scanZipSetting == QLatin1String( "basic" ) ) )
+  // netCDF files can be both raster or vector, so fallback to opening
+  if ( ( scanExtSetting ||
+         ( ( is_vsizip || is_vsitar ) && scanZipSetting == QLatin1String( "basic" ) ) ) &&
+       suffix != QLatin1String( "nc" ) )
   {
     // if this is a VRT file make sure it is vector VRT to avoid duplicates
     if ( suffix == QLatin1String( "vrt" ) )


### PR DESCRIPTION
- Read GDAL 2.0 GDAL_DMD_EXTENSIONS metadata item to retrieve a list of extensions
- Remove 'duplicated' drivers from list (such as KML/LIBKML, DGN/DGNv8)
- Support netCDF as a vector format (in addition to raster)
- For OGR formats, dynamically build list for unknown drivers ('static' list kept for now)
