### PR TITLE
Use layer scope in refactor fields algorithm

### DIFF
--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -326,10 +326,12 @@ class QgsProcessingAlgorithm
 %End
 
     QgsExpressionContext createExpressionContext( const QVariantMap &parameters,
-        QgsProcessingContext &context ) const;
+        QgsProcessingContext &context, QgsProcessingFeatureSource *source = 0 ) const;
 %Docstring
  Creates an expression context relating to the algorithm. This can be called by algorithms
  to create a new expression context ready for evaluating expressions within the algorithm.
+ Optionally, a ``source`` can be specified which will be used to populate the context if it
+ implements the QgsExpressionContextGenerator interface.
  :rtype: QgsExpressionContext
 %End
 

--- a/python/core/processing/qgsprocessingutils.sip
+++ b/python/core/processing/qgsprocessingutils.sip
@@ -274,6 +274,12 @@ class QgsProcessingFeatureSource : QgsFeatureSource
     virtual QVariant maximumValue( int fieldIndex ) const;
 
 
+    QgsFeatureSource *source() const;
+%Docstring
+ Access the underlying original ``source``.
+ :rtype: QgsFeatureSource
+%End
+
 };
 
 

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -562,6 +562,7 @@ Constructor for QgsExpressionContext
 %End
 
 
+
     void setFeature( const QgsFeature &feature );
 %Docstring
  Convenience function for setting a feature for the context. The feature

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -121,6 +121,9 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
         da.setSourceCrs(source.sourceCrs())
         da.setEllipsoid(context.project().ellipsoid())
 
+        # create an expression context using thread safe processing context
+        self.expr_context = self.createExpressionContext(parameters, context, source)
+
         for field_def in mapping:
             self.fields.append(QgsField(name=field_def['name'],
                                         type=field_def['type'],
@@ -143,8 +146,6 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
         return self.fields
 
     def processAlgorithm(self, parameters, context, feeback):
-        # create an expression context using thead safe processing context
-        self.expr_context = self.createExpressionContext(parameters, context)
         for expression in self.expressions:
             expression.prepare(self.expr_context)
         self._row_number = 0

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -339,9 +339,11 @@ class CORE_EXPORT QgsProcessingAlgorithm
     /**
      * Creates an expression context relating to the algorithm. This can be called by algorithms
      * to create a new expression context ready for evaluating expressions within the algorithm.
+     * Optionally, a \a source can be specified which will be used to populate the context if it
+     * implements the QgsExpressionContextGenerator interface.
      */
     QgsExpressionContext createExpressionContext( const QVariantMap &parameters,
-        QgsProcessingContext &context ) const;
+        QgsProcessingContext &context, QgsProcessingFeatureSource *source = nullptr ) const;
 
     /**
      * Checks whether the coordinate reference systems for the specified set of \a parameters

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -695,3 +695,8 @@ QVariant QgsProcessingFeatureSource::maximumValue( int fieldIndex ) const
 {
   return mSource->maximumValue( fieldIndex );
 }
+
+QgsFeatureSource *QgsProcessingFeatureSource::source() const
+{
+  return mSource;
+}

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -317,6 +317,11 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
     QVariant minimumValue( int fieldIndex ) const override;
     QVariant maximumValue( int fieldIndex ) const override;
 
+    /**
+     * Access the underlying original \a source.
+     */
+    QgsFeatureSource *source() const;
+
   private:
 
     QgsFeatureSource *mSource = nullptr;

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -474,6 +474,13 @@ QgsExpressionContextScope *QgsExpressionContext::popScope()
   return nullptr;
 }
 
+QList<QgsExpressionContextScope *> QgsExpressionContext::takeScopes()
+{
+  QList<QgsExpressionContextScope *> stack = mStack;
+  mStack.clear();
+  return stack;
+}
+
 QgsExpressionContext &QgsExpressionContext::operator<<( QgsExpressionContextScope *scope )
 {
   mStack.append( scope );

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -582,6 +582,16 @@ class CORE_EXPORT QgsExpressionContext
     QgsExpressionContextScope *popScope();
 
     /**
+     * Return all scopes from this context and remove them, leaving this context without
+     * any context.
+     * Ownership is transferred to the caller.
+     *
+     * \since QGIS 3.0
+     * \note Not available in Python
+     */
+    QList<QgsExpressionContextScope *> takeScopes() SIP_SKIP;
+
+    /**
      * Appends a scope to the end of the context. This scope will override
      * any matching variables or functions provided by existing scopes within the
      * context. Ownership of the scope is transferred to the stack.


### PR DESCRIPTION
The refactor fields algorithm wasn't using the layer scope when executing.

This proposes a generic interface for processing to specify a feature source when creating an expression context, which already works for vector layers (as required here to make expression functions like `represent_value` work) but will also work for any other source that implements the `QgsExpressionContextGenerator` interface if this is required in the future.