### PR TITLE
Cleanup fragile 'capitalize layer names' option 

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1666,6 +1666,7 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 - setMaximumScale() and setMinimumScale(), maximumScale() and minimumScale() had the opposite meaning to other min/max scales in the API, and their definitions have now been swapped. setMaximumScale
 now sets the maximum (i.e. largest scale, or most zoomed in) at which the layer will appear, and setMinimumScale now sets the minimum (i.e. smallest scale,
 or most zoomed out) at which the layer will appear. The same is true for the maximumScale and minimumScale getters.
+- capitalizeLayerName() was removed. Use formatLayerName() instead.
 
 
 QgsMapLayerActionRegistry        {#qgis_api_break_3_0_QgsMapLayerActionRegistry}

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1667,6 +1667,7 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 now sets the maximum (i.e. largest scale, or most zoomed in) at which the layer will appear, and setMinimumScale now sets the minimum (i.e. smallest scale,
 or most zoomed out) at which the layer will appear. The same is true for the maximumScale and minimumScale getters.
 - capitalizeLayerName() was removed. Use formatLayerName() instead.
+- originalName() was removed. Use name() instead.
 
 
 QgsMapLayerActionRegistry        {#qgis_api_break_3_0_QgsMapLayerActionRegistry}

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -512,9 +512,11 @@ Invoked by QgsProject.read().
 Sets layer's spatial reference system
 %End
 
-    static QString capitalizeLayerName( const QString &name );
+    static QString formatLayerName( const QString &name );
 %Docstring
-A convenience function to (un)capitalize the layer name
+ A convenience function to capitalize and format a layer ``name``.
+
+.. versionadded:: 3.0
  :rtype: str
 %End
 

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -97,7 +97,6 @@ Returns the layer's unique ID, which is used to access this layer from QgsProjec
     QString name() const;
 %Docstring
  Returns the display name of the layer.
- :return: the layer name
 .. seealso:: setName()
  :rtype: str
 %End
@@ -108,12 +107,6 @@ Returns the layer's unique ID, which is used to access this layer from QgsProjec
  :rtype: QgsDataProvider
 %End
 
-
-    QString originalName() const;
-%Docstring
- Returns the original name of the layer.
- :rtype: str
-%End
 
     void setShortName( const QString &shortName );
 %Docstring
@@ -1171,7 +1164,6 @@ Add error message
 %Docstring
 Set error message
 %End
-
 
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4203,7 +4203,7 @@ bool QgisApp::addVectorLayers( const QStringList &layerQStringList, const QStrin
 
         if ( elements.size() >= 4 && layer->name() != elements.at( 1 ) )
         {
-          layer->setName( QStringLiteral( "%1 %2 %3" ).arg( layer->name(), elements.at( 1 ), elements.at( 3 ) ) );
+          layer->setName( QStringLiteral( "%1 %2" ).arg( layer->name(), elements.at( 1 ) ) );
         }
 
         myList << layer;
@@ -4636,8 +4636,6 @@ void QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
 
     QgsDebugMsg( "Creating new vector layer using " + composedURI );
     QString name = fileName + " " + def.layerName;
-    if ( !layerGeometryType.isEmpty() )
-      name += " " + layerGeometryType;
     QgsVectorLayer::LayerOptions options;
     options.loadDefaultStyle = false;
     QgsVectorLayer *layer = new QgsVectorLayer( composedURI, name, QStringLiteral( "ogr" ), options );
@@ -9999,7 +9997,7 @@ QgsVectorLayer *QgisApp::addVectorLayer( const QString &vectorLayerPath, const Q
 
         if ( elements.size() >= 4 && layer->name() != elements.at( 1 ) )
         {
-          layer->setName( QStringLiteral( "%1 %2 %3" ).arg( layer->name(), elements.at( 1 ), elements.at( 3 ) ) );
+          layer->setName( QStringLiteral( "%1 %2" ).arg( layer->name(), elements.at( 1 ) ) );
         }
       }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9941,15 +9941,7 @@ QgsVectorLayer *QgisApp::addVectorLayer( const QString &vectorLayerPath, const Q
 
   freezeCanvases();
 
-// Let render() do its own cursor management
-//  QApplication::setOverrideCursor(Qt::WaitCursor);
-
-  QString baseName = name;
-  QgsSettings settings;
-  if ( settings.value( QStringLiteral( "qgis/capitalizeLayerName" ), QVariant( false ) ).toBool() )
-  {
-    baseName = QgsMapLayer::formatLayerName( baseName );
-  }
+  QString baseName = QgsMapLayer::formatLayerName( name );
 
   /* Eliminate the need to instantiate the layer based on provider type.
      The caller is responsible for cobbling together the needed information to
@@ -11857,12 +11849,7 @@ QgsRasterLayer *QgisApp::addRasterLayerPrivate(
     freezeCanvases();
   }
 
-  QString baseName = name;
-  QgsSettings settings;
-  if ( settings.value( QStringLiteral( "qgis/capitalizeLayerName" ), QVariant( false ) ).toBool() )
-  {
-    baseName = QgsMapLayer::formatLayerName( baseName );
-  }
+  QString baseName =  QgsMapLayer::formatLayerName( name );
 
   QgsDebugMsg( "Creating new raster layer using " + uri
                + " with baseName of " + baseName );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4157,6 +4157,7 @@ bool QgisApp::addVectorLayers( const QStringList &layerQStringList, const QStrin
       QFileInfo fi( src );
       base = fi.completeBaseName();
     }
+    base = QgsMapLayer::formatLayerName( base );
 
     QgsDebugMsg( "completeBaseName: " + base );
 
@@ -4200,8 +4201,10 @@ bool QgisApp::addVectorLayers( const QStringList &layerQStringList, const QStrin
       {
         //set friendly name for datasources with only one layer
         QStringList elements = sublayers.at( 0 ).split( ':' );
+        QString subLayerNameFormatted = elements.size() >= 2 ? QgsMapLayer::formatLayerName( elements.at( 1 ) ) : QString();
 
-        if ( elements.size() >= 4 && layer->name() != elements.at( 1 ) )
+        if ( elements.size() >= 4 && layer->name().compare( elements.at( 1 ), Qt::CaseInsensitive ) != 0
+             && layer->name().compare( subLayerNameFormatted, Qt::CaseInsensitive ) != 0 )
         {
           layer->setName( QStringLiteral( "%1 %2" ).arg( layer->name(), elements.at( 1 ) ) );
         }
@@ -9994,8 +9997,10 @@ QgsVectorLayer *QgisApp::addVectorLayer( const QString &vectorLayerPath, const Q
       if ( !sublayers.isEmpty() )
       {
         QStringList elements = sublayers.at( 0 ).split( ':' );
+        QString subLayerNameFormatted = elements.size() >= 2 ? QgsMapLayer::formatLayerName( elements.at( 1 ) ) : QString();
 
-        if ( elements.size() >= 4 && layer->name() != elements.at( 1 ) )
+        if ( elements.size() >= 4 && layer->name().compare( elements.at( 1 ), Qt::CaseInsensitive ) != 0
+             && layer->name().compare( subLayerNameFormatted, Qt::CaseInsensitive ) != 0 )
         {
           layer->setName( QStringLiteral( "%1 %2" ).arg( layer->name(), elements.at( 1 ) ) );
         }

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -746,8 +746,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   pbnMeasureColor->setContext( QStringLiteral( "gui" ) );
   pbnMeasureColor->setDefaultColor( QColor( 222, 155, 67 ) );
 
-  capitalizeCheckBox->setChecked( mSettings->value( QStringLiteral( "/qgis/capitalizeLayerName" ), QVariant( false ) ).toBool() );
-
   int projOpen = mSettings->value( QStringLiteral( "/qgis/projOpenAtLaunch" ), 0 ).toInt();
   mProjectOnLaunchCmbBx->setCurrentIndex( projOpen );
   mProjectOnLaunchLineEdit->setText( mSettings->value( QStringLiteral( "/qgis/projOpenAtLaunchPath" ) ).toString() );
@@ -1299,8 +1297,6 @@ void QgsOptions::saveOptions()
 
   mSettings->setValue( QStringLiteral( "/qgis/map_update_interval" ), spinMapUpdateInterval->value() );
   mSettings->setValue( QStringLiteral( "/qgis/legendDoubleClickAction" ), cmbLegendDoubleClickAction->currentIndex() );
-  bool legendLayersCapitalize = mSettings->value( QStringLiteral( "/qgis/capitalizeLayerName" ), false ).toBool();
-  mSettings->setValue( QStringLiteral( "/qgis/capitalizeLayerName" ), capitalizeCheckBox->isChecked() );
 
   // Default simplify drawing configuration
   QgsVectorSimplifyMethod::SimplifyHints simplifyHints = QgsVectorSimplifyMethod::NoSimplification;
@@ -1551,12 +1547,6 @@ void QgsOptions::saveOptions()
   // Gdal skip driver list
   if ( mLoadedGdalDriverList )
     saveGdalDriverList();
-
-  // refresh legend if any legend item's state is to be changed
-  if ( legendLayersCapitalize != capitalizeCheckBox->isChecked() )
-  {
-    // TODO[MD] QgisApp::instance()->legend()->updateLegendItemStyles();
-  }
 
   // refresh symbology for any legend items, only if needed
   if ( showLegendClassifiers != cbxLegendClassifiers->isChecked()

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1051,7 +1051,7 @@ void QgsRasterLayerProperties::apply()
 
 void QgsRasterLayerProperties::mLayerOrigNameLineEd_textEdited( const QString &text )
 {
-  leDisplayName->setText( mRasterLayer->capitalizeLayerName( text ) );
+  leDisplayName->setText( mRasterLayer->formatLayerName( text ) );
 }
 
 void QgsRasterLayerProperties::buttonBuildPyramids_clicked()

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -724,7 +724,7 @@ void QgsRasterLayerProperties::sync()
    */
 
   //these properties (layer name and label) are provided by the qgsmaplayer superclass
-  mLayerOrigNameLineEd->setText( mRasterLayer->originalName() );
+  mLayerOrigNameLineEd->setText( mRasterLayer->name() );
   leDisplayName->setText( mRasterLayer->name() );
 
   //get the thumbnail for the layer

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -804,7 +804,7 @@ QString QgsVectorLayerProperties::htmlMetadata()
 
 void QgsVectorLayerProperties::mLayerOrigNameLineEdit_textEdited( const QString &text )
 {
-  txtDisplayName->setText( mLayer->capitalizeLayerName( text ) );
+  txtDisplayName->setText( mLayer->formatLayerName( text ) );
 }
 
 void QgsVectorLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -432,7 +432,7 @@ void QgsVectorLayerProperties::insertFieldOrExpression()
 void QgsVectorLayerProperties::syncToLayer()
 {
   // populate the general information
-  mLayerOrigNameLineEdit->setText( mLayer->originalName() );
+  mLayerOrigNameLineEdit->setText( mLayer->name() );
   txtDisplayName->setText( mLayer->name() );
   pbnQueryBuilder->setWhatsThis( tr( "This button opens the query "
                                      "builder and allows you to create a subset of features to display on "

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -297,7 +297,12 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
           title = layer->name();
         title = "<b>" + title + "</b>";
         if ( layer->crs().isValid() )
-          title = tr( "%1 (%2)" ).arg( title, layer->crs().authid() );
+        {
+          if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer ) )
+            title = tr( "%1 (%2 - %3)" ).arg( title, QgsWkbTypes::displayString( vl->wkbType() ), layer->crs().authid() );
+          else
+            title = tr( "%1 (%2) " ).arg( title, layer->crs().authid() );
+        }
 
         parts << title;
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1022,12 +1022,8 @@ void QgsMapLayer::setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSign
 QString QgsMapLayer::formatLayerName( const QString &name )
 {
   QString layerName( name );
-
-  if ( !layerName.isEmpty() )
-    layerName = QgsStringUtils::capitalize( name, QgsStringUtils::ForceFirstLetterToCapital );
-
   layerName.replace( '_', ' ' );
-
+  layerName = QgsStringUtils::capitalize( layerName, QgsStringUtils::ForceFirstLetterToCapital );
   return layerName;
 }
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -55,7 +55,6 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
                           const QString &lyrname,
                           const QString &source )
   : mDataSource( source )
-  , mLayerOrigName( lyrname ) // store the original name
   , mLayerType( type )
   , mStyleManager( new QgsMapLayerStyleManager( this ) )
 {
@@ -137,10 +136,9 @@ QString QgsMapLayer::id() const
 
 void QgsMapLayer::setName( const QString &name )
 {
-  if ( name == mLayerOrigName && name == mLayerName )
+  if ( name == mLayerName )
     return;
 
-  mLayerOrigName = name;
   mLayerName = name;
 
   emit nameChanged();
@@ -160,11 +158,6 @@ QgsDataProvider *QgsMapLayer::dataProvider()
 const QgsDataProvider *QgsMapLayer::dataProvider() const
 {
   return nullptr;
-}
-
-QString QgsMapLayer::originalName() const
-{
-  return mLayerOrigName;
 }
 
 QString QgsMapLayer::publicSource() const
@@ -720,7 +713,7 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 
   // layer name
   QDomElement layerName = document.createElement( QStringLiteral( "layername" ) );
-  QDomText layerNameText = document.createTextNode( originalName() );
+  QDomText layerNameText = document.createTextNode( name() );
   layerName.appendChild( layerNameText );
   layerElement.appendChild( layerName );
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -49,7 +49,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsxmlutils.h"
 #include "qgssettings.h" // TODO: get rid of it [MD]
-
+#include "qgsstringutils.h"
 
 QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
                           const QString &lyrname,
@@ -60,7 +60,7 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
   , mStyleManager( new QgsMapLayerStyleManager( this ) )
 {
   // Set the display name = internal name
-  mLayerName = capitalizeLayerName( mLayerOrigName );
+  mLayerName = lyrname;
 
   //mShortName.replace( QRegExp( "[\\W]" ), "_" );
 
@@ -137,12 +137,11 @@ QString QgsMapLayer::id() const
 
 void QgsMapLayer::setName( const QString &name )
 {
-  QString newName = capitalizeLayerName( name );
-  if ( name == mLayerOrigName && newName == mLayerName )
+  if ( name == mLayerOrigName && name == mLayerName )
     return;
 
-  mLayerOrigName = name; // store the new original name
-  mLayerName = newName;
+  mLayerOrigName = name;
+  mLayerName = name;
 
   emit nameChanged();
 }
@@ -1027,17 +1026,14 @@ void QgsMapLayer::setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSign
     emit crsChanged();
 }
 
-QString QgsMapLayer::capitalizeLayerName( const QString &name )
+QString QgsMapLayer::formatLayerName( const QString &name )
 {
-  // Capitalize the first letter of the layer name if requested
-  QgsSettings settings;
-  bool capitalizeLayerName =
-    settings.value( QStringLiteral( "qgis/capitalizeLayerName" ), QVariant( false ) ).toBool();
-
   QString layerName( name );
 
-  if ( capitalizeLayerName && !layerName.isEmpty() )
-    layerName = layerName.at( 0 ).toUpper() + layerName.mid( 1 );
+  if ( !layerName.isEmpty() )
+    layerName = QgsStringUtils::capitalize( name, QgsStringUtils::ForceFirstLetterToCapital );
+
+  layerName.replace( '_', ' ' );
 
   return layerName;
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -524,8 +524,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Sets layer's spatial reference system
     void setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSignal = true );
 
-    //! A convenience function to (un)capitalize the layer name
-    static QString capitalizeLayerName( const QString &name );
+    /**
+     * A convenience function to capitalize and format a layer \a name.
+     *
+     * \since QGIS 3.0
+     */
+    static QString formatLayerName( const QString &name );
 
     /**
      * Retrieve the style URI for this layer

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -138,7 +138,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Returns the display name of the layer.
-     * \returns the layer name
      * \see setName()
      */
     QString name() const;
@@ -153,11 +152,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \note not available in Python bindings
      */
     virtual const QgsDataProvider *dataProvider() const SIP_SKIP;
-
-    /**
-     * Returns the original name of the layer.
-     */
-    QString originalName() const;
 
     /**
      * Sets the short name of the layer
@@ -1124,11 +1118,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     //! Name of the layer - used for display
     QString mLayerName;
-
-    /**
-     * Original name of the layer
-     */
-    QString mLayerOrigName;
 
     QString mShortName;
     QString mTitle;

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -288,8 +288,12 @@ QVariant QgsMapLayerModel::data( const QModelIndex &index, int role ) const
           title = layer->name();
         title = "<b>" + title + "</b>";
         if ( layer->crs().isValid() )
-          title = tr( "%1 (%2)" ).arg( title, layer->crs().authid() );
-
+        {
+          if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer ) )
+            title = tr( "%1 (%2 - %3)" ).arg( title, QgsWkbTypes::displayString( vl->wkbType() ), layer->crs().authid() );
+          else
+            title = tr( "%1 (%2) " ).arg( title, layer->crs().authid() );
+        }
         parts << title;
 
         if ( !layer->abstract().isEmpty() )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1475,8 +1475,7 @@ void QgsVectorLayer::setDataSource( const QString &dataSource, const QString &ba
   QgsWkbTypes::GeometryType geomType = mValid && mDataProvider ? geometryType() : QgsWkbTypes::UnknownGeometry;
 
   mDataSource = dataSource;
-  mLayerName = capitalizeLayerName( baseName );
-  setName( mLayerName );
+  setName( baseName );
   setDataProvider( provider );
 
   if ( !mValid )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -194,7 +194,7 @@ QgsVectorLayer::~QgsVectorLayer()
 
 QgsVectorLayer *QgsVectorLayer::clone() const
 {
-  QgsVectorLayer *layer = new QgsVectorLayer( source(), originalName(), mProviderKey );
+  QgsVectorLayer *layer = new QgsVectorLayer( source(), name(), mProviderKey );
   QgsMapLayer::clone( layer );
 
   QList<QgsVectorLayerJoinInfo> joins = vectorJoins();
@@ -3997,7 +3997,7 @@ QString QgsVectorLayer::htmlMetadata() const
   myMetadata += QLatin1String( "<table class=\"list-view\">\n" );
 
   // original name
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Original" ) + QStringLiteral( "</td><td>" ) + originalName() + QStringLiteral( "</td></tr>\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Original" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );
 
   // name
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -146,7 +146,7 @@ QgsRasterLayer::~QgsRasterLayer()
 
 QgsRasterLayer *QgsRasterLayer::clone() const
 {
-  QgsRasterLayer *layer = new QgsRasterLayer( source(), originalName(), mProviderKey );
+  QgsRasterLayer *layer = new QgsRasterLayer( source(), name(), mProviderKey );
   QgsMapLayer::clone( layer );
 
   // do not clone data provider which is the first element in pipe
@@ -317,7 +317,7 @@ QString QgsRasterLayer::htmlMetadata() const
   myMetadata += QLatin1String( "<table class=\"list-view\">\n" );
 
   // original name
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Original" ) + QStringLiteral( "</td><td>" ) + originalName() + QStringLiteral( "</td></tr>\n" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Original" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );
 
   // name
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2991,31 +2991,11 @@
                    </layout>
                   </item>
                   <item>
-                   <layout class="QGridLayout" name="gridLayout_3">
-                    <item row="3" column="1" colspan="2">
-                     <widget class="QCheckBox" name="cbxCreateRasterLegendIcons">
-                      <property name="text">
-                       <string>Create raster icons (may be slow)</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="1" colspan="2">
+                   <layout class="QGridLayout" name="gridLayout_3" columnminimumwidth="0,1,0">
+                    <item row="1" column="1" colspan="2">
                      <widget class="QCheckBox" name="cbxLegendClassifiers">
                       <property name="text">
                        <string>Display classification attribute names</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="1">
-                     <widget class="QCheckBox" name="capitalizeCheckBox">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Capitalize layer names</string>
                       </property>
                      </widget>
                     </item>
@@ -3047,6 +3027,13 @@
                        </size>
                       </property>
                      </spacer>
+                    </item>
+                    <item row="2" column="1" colspan="2">
+                     <widget class="QCheckBox" name="cbxCreateRasterLegendIcons">
+                      <property name="text">
+                       <string>Create raster icons (may be slow)</string>
+                      </property>
+                     </widget>
                     </item>
                    </layout>
                   </item>
@@ -5538,7 +5525,6 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
   <tabstop>pbnCanvasColor</tabstop>
   <tabstop>mLegendGrpBx</tabstop>
   <tabstop>cmbLegendDoubleClickAction</tabstop>
-  <tabstop>capitalizeCheckBox</tabstop>
   <tabstop>cbxLegendClassifiers</tabstop>
   <tabstop>cbxCreateRasterLegendIcons</tabstop>
   <tabstop>mLegendGraphicResolutionSpinBox</tabstop>

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -62,6 +62,7 @@ class TestQgsMapLayer : public QObject
     void cleanup(); // will be called after every testfunction.
 
     void isValid();
+    void formatName();
 
     void setBlendMode();
 
@@ -114,6 +115,14 @@ void TestQgsMapLayer::cleanupTestCase()
 void TestQgsMapLayer::isValid()
 {
   QVERIFY( mpLayer->isValid() );
+}
+
+void TestQgsMapLayer::formatName()
+{
+  QCOMPARE( QgsMapLayer::formatLayerName( QString() ), QString() );
+  QCOMPARE( QgsMapLayer::formatLayerName( QStringLiteral( "layer" ) ), QStringLiteral( "Layer" ) );
+  QCOMPARE( QgsMapLayer::formatLayerName( QStringLiteral( "layer name" ) ), QStringLiteral( "Layer Name" ) );
+  QCOMPARE( QgsMapLayer::formatLayerName( QStringLiteral( "layer_name" ) ), QStringLiteral( "Layer Name" ) );
 }
 
 void TestQgsMapLayer::setBlendMode()


### PR DESCRIPTION
This option was being applied in the wrong place - within the map layer classes themselves. This meant that depending on the user's setting for this option, a plugin calling QgsMapLayer::setName would not be guaranteed the same behaviour across installs. (and the same with setDataSource)

Similarly, the option was re-applied on project load, so moving projects between installs with different values for this setting would affect the project layer names, breaking expressions which relied on these...

In other words, exactly the kind of user setting we want to avoid!

Instead, move the formatting and capitalization of layer names to the QgisApp add*Layer methods instead, so this option only applies on adding new layers to a project.

I've followed this up with some other related tweaks:
- Remove the capitalize setting from options and make it always on instead (it's nice to have a better auto-generated layer name, since it saves user work!)
- Show vector layer WKB types in the layer tree tooltip, and remove this from auto-generated layer names