### PR TITLE
improve layout in Python init function editor (fix #17428)

### DIFF
--- a/src/app/qgsattributesforminitcode.cpp
+++ b/src/app/qgsattributesforminitcode.cpp
@@ -29,9 +29,12 @@ QgsAttributesFormInitCode::QgsAttributesFormInitCode()
   mInitCodeSourceComboBox->addItem( tr( "Provide code in this dialog" ) );
   mInitCodeSourceComboBox->addItem( tr( "Load from the environment" ) );
 
-  connect( mInitCodeSourceComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsAttributesFormInitCode::mInitCodeSourceComboBox_currentIndexChanged );
-  connect( pbtnSelectInitFilePath, &QToolButton::clicked, this, &QgsAttributesFormInitCode::pbtnSelectInitFilePath_clicked );
+  QgsSettings settings;
+  mInitFileWidget->setDefaultRoot( settings.value( QStringLiteral( "style/lastInitFilePathDir" ), "." ).toString() );
+  mInitFileWidget->setDialogTitle( tr( "Select Python file" ) );
+  mInitFileWidget->setFilter( tr( "Python files (*.py *.PY)" ) );
 
+  connect( mInitCodeSourceComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsAttributesFormInitCode::mInitCodeSourceComboBox_currentIndexChanged );
 }
 
 void QgsAttributesFormInitCode::setCodeSource( QgsEditFormConfig::PythonInitCodeSource initCodeSource )
@@ -46,7 +49,7 @@ void QgsAttributesFormInitCode::setInitFunction( const QString &initFunction )
 }
 void QgsAttributesFormInitCode::setInitFilePath( const QString &initFilePath )
 {
-  mInitFilePathLineEdit->setText( initFilePath );
+  mInitFileWidget->setFilePath( initFilePath );
 }
 void QgsAttributesFormInitCode::setInitCode( const QString &initCode )
 {
@@ -64,7 +67,7 @@ QString QgsAttributesFormInitCode::initFunction() const
 }
 QString QgsAttributesFormInitCode::initFilePath() const
 {
-  return mInitFilePathLineEdit->text();
+  return mInitFileWidget->filePath();
 }
 QString QgsAttributesFormInitCode::initCode() const
 {
@@ -74,23 +77,7 @@ QString QgsAttributesFormInitCode::initCode() const
 void QgsAttributesFormInitCode::mInitCodeSourceComboBox_currentIndexChanged( int codeSource )
 {
   mInitFunctionContainer->setVisible( codeSource != QgsEditFormConfig::CodeSourceNone );
-  mInitFilePathLineEdit->setVisible( codeSource == QgsEditFormConfig::CodeSourceFile );
   mInitFilePathLabel->setVisible( codeSource == QgsEditFormConfig::CodeSourceFile );
-  pbtnSelectInitFilePath->setVisible( codeSource == QgsEditFormConfig::CodeSourceFile );
+  mInitFileWidget->setVisible( codeSource == QgsEditFormConfig::CodeSourceFile );
   mInitCodeEditorPython->setVisible( codeSource == QgsEditFormConfig::CodeSourceDialog );
 }
-
-void QgsAttributesFormInitCode::pbtnSelectInitFilePath_clicked( )
-{
-  QgsSettings myQSettings;
-  QString lastUsedDir = myQSettings.value( QStringLiteral( "style/lastInitFilePathDir" ), "." ).toString();
-  QString pyfilename = QFileDialog::getOpenFileName( this, tr( "Select Python file" ), lastUsedDir, tr( "Python file" )  + " (*.py)" );
-
-  if ( pyfilename.isNull() )
-    return;
-
-  QFileInfo fi( pyfilename );
-  myQSettings.setValue( QStringLiteral( "style/lastInitFilePathDir" ), fi.path() );
-  mInitFilePathLineEdit->setText( pyfilename );
-}
-

--- a/src/app/qgsattributesforminitcode.h
+++ b/src/app/qgsattributesforminitcode.h
@@ -49,7 +49,6 @@ class APP_EXPORT QgsAttributesFormInitCode: public QDialog, private Ui::QgsAttri
 
   private slots:
     void mInitCodeSourceComboBox_currentIndexChanged( int codeSource );
-    void pbtnSelectInitFilePath_clicked();
 };
 
 #endif // QGSATTRIBUTESFORMINITCODE_H

--- a/src/ui/qgsattributesforminitcode.ui
+++ b/src/ui/qgsattributesforminitcode.ui
@@ -7,95 +7,96 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>283</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Python Init Code Configuration</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="toolTip">
+      <string>The function code of the function can be loaded from the source code entered 
+in this dialog,  from an external python file or from the environment (for example 
+from a plugin or from startup.py).
+
+An example is:
+
+          rom qgis.PyQt.QtWidgets import QWidget
+
+          def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
+
+Reference in function name: my_form_open
+
+</string>
+     </property>
+     <property name="text">
+      <string>Python Init function</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="mInitCodeSourceComboBox">
+     <property name="toolTip">
+      <string>The function code of the function can be loaded from the source code entered 
+in this dialog,  from an external python file or from the environment (for example 
+from a plugin or from startup.py).
+
+An example is:
+
+          rom qgis.PyQt.QtWidgets import QWidget
+
+          def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
+
+Reference in function name: my_form_open
+
+</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
     <widget class="QWidget" name="mInitFunctionContainer" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>50</height>
-      </size>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
        <number>0</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
       </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="mInitFunctionLabel">
-        <property name="text">
-         <string>Function name</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="mInitFunctionLineEdit">
-        <property name="toolTip">
-         <string>Enter the name of the form init function.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
+      <item row="0" column="0">
        <widget class="QLabel" name="mInitFilePathLabel">
         <property name="text">
          <string>External file</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QLineEdit" name="mInitFilePathLineEdit"/>
+      <item row="0" column="1">
+       <widget class="QgsFileWidget" name="mInitFileWidget" native="true"/>
       </item>
-      <item>
-       <widget class="QToolButton" name="pbtnSelectInitFilePath">
+      <item row="1" column="0">
+       <widget class="QLabel" name="mInitFunctionLabel">
         <property name="text">
-         <string>…</string>
+         <string>Function name</string>
         </property>
        </widget>
       </item>
-      <item>
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mInitFunctionLineEdit">
+        <property name="toolTip">
+         <string>Enter the name of the form init function.</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>50</height>
-      </size>
-     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -104,67 +105,17 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QgsCodeEditorPython" name="mInitCodeEditorPython" native="true"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QWidget" name="mInitCodeSourceContainter" native="true">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>50</height>
-      </size>
+   <item row="3" column="0" colspan="3">
+    <widget class="QgsCodeEditorPython" name="mInitCodeEditorPython" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="label_3">
-        <property name="toolTip">
-         <string>The function code of the function can be loaded from the source code entered 
-in this dialog,  from an external python file or from the environment (for example 
-from a plugin or from startup.py).
-
-An example is:
-
-          rom qgis.PyQt.QtWidgets import QWidget
-
-          def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
-
-Reference in function name: my_form_open
-
-</string>
-        </property>
-        <property name="text">
-         <string>Python Init function</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="mInitCodeSourceComboBox">
-        <property name="toolTip">
-         <string>The function code of the function can be loaded from the source code entered 
-in this dialog,  from an external python file or from the environment (for example 
-from a plugin or from startup.py).
-
-An example is:
-
-          rom qgis.PyQt.QtWidgets import QWidget
-
-          def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
-
-Reference in function name: my_form_open
-
-</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -186,6 +137,11 @@ Reference in function name: my_form_open
    <header>qgscodeeditorpython.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections>
@@ -196,8 +152,8 @@ Reference in function name: my_form_open
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>254</x>
-     <y>293</y>
+     <x>248</x>
+     <y>254</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>


### PR DESCRIPTION
## Description
Improve layout in the Python Init function editor dialog:

- use QGIS file selector instead of regular Qt widges
- maximize code editor

Fixes https://issues.qgis.org/issues/17428.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
