### PR TITLE
[processing] fix error when adding refactor fields alg in empty model

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -477,7 +477,8 @@ class FieldsMappingWidgetWrapper(WidgetWrapper):
     def postInitialize(self, wrappers):
         for wrapper in wrappers:
             if wrapper.param.name() == self.param.parentLayerParameter():
-                self.setLayer(wrapper.value())
+                if wrapper.value():
+                    self.setLayer(wrapper.value())
                 wrapper.widgetValueHasChanged.connect(self.parentLayerChanged)
                 break
 

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -999,7 +999,10 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
                 else:
                     return os.path.exists(v)
 
-            return self.comboValue(validator, combobox=self.combo)
+            if self.combo.currentText():
+                return self.comboValue(validator, combobox=self.combo)
+            else:
+                return None
 
 
 class StringWidgetWrapper(WidgetWrapper):


### PR DESCRIPTION
## Description
@nyalldawson , @m-kuhn , this fixes an error when adding the refactor fields algorithm in an empty model. Does this look good to you guys?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
