### PR TITLE
Return ids of the new child features on duplication

### DIFF
--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -367,10 +367,7 @@ QgsFeature QgsVectorLayerUtils::duplicateFeature( QgsVectorLayer *layer, const Q
           childFeature.setAttribute( fieldPair.first, newFeature.attribute( fieldPair.second ) );
         }
         //call the function for the child
-        duplicateFeature( relation.referencingLayer(), childFeature, project, depth, duplicateFeatureContext );
-
-        //add the new feature id for feedback
-        childFeatureIds.insert( childFeature.id() );
+        childFeatureIds.insert( duplicateFeature( relation.referencingLayer(), childFeature, project, depth, duplicateFeatureContext ).id() );
       }
 
       //store for feedback


### PR DESCRIPTION
When duplicating a feature in QgsVectorLayerUtils::duplicateFeature and this feature has over a relation the child features, we return now the ids of the new created child features in the respone object QgsDuplicateFeatureContext.