### PR TITLE
Constraint result not displayed in non editable mode

### DIFF
--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -266,6 +266,19 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
  Will call the value() method to determine the emitted value
 %End
 
+    virtual void resetConstraintWidgetStatus( bool editable );
+%Docstring
+ It cleans background color (and any other style) in case the feature is not
+ editable. In case it is, it resets it to the stored constraint status.
+
+ This could be overwritten in subclasses in case individual widgets need other
+ behavior.
+
+ \param editable if editable or not
+
+.. versionadded:: 3.0
+%End
+
   protected:
 
     virtual void updateConstraintWidgetStatus( ConstraintResult status );

--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -174,6 +174,32 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
 .. versionadded:: 3.0
 %End
 
+    ConstraintResult constraintResult() const;
+%Docstring
+ Getter of constraintResult
+ It's the current result of the constraint on the widget influencing it's visualization.
+.. versionadded:: 3.0
+ :rtype: ConstraintResult
+%End
+
+    bool constraintResultVisible() const;
+%Docstring
+ Getter of constraintResultVisible
+ Defines if the constraint result should be visualized on the widget (with color).
+ This will be disabled when the form is not editable.
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
+    void setConstraintResultVisible( bool constraintResultVisible );
+%Docstring
+ Setter of constraintResultVisible
+ Defines if the constraint result should be visualized on the widget (with color).
+ This will be disabled when the form is not editable.
+ \param constraintResultVisible if constraintResult should be displayed (mostly editable status)
+.. versionadded:: 3.0
+%End
+
   signals:
 
     void valueChanged( const QVariant &value );
@@ -191,6 +217,11 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
  \param desc is the constraint description
  \param err the error represented as a string. Empty if none.
  \param status
+%End
+
+    void constraintResultVisibleChanged( bool visible );
+%Docstring
+ Emit this signal when the constraint result visibility changed.
 %End
 
   public slots:
@@ -266,22 +297,9 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
  Will call the value() method to determine the emitted value
 %End
 
-    virtual void resetConstraintWidgetStatus( bool editable );
-%Docstring
- It cleans background color (and any other style) in case the feature is not
- editable. In case it is, it resets it to the stored constraint status.
-
- This could be overwritten in subclasses in case individual widgets need other
- behavior.
-
- \param editable if editable or not
-
-.. versionadded:: 3.0
-%End
-
   protected:
 
-    virtual void updateConstraintWidgetStatus( ConstraintResult status );
+    virtual void updateConstraintWidgetStatus();
 %Docstring
  This should update the widget with a visual cue if a constraint status
  changed.
@@ -291,8 +309,6 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
 
  This can be overwritten in subclasses to allow individual widgets to
  change the visual cue.
-
- \param status The current constraint status.
 
 .. versionadded:: 2.16
 %End

--- a/python/gui/editorwidgets/qgsrelationreferencewidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationreferencewidgetwrapper.sip
@@ -51,7 +51,7 @@ class QgsRelationReferenceWidgetWrapper : QgsEditorWidgetWrapper
 
   protected:
 
-    virtual void updateConstraintWidgetStatus( ConstraintResult status );
+    virtual void updateConstraintWidgetStatus();
 
 
 };

--- a/python/gui/qgsattributeformeditorwidget.sip
+++ b/python/gui/qgsattributeformeditorwidget.sip
@@ -101,7 +101,7 @@ class QgsAttributeFormEditorWidget : QWidget
  Set the constraint status for this widget.
 %End
 
-    void setConstraintResultVisibility( bool editable );
+    void setConstraintResultVisible( bool editable );
 %Docstring
  Set the constraint result lable visible or invisible according to the layer editable status
 %End

--- a/python/gui/qgsattributeformeditorwidget.sip
+++ b/python/gui/qgsattributeformeditorwidget.sip
@@ -101,6 +101,11 @@ class QgsAttributeFormEditorWidget : QWidget
  Set the constraint status for this widget.
 %End
 
+    void setConstraintResultVisibility( bool editable );
+%Docstring
+ Set the constraint result lable visible or invisible according to the layer editable status
+%End
+
   public slots:
 
     void setIsMixed( bool mixed );

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -101,8 +101,19 @@ void QgsEditorWidgetWrapper::valueChanged()
   emit valueChanged( value() );
 }
 
+void QgsEditorWidgetWrapper::resetConstraintWidgetStatus( bool editable )
+{
+  if ( editable )
+    updateConstraintWidgetStatus( mConstraintResult );
+  else
+    widget()->setStyleSheet( QString() );
+}
+
 void QgsEditorWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult constraintResult )
 {
+  //set the constraint result
+  mConstraintResult = constraintResult;
+
   switch ( constraintResult )
   {
     case ConstraintResultPass:

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -101,33 +101,51 @@ void QgsEditorWidgetWrapper::valueChanged()
   emit valueChanged( value() );
 }
 
-void QgsEditorWidgetWrapper::resetConstraintWidgetStatus( bool editable )
+void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
 {
-  if ( editable )
-    updateConstraintWidgetStatus( mConstraintResult );
-  else
+  if ( !mConstraintResultVisible )
+  {
     widget()->setStyleSheet( QString() );
+  }
+  else
+  {
+    switch ( mConstraintResult )
+    {
+      case ConstraintResultPass:
+        widget()->setStyleSheet( QString() );
+        break;
+
+      case ConstraintResultFailHard:
+        widget()->setStyleSheet( QStringLiteral( "background-color: #FFE0B2;" ) );
+        break;
+
+      case ConstraintResultFailSoft:
+        widget()->setStyleSheet( QStringLiteral( "background-color: #FFECB3;" ) );
+        break;
+    }
+  }
 }
 
-void QgsEditorWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult constraintResult )
+QgsEditorWidgetWrapper::ConstraintResult QgsEditorWidgetWrapper::constraintResult() const
 {
-  //set the constraint result
-  mConstraintResult = constraintResult;
+  return mConstraintResult;
+}
 
-  switch ( constraintResult )
-  {
-    case ConstraintResultPass:
-      widget()->setStyleSheet( QString() );
-      break;
+bool QgsEditorWidgetWrapper::constraintResultVisible() const
+{
+  return mConstraintResultVisible;
+}
 
-    case ConstraintResultFailHard:
-      widget()->setStyleSheet( QStringLiteral( "background-color: #FFE0B2;" ) );
-      break;
+void QgsEditorWidgetWrapper::setConstraintResultVisible( bool constraintResultVisible )
+{
+  if ( mConstraintResultVisible == constraintResultVisible )
+    return;
 
-    case ConstraintResultFailSoft:
-      widget()->setStyleSheet( QStringLiteral( "background-color: #FFECB3;" ) );
-      break;
-  }
+  mConstraintResultVisible = constraintResultVisible;
+
+  updateConstraintWidgetStatus();
+
+  emit constraintResultVisibleChanged( mConstraintResultVisible );
 }
 
 void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft, QgsFieldConstraints::ConstraintOrigin constraintOrigin )
@@ -221,7 +239,9 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsVectorLayer *layer, int 
 
     ConstraintResult result = !hardConstraintsOk ? ConstraintResultFailHard
                               : ( !softConstraintsOk ? ConstraintResultFailSoft : ConstraintResultPass );
-    updateConstraintWidgetStatus( result );
+    //set the constraint result
+    mConstraintResult = result;
+    updateConstraintWidgetStatus();
     emit constraintStatusChanged( expressionDesc, description, errStr, result );
   }
 }

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -42,6 +42,10 @@ class QgsField;
 class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
 {
     Q_OBJECT
+
+    Q_PROPERTY( bool constraintResultVisible READ constraintResultVisible WRITE setConstraintResultVisible NOTIFY constraintResultVisibleChanged )
+    Q_PROPERTY( ConstraintResult constraintResult READ constraintResult NOTIFY constraintStatusChanged )
+
   public:
 
     /**
@@ -185,6 +189,30 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     virtual void setHint( const QString &hintText );
 
+    /**
+     * Getter of constraintResult
+     * It's the current result of the constraint on the widget influencing it's visualization.
+     * \since QGIS 3.0
+     */
+    ConstraintResult constraintResult() const;
+
+    /**
+     * Getter of constraintResultVisible
+     * Defines if the constraint result should be visualized on the widget (with color).
+     * This will be disabled when the form is not editable.
+     * \since QGIS 3.0
+     */
+    bool constraintResultVisible() const;
+
+    /**
+     * Setter of constraintResultVisible
+     * Defines if the constraint result should be visualized on the widget (with color).
+     * This will be disabled when the form is not editable.
+     * \param constraintResultVisible if constraintResult should be displayed (mostly editable status)
+     * \since QGIS 3.0
+     */
+    void setConstraintResultVisible( bool constraintResultVisible );
+
   signals:
 
     /**
@@ -203,6 +231,11 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \param status
      */
     void constraintStatusChanged( const QString &constraint, const QString &desc, const QString &err, ConstraintResult status );
+
+    /**
+     * Emit this signal when the constraint result visibility changed.
+     */
+    void constraintResultVisibleChanged( bool visible );
 
   public slots:
 
@@ -283,19 +316,6 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     void valueChanged();
 
-    /**
-     * It cleans background color (and any other style) in case the feature is not
-     * editable. In case it is, it resets it to the stored constraint status.
-     *
-     * This could be overwritten in subclasses in case individual widgets need other
-     * behavior.
-     *
-     * \param editable if editable or not
-     *
-     * \since QGIS 3.0
-     */
-    virtual void resetConstraintWidgetStatus( bool editable );
-
   protected:
 
     /**
@@ -308,11 +328,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * This can be overwritten in subclasses to allow individual widgets to
      * change the visual cue.
      *
-     * \param status The current constraint status.
-     *
      * \since QGIS 2.16
      */
-    virtual void updateConstraintWidgetStatus( ConstraintResult status );
+    virtual void updateConstraintWidgetStatus();
 
   private:
 
@@ -329,6 +347,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
 
     //! The current constraint result
     ConstraintResult mConstraintResult;
+
+    //! The current constraint result
+    bool mConstraintResultVisible;
 
     int mFieldIdx;
     QgsFeature mFeature;

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -283,6 +283,19 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     void valueChanged();
 
+    /**
+     * It cleans background color (and any other style) in case the feature is not
+     * editable. In case it is, it resets it to the stored constraint status.
+     *
+     * This could be overwritten in subclasses in case individual widgets need other
+     * behavior.
+     *
+     * \param editable if editable or not
+     *
+     * \since QGIS 3.0
+     */
+    virtual void resetConstraintWidgetStatus( bool editable );
+
   protected:
 
     /**
@@ -313,6 +326,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
 
     //! Contains the string explanation of why a constraint check failed
     QString mConstraintFailureReason;
+
+    //! The current constraint result
+    ConstraintResult mConstraintResult;
 
     int mFieldIdx;
     QgsFeature mFeature;

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -80,7 +80,7 @@ void QgsColorWidgetWrapper::setValue( const QVariant &value )
     mColorButton->setColor( !value.isNull() ? QColor( value.toString() ) : QColor() );
 }
 
-void QgsColorWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult /*constraintValid*/ )
+void QgsColorWidgetWrapper::updateConstraintWidgetStatus()
 {
   // nothing
 }

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.h
@@ -49,7 +49,7 @@ class GUI_EXPORT  QgsColorWidgetWrapper : public QgsEditorWidgetWrapper
     void setValue( const QVariant &value ) override;
 
   private:
-    void updateConstraintWidgetStatus( ConstraintResult status ) override;
+    void updateConstraintWidgetStatus() override;
 
     QgsColorButton *mColorButton = nullptr;
 };

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -233,23 +233,30 @@ void QgsExternalResourceWidgetWrapper::setEnabled( bool enabled )
     mQgsWidget->setReadOnly( !enabled );
 }
 
-void QgsExternalResourceWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult status )
+void QgsExternalResourceWidgetWrapper::updateConstraintWidgetStatus()
 {
   if ( mLineEdit )
   {
-    switch ( status )
+    if ( !constraintResultVisible() )
     {
-      case ConstraintResultPass:
-        mLineEdit->setStyleSheet( QString() );
-        break;
+      widget()->setStyleSheet( QString() );
+    }
+    else
+    {
+      switch ( constraintResult() )
+      {
+        case ConstraintResultPass:
+          mLineEdit->setStyleSheet( QString() );
+          break;
 
-      case ConstraintResultFailHard:
-        mLineEdit->setStyleSheet( QStringLiteral( "QgsFilterLineEdit { background-color: #dd7777; }" ) );
-        break;
+        case ConstraintResultFailHard:
+          mLineEdit->setStyleSheet( QStringLiteral( "QgsFilterLineEdit { background-color: #dd7777; }" ) );
+          break;
 
-      case ConstraintResultFailSoft:
-        mLineEdit->setStyleSheet( QStringLiteral( "QgsFilterLineEdit { background-color: #ffd85d; }" ) );
-        break;
+        case ConstraintResultFailSoft:
+          mLineEdit->setStyleSheet( QStringLiteral( "QgsFilterLineEdit { background-color: #ffd85d; }" ) );
+          break;
+      }
     }
   }
 }

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
@@ -59,7 +59,7 @@ class GUI_EXPORT QgsExternalResourceWidgetWrapper : public QgsEditorWidgetWrappe
     void setEnabled( bool enabled ) override;
 
   private:
-    void updateConstraintWidgetStatus( ConstraintResult status ) override;
+    void updateConstraintWidgetStatus() override;
 
     QLineEdit *mLineEdit = nullptr;
     QLabel *mLabel = nullptr;

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -72,7 +72,7 @@ void QgsKeyValueWidgetWrapper::setValue( const QVariant &value )
   mWidget->setMap( value.toMap() );
 }
 
-void QgsKeyValueWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult /*constraintValid*/ )
+void QgsKeyValueWidgetWrapper::updateConstraintWidgetStatus()
 {
   // Nothing
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
@@ -56,7 +56,7 @@ class GUI_EXPORT QgsKeyValueWidgetWrapper : public QgsEditorWidgetWrapper
     void onValueChanged();
 
   private:
-    void updateConstraintWidgetStatus( ConstraintResult status ) override;
+    void updateConstraintWidgetStatus() override;
 
     QgsKeyValueWidget *mWidget = nullptr;
 };

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -87,7 +87,7 @@ void QgsListWidgetWrapper::onValueChanged()
   emit valueChanged( value() );
 }
 
-void QgsListWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult /*constraintValid*/ )
+void QgsListWidgetWrapper::updateConstraintWidgetStatus()
 {
   // Nothing
 }

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.h
@@ -56,7 +56,7 @@ class GUI_EXPORT QgsListWidgetWrapper : public QgsEditorWidgetWrapper
     void onValueChanged();
 
   private:
-    void updateConstraintWidgetStatus( ConstraintResult status ) override;
+    void updateConstraintWidgetStatus() override;
 
     QgsListWidget *mWidget = nullptr;
 };

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -145,23 +145,30 @@ void QgsRelationReferenceWidgetWrapper::foreignKeyChanged( QVariant value )
   emit valueChanged( value );
 }
 
-void QgsRelationReferenceWidgetWrapper::updateConstraintWidgetStatus( ConstraintResult status )
+void QgsRelationReferenceWidgetWrapper::updateConstraintWidgetStatus()
 {
   if ( mWidget )
   {
-    switch ( status )
+    if ( !constraintResultVisible() )
     {
-      case ConstraintResultPass:
-        mWidget->setStyleSheet( QString() );
-        break;
+      widget()->setStyleSheet( QString() );
+    }
+    else
+    {
+      switch ( constraintResult() )
+      {
+        case ConstraintResultPass:
+          mWidget->setStyleSheet( QString() );
+          break;
 
-      case ConstraintResultFailHard:
-        mWidget->setStyleSheet( QStringLiteral( ".QComboBox { background-color: #dd7777; }" ) );
-        break;
+        case ConstraintResultFailHard:
+          mWidget->setStyleSheet( QStringLiteral( ".QComboBox { background-color: #dd7777; }" ) );
+          break;
 
-      case ConstraintResultFailSoft:
-        mWidget->setStyleSheet( QStringLiteral( ".QComboBox { background-color: #ffd85d; }" ) );
-        break;
+        case ConstraintResultFailSoft:
+          mWidget->setStyleSheet( QStringLiteral( ".QComboBox { background-color: #ffd85d; }" ) );
+          break;
+      }
     }
   }
 }

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
 
   protected:
 
-    void updateConstraintWidgetStatus( ConstraintResult status ) override;
+    void updateConstraintWidgetStatus() override;
 
   private:
     QgsRelationReferenceWidget *mWidget = nullptr;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -966,9 +966,9 @@ void QgsAttributeForm::synchronizeEnabledState()
     QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
     if ( eww )
     {
-      mFormEditorWidgets.value( eww->fieldIdx() )->setConstraintResultVisibility( isEditable );
+      mFormEditorWidgets.value( eww->fieldIdx() )->setConstraintResultVisible( isEditable );
 
-      eww->resetConstraintWidgetStatus( isEditable );
+      eww->setConstraintResultVisible( isEditable );
 
       bool enabled = isEditable && fieldIsEditable( eww->fieldIdx() );
       ww->setEnabled( enabled );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -968,6 +968,8 @@ void QgsAttributeForm::synchronizeEnabledState()
     {
       mFormEditorWidgets.value( eww->fieldIdx() )->setConstraintResultVisibility( isEditable );
 
+      eww->resetConstraintWidgetStatus( isEditable );
+
       bool enabled = isEditable && fieldIsEditable( eww->fieldIdx() );
       ww->setEnabled( enabled );
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -966,6 +966,8 @@ void QgsAttributeForm::synchronizeEnabledState()
     QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
     if ( eww )
     {
+      mFormEditorWidgets.value( eww->fieldIdx() )->setConstraintResultVisibility( isEditable );
+
       bool enabled = isEditable && fieldIsEditable( eww->fieldIdx() );
       ww->setEnabled( enabled );
 

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -159,6 +159,11 @@ void QgsAttributeFormEditorWidget::setConstraintStatus( const QString &constrain
   }
 }
 
+void QgsAttributeFormEditorWidget::setConstraintResultVisibility( bool editable )
+{
+  mConstraintResultLabel->setHidden( !editable );
+}
+
 void QgsAttributeFormEditorWidget::setMode( QgsAttributeFormEditorWidget::Mode mode )
 {
   mMode = mode;

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -159,7 +159,7 @@ void QgsAttributeFormEditorWidget::setConstraintStatus( const QString &constrain
   }
 }
 
-void QgsAttributeFormEditorWidget::setConstraintResultVisibility( bool editable )
+void QgsAttributeFormEditorWidget::setConstraintResultVisible( bool editable )
 {
   mConstraintResultLabel->setHidden( !editable );
 }

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -123,6 +123,11 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
      */
     void setConstraintStatus( const QString &constraint, const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result );
 
+    /**
+     * Set the constraint result lable visible or invisible according to the layer editable status
+     */
+    void setConstraintResultVisibility( bool editable );
+
   public slots:
 
     /**

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -126,7 +126,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QWidget
     /**
      * Set the constraint result lable visible or invisible according to the layer editable status
      */
-    void setConstraintResultVisibility( bool editable );
+    void setConstraintResultVisible( bool editable );
 
   public slots:
 


### PR DESCRIPTION
- Constraint Result Indicator invisible when not in editable mode: The icon for the constraint result indicator cross/tipp disappears when not in editable mode. This is made by the new method setconstraintresult. 
- The background color on constraint fields reset on toggle edit: 
If editable, the backgroundcolor should be set according the constraint result. If not editable, the backgroundcolor should be empty anyway. So it has to be reseted when synchronizeEditableState.

![image](https://user-images.githubusercontent.com/28384354/32718780-7943c22a-c85e-11e7-9efa-3a04dac4471f.png)

![image](https://user-images.githubusercontent.com/28384354/32718801-89405594-c85e-11e7-85a3-3679f010eba5.png)
