### PR TITLE
Fix #17444 : GeoNode data provider completely ignores authentication

### DIFF
--- a/python/gui/qgsnewhttpconnection.sip
+++ b/python/gui/qgsnewhttpconnection.sip
@@ -35,6 +35,7 @@ class QgsNewHttpConnection : QDialog
     enum Flag
     {
       FlagShowTestConnection,
+      FlagHideAuthenticationGroup,
     };
     typedef QFlags<QgsNewHttpConnection::Flag> Flags;
 

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -121,6 +121,11 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
     mGroupBox->layout()->removeWidget( mTestConnectionButton );
   }
 
+  if ( flags & FlagHideAuthenticationGroup )
+  {
+    mAuthGroupBox->hide();
+    mGroupBox->layout()->removeWidget( mAuthGroupBox );
+  }
   // Adjust height
   int w = width();
   adjustSize();

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -56,7 +56,7 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     enum Flag
     {
       FlagShowTestConnection = 1 << 1, //!< Display the 'test connection' button
-      FlagHideAuthenticationGroup = 2 << 2, //!< Hide the Authentication dialog
+      FlagHideAuthenticationGroup = 2 << 2, //!< Hide the Authentication group
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -56,6 +56,7 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     enum Flag
     {
       FlagShowTestConnection = 1 << 1, //!< Display the 'test connection' button
+      FlagHideAuthenticationGroup = 2 << 2, //!< Hide the Authentication dialog
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -56,7 +56,7 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     enum Flag
     {
       FlagShowTestConnection = 1 << 1, //!< Display the 'test connection' button
-      FlagHideAuthenticationGroup = 2 << 2, //!< Hide the Authentication group
+      FlagHideAuthenticationGroup = 1 << 2, //!< Hide the Authentication group
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/providers/geonode/qgsgeonodenewconnection.cpp
+++ b/src/providers/geonode/qgsgeonodenewconnection.cpp
@@ -20,14 +20,16 @@
 #include "qgsgeonodeconnection.h"
 #include "qgsgeonoderequest.h"
 
+// For now we are hiding away authentication options since
+// there is no support yet for tication in the GeoNode
+// We will re-enable this when this limitation changes. TS
 QgsGeoNodeNewConnection::QgsGeoNodeNewConnection( QWidget *parent, const QString &connName, Qt::WindowFlags fl )
   : QgsNewHttpConnection( parent, QgsNewHttpConnection::ConnectionWfs | QgsNewHttpConnection::ConnectionWms,
-                          QgsGeoNodeConnectionUtils::pathGeoNodeConnection() + '/', connName, QgsNewHttpConnection::FlagShowTestConnection, fl )
+                          QgsGeoNodeConnectionUtils::pathGeoNodeConnection() + '/', connName,
+                          QgsNewHttpConnection::FlagShowTestConnection | QgsNewHttpConnection::FlagHideAuthenticationGroup, fl )
 {
   setWindowTitle( tr( "Create a New GeoNode Connection" ) );
-
   updateServiceSpecificSettings();
-
   connect( testConnectButton(), &QPushButton::clicked, this, &QgsGeoNodeNewConnection::testConnection );
 }
 

--- a/src/providers/geonode/qgsgeonodenewconnection.cpp
+++ b/src/providers/geonode/qgsgeonodenewconnection.cpp
@@ -21,8 +21,8 @@
 #include "qgsgeonoderequest.h"
 
 /* For now we are hiding away authentication options since
-   there is no support yet for authentication in the GeoNode
-   We will re-enable this when this limitation changes. 
+   there is no support yet for authentication in GeoNode's API.
+   We will re-enable this when this limitation changes.
    See https://github.com/GeoNode/geonode/issues/3442 TS */
 
 QgsGeoNodeNewConnection::QgsGeoNodeNewConnection( QWidget *parent, const QString &connName, Qt::WindowFlags fl )

--- a/src/providers/geonode/qgsgeonodenewconnection.cpp
+++ b/src/providers/geonode/qgsgeonodenewconnection.cpp
@@ -21,8 +21,9 @@
 #include "qgsgeonoderequest.h"
 
 // For now we are hiding away authentication options since
-// there is no support yet for tication in the GeoNode
-// We will re-enable this when this limitation changes. TS
+// there is no support yet for authentication in the GeoNode
+// We will re-enable this when this limitation changes. 
+// See https://github.com/GeoNode/geonode/issues/3442 TS
 QgsGeoNodeNewConnection::QgsGeoNodeNewConnection( QWidget *parent, const QString &connName, Qt::WindowFlags fl )
   : QgsNewHttpConnection( parent, QgsNewHttpConnection::ConnectionWfs | QgsNewHttpConnection::ConnectionWms,
                           QgsGeoNodeConnectionUtils::pathGeoNodeConnection() + '/', connName,

--- a/src/providers/geonode/qgsgeonodenewconnection.cpp
+++ b/src/providers/geonode/qgsgeonodenewconnection.cpp
@@ -20,10 +20,11 @@
 #include "qgsgeonodeconnection.h"
 #include "qgsgeonoderequest.h"
 
-// For now we are hiding away authentication options since
-// there is no support yet for authentication in the GeoNode
-// We will re-enable this when this limitation changes. 
-// See https://github.com/GeoNode/geonode/issues/3442 TS
+/* For now we are hiding away authentication options since
+   there is no support yet for authentication in the GeoNode
+   We will re-enable this when this limitation changes. 
+   See https://github.com/GeoNode/geonode/issues/3442 TS */
+
 QgsGeoNodeNewConnection::QgsGeoNodeNewConnection( QWidget *parent, const QString &connName, Qt::WindowFlags fl )
   : QgsNewHttpConnection( parent, QgsNewHttpConnection::ConnectionWfs | QgsNewHttpConnection::ConnectionWms,
                           QgsGeoNodeConnectionUtils::pathGeoNodeConnection() + '/', connName,


### PR DESCRIPTION
For now we deal with this by adding a flag to QgsNewHttpConnection that allows you to hide the authentication group until GeoNode API supports authentication.

With ``QgsNewHttpConnection::FlagHideAuthenticationGroup`` set (in GeoNode connection dialog):

![screen shot 2017-11-14 at 23 53 51](https://user-images.githubusercontent.com/178003/32807468-997a500a-c998-11e7-9f70-09d6c2e7d3ac.png)

With ``QgsNewHttpConnection::FlagHideAuthenticationGroup`` omitted (default behaviour) e.g. in WMS connection dialog:

![screen shot 2017-11-14 at 23 54 07](https://user-images.githubusercontent.com/178003/32807506-b9ead7b0-c998-11e7-82cf-033002de3ad8.png)


## Description

The GeoNode API does not yet support authentication through the API, only from the underlying backend. In the future we will probably work for GeoNode to support authentication through their API but for now we are excluding the authentication options which do nothing which is confusing and misleading to users.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit