### PR TITLE
[ui] split Z/M values checkbox in new memory layer dialog

### DIFF
--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -98,8 +98,13 @@ QgsWkbTypes::Type QgsNewMemoryLayerDialog::selectedType() const
     wkbType = QgsWkbTypes::MultiPolygon;
   }
 
-  if ( mGeometryWithZCheckBox->isChecked() && wkbType != QgsWkbTypes::Unknown && wkbType != QgsWkbTypes::NoGeometry )
-    wkbType = QgsWkbTypes::zmType( wkbType, true, true );
+  if ( wkbType != QgsWkbTypes::Unknown && wkbType != QgsWkbTypes::NoGeometry )
+  {
+    if ( mGeometryWithZCheckBox->isChecked() )
+      wkbType = QgsWkbTypes::addZ( wkbType );
+    if ( mGeometryWithMCheckBox->isChecked() )
+      wkbType = QgsWkbTypes::addM( wkbType );
+  }
 
   return wkbType;
 }

--- a/src/ui/qgsnewmemorylayerdialogbase.ui
+++ b/src/ui/qgsnewmemorylayerdialogbase.ui
@@ -79,11 +79,22 @@
        </layout>
       </item>
       <item>
-       <widget class="QCheckBox" name="mGeometryWithZCheckBox">
-        <property name="text">
-         <string>Geometries with Z/M coordinate</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="mGeometryWithZCheckBox">
+          <property name="text">
+           <string>Include Z dimension</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="mGeometryWithMCheckBox">
+          <property name="text">
+           <string>Include M values</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">


### PR DESCRIPTION
## Description
Split the Z dimension / M values checkbox in the new memory layer dialog, and improve the wording:
![screenshot from 2017-11-21 17-37-04](https://user-images.githubusercontent.com/1728657/33068189-13c438ea-cee3-11e7-90ba-a1c4029ac6d2.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
