### PR TITLE
Two UX improvements for recent projects menu

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3891,19 +3891,32 @@ void QgisApp::saveRecentProjectPath( const QString &projectPath, bool savePrevie
       projectData.previewImagePath = mRecentProjects.at( idx ).previewImagePath;
   }
 
-  // If this file is already in the list, remove it
-  mRecentProjects.removeAll( projectData );
-
-  // Prepend this file to the list
-  mRecentProjects.prepend( projectData );
-
   // Count the number of pinned items, those shouldn't affect trimming
   int pinnedCount = 0;
+  int nonPinnedPos = 0;
+  bool pinnedTop = true;
   Q_FOREACH ( const QgsWelcomePageItemsModel::RecentProjectData &recentProject, mRecentProjects )
   {
     if ( recentProject.pin )
+    {
       pinnedCount++;
+      if ( pinnedTop )
+      {
+        nonPinnedPos++;
+      }
+    }
+    else if ( pinnedTop )
+    {
+      pinnedTop = false;
+    }
   }
+
+  // If this file is already in the list, remove it
+  mRecentProjects.removeAll( projectData );
+
+  // Insert this file to the list
+  mRecentProjects.insert( projectData.pin ? 0 : nonPinnedPos, projectData );
+
   // Keep the list to 10 items by trimming excess off the bottom
   // And remove the associated image
   while ( mRecentProjects.count() > 10 + pinnedCount )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -736,16 +736,19 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   {
     mRecentProjects.removeAt( row );
     saveRecentProjects();
+    updateRecentProjectPaths();
   } );
   connect( mWelcomePage, &QgsWelcomePage::projectPinned, this, [ this ]( int row )
   {
     mRecentProjects.at( row ).pin = true;
     saveRecentProjects();
+    updateRecentProjectPaths();
   } );
   connect( mWelcomePage, &QgsWelcomePage::projectUnpinned, this, [ this ]( int row )
   {
     mRecentProjects.at( row ).pin = false;
     saveRecentProjects();
+    updateRecentProjectPaths();
   } );
   endProfile();
 
@@ -831,7 +834,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   functionProfile( &QgisApp::createMapTips, this, QStringLiteral( "Create map tips" ) );
   functionProfile( &QgisApp::createDecorations, this, QStringLiteral( "Create decorations" ) );
   functionProfile( &QgisApp::readSettings, this, QStringLiteral( "Read settings" ) );
-  functionProfile( &QgisApp::updateRecentProjectPaths, this, QStringLiteral( "Update recent project paths" ) );
   functionProfile( &QgisApp::updateProjectFromTemplates, this, QStringLiteral( "Update project from templates" ) );
   functionProfile( &QgisApp::legendLayerSelectionChanged, this, QStringLiteral( "Legend layer selection changed" ) );
   functionProfile( &QgisApp::init3D, this, QStringLiteral( "Initialize 3D support" ) );
@@ -857,6 +859,12 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
     projectsTemplateWatcher->addPath( templateDirName );
     connect( projectsTemplateWatcher, &QFileSystemWatcher::directoryChanged, this, [this] { updateProjectFromTemplates(); } );
   }
+
+  // Update welcome page list
+  startProfile( QStringLiteral( "Update recent project paths" ) );
+  updateRecentProjectPaths();
+  mWelcomePage->setRecentProjects( mRecentProjects );
+  endProfile();
 
   // initialize the plugin manager
   startProfile( QStringLiteral( "Plugin manager" ) );
@@ -3819,9 +3827,6 @@ void QgisApp::updateRecentProjectPaths()
     }
   }
 
-  if ( mWelcomePage )
-    mWelcomePage->setRecentProjects( mRecentProjects );
-
 #if defined(Q_OS_WIN)
   QWinJumpList jumplist;
   jumplist.recent()->clear();
@@ -3911,6 +3916,10 @@ void QgisApp::saveRecentProjectPath( const QString &projectPath, bool savePrevie
 
   // Update menu list of paths
   updateRecentProjectPaths();
+
+  // Update welcome page list
+  if ( mWelcomePage )
+    mWelcomePage->setRecentProjects( mRecentProjects );
 
 } // QgisApp::saveRecentProjectPath
 


### PR DESCRIPTION
## Description
This PR improves the UX for the recent projects menu:
- when a recent project is removed / pinned / unpinned through the welcome page's right click menu, the recent projects menu is updated
- when a non-pinned project is opened, it'll be inserted _below_ the pinned projects in the recent projects menu

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
