### PR TITLE
Remove useless cast breaking build on 32-bits os

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -583,7 +583,7 @@ QString QgsOgrProvider::ogrWkbGeometryTypeName( OGRwkbGeometryType type ) const
     return geom;
   }
 
-  switch ( ( long )type )
+  switch ( type )
   {
     case wkbUnknown:
       geom = QStringLiteral( "Unknown" );


### PR DESCRIPTION
error: case value evaluates to 2147483655, which cannot be narrowed to type 'long' [-Wc++11-narrowing]

## Description
Fix the build on 32-bits OS. Right now on OpenBSD/i386 the build fails on `QgsOgrProvider::ogrWkbGeometryTypeName( OGRwkbGeometryType type )` switch block with:

```
error: case value evaluates to 2147483655, which cannot be narrowed to type 'long' [-Wc++11-narrowing]
```

Removing the `(long)` cast fixes this build error, and causes no error on OpenBSD/amd64. The cast was changed from `(int)` to `(long)` in 93649bc4862776ddb492849817647f0525d08727, and the previous cast was introduced in aeed1229e070c655078644e3ef257c2684393317 - `OGRwkbGeometryType` is an enum and shouldnt be casted imo.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
