### PR TITLE
[bugfix] Editing a GPKG layer added by d&d leads

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -935,12 +935,18 @@ void QgsOgrProvider::loadFields()
                      fdef.GetFieldIndex( fidColumn ) < 0;
   if ( mFirstFieldIsFid )
   {
+    QgsField fidField(
+      fidColumn,
+      QVariant::LongLong,
+      QStringLiteral( "Integer64" )
+    );
+    // Set constraints for feature id
+    QgsFieldConstraints constraints = fidField.constraints();
+    constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
+    constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
+    fidField.setConstraints( constraints );
     mAttributeFields.append(
-      QgsField(
-        fidColumn,
-        QVariant::LongLong,
-        QStringLiteral( "Integer64" )
-      )
+      fidField
     );
   }
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -948,6 +948,10 @@ void QgsOgrProvider::loadFields()
     mAttributeFields.append(
       fidField
     );
+    // Set default value for fid, this is needed because
+    // the attribute form will not accept a NULL value, passing
+    // -1 will delegate to the back-end.
+    mDefaultValues.insert( 0, QStringLiteral( "-1" ) );
   }
 
   for ( int i = 0; i < fdef.GetFieldCount(); ++i )
@@ -1199,6 +1203,18 @@ QVariant QgsOgrProvider::defaultValue( int fieldId ) const
 
   ( void )mAttributeFields.at( fieldId ).convertCompatible( resultVar );
   return resultVar;
+}
+
+QString QgsOgrProvider::defaultValueClause( int fieldIndex ) const
+{
+  QString defVal = mDefaultValues.value( fieldIndex, QString() );
+
+  if ( !providerProperty( EvaluateDefaultValues, false ).toBool() && !defVal.isEmpty() )
+  {
+    return defVal;
+  }
+
+  return QString();
 }
 
 void QgsOgrProvider::updateExtents()

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -109,6 +109,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     virtual QgsFields fields() const override;
     virtual QgsRectangle extent() const override;
     QVariant defaultValue( int fieldId ) const override;
+    QString defaultValueClause( int fieldIndex ) const override;
     virtual void updateExtents() override;
     virtual bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = 0 ) override;
     virtual bool deleteFeatures( const QgsFeatureIds &id ) override;

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -108,8 +108,9 @@ class QgsOgrProvider : public QgsVectorDataProvider
     virtual long featureCount() const override;
     virtual QgsFields fields() const override;
     virtual QgsRectangle extent() const override;
-    QVariant defaultValue( int fieldId ) const override;
-    QString defaultValueClause( int fieldIndex ) const override;
+    virtual QVariant defaultValue( int fieldId ) const override;
+    virtual QString defaultValueClause( int fieldIndex ) const override;
+    virtual bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value = QVariant() ) const override;
     virtual void updateExtents() override;
     virtual bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = 0 ) override;
     virtual bool deleteFeatures( const QgsFeatureIds &id ) override;

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -634,7 +634,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         self.assertTrue(vl.commitChanges())
 
     def test_SplitFeature(self):
-        """Test gpkg feature can be splitted"""
+        """Test gpkg feature can be split"""
         tmpfile = os.path.join(self.basetestpath, 'testGeopackageSplitFeatures.gpkg')
         ds = ogr.GetDriverByName('GPKG').CreateDataSource(tmpfile)
         lyr = ds.CreateLayer('test', geom_type=ogr.wkbPolygon)


### PR DESCRIPTION
... to error and data corruption

Fixes #16935 for GPKG (OGR), still  needs to check spatialite

Thanks to Matthias Kuhn for pointing me into the right direction
