### PR TITLE
[3d] Fix crash in tessellator with near coords (fixes #17286, fixes #17515)

### DIFF
--- a/src/3d/qgstessellator.cpp
+++ b/src/3d/qgstessellator.cpp
@@ -17,6 +17,7 @@
 
 #include "qgscurve.h"
 #include "qgsgeometry.h"
+#include "qgsmessagelog.h"
 #include "qgsmultipolygon.h"
 #include "qgspoint.h"
 #include "qgspolygon.h"
@@ -301,7 +302,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
     {
       // Failed to fix that. It could be a really tiny geometry... or maybe they gave us
       // geometry in unprojected lat/lon coordinates
-      qDebug() << "geometry's coordinates are too close to each other and simplification failed - skipping";
+      QgsMessageLog::logMessage( "geometry's coordinates are too close to each other and simplification failed - skipping", "3D" );
     }
     else
     {
@@ -313,7 +314,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
   if ( !_check_intersecting_rings( polygon ) )
   {
     // skip the polygon - it would cause a crash inside poly2tri library
-    qDebug() << "polygon rings intersect each other - skipping";
+    QgsMessageLog::logMessage( "polygon rings intersect each other - skipping", "3D" );
     return;
   }
 
@@ -423,7 +424,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
       }
       catch ( ... )
       {
-        qDebug() << "Triangulation failed. Skipping polygon...";
+        QgsMessageLog::logMessage( "Triangulation failed. Skipping polygon...", "3D" );
       }
 
       delete cdt;

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -78,7 +78,10 @@ bool checkTriangleOutput( const QVector<float> &data, bool withNormals, const QL
 {
   int valuesPerTriangle = withNormals ? 18 : 9;
   if ( data.count() != expected.count() * valuesPerTriangle )
+  {
+    qDebug() << "expected" << expected.count() << "triangles, got" << data.count() / valuesPerTriangle;
     return false;
+  }
 
   // TODO: allow arbitrary order of triangles in output
   const float *dataRaw = data.constData();
@@ -117,6 +120,7 @@ class TestQgsTessellator : public QObject
     void testBasic();
     void testWalls();
     void asMultiPolygon();
+    void testBadCoordinates();
 
   private:
 };
@@ -208,7 +212,22 @@ void TestQgsTessellator::asMultiPolygon()
   QgsTessellator t2( 0, 0, false );
   t2.addPolygon( polygonZ, 0 );
   QCOMPARE( t2.asMultiPolygon()->asWkt(), QStringLiteral( "MultiPolygonZ (((1 2 4, 2 1 2, 3 2 3, 1 2 4)),((1 2 4, 1 1 1, 2 1 2, 1 2 4)))" ) );
+}
 
+void TestQgsTessellator::testBadCoordinates()
+{
+  // triangulation would crash for me with this polygon if there is no simplification
+  // to remove the coordinates that are very close to each other
+  QgsPolygon polygon;
+  polygon.fromWkt( "POLYGON((1 1, 2 1, 2.0000001 1.0000001, 2.0000002 1.0000001, 2.0000001 1.0000002, 2.0000002 1.0000002, 3 2, 1 2, 1 1))" );
+
+  QList<TriangleCoords> tc;
+  tc << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 3, 2, 0 ) );
+  tc << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 1, 1, 0 ), QVector3D( 2, 1, 0 ) );
+
+  QgsTessellator t( 0, 0, false );
+  t.addPolygon( polygon, 0 );
+  QVERIFY( checkTriangleOutput( t.data(), false, tc ) );
 }
 
 


### PR DESCRIPTION
As the readme of poly2tri library says: "Poly2Tri does not support repeat points within epsilon."

When the coordinates are very near to each other, we get crashes in triangulation code.
To prevent that, we try to simplify geometries to hopefully fix the problem automatically,
if that fails we just skip the polygon as the last resort.

Usually this happens if user tries to use 3D renderer on unprojected lat/lon coordinates.
