### PR TITLE
[ArcGIS REST] Add missing mutex to QgsAfsProvider (fixes #17513)

### DIFF
--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -199,7 +199,7 @@ QgsRectangle QgsAfsProvider::extent() const
 
 void QgsAfsProvider::reloadData()
 {
-  mSharedData->mCache.clear();
+  mSharedData->clearCache();
 }
 
 

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -17,9 +17,15 @@
 #include "qgsarcgisrestutils.h"
 #include "qgslogger.h"
 
+void QgsAfsSharedData::clearCache()
+{
+  QMutexLocker locker( &mMutex );
+  mCache.clear();
+}
+
 bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeometry, const QList<int> & /*fetchAttributes*/, const QgsRectangle &filterRect )
 {
-  QMutexLocker locker(&mMutex);
+  QMutexLocker locker( &mMutex );
 
   // If cached, return cached feature
   QMap<QgsFeatureId, QgsFeature>::const_iterator it = mCache.constFind( id );

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -19,6 +19,8 @@
 
 bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeometry, const QList<int> & /*fetchAttributes*/, const QgsRectangle &filterRect )
 {
+  QMutexLocker locker(&mMutex);
+
   // If cached, return cached feature
   QMap<QgsFeatureId, QgsFeature>::const_iterator it = mCache.constFind( id );
   if ( it != mCache.constEnd() )

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -17,6 +17,7 @@
 #define QGSAFSSHAREDDATA_H
 
 #include <QObject>
+#include <QMutex>
 #include "qgsfields.h"
 #include "qgsfeature.h"
 #include "qgsdatasourceuri.h"
@@ -38,6 +39,7 @@ class QgsAfsSharedData : public QObject
 
   private:
     friend class QgsAfsProvider;
+    QMutex mMutex;
     QgsDataSourceUri mDataSource;
     QgsRectangle mExtent;
     QgsWkbTypes::Type mGeometryType = QgsWkbTypes::Unknown;

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -34,6 +34,7 @@ class QgsAfsSharedData : public QObject
     const QgsFields &fields() const { return mFields; }
     QgsRectangle extent() const { return mExtent; }
     QgsCoordinateReferenceSystem crs() const { return mSourceCRS; }
+    void clearCache();
 
     bool getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeometry, const QList<int> &fetchAttributes, const QgsRectangle &filterRect = QgsRectangle() );
 


### PR DESCRIPTION
`QgsAfsSharedData` is accessed simultaneously by multiple threads and `QgsAfsSharedData::mCache` was not protected my a mutex.