### PR TITLE
[3d] Update world origin and camera after terrain change (#17514)

### DIFF
--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -61,7 +61,17 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     //! Resolves references to other objects (map layers) after the call to readXml()
     void resolveReferences( const QgsProject &project );
 
-    //! Sets coordinates in map CRS at which our 3D world has origin (0,0,0)
+    /**
+     * Sets coordinates in map CRS at which our 3D world has origin (0,0,0)
+     *
+     * We move the 3D world origin to the center of the extent of our terrain: this is done
+     * to minimize the impact of numerical errors when operating with 32-bit floats.
+     * Unfortunately this is not enough when working with a large area (still results in jitter
+     * with scenes spanning hundreds of kilometers and zooming in a lot).
+     *
+     * Need to look into more advanced techniques like "relative to center" or "relative to eye"
+     * to improve the precision.
+     */
     void setOrigin( double originX, double originY, double originZ );
     //! Returns X coordinate in map CRS at which 3D scene has origin (zero)
     double originX() const { return mOriginX; }

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -290,6 +290,12 @@ void QgsCameraController::resetView( float distance )
   emit cameraChanged();
 }
 
+void QgsCameraController::translateWorld( const QVector3D &vWorld )
+{
+  setCameraData( mCameraData.x - vWorld.x(), mCameraData.y + vWorld.y(), mCameraData.dist, mCameraData.pitch, mCameraData.yaw );
+  emit cameraChanged();
+}
+
 void QgsCameraController::onPositionChanged( Qt3DInput::QMouseEvent *mouse )
 {
   mMousePos = QPoint( mouse->x(), mouse->y() );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -282,7 +282,12 @@ void QgsCameraController::frameTriggered( float dt )
 
 void QgsCameraController::resetView( float distance )
 {
-  setCameraData( 0, 0, distance );
+  setViewFromTop( 0, 0, distance );
+}
+
+void QgsCameraController::setViewFromTop( float worldX, float worldY, float distance, float yaw )
+{
+  setCameraData( worldX, worldY, distance, 0, yaw );
   // a basic setup to make frustum depth range long enough that it does not cull everything
   mCamera->setNearPlane( distance / 2 );
   mCamera->setFarPlane( distance * 2 );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -57,6 +57,9 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! Move camera back to the initial position (looking down towards origin of world's coordinates)
     void resetView( float distance );
 
+    //! Sets camera to look down towards given point in world coordinate, in given distance from plane with zero elevation
+    void setViewFromTop( float worldX, float worldY, float distance, float yaw = 0 );
+
     //! Moves the point toward which the camera is looking - this is used when world origin changes (e.g. after terrain generator changes)
     void translateWorld( const QVector3D &vWorld );
 
@@ -85,8 +88,8 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     {
       float x = 0, y = 0;  // ground point towards which the camera is looking
       float dist = 40;  // distance of camera from the point it is looking at
-      float pitch = 0; // aircraft nose up/down (0 = looking straight down to the plane)
-      float yaw = 0;   // aircraft nose left/right
+      float pitch = 0; // aircraft nose up/down (0 = looking straight down to the plane). angle in degrees
+      float yaw = 0;   // aircraft nose left/right. angle in degrees
 
       bool operator==( const CameraData &other ) const
       {

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -57,6 +57,9 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! Move camera back to the initial position (looking down towards origin of world's coordinates)
     void resetView( float distance );
 
+    //! Moves the point toward which the camera is looking - this is used when world origin changes (e.g. after terrain generator changes)
+    void translateWorld( const QVector3D &vWorld );
+
   private:
     void setCameraData( float x, float y, float dist, float pitch = 0, float yaw = 0 );
 

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -73,6 +73,11 @@ void Qgs3DMapCanvas::setMap( Qgs3DMapSettings *map )
   resetView();
 }
 
+QgsCameraController *Qgs3DMapCanvas::cameraController()
+{
+  return mScene ? mScene->cameraController() : nullptr;
+}
+
 void Qgs3DMapCanvas::resetView()
 {
   mScene->viewZoomFull();

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -82,3 +82,10 @@ void Qgs3DMapCanvas::resetView()
 {
   mScene->viewZoomFull();
 }
+
+void Qgs3DMapCanvas::setViewFromTop( const QgsPointXY &center, float distance, float rotation )
+{
+  float worldX = center.x() - mMap->originX();
+  float worldY = center.y() - mMap->originY();
+  mScene->cameraController()->setViewFromTop( worldX, -worldY, distance, rotation );
+}

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -26,6 +26,7 @@ namespace Qt3DExtras
 class Qgs3DMapSettings;
 class Qgs3DMapScene;
 class QgsCameraController;
+class QgsPointXY;
 
 
 class Qgs3DMapCanvas : public QWidget
@@ -45,6 +46,9 @@ class Qgs3DMapCanvas : public QWidget
 
     //! Resets camera position to the default: looking down at the origin of world coordinates
     void resetView();
+
+    //! Sets camera position to look down at the given point (in map coordinates) in given distance from plane with zero elevation
+    void setViewFromTop( const QgsPointXY &center, float distance, float rotation = 0 );
 
   protected:
     void resizeEvent( QResizeEvent *ev ) override;

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -25,6 +25,7 @@ namespace Qt3DExtras
 
 class Qgs3DMapSettings;
 class Qgs3DMapScene;
+class QgsCameraController;
 
 
 class Qgs3DMapCanvas : public QWidget
@@ -38,6 +39,9 @@ class Qgs3DMapCanvas : public QWidget
     void setMap( Qgs3DMapSettings *map );
 
     Qgs3DMapSettings *map() { return mMap; }
+
+    //! Returns access to the view's camera controller. Returns null pointer if the scene has not been initialized yet with setMap()
+    QgsCameraController *cameraController();
 
     //! Resets camera position to the default: looking down at the origin of world coordinates
     void resetView();

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -72,6 +72,8 @@ void Qgs3DMapConfigWidget::apply()
 {
   QgsRasterLayer *demLayer = qobject_cast<QgsRasterLayer *>( cboTerrainLayer->currentLayer() );
 
+  bool needsUpdateOrigin = false;
+
   if ( demLayer )
   {
     bool tGenNeedsUpdate = true;
@@ -92,6 +94,7 @@ void Qgs3DMapConfigWidget::apply()
       demTerrainGen->setResolution( spinTerrainResolution->value() );
       demTerrainGen->setSkirtHeight( spinTerrainSkirtHeight->value() );
       mMap->setTerrainGenerator( demTerrainGen );
+      needsUpdateOrigin = true;
     }
   }
   else if ( !demLayer && mMap->terrainGenerator()->type() != QgsTerrainGenerator::Flat )
@@ -100,6 +103,13 @@ void Qgs3DMapConfigWidget::apply()
     flatTerrainGen->setCrs( mMap->crs() );
     flatTerrainGen->setExtent( mMainCanvas->fullExtent() );
     mMap->setTerrainGenerator( flatTerrainGen );
+    needsUpdateOrigin = true;
+  }
+
+  if ( needsUpdateOrigin )
+  {
+    QgsPointXY center = mMap->terrainGenerator()->extent().center();
+    mMap->setOrigin( center.x(), center.y(), 0 );
   }
 
   mMap->setTerrainVerticalScale( spinTerrainScale->value() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10251,6 +10251,10 @@ void QgisApp::new3DMapCanvas()
     map->setTerrainGenerator( flatTerrain );
 
     dock->setMapSettings( map );
+
+    QgsRectangle extent = mMapCanvas->extent();
+    float dist = qMax( extent.width(), extent.height() );
+    dock->mapCanvas3D()->setViewFromTop( mMapCanvas->extent().center(), dist, mMapCanvas->rotation() );
   }
 #endif
 }


### PR DESCRIPTION
This makes "zoom full" in 3D view working again after modification of terrain generator.
Also we update the camera position so it looks at the same spot as it was before.

+ set initial extent of a new 3D view to extent of the main canvas