### PR TITLE
Add a setting to be able to disable preview jobs in main canvas

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -717,7 +717,13 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   connect( mMapCanvas, &QgsMapCanvas::messageEmitted, this, &QgisApp::displayMessage );
   mMapCanvas->setWhatsThis( tr( "Map canvas. This is where raster and vector "
                                 "layers are displayed when added to the map" ) );
-  mMapCanvas->setPreviewJobsEnabled( true );
+
+  if ( settings.value( QStringLiteral( "qgis/main_canvas_preview_jobs" ) ).isNull() )
+  {
+    // So that it appears in advanced settings
+    settings.setValue( QStringLiteral( "qgis/main_canvas_preview_jobs" ), true );
+  }
+  mMapCanvas->setPreviewJobsEnabled( settings.value( QStringLiteral( "qgis/main_canvas_preview_jobs" ), true ).toBool() );
 
   // set canvas color right away
   int myRed = settings.value( QStringLiteral( "qgis/default_canvas_color_red" ), 255 ).toInt();


### PR DESCRIPTION
Can be used by power users to disable preview jobs, for very slow datasources
(especially when network bandwidth is saturated), where it decreases performance.

More clever approaches have been discussed per https://github.com/qgis/QGIS/pull/5645
and https://lists.osgeo.org/pipermail/qgis-developer/2017-November/050524.html,
but at least offer this setting for now, pending further improvements.
