### PR TITLE
Autogenerated relation names in dialog instead of ids

### DIFF
--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -106,9 +106,9 @@ void QgsRelationManagerDialog::mBtnAddRelation_clicked()
     QString relationId = addDlg.relationId();
     if ( addDlg.relationId().isEmpty() )
       relationId = QStringLiteral( "%1_%2_%3_%4" )
-                   .arg( addDlg.referencingLayerId(),
+                   .arg( addDlg.referencingLayerId().left( 10 ),
                          addDlg.references().at( 0 ).first,
-                         addDlg.referencedLayerId(),
+                         addDlg.referencedLayerId().left( 10 ),
                          addDlg.references().at( 0 ).second );
 
     QStringList existingNames;

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -36,7 +36,7 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
 
   Q_FOREACH ( const QgsRelation &relation, vl->referencingRelations( fieldIdx ) )
   {
-    mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.id(), relation.referencedLayerId() ), relation.id() );
+    mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.name(), relation.referencedLayerId() ), relation.id() );
     if ( relation.referencedLayer() )
     {
       mExpressionWidget->setField( relation.referencedLayer()->displayExpression() );

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -36,7 +36,10 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer *vl
 
   Q_FOREACH ( const QgsRelation &relation, vl->referencingRelations( fieldIdx ) )
   {
-    mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.name(), relation.referencedLayerId() ), relation.id() );
+    if ( relation.name().isEmpty() )
+      mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.id(), relation.referencedLayerId() ), relation.id() );
+    else
+      mComboRelation->addItem( QStringLiteral( "%1 (%2)" ).arg( relation.name(), relation.referencedLayerId() ), relation.id() );
     if ( relation.referencedLayer() )
     {
       mExpressionWidget->setField( relation.referencedLayer()->displayExpression() );


### PR DESCRIPTION
The autogenerated ids are quite long and this leads that they where very unconfortable to use in the configuration of relation reference in the attribute type widget of layer properties - attribute form. So now the names are used in the combo instead of the ids. This effects only the GUI.

Fix: #17441