### PR TITLE
[bugfix]  Fixes #17070 by considering bool fields as OGR integer fields with boolean subtype

### DIFF
--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -129,7 +129,10 @@ QgsFields QgsOgrUtils::readOgrFields( OGRFeatureH ogrFet, QTextCodec *encoding )
     switch ( OGR_Fld_GetType( fldDef ) )
     {
       case OFTInteger:
-        varType = QVariant::Int;
+        if ( OGR_Fld_GetSubType( fldDef ) == OFSTBoolean )
+          varType = QVariant::Bool;
+        else
+          varType = QVariant::Int;
         break;
       case OFTInteger64:
         varType = QVariant::LongLong;
@@ -193,6 +196,7 @@ QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField
         break;
       }
       case QVariant::Int:
+      case QVariant::Bool:
         value = QVariant( OGR_F_GetFieldAsInteger( ogrFet, attIndex ) );
         break;
       case QVariant::LongLong:

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -579,6 +579,15 @@ void QgsVectorFileWriter::init( QString vectorFileName,
       OGR_Fld_SetPrecision( fld.get(), ogrPrecision );
     }
 
+    switch ( attrField.type() )
+    {
+      case QVariant::Bool:
+        OGR_Fld_SetSubType( fld.get(), OFSTBoolean );
+        break;
+      default:
+        break;
+    }
+
     // create the field
     QgsDebugMsg( "creating field " + attrField.name() +
                  " type " + QString( QVariant::typeToName( attrField.type() ) ) +
@@ -2047,7 +2056,6 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
         break;
       case QVariant::Bool:
         OGR_F_SetFieldInteger( poFeature.get(), ogrField, attrValue.toInt() );
-        OGR_Fld_SetSubType( OGR_F_GetFieldDefnRef( poFeature.get(), ogrField ), OFSTBoolean );
         break;
       case QVariant::String:
         OGR_F_SetFieldString( poFeature.get(), ogrField, mCodec->fromUnicode( attrValue.toString() ).constData() );

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -496,6 +496,12 @@ void QgsVectorFileWriter::init( QString vectorFileName,
         ogrPrecision = 0;
         break;
 
+      case QVariant::Bool:
+        ogrType = OFTInteger;
+        ogrWidth = 1;
+        ogrPrecision = 0;
+        break;
+
       case QVariant::Double:
         ogrType = OFTReal;
         break;
@@ -2038,6 +2044,10 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
       case QVariant::LongLong:
       case QVariant::ULongLong:
         OGR_F_SetFieldInteger64( poFeature.get(), ogrField, attrValue.toLongLong() );
+        break;
+      case QVariant::Bool:
+        OGR_F_SetFieldInteger( poFeature.get(), ogrField, attrValue.toInt() );
+        OGR_Fld_SetSubType( OGR_F_GetFieldDefnRef( poFeature.get(), ogrField ), OFSTBoolean );
         break;
       case QVariant::String:
         OGR_F_SetFieldString( poFeature.get(), ogrField, mCodec->fromUnicode( attrValue.toString() ).constData() );

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -127,7 +127,7 @@ class TestQgsVectorFileWriter(unittest.TestCase):
 
         # test type of converted field
         idx = fields.indexFromName('fld1')
-        self.assertEqual(fields.at(idx).type(), QVariant.Int)
+        self.assertEqual(fields.at(idx).type(), QVariant.Bool)
 
         # test values
         self.assertEqual(vl.getFeature(1).attributes()[idx], 1)


### PR DESCRIPTION
## Description

This PR fixes https://issues.qgis.org/issues/17070 by considering bool fields as OGR integer fields with boolean subtype in `QgsVectorFileWriter`.

Some tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
