### PR TITLE
Add test for tesselated normals when input coordinates do not share same z value

### DIFF
--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -76,7 +76,7 @@ struct TriangleCoords
 
   void dump() const
   {
-    qDebug() << pts[0] << pts[1] << pts[2] << normals[0] << normals[1] << normals[2];
+    qDebug() << pts[0] << "," << pts[1] << ","  << pts[2] << "," << normals[0] << "," << normals[1] << "," << normals[2];
   }
 
   QVector3D pts[3];
@@ -238,9 +238,26 @@ void TestQgsTessellator::testWalls()
   tc << TriangleCoords( QVector3D( 2, 1, 12 ), QVector3D( 1, 1, 11 ), QVector3D( 2, 1, 2 ) );
   tc << TriangleCoords( QVector3D( 2, 1, 2 ), QVector3D( 1, 1, 11 ), QVector3D( 1, 1, 1 ) );
 
+  QList<TriangleCoords> tn;
+  tn << TriangleCoords( QVector3D( 1, 2, 14 ), QVector3D( 2, 1, 12 ), QVector3D( 3, 2, 13 ), QVector3D( 0, -0.894427, 0.447214 ), QVector3D( 0, -0.894427, 0.447214 ), QVector3D( 0, -0.894427, 0.447214 ) );
+  tn << TriangleCoords( QVector3D( 1, 2, 14 ), QVector3D( 1, 1, 11 ), QVector3D( 2, 1, 12 ), QVector3D( 0, -0.894427, 0.447214 ), QVector3D( 0, -0.894427, 0.447214 ), QVector3D( 0, -0.894427, 0.447214 ) );
+  tn << TriangleCoords( QVector3D( 1, 1, 11 ), QVector3D( 1, 2, 14 ), QVector3D( 1, 1, 1 ), QVector3D( -1, 0, 0 ), QVector3D( -1, 0, 0 ), QVector3D( -1, 0, 0 ) );
+  tn << TriangleCoords( QVector3D( 1, 1, 1 ), QVector3D( 1, 2, 14 ), QVector3D( 1, 2, 4 ), QVector3D( -1, 0, 0 ), QVector3D( -1, 0, 0 ), QVector3D( -1, 0, 0 ) );
+  tn << TriangleCoords( QVector3D( 1, 2, 14 ), QVector3D( 3, 2, 13 ), QVector3D( 1, 2, 4 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ) );
+  tn << TriangleCoords( QVector3D( 1, 2, 4 ), QVector3D( 3, 2, 13 ), QVector3D( 3, 2, 3 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ) );
+  tn << TriangleCoords( QVector3D( 3, 2, 13 ), QVector3D( 2, 1, 12 ), QVector3D( 3, 2, 3 ), QVector3D( 0.707107, -0.707107, 0 ), QVector3D( 0.707107, -0.707107, 0 ), QVector3D( 0.707107, -0.707107, 0 ) );
+  tn << TriangleCoords( QVector3D( 3, 2, 3 ), QVector3D( 2, 1, 12 ), QVector3D( 2, 1, 2 ), QVector3D( 0.707107, -0.707107, 0 ), QVector3D( 0.707107, -0.707107, 0 ), QVector3D( 0.707107, -0.707107, 0 ) );
+  tn << TriangleCoords( QVector3D( 2, 1, 12 ), QVector3D( 1, 1, 11 ), QVector3D( 2, 1, 2 ), QVector3D( 0, -1, 0 ), QVector3D( 0, -1, 0 ), QVector3D( 0, -1, 0 ) );
+  tn << TriangleCoords( QVector3D( 2, 1, 2 ), QVector3D( 1, 1, 11 ), QVector3D( 1, 1, 1 ), QVector3D( 0, -1, 0 ), QVector3D( 0, -1, 0 ), QVector3D( 0, -1, 0 ) );
+
   QgsTessellator tZ( 0, 0, false );
   tZ.addPolygon( polygonZ, 10 );
   QVERIFY( checkTriangleOutput( tZ.data(), false, tc ) );
+
+  // with normals
+  QgsTessellator tZN( 0, 0, true );
+  tZN.addPolygon( polygonZ, 10 );
+  QVERIFY( checkTriangleOutput( tZN.data(), true, tn ) );
 }
 
 void TestQgsTessellator::asMultiPolygon()


### PR DESCRIPTION
@wonder-sk 

Been trying to work out why the top surfaces are missing for me - the results for this test look wrong for the first two triangle normals (e.g. those corresponding to the top surface)

I suspect we have an issue with the normal calculation in the non-planar situation too..