### PR TITLE
Fix crash when overwriting gpkg layer

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1082,10 +1082,13 @@ void QgsOgrProviderUtils::setRelevantFields( OGRLayerH ogrLayer, int fieldCount,
       if ( !fetchAttributes.contains( i ) )
       {
         // add to ignored fields
-        const char *fieldName = OGR_Fld_GetNameRef( OGR_FD_GetFieldDefn( featDefn, firstAttrIsFid ? i - 1 : i ) );
-        if ( qstrcmp( fieldName, ORIG_OGC_FID ) != 0 )
+        if ( OGRFieldDefnH field = OGR_FD_GetFieldDefn( featDefn, firstAttrIsFid ? i - 1 : i ) )
         {
-          ignoredFields.append( fieldName );
+          const char *fieldName = OGR_Fld_GetNameRef( field );
+          if ( qstrcmp( fieldName, ORIG_OGC_FID ) != 0 )
+          {
+            ignoredFields.append( fieldName );
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes a crash when a geopackage layer is open in QGIS, and then is overwritten with another layer with different field definitions
