### PR TITLE
Ask confirmation before removing a map theme

### DIFF
--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -156,11 +156,17 @@ void QgsMapThemes::applyState( const QString &presetName )
 
 void QgsMapThemes::removeCurrentPreset()
 {
-  Q_FOREACH ( QAction *a, mMenuPresetActions )
+  for ( QAction *actionPreset : qgis::as_const( mMenuPresetActions ) )
   {
-    if ( a->isChecked() )
+    if ( actionPreset->isChecked() )
     {
-      QgsProject::instance()->mapThemeCollection()->removeMapTheme( a->text() );
+      int res = QMessageBox::question( mMenu, tr( "Remove Theme" ),
+                                       trUtf8( "Are you sure you want to remove the existing theme “%1”?" ).arg( actionPreset->text() ),
+                                       QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
+      if ( res != QMessageBox::Yes )
+        return;
+      //remove the selected preset
+      QgsProject::instance()->mapThemeCollection()->removeMapTheme( actionPreset->text() );
       break;
     }
   }

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -163,10 +163,8 @@ void QgsMapThemes::removeCurrentPreset()
       int res = QMessageBox::question( mMenu, tr( "Remove Theme" ),
                                        trUtf8( "Are you sure you want to remove the existing theme “%1”?" ).arg( actionPreset->text() ),
                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
-      if ( res != QMessageBox::Yes )
-        return;
-      //remove the selected preset
-      QgsProject::instance()->mapThemeCollection()->removeMapTheme( actionPreset->text() );
+      if ( res == QMessageBox::Yes )
+        QgsProject::instance()->mapThemeCollection()->removeMapTheme( actionPreset->text() );
       break;
     }
   }


### PR DESCRIPTION
Currently, removing a map theme is processed directly without asking confirmation while a replacement requires one. Both have same consequences (lost for ever) so better ask confirmation before deletion.

Also tried to replace a qforeach without big confidence :) 