### PR TITLE
Fedora 26 now provides Qt 5.9, enable 3D in rpm spec for it

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,18 +12,6 @@
 %define builddate %(date '+%a %b %d %Y')
 %endif
 
-# Qt53D support
-# Fedora 26 provides Qt 5.7 which is not supported at the moment.
-# This check may be removed when https://bodhi.fedoraproject.org/updates/FEDORA-2017-c133443edc
-# is pushed to stable
-%if 0%{?fedora} > 26
-%global configure_with_3d -D WITH_3D:BOOL=TRUE
-%global build_with_3d 1
-%else
-%global configure_with_3d -D WITH_3D:BOOL=FALSE
-%global build_with_3d 0
-%endif
-
 Name:           qgis
 Version:        %{_version}
 Release:        %{_relver}%{?dist}
@@ -103,9 +91,7 @@ BuildRequires: qt5-qtwebkit-devel
 BuildRequires: qt5-qtxmlpatterns-devel
 BuildRequires: qtkeychain-qt5-devel
 BuildRequires: qextserialport-devel
-%if 0%{?build_with_3d}
 BuildRequires: qt5-qt3d-devel
-%endif
 
 # Qwt stuff
 BuildRequires: qwt-devel
@@ -223,7 +209,7 @@ gzip ChangeLog
       -D ENABLE_TESTS:BOOL=FALSE \
       -D WITH_QSPATIALITE:BOOL=TRUE \
       -D WITH_SERVER:BOOL=TRUE \
-      %{configure_with_3d} \
+      -D WITH_3D:BOOL=TRUE \
       .
 
       # Using external QEXTSERIALPORT causes segfaults
@@ -331,9 +317,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %{_libdir}/lib%{name}_analysis.so.*
 %{_libdir}/lib%{name}_core.so.*
 %{_libdir}/lib%{name}_gui.so.*
-%if 0%{?build_with_3d}
 %{_libdir}/lib%{name}_3d.so.*
-%endif
 %{_libdir}/%{name}/
 %{_qt5_prefix}/plugins/sqldrivers/libqsqlspatialite.so
 %{_bindir}/%{name}


### PR DESCRIPTION
## Description
Qt 5.9 has finally landed into Fedora 26[1], so 3D can enabled on F26 too.
Build in progress on https://ci.services.vigano.me/#/builders/2/builds/9 but it also builds clean locally.

[1] https://bodhi.fedoraproject.org/updates/FEDORA-2017-c133443edc

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
