### PR TITLE
Browser geopackage improvements

### DIFF
--- a/python/gui/qgsnewgeopackagelayerdialog.sip
+++ b/python/gui/qgsnewgeopackagelayerdialog.sip
@@ -19,6 +19,14 @@ class QgsNewGeoPackageLayerDialog: QDialog
 #include "qgsnewgeopackagelayerdialog.h"
 %End
   public:
+
+    enum OverwriteBehavior
+    {
+      Prompt,
+      Overwrite,
+      AddNewLayer,
+    };
+
     QgsNewGeoPackageLayerDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 %Docstring
 Constructor
@@ -40,7 +48,22 @@ Constructor
 
     void setDatabasePath( const QString &path );
 %Docstring
- Sets the the database ``path``
+ Sets the initial database ``path``
+.. versionadded:: 3.0
+%End
+
+    void lockDatabasePath();
+%Docstring
+ Sets the database path widgets to a locked and read-only mode.
+.. versionadded:: 3.0
+%End
+
+    void setOverwriteBehavior( OverwriteBehavior behavior );
+%Docstring
+ Sets the ``behavior`` to use when a path to an existing geopackage file is used.
+
+ The default behavior is to prompt the user for an action to take.
+
 .. versionadded:: 3.0
 %End
 

--- a/src/gui/qgsnewgeopackagelayerdialog.h
+++ b/src/gui/qgsnewgeopackagelayerdialog.h
@@ -31,6 +31,15 @@ class GUI_EXPORT QgsNewGeoPackageLayerDialog: public QDialog, private Ui::QgsNew
     Q_OBJECT
 
   public:
+
+    //! Behavior to use when an existing geopackage already exists
+    enum OverwriteBehavior
+    {
+      Prompt, //!< Prompt user for action
+      Overwrite, //!< Overwrite whole geopackage
+      AddNewLayer, //!< Keep existing contents and add new layer
+    };
+
     //! Constructor
     QgsNewGeoPackageLayerDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
     ~QgsNewGeoPackageLayerDialog();
@@ -48,10 +57,25 @@ class GUI_EXPORT QgsNewGeoPackageLayerDialog: public QDialog, private Ui::QgsNew
     QString databasePath() const { return mDatabaseEdit->text(); }
 
     /**
-     * Sets the the database \a path
+     * Sets the initial database \a path
      * \since QGIS 3.0
      */
     void setDatabasePath( const QString &path ) { mDatabaseEdit->setText( path ); }
+
+    /**
+     * Sets the database path widgets to a locked and read-only mode.
+     * \since QGIS 3.0
+     */
+    void lockDatabasePath();
+
+    /**
+     * Sets the \a behavior to use when a path to an existing geopackage file is used.
+     *
+     * The default behavior is to prompt the user for an action to take.
+     *
+     * \since QGIS 3.0
+     */
+    void setOverwriteBehavior( OverwriteBehavior behavior );
 
   private slots:
     void mAddAttributeButton_clicked();
@@ -78,6 +102,7 @@ class GUI_EXPORT QgsNewGeoPackageLayerDialog: public QDialog, private Ui::QgsNew
     QString mCrsId;
     bool mTableNameEdited = false;
     bool mLayerIdentifierEdited = false;
+    OverwriteBehavior mBehavior = Prompt;
 };
 
 #endif // QGSNEWVECTORLAYERDIALOG_H

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -507,6 +507,8 @@ void QgsGeoPackageCollectionItem::addTable()
   QgsNewGeoPackageLayerDialog dialog( nullptr );
   dialog.setDatabasePath( mPath );
   dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
+  dialog.setOverwriteBehavior( QgsNewGeoPackageLayerDialog::AddNewLayer );
+  dialog.lockDatabasePath();
   if ( dialog.exec() == QDialog::Accepted )
   {
     refreshConnections();

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -505,21 +505,11 @@ void QgsGeoPackageCollectionItem::deleteConnection()
 void QgsGeoPackageCollectionItem::addTable()
 {
   QgsNewGeoPackageLayerDialog dialog( nullptr );
-  QFileInfo fileInfo( mPath );
-  QString connName = fileInfo.fileName();
-  QgsOgrDbConnection connection( connName, QStringLiteral( "GPKG" ) );
-  if ( ! connection.path().isEmpty() )
+  dialog.setDatabasePath( mPath );
+  dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
+  if ( dialog.exec() == QDialog::Accepted )
   {
-    dialog.setDatabasePath( connection.path() );
-    dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
-    if ( dialog.exec() == QDialog::Accepted )
-    {
-      refreshConnections();
-    }
-  }
-  else
-  {
-    QgsDebugMsg( QStringLiteral( "Cannot add Table: connection %1 does not exist or the path is empty!" ).arg( connName ) );
+    refreshConnections();
   }
 }
 


### PR DESCRIPTION
@elpaso 
I noticed that the browser action for gpkg "add new layer" is broken when a connection doesn't exist to the gpkg. I think this is an artificial limitation - it seems to work fine without this requirement.