### PR TITLE
[processing] preserve field length and precision for temporary outputs

### DIFF
--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -63,7 +63,16 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
   }
   for ( const auto &field : fields )
   {
-    parts << QStringLiteral( "field=%1:%2" ).arg( field.name(), memoryLayerFieldType( field.type() ) );
+    QString lengthPrecision;
+    if ( field.length() > 0 && field.precision() > 0 )
+    {
+      lengthPrecision = QStringLiteral( "(%1,%2)" ).arg( field.length() ).arg( field.precision() );
+    }
+    else if ( field.length() > 0 )
+    {
+      lengthPrecision = QStringLiteral( "(%1)" ).arg( field.length() );
+    }
+    parts << QStringLiteral( "field=%1:%2%3" ).arg( field.name(), memoryLayerFieldType( field.type() ), lengthPrecision );
   }
 
   QString uri = geomType + '?' + parts.join( '&' );

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -263,6 +263,16 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
         myProvider = myMemoryLayer.dataProvider()
         assert myProvider is not None
 
+    def testLengthPrecisionFromUri(self):
+        """Test we can assign length and precision from a uri"""
+        myMemoryLayer = QgsVectorLayer(
+            ('Point?crs=epsg:4326&field=size:double(12,9)&index=yes'),
+            'test',
+            'memory')
+
+        self.assertEqual(myMemoryLayer.fields().field('size').length(), 12)
+        self.assertEqual(myMemoryLayer.fields().field('size').precision(), 9)
+
     def testSaveFields(self):
         # Create a new memory layer with no fields
         myMemoryLayer = QgsVectorLayer(


### PR DESCRIPTION
## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
