### PR TITLE
[Rendering] Only render in preview jobs layers that are fast enough

### DIFF
--- a/python/core/qgis.sip
+++ b/python/core/qgis.sip
@@ -241,6 +241,8 @@ const double DEFAULT_LINE_WIDTH;
 const double DEFAULT_SEGMENT_EPSILON;
 
 
+
+
 typedef unsigned long long qgssize;
 
 

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -916,6 +916,7 @@ Time stamp of data source in the moment when data/metadata were loaded by provid
  :rtype: bool
 %End
 
+
   public slots:
 
     void setMinimumScale( double scale );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -440,6 +440,18 @@ const double DEFAULT_LINE_WIDTH = 0.26;
 //! Default snapping tolerance for segments
 const double DEFAULT_SEGMENT_EPSILON = 1e-8;
 
+///@cond PRIVATE
+#ifndef SIP_RUN
+
+//! Delay between the scheduling of 2 preview jobs
+const int PREVIEW_JOB_DELAY_MS = 250;
+
+//! Maximum rendering time for a layer of a preview job
+const int MAXIMUM_LAYER_PREVIEW_TIME_MS = 250;
+#endif
+
+///@endcond
+
 typedef QMap<QString, QString> QgsStringMap SIP_SKIP;
 
 /**

--- a/src/core/qgsdataprovider.cpp
+++ b/src/core/qgsdataprovider.cpp
@@ -41,3 +41,7 @@ void QgsDataProvider::setListening( bool isListening )
   Q_UNUSED( isListening );
 }
 
+bool QgsDataProvider::renderInPreview( double lastRenderingTimeMS, double maxRenderingTimeMS )
+{
+  return lastRenderingTimeMS <= maxRenderingTimeMS;
+}

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -453,6 +453,21 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     virtual void setListening( bool isListening );
 
+    /**
+     * Returns whether the layer must be rendered in preview jobs.
+     *
+     * The base implementation returns lastRenderingTimeMS <= maxRenderingTimeMS
+     *
+     * \param lastRenderingTimeMS last rendering time in milliseconds.
+     * \param maxRenderingTimeMS maximum allowed rendering time in milliseconds.
+     * \returns true if the layer must be rendered.
+     *
+     * \since QGIS 3.0
+     *
+     * \note not available in Python bindings
+     */
+    virtual bool renderInPreview( double lastRenderingTimeMS, double maxRenderingTimeMS ); // SIP_SKIP
+
   signals:
 
     /**

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -882,6 +882,25 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     bool isRefreshOnNotifyEnabled() const { return mIsRefreshOnNofifyEnabled; }
 
+///@cond PRIVATE
+#ifndef SIP_RUN
+
+    /**
+     * Set last rendering time.
+     *
+     * \note not available in Python bindings
+     */
+    void setLastRenderingTime( double time ) { mLastRenderingTime = time; }
+
+    /**
+     * Get last rendering time.
+     *
+     * \note not available in Python bindings
+     */
+    double lastRenderingTime() const { return mLastRenderingTime; }
+#endif
+///@endcond
+
   public slots:
 
     /**
@@ -1209,6 +1228,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Renderer for 3D views
     QgsAbstract3DRenderer *m3DRenderer = nullptr;
 
+    double mLastRenderingTime = 0.0;
 };
 
 Q_DECLARE_METATYPE( QgsMapLayer * )

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -265,6 +265,10 @@ void QgsMapRendererCustomPainterJob::doRender()
       job.renderer->render();
 
       job.renderingTime = layerTime.elapsed();
+      if ( job.layer )
+      {
+        job.layer->setLastRenderingTime( job.renderingTime );
+      }
     }
 
     if ( job.img )

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -242,6 +242,13 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
       continue;
     }
 
+    if ( ( mSettings.flags() & QgsMapSettings::RenderPreviewJob ) &&
+         !ml->dataProvider()->renderInPreview( ml->lastRenderingTime(), MAXIMUM_LAYER_PREVIEW_TIME_MS ) )
+    {
+      QgsDebugMsgLevel( "Layer not rendered because it does not match the renderInPreview criterion", 3 );
+      continue;
+    }
+
     QgsRectangle r1 = mSettings.visibleExtent(), r2;
     QgsCoordinateTransform ct;
 

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -270,6 +270,10 @@ void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
     QgsDebugMsg( "Caught unhandled unknown exception" );
   }
   job.renderingTime = t.elapsed();
+  if ( job.layer )
+  {
+    job.layer->setLastRenderingTime( job.renderingTime );
+  }
   QgsDebugMsgLevel( QString( "job %1 end [%2 ms] (layer %3)" ).arg( reinterpret_cast< quint64 >( &job ), 0, 16 ).arg( job.renderingTime ).arg( job.layer ? job.layer->id() : QString() ), 2 );
 }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -67,7 +67,6 @@ email                : sherman at mrcc.com
 #include "qgsmapthemecollection.h"
 #include <cmath>
 
-
 /**
  * \ingroup gui
  * Deprecated to be deleted, stuff from here should be moved elsewhere.
@@ -2301,7 +2300,7 @@ void QgsMapCanvas::stopPreviewJobs()
 void QgsMapCanvas::schedulePreviewJob( int number )
 {
   mPreviewTimer.setSingleShot( true );
-  mPreviewTimer.setInterval( 250 );
+  mPreviewTimer.setInterval( PREVIEW_JOB_DELAY_MS );
   disconnect( mPreviewTimerConnection );
   mPreviewTimerConnection = connect( &mPreviewTimer, &QTimer::timeout, this, [ = ]()
   {


### PR DESCRIPTION
This implements the improvements discussed in the mailing list thread
https://lists.osgeo.org/pipermail/qgis-developer/2017-November/050524.html
to avoid rendering layers in preview jobs that take too much time to render.
