### PR TITLE
[server][bugfix] Store requestHandler in threaded storage

### DIFF
--- a/python/server/qgsserverinterface.sip
+++ b/python/server/qgsserverinterface.sip
@@ -35,7 +35,6 @@ class QgsServerInterface
     virtual ~QgsServerInterface();
 
 
-
     virtual QgsCapabilitiesCache *capabilitiesCache() = 0 /KeepReference/;
 %Docstring
  Get pointer to the capabiblities cache

--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -32,6 +32,7 @@
 #include <QStringList>
 #include <QUrl>
 #include <QUrlQuery>
+#include <QDebug>
 
 QgsRequestHandler::QgsRequestHandler( QgsServerRequest &request, QgsServerResponse &response )
   : mExceptionRaised( false )

--- a/src/server/qgsserverinterface.h
+++ b/src/server/qgsserverinterface.h
@@ -71,13 +71,6 @@ class SERVER_EXPORT QgsServerInterface
     virtual void setRequestHandler( QgsRequestHandler *requestHandler ) = 0 SIP_SKIP;
 
     /**
-     * Clear the request handler
-     *
-     * \note not available in Python bindings
-     */
-    virtual void clearRequestHandler() = 0 SIP_SKIP;
-
-    /**
      * Get pointer to the capabiblities cache
      * \returns QgsCapabilitiesCache
      */

--- a/src/server/qgsserverinterfaceimpl.cpp
+++ b/src/server/qgsserverinterfaceimpl.cpp
@@ -27,7 +27,6 @@ QgsServerInterfaceImpl::QgsServerInterfaceImpl( QgsCapabilitiesCache *capCache, 
   , mServiceRegistry( srvRegistry )
   , mServerSettings( settings )
 {
-  mRequestHandler = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   mAccessControls = new QgsAccessControl();
 #else
@@ -49,14 +48,16 @@ QgsServerInterfaceImpl::~QgsServerInterfaceImpl()
 }
 
 
-void QgsServerInterfaceImpl::clearRequestHandler()
+QgsRequestHandler *QgsServerInterfaceImpl::requestHandler()
 {
-  mRequestHandler = nullptr;
+  if ( mRequestHandler.hasLocalData() )
+    return  mRequestHandler.localData();
+  return nullptr;
 }
 
 void QgsServerInterfaceImpl::setRequestHandler( QgsRequestHandler *requestHandler )
 {
-  mRequestHandler = requestHandler;
+  mRequestHandler.setLocalData( requestHandler );
 }
 
 void QgsServerInterfaceImpl::setConfigFilePath( const QString &configFilePath )

--- a/src/server/qgsserverinterfaceimpl.h
+++ b/src/server/qgsserverinterfaceimpl.h
@@ -25,6 +25,8 @@
 #include "qgsserverinterface.h"
 #include "qgscapabilitiescache.h"
 
+#include <QThreadStorage>
+
 /**
  * QgsServerInterface
  * Class defining interfaces exposed by QGIS Server and
@@ -46,10 +48,9 @@ class QgsServerInterfaceImpl : public QgsServerInterface
     ~QgsServerInterfaceImpl();
 
     void setRequestHandler( QgsRequestHandler *requestHandler ) override;
-    void clearRequestHandler() override;
     QgsCapabilitiesCache *capabilitiesCache() override { return mCapabilitiesCache; }
     //! Return the QgsRequestHandler, to be used only in server plugins
-    QgsRequestHandler  *requestHandler() override { return mRequestHandler; }
+    QgsRequestHandler  *requestHandler() override;
     void registerFilter( QgsServerFilter *filter, int priority = 0 ) override;
     QgsServerFiltersMap filters() override { return mFilters; }
     //! Register an access control filter
@@ -78,7 +79,7 @@ class QgsServerInterfaceImpl : public QgsServerInterface
     QgsServerFiltersMap mFilters;
     QgsAccessControl *mAccessControls = nullptr;
     QgsCapabilitiesCache *mCapabilitiesCache = nullptr;
-    QgsRequestHandler *mRequestHandler = nullptr;
+    QThreadStorage<QgsRequestHandler *> mRequestHandler;
     QgsServiceRegistry *mServiceRegistry = nullptr;
     QgsServerSettings *mServerSettings = nullptr;
 };


### PR DESCRIPTION
This fixes an unreported bug about thread safety of the
request handler stored in the QgsServerInterface instance.

When using QgsServer from a threaded server in Python
(this issue did not affect FCGI server implementation
which is not threaded) a race condition could modify
the request handler instance from different threads
making impossible to access the right instance from
the server filters (the Python server plugins).

The proposed solution introduces QThreadStorage as a
mean to keep the correct per-thread instance of the
request handler.
