### PR TITLE
[Bugfix] Snapping widget: Ensure layer column is fully visible

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -197,18 +197,13 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
     QToolButton *topoButton = new QToolButton();
     topoButton->addAction( mTopologicalEditingAction );
     topoButton->setDefaultAction( mTopologicalEditingAction );
-    if ( mDisplayMode == Widget )
-    {
-      topoButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
-    }
+    topoButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
     layout->addWidget( topoButton );
+
     QToolButton *interButton = new QToolButton();
     interButton->addAction( mIntersectionSnappingAction );
     interButton->setDefaultAction( mIntersectionSnappingAction );
-    if ( mDisplayMode == Widget )
-    {
-      interButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
-    }
+    interButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
     layout->addWidget( interButton );
 
     layout->setContentsMargins( 0, 0, 0, 0 );
@@ -384,8 +379,8 @@ void QgsSnappingWidget::enableIntersectionSnapping( bool enabled )
 
 void QgsSnappingWidget::onSnappingTreeLayersChanged()
 {
+  mLayerTreeView->expandAll();
   mLayerTreeView->resizeColumnToContents( 0 );
-  QTimer::singleShot( 0, mLayerTreeView, &QTreeView::expandAll );
 }
 
 void QgsSnappingWidget::modeButtonTriggered( QAction *action )


### PR DESCRIPTION
When adding, removing and moving layers in the Layers panel, the first column of the snapping widget (in advanced mode) is often resized to the column header, hiding layer name. 
