### PR TITLE
Fixes and optimisations for calculating distance to vertex

### DIFF
--- a/python/core/geometry/qgsabstractgeometry.sip
+++ b/python/core/geometry/qgsabstractgeometry.sip
@@ -366,6 +366,13 @@ class QgsAbstractGeometry
  :rtype: float
 %End
 
+    virtual double segmentLength( QgsVertexId startVertex ) const = 0;
+%Docstring
+ Returns the length of the segment of the geometry which begins at ``startVertex``.
+.. versionadded:: 3.0
+ :rtype: float
+%End
+
     virtual QgsPoint centroid() const;
 %Docstring
 Returns the centroid of the geometry

--- a/python/core/geometry/qgscircularstring.sip
+++ b/python/core/geometry/qgscircularstring.sip
@@ -79,22 +79,9 @@ class QgsCircularString: QgsCurve
 
     virtual QgsPoint endPoint() const;
 
-
     virtual QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const /Factory/;
 
-%Docstring
- Returns a new line string geometry corresponding to a segmentized approximation
- of the curve.
- \param tolerance segmentation tolerance
- \param toleranceType maximum segmentation angle or maximum difference between approximation and curve
-
- Uses a MaximumAngle tolerance of 1 degrees by default (360
- segments in a full circle)
- :rtype: QgsLineString
-%End
-
     virtual QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const /Factory/;
-
 
     virtual void draw( QPainter &p ) const;
 
@@ -120,28 +107,19 @@ class QgsCircularString: QgsCurve
 
     virtual bool hasCurvedSegments() const;
 
-
     virtual double vertexAngle( QgsVertexId vertex ) const;
 
-%Docstring
- Returns approximate rotation angle for a vertex. Usually average angle between adjacent segments.
-\param vertex the vertex id
-:return: rotation in radians, clockwise from north*
- :rtype: float
-%End
+    virtual double segmentLength( QgsVertexId startVertex ) const;
 
     virtual QgsCircularString *reversed() const  /Factory/;
-
 
     virtual bool addZValue( double zValue = 0 );
 
     virtual bool addMValue( double mValue = 0 );
 
-
     virtual bool dropZValue();
 
     virtual bool dropMValue();
-
 
     virtual double xAt( int index ) const;
 

--- a/python/core/geometry/qgscompoundcurve.sip
+++ b/python/core/geometry/qgscompoundcurve.sip
@@ -138,15 +138,9 @@ Appends first point if not already closed.
 
     virtual bool hasCurvedSegments() const;
 
-
     virtual double vertexAngle( QgsVertexId vertex ) const;
 
-%Docstring
- Returns approximate rotation angle for a vertex. Usually average angle between adjacent segments.
-\param vertex the vertex id
-:return: rotation in radians, clockwise from north*
- :rtype: float
-%End
+    virtual double segmentLength( QgsVertexId startVertex ) const;
 
     virtual QgsCompoundCurve *reversed() const /Factory/;
 

--- a/python/core/geometry/qgscurve.sip
+++ b/python/core/geometry/qgscurve.sip
@@ -67,7 +67,10 @@ class QgsCurve: QgsAbstractGeometry
  Returns a new line string geometry corresponding to a segmentized approximation
  of the curve.
  \param tolerance segmentation tolerance
- \param toleranceType maximum segmentation angle or maximum difference between approximation and curve*
+ \param toleranceType maximum segmentation angle or maximum difference between approximation and curve
+
+ Uses a MaximumAngle tolerance of 1 degrees by default (360
+ segments in a full circle)
  :rtype: QgsLineString
 %End
 

--- a/python/core/geometry/qgscurvepolygon.sip
+++ b/python/core/geometry/qgscurvepolygon.sip
@@ -185,6 +185,8 @@ Adds an interior ring to the geometry (takes ownership)
 
     virtual QgsPoint vertexAt( QgsVertexId id ) const;
 
+    virtual double segmentLength( QgsVertexId startVertex ) const;
+
 
     virtual bool addZValue( double zValue = 0 );
 

--- a/python/core/geometry/qgsgeometrycollection.sip
+++ b/python/core/geometry/qgsgeometrycollection.sip
@@ -145,12 +145,7 @@ Adds a geometry and takes ownership. Returns true in case of success.
 
     virtual double vertexAngle( QgsVertexId vertex ) const;
 
-%Docstring
- Returns approximate rotation angle for a vertex. Usually average angle between adjacent segments.
- \param vertex the vertex id
- :return: rotation in radians, clockwise from north
- :rtype: float
-%End
+    virtual double segmentLength( QgsVertexId startVertex ) const;
 
     virtual int vertexCount( int part = 0, int ring = 0 ) const;
 

--- a/python/core/geometry/qgslinestring.sip
+++ b/python/core/geometry/qgslinestring.sip
@@ -255,6 +255,7 @@ Closes the line string by appending the first point to the end of the line, if i
 
     virtual double vertexAngle( QgsVertexId vertex ) const;
 
+    virtual double segmentLength( QgsVertexId startVertex ) const;
 
     virtual bool addZValue( double zValue = 0 );
 

--- a/python/core/geometry/qgsmultipoint.sip
+++ b/python/core/geometry/qgsmultipoint.sip
@@ -47,6 +47,7 @@ class QgsMultiPoint: QgsGeometryCollection
 
     virtual int vertexNumberFromVertexId( QgsVertexId id ) const;
 
+    virtual double segmentLength( QgsVertexId startVertex ) const;
 
 
   protected:

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -403,6 +403,8 @@ class QgsPoint: QgsAbstractGeometry
 
     virtual QgsPoint *toCurveType() const /Factory/;
 
+    virtual double segmentLength( QgsVertexId startVertex ) const;
+
 
     virtual bool addZValue( double zValue = 0 );
 

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_multilines.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_multilines.gml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ogr:FeatureCollection
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation=""
+     xsi:schemaLocation="http://ogr.maptools.org/ extract_nodes_multilines.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
      xmlns:gml="http://www.opengis.net/gml">
   <gml:boundedBy>
@@ -15,48 +15,48 @@
     <ogr:extract_nodes_multilines fid="lines.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.2">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.024184261036468,2.414779270633399</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.02418426103647,2.4147792706334</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>3.41498595862145</ogr:distance>
-      <ogr:angle>180.979319654339</ogr:angle>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>180.97931965433949</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>4.82997191724289</ogr:distance>
-      <ogr:angle>180.979319654339</ogr:angle>
+      <ogr:distance>3.41498595862145</ogr:distance>
+      <ogr:angle>180.97931965433949</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
@@ -67,64 +67,64 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>0</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>0.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>3.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>0</ogr:angle>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>0.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2.944337811900192,4.04721689059501</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2.94433781190019,4.04721689059501</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>5.04869513927144</ogr:distance>
-      <ogr:angle>88.3476953223487</ogr:angle>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>88.34769532234870</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.459500959692898,4.119769673704415</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.4595009596929,4.11976967370441</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>7.56490450384177</ogr:distance>
-      <ogr:angle>88.3476953223487</ogr:angle>
+      <ogr:distance>6.51620936457033</ogr:distance>
+      <ogr:angle>88.34769532234870</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>6</ogr:node_index>
-      <ogr:distance>10.2673162217113</ogr:distance>
-      <ogr:angle>91.1803544802029</ogr:angle>
+      <ogr:distance>6.51620936457033</ogr:distance>
+      <ogr:angle>91.18035448020294</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.58042226487524,2.946833013435702</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.58042226487524,2.9468330134357</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>7</ogr:node_index>
-      <ogr:distance>12.8482861544157</ogr:distance>
-      <ogr:angle>91.1803544802029</ogr:angle>
+      <ogr:distance>9.09717929727474</ogr:distance>
+      <ogr:angle>91.18035448020294</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_multipolys.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_multipolys.gml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ogr:FeatureCollection
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation=""
+     xsi:schemaLocation="http://ogr.maptools.org/ extract_nodes_multipolys.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
      xmlns:gml="http://www.opengis.net/gml">
   <gml:boundedBy>
@@ -18,8 +18,8 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -29,8 +29,8 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>1</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>1.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -40,8 +40,8 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -51,8 +51,8 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>3.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -62,8 +62,8 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -73,8 +73,8 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>6</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>6.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -84,104 +84,104 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>6</ogr:node_index>
-      <ogr:distance>8</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>8.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>1</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>1.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>5</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>5.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>6</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>6.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>10</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>10.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,6</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>17</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>10.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>6</ogr:node_index>
-      <ogr:distance>18</ogr:distance>
-      <ogr:angle>180</ogr:angle>
+      <ogr:distance>11.00000000000000</ogr:distance>
+      <ogr:angle>180.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,4</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>7</ogr:node_index>
-      <ogr:distance>19</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>12.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,4</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>8</ogr:node_index>
-      <ogr:distance>20</ogr:distance>
-      <ogr:angle>67.5</ogr:angle>
+      <ogr:distance>13.00000000000000</ogr:distance>
+      <ogr:angle>67.50000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>9</ogr:node_index>
-      <ogr:distance>21.4142135623731</ogr:distance>
-      <ogr:angle>22.5</ogr:angle>
+      <ogr:distance>14.41421356237310</ogr:distance>
+      <ogr:angle>22.50000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,6</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>10</ogr:node_index>
-      <ogr:distance>22.4142135623731</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>15.41421356237310</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,6</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>11</ogr:node_index>
-      <ogr:distance>24.4142135623731</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>17.41421356237310</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -191,8 +191,8 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -202,8 +202,8 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>1</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>1.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -213,8 +213,8 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -224,8 +224,8 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>3.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>
@@ -235,8 +235,8 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
   <gml:featureMember>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_polys.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_polys.gml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ogr:FeatureCollection
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation=""
+     xsi:schemaLocation="http://ogr.maptools.org/ extract_nodes_polys.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
      xmlns:gml="http://www.opengis.net/gml">
   <gml:boundedBy>
@@ -18,8 +18,8 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -29,8 +29,8 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -40,8 +40,8 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>8</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>8.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -51,8 +51,8 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>9</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>9.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -62,8 +62,8 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>10</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>10.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -73,8 +73,8 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>13</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>13.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -84,8 +84,8 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>6</ogr:node_index>
-      <ogr:distance>16</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>16.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -95,8 +95,8 @@
       <ogr:intval>-33</ogr:intval>
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -106,8 +106,8 @@
       <ogr:intval>-33</ogr:intval>
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>1.4142135623731</ogr:distance>
-      <ogr:angle>202.5</ogr:angle>
+      <ogr:distance>1.41421356237310</ogr:distance>
+      <ogr:angle>202.49999999999997</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -118,7 +118,7 @@
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
       <ogr:distance>3.41421356237309</ogr:distance>
-      <ogr:angle>337.5</ogr:angle>
+      <ogr:angle>337.49999999999994</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -129,7 +129,7 @@
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
       <ogr:distance>4.82842712474619</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -138,8 +138,8 @@
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -148,8 +148,8 @@
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>1</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>1.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -158,8 +158,8 @@
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -168,8 +168,8 @@
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>3.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -178,8 +178,8 @@
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -188,8 +188,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -198,8 +198,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -208,8 +208,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>8</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>8.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -218,8 +218,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>12</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>12.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -228,8 +228,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>16</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>16.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -238,8 +238,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>17.4142135623731</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>16.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -248,8 +248,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>6</ogr:node_index>
-      <ogr:distance>19.4142135623731</ogr:distance>
-      <ogr:angle>135</ogr:angle>
+      <ogr:distance>18.00000000000000</ogr:distance>
+      <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -258,8 +258,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>7</ogr:node_index>
-      <ogr:distance>21.4142135623731</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>20.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -268,8 +268,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>8</ogr:node_index>
-      <ogr:distance>23.4142135623731</ogr:distance>
-      <ogr:angle>315</ogr:angle>
+      <ogr:distance>22.00000000000000</ogr:distance>
+      <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -278,8 +278,8 @@
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_index>9</ogr:node_index>
-      <ogr:distance>25.4142135623731</ogr:distance>
-      <ogr:angle>225</ogr:angle>
+      <ogr:distance>24.00000000000000</ogr:distance>
+      <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -295,8 +295,8 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>99.217474411461</ogr:angle>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>99.21747441146101</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -307,7 +307,7 @@
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
       <ogr:distance>3.16227766016838</ogr:distance>
-      <ogr:angle>144.217474411461</ogr:angle>
+      <ogr:angle>144.21747441146101</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -318,7 +318,7 @@
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
       <ogr:distance>7.16227766016838</ogr:distance>
-      <ogr:angle>238.282525588539</ogr:angle>
+      <ogr:angle>238.28252558853902</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -328,8 +328,8 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>11.634413615168</ogr:distance>
-      <ogr:angle>328.282525588539</ogr:angle>
+      <ogr:distance>11.63441361516796</ogr:distance>
+      <ogr:angle>328.28252558853899</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -339,8 +339,8 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>4</ogr:node_index>
-      <ogr:distance>14.634413615168</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:distance>14.63441361516796</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -350,8 +350,8 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>15.634413615168</ogr:distance>
-      <ogr:angle>99.217474411461</ogr:angle>
+      <ogr:distance>15.63441361516796</ogr:distance>
+      <ogr:angle>99.21747441146101</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_polys.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_polys.gml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ogr:FeatureCollection
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation=""
+     xsi:schemaLocation="http://ogr.maptools.org/ extract_specific_nodes_polys.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
      xmlns:gml="http://www.opengis.net/gml">
   <gml:boundedBy>
@@ -12,7 +12,7 @@
   </gml:boundedBy>
                                                                                                                                                               
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.1">
+    <ogr:extract_specific_nodes_polys fid="polys.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>aaaaa</ogr:name>
       <ogr:intval>33</ogr:intval>
@@ -24,7 +24,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.2">
+    <ogr:extract_specific_nodes_polys fid="polys.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>aaaaa</ogr:name>
       <ogr:intval>33</ogr:intval>
@@ -36,7 +36,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.3">
+    <ogr:extract_specific_nodes_polys fid="polys.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>aaaaa</ogr:name>
       <ogr:intval>33</ogr:intval>
@@ -48,7 +48,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.4">
+    <ogr:extract_specific_nodes_polys fid="polys.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>aaaaa</ogr:name>
       <ogr:intval>33</ogr:intval>
@@ -60,7 +60,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.5">
+    <ogr:extract_specific_nodes_polys fid="polys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>Aaaaa</ogr:name>
       <ogr:intval>-33</ogr:intval>
@@ -72,7 +72,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.6">
+    <ogr:extract_specific_nodes_polys fid="polys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>Aaaaa</ogr:name>
       <ogr:intval>-33</ogr:intval>
@@ -84,7 +84,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.7">
+    <ogr:extract_specific_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
@@ -95,7 +95,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.8">
+    <ogr:extract_specific_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
@@ -106,7 +106,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.9">
+    <ogr:extract_specific_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
       <ogr:floatval>0.123</ogr:floatval>
@@ -117,7 +117,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.10">
+    <ogr:extract_specific_nodes_polys fid="polys.3">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
@@ -128,46 +128,46 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.11">
+    <ogr:extract_specific_nodes_polys fid="polys.3">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>9</ogr:node_index>
-      <ogr:distance>25.4142135623731</ogr:distance>
+      <ogr:distance>24</ogr:distance>
       <ogr:angle>225</ogr:angle>
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.12">
+    <ogr:extract_specific_nodes_polys fid="polys.3">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_pos>5</ogr:node_pos>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>17.4142135623731</ogr:distance>
+      <ogr:distance>16</ogr:distance>
       <ogr:angle>225</ogr:angle>
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.13">
+    <ogr:extract_specific_nodes_polys fid="polys.3">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
       <ogr:node_pos>-5</ogr:node_pos>
       <ogr:node_index>5</ogr:node_index>
-      <ogr:distance>17.4142135623731</ogr:distance>
+      <ogr:distance>16</ogr:distance>
       <ogr:angle>225</ogr:angle>
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.14">
+    <ogr:extract_specific_nodes_polys fid="polys.4">
       <ogr:intval>120</ogr:intval>
       <ogr:floatval>-100291.43213</ogr:floatval>
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.15">
+    <ogr:extract_specific_nodes_polys fid="polys.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>elim</ogr:name>
       <ogr:intval>2</ogr:intval>
@@ -179,7 +179,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.16">
+    <ogr:extract_specific_nodes_polys fid="polys.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>elim</ogr:name>
       <ogr:intval>2</ogr:intval>
@@ -191,7 +191,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.17">
+    <ogr:extract_specific_nodes_polys fid="polys.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>elim</ogr:name>
       <ogr:intval>2</ogr:intval>
@@ -203,7 +203,7 @@
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_polys fid="polys.18">
+    <ogr:extract_specific_nodes_polys fid="polys.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>elim</ogr:name>
       <ogr:intval>2</ogr:intval>

--- a/src/analysis/processing/qgsalgorithmextractnodes.cpp
+++ b/src/analysis/processing/qgsalgorithmextractnodes.cpp
@@ -107,16 +107,15 @@ QVariantMap QgsExtractNodesAlgorithm::processAlgorithm( const QVariantMap &param
     else
     {
       QgsAbstractGeometry::vertex_iterator vi = inputGeom.constGet()->vertices_begin();
-      QgsPoint vertex;
+      double cumulativeDistance = 0.0;
       int vertexPos = 0;
       while ( vi != inputGeom.constGet()->vertices_end() )
       {
         QgsVertexId vertexId = vi.vertexId();
-        double distance = QgsGeometryUtils::distanceToVertex( *( inputGeom.constGet() ), vertexId );
         double angle = inputGeom.constGet()->vertexAngle( vertexId ) * 180 / M_PI;
         QgsAttributes attrs = f.attributes();
         attrs << vertexPos
-              << distance
+              << cumulativeDistance
               << angle;
         QgsFeature outputFeature = QgsFeature();
         outputFeature.setAttributes( attrs );
@@ -124,6 +123,10 @@ QVariantMap QgsExtractNodesAlgorithm::processAlgorithm( const QVariantMap &param
         sink->addFeature( outputFeature, QgsFeatureSink::FastInsert );
         vi++;
         vertexPos++;
+
+        // calculate distance to next vertex
+        double distanceToNext = inputGeom.constGet()->segmentLength( vertexId );
+        cumulativeDistance += distanceToNext;
       }
     }
     feedback->setProgress( i * step );

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -382,6 +382,12 @@ class CORE_EXPORT QgsAbstractGeometry
      */
     virtual double area() const;
 
+    /**
+     * Returns the length of the segment of the geometry which begins at \a startVertex.
+     * \since QGIS 3.0
+     */
+    virtual double segmentLength( QgsVertexId startVertex ) const = 0;
+
     //! Returns the centroid of the geometry
     virtual QgsPoint centroid() const;
 

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -975,6 +975,23 @@ double QgsCircularString::vertexAngle( QgsVertexId vId ) const
   return 0.0;
 }
 
+double QgsCircularString::segmentLength( QgsVertexId startVertex ) const
+{
+  if ( startVertex.vertex < 0 || startVertex.vertex >= mX.count() - 2 )
+    return 0.0;
+
+  if ( startVertex.vertex % 2 == 1 )
+    return 0.0; // curve point?
+
+  double x1 = mX.at( startVertex.vertex );
+  double y1 = mY.at( startVertex.vertex );
+  double x2 = mX.at( startVertex.vertex + 1 );
+  double y2 = mY.at( startVertex.vertex + 1 );
+  double x3 = mX.at( startVertex.vertex + 2 );
+  double y3 = mY.at( startVertex.vertex + 2 );
+  return QgsGeometryUtils::circleLength( x1, y1, x2, y2, x3, y3 );
+}
+
 QgsCircularString *QgsCircularString::reversed() const
 {
   QgsCircularString *copy = clone();

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -71,20 +71,8 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     double length() const override;
     QgsPoint startPoint() const override;
     QgsPoint endPoint() const override;
-
-    /**
-     * Returns a new line string geometry corresponding to a segmentized approximation
-     * of the curve.
-     * \param tolerance segmentation tolerance
-     * \param toleranceType maximum segmentation angle or maximum difference between approximation and curve
-     *
-     * Uses a MaximumAngle tolerance of 1 degrees by default (360
-     * segments in a full circle)
-     */
     QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const override SIP_FACTORY;
-
     QgsCircularString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
-
     void draw( QPainter &p ) const override;
     void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform,
                     bool transformZ = false ) override;
@@ -98,21 +86,13 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     bool pointAt( int node, QgsPoint &point, QgsVertexId::VertexType &type ) const override;
     void sumUpArea( double &sum SIP_OUT ) const override;
     bool hasCurvedSegments() const override;
-
-    /**
-     * Returns approximate rotation angle for a vertex. Usually average angle between adjacent segments.
-        \param vertex the vertex id
-        \returns rotation in radians, clockwise from north*/
     double vertexAngle( QgsVertexId vertex ) const override;
-
+    double segmentLength( QgsVertexId startVertex ) const override;
     QgsCircularString *reversed() const override  SIP_FACTORY;
-
     bool addZValue( double zValue = 0 ) override;
     bool addMValue( double mValue = 0 ) override;
-
     bool dropZValue() override;
     bool dropMValue() override;
-
     double xAt( int index ) const override;
     double yAt( int index ) const override;
 #ifndef SIP_RUN

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -807,6 +807,17 @@ double QgsCompoundCurve::vertexAngle( QgsVertexId vertex ) const
   }
 }
 
+double QgsCompoundCurve::segmentLength( QgsVertexId startVertex ) const
+{
+  QList< QPair<int, QgsVertexId> > curveIds = curveVertexId( startVertex );
+  double length = 0.0;
+  for ( auto it = curveIds.constBegin(); it != curveIds.constEnd(); ++it )
+  {
+    length += mCurves.at( it->first )->segmentLength( it->second );
+  }
+  return length;
+}
+
 QgsCompoundCurve *QgsCompoundCurve::reversed() const
 {
   QgsCompoundCurve *clone = new QgsCompoundCurve();

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -113,13 +113,8 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     void close();
 
     bool hasCurvedSegments() const override;
-
-    /**
-     * Returns approximate rotation angle for a vertex. Usually average angle between adjacent segments.
-        \param vertex the vertex id
-        \returns rotation in radians, clockwise from north*/
     double vertexAngle( QgsVertexId vertex ) const override;
-
+    double segmentLength( QgsVertexId startVertex ) const override;
     QgsCompoundCurve *reversed() const override SIP_FACTORY;
 
     bool addZValue( double zValue = 0 ) override;

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -72,7 +72,11 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry
      * Returns a new line string geometry corresponding to a segmentized approximation
      * of the curve.
      * \param tolerance segmentation tolerance
-     * \param toleranceType maximum segmentation angle or maximum difference between approximation and curve*/
+     * \param toleranceType maximum segmentation angle or maximum difference between approximation and curve
+     *
+     * Uses a MaximumAngle tolerance of 1 degrees by default (360
+     * segments in a full circle)
+     */
     virtual QgsLineString *curveToLine( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const = 0 SIP_FACTORY;
 
     /**

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -1058,6 +1058,17 @@ QgsPoint QgsCurvePolygon::vertexAt( QgsVertexId id ) const
   return id.ring == 0 ? mExteriorRing->vertexAt( id ) : mInteriorRings[id.ring - 1]->vertexAt( id );
 }
 
+double QgsCurvePolygon::segmentLength( QgsVertexId startVertex ) const
+{
+  if ( !mExteriorRing || startVertex.ring < 0 || startVertex.ring >= 1 + mInteriorRings.size() )
+  {
+    return 0.0;
+  }
+
+  const QgsCurve *ring = startVertex.ring == 0 ? mExteriorRing.get() : mInteriorRings[startVertex.ring - 1];
+  return ring->segmentLength( startVertex );
+}
+
 bool QgsCurvePolygon::addZValue( double zValue )
 {
   if ( QgsWkbTypes::hasZ( mWkbType ) )

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -144,6 +144,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     int ringCount( int part = 0 ) const override;
     int partCount() const override;
     QgsPoint vertexAt( QgsVertexId id ) const override;
+    double segmentLength( QgsVertexId startVertex ) const override;
 
     bool addZValue( double zValue = 0 ) override;
     bool addMValue( double mValue = 0 ) override;

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -695,6 +695,22 @@ double QgsGeometryCollection::vertexAngle( QgsVertexId vertex ) const
   return geom->vertexAngle( vertex );
 }
 
+double QgsGeometryCollection::segmentLength( QgsVertexId startVertex ) const
+{
+  if ( startVertex.part < 0 || startVertex.part >= mGeometries.size() )
+  {
+    return 0.0;
+  }
+
+  const QgsAbstractGeometry *geom = mGeometries[startVertex.part];
+  if ( !geom )
+  {
+    return 0.0;
+  }
+
+  return geom->segmentLength( startVertex );
+}
+
 int QgsGeometryCollection::vertexCount( int part, int ring ) const
 {
   if ( part < 0 || part >= mGeometries.size() )

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -125,13 +125,8 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
      * \param toleranceType maximum segmentation angle or maximum difference between approximation and curve*/
     QgsAbstractGeometry *segmentize( double tolerance = M_PI_2 / 90, SegmentationToleranceType toleranceType = MaximumAngle ) const override SIP_FACTORY;
 
-    /**
-     * Returns approximate rotation angle for a vertex. Usually average angle between adjacent segments.
-     * \param vertex the vertex id
-     * \returns rotation in radians, clockwise from north
-     */
     double vertexAngle( QgsVertexId vertex ) const override;
-
+    double segmentLength( QgsVertexId startVertex ) const override;
     int vertexCount( int part = 0, int ring = 0 ) const override;
     int ringCount( int part = 0 ) const override;
     int partCount() const override;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -133,24 +133,14 @@ double QgsGeometryUtils::distanceToVertex( const QgsAbstractGeometry &geom, QgsV
   double currentDist = 0;
   QgsVertexId vertexId;
   QgsPoint vertex;
-  QgsPoint previousVertex;
-
-  bool first = true;
   while ( geom.nextVertex( vertexId, vertex ) )
   {
-    if ( !first )
-    {
-      currentDist += std::sqrt( QgsGeometryUtils::sqrDistance2D( previousVertex, vertex ) );
-    }
-
-    previousVertex = vertex;
-    first = false;
-
     if ( vertexId == id )
     {
       //found target vertex
       return currentDist;
     }
+    currentDist += geom.segmentLength( vertexId );
   }
 
   //could not find target vertex

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1081,6 +1081,16 @@ double QgsLineString::vertexAngle( QgsVertexId vertex ) const
   }
 }
 
+double QgsLineString::segmentLength( QgsVertexId startVertex ) const
+{
+  if ( startVertex.vertex < 0 || startVertex.vertex >= mX.count() - 1 )
+    return 0.0;
+
+  double dx = mX.at( startVertex.vertex + 1 ) - mX.at( startVertex.vertex );
+  double dy = mY.at( startVertex.vertex + 1 ) - mY.at( startVertex.vertex );
+  return std::sqrt( dx * dx + dy * dy );
+}
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests.

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -228,7 +228,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     void sumUpArea( double &sum SIP_OUT ) const override;
     double vertexAngle( QgsVertexId vertex ) const override;
-
+    double segmentLength( QgsVertexId startVertex ) const override;
     bool addZValue( double zValue = 0 ) override;
     bool addMValue( double mValue = 0 ) override;
 

--- a/src/core/geometry/qgsmultipoint.cpp
+++ b/src/core/geometry/qgsmultipoint.cpp
@@ -177,6 +177,11 @@ int QgsMultiPoint::vertexNumberFromVertexId( QgsVertexId id ) const
   return id.part; // can shortcut the calculation, since each part will have 1 vertex
 }
 
+double QgsMultiPoint::segmentLength( QgsVertexId ) const
+{
+  return 0.0;
+}
+
 bool QgsMultiPoint::wktOmitChildType() const
 {
   return true;

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsMultiPoint: public QgsGeometryCollection
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
     int vertexNumberFromVertexId( QgsVertexId id ) const override;
-
+    double segmentLength( QgsVertexId startVertex ) const override;
 
 #ifndef SIP_RUN
 

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -461,6 +461,11 @@ QgsPoint *QgsPoint::toCurveType() const
   return clone();
 }
 
+double QgsPoint::segmentLength( QgsVertexId ) const
+{
+  return 0.0;
+}
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests.

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -429,6 +429,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     int partCount() const override;
     QgsPoint vertexAt( QgsVertexId /*id*/ ) const override;
     QgsPoint *toCurveType() const override SIP_FACTORY;
+    double segmentLength( QgsVertexId startVertex ) const override;
 
     bool addZValue( double zValue = 0 ) override;
     bool addMValue( double mValue = 0 ) override;

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -1044,6 +1044,13 @@ void TestQgsGeometry::point()
   QCOMPARE( QgsPoint( 1, 2 ).vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
   QCOMPARE( QgsPoint( 1, 2 ).vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), -1 );
   QCOMPARE( QgsPoint( 1, 2 ).vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
+
+  //segmentLength
+  QCOMPARE( QgsPoint( 1, 2 ).segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( QgsPoint( 1, 2 ).segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( QgsPoint( 1, 2 ).segmentLength( QgsVertexId( -1, 0, 1 ) ), 0.0 );
+  QCOMPARE( QgsPoint( 1, 2 ).segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( QgsPoint( 1, 2 ).segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
 }
 
 void TestQgsGeometry::circularString()
@@ -2324,6 +2331,29 @@ void TestQgsGeometry::circularString()
   QCOMPARE( curveType->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 1, 2 ) );
   QCOMPARE( curveType->vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPoint( 11, 12 ) );
   QCOMPARE( curveType->vertexAt( QgsVertexId( 0, 0, 2 ) ), QgsPoint( 1, 22 ) );
+
+  //segmentLength
+  QgsCircularString curveLine2;
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
+  curveLine2.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 1, 22 ) );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QGSCOMPARENEAR( curveLine2.segmentLength( QgsVertexId( 0, 0, 0 ) ), 31.4159, 0.001 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 0, 0, 1 ) ), 0.0 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 0, 0, 2 ) ), 0.0 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QGSCOMPARENEAR( curveLine2.segmentLength( QgsVertexId( -1, 0, 0 ) ), 31.4159, 0.001 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 1, 0, 1 ) ), 0.0 );
+  QGSCOMPARENEAR( curveLine2.segmentLength( QgsVertexId( 1, 1, 0 ) ), 31.4159, 0.001 );
+  curveLine2.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 1, 22 ) << QgsPoint( -9, 32 ) << QgsPoint( 1, 42 ) );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QGSCOMPARENEAR( curveLine2.segmentLength( QgsVertexId( 0, 0, 0 ) ), 31.4159, 0.001 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 0, 0, 1 ) ), 0.0 );
+  QGSCOMPARENEAR( curveLine2.segmentLength( QgsVertexId( 0, 0, 2 ) ), 31.4159, 0.001 );
+  QCOMPARE( curveLine2.segmentLength( QgsVertexId( 0, 0, 3 ) ), 0.0 );
 }
 
 
@@ -4046,6 +4076,22 @@ void TestQgsGeometry::lineString()
   QCOMPARE( vertexLine2.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
   QCOMPARE( vertexLine2.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
   QCOMPARE( vertexLine2.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), -1 );
+
+  //segmentLength
+  QgsLineString vertexLine3;
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
+  vertexLine3.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 111, 12 ) );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 0, 0, 2 ) ), 0.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
+  QCOMPARE( vertexLine3.segmentLength( QgsVertexId( 1, 1, 1 ) ), 100.0 );
 }
 
 void TestQgsGeometry::polygon()
@@ -5714,6 +5760,56 @@ void TestQgsGeometry::polygon()
   QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 3 ) ), 8 );
   QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 4 ) ), 9 );
   QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 5 ) ), -1 );
+
+
+  //segmentLength
+  QgsPolygon p30;
+  QgsLineString vertexLine3;
+  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
+  vertexLine3.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 111, 12 )
+                         << QgsPoint( 111, 2 ) << QgsPoint( 11, 2 ) );
+  p30.setExteriorRing( vertexLine3.clone() );
+  QCOMPARE( p30.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 1 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 1, 1 ) ), 0.0 );
+
+  // add interior ring
+  vertexLine3.setPoints( QgsPointSequence() << QgsPoint( 30, 6 ) << QgsPoint( 34, 6 ) << QgsPoint( 34, 8 )
+                         << QgsPoint( 30, 8 ) << QgsPoint( 30, 6 ) );
+  p30.addInteriorRing( vertexLine3.clone() );
+  QCOMPARE( p30.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, -1 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 0 ) ), 4.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 1 ) ), 2.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 2 ) ), 4.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 3 ) ), 2.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 4 ) ), 0.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
+  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 1, 1 ) ), 2.0 );
 }
 
 void TestQgsGeometry::triangle()
@@ -10315,6 +10411,43 @@ void TestQgsGeometry::compoundCurve()
   QCOMPARE( closeCc1.numPoints(), 4 );
   QVERIFY( closeCc1.isClosed() );
 
+  //segmentLength
+  QgsCircularString curveLine2;
+  QgsCompoundCurve slc1;
+  QCOMPARE( slc1.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
+  curveLine2.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 1, 22 ) );
+  slc1.addCurve( curveLine2.clone() );
+  QCOMPARE( slc1.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QGSCOMPARENEAR( slc1.segmentLength( QgsVertexId( 0, 0, 0 ) ), 31.4159, 0.001 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 1 ) ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 2 ) ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QGSCOMPARENEAR( slc1.segmentLength( QgsVertexId( -1, 0, 0 ) ), 31.4159, 0.001 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 1, 0, 1 ) ), 0.0 );
+  QGSCOMPARENEAR( slc1.segmentLength( QgsVertexId( 1, 1, 0 ) ), 31.4159, 0.001 );
+  curveLine2.setPoints( QgsPointSequence() << QgsPoint( 1, 22 ) << QgsPoint( -9, 32 ) << QgsPoint( 1, 42 ) );
+  slc1.addCurve( curveLine2.clone() );
+  QCOMPARE( slc1.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QGSCOMPARENEAR( slc1.segmentLength( QgsVertexId( 0, 0, 0 ) ), 31.4159, 0.001 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 1 ) ), 0.0 );
+  QGSCOMPARENEAR( slc1.segmentLength( QgsVertexId( 0, 0, 2 ) ), 31.4159, 0.001 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 3 ) ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QgsLineString curveLine3;
+  curveLine3.setPoints( QgsPointSequence() << QgsPoint( 1, 42 ) << QgsPoint( 10, 42 ) );
+  slc1.addCurve( curveLine3.clone() );
+  QCOMPARE( slc1.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QGSCOMPARENEAR( slc1.segmentLength( QgsVertexId( 0, 0, 0 ) ), 31.4159, 0.001 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 1 ) ), 0.0 );
+  QGSCOMPARENEAR( slc1.segmentLength( QgsVertexId( 0, 0, 2 ) ), 31.4159, 0.001 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 3 ) ), 0.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 4 ) ), 9.0 );
+  QCOMPARE( slc1.segmentLength( QgsVertexId( 0, 0, 5 ) ), 0.0 );
 }
 
 void TestQgsGeometry::multiPoint()
@@ -11372,6 +11505,55 @@ void TestQgsGeometry::multiLineString()
   QCOMPARE( static_cast< QgsPoint *>( mpBoundary->geometryN( 3 ) )->y(), 20.0 );
   QCOMPARE( static_cast< QgsPoint *>( mpBoundary->geometryN( 3 ) )->z(), 200.0 );
   delete boundary;
+
+  //segmentLength
+  QgsMultiLineString multiLine3;
+  QgsLineString vertexLine3;
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
+  vertexLine3.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 111, 12 )
+                         << QgsPoint( 111, 2 ) << QgsPoint( 11, 2 ) );
+  multiLine3.addGeometry( vertexLine3.clone() );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, -1, 0 ) ), 10.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 1, 0 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 1, 1 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, 1 ) ), 0.0 );
+
+  // add another line
+  vertexLine3.setPoints( QgsPointSequence() << QgsPoint( 30, 6 ) << QgsPoint( 34, 6 ) << QgsPoint( 34, 8 )
+                         << QgsPoint( 30, 8 ) << QgsPoint( 30, 6 ) );
+  multiLine3.addGeometry( vertexLine3.clone() );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 0, -1, 0 ) ), 10.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, -1 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, 0 ) ), 4.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, 1 ) ), 2.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, 2 ) ), 4.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, 3 ) ), 2.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 0, 4 ) ), 0.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 1, 1 ) ), 2.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 1, 1, 2 ) ), 4.0 );
+  QCOMPARE( multiLine3.segmentLength( QgsVertexId( 2, 0, 0 ) ), 0.0 );
 }
 
 void TestQgsGeometry::multiCurve()


### PR DESCRIPTION
Fixes the calculation of distance to vertex for multi part, multi ring and curved geometries. Before these were incorrectly including the distance between vertices from one ring/part to the next, and ignoring any curves in the geometry.

But more interesting is the speed boost unlocked by these changes for the "extract nodes" algorithm.

Instead of calculating the whole distance from the start of the geometry to the vertex for EVERY vertex, we just keep a running sum of the cumulative distance so far and add the length of each segment as we go.

Stats:

Before:
- dataset 1: > 20 minutes, still going at 14%....
- dataset 2: 92 seconds

After:
- dataset 1: 3 seconds
- dataset 2: 1.7 seconds

BAM!