### PR TITLE
Avoid recursion in ValueRelation widget

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -43,7 +43,7 @@ QgsValueRelationWidgetWrapper::QgsValueRelationWidgetWrapper( QgsVectorLayer* vl
     , mListWidget( nullptr )
     , mLineEdit( nullptr )
     , mLayer( nullptr )
-    , mUpdating( false )
+    , mEnabled( false )
 {
 }
 
@@ -252,12 +252,13 @@ void QgsValueRelationWidgetWrapper::showIndeterminateState()
 
 void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
 {
-  if ( mUpdating )
+  if ( mEnabled == enabled )
     return;
+
+  mEnabled = enabled;
 
   if ( mListWidget )
   {
-    mUpdating = true;
     for ( int i = 0; i < mListWidget->count(); ++i )
     {
       QListWidgetItem *item = mListWidget->item( i );
@@ -267,7 +268,6 @@ void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
       else
         item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
     }
-    mUpdating = false;
   }
   else
     QgsEditorWidgetWrapper::setEnabled( enabled );

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -86,7 +86,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     ValueRelationCache mCache;
     QgsVectorLayer* mLayer;
 
-    bool mUpdating;
+    bool mEnabled;
 
     friend class QgsValueRelationWidgetFactory;
     friend class TestQgsValueRelationWidgetWrapper;


### PR DESCRIPTION
Fix #17521

The value relation was freezing on opening the attribute form, when the provider was delivering arrays and multi type was enabled.