### PR TITLE
[server] Fix obsolete QUrl method

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1154,7 +1154,7 @@ namespace QgsWms
             layerName = currentLayer->id();
           else if ( !currentLayer->shortName().isEmpty() )
             layerName = currentLayer->shortName();
-          QUrl mapUrl( hrefString );
+          QUrlQuery mapUrl( hrefString );
           mapUrl.addQueryItem( QStringLiteral( "SERVICE" ), QStringLiteral( "WMS" ) );
           mapUrl.addQueryItem( QStringLiteral( "VERSION" ), version );
           mapUrl.addQueryItem( QStringLiteral( "REQUEST" ), QStringLiteral( "GetLegendGraphic" ) );


### PR DESCRIPTION
## Description

Remove the only call to an obsolete QUrl method (https://doc-snapshots.qt.io/qt5-5.9/qurl-obsolete.html) in server.
