### PR TITLE
Fixes for Value relation widget, multi select

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -149,7 +149,11 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
 {
   if ( mListWidget )
   {
-    QStringList checkList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
+    QStringList checkList;
+    if ( value.type() == QVariant::StringList )
+      checkList = value.toStringList();
+    else if ( value.type() == QVariant::String )
+      checkList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
 
     for ( int i = 0; i < mListWidget->count(); ++i )
     {

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -29,7 +29,6 @@
 
 QgsValueRelationWidgetWrapper::QgsValueRelationWidgetWrapper( QgsVectorLayer *vl, int fieldIdx, QWidget *editor, QWidget *parent )
   : QgsEditorWidgetWrapper( vl, fieldIdx, editor, parent )
-  , mUpdating( false )
 {
 }
 
@@ -198,12 +197,13 @@ void QgsValueRelationWidgetWrapper::showIndeterminateState()
 
 void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
 {
-  if ( mUpdating )
+  if ( mEnabled == enabled )
     return;
+
+  mEnabled = enabled;
 
   if ( mListWidget )
   {
-    mUpdating = true;
     for ( int i = 0; i < mListWidget->count(); ++i )
     {
       QListWidgetItem *item = mListWidget->item( i );
@@ -213,7 +213,6 @@ void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
       else
         item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
     }
-    mUpdating = false;
   }
   else
     QgsEditorWidgetWrapper::setEnabled( enabled );

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     QgsValueRelationFieldFormatter::ValueRelationCache mCache;
     QgsVectorLayer *mLayer = nullptr;
 
-    bool mUpdating;
+    bool mEnabled = false;
 
     friend class QgsValueRelationWidgetFactory;
     friend class TestQgsValueRelationWidgetWrapper;


### PR DESCRIPTION
Fixes two problems:

1. a freeze caused by certain scenarios (empty lists I guess) and infinite recursion (https://issues.qgis.org/issues/17521)
2. usage of array typed data sources (so far it was always mapping to strings back and forth)