### PR TITLE
[offline-editing] Add a warning icon and tooltip to WFS sources

### DIFF
--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -39,7 +39,6 @@ QgsSelectLayerTreeModel::QgsSelectLayerTreeModel( QgsLayerTree *rootNode, QObjec
 
 int QgsSelectLayerTreeModel::columnCount( const QModelIndex &parent ) const
 {
-  Q_UNUSED( parent );
   return QgsLayerTreeModel::columnCount( parent ) + 1;
 }
 
@@ -79,10 +78,10 @@ QVariant QgsSelectLayerTreeModel::data( const QModelIndex &index, int role ) con
           case Qt::ToolTipRole:
             return tr( "The source of this layer is a <b>WFS</b> server.<br>"
                        "Some WFS layers are not suitable for offline<br>"
-                       "editing due to unreliable/missing primary<br>"
-                       "keys, please check with your system<br>"
-                       "administrator if this WFS layer can<br>"
-                       "be used for offline editing." );
+                       "editing due to unstable primary keys<br>"
+                       "please check with your system administrator<br>"
+                       "if this WFS layer can be used for offline<br>"
+                       "editing." );
             break;
           case Qt::DecorationRole:
             return QgsApplication::getThemeIcon( "/mIconWarning.svg" );

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.h
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.h
@@ -30,9 +30,8 @@ class QgsSelectLayerTreeModel : public QgsLayerTreeModel
     Q_OBJECT
   public:
     QgsSelectLayerTreeModel( QgsLayerTree *rootNode, QObject *parent = nullptr );
-
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
-    // bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 };
 
 class QgsOfflineEditingPluginGui : public QDialog, private Ui::QgsOfflineEditingPluginGuiBase


### PR DESCRIPTION
Fixes #16753 off-line editing synchronization cripples
the original datasource if this is a WFS-T Layer

As stated in the ticket, there is no solution for this bug:
certain remote WFS-T are simply not suitable for offline
editing, this PR adds a warning message to the
layer selection dialog.

![qgis-offline-warning](https://user-images.githubusercontent.com/142164/33075929-65680cac-cecb-11e7-88aa-277f144c1ed5.png)

