### PR TITLE
[ArcGIS REST] backport for crasher and mutex

### DIFF
--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -18,6 +18,8 @@
 #ifndef QGSAFSPROVIDER_H
 #define QGSAFSPROVIDER_H
 
+#include <QMutex>
+
 #include "qgsvectordataprovider.h"
 #include "qgsdatasourceuri.h"
 #include "qgscoordinatereferencesystem.h"
@@ -69,6 +71,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     void reloadData() override { mCache.clear(); }
 
   private:
+    QMutex mMutex;
     bool mValid;
     QgsDataSourceURI mDataSource;
     QgsRectangle mExtent;


### PR DESCRIPTION
## Description
Backporting a couple of ArcGIS REST provider fixes.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
