### PR TITLE
[FEATURE] Add a name for transactions created from executeSql

### DIFF
--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -84,13 +84,14 @@ Commit transaction.
 Roll back transaction.
 %End
 
-    virtual bool executeSql( const QString &sql, QString &error /Out/, bool isDirty = false ) = 0;
+    virtual bool executeSql( const QString &sql, QString &error /Out/, bool isDirty = false, const QString &name = QString() ) = 0;
 %Docstring
 Execute the ``sql`` string.
 
 :param sql: The sql query to execute
 :param error: The error message
 :param isDirty: Flag to indicate if the underlying data will be modified
+:param name: Name of the transaction ( only used if `isDirty` is true)
 
 :return: true if everything is OK, false otherwise
 %End
@@ -152,7 +153,7 @@ returns the last created savepoint
 Emitted after a rollback
 %End
 
-    void dirtied( const QString &sql );
+    void dirtied( const QString &sql, const QString &name );
 %Docstring
 Emitted if a sql query is executed and the underlying data is modified
 %End

--- a/python/core/qgsvectorlayereditpassthrough.sip
+++ b/python/core/qgsvectorlayereditpassthrough.sip
@@ -41,12 +41,13 @@ class QgsVectorLayerEditPassthrough : QgsVectorLayerEditBuffer
     virtual void rollBack();
 
 
-    bool update( QgsTransaction *transaction, const QString &sql );
+    bool update( QgsTransaction *transaction, const QString &sql, const QString &name );
 %Docstring
 Update underlying data with a SQL query embedded in a transaction.
 
 :param transaction: Transaction in which the sql query has been run
 :param sql: The SQL query updating data
+:param name: The name of the undo/redo command
 
 :return: true if the undo/redo command is well added to the stack, false otherwise
 

--- a/python/core/qgsvectorlayerundopassthroughcommand.sip
+++ b/python/core/qgsvectorlayerundopassthroughcommand.sip
@@ -303,13 +303,14 @@ class QgsVectorLayerUndoPassthroughCommandUpdate : QgsVectorLayerUndoPassthrough
 %End
   public:
 
-    QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer /Transfer/, QgsTransaction *transaction, const QString &sql );
+    QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer /Transfer/, QgsTransaction *transaction, const QString &sql, const QString &name );
 %Docstring
 Constructor for :py:class:`QgsVectorLayerUndoCommandUpdate`
 
 :param buffer: associated edit buffer
 :param transaction: transaction running the sql query
 :param sql: the query
+:param name: The name of the command
 %End
 
     virtual void undo();

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -108,10 +108,11 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
      * \param sql The sql query to execute
      * \param error The error message
      * \param isDirty Flag to indicate if the underlying data will be modified
+     * \param name Name of the transaction ( only used if `isDirty` is true)
      *
      * \returns true if everything is OK, false otherwise
      */
-    virtual bool executeSql( const QString &sql, QString &error SIP_OUT, bool isDirty = false ) = 0;
+    virtual bool executeSql( const QString &sql, QString &error SIP_OUT, bool isDirty = false, const QString &name = QString() ) = 0;
 
     /**
      * Checks if the provider of a given \a layer supports transactions.
@@ -167,7 +168,7 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     /**
      * Emitted if a sql query is executed and the underlying data is modified
      */
-    void dirtied( const QString &sql );
+    void dirtied( const QString &sql, const QString &name );
 
   protected:
     QgsTransaction( const QString &connString ) SIP_SKIP;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4591,11 +4591,11 @@ bool QgsVectorLayer::readExtentFromXml() const
   return mReadExtentFromXml;
 }
 
-void QgsVectorLayer::onDirtyTransaction( const QString &sql )
+void QgsVectorLayer::onDirtyTransaction( const QString &sql, const QString &name )
 {
   QgsTransaction *tr = dataProvider()->transaction();
   if ( tr && mEditBuffer )
   {
-    qobject_cast<QgsVectorLayerEditPassthrough *>( mEditBuffer )->update( tr, sql );
+    qobject_cast<QgsVectorLayerEditPassthrough *>( mEditBuffer )->update( tr, sql, name );
   }
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2236,7 +2236,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onFeatureDeleted( QgsFeatureId fid );
     void onRelationsLoaded();
     void onSymbolsCounted();
-    void onDirtyTransaction( const QString &sql );
+    void onDirtyTransaction( const QString &sql, const QString &name );
 
   protected:
     //! Set the extent

--- a/src/core/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/qgsvectorlayereditpassthrough.cpp
@@ -112,7 +112,7 @@ void QgsVectorLayerEditPassthrough::rollBack()
   mModified = false;
 }
 
-bool QgsVectorLayerEditPassthrough::update( QgsTransaction *tr, const QString &sql )
+bool QgsVectorLayerEditPassthrough::update( QgsTransaction *tr, const QString &sql, const QString &name )
 {
-  return modify( new QgsVectorLayerUndoPassthroughCommandUpdate( this, tr, sql ) );
+  return modify( new QgsVectorLayerUndoPassthroughCommandUpdate( this, tr, sql, name ) );
 }

--- a/src/core/qgsvectorlayereditpassthrough.h
+++ b/src/core/qgsvectorlayereditpassthrough.h
@@ -49,12 +49,13 @@ class CORE_EXPORT QgsVectorLayerEditPassthrough : public QgsVectorLayerEditBuffe
      *
      * \param transaction Transaction in which the sql query has been run
      * \param sql The SQL query updating data
+     * \param name The name of the undo/redo command
      *
      * \returns true if the undo/redo command is well added to the stack, false otherwise
      *
      * \since QGIS 3.0
      */
-    bool update( QgsTransaction *transaction, const QString &sql );
+    bool update( QgsTransaction *transaction, const QString &sql, const QString &name );
 
   private:
     bool mModified;

--- a/src/core/qgsvectorlayerundopassthroughcommand.cpp
+++ b/src/core/qgsvectorlayerundopassthroughcommand.cpp
@@ -352,8 +352,8 @@ void QgsVectorLayerUndoPassthroughCommandRenameAttribute::redo()
   }
 }
 
-QgsVectorLayerUndoPassthroughCommandUpdate::QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer, QgsTransaction *transaction, const QString &sql )
-  : QgsVectorLayerUndoPassthroughCommand( buffer, QObject::tr( "custom transaction" ), false )
+QgsVectorLayerUndoPassthroughCommandUpdate::QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer, QgsTransaction *transaction, const QString &sql, const QString &name )
+  : QgsVectorLayerUndoPassthroughCommand( buffer, name.isEmpty() ? QObject::tr( "custom transaction" ) : name, false )
   , mTransaction( transaction )
   , mSql( sql )
 {

--- a/src/core/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/qgsvectorlayerundopassthroughcommand.h
@@ -297,8 +297,9 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandUpdate : public QgsVectorL
      * \param buffer associated edit buffer
      * \param transaction transaction running the sql query
      * \param sql the query
+     * \param name The name of the command
      */
-    QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer SIP_TRANSFER, QgsTransaction *transaction, const QString &sql );
+    QgsVectorLayerUndoPassthroughCommandUpdate( QgsVectorLayerEditBuffer *buffer SIP_TRANSFER, QgsTransaction *transaction, const QString &sql, const QString &name );
 
     void undo() override;
     void redo() override;

--- a/src/providers/postgres/qgspostgrestransaction.cpp
+++ b/src/providers/postgres/qgspostgrestransaction.cpp
@@ -57,7 +57,7 @@ bool QgsPostgresTransaction::rollbackTransaction( QString &error )
   return false;
 }
 
-bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg, bool isDirty )
+bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg, bool isDirty, const QString &name )
 {
   if ( !mConn )
   {
@@ -91,7 +91,7 @@ bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg, 
   if ( isDirty )
   {
     dirtyLastSavePoint();
-    emit dirtied( sql );
+    emit dirtied( sql, name );
   }
 
   QgsDebugMsg( QString( "Status %1 (OK)" ).arg( r.PQresultStatus() ) );

--- a/src/providers/postgres/qgspostgrestransaction.h
+++ b/src/providers/postgres/qgspostgrestransaction.h
@@ -36,7 +36,7 @@ class QgsPostgresTransaction : public QgsTransaction
      * \param sql The SQL query to execute
      * \param error The error or an empty string if none
      * \param isDirty True to add an undo/redo command in the edition buffer, false otherwise
-     * \param name Name of the transaction ( only used if `isDirty` is true)
+     * \param name Name of the operation ( only used if `isDirty` is true)
      */
     bool executeSql( const QString &sql, QString &error, bool isDirty = false, const QString &name = QString() ) override;
 

--- a/src/providers/postgres/qgspostgrestransaction.h
+++ b/src/providers/postgres/qgspostgrestransaction.h
@@ -29,7 +29,17 @@ class QgsPostgresTransaction : public QgsTransaction
 
   public:
     explicit QgsPostgresTransaction( const QString &connString );
-    bool executeSql( const QString &sql, QString &error, bool isDirty = false ) override;
+
+    /**
+     * Executes the SQL query in database.
+     *
+     * \param sql The SQL query to execute
+     * \param error The error or an empty string if none
+     * \param isDirty True to add an undo/redo command in the edition buffer, false otherwise
+     * \param name Name of the transaction ( only used if `isDirty` is true)
+     */
+    bool executeSql( const QString &sql, QString &error, bool isDirty = false, const QString &name = QString() ) override;
+
     QgsPostgresConn *connection() const { return mConn; }
 
 


### PR DESCRIPTION
## Description

This PR adds the possibility to give a name to a dirty transaction created from the `executeSql` method.

A test has been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
