### PR TITLE
Autogenerated relation names in dialog instead of ids

### DIFF
--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -92,9 +92,9 @@ void QgsRelationManagerDialog::on_mBtnAddRelation_clicked()
     QString relationId = addDlg.relationId();
     if ( addDlg.relationId() == "" )
       relationId = QString( "%1_%2_%3_%4" )
-                   .arg( addDlg.referencingLayerId(),
+                   .arg( addDlg.referencingLayerId().left( 10 ),
                          addDlg.references().at( 0 ).first,
-                         addDlg.referencedLayerId(),
+                         addDlg.referencedLayerId().left( 10 ),
                          addDlg.references().at( 0 ).second );
 
     QStringList existingNames;

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -47,7 +47,11 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer* vl
 
   Q_FOREACH ( const QgsRelation& relation, vl->referencingRelations( fieldIdx ) )
   {
-    mComboRelation->addItem( QString( "%1 (%2)" ).arg( relation.name(), relation.referencedLayerId() ), relation.id() );
+    if ( relation.name().isEmpty() )
+      mComboRelation->addItem( QString( "%1 (%2)" ).arg( relation.id(), relation.referencedLayerId() ), relation.id() );
+    else
+      mComboRelation->addItem( QString( "%1 (%2)" ).arg( relation.name(), relation.referencedLayerId() ), relation.id() );
+
     if ( relation.referencedLayer() )
     {
       mExpressionWidget->setField( relation.referencedLayer()->displayExpression() );

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -47,7 +47,7 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer* vl
 
   Q_FOREACH ( const QgsRelation& relation, vl->referencingRelations( fieldIdx ) )
   {
-    mComboRelation->addItem( QString( "%1 (%2)" ).arg( relation.id(), relation.referencedLayerId() ), relation.id() );
+    mComboRelation->addItem( QString( "%1 (%2)" ).arg( relation.name(), relation.referencedLayerId() ), relation.id() );
     if ( relation.referencedLayer() )
     {
       mExpressionWidget->setField( relation.referencedLayer()->displayExpression() );


### PR DESCRIPTION
The autogenerated ids are quite long and this leads that they where very unconfortable to use in the configuration of relation reference in the attribute type widget of layer properties - attribute form. So now the names are used in the combo instead of the ids. This effects only the GUI.

Done it in 

Fix: #17441