### PR TITLE
executeSql in transaction does not return an error on tuple

### DIFF
--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -92,8 +92,7 @@ class QgsTransaction : QObject /Abstract/
 
     virtual bool executeSql( const QString &sql, QString &error /Out/, bool isDirty = false ) = 0;
 %Docstring
- Execute the ``sql`` string. The result must not be a tuple, so running a
- ``SELECT`` query will return an error.
+ Execute the ``sql`` string.
 
  \param sql The sql query to execute
  \param error The error message

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -103,8 +103,7 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     bool rollback( QString &errorMsg SIP_OUT );
 
     /**
-     * Execute the \a sql string. The result must not be a tuple, so running a
-     * ``SELECT`` query will return an error.
+     * Execute the \a sql string.
      *
      * \param sql The sql query to execute
      * \param error The error message

--- a/src/providers/postgres/qgspostgrestransaction.cpp
+++ b/src/providers/postgres/qgspostgrestransaction.cpp
@@ -74,7 +74,8 @@ bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg, 
   mConn->lock();
   QgsPostgresResult r( mConn->PQexec( sql, true ) );
   mConn->unlock();
-  if ( r.PQresultStatus() != PGRES_COMMAND_OK )
+  if ( r.PQresultStatus() == PGRES_BAD_RESPONSE ||
+       r.PQresultStatus() == PGRES_FATAL_ERROR )
   {
     errorMsg = QStringLiteral( "Status %1 (%2)" ).arg( r.PQresultStatus() ).arg( r.PQresultErrorMessage() );
     QgsDebugMsg( errorMsg );


### PR DESCRIPTION
## Description

As described by @haubourg here https://github.com/qgis/QGIS-Enhancement-Proposals/issues/97, the current implementation of `executeSql` in transactions returns an error when a tuple is returned by the underlying database.

As it's pretty limiting (already mentioned in https://github.com/qgis/QGIS/pull/5376), this PR considers a tuple as a valid output. 

A test have been added.

It's not really a bugfix, but it's not a feature either. So I would like some kind of approval (or not) before merging this PR.

## Checklist


- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
