### PR TITLE
Reintroduce postgres9.5/postgis2.3 and avoided to remove python2.7 

### DIFF
--- a/.ci/travis/linux/blacklist.txt
+++ b/.ci/travis/linux/blacklist.txt
@@ -30,7 +30,3 @@ PyQgsSpatialiteProvider
 # Flaky, see https://travis-ci.org/qgis/QGIS/jobs/297708174
 PyQgsServerAccessControl
 
-# Need a local postgres installation
-PyQgsAuthManagerPKIPostgresTest
-PyQgsAuthManagerPasswordPostgresTest
-PyQgsAuthManagerOgrPostgresTest

--- a/.ci/travis/linux/docker-build-test.sh
+++ b/.ci/travis/linux/docker-build-test.sh
@@ -81,6 +81,14 @@ pushd /root/QGIS > /dev/null
 /root/QGIS/tests/testdata/provider/testdata_pg.sh
 popd > /dev/null # /root/QGIS
 
+##########################################################
+# Set Postgres server location for that tests that require
+# setting up a custom server and not use a standard 
+# dockerised one
+##########################################################
+export QGIS_POSTGRES_EXECUTABLE_PATH=/usr/lib/postgresql/9.5/bin
+export QGIS_POSTGRES_SERVER_PORT=55432
+
 ###########
 # Run tests
 ###########

--- a/.ci/travis/linux/docker-build-test.sh
+++ b/.ci/travis/linux/docker-build-test.sh
@@ -82,9 +82,9 @@ pushd /root/QGIS > /dev/null
 popd > /dev/null # /root/QGIS
 
 ##########################################################
-# Set Postgres server location for that tests that require
-# setting up a custom server and not use a standard 
-# dockerised one
+# Set Postgres server location inside the docker running 
+# the test. This is for that tests that require
+# setting up a custom server
 ##########################################################
 export QGIS_POSTGRES_EXECUTABLE_PATH=/usr/lib/postgresql/9.5/bin
 export QGIS_POSTGRES_SERVER_PORT=55432

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -80,6 +80,8 @@ RUN  apt-get update \
     xfonts-base \
     xfonts-scalable \
     xvfb \
+    postgresql-9.5 \
+    postgresql-9.5-postgis-2.3 \
   && pip3 install \
     psycopg2 \
     numpy \
@@ -88,7 +90,7 @@ RUN  apt-get update \
     mock \
     future \
     termcolor \
-  && apt-get autoremove -y python3-pip python2.7 \
+  && apt-get autoremove -y python3-pip \
   && apt-get clean
 
 RUN echo "alias python=python3" >> ~/.bash_aliases


### PR DESCRIPTION
## Description
Some integrations test are configured to not use postgres on docker due to a more detailed configuration. so it's necessary to reintroduce a postgres server that can be configured and run in the test environment.

the docker where tests run has been changed
Adding:
Postgres 9.5
Postgis 2.3
Avoid removing of:
python2.7
that, for some ubuntu reason fail raising unmet dependencies (when the dependency is available)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
