### PR TITLE
[processing] add vertex id details to extract nodes algorithms

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -186,7 +186,7 @@ qgis:extractspecificnodes: >
 
   The node indices parameter accepts a comma separated string specifying the indices of the nodes to extract. The first node corresponds to an index of 0, the second node has an index of 1, etc. Negative indices can be used to find nodes at the end of the geometry, e.g., an index of -1 corresponds to the last node, -2 corresponds to the second last node, etc.
 
-  Additional fields are added to the nodes indicating the specific node position (e.g., 0, -1, etc), the original node index, distance along the original geometry and bisector angle of node for the original geometry.
+  Additional fields are added to the nodes indicating the specific node position (e.g., 0, -1, etc), the original node index, the node’s part and its index within the part (as well as its ring for polygons), distance along the original geometry and bisector angle of node for the original geometry.
 
 qgis:fieldcalculator: >
   This algorithm computes a new vector layer with the same features of the input layer, but with an additional attribute. The values of this new attribute are computed from each feature using a mathematical formula, based on the properties and attributes of the feature.

--- a/python/plugins/processing/algs/qgis/ExtractSpecificNodes.py
+++ b/python/plugins/processing/algs/qgis/ExtractSpecificNodes.py
@@ -29,6 +29,7 @@ import math
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 from qgis.core import (QgsWkbTypes,
+                       QgsVertexId,
                        QgsFeature,
                        QgsFeatureSink,
                        QgsGeometry,
@@ -74,9 +75,12 @@ class ExtractSpecificNodes(QgisAlgorithm):
         fields = source.fields()
         fields.append(QgsField('node_pos', QVariant.Int))
         fields.append(QgsField('node_index', QVariant.Int))
+        fields.append(QgsField('node_part', QVariant.Int))
+        if QgsWkbTypes.geometryType(source.wkbType()) == QgsWkbTypes.PolygonGeometry:
+            fields.append(QgsField('node_part_ring', QVariant.Int))
+        fields.append(QgsField('node_part_index', QVariant.Int))
         fields.append(QgsField('distance', QVariant.Double))
         fields.append(QgsField('angle', QVariant.Double))
-        fields.append(QgsField('NUM_FIELD', QVariant.Int))
 
         wkb_type = QgsWkbTypes.Point
         if QgsWkbTypes.hasM(source.wkbType()):
@@ -118,6 +122,8 @@ class ExtractSpecificNodes(QgisAlgorithm):
                     if node_index < 0 or node_index >= total_nodes:
                         continue
 
+                    (success, vertex_id) = input_geometry.vertexIdFromVertexNr(node_index)
+
                     distance = input_geometry.distanceToVertex(node_index)
                     angle = math.degrees(input_geometry.angleAtVertex(node_index))
 
@@ -125,6 +131,10 @@ class ExtractSpecificNodes(QgisAlgorithm):
                     attrs = f.attributes()
                     attrs.append(node)
                     attrs.append(node_index)
+                    attrs.append(vertex_id.part)
+                    if QgsWkbTypes.geometryType(source.wkbType()) == QgsWkbTypes.PolygonGeometry:
+                        attrs.append(vertex_id.ring)
+                    attrs.append(vertex_id.vertex)
                     attrs.append(distance)
                     attrs.append(angle)
                     output_feature.setAttributes(attrs)

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_lines.gfs
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_lines.gfs
@@ -12,6 +12,21 @@
       <ExtentYMax>5.00000</ExtentYMax>
     </DatasetSpecificInfo>
     <PropertyDefn>
+      <Name>node_index</Name>
+      <ElementPath>node_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part</Name>
+      <ElementPath>node_part</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_index</Name>
+      <ElementPath>node_part_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
       <Name>distance</Name>
       <ElementPath>distance</ElementPath>
       <Type>Real</Type>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_lines.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_lines.gml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ogr:FeatureCollection
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation=""
+     xsi:schemaLocation="http://ogr.maptools.org/ extract_nodes_lines.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
      xmlns:gml="http://www.opengis.net/gml">
   <gml:boundedBy>
@@ -15,132 +15,169 @@
     <ogr:extract_nodes_lines fid="lines.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>3.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>22.5</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>2</ogr:node_part_index>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>22.50000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>11,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>6.82842712474619</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>0</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>0.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>2</ogr:node_part_index>
+      <ogr:distance>3.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>0</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>3</ogr:node_part_index>
+      <ogr:distance>4.00000000000000</ogr:distance>
+      <ogr:angle>0.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.3">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.3">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>2.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>90</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>3.00000000000000</ogr:distance>
+      <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0.00000000000000</ogr:distance>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>5.65685424949238</ogr:distance>
-      <ogr:angle>45</ogr:angle>
+      <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_lines fid="lines.6">
+      <ogr:node_index xsi:nil="true"/>
+      <ogr:node_part xsi:nil="true"/>
+      <ogr:node_part_index xsi:nil="true"/>
+      <ogr:distance xsi:nil="true"/>
+      <ogr:angle xsi:nil="true"/>
     </ogr:extract_nodes_lines>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_multilines.gfs
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_multilines.gfs
@@ -12,6 +12,21 @@
       <ExtentYMax>4.11977</ExtentYMax>
     </DatasetSpecificInfo>
     <PropertyDefn>
+      <Name>node_index</Name>
+      <ElementPath>node_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part</Name>
+      <ElementPath>node_part</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_index</Name>
+      <ElementPath>node_part_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
       <Name>distance</Name>
       <ElementPath>distance</ElementPath>
       <Type>Real</Type>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_multilines.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_multilines.gml
@@ -15,6 +15,8 @@
     <ogr:extract_nodes_multilines fid="lines.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -23,6 +25,8 @@
     <ogr:extract_nodes_multilines fid="lines.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>2.00000000000000</ogr:distance>
       <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -31,6 +35,8 @@
     <ogr:extract_nodes_multilines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -39,6 +45,8 @@
     <ogr:extract_nodes_multilines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>2.00000000000000</ogr:distance>
       <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -47,6 +55,8 @@
     <ogr:extract_nodes_multilines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.02418426103647,2.4147792706334</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>2.00000000000000</ogr:distance>
       <ogr:angle>180.97931965433949</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -55,18 +65,27 @@
     <ogr:extract_nodes_multilines fid="lines.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>3.41498595862145</ogr:distance>
       <ogr:angle>180.97931965433949</ogr:angle>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.3">
+      <ogr:node_index xsi:nil="true"/>
+      <ogr:node_part xsi:nil="true"/>
+      <ogr:node_part_index xsi:nil="true"/>
+      <ogr:distance xsi:nil="true"/>
+      <ogr:angle xsi:nil="true"/>
     </ogr:extract_nodes_multilines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>0.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -75,6 +94,8 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>2.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -83,6 +104,8 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>3.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -91,6 +114,8 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>4.00000000000000</ogr:distance>
       <ogr:angle>0.00000000000000</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -99,6 +124,8 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2.94433781190019,4.04721689059501</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>4.00000000000000</ogr:distance>
       <ogr:angle>88.34769532234870</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -107,6 +134,8 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.4595009596929,4.11976967370441</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>6.51620936457033</ogr:distance>
       <ogr:angle>88.34769532234870</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -115,6 +144,8 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>6</ogr:node_index>
+      <ogr:node_part>2</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>6.51620936457033</ogr:distance>
       <ogr:angle>91.18035448020294</ogr:angle>
     </ogr:extract_nodes_multilines>
@@ -123,6 +154,8 @@
     <ogr:extract_nodes_multilines fid="lines.4">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.58042226487524,2.9468330134357</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_index>7</ogr:node_index>
+      <ogr:node_part>2</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>9.09717929727474</ogr:distance>
       <ogr:angle>91.18035448020294</ogr:angle>
     </ogr:extract_nodes_multilines>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_multipolys.gfs
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_multipolys.gfs
@@ -28,6 +28,26 @@
       <Type>Real</Type>
     </PropertyDefn>
     <PropertyDefn>
+      <Name>node_index</Name>
+      <ElementPath>node_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part</Name>
+      <ElementPath>node_part</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_ring</Name>
+      <ElementPath>node_part_ring</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_index</Name>
+      <ElementPath>node_part_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
       <Name>distance</Name>
       <ElementPath>distance</ElementPath>
       <Type>Real</Type>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_multipolys.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_multipolys.gml
@@ -18,6 +18,9 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -29,6 +32,9 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>1.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -40,6 +46,9 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>2.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -51,6 +60,9 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>3.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -62,6 +74,9 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>4.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -73,6 +88,9 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>5</ogr:node_part_index>
       <ogr:distance>6.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -84,6 +102,9 @@
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
       <ogr:node_index>6</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>6</ogr:node_part_index>
       <ogr:distance>8.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -91,7 +112,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -99,7 +126,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>1.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -107,7 +140,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>5.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -115,7 +154,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>6.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -123,7 +168,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>10.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -131,7 +182,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,6</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>10.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -139,7 +196,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>6</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>11.00000000000000</ogr:distance>
       <ogr:angle>180.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -147,7 +210,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,4</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>7</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>12.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -155,7 +224,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,4</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>8</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>13.00000000000000</ogr:distance>
       <ogr:angle>67.50000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -163,7 +238,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>9</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>14.41421356237310</ogr:distance>
       <ogr:angle>22.50000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -171,7 +252,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,6</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>10</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>5</ogr:node_part_index>
       <ogr:distance>15.41421356237310</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -179,7 +266,13 @@
   <gml:featureMember>
     <ogr:extract_nodes_multipolys fid="multipolys.1">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,6</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
       <ogr:node_index>11</ogr:node_index>
+      <ogr:node_part>1</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>6</ogr:node_part_index>
       <ogr:distance>17.41421356237310</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -191,6 +284,9 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -202,6 +298,9 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>1.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -213,6 +312,9 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>2.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -224,6 +326,9 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>3.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -235,6 +340,9 @@
       <ogr:Bintval>2</ogr:Bintval>
       <ogr:Bfloatval>-0.123</ogr:Bfloatval>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>4.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_multipolys>
@@ -244,6 +352,12 @@
       <ogr:Bname>Test</ogr:Bname>
       <ogr:Bintval>3</ogr:Bintval>
       <ogr:Bfloatval>0</ogr:Bfloatval>
+      <ogr:node_index xsi:nil="true"/>
+      <ogr:node_part xsi:nil="true"/>
+      <ogr:node_part_ring xsi:nil="true"/>
+      <ogr:node_part_index xsi:nil="true"/>
+      <ogr:distance xsi:nil="true"/>
+      <ogr:angle xsi:nil="true"/>
     </ogr:extract_nodes_multipolys>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_polys.gfs
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_polys.gfs
@@ -28,6 +28,26 @@
       <Type>Real</Type>
     </PropertyDefn>
     <PropertyDefn>
+      <Name>node_index</Name>
+      <ElementPath>node_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part</Name>
+      <ElementPath>node_part</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_ring</Name>
+      <ElementPath>node_part_ring</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_index</Name>
+      <ElementPath>node_part_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
       <Name>distance</Name>
       <ElementPath>distance</ElementPath>
       <Type>Real</Type>

--- a/python/plugins/processing/tests/testdata/expected/extract_nodes_polys.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_nodes_polys.gml
@@ -18,6 +18,9 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -29,6 +32,9 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>4.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -40,6 +46,9 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>8.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -51,6 +60,9 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>9.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -62,6 +74,9 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>10.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -73,6 +88,9 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>5</ogr:node_part_index>
       <ogr:distance>13.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -84,6 +102,9 @@
       <ogr:intval>33</ogr:intval>
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_index>6</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>6</ogr:node_part_index>
       <ogr:distance>16.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -95,6 +116,9 @@
       <ogr:intval>-33</ogr:intval>
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -106,6 +130,9 @@
       <ogr:intval>-33</ogr:intval>
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>1.41421356237310</ogr:distance>
       <ogr:angle>202.49999999999997</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -117,6 +144,9 @@
       <ogr:intval>-33</ogr:intval>
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>3.41421356237309</ogr:distance>
       <ogr:angle>337.49999999999994</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -128,6 +158,9 @@
       <ogr:intval>-33</ogr:intval>
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>4.82842712474619</ogr:distance>
       <ogr:angle>90.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -136,8 +169,12 @@
     <ogr:extract_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -146,8 +183,12 @@
     <ogr:extract_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,6</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>1.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -156,8 +197,12 @@
     <ogr:extract_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,6</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>2.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -166,8 +211,12 @@
     <ogr:extract_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>3.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -176,8 +225,12 @@
     <ogr:extract_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>4.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -187,7 +240,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -197,7 +254,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>4.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -207,7 +268,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>8.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -217,7 +282,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>12.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -227,7 +296,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>16.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -237,7 +310,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>16.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -247,7 +324,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>6</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>18.00000000000000</ogr:distance>
       <ogr:angle>135.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -257,7 +338,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,-2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>7</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>20.00000000000000</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -267,7 +352,11 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>8</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>22.00000000000000</ogr:distance>
       <ogr:angle>315.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -277,15 +366,26 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_index>9</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>24.00000000000000</ogr:distance>
       <ogr:angle>225.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_nodes_polys fid="polys.4">
+      <ogr:name xsi:nil="true"/>
       <ogr:intval>120</ogr:intval>
       <ogr:floatval>-100291.43213</ogr:floatval>
+      <ogr:node_index xsi:nil="true"/>
+      <ogr:node_part xsi:nil="true"/>
+      <ogr:node_part_ring xsi:nil="true"/>
+      <ogr:node_part_index xsi:nil="true"/>
+      <ogr:distance xsi:nil="true"/>
+      <ogr:angle xsi:nil="true"/>
     </ogr:extract_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -295,6 +395,9 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0.00000000000000</ogr:distance>
       <ogr:angle>99.21747441146101</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -306,6 +409,9 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>3.16227766016838</ogr:distance>
       <ogr:angle>144.21747441146101</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -317,6 +423,9 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>7.16227766016838</ogr:distance>
       <ogr:angle>238.28252558853902</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -328,6 +437,9 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>11.63441361516796</ogr:distance>
       <ogr:angle>328.28252558853899</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -339,6 +451,9 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>14.63441361516796</ogr:distance>
       <ogr:angle>45.00000000000000</ogr:angle>
     </ogr:extract_nodes_polys>
@@ -350,6 +465,9 @@
       <ogr:intval>2</ogr:intval>
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>5</ogr:node_part_index>
       <ogr:distance>15.63441361516796</ogr:distance>
       <ogr:angle>99.21747441146101</ogr:angle>
     </ogr:extract_nodes_polys>

--- a/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_lines.gfs
+++ b/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_lines.gfs
@@ -22,6 +22,16 @@
       <Type>Integer</Type>
     </PropertyDefn>
     <PropertyDefn>
+      <Name>node_part</Name>
+      <ElementPath>node_part</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_index</Name>
+      <ElementPath>node_part_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
       <Name>distance</Name>
       <ElementPath>distance</ElementPath>
       <Type>Real</Type>

--- a/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_lines.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_lines.gml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ogr:FeatureCollection
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation=""
+     xsi:schemaLocation="http://ogr.maptools.org/ extract_specific_nodes_lines.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
      xmlns:gml="http://www.opengis.net/gml">
   <gml:boundedBy>
@@ -12,187 +12,233 @@
   </gml:boundedBy>
                                                                                                                                                              
   <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.1">
+    <ogr:extract_specific_nodes_lines fid="lines.0">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,2</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_pos>0</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>90</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>11,5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-1</ogr:node_pos>
+      <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>3</ogr:node_part_index>
+      <ogr:distance>6.82842712474619</ogr:distance>
+      <ogr:angle>45</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>2</ogr:node_pos>
+      <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>2</ogr:node_part_index>
+      <ogr:distance>4</ogr:distance>
+      <ogr:angle>22.5</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-2</ogr:node_pos>
+      <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>2</ogr:node_part_index>
+      <ogr:distance>4</ogr:distance>
+      <ogr:angle>22.5</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>0</ogr:node_pos>
+      <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>90</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-1</ogr:node_pos>
+      <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>2</ogr:distance>
+      <ogr:angle>90</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-2</ogr:node_pos>
+      <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>90</ogr:angle>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_specific_nodes_lines fid="lines.2">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>11,5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>0</ogr:node_pos>
+      <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>0</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>6.82842712474619</ogr:distance>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>3</ogr:node_part_index>
+      <ogr:distance>4</ogr:distance>
+      <ogr:angle>0</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>2</ogr:node_pos>
+      <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>2</ogr:node_part_index>
+      <ogr:distance>3</ogr:distance>
+      <ogr:angle>45</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-2</ogr:node_pos>
+      <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>2</ogr:node_part_index>
+      <ogr:distance>3</ogr:distance>
       <ogr:angle>45</ogr:angle>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_specific_nodes_lines fid="lines.3">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,3</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>2</ogr:node_pos>
-      <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>22.5</ogr:angle>
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>0</ogr:node_pos>
+      <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>90</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-1</ogr:node_pos>
+      <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>2</ogr:distance>
+      <ogr:angle>90</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-2</ogr:node_pos>
+      <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>90</ogr:angle>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_specific_nodes_lines fid="lines.4">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>0</ogr:node_pos>
+      <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>90</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:node_pos>-1</ogr:node_pos>
+      <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
+      <ogr:distance>3</ogr:distance>
+      <ogr:angle>90</ogr:angle>
+    </ogr:extract_specific_nodes_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:extract_specific_nodes_lines fid="lines.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_pos>-2</ogr:node_pos>
-      <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>22.5</ogr:angle>
+      <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
+      <ogr:distance>0</ogr:distance>
+      <ogr:angle>90</ogr:angle>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_specific_nodes_lines fid="lines.5">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>0</ogr:node_pos>
-      <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.6">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-1</ogr:node_pos>
-      <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.7">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>-1,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-2</ogr:node_pos>
-      <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.8">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,0</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>0</ogr:node_pos>
-      <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>0</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.9">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-1</ogr:node_pos>
-      <ogr:node_index>3</ogr:node_index>
-      <ogr:distance>4</ogr:distance>
-      <ogr:angle>0</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.10">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>2</ogr:node_pos>
-      <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>45</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.11">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-2</ogr:node_pos>
-      <ogr:node_index>2</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>45</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.12">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,1</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>0</ogr:node_pos>
-      <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.13">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-1</ogr:node_pos>
-      <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>2</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.14">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,1</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-2</ogr:node_pos>
-      <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.15">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>0</ogr:node_pos>
-      <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.16">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-1</ogr:node_pos>
-      <ogr:node_index>1</ogr:node_index>
-      <ogr:distance>3</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.17">
-      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
-      <ogr:node_pos>-2</ogr:node_pos>
-      <ogr:node_index>0</ogr:node_index>
-      <ogr:distance>0</ogr:distance>
-      <ogr:angle>90</ogr:angle>
-    </ogr:extract_specific_nodes_lines>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.18">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_pos>0</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>45</ogr:angle>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.19">
+    <ogr:extract_specific_nodes_lines fid="lines.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>10,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>5.65685424949238</ogr:distance>
       <ogr:angle>45</ogr:angle>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.20">
+    <ogr:extract_specific_nodes_lines fid="lines.5">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:node_pos>-2</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>45</ogr:angle>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
   <gml:featureMember>
-    <ogr:extract_specific_nodes_lines fid="lines.21">
+    <ogr:extract_specific_nodes_lines fid="lines.6">
+      <ogr:node_pos xsi:nil="true"/>
+      <ogr:node_index xsi:nil="true"/>
+      <ogr:node_part xsi:nil="true"/>
+      <ogr:node_part_index xsi:nil="true"/>
+      <ogr:distance xsi:nil="true"/>
+      <ogr:angle xsi:nil="true"/>
     </ogr:extract_specific_nodes_lines>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_polys.gfs
+++ b/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_polys.gfs
@@ -38,6 +38,21 @@
       <Type>Integer</Type>
     </PropertyDefn>
     <PropertyDefn>
+      <Name>node_part</Name>
+      <ElementPath>node_part</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_ring</Name>
+      <ElementPath>node_part_ring</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>node_part_index</Name>
+      <ElementPath>node_part_index</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
       <Name>distance</Name>
       <ElementPath>distance</ElementPath>
       <Type>Real</Type>

--- a/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_polys.gml
+++ b/python/plugins/processing/tests/testdata/expected/extract_specific_nodes_polys.gml
@@ -19,6 +19,9 @@
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_pos>0</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>315</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -31,6 +34,9 @@
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>6</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>6</ogr:node_part_index>
       <ogr:distance>16</ogr:distance>
       <ogr:angle>315</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -43,6 +49,9 @@
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_pos>5</ogr:node_pos>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>5</ogr:node_part_index>
       <ogr:distance>13</ogr:distance>
       <ogr:angle>225</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -55,6 +64,9 @@
       <ogr:floatval>44.123456</ogr:floatval>
       <ogr:node_pos>-5</ogr:node_pos>
       <ogr:node_index>2</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>2</ogr:node_part_index>
       <ogr:distance>8</ogr:distance>
       <ogr:angle>135</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -67,6 +79,9 @@
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_pos>0</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>90</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -79,6 +94,9 @@
       <ogr:floatval>0</ogr:floatval>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>3</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>3</ogr:node_part_index>
       <ogr:distance>4.82842712474619</ogr:distance>
       <ogr:angle>90</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -87,9 +105,13 @@
     <ogr:extract_specific_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_pos>0</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>315</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -98,9 +120,13 @@
     <ogr:extract_specific_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>4</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>4</ogr:distance>
       <ogr:angle>315</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -109,9 +135,13 @@
     <ogr:extract_specific_nodes_polys fid="polys.2">
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,5</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
       <ogr:floatval>0.123</ogr:floatval>
       <ogr:node_pos>-5</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>315</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -121,8 +151,12 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,1</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_pos>0</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>45</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -132,8 +166,12 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>9</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>4</ogr:node_part_index>
       <ogr:distance>24</ogr:distance>
       <ogr:angle>225</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -143,8 +181,12 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_pos>5</ogr:node_pos>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>16</ogr:distance>
       <ogr:angle>225</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -154,16 +196,28 @@
       <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,0</gml:coordinates></gml:Point></ogr:geometryProperty>
       <ogr:name>ASDF</ogr:name>
       <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
       <ogr:node_pos>-5</ogr:node_pos>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>1</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>16</ogr:distance>
       <ogr:angle>225</ogr:angle>
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
     <ogr:extract_specific_nodes_polys fid="polys.4">
+      <ogr:name xsi:nil="true"/>
       <ogr:intval>120</ogr:intval>
       <ogr:floatval>-100291.43213</ogr:floatval>
+      <ogr:node_pos xsi:nil="true"/>
+      <ogr:node_index xsi:nil="true"/>
+      <ogr:node_part xsi:nil="true"/>
+      <ogr:node_part_ring xsi:nil="true"/>
+      <ogr:node_part_index xsi:nil="true"/>
+      <ogr:distance xsi:nil="true"/>
+      <ogr:angle xsi:nil="true"/>
     </ogr:extract_specific_nodes_polys>
   </gml:featureMember>
   <gml:featureMember>
@@ -174,6 +228,9 @@
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_pos>0</ogr:node_pos>
       <ogr:node_index>0</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>0</ogr:node_part_index>
       <ogr:distance>0</ogr:distance>
       <ogr:angle>99.217474411461</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -186,6 +243,9 @@
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_pos>-1</ogr:node_pos>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>5</ogr:node_part_index>
       <ogr:distance>15.634413615168</ogr:distance>
       <ogr:angle>99.217474411461</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -198,6 +258,9 @@
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_pos>5</ogr:node_pos>
       <ogr:node_index>5</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>5</ogr:node_part_index>
       <ogr:distance>15.634413615168</ogr:distance>
       <ogr:angle>99.217474411461</ogr:angle>
     </ogr:extract_specific_nodes_polys>
@@ -210,6 +273,9 @@
       <ogr:floatval>3.33</ogr:floatval>
       <ogr:node_pos>-5</ogr:node_pos>
       <ogr:node_index>1</ogr:node_index>
+      <ogr:node_part>0</ogr:node_part>
+      <ogr:node_part_ring>0</ogr:node_part_ring>
+      <ogr:node_part_index>1</ogr:node_part_index>
       <ogr:distance>3.16227766016838</ogr:distance>
       <ogr:angle>144.217474411461</ogr:angle>
     </ogr:extract_specific_nodes_polys>


### PR DESCRIPTION
## Description
This PR adds a vertex id details to the nodes/vertices extracted from the extract nodes & extract specific nodes' algorithms. The new fields are: 
- node_part
- node_part_ring (polygon-only)
- node_part_index (the index of a node/vertex within its given part / ring)

@nyalldawson , review appreciated as always.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
