### PR TITLE
Use title from template as default in composer manager

### DIFF
--- a/src/app/composer/qgscomposermanager.cpp
+++ b/src/app/composer/qgscomposermanager.cpp
@@ -192,6 +192,10 @@ void QgsComposerManager::mAddButton_clicked()
 {
   QFile templateFile;
   bool loadingTemplate = ( mTemplate->currentIndex() > 0 );
+  QDomDocument templateDoc;
+
+  QString currentTitle;
+
   if ( loadingTemplate )
   {
     if ( mTemplate->currentIndex() == 1 )
@@ -213,13 +217,20 @@ void QgsComposerManager::mAddButton_clicked()
       QMessageBox::warning( this, tr( "Template error" ), tr( "Error, could not read file" ) );
       return;
     }
+
+    if ( templateDoc.setContent( &templateFile, false ) )
+    {
+      QDomElement compositionElem = templateDoc.documentElement().firstChildElement( QStringLiteral( "Composition" ) );
+      if ( !compositionElem.isNull() )
+        currentTitle = compositionElem.attribute( "name" );
+    }
   }
 
   QgsComposer *newComposer = nullptr;
   bool loadedOK = false;
 
   QString title;
-  if ( !QgisApp::instance()->uniqueComposerTitle( this, title, true ) )
+  if ( !QgisApp::instance()->uniqueComposerTitle( this, title, true, currentTitle ) )
   {
     return;
   }
@@ -237,7 +248,6 @@ void QgsComposerManager::mAddButton_clicked()
 
   if ( loadingTemplate )
   {
-    QDomDocument templateDoc;
     if ( templateDoc.setContent( &templateFile, false ) )
     {
       loadedOK = newComposer->loadFromTemplate( templateDoc, true );

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -927,6 +927,8 @@ bool QgsComposition::readXml( const QDomElement &compositionElem, const QDomDocu
     return false;
   }
 
+  setName( compositionElem.attribute( QStringLiteral( "name" ) ) );
+
   //create pages
   bool widthConversionOk, heightConversionOk;
   mPageWidth = compositionElem.attribute( QStringLiteral( "paperWidth" ) ).toDouble( &widthConversionOk );

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -927,8 +927,6 @@ bool QgsComposition::readXml( const QDomElement &compositionElem, const QDomDocu
     return false;
   }
 
-  setName( compositionElem.attribute( QStringLiteral( "name" ) ) );
-
   //create pages
   bool widthConversionOk, heightConversionOk;
   mPageWidth = compositionElem.attribute( QStringLiteral( "paperWidth" ) ).toDouble( &widthConversionOk );


### PR DESCRIPTION
In 2.18 you had to create a new name when you opened a template.
On master you where still able to create a name but it was overwritten by the template name.
This leaded to problems:
- when the template name was empty (without names were created)
- when it was already existing (duplicates were created)

So the sollution:
Use the template name (if empty or not) as default value in the dialog. User can edit it.
If it is already existing, the user has to change it.

Fix: #17478