### PR TITLE
[auth] Thread safe auth methods with recursive mutex

### DIFF
--- a/python/core/auth/qgsauthmethod.sip
+++ b/python/core/auth/qgsauthmethod.sip
@@ -34,6 +34,11 @@ class QgsAuthMethod : QObject
     typedef QFlags<QgsAuthMethod::Expansion> Expansions;
 
 
+    ~QgsAuthMethod();
+%Docstring
+Destructor: delete the mutex
+%End
+
     virtual QString key() const = 0;
 %Docstring
 A non-translated short name representing the auth method
@@ -151,6 +156,7 @@ Increment this if method is significantly updated, allow updater code to be writ
    Non-public since this is an abstract base class
 %End
 
+
     static QString authMethodTag();
 %Docstring
 Tag signifying that this is an authentcation method (e.g. for use as title in message log panel output)
@@ -170,6 +176,7 @@ Set the support expansions (points in providers where the authentication is inje
 %Docstring
 Set list of data providers this auth method supports
 %End
+
 
 };
 QFlags<QgsAuthMethod::Expansion> operator|(QgsAuthMethod::Expansion f1, QFlags<QgsAuthMethod::Expansion> f2);

--- a/python/core/auth/qgsauthmethod.sip
+++ b/python/core/auth/qgsauthmethod.sip
@@ -34,11 +34,6 @@ class QgsAuthMethod : QObject
     typedef QFlags<QgsAuthMethod::Expansion> Expansions;
 
 
-    ~QgsAuthMethod();
-%Docstring
-Destructor: delete the mutex
-%End
-
     virtual QString key() const = 0;
 %Docstring
 A non-translated short name representing the auth method

--- a/src/auth/basic/qgsauthbasicmethod.cpp
+++ b/src/auth/basic/qgsauthbasicmethod.cpp
@@ -44,6 +44,7 @@ QgsAuthBasicMethod::QgsAuthBasicMethod()
                     << QStringLiteral( "wms" )
                     << QStringLiteral( "ogr" )
                     << QStringLiteral( "proxy" ) );
+
 }
 
 QString QgsAuthBasicMethod::key() const
@@ -65,7 +66,7 @@ bool QgsAuthBasicMethod::updateNetworkRequest( QNetworkRequest &request, const Q
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-
+  QMutexLocker locker( mMutex );
   QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
   if ( !mconfig.isValid() )
   {
@@ -86,6 +87,8 @@ bool QgsAuthBasicMethod::updateNetworkRequest( QNetworkRequest &request, const Q
 bool QgsAuthBasicMethod::updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg,
     const QString &dataprovider )
 {
+  Q_UNUSED( dataprovider )
+  QMutexLocker locker( mMutex );
   QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
   if ( !mconfig.isValid() )
   {
@@ -277,6 +280,7 @@ bool QgsAuthBasicMethod::updateDataSourceUriItems( QStringList &connectionItems,
 bool QgsAuthBasicMethod::updateNetworkProxy( QNetworkProxy &proxy, const QString &authcfg, const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
+  QMutexLocker locker( mMutex );
 
   QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
   if ( !mconfig.isValid() )
@@ -298,6 +302,7 @@ bool QgsAuthBasicMethod::updateNetworkProxy( QNetworkProxy &proxy, const QString
 
 void QgsAuthBasicMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
+  QMutexLocker locker( mMutex );
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
     QgsDebugMsg( "Updating old style auth method config" );
@@ -319,7 +324,7 @@ void QgsAuthBasicMethod::clearCachedConfig( const QString &authcfg )
 
 QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg, bool fullconfig )
 {
-  QMutexLocker locker( &mConfigMutex );
+  QMutexLocker locker( mMutex );
   QgsAuthMethodConfig mconfig;
 
   // check if it is cached
@@ -338,7 +343,6 @@ QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg,
   }
 
   // cache bundle
-  locker.unlock();
   putMethodConfig( authcfg, mconfig );
 
   return mconfig;
@@ -346,14 +350,14 @@ QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg,
 
 void QgsAuthBasicMethod::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
 {
-  QMutexLocker locker( &mConfigMutex );
+  QMutexLocker locker( mMutex );
   QgsDebugMsg( QString( "Putting basic config for authcfg: %1" ).arg( authcfg ) );
   sAuthConfigCache.insert( authcfg, mconfig );
 }
 
 void QgsAuthBasicMethod::removeMethodConfig( const QString &authcfg )
 {
-  QMutexLocker locker( &mConfigMutex );
+  QMutexLocker locker( mMutex );
   if ( sAuthConfigCache.contains( authcfg ) )
   {
     sAuthConfigCache.remove( authcfg );

--- a/src/auth/basic/qgsauthbasicmethod.cpp
+++ b/src/auth/basic/qgsauthbasicmethod.cpp
@@ -66,7 +66,7 @@ bool QgsAuthBasicMethod::updateNetworkRequest( QNetworkRequest &request, const Q
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
   if ( !mconfig.isValid() )
   {
@@ -88,7 +88,7 @@ bool QgsAuthBasicMethod::updateDataSourceUriItems( QStringList &connectionItems,
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
   if ( !mconfig.isValid() )
   {
@@ -280,7 +280,7 @@ bool QgsAuthBasicMethod::updateDataSourceUriItems( QStringList &connectionItems,
 bool QgsAuthBasicMethod::updateNetworkProxy( QNetworkProxy &proxy, const QString &authcfg, const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
 
   QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
   if ( !mconfig.isValid() )
@@ -302,7 +302,7 @@ bool QgsAuthBasicMethod::updateNetworkProxy( QNetworkProxy &proxy, const QString
 
 void QgsAuthBasicMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
     QgsDebugMsg( "Updating old style auth method config" );
@@ -324,7 +324,7 @@ void QgsAuthBasicMethod::clearCachedConfig( const QString &authcfg )
 
 QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg, bool fullconfig )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsAuthMethodConfig mconfig;
 
   // check if it is cached
@@ -350,14 +350,14 @@ QgsAuthMethodConfig QgsAuthBasicMethod::getMethodConfig( const QString &authcfg,
 
 void QgsAuthBasicMethod::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsDebugMsg( QString( "Putting basic config for authcfg: %1" ).arg( authcfg ) );
   sAuthConfigCache.insert( authcfg, mconfig );
 }
 
 void QgsAuthBasicMethod::removeMethodConfig( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( sAuthConfigCache.contains( authcfg ) )
   {
     sAuthConfigCache.remove( authcfg );

--- a/src/auth/basic/qgsauthbasicmethod.h
+++ b/src/auth/basic/qgsauthbasicmethod.h
@@ -63,7 +63,6 @@ class QgsAuthBasicMethod : public QgsAuthMethod
 
     static QMap<QString, QgsAuthMethodConfig> sAuthConfigCache;
 
-    QMutex mConfigMutex;
 };
 
 #endif // QGSAUTHBASICMETHOD_H

--- a/src/auth/identcert/qgsauthidentcertmethod.cpp
+++ b/src/auth/identcert/qgsauthidentcertmethod.cpp
@@ -52,7 +52,7 @@ QgsAuthIdentCertMethod::QgsAuthIdentCertMethod()
 
 QgsAuthIdentCertMethod::~QgsAuthIdentCertMethod()
 {
-  QMutexLocker locker( &mConfigMutex );
+  QMutexLocker locker( mMutex );
   qDeleteAll( sPkiConfigBundleCache );
   sPkiConfigBundleCache.clear();
 }
@@ -76,6 +76,7 @@ bool QgsAuthIdentCertMethod::updateNetworkRequest( QNetworkRequest &request, con
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
+  QMutexLocker locker( mMutex );
 
   // TODO: is this too restrictive, to intercept only HTTPS connections?
   if ( request.url().scheme().toLower() != QLatin1String( "https" ) )
@@ -110,6 +111,7 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
+  QMutexLocker locker( mMutex );
 
   QgsDebugMsg( QString( "Update URI items for authcfg: %1" ).arg( authcfg ) );
 
@@ -208,6 +210,7 @@ void QgsAuthIdentCertMethod::clearCachedConfig( const QString &authcfg )
 
 void QgsAuthIdentCertMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
+  QMutexLocker locker( mMutex );
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
     QgsDebugMsg( "Updating old style auth method config" );
@@ -222,7 +225,7 @@ void QgsAuthIdentCertMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 
 QgsPkiConfigBundle *QgsAuthIdentCertMethod::getPkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( &mConfigMutex );
+  QMutexLocker locker( mMutex );
   QgsPkiConfigBundle *bundle = nullptr;
 
   // check if it is cached
@@ -267,7 +270,6 @@ QgsPkiConfigBundle *QgsAuthIdentCertMethod::getPkiConfigBundle( const QString &a
 
   bundle = new QgsPkiConfigBundle( mconfig, clientcert, clientkey );
 
-  locker.unlock();
   // cache bundle
   putPkiConfigBundle( authcfg, bundle );
 
@@ -276,14 +278,14 @@ QgsPkiConfigBundle *QgsAuthIdentCertMethod::getPkiConfigBundle( const QString &a
 
 void QgsAuthIdentCertMethod::putPkiConfigBundle( const QString &authcfg, QgsPkiConfigBundle *pkibundle )
 {
-  QMutexLocker locker( &mConfigMutex );
+  QMutexLocker locker( mMutex );
   QgsDebugMsg( QString( "Putting PKI bundle for authcfg %1" ).arg( authcfg ) );
   sPkiConfigBundleCache.insert( authcfg, pkibundle );
 }
 
 void QgsAuthIdentCertMethod::removePkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( &mConfigMutex );
+  QMutexLocker locker( mMutex );
   if ( sPkiConfigBundleCache.contains( authcfg ) )
   {
     QgsPkiConfigBundle *pkibundle = sPkiConfigBundleCache.take( authcfg );

--- a/src/auth/identcert/qgsauthidentcertmethod.cpp
+++ b/src/auth/identcert/qgsauthidentcertmethod.cpp
@@ -52,7 +52,7 @@ QgsAuthIdentCertMethod::QgsAuthIdentCertMethod()
 
 QgsAuthIdentCertMethod::~QgsAuthIdentCertMethod()
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   qDeleteAll( sPkiConfigBundleCache );
   sPkiConfigBundleCache.clear();
 }
@@ -76,7 +76,7 @@ bool QgsAuthIdentCertMethod::updateNetworkRequest( QNetworkRequest &request, con
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
 
   // TODO: is this too restrictive, to intercept only HTTPS connections?
   if ( request.url().scheme().toLower() != QLatin1String( "https" ) )
@@ -111,7 +111,7 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
 
   QgsDebugMsg( QString( "Update URI items for authcfg: %1" ).arg( authcfg ) );
 
@@ -210,7 +210,7 @@ void QgsAuthIdentCertMethod::clearCachedConfig( const QString &authcfg )
 
 void QgsAuthIdentCertMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
     QgsDebugMsg( "Updating old style auth method config" );
@@ -225,7 +225,7 @@ void QgsAuthIdentCertMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 
 QgsPkiConfigBundle *QgsAuthIdentCertMethod::getPkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsPkiConfigBundle *bundle = nullptr;
 
   // check if it is cached
@@ -278,14 +278,14 @@ QgsPkiConfigBundle *QgsAuthIdentCertMethod::getPkiConfigBundle( const QString &a
 
 void QgsAuthIdentCertMethod::putPkiConfigBundle( const QString &authcfg, QgsPkiConfigBundle *pkibundle )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsDebugMsg( QString( "Putting PKI bundle for authcfg %1" ).arg( authcfg ) );
   sPkiConfigBundleCache.insert( authcfg, pkibundle );
 }
 
 void QgsAuthIdentCertMethod::removePkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( sPkiConfigBundleCache.contains( authcfg ) )
   {
     QgsPkiConfigBundle *pkibundle = sPkiConfigBundleCache.take( authcfg );

--- a/src/auth/identcert/qgsauthidentcertmethod.h
+++ b/src/auth/identcert/qgsauthidentcertmethod.h
@@ -59,7 +59,6 @@ class QgsAuthIdentCertMethod : public QgsAuthMethod
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
 
-    QMutex mConfigMutex;
 };
 
 #endif // QGSAUTHIDENTCERTMETHOD_H

--- a/src/auth/pkipaths/qgsauthpkipathsmethod.cpp
+++ b/src/auth/pkipaths/qgsauthpkipathsmethod.cpp
@@ -53,7 +53,7 @@ QgsAuthPkiPathsMethod::QgsAuthPkiPathsMethod()
 
 QgsAuthPkiPathsMethod::~QgsAuthPkiPathsMethod()
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   qDeleteAll( sPkiConfigBundleCache );
   sPkiConfigBundleCache.clear();
 }
@@ -77,7 +77,7 @@ bool QgsAuthPkiPathsMethod::updateNetworkRequest( QNetworkRequest &request, cons
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
 
   // TODO: is this too restrictive, to intercept only HTTPS connections?
   if ( request.url().scheme().toLower() != QLatin1String( "https" ) )
@@ -125,7 +125,7 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
 
   QgsDebugMsg( QString( "Update URI items for authcfg: %1" ).arg( authcfg ) );
 
@@ -239,13 +239,13 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
 
 void QgsAuthPkiPathsMethod::clearCachedConfig( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   removePkiConfigBundle( authcfg );
 }
 
 void QgsAuthPkiPathsMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
     QgsDebugMsg( "Updating old style auth method config" );
@@ -262,7 +262,7 @@ void QgsAuthPkiPathsMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 
 QgsPkiConfigBundle *QgsAuthPkiPathsMethod::getPkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsPkiConfigBundle *bundle = nullptr;
 
   // check if it is cached
@@ -313,14 +313,14 @@ QgsPkiConfigBundle *QgsAuthPkiPathsMethod::getPkiConfigBundle( const QString &au
 
 void QgsAuthPkiPathsMethod::putPkiConfigBundle( const QString &authcfg, QgsPkiConfigBundle *pkibundle )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsDebugMsg( QString( "Putting PKI bundle for authcfg %1" ).arg( authcfg ) );
   sPkiConfigBundleCache.insert( authcfg, pkibundle );
 }
 
 void QgsAuthPkiPathsMethod::removePkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( sPkiConfigBundleCache.contains( authcfg ) )
   {
     QgsPkiConfigBundle *pkibundle = sPkiConfigBundleCache.take( authcfg );

--- a/src/auth/pkipaths/qgsauthpkipathsmethod.h
+++ b/src/auth/pkipaths/qgsauthpkipathsmethod.h
@@ -59,8 +59,6 @@ class QgsAuthPkiPathsMethod : public QgsAuthMethod
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
 
-    QMutex mConfigMutex;
-
 };
 
 #endif // QGSAUTHPKIPATHSMETHOD_H

--- a/src/auth/pkipkcs12/qgsauthpkcs12method.cpp
+++ b/src/auth/pkipkcs12/qgsauthpkcs12method.cpp
@@ -76,7 +76,7 @@ bool QgsAuthPkcs12Method::updateNetworkRequest( QNetworkRequest &request, const 
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
 
   // TODO: is this too restrictive, to intercept only HTTPS connections?
   if ( request.url().scheme().toLower() != QLatin1String( "https" ) )
@@ -124,7 +124,7 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
 
   QgsDebugMsg( QString( "Update URI items for authcfg: %1" ).arg( authcfg ) );
 
@@ -238,13 +238,13 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
 
 void QgsAuthPkcs12Method::clearCachedConfig( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   removePkiConfigBundle( authcfg );
 }
 
 void QgsAuthPkcs12Method::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
     QgsDebugMsg( "Updating old style auth method config" );
@@ -260,7 +260,7 @@ void QgsAuthPkcs12Method::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 
 QgsPkiConfigBundle *QgsAuthPkcs12Method::getPkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsPkiConfigBundle *bundle = nullptr;
 
   // check if it is cached
@@ -334,14 +334,14 @@ QgsPkiConfigBundle *QgsAuthPkcs12Method::getPkiConfigBundle( const QString &auth
 
 void QgsAuthPkcs12Method::putPkiConfigBundle( const QString &authcfg, QgsPkiConfigBundle *pkibundle )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   QgsDebugMsg( QString( "Putting PKI bundle for authcfg %1" ).arg( authcfg ) );
   sPkiConfigBundleCache.insert( authcfg, pkibundle );
 }
 
 void QgsAuthPkcs12Method::removePkiConfigBundle( const QString &authcfg )
 {
-  QMutexLocker locker( mMutex );
+  QMutexLocker locker( &mMutex );
   if ( sPkiConfigBundleCache.contains( authcfg ) )
   {
     QgsPkiConfigBundle *pkibundle = sPkiConfigBundleCache.take( authcfg );

--- a/src/auth/pkipkcs12/qgsauthpkcs12method.h
+++ b/src/auth/pkipkcs12/qgsauthpkcs12method.h
@@ -60,7 +60,6 @@ class QgsAuthPkcs12Method : public QgsAuthMethod
 
     static QMap<QString, QgsPkiConfigBundle *> sPkiConfigBundleCache;
 
-    QMutex mConfigMutex;
 };
 
 #endif // QGSAUTHPKCS12METHOD_H

--- a/src/core/auth/qgsauthmethod.h
+++ b/src/core/auth/qgsauthmethod.h
@@ -23,6 +23,7 @@
 #include <QNetworkRequest>
 #include <QStringList>
 #include <QUrl>
+#include <QMutex>
 
 #include "qgis_core.h"
 
@@ -57,6 +58,9 @@ class CORE_EXPORT QgsAuthMethod : public QObject
       All = NetworkRequest | NetworkReply | DataSourceUri | GenericDataSourceUri | NetworkProxy
     };
     Q_DECLARE_FLAGS( Expansions, Expansion )
+
+    //! Destructor: delete the mutex
+    ~QgsAuthMethod() { delete mMutex; }
 
     //! A non-translated short name representing the auth method
     virtual QString key() const = 0;
@@ -174,7 +178,9 @@ class CORE_EXPORT QgsAuthMethod : public QObject
     explicit QgsAuthMethod()
       : mExpansions( QgsAuthMethod::Expansions( nullptr ) )
       , mDataProviders( QStringList() )
+      , mMutex( new QMutex( QMutex::RecursionMode::Recursive ) )
     {}
+
 
     //! Tag signifying that this is an authentcation method (e.g. for use as title in message log panel output)
     static QString authMethodTag() { return QObject::tr( "Authentication method" ); }
@@ -190,6 +196,8 @@ class CORE_EXPORT QgsAuthMethod : public QObject
     QgsAuthMethod::Expansions mExpansions;
     QStringList mDataProviders;
     int mVersion = 0;
+    QMutex *mMutex;
+
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAuthMethod::Expansions )
 

--- a/src/core/auth/qgsauthmethod.h
+++ b/src/core/auth/qgsauthmethod.h
@@ -59,9 +59,6 @@ class CORE_EXPORT QgsAuthMethod : public QObject
     };
     Q_DECLARE_FLAGS( Expansions, Expansion )
 
-    //! Destructor: delete the mutex
-    ~QgsAuthMethod() { delete mMutex; }
-
     //! A non-translated short name representing the auth method
     virtual QString key() const = 0;
 
@@ -178,7 +175,7 @@ class CORE_EXPORT QgsAuthMethod : public QObject
     explicit QgsAuthMethod()
       : mExpansions( QgsAuthMethod::Expansions( nullptr ) )
       , mDataProviders( QStringList() )
-      , mMutex( new QMutex( QMutex::RecursionMode::Recursive ) )
+      , mMutex( QMutex::RecursionMode::Recursive )
     {}
 
 
@@ -196,7 +193,7 @@ class CORE_EXPORT QgsAuthMethod : public QObject
     QgsAuthMethod::Expansions mExpansions;
     QStringList mDataProviders;
     int mVersion = 0;
-    QMutex *mMutex;
+    QMutex mMutex;
 
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAuthMethod::Expansions )


### PR DESCRIPTION
Add a mutex to the base class and use that
mutex to protect all public methods of the
authentication methods.
