### PR TITLE
[gui] Datasource manager remove Ok and add Close

### DIFF
--- a/python/gui/qgsabstractdatasourcewidget.sip
+++ b/python/gui/qgsabstractdatasourcewidget.sip
@@ -53,11 +53,6 @@ Destructor
  being added.
 %End
 
-    virtual void okButtonClicked();
-%Docstring
- Triggered when the dialog is accepted, call addButtonClicked() and
- emit the accepted() signal
-%End
 
   signals:
 

--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -38,13 +38,6 @@ const QgsMapCanvas *QgsAbstractDataSourceWidget::mapCanvas() const
 void QgsAbstractDataSourceWidget::setupButtons( QDialogButtonBox *buttonBox )
 {
 
-  if ( mWidgetMode == QgsProviderRegistry::WidgetMode::None )
-  {
-    QPushButton *closeButton = new QPushButton( tr( "&Close" ) );
-    buttonBox->addButton( closeButton, QDialogButtonBox::ApplyRole );
-    connect( closeButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addButtonClicked );
-  }
-
   mAddButton = new QPushButton( tr( "&Add" ) );
   mAddButton->setToolTip( tr( "Add selected layers to map" ) );
   mAddButton->setEnabled( false );

--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -52,12 +52,10 @@ void QgsAbstractDataSourceWidget::setupButtons( QDialogButtonBox *buttonBox )
   connect( mAddButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addButtonClicked );
   connect( this, &QgsAbstractDataSourceWidget::enableButtons, mAddButton, &QPushButton::setEnabled );
 
-  QPushButton *okButton = new QPushButton( tr( "&Ok" ) );
-  okButton->setToolTip( tr( "Add selected layers to map and close this dialog" ) );
-  okButton->setEnabled( false );
-  buttonBox->addButton( okButton, QDialogButtonBox::AcceptRole );
-  connect( okButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::okButtonClicked );
-  connect( this, &QgsAbstractDataSourceWidget::enableButtons, okButton, &QPushButton::setEnabled );
+  QPushButton *closeButton = new QPushButton( tr( "&Close" ) );
+  closeButton->setToolTip( tr( "Close this dialog without adding any layer" ) );
+  buttonBox->addButton( closeButton, QDialogButtonBox::RejectRole );
+  connect( closeButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::reject );
 
 }
 
@@ -67,8 +65,3 @@ void QgsAbstractDataSourceWidget::setMapCanvas( const QgsMapCanvas *mapCanvas )
   mMapCanvas = mapCanvas;
 }
 
-void QgsAbstractDataSourceWidget::okButtonClicked()
-{
-  addButtonClicked();
-  emit accepted();
-}

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -69,11 +69,6 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      */
     virtual void addButtonClicked() { }
 
-    /**
-     * Triggered when the dialog is accepted, call addButtonClicked() and
-     * emit the accepted() signal
-     */
-    virtual void okButtonClicked();
 
   signals:
 

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -60,7 +60,7 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QgsBrowserModel *browser
 
   // Add provider dialogs
   const QList<QgsSourceSelectProvider *> sourceSelectProviders = QgsGui::sourceSelectProviderRegistry()->providers( );
-  for ( const auto provider : sourceSelectProviders )
+  for ( const auto &provider : sourceSelectProviders )
   {
     QgsAbstractDataSourceWidget *dlg = provider->createDataSourceWidget( this );
     if ( !dlg )


### PR DESCRIPTION
Remove the "Ok" button (that was really an Add+Close: it added the layer and exited the dialog) in favour of "Close" button:

![qgis-add-close](https://user-images.githubusercontent.com/142164/32721339-73428c32-c866-11e7-804b-2ecb42c5291a.png)

@rduivenvoorde , @nirvn , @SrNetoChan , @m-kuhn  what's your feeling?