### PR TITLE
rename metadata() to htmlMetadata() in QgsRasterDataProvider

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -560,8 +560,8 @@ QgsAuthManager        {#qgis_api_break_3_0_QgsAuthManager}
 - getCertIdentity() was renamed to certIdentity()
 - getCertIdentityBundle() was renamed to certIdentityBundle()
 - getCertIdentityBundleToPem() was renamed to certIdentityBundleToPem()
-- getCertIdentities() was renamed to certIdentities() 
-- getCertIdentityIds() was renamed to certIdentityIds() 
+- getCertIdentities() was renamed to certIdentities()
+- getCertIdentityIds() was renamed to certIdentityIds()
 - getSslCertCustomConfig() was renamed to sslCertCustomConfig()
 - getSslCertCustomConfigByHost() was renamed to sslCertCustomConfigByHost()
 - getSslCertCustomConfigs() was renamed to sslCertCustomConfigs()
@@ -573,8 +573,8 @@ QgsAuthManager        {#qgis_api_break_3_0_QgsAuthManager}
 - getMappedDatabaseCAs() was renamed to mappedDatabaseCAs()
 - getCaCertsCache() was renamed to caCertsCache()
 - getCertTrustPolicy() was renamed to certTrustPolicy()
-- getCertificateTrustPolicy() was renamed to certificateTrustPolicy() 
-- getCertTrustCache() was renamed to certTrustCache() 
+- getCertificateTrustPolicy() was renamed to certificateTrustPolicy()
+- getCertTrustCache() was renamed to certTrustCache()
 - getTrustedCaCerts() was renamed to trustedCaCerts()
 - getUntrustedCaCerts() was renamed to untrustedCaCerts()
 - getTrustedCaCertsCache() was renamed to trustedCaCertsCache()
@@ -1406,7 +1406,7 @@ QgsGraphEdge        {#qgis_api_break_3_0_QgsGraphEdge}
 ------------
 
 - outVertex() was renamed as toVertex() (yes, the original name was the opposite of the returned value!)
-- inVertex() was renamed as fromVertex() (yes, the original name was the opposite of the returned value!) 
+- inVertex() was renamed as fromVertex() (yes, the original name was the opposite of the returned value!)
 
 
 QgsGraphVertex        {#qgis_api_break_3_0_QgsGraphVertex}
@@ -1669,7 +1669,7 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 - readStyle() and writeStyle() expect QgsReadWriteContext reference as the last argument
 - readXml() and writeXml() expect QgsReadWriteContext reference as the last argument
 - the invalidTransformInput() slot was removed - calling this slot had no effect
-- metadata() was renamed to htmlMetadata()
+- metadata() was renamed to htmlMetadata() in both QgsMapLayer and QgsRasterDataProvider
 - setMaximumScale() and setMinimumScale(), maximumScale() and minimumScale() had the opposite meaning to other min/max scales in the API, and their definitions have now been swapped. setMaximumScale
 now sets the maximum (i.e. largest scale, or most zoomed in) at which the layer will appear, and setMinimumScale now sets the minimum (i.e. smallest scale,
 or most zoomed out) at which the layer will appear. The same is true for the maximumScale and minimumScale getters.

--- a/python/core/raster/qgsrasterdataprovider.sip
+++ b/python/core/raster/qgsrasterdataprovider.sip
@@ -227,7 +227,7 @@ Get list of user no data value ranges
  :rtype: bool
 %End
 
-    virtual QString metadata() = 0;
+    virtual QString htmlMetadata() = 0;
 %Docstring
  Get metadata in a format suitable for feeding directly
  into a subset of the GUI raster properties "Metadata" tab.

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -258,7 +258,7 @@ QString QgsRasterDataProvider::makeTableCells( QStringList const &values )
   return s;
 } // makeTableCell_
 
-QString QgsRasterDataProvider::metadata()
+QString QgsRasterDataProvider::htmlMetadata()
 {
   QString s;
   return s;

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -300,7 +300,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      * Get metadata in a format suitable for feeding directly
      * into a subset of the GUI raster properties "Metadata" tab.
      */
-    virtual QString metadata() = 0;
+    virtual QString htmlMetadata() = 0;
 
     /**
      * \brief Identify raster value(s) found on the point position. The context

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -237,7 +237,7 @@ static inline QString dumpVariantMap( const QVariantMap &variantMap, const QStri
   return result;
 }
 
-QString QgsAmsProvider::metadata()
+QString QgsAmsProvider::htmlMetadata()
 {
   return dumpVariantMap( mServiceInfo, tr( "Service Info" ) ) + dumpVariantMap( mLayerInfo, tr( "Layer Info" ) );
 }

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -79,7 +79,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     Qgis::DataType dataType( int /*bandNo*/ ) const override { return Qgis::ARGB32; }
     Qgis::DataType sourceDataType( int /*bandNo*/ ) const override { return Qgis::ARGB32; }
     QgsRasterInterface *clone() const override;
-    QString metadata() override;
+    QString htmlMetadata() override;
     bool supportsLegendGraphic() const override { return true; }
     QImage getLegendGraphic( double scale = 0, bool forceRefresh = false, const QgsRectangle *visibleExtent = 0 ) override;
     QgsImageFetcher *getLegendGraphicFetcher( const QgsMapSettings *mapSettings ) override;

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -474,7 +474,7 @@ void QgsGdalProvider::closeDataset()
   mGdalDataset = nullptr;
 }
 
-QString QgsGdalProvider::metadata()
+QString QgsGdalProvider::htmlMetadata()
 {
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -113,7 +113,7 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     double bandScale( int bandNo ) const override;
     double bandOffset( int bandNo ) const override;
     QList<QgsColorRampShader::ColorRampItem> colorTable( int bandNo )const override;
-    QString metadata() override;
+    QString htmlMetadata() override;
     QStringList subLayers() const override;
     static QStringList subLayers( GDALDatasetH dataset );
 

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1230,7 +1230,7 @@ QString QgsWcsProvider::coverageMetadata( const QgsWcsCoverageSummary &coverage 
   return metadata;
 }
 
-QString QgsWcsProvider::metadata()
+QString QgsWcsProvider::htmlMetadata()
 {
   QString metadata;
 

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -173,7 +173,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     int yBlockSize() const override;
     int xSize() const override;
     int ySize() const override;
-    QString metadata() override;
+    QString htmlMetadata() override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QString lastErrorTitle() override;
     QString lastError() override;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1848,7 +1848,7 @@ QString QgsWmsProvider::layerMetadata( QgsWmsLayerProperty &layer )
   return metadata;
 }
 
-QString QgsWmsProvider::metadata()
+QString QgsWmsProvider::htmlMetadata()
 {
   QString metadata;
 

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -200,7 +200,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
     Qgis::DataType dataType( int bandNo ) const override;
     Qgis::DataType sourceDataType( int bandNo ) const override;
     int bandCount() const override;
-    QString metadata() override;
+    QString htmlMetadata() override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QString lastErrorTitle() override;
     QString lastError() override;

--- a/tests/src/core/testqgsrasterfilewriter.cpp
+++ b/tests/src/core/testqgsrasterfilewriter.cpp
@@ -115,7 +115,7 @@ bool TestQgsRasterFileWriter::writeTest( const QString &rasterName )
 
   std::unique_ptr<QgsRasterLayer> mpRasterLayer( new QgsRasterLayer( myRasterFileInfo.filePath(),
       myRasterFileInfo.completeBaseName() ) );
-  qDebug() << rasterName <<  " metadata: " << mpRasterLayer->dataProvider()->metadata();
+  qDebug() << rasterName <<  " metadata: " << mpRasterLayer->dataProvider()->htmlMetadata();
 
   if ( !mpRasterLayer->isValid() ) return false;
 

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -148,17 +148,17 @@ void TestQgsRasterLayer::initTestCase()
   QFileInfo myRasterFileInfo( myFileName );
   mpRasterLayer = new QgsRasterLayer( myRasterFileInfo.filePath(),
                                       myRasterFileInfo.completeBaseName() );
-  qDebug() << "tenbyteraster metadata: " << mpRasterLayer->dataProvider()->metadata();
+  qDebug() << "tenbyteraster metadata: " << mpRasterLayer->dataProvider()->htmlMetadata();
 
   QFileInfo myLandsatRasterFileInfo( myLandsatFileName );
   mpLandsatRasterLayer = new QgsRasterLayer( myLandsatRasterFileInfo.filePath(),
       myLandsatRasterFileInfo.completeBaseName() );
-  qDebug() << "landsat metadata: " << mpLandsatRasterLayer->dataProvider()->metadata();
+  qDebug() << "landsat metadata: " << mpLandsatRasterLayer->dataProvider()->htmlMetadata();
 
   QFileInfo myFloat32RasterFileInfo( myFloat32FileName );
   mpFloat32RasterLayer = new QgsRasterLayer( myFloat32RasterFileInfo.filePath(),
       myFloat32RasterFileInfo.completeBaseName() );
-  qDebug() << "float32raster metadata: " << mpFloat32RasterLayer->dataProvider()->metadata();
+  qDebug() << "float32raster metadata: " << mpFloat32RasterLayer->dataProvider()->htmlMetadata();
 
   QFileInfo pngRasterFileInfo( pngRasterFileName );
   mPngRasterLayer = new QgsRasterLayer( pngRasterFileInfo.filePath(),

--- a/tests/src/core/testqgsrastersublayer.cpp
+++ b/tests/src/core/testqgsrastersublayer.cpp
@@ -96,8 +96,8 @@ void TestQgsRasterSubLayer::initTestCase()
     QFileInfo myRasterFileInfo( mFileName );
     mpRasterLayer = new QgsRasterLayer( myRasterFileInfo.filePath(),
                                         myRasterFileInfo.completeBaseName() );
-    qDebug() << "raster metadata: " << mpRasterLayer->dataProvider()->metadata();
-    mReport += "raster metadata: " + mpRasterLayer->dataProvider()->metadata();
+    qDebug() << "raster metadata: " << mpRasterLayer->dataProvider()->htmlMetadata();
+    mReport += "raster metadata: " + mpRasterLayer->dataProvider()->htmlMetadata();
   }
   else
   {


### PR DESCRIPTION
## Description

Can we merge this small API break? @nyalldawson started this API break a few months ago in QgsMapLayer. It would be good to have the same in QgsRasterDataProvider.

I'm updating raster providers to display their own HTML in the metadata HTML

In QgsVectorDataProvider, the metadata property is not a HTML string so I'm not updating it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
