### PR TITLE
[BUGFIX][Server] GetFeaturInfo: do not identify raster data if point …

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1319,23 +1319,27 @@ namespace QgsWms
           }
           else
           {
+            QgsRasterLayer *rasterLayer = qobject_cast<QgsRasterLayer *>( layer );
+            if ( !rasterLayer )
+            {
+              break;
+            }
+            if ( !infoPoint )
+            {
+              break;
+            }
+            QgsPointXY layerInfoPoint = mapSettings.mapToLayerCoordinates( layer, *( infoPoint.get() ) );
+            if ( !rasterLayer->extent().contains( layerInfoPoint ) )
+            {
+              break;
+            }
             if ( infoFormat == QgsWmsParameters::Format::GML )
             {
               layerElement = result.createElement( QStringLiteral( "gml:featureMember" )/*wfs:FeatureMember*/ );
               getFeatureInfoElement.appendChild( layerElement );
             }
 
-            QgsRasterLayer *rasterLayer = qobject_cast<QgsRasterLayer *>( layer );
-            if ( rasterLayer )
-            {
-              if ( !infoPoint )
-              {
-                break;
-              }
-              QgsPointXY layerInfoPoint = mapSettings.mapToLayerCoordinates( layer, *( infoPoint.get() ) );
-              ( void )featureInfoFromRasterLayer( rasterLayer, mapSettings, &layerInfoPoint, result, layerElement, version );
-              break;
-            }
+            ( void )featureInfoFromRasterLayer( rasterLayer, mapSettings, &layerInfoPoint, result, layerElement, version );
           }
           break;
         }


### PR DESCRIPTION
…not contains

Manual forwardporting #5548 with enhancement for raster data values displayed

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
