### PR TITLE
[ArcGIS REST] fix caching logic for extent filtered requests

### DIFF
--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -32,7 +32,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeo
   if ( it != mCache.constEnd() )
   {
     f = it.value();
-    return filterRect.isNull() || f.geometry().intersects( filterRect );
+    return filterRect.isNull() || ( f.hasGeometry() && f.geometry().intersects( filterRect ) );
   }
 
   // Determine attributes to fetch
@@ -86,9 +86,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeo
   {
     QVariantMap featureData = featuresData[i].toMap();
     QgsFeature feature;
-
-    // Set FID
-    feature.setId( startId + i );
+    int objectId = startId + i;
 
     // Set attributes
     if ( !fetchAttribIdx.isEmpty() )
@@ -99,9 +97,16 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeo
       foreach ( int idx, fetchAttribIdx )
       {
         attributes[idx] = attributesData[mFields.at( idx ).name()];
+        if ( mFields.at( idx ).name() == QStringLiteral( "OBJECTID" ) )
+        {
+          objectId = attributesData[mFields.at( idx ).name()].toInt();
+        }
       }
       feature.setAttributes( attributes );
     }
+
+    // Set FID
+    feature.setId( startId + objectIds.indexOf( objectId ) );
 
     // Set geometry
     if ( fetchGeometry )
@@ -115,7 +120,14 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, bool fetchGeo
     feature.setValid( true );
     mCache.insert( feature.id(), feature );
   }
-  f = mCache[id];
-  Q_ASSERT( f.isValid() );
-  return filterRect.isNull() || ( f.hasGeometry() && f.geometry().intersects( filterRect ) );
+
+  // If added to cache, return feature
+  it = mCache.constFind( id );
+  if ( it != mCache.constEnd() )
+  {
+    f = it.value();
+    return filterRect.isNull() || ( f.hasGeometry() && f.geometry().intersects( filterRect ) );
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Description
@manisandro , turns out your PR - which did fix an issue - didn't address the crasher over here.

I've looked into it some more and realize the caching logic for queries filtered using an extent was broken. This PR fixes the logic. 

Basically, we assumed that a request for OBJECTID=1,2,3,4 would always return 1,2,3,4 , whereas it could return 1,4 if filtered via extent rect. If it returned 1,4, we would cache 1,4 as 1,2 (bad 😉).

This assumption that 1,2,3,4 would always return 1,2,3,4 led to a crasher because of the Q_ASSERT, which shouldn't be there to begin with since we might not have a given requested feature even though we successfully went through a request.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
