### PR TITLE
[Save As] Set fields export options visible only when compatible

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -360,12 +360,12 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
   const QString sFormat( format() );
   if ( sFormat == QLatin1String( "DXF" ) || sFormat == QLatin1String( "DGN" ) )
   {
-    mAttributesSelection->setEnabled( false );
+    mAttributesSelection->setVisible( false );
     selectAllFields = false;
   }
   else
   {
-    mAttributesSelection->setEnabled( true );
+    mAttributesSelection->setVisible( true );
     fieldsAsDisplayedValues = ( sFormat == QLatin1String( "CSV" ) || sFormat == QLatin1String( "XLS" ) || sFormat == QLatin1String( "XLSX" ) || sFormat == QLatin1String( "ODS" ) );
   }
 


### PR DESCRIPTION
with the destination format, instead of simply disabling it. It will be coherent with the way other groups (Custom, Layer, Datasource... options) are handled: made invisible and not grayed.
 
![image](https://user-images.githubusercontent.com/7983394/32082862-c2ddb38a-babe-11e7-80ee-d562c5d824c2.png)
