### PR TITLE
Fix memory leaks by using sqlite3_close_v2

### DIFF
--- a/src/core/qgsspatialiteutils.cpp
+++ b/src/core/qgsspatialiteutils.cpp
@@ -75,10 +75,10 @@ sqlite3_statement_unique_ptr spatialite_database_unique_ptr::prepare( const QStr
 
 void QgsSpatialiteCloser::operator()( sqlite3 *handle )
 {
-  int res = sqlite3_close( handle );
+  int res = sqlite3_close_v2( handle );
   if ( res != SQLITE_OK )
   {
-    QgsDebugMsg( QStringLiteral( "sqlite3_close() failed: %1" ).arg( res ) );
+    QgsDebugMsg( QStringLiteral( "sqlite3_close_v2() failed: %1" ).arg( res ) );
   }
 
   spatialite_cleanup_ex( mSpatialiteContext );

--- a/src/core/qgssqliteutils.cpp
+++ b/src/core/qgssqliteutils.cpp
@@ -21,7 +21,7 @@
 
 void QgsSqlite3Closer::operator()( sqlite3 *database )
 {
-  sqlite3_close( database );
+  sqlite3_close_v2( database );
 }
 
 void QgsSqlite3StatementFinalizer::operator()( sqlite3_stmt *statement )


### PR DESCRIPTION
sqlite3_close causes memory leaks if it's called before all associated statements are properly cleaned up.