### PR TITLE
Thread safe use of QgsVectorLayer::renderer()

### DIFF
--- a/python/core/symbology/qgsnullsymbolrenderer.sip
+++ b/python/core/symbology/qgsnullsymbolrenderer.sip
@@ -27,7 +27,6 @@ class QgsNullSymbolRenderer : QgsFeatureRenderer
     virtual QgsSymbol *originalSymbolForFeature( QgsFeature &feature, QgsRenderContext &context );
 
     virtual bool renderFeature( QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
-    virtual void startRender( QgsRenderContext &context, const QgsFields &fields );
     virtual void stopRender( QgsRenderContext &context );
     virtual bool willRenderFeature( QgsFeature &feat, QgsRenderContext &context );
 

--- a/python/core/symbology/qgsrenderer.sip
+++ b/python/core/symbology/qgsrenderer.sip
@@ -131,7 +131,7 @@ return a new renderer - used by default in vector layers
 %Docstring
  Must be called when a render cycle has finished, to allow the renderer to clean up.
 
- Calls to stopRender() must always be preceeded by a call to startRender().
+ Calls to stopRender() must always be preceded by a call to startRender().
 
  \warning This method is not thread safe. Before calling startRender() in a non-main thread,
  the renderer should instead be cloned and startRender()/stopRender() called on the clone.

--- a/python/core/symbology/qgsrenderer.sip
+++ b/python/core/symbology/qgsrenderer.sip
@@ -113,7 +113,7 @@ return a new renderer - used by default in vector layers
  :rtype: set of str
 %End
 
-    virtual void startRender( QgsRenderContext &context, const QgsFields &fields ) = 0;
+    virtual void startRender( QgsRenderContext &context, const QgsFields &fields );
 %Docstring
  Must be called when a new render cycle is started. A call to startRender() must always
  be followed by a corresponding call to stopRender() after all features have been rendered.
@@ -127,7 +127,7 @@ return a new renderer - used by default in vector layers
  the renderer should instead be cloned and startRender()/stopRender() called on the clone.
 %End
 
-    virtual void stopRender( QgsRenderContext &context ) = 0;
+    virtual void stopRender( QgsRenderContext &context );
 %Docstring
  Must be called when a render cycle has finished, to allow the renderer to clean up.
 

--- a/python/core/symbology/qgsrenderer.sip
+++ b/python/core/symbology/qgsrenderer.sip
@@ -115,16 +115,28 @@ return a new renderer - used by default in vector layers
 
     virtual void startRender( QgsRenderContext &context, const QgsFields &fields ) = 0;
 %Docstring
- Needs to be called when a new render cycle is started
+ Must be called when a new render cycle is started. A call to startRender() must always
+ be followed by a corresponding call to stopRender() after all features have been rendered.
 
  \param context  Additional information passed to the renderer about the job which will be rendered
  \param fields   The fields available for rendering
- :return:         Information passed back from the renderer that can e.g. be used to reduce the amount of requested features
+
+.. seealso:: stopRender()
+
+ \warning This method is not thread safe. Before calling startRender() in a non-main thread,
+ the renderer should instead be cloned and startRender()/stopRender() called on the clone.
 %End
 
     virtual void stopRender( QgsRenderContext &context ) = 0;
 %Docstring
- Needs to be called when a render cycle has finished to clean up.
+ Must be called when a render cycle has finished, to allow the renderer to clean up.
+
+ Calls to stopRender() must always be preceeded by a call to startRender().
+
+ \warning This method is not thread safe. Before calling startRender() in a non-main thread,
+ the renderer should instead be cloned and startRender()/stopRender() called on the clone.
+
+.. seealso:: startRender()
 %End
 
     virtual QString filter( const QgsFields &fields = QgsFields() );
@@ -177,6 +189,9 @@ return a new renderer - used by default in vector layers
 
  If layer is not -1, the renderer should draw only a particula layer from symbols
  (in order to support symbol level rendering).
+
+.. seealso:: startRender()
+.. seealso:: stopRender()
  :rtype: bool
 %End
 

--- a/src/app/qgsmaptoolpointsymbol.cpp
+++ b/src/app/qgsmaptoolpointsymbol.cpp
@@ -70,9 +70,10 @@ void QgsMapToolPointSymbol::canvasPressEvent( QgsMapMouseEvent *e )
   }
 
   //check whether selected feature has a modifiable symbol
-  QgsFeatureRenderer *renderer = mActiveLayer->renderer();
-  if ( !renderer )
+  if ( !mActiveLayer->renderer() )
     return;
+
+  std::unique_ptr< QgsFeatureRenderer > renderer( mActiveLayer->renderer()->clone() );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mCanvas->mapSettings() );
   context.expressionContext() << QgsExpressionContextUtils::layerScope( mActiveLayer );
   context.expressionContext().setFeature( feature );

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -229,9 +229,12 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
 
   QgsRenderContext context = QgsRenderContext::fromMapSettings( canvas->mapSettings() );
   context.expressionContext() << QgsExpressionContextUtils::layerScope( vlayer );
-  QgsFeatureRenderer *r = vlayer->renderer();
-  if ( r )
+  std::unique_ptr< QgsFeatureRenderer > r;
+  if ( vlayer->renderer() )
+  {
+    r.reset( vlayer->renderer()->clone() );
     r->startRender( context, vlayer->fields() );
+  }
 
   QgsFeatureRequest request;
   request.setFilterRect( selectGeomTrans.boundingBox() );

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -979,13 +979,14 @@ void QgsDxfExport::writeEntities()
     }
 
     QgsSymbolRenderContext sctx( ctx, QgsUnitTypes::RenderMillimeters, 1.0, false, 0, nullptr );
-    QgsFeatureRenderer *renderer = vl->renderer();
-    if ( !renderer )
+    if ( !vl->renderer() )
     {
       if ( hasStyleOverride )
         vl->styleManager()->restoreOverrideStyle();
       continue;
     }
+
+    std::unique_ptr< QgsFeatureRenderer > renderer( vl->renderer()->clone() );
     renderer->startRender( ctx, vl->fields() );
 
     QSet<QString> attributes = renderer->usedAttributes( ctx );
@@ -1114,12 +1115,12 @@ void QgsDxfExport::writeEntitiesSymbolLevels( QgsVectorLayer *layer )
     return;
   }
 
-  QgsFeatureRenderer *renderer = layer->renderer();
-  if ( !renderer )
+  if ( !layer->renderer() )
   {
     // TODO return error
     return;
   }
+  std::unique_ptr< QgsFeatureRenderer > renderer( layer->renderer()->clone() );
   QHash< QgsSymbol *, QList<QgsFeature> > features;
 
   QgsRenderContext ctx = renderContext();

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -106,7 +106,7 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
   if ( hasStyleOverride )
     vl->styleManager()->setOverrideStyle( mSettings.layerStyleOverrides().value( vl->id() ) );
 
-  QgsFeatureRenderer *r = vl->renderer();
+  std::unique_ptr< QgsFeatureRenderer > r( vl->renderer()->clone() );
   bool moreSymbolsPerFeature = r->capabilities() & QgsFeatureRenderer::MoreSymbolsPerFeature;
   r->startRender( context, vl->fields() );
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2637,7 +2637,7 @@ QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
     n++;
   }
 
-  writer->stopRender( layer );
+  writer->stopRender();
   delete writer;
 
   if ( errors > 0 && errorMessage && n > 0 )
@@ -3117,7 +3117,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::exportFeaturesSymbolLevels
     }
   }
 
-  stopRender( layer );
+  stopRender();
 
   if ( nErrors > 0 && errorMessage )
   {
@@ -3163,46 +3163,44 @@ double QgsVectorFileWriter::mapUnitScaleFactor( double scale, QgsUnitTypes::Rend
 
 void QgsVectorFileWriter::startRender( QgsVectorLayer *vl )
 {
-  QgsFeatureRenderer *renderer = symbologyRenderer( vl );
-  if ( !renderer )
+  mRenderer = createSymbologyRenderer( vl );
+  if ( !mRenderer )
   {
     return;
   }
 
-  renderer->startRender( mRenderContext, vl->fields() );
+  mRenderer->startRender( mRenderContext, vl->fields() );
 }
 
-void QgsVectorFileWriter::stopRender( QgsVectorLayer *vl )
+void QgsVectorFileWriter::stopRender()
 {
-  QgsFeatureRenderer *renderer = symbologyRenderer( vl );
-  if ( !renderer )
+  if ( !mRenderer )
   {
     return;
   }
 
-  renderer->stopRender( mRenderContext );
+  mRenderer->stopRender( mRenderContext );
 }
 
-QgsFeatureRenderer *QgsVectorFileWriter::symbologyRenderer( QgsVectorLayer *vl ) const
+std::unique_ptr<QgsFeatureRenderer> QgsVectorFileWriter::createSymbologyRenderer( QgsVectorLayer *vl ) const
 {
   if ( mSymbologyExport == NoSymbology )
   {
     return nullptr;
   }
-  if ( !vl )
+  if ( !vl || !vl->renderer() )
   {
     return nullptr;
   }
 
-  return vl->renderer();
+  return std::unique_ptr< QgsFeatureRenderer >( vl->renderer()->clone() );
 }
 
 void QgsVectorFileWriter::addRendererAttributes( QgsVectorLayer *vl, QgsAttributeList &attList )
 {
-  QgsFeatureRenderer *renderer = symbologyRenderer( vl );
-  if ( renderer )
+  if ( mRenderer )
   {
-    const QSet<QString> rendererAttributes = renderer->usedAttributes( mRenderContext );
+    const QSet<QString> rendererAttributes = mRenderer->usedAttributes( mRenderContext );
     for ( const QString &attr : rendererAttributes )
     {
       int index = vl->fields().lookupField( attr );

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -729,6 +729,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                QgsVectorFileWriter::ActionOnExistingFile action );
     void resetMap( const QgsAttributeList &attributes );
 
+    std::unique_ptr< QgsFeatureRenderer > mRenderer;
     QgsRenderContext mRenderContext;
 
     bool mUsingTransaction = false;
@@ -744,8 +745,8 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     double mapUnitScaleFactor( double scale, QgsUnitTypes::RenderUnit symbolUnits, QgsUnitTypes::DistanceUnit mapUnits );
 
     void startRender( QgsVectorLayer *vl );
-    void stopRender( QgsVectorLayer *vl );
-    QgsFeatureRenderer *symbologyRenderer( QgsVectorLayer *vl ) const;
+    void stopRender();
+    std::unique_ptr< QgsFeatureRenderer > createSymbologyRenderer( QgsVectorLayer *vl ) const;
     //! Adds attributes needed for classification
     void addRendererAttributes( QgsVectorLayer *vl, QgsAttributeList &attList );
     static QMap<QString, MetaData> sDriverMetadata;

--- a/src/core/symbology/qgs25drenderer.cpp
+++ b/src/core/symbology/qgs25drenderer.cpp
@@ -138,11 +138,15 @@ QgsFeatureRenderer *Qgs25DRenderer::create( QDomElement &element, const QgsReadW
 
 void Qgs25DRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
+  QgsFeatureRenderer::startRender( context, fields );
+
   mSymbol->startRender( context, fields );
 }
 
 void Qgs25DRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   mSymbol->stopRender( context );
 }
 

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -377,6 +377,8 @@ void QgsCategorizedSymbolRenderer::sortByLabel( Qt::SortOrder order )
 
 void QgsCategorizedSymbolRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
+  QgsFeatureRenderer::startRender( context, fields );
+
   mCounting = context.rendererScale() == 0.0;
 
   // make sure that the hash table is up to date
@@ -398,6 +400,8 @@ void QgsCategorizedSymbolRenderer::startRender( QgsRenderContext &context, const
 
 void QgsCategorizedSymbolRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
   {
     cat.symbol()->stopRender( context );

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -364,6 +364,8 @@ QgsSymbol *QgsGraduatedSymbolRenderer::originalSymbolForFeature( QgsFeature &fea
 
 void QgsGraduatedSymbolRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
+  QgsFeatureRenderer::startRender( context, fields );
+
   mCounting = context.rendererScale() == 0.0;
 
   // find out classification attribute index from name
@@ -386,6 +388,8 @@ void QgsGraduatedSymbolRenderer::startRender( QgsRenderContext &context, const Q
 
 void QgsGraduatedSymbolRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   Q_FOREACH ( const QgsRendererRange &range, mRanges )
   {
     if ( !range.symbol() )

--- a/src/core/symbology/qgsheatmaprenderer.cpp
+++ b/src/core/symbology/qgsheatmaprenderer.cpp
@@ -54,7 +54,8 @@ void QgsHeatmapRenderer::initializeValues( QgsRenderContext &context )
 
 void QgsHeatmapRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
-  Q_UNUSED( fields );
+  QgsFeatureRenderer::startRender( context, fields );
+
   if ( !context.painter() )
   {
     return;
@@ -212,6 +213,8 @@ double QgsHeatmapRenderer::triangularKernel( const double distance, const int ba
 
 void QgsHeatmapRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   renderImage( context );
   mWeightExpression.reset();
 }

--- a/src/core/symbology/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.cpp
@@ -93,6 +93,8 @@ void QgsInvertedPolygonRenderer::checkLegendSymbolItem( const QString &key, bool
 
 void QgsInvertedPolygonRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
+  QgsFeatureRenderer::startRender( context, fields );
+
   if ( !mSubRenderer )
   {
     return;
@@ -243,6 +245,8 @@ bool QgsInvertedPolygonRenderer::renderFeature( QgsFeature &feature, QgsRenderCo
 
 void QgsInvertedPolygonRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   if ( !mSubRenderer )
   {
     return;

--- a/src/core/symbology/qgsnullsymbolrenderer.cpp
+++ b/src/core/symbology/qgsnullsymbolrenderer.cpp
@@ -60,14 +60,10 @@ bool QgsNullSymbolRenderer::renderFeature( QgsFeature &feature, QgsRenderContext
   return true;
 }
 
-void QgsNullSymbolRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
-{
-  Q_UNUSED( context );
-  Q_UNUSED( fields );
-}
-
 void QgsNullSymbolRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   if ( mSymbol )
   {
     mSymbol->stopRender( context );

--- a/src/core/symbology/qgsnullsymbolrenderer.h
+++ b/src/core/symbology/qgsnullsymbolrenderer.h
@@ -38,7 +38,6 @@ class CORE_EXPORT QgsNullSymbolRenderer : public QgsFeatureRenderer
     virtual QgsSymbol *originalSymbolForFeature( QgsFeature &feature, QgsRenderContext &context ) override;
 
     virtual bool renderFeature( QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false ) override;
-    virtual void startRender( QgsRenderContext &context, const QgsFields &fields ) override;
     virtual void stopRender( QgsRenderContext &context ) override;
     virtual bool willRenderFeature( QgsFeature &feat, QgsRenderContext &context ) override;
 

--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -287,6 +287,8 @@ bool QgsPointDistanceRenderer::willRenderFeature( QgsFeature &feat, QgsRenderCon
 
 void QgsPointDistanceRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
+  QgsFeatureRenderer::startRender( context, fields );
+
   mRenderer->startRender( context, fields );
 
   mClusteredGroups.clear();
@@ -315,6 +317,8 @@ void QgsPointDistanceRenderer::startRender( QgsRenderContext &context, const Qgs
 
 void QgsPointDistanceRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   //printInfoDisplacementGroups(); //just for debugging
 
   Q_FOREACH ( const ClusteredGroup &group, mClusteredGroups )

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -89,6 +89,27 @@ QSet< QString > QgsFeatureRenderer::legendKeysForFeature( QgsFeature &feature, Q
   return QSet< QString >();
 }
 
+void QgsFeatureRenderer::startRender( QgsRenderContext &, const QgsFields & )
+{
+#ifdef QGISDEBUG
+  if ( !mThread )
+  {
+    mThread = QThread::currentThread();
+  }
+  else
+  {
+    Q_ASSERT_X( mThread == QThread::currentThread(), "QgsFeatureRenderer::startRender", "startRender called in a different thread - use a cloned renderer instead" );
+  }
+#endif
+}
+
+void QgsFeatureRenderer::stopRender( QgsRenderContext & )
+{
+#ifdef QGISDEBUG
+  Q_ASSERT_X( mThread == QThread::currentThread(), "QgsFeatureRenderer::stopRender", "stopRender called in a different thread - use a cloned renderer instead" );
+#endif
+}
+
 bool QgsFeatureRenderer::filterNeedsGeometry() const
 {
   return false;
@@ -96,6 +117,10 @@ bool QgsFeatureRenderer::filterNeedsGeometry() const
 
 bool QgsFeatureRenderer::renderFeature( QgsFeature &feature, QgsRenderContext &context, int layer, bool selected, bool drawVertexMarker )
 {
+#ifdef QGISDEBUG
+  Q_ASSERT_X( mThread == QThread::currentThread(), "QgsFeatureRenderer::renderFeature", "renderFeature called in a different thread - use a cloned renderer instead" );
+#endif
+
   QgsSymbol *symbol = symbolForFeature( feature, context );
   if ( !symbol )
     return false;

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -167,7 +167,7 @@ class CORE_EXPORT QgsFeatureRenderer
     /**
      * Must be called when a render cycle has finished, to allow the renderer to clean up.
      *
-     * Calls to stopRender() must always be preceeded by a call to startRender().
+     * Calls to stopRender() must always be preceded by a call to startRender().
      *
      * \warning This method is not thread safe. Before calling startRender() in a non-main thread,
      * the renderer should instead be cloned and startRender()/stopRender() called on the clone.

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -162,7 +162,7 @@ class CORE_EXPORT QgsFeatureRenderer
      * \warning This method is not thread safe. Before calling startRender() in a non-main thread,
      * the renderer should instead be cloned and startRender()/stopRender() called on the clone.
      */
-    virtual void startRender( QgsRenderContext &context, const QgsFields &fields ) = 0;
+    virtual void startRender( QgsRenderContext &context, const QgsFields &fields );
 
     /**
      * Must be called when a render cycle has finished, to allow the renderer to clean up.
@@ -174,7 +174,7 @@ class CORE_EXPORT QgsFeatureRenderer
      *
      * \see startRender()
      */
-    virtual void stopRender( QgsRenderContext &context ) = 0;
+    virtual void stopRender( QgsRenderContext &context );
 
     /**
      * If a renderer does not require all the features this method may be overridden
@@ -522,6 +522,11 @@ class CORE_EXPORT QgsFeatureRenderer
 #ifdef SIP_RUN
     QgsFeatureRenderer( const QgsFeatureRenderer & );
     QgsFeatureRenderer &operator=( const QgsFeatureRenderer & );
+#endif
+
+#ifdef QGISDEBUG
+    //! Pointer to thread in which startRender was first called
+    QThread *mThread = nullptr;
 #endif
 
     Q_DISABLE_COPY( QgsFeatureRenderer )

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -151,16 +151,28 @@ class CORE_EXPORT QgsFeatureRenderer
     virtual QSet< QString > legendKeysForFeature( QgsFeature &feature, QgsRenderContext &context );
 
     /**
-     * Needs to be called when a new render cycle is started
+     * Must be called when a new render cycle is started. A call to startRender() must always
+     * be followed by a corresponding call to stopRender() after all features have been rendered.
      *
      * \param context  Additional information passed to the renderer about the job which will be rendered
      * \param fields   The fields available for rendering
-     * \returns         Information passed back from the renderer that can e.g. be used to reduce the amount of requested features
+     *
+     * \see stopRender()
+     *
+     * \warning This method is not thread safe. Before calling startRender() in a non-main thread,
+     * the renderer should instead be cloned and startRender()/stopRender() called on the clone.
      */
     virtual void startRender( QgsRenderContext &context, const QgsFields &fields ) = 0;
 
     /**
-     * Needs to be called when a render cycle has finished to clean up.
+     * Must be called when a render cycle has finished, to allow the renderer to clean up.
+     *
+     * Calls to stopRender() must always be preceeded by a call to startRender().
+     *
+     * \warning This method is not thread safe. Before calling startRender() in a non-main thread,
+     * the renderer should instead be cloned and startRender()/stopRender() called on the clone.
+     *
+     * \see startRender()
      */
     virtual void stopRender( QgsRenderContext &context ) = 0;
 
@@ -209,6 +221,9 @@ class CORE_EXPORT QgsFeatureRenderer
      *
      * If layer is not -1, the renderer should draw only a particula layer from symbols
      * (in order to support symbol level rendering).
+     *
+     * \see startRender()
+     * \see stopRender()
      */
     virtual bool renderFeature( QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
 

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -826,6 +826,8 @@ bool QgsRuleBasedRenderer::renderFeature( QgsFeature &feature,
 
 void QgsRuleBasedRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
+  QgsFeatureRenderer::startRender( context, fields );
+
   // prepare active children
   mRootRule->startRender( context, fields, mFilter );
 
@@ -849,6 +851,8 @@ void QgsRuleBasedRenderer::startRender( QgsRenderContext &context, const QgsFiel
 
 void QgsRuleBasedRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   //
   // do the actual rendering
   //

--- a/src/core/symbology/qgssinglesymbolrenderer.cpp
+++ b/src/core/symbology/qgssinglesymbolrenderer.cpp
@@ -54,6 +54,8 @@ QgsSymbol *QgsSingleSymbolRenderer::originalSymbolForFeature( QgsFeature &featur
 
 void QgsSingleSymbolRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )
 {
+  QgsFeatureRenderer::startRender( context, fields );
+
   if ( !mSymbol )
     return;
 
@@ -62,6 +64,8 @@ void QgsSingleSymbolRenderer::startRender( QgsRenderContext &context, const QgsF
 
 void QgsSingleSymbolRenderer::stopRender( QgsRenderContext &context )
 {
+  QgsFeatureRenderer::stopRender( context );
+
   if ( !mSymbol )
     return;
 

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -120,7 +120,7 @@ class GUI_EXPORT QgsHighlight: public QgsMapCanvasItem
     void setSymbol( QgsSymbol *symbol, const QgsRenderContext &context, const QColor &color, const QColor &fillColor );
     double getSymbolWidth( const QgsRenderContext &context, double width, QgsUnitTypes::RenderUnit unit );
     //! Get renderer for current color mode and colors. The renderer should be freed by caller.
-    QgsFeatureRenderer *getRenderer( QgsRenderContext &context, const QColor &color, const QColor &fillColor );
+    std::unique_ptr< QgsFeatureRenderer > createRenderer( QgsRenderContext &context, const QColor &color, const QColor &fillColor );
     void paintPoint( QPainter *p, const QgsPointXY &point );
     void paintLine( QPainter *p, QgsPolylineXY line );
     void paintPolygon( QPainter *p, const QgsPolygonXY &polygon );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -253,8 +253,8 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<IdentifyResult> *results, Qg
 
   QgsRenderContext context( QgsRenderContext::fromMapSettings( mCanvas->mapSettings() ) );
   context.expressionContext() << QgsExpressionContextUtils::layerScope( layer );
-  QgsFeatureRenderer *renderer = layer->renderer();
-  if ( renderer && renderer->capabilities() & QgsFeatureRenderer::ScaleDependent )
+  std::unique_ptr< QgsFeatureRenderer > renderer( layer->renderer() ? layer->renderer()->clone() : nullptr );
+  if ( renderer )
   {
     // setup scale for scale dependent visibility (rule based)
     renderer->startRender( context, layer->fields() );
@@ -280,7 +280,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<IdentifyResult> *results, Qg
     results->append( IdentifyResult( qobject_cast<QgsMapLayer *>( layer ), *f_it, derivedAttributes ) );
   }
 
-  if ( renderer && renderer->capabilities() & QgsFeatureRenderer::ScaleDependent )
+  if ( renderer )
   {
     renderer->stopRender( context );
   }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -255,7 +255,7 @@ namespace QgsWms
 
   void QgsRenderer::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols, QgsRenderContext &context ) const
   {
-    QgsFeatureRenderer *r = vl->renderer();
+    std::unique_ptr< QgsFeatureRenderer > r( vl->renderer()->clone() );
     bool moreSymbolsPerFeature = r->capabilities() & QgsFeatureRenderer::MoreSymbolsPerFeature;
     r->startRender( context, vl->pendingFields() );
     QgsFeature f;
@@ -1472,7 +1472,7 @@ namespace QgsWms
 #endif
 
     QgsFeatureIterator fit = layer->getFeatures( fReq );
-    QgsFeatureRenderer *r2 = layer->renderer();
+    std::unique_ptr< QgsFeatureRenderer > r2( layer->renderer() ? layer->renderer()->clone() : nullptr );
     if ( r2 )
     {
       r2->startRender( renderContext, layer->pendingFields() );


### PR DESCRIPTION
This fixes some definite crashes, e.g. saving a vector layer with symbology, which is caused by accessing the same layer renderer across different threads. 

But I've also swapped a lot of non-threaded code to use clones of the renderers for extra safety, e.g. if this code is ever moved to a thread in future. 