### PR TITLE
[bugfix] virtual layer test crash

### DIFF
--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -43,12 +43,12 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
   setupUi( this );
   setupButtons( buttonBox );
 
-  connect( mTestButton, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::onTestQuery );
-  connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::onBrowseCRS );
-  connect( mAddLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::onAddLayer );
-  connect( mRemoveLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::onRemoveLayer );
-  connect( mImportLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::onImportLayer );
-  connect( mLayersTable->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &QgsVirtualLayerSourceSelect::onTableRowChanged );
+  connect( mTestButton, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::testQuery );
+  connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::browseCRS );
+  connect( mAddLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::addLayer );
+  connect( mRemoveLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::removeLayer );
+  connect( mImportLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::importLayer );
+  connect( mLayersTable->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &QgsVirtualLayerSourceSelect::tableRowChanged );
 
   // prepare provider list
   Q_FOREACH ( const QString &pk, QgsProviderRegistry::instance()->providerList() )
@@ -72,8 +72,8 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
     }
   }
   updateLayersList();
-  connect( mLayerNameCombo, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsVirtualLayerSourceSelect::onLayerComboChanged );
-  onLayerComboChanged( mLayerNameCombo->currentIndex() );
+  connect( mLayerNameCombo, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsVirtualLayerSourceSelect::layerComboChanged );
+  layerComboChanged( mLayerNameCombo->currentIndex() );
 
   // Prepare embedded layer selection dialog and
   // connect to model changes in the treeview
@@ -97,7 +97,7 @@ void QgsVirtualLayerSourceSelect::refresh()
   updateLayersList();
 }
 
-void QgsVirtualLayerSourceSelect::onLayerComboChanged( int idx )
+void QgsVirtualLayerSourceSelect::layerComboChanged( int idx )
 {
   if ( idx == -1 )
     return;
@@ -145,7 +145,7 @@ void QgsVirtualLayerSourceSelect::onLayerComboChanged( int idx )
   }
 }
 
-void QgsVirtualLayerSourceSelect::onBrowseCRS()
+void QgsVirtualLayerSourceSelect::browseCRS()
 {
   QgsProjectionSelectionDialog crsSelector( this );
   QgsCoordinateReferenceSystem crs( mSrid );
@@ -196,7 +196,7 @@ QgsVirtualLayerDefinition QgsVirtualLayerSourceSelect::getVirtualLayerDef()
   return def;
 }
 
-void QgsVirtualLayerSourceSelect::onTestQuery()
+void QgsVirtualLayerSourceSelect::testQuery()
 {
   QgsVirtualLayerDefinition def = getVirtualLayerDef();
   // If the definition is empty just do nothing.
@@ -216,7 +216,7 @@ void QgsVirtualLayerSourceSelect::onTestQuery()
   }
 }
 
-void QgsVirtualLayerSourceSelect::onAddLayer()
+void QgsVirtualLayerSourceSelect::addLayer()
 {
   mLayersTable->insertRow( mLayersTable->rowCount() );
 
@@ -234,14 +234,14 @@ void QgsVirtualLayerSourceSelect::onAddLayer()
   mLayersTable->setCellWidget( mLayersTable->rowCount() - 1, 2, encodingCombo );
 }
 
-void QgsVirtualLayerSourceSelect::onRemoveLayer()
+void QgsVirtualLayerSourceSelect::removeLayer()
 {
   int currentRow = mLayersTable->selectionModel()->currentIndex().row();
   if ( currentRow != -1 )
     mLayersTable->removeRow( currentRow );
 }
 
-void QgsVirtualLayerSourceSelect::onTableRowChanged( const QModelIndex &current, const QModelIndex &previous )
+void QgsVirtualLayerSourceSelect::tableRowChanged( const QModelIndex &current, const QModelIndex &previous )
 {
   Q_UNUSED( previous );
   mRemoveLayerBtn->setEnabled( current.row() != -1 );
@@ -321,7 +321,7 @@ void QgsVirtualLayerSourceSelect::updateLayersList()
 void QgsVirtualLayerSourceSelect::addEmbeddedLayer( const QString &name, const QString &provider, const QString &encoding, const QString &source )
 {
   // insert a new row
-  onAddLayer();
+  addLayer();
   const int n = mLayersTable->rowCount() - 1;
   // local name
   mLayersTable->item( n, 0 )->setText( name );
@@ -335,7 +335,7 @@ void QgsVirtualLayerSourceSelect::addEmbeddedLayer( const QString &name, const Q
   encodingCombo->setCurrentIndex( encodingCombo->findText( encoding ) );
 }
 
-void QgsVirtualLayerSourceSelect::onImportLayer()
+void QgsVirtualLayerSourceSelect::importLayer()
 {
   if ( mEmbeddedSelectionDialog && mEmbeddedSelectionDialog->exec() == QDialog::Accepted )
   {

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -199,15 +199,20 @@ QgsVirtualLayerDefinition QgsVirtualLayerSourceSelect::getVirtualLayerDef()
 void QgsVirtualLayerSourceSelect::onTestQuery()
 {
   QgsVirtualLayerDefinition def = getVirtualLayerDef();
-
-  std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( def.toString(), QStringLiteral( "test" ), QStringLiteral( "virtual" ) ) );
-  if ( vl->isValid() )
+  // If the definition is empty just do nothing.
+  // TODO: a validation function that can enable/disable the test button
+  //       according to the validity of the active layer definition
+  if ( ! def.toString().isEmpty() )
   {
-    QMessageBox::information( nullptr, tr( "Virtual layer test" ), tr( "No error" ) );
-  }
-  else
-  {
-    QMessageBox::critical( nullptr, tr( "Virtual layer test" ), vl->dataProvider()->error().summary() );
+    std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( def.toString(), QStringLiteral( "test" ), QStringLiteral( "virtual" ) ) );
+    if ( vl->isValid() )
+    {
+      QMessageBox::information( nullptr, tr( "Virtual layer test" ), tr( "No error" ) );
+    }
+    else
+    {
+      QMessageBox::critical( nullptr, tr( "Virtual layer test" ), vl->dataProvider()->error().summary() );
+    }
   }
 }
 

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -44,13 +44,13 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     void addButtonClicked() override;
 
   private slots:
-    void onTestQuery();
-    void onBrowseCRS();
-    void onLayerComboChanged( int );
-    void onAddLayer();
-    void onRemoveLayer();
-    void onImportLayer();
-    void onTableRowChanged( const QModelIndex &current, const QModelIndex &previous );
+    void testQuery();
+    void browseCRS();
+    void layerComboChanged( int );
+    void addLayer();
+    void removeLayer();
+    void importLayer();
+    void tableRowChanged( const QModelIndex &current, const QModelIndex &previous );
     void updateLayersList();
 
 


### PR DESCRIPTION
Fixes 17489  [Data Source Manager] Click the Test button in the virtual layer tab without a query entered crashes QGIS

Requires backporting.