### PR TITLE
[processing] Expose dynamic ("data defined") numeric parameters to gui 

### DIFF
--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -872,7 +872,7 @@ class QgsProcessingFeatureBasedAlgorithm : QgsProcessingAlgorithm
  :rtype: QgsCoordinateReferenceSystem
 %End
 
-    virtual QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) = 0;
+    virtual QgsFeature processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) = 0;
 %Docstring
  Processes an individual input ``feature`` from the source. Algorithms should implement their
  logic in this method for performing the algorithm's operation (e.g. replacing the feature's

--- a/python/core/processing/qgsprocessingparameters.sip
+++ b/python/core/processing/qgsprocessingparameters.sip
@@ -376,7 +376,73 @@ class QgsProcessingParameterDefinition
  :rtype: str
 %End
 
+    bool isDynamic() const;
+%Docstring
+ Returns true if the parameter supports is dynamic, and can support data-defined values
+ (i.e. QgsProperty based values).
+.. seealso:: setIsDynamic()
+.. seealso:: dynamicPropertyDefinition()
+.. seealso:: dynamicLayerParameterName()
+ :rtype: bool
+%End
+
+    void setIsDynamic( bool dynamic );
+%Docstring
+ Sets whether the parameter is ``dynamic``, and can support data-defined values
+ (i.e. QgsProperty based values).
+.. seealso:: isDynamic()
+.. seealso:: setDynamicPropertyDefinition()
+.. seealso:: setDynamicLayerParameterName()
+%End
+
+    QgsPropertyDefinition dynamicPropertyDefinition() const;
+%Docstring
+ Returns the property definition for dynamic properties.
+.. seealso:: isDynamic()
+.. seealso:: setDynamicPropertyDefinition()
+.. seealso:: dynamicLayerParameterName()
+ :rtype: QgsPropertyDefinition
+%End
+
+    void setDynamicPropertyDefinition( const QgsPropertyDefinition &definition );
+%Docstring
+ Sets the property ``definition`` for dynamic properties.
+.. seealso:: isDynamic()
+.. seealso:: dynamicPropertyDefinition()
+.. seealso:: setDynamicLayerParameterName()
+%End
+
+    QString dynamicLayerParameterName() const;
+%Docstring
+ Returns the name of the parameter for a layer linked to a dynamic parameter, or an empty string if this is not set.
+
+ Dynamic parameters (see isDynamic()) can have an optional vector layer parameter linked to them,
+ which indicates which layer the fields and values will be available from when evaluating
+ the dynamic parameter.
+
+.. seealso:: setDynamicLayerParameterName()
+.. seealso:: isDynamic()
+.. seealso:: dynamicPropertyDefinition()
+ :rtype: str
+%End
+
+    void setDynamicLayerParameterName( const QString &name );
+%Docstring
+ Sets the ``name`` for the parameter for a layer linked to a dynamic parameter, or an empty string if this is not set.
+
+ Dynamic parameters (see isDynamic()) can have an optional vector layer parameter linked to them,
+ which indicates which layer the fields and values will be available from when evaluating
+ the dynamic parameter.
+
+.. seealso:: dynamicLayerParameterName()
+.. seealso:: isDynamic()
+.. seealso:: setDynamicPropertyDefinition()
+%End
+
   protected:
+
+
+
 
 
 

--- a/python/gui/qgspropertyoverridebutton.sip
+++ b/python/gui/qgspropertyoverridebutton.sip
@@ -54,6 +54,20 @@ class QgsPropertyOverrideButton: QToolButton
 %End
 
     void init( int propertyKey,
+               const QgsProperty &property,
+               const QgsPropertyDefinition &definition,
+               const QgsVectorLayer *layer = 0,
+               bool auxiliaryStorageEnabled = false );
+%Docstring
+ Initialize a newly constructed property button (useful if button was included in a UI layout).
+ \param propertyKey key for corresponding property
+ \param property initial value of associated property to show in widget
+ \param definition properties definition for button
+ \param layer associated vector layer
+ \param auxiliaryStorageEnabled If true, activate the button to store data defined in auxiliary storage
+%End
+
+    void init( int propertyKey,
                const QgsAbstractPropertyCollection &collection,
                const QgsPropertiesDefinition &definitions,
                const QgsVectorLayer *layer = 0,

--- a/python/plugins/processing/algs/qgis/AddTableField.py
+++ b/python/plugins/processing/algs/qgis/AddTableField.py
@@ -90,7 +90,7 @@ class AddTableField(QgisFeatureBasedAlgorithm):
         inputFields.append(self.field)
         return inputFields
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         attributes = feature.attributes()
         attributes.append(None)
         feature.setAttributes(attributes)

--- a/python/plugins/processing/algs/qgis/DeleteColumn.py
+++ b/python/plugins/processing/algs/qgis/DeleteColumn.py
@@ -80,7 +80,7 @@ class DeleteColumn(QgisFeatureBasedAlgorithm):
             input_fields.remove(index)
         return input_fields
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         attributes = feature.attributes()
         for index in self.field_indices:
             del attributes[index]

--- a/python/plugins/processing/algs/qgis/DeleteHoles.py
+++ b/python/plugins/processing/algs/qgis/DeleteHoles.py
@@ -66,7 +66,7 @@ class DeleteHoles(QgisFeatureBasedAlgorithm):
             self.min_area = -1.0
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         if feature.hasGeometry():
             feature.setGeometry(feature.geometry().removeInteriorRings(self.min_area))
         return feature

--- a/python/plugins/processing/algs/qgis/DensifyGeometries.py
+++ b/python/plugins/processing/algs/qgis/DensifyGeometries.py
@@ -68,7 +68,7 @@ class DensifyGeometries(QgisFeatureBasedAlgorithm):
         self.vertices = self.parameterAsInt(parameters, self.VERTICES, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         if feature.hasGeometry():
             new_geometry = feature.geometry().densifyByCount(self.vertices)
             feature.setGeometry(new_geometry)

--- a/python/plugins/processing/algs/qgis/DensifyGeometriesInterval.py
+++ b/python/plugins/processing/algs/qgis/DensifyGeometriesInterval.py
@@ -64,7 +64,7 @@ class DensifyGeometriesInterval(QgisFeatureBasedAlgorithm):
         interval = self.parameterAsDouble(parameters, self.INTERVAL, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         if feature.hasGeometry():
             new_geometry = feature.geometry().densifyByDistance(float(interval))
             feature.setGeometry(new_geometry)

--- a/python/plugins/processing/algs/qgis/ExtendLines.py
+++ b/python/plugins/processing/algs/qgis/ExtendLines.py
@@ -67,7 +67,7 @@ class ExtendLines(QgisFeatureBasedAlgorithm):
         self.end_distance = self.parameterAsDouble(parameters, self.END_DISTANCE, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         input_geometry = feature.geometry()
         if input_geometry:
             output_geometry = input_geometry.extendLine(self.start_distance, self.end_distance)

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -151,7 +151,7 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
         self._row_number = 0
         return super().processAlgorithm(parameters, context, feeback)
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         attributes = []
         for expression in self.expressions:
             self.expr_context.setFeature(feature)

--- a/python/plugins/processing/algs/qgis/GeometryByExpression.py
+++ b/python/plugins/processing/algs/qgis/GeometryByExpression.py
@@ -101,7 +101,7 @@ class GeometryByExpression(QgisFeatureBasedAlgorithm):
     def outputWkbType(self, input_wkb_type):
         return self.wkb_type
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         self.expression_context.setFeature(feature)
         value = self.expression.evaluate(self.expression_context)
         if self.expression.hasEvalError():

--- a/python/plugins/processing/algs/qgis/LinesToPolygons.py
+++ b/python/plugins/processing/algs/qgis/LinesToPolygons.py
@@ -80,7 +80,7 @@ class LinesToPolygons(QgisFeatureBasedAlgorithm):
     def outputWkbType(self, input_wkb_type):
         return self.convertWkbToPolygons(input_wkb_type)
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         if feature.hasGeometry():
             feature.setGeometry(QgsGeometry(self.convertToPolygons(feature.geometry())))
             if feature.geometry().isEmpty():

--- a/python/plugins/processing/algs/qgis/OffsetLine.py
+++ b/python/plugins/processing/algs/qgis/OffsetLine.py
@@ -100,7 +100,7 @@ class OffsetLine(QgisFeatureBasedAlgorithm):
         self.miter_limit = self.parameterAsDouble(parameters, self.MITER_LIMIT, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         input_geometry = feature.geometry()
         if input_geometry:
             output_geometry = input_geometry.offsetCurve(self.distance, self.segments, self.join_style, self.miter_limit)

--- a/python/plugins/processing/algs/qgis/Orthogonalize.py
+++ b/python/plugins/processing/algs/qgis/Orthogonalize.py
@@ -79,7 +79,7 @@ class Orthogonalize(QgisFeatureBasedAlgorithm):
         self.angle_tolerance = self.parameterAsDouble(parameters, self.ANGLE_TOLERANCE, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         input_geometry = feature.geometry()
         if input_geometry:
             output_geometry = input_geometry.orthogonalize(1.0e-8, self.max_iterations, self.angle_tolerance)

--- a/python/plugins/processing/algs/qgis/PointOnSurface.py
+++ b/python/plugins/processing/algs/qgis/PointOnSurface.py
@@ -64,7 +64,7 @@ class PointOnSurface(QgisFeatureBasedAlgorithm):
     def outputWkbType(self, input_wkb_type):
         return QgsWkbTypes.Point
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         input_geometry = feature.geometry()
         if input_geometry:
             output_geometry = input_geometry.pointOnSurface()

--- a/python/plugins/processing/algs/qgis/PolygonsToLines.py
+++ b/python/plugins/processing/algs/qgis/PolygonsToLines.py
@@ -73,7 +73,7 @@ class PolygonsToLines(QgisFeatureBasedAlgorithm):
     def outputWkbType(self, input_wkb_type):
         return self.convertWkbToLines(input_wkb_type)
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         if feature.hasGeometry():
             feature.setGeometry(QgsGeometry(self.convertToLines(feature.geometry())))
         return feature

--- a/python/plugins/processing/algs/qgis/ReverseLineDirection.py
+++ b/python/plugins/processing/algs/qgis/ReverseLineDirection.py
@@ -54,7 +54,7 @@ class ReverseLineDirection(QgisFeatureBasedAlgorithm):
     def inputLayerTypes(self):
         return [QgsProcessing.TypeVectorLine]
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         if feature.geometry():
             inGeom = feature.geometry()
             reversedLine = inGeom.constGet().reversed()

--- a/python/plugins/processing/algs/qgis/SetMValue.py
+++ b/python/plugins/processing/algs/qgis/SetMValue.py
@@ -71,7 +71,7 @@ class SetMValue(QgisFeatureBasedAlgorithm):
         self.m_value = self.parameterAsDouble(parameters, self.M_VALUE, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         input_geometry = feature.geometry()
         if input_geometry:
             new_geom = input_geometry.constGet().clone()

--- a/python/plugins/processing/algs/qgis/SetMValue.py
+++ b/python/plugins/processing/algs/qgis/SetMValue.py
@@ -29,6 +29,8 @@ import os
 
 from qgis.core import (QgsGeometry,
                        QgsWkbTypes,
+                       QgsPropertyDefinition,
+                       QgsProcessingParameters,
                        QgsProcessingParameterNumber)
 
 
@@ -47,6 +49,8 @@ class SetMValue(QgisFeatureBasedAlgorithm):
     def __init__(self):
         super().__init__()
         self.m_value = 0
+        self.dynamic_m = False
+        self.m_property = None
 
     def name(self):
         return 'setmvalue'
@@ -61,14 +65,21 @@ class SetMValue(QgisFeatureBasedAlgorithm):
         return self.tr('set,add,m,measure,values').split(',')
 
     def initParameters(self, config=None):
-        self.addParameter(QgsProcessingParameterNumber(self.M_VALUE,
-                                                       self.tr('M Value'), QgsProcessingParameterNumber.Double, defaultValue=0.0))
+        m_param = QgsProcessingParameterNumber(self.M_VALUE,
+                                               self.tr('M Value'), QgsProcessingParameterNumber.Double, defaultValue=0.0)
+        m_param.setIsDynamic(True)
+        m_param.setDynamicLayerParameterName('INPUT')
+        m_param.setDynamicPropertyDefinition(QgsPropertyDefinition(self.M_VALUE, self.tr("M Value"), QgsPropertyDefinition.Double))
+        self.addParameter(m_param)
 
     def outputWkbType(self, inputWkb):
         return QgsWkbTypes.addM(inputWkb)
 
     def prepareAlgorithm(self, parameters, context, feedback):
         self.m_value = self.parameterAsDouble(parameters, self.M_VALUE, context)
+        self.dynamic_m = QgsProcessingParameters.isDynamic(parameters, self.M_VALUE)
+        if self.dynamic_m:
+            self.m_property = parameters[self.M_VALUE]
         return True
 
     def processFeature(self, feature, context, feedback):
@@ -79,7 +90,10 @@ class SetMValue(QgisFeatureBasedAlgorithm):
                 # addMValue won't alter existing M values, so drop them first
                 new_geom.dropMValue()
 
-            new_geom.addMValue(self.m_value)
+            m = self.m_value
+            if self.dynamic_m:
+                m, ok = self.m_property.valueAsDouble(context.expressionContext(), m)
+            new_geom.addMValue(m)
 
             feature.setGeometry(QgsGeometry(new_geom))
 

--- a/python/plugins/processing/algs/qgis/SetZValue.py
+++ b/python/plugins/processing/algs/qgis/SetZValue.py
@@ -52,7 +52,6 @@ class SetZValue(QgisFeatureBasedAlgorithm):
         self.z_value = 0
         self.dynamic_z = False
         self.z_property = None
-        self.expression_context = None
 
     def name(self):
         return 'setzvalue'
@@ -82,14 +81,9 @@ class SetZValue(QgisFeatureBasedAlgorithm):
         self.dynamic_z = QgsProcessingParameters.isDynamic(parameters, self.Z_VALUE)
         if self.dynamic_z:
             self.z_property = parameters[self.Z_VALUE]
-            source = self.parameterAsSource(parameters, 'INPUT', context)
-            if not isinstance(source, QgsProcessingFeatureSource):
-                source = None
-            self.expression_context = self.createExpressionContext(parameters, context, source)
-            self.z_property.prepare(self.expression_context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         input_geometry = feature.geometry()
         if input_geometry:
             new_geom = input_geometry.constGet().clone()
@@ -99,8 +93,7 @@ class SetZValue(QgisFeatureBasedAlgorithm):
 
             z = self.z_value
             if self.dynamic_z:
-                self.expression_context.setFeature(feature)
-                z, ok = self.z_property.valueAsDouble(self.expression_context, z)
+                z, ok = self.z_property.valueAsDouble(context.expressionContext(), z)
             new_geom.addZValue(z)
 
             feature.setGeometry(QgsGeometry(new_geom))

--- a/python/plugins/processing/algs/qgis/SingleSidedBuffer.py
+++ b/python/plugins/processing/algs/qgis/SingleSidedBuffer.py
@@ -108,7 +108,7 @@ class SingleSidedBuffer(QgisFeatureBasedAlgorithm):
         self.miter_limit = self.parameterAsDouble(parameters, self.MITER_LIMIT, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         input_geometry = feature.geometry()
         if input_geometry:
             output_geometry = input_geometry.singleSidedBuffer(self.distance, self.segments,

--- a/python/plugins/processing/algs/qgis/TextToFloat.py
+++ b/python/plugins/processing/algs/qgis/TextToFloat.py
@@ -73,7 +73,7 @@ class TextToFloat(QgisFeatureBasedAlgorithm):
         self.field_name = self.parameterAsString(parameters, self.FIELD, context)
         return True
 
-    def processFeature(self, feature, feedback):
+    def processFeature(self, feature, context, feedback):
         value = feature[self.field_idx]
         try:
             if '%' in value:

--- a/python/plugins/processing/gui/NumberInputPanel.py
+++ b/python/plugins/processing/gui/NumberInputPanel.py
@@ -198,6 +198,7 @@ class NumberInputPanel(NUMBER_BASE, NUMBER_WIDGET):
             self.btnDataDefined = None
         else:
             self.btnDataDefined.init(0, QgsProperty(), self.param.dynamicPropertyDefinition())
+            self.btnDataDefined.registerEnabledWidget(self.spnValue, False)
 
         self.spnValue.valueChanged.connect(lambda: self.hasChanged.emit())
 

--- a/python/plugins/processing/gui/NumberInputPanel.py
+++ b/python/plugins/processing/gui/NumberInputPanel.py
@@ -74,11 +74,6 @@ class ModellerNumberInputPanel(BASE, WIDGET):
         self.btnSelect.clicked.connect(self.showExpressionsBuilder)
         self.leText.textChanged.connect(lambda: self.hasChanged.emit())
 
-        # remove data defined button from modeler
-        self.layout().removeWidget(self.btnDataDefined)
-        sip.delete(self.btnDataDefined)
-        self.btnDataDefined = None
-
     def showExpressionsBuilder(self):
         context = createExpressionContext()
         processing_context = createContext()

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -671,6 +671,17 @@ class NumberWidgetWrapper(WidgetWrapper):
     def value(self):
         return self.widget.getValue()
 
+    def postInitialize(self, wrappers):
+        if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH) and self.param.isDynamic():
+            for wrapper in wrappers:
+                if wrapper.param.name() == self.param.dynamicLayerParameterName():
+                    self.widget.setDynamicLayer(wrapper.value())
+                    wrapper.widgetValueHasChanged.connect(self.parentLayerChanged)
+                    break
+
+    def parentLayerChanged(self, wrapper):
+        self.widget.setDynamicLayer(wrapper.value())
+
 
 class RangeWidgetWrapper(WidgetWrapper):
 

--- a/python/plugins/processing/ui/widgetNumberSelector.ui
+++ b/python/plugins/processing/ui/widgetNumberSelector.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>249</width>
-    <height>37</height>
+    <width>380</width>
+    <height>52</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -61,6 +61,19 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QgsPropertyOverrideButton" name="btnDataDefined">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -69,6 +82,11 @@
    <extends>QDoubleSpinBox</extends>
    <header>qgis.gui</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgis.gui</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/3d/processing/qgsalgorithmtessellate.cpp
+++ b/src/3d/processing/qgsalgorithmtessellate.cpp
@@ -74,7 +74,7 @@ QgsTessellateAlgorithm *QgsTessellateAlgorithm::createInstance() const
   return new QgsTessellateAlgorithm();
 }
 
-QgsFeature QgsTessellateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsTessellateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/3d/processing/qgsalgorithmtessellate.h
+++ b/src/3d/processing/qgsalgorithmtessellate.h
@@ -47,7 +47,7 @@ class QgsTessellateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsProcessing::SourceType outputLayerType() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
 
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -90,7 +90,7 @@ bool QgsAddIncrementalFieldAlgorithm::prepareAlgorithm( const QVariantMap &param
   return true;
 }
 
-QgsFeature QgsAddIncrementalFieldAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsAddIncrementalFieldAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   if ( !mGroupedFieldNames.empty() && mGroupedFields.empty() )
   {

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.h
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.h
@@ -49,7 +49,7 @@ class QgsAddIncrementalFieldAlgorithm : public QgsProcessingFeatureBasedAlgorith
     QgsFields outputFields( const QgsFields &inputFields ) const override;
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmassignprojection.cpp
+++ b/src/analysis/processing/qgsalgorithmassignprojection.cpp
@@ -68,7 +68,7 @@ bool QgsAssignProjectionAlgorithm::prepareAlgorithm( const QVariantMap &paramete
   return true;
 }
 
-QgsFeature QgsAssignProjectionAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsAssignProjectionAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   return feature;
 }

--- a/src/analysis/processing/qgsalgorithmassignprojection.h
+++ b/src/analysis/processing/qgsalgorithmassignprojection.h
@@ -48,7 +48,7 @@ class QgsAssignProjectionAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmboundary.cpp
+++ b/src/analysis/processing/qgsalgorithmboundary.cpp
@@ -90,7 +90,7 @@ QgsWkbTypes::Type QgsBoundaryAlgorithm::outputWkbType( QgsWkbTypes::Type inputWk
   return outputWkb;
 }
 
-QgsFeature QgsBoundaryAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback )
+QgsFeature QgsBoundaryAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   QgsFeature outFeature = feature;
 

--- a/src/analysis/processing/qgsalgorithmboundary.h
+++ b/src/analysis/processing/qgsalgorithmboundary.h
@@ -46,7 +46,7 @@ class QgsBoundaryAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmboundingbox.cpp
@@ -66,7 +66,7 @@ QgsFields QgsBoundingBoxAlgorithm::outputFields( const QgsFields &inputFields ) 
   return fields;
 }
 
-QgsFeature QgsBoundingBoxAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsBoundingBoxAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmboundingbox.h
@@ -45,7 +45,7 @@ class QgsBoundingBoxAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type ) const override { return QgsWkbTypes::Polygon; }
     QgsFields outputFields( const QgsFields &inputFields ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -91,13 +91,11 @@ QVariantMap QgsBufferAlgorithm::processAlgorithm( const QVariantMap &parameters,
   double miterLimit = parameterAsDouble( parameters, QStringLiteral( "MITER_LIMIT" ), context );
   double bufferDistance = parameterAsDouble( parameters, QStringLiteral( "DISTANCE" ), context );
   bool dynamicBuffer = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DISTANCE" ) );
-  QgsExpressionContext expressionContext;
+  QgsExpressionContext expressionContext = createExpressionContext( parameters, context, dynamic_cast< QgsProcessingFeatureSource * >( source.get() ) );
   QgsProperty bufferProperty;
   if ( dynamicBuffer )
   {
     bufferProperty = parameters.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >();
-    expressionContext = createExpressionContext( parameters, context, dynamic_cast< QgsProcessingFeatureSource * >( source.get() ) );
-    bufferProperty.prepare( expressionContext );
   }
 
   long count = source->featureCount();

--- a/src/analysis/processing/qgsalgorithmcentroid.cpp
+++ b/src/analysis/processing/qgsalgorithmcentroid.cpp
@@ -61,7 +61,7 @@ QgsCentroidAlgorithm *QgsCentroidAlgorithm::createInstance() const
   return new QgsCentroidAlgorithm();
 }
 
-QgsFeature QgsCentroidAlgorithm::processFeature( const QgsFeature &f, QgsProcessingFeedback *feedback )
+QgsFeature QgsCentroidAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   QgsFeature feature = f;
   if ( feature.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmcentroid.h
+++ b/src/analysis/processing/qgsalgorithmcentroid.h
@@ -48,7 +48,7 @@ class QgsCentroidAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsProcessing::SourceType outputLayerType() const override { return QgsProcessing::TypeVectorPoint; }
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override { Q_UNUSED( inputWkbType ); return QgsWkbTypes::Point; }
 
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmconvexhull.cpp
+++ b/src/analysis/processing/qgsalgorithmconvexhull.cpp
@@ -64,7 +64,7 @@ QgsFields QgsConvexHullAlgorithm::outputFields( const QgsFields &inputFields ) c
   return fields;
 }
 
-QgsFeature QgsConvexHullAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback )
+QgsFeature QgsConvexHullAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmconvexhull.h
+++ b/src/analysis/processing/qgsalgorithmconvexhull.h
@@ -46,7 +46,7 @@ class QgsConvexHullAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type ) const override { return QgsWkbTypes::Polygon; }
     QgsFields outputFields( const QgsFields &inputFields ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmdropgeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmdropgeometry.cpp
@@ -69,7 +69,7 @@ QgsFeatureRequest QgsDropGeometryAlgorithm::request() const
   return QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry );
 }
 
-QgsFeature QgsDropGeometryAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsDropGeometryAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   f.clearGeometry();

--- a/src/analysis/processing/qgsalgorithmdropgeometry.h
+++ b/src/analysis/processing/qgsalgorithmdropgeometry.h
@@ -47,7 +47,7 @@ class QgsDropGeometryAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
     QgsFeatureRequest request() const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmdropmzvalues.cpp
+++ b/src/analysis/processing/qgsalgorithmdropmzvalues.cpp
@@ -77,7 +77,7 @@ bool QgsDropMZValuesAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
   return true;
 }
 
-QgsFeature QgsDropMZValuesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsDropMZValuesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmdropmzvalues.h
+++ b/src/analysis/processing/qgsalgorithmdropmzvalues.h
@@ -47,7 +47,7 @@ class QgsDropMZValuesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
@@ -168,7 +168,7 @@ QVariantMap QgsExtractByAttributeAlgorithm::processAlgorithm( const QVariantMap 
     throw QgsProcessingException( expression.parserErrorString() );
   }
 
-  QgsExpressionContext expressionContext = createExpressionContext( parameters, context );
+  QgsExpressionContext expressionContext = createExpressionContext( parameters, context, dynamic_cast< QgsProcessingFeatureSource * >( source.get() ) );
 
   long count = source->featureCount();
 

--- a/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
@@ -87,7 +87,7 @@ QVariantMap QgsExtractByExpressionAlgorithm::processAlgorithm( const QVariantMap
     throw QgsProcessingException( expression.parserErrorString() );
   }
 
-  QgsExpressionContext expressionContext = createExpressionContext( parameters, context );
+  QgsExpressionContext expressionContext = createExpressionContext( parameters, context, dynamic_cast< QgsProcessingFeatureSource * >( source.get() ) );
 
   long count = source->featureCount();
 

--- a/src/analysis/processing/qgsalgorithmfixgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.cpp
@@ -67,7 +67,7 @@ QgsFixGeometriesAlgorithm *QgsFixGeometriesAlgorithm::createInstance() const
   return new QgsFixGeometriesAlgorithm();
 }
 
-QgsFeature QgsFixGeometriesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback )
+QgsFeature QgsFixGeometriesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   if ( !feature.hasGeometry() )
     return feature;

--- a/src/analysis/processing/qgsalgorithmfixgeometries.h
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.h
@@ -45,7 +45,7 @@ class QgsFixGeometriesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsProcessingFeatureSource::Flag sourceFlags() const override;
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type type ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmmergelines.cpp
+++ b/src/analysis/processing/qgsalgorithmmergelines.cpp
@@ -71,7 +71,7 @@ QgsMergeLinesAlgorithm *QgsMergeLinesAlgorithm::createInstance() const
   return new QgsMergeLinesAlgorithm();
 }
 
-QgsFeature QgsMergeLinesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback )
+QgsFeature QgsMergeLinesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   if ( !feature.hasGeometry() )
     return feature;

--- a/src/analysis/processing/qgsalgorithmmergelines.h
+++ b/src/analysis/processing/qgsalgorithmmergelines.h
@@ -50,7 +50,7 @@ class QgsMergeLinesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsProcessing::SourceType outputLayerType() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmminimumenclosingcircle.cpp
+++ b/src/analysis/processing/qgsalgorithmminimumenclosingcircle.cpp
@@ -81,7 +81,7 @@ bool QgsMinimumEnclosingCircleAlgorithm::prepareAlgorithm( const QVariantMap &pa
   return true;
 }
 
-QgsFeature QgsMinimumEnclosingCircleAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsMinimumEnclosingCircleAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
+++ b/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
@@ -47,7 +47,7 @@ class QgsMinimumEnclosingCircleAlgorithm : public QgsProcessingFeatureBasedAlgor
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type ) const override;
     QgsFields outputFields( const QgsFields &inputFields ) const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
@@ -72,7 +72,7 @@ QgsFields QgsOrientedMinimumBoundingBoxAlgorithm::outputFields( const QgsFields 
   return fields;
 }
 
-QgsFeature QgsOrientedMinimumBoundingBoxAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsOrientedMinimumBoundingBoxAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
@@ -45,7 +45,7 @@ class QgsOrientedMinimumBoundingBoxAlgorithm : public QgsProcessingFeatureBasedA
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type ) const override;
     QgsFields outputFields( const QgsFields &inputFields ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.cpp
@@ -65,7 +65,7 @@ QgsWkbTypes::Type QgsPromoteToMultipartAlgorithm::outputWkbType( QgsWkbTypes::Ty
   return QgsWkbTypes::multiType( inputWkbType );
 }
 
-QgsFeature QgsPromoteToMultipartAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsPromoteToMultipartAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() && !f.geometry().isMultipart() )

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.h
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.h
@@ -46,7 +46,7 @@ class QgsPromoteToMultipartAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
 
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
 };
 

--- a/src/analysis/processing/qgsalgorithmsimplify.cpp
+++ b/src/analysis/processing/qgsalgorithmsimplify.cpp
@@ -88,7 +88,7 @@ bool QgsSimplifyAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsP
   return true;
 }
 
-QgsFeature QgsSimplifyAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsSimplifyAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmsimplify.h
+++ b/src/analysis/processing/qgsalgorithmsimplify.h
@@ -47,7 +47,7 @@ class QgsSimplifyAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   protected:
     QString outputName() const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &, QgsProcessingFeedback *feedback ) override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmsmooth.cpp
+++ b/src/analysis/processing/qgsalgorithmsmooth.cpp
@@ -96,7 +96,7 @@ bool QgsSmoothAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsPro
   return true;
 }
 
-QgsFeature QgsSmoothAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback )
+QgsFeature QgsSmoothAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmsmooth.h
+++ b/src/analysis/processing/qgsalgorithmsmooth.h
@@ -47,7 +47,7 @@ class QgsSmoothAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsProcessing::SourceType outputLayerType() const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
     int mIterations = 1;

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
@@ -85,7 +85,7 @@ bool QgsSnapToGridAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qg
   return true;
 }
 
-QgsFeature QgsSnapToGridAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback )
+QgsFeature QgsSnapToGridAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.h
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.h
@@ -45,7 +45,7 @@ class QgsSnapToGridAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   protected:
     QString outputName() const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
     double mIntervalX = 0.0;

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -71,7 +71,7 @@ QgsWkbTypes::Type QgsSubdivideAlgorithm::outputWkbType( QgsWkbTypes::Type inputW
   return QgsWkbTypes::multiType( inputWkbType );
 }
 
-QgsFeature QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsProcessingFeedback *feedback )
+QgsFeature QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   QgsFeature feature = f;
   if ( feature.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmsubdivide.h
+++ b/src/analysis/processing/qgsalgorithmsubdivide.h
@@ -46,7 +46,7 @@ class QgsSubdivideAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
 
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -73,7 +73,7 @@ bool QgsTransformAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
   return true;
 }
 
-QgsFeature QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsProcessingFeedback * )
+QgsFeature QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature feature = f;
   if ( !mCreatedTransform )

--- a/src/analysis/processing/qgsalgorithmtransform.h
+++ b/src/analysis/processing/qgsalgorithmtransform.h
@@ -48,7 +48,7 @@ class QgsTransformAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
 
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
 

--- a/src/analysis/processing/qgsalgorithmtranslate.cpp
+++ b/src/analysis/processing/qgsalgorithmtranslate.cpp
@@ -82,7 +82,7 @@ bool QgsTranslateAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
   return true;
 }
 
-QgsFeature QgsTranslateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingFeedback * )
+QgsFeature QgsTranslateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmtranslate.h
+++ b/src/analysis/processing/qgsalgorithmtranslate.h
@@ -45,7 +45,7 @@ class QgsTranslateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   protected:
     QString outputName() const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) override;
+    QgsFeature processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
 
   private:

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -874,7 +874,7 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
      * can break valid model execution - so use with extreme caution, and consider using
      * \a feedback to instead report non-fatal processing failures for features instead.
      */
-    virtual QgsFeature processFeature( const QgsFeature &feature, QgsProcessingFeedback *feedback ) = 0;
+    virtual QgsFeature processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) = 0;
 
     virtual QVariantMap processAlgorithm( const QVariantMap &parameters,
                                           QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -412,6 +412,66 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      */
     virtual QString toolTip() const;
 
+    /**
+     * Returns true if the parameter supports is dynamic, and can support data-defined values
+     * (i.e. QgsProperty based values).
+     * \see setIsDynamic()
+     * \see dynamicPropertyDefinition()
+     * \see dynamicLayerParameterName()
+     */
+    bool isDynamic() const { return mIsDynamic; }
+
+    /**
+     * Sets whether the parameter is \a dynamic, and can support data-defined values
+     * (i.e. QgsProperty based values).
+     * \see isDynamic()
+     * \see setDynamicPropertyDefinition()
+     * \see setDynamicLayerParameterName()
+     */
+    void setIsDynamic( bool dynamic ) { mIsDynamic = dynamic; }
+
+    /**
+     * Returns the property definition for dynamic properties.
+     * \see isDynamic()
+     * \see setDynamicPropertyDefinition()
+     * \see dynamicLayerParameterName()
+     */
+    QgsPropertyDefinition dynamicPropertyDefinition() const { return mPropertyDefinition; }
+
+    /**
+     * Sets the property \a definition for dynamic properties.
+     * \see isDynamic()
+     * \see dynamicPropertyDefinition()
+     * \see setDynamicLayerParameterName()
+     */
+    void setDynamicPropertyDefinition( const QgsPropertyDefinition &definition ) { mPropertyDefinition = definition; }
+
+    /**
+     * Returns the name of the parameter for a layer linked to a dynamic parameter, or an empty string if this is not set.
+     *
+     * Dynamic parameters (see isDynamic()) can have an optional vector layer parameter linked to them,
+     * which indicates which layer the fields and values will be available from when evaluating
+     * the dynamic parameter.
+     *
+     * \see setDynamicLayerParameterName()
+     * \see isDynamic()
+     * \see dynamicPropertyDefinition()
+     */
+    QString dynamicLayerParameterName() const { return mDynamicLayerParameterName; }
+
+    /**
+     * Sets the \a name for the parameter for a layer linked to a dynamic parameter, or an empty string if this is not set.
+     *
+     * Dynamic parameters (see isDynamic()) can have an optional vector layer parameter linked to them,
+     * which indicates which layer the fields and values will be available from when evaluating
+     * the dynamic parameter.
+     *
+     * \see dynamicLayerParameterName()
+     * \see isDynamic()
+     * \see setDynamicPropertyDefinition()
+     */
+    void setDynamicLayerParameterName( const QString &name ) { mDynamicLayerParameterName = name; }
+
   protected:
 
     //! Parameter name
@@ -431,6 +491,15 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 
     //! Pointer to algorithm which owns this parameter
     QgsProcessingAlgorithm *mAlgorithm = nullptr;
+
+    //! True for dynamic parameters, which can have data-defined (QgsProperty) based values
+    bool mIsDynamic = false;
+
+    //! Data defined property definition
+    QgsPropertyDefinition mPropertyDefinition;
+
+    //! Linked vector layer parameter name for dynamic properties
+    QString mDynamicLayerParameterName;
 
     // To allow access to mAlgorithm. We don't want a public setter for this!
     friend class QgsProcessingAlgorithm;

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -448,14 +448,13 @@ QVariant QgsProperty::propertyValue( const QgsExpressionContext &context, const 
           *ok = true;
         return f.attribute( d->cachedFieldIdx );
       }
-
-      int fieldIdx = f.fieldNameIndex( d->fieldName );
-      if ( fieldIdx < 0 )
+      prepare( context );
+      if ( d->cachedFieldIdx < 0 )
         return defaultValue;
 
       if ( ok )
         *ok = true;
-      return f.attribute( fieldIdx );
+      return f.attribute( d->cachedFieldIdx );
     }
 
     case ExpressionBasedProperty:

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -423,25 +423,37 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( QgsFeatur
     //add details of closest vertex to identify point
     closestVertexAttributes( *feature->geometry().constGet(), vId, layer, derivedAttributes );
   }
-  else if ( geometryType == QgsWkbTypes::PointGeometry &&
-            QgsWkbTypes::flatType( wkbType ) == QgsWkbTypes::Point )
+  else if ( geometryType == QgsWkbTypes::PointGeometry )
   {
-    // Include the x and y coordinates of the point as a derived attribute
-    QgsPointXY pnt = mCanvas->mapSettings().layerToMapCoordinates( layer, feature->geometry().asPoint() );
-    QString str = formatXCoordinate( pnt );
-    derivedAttributes.insert( QStringLiteral( "X" ), str );
-    str = formatYCoordinate( pnt );
-    derivedAttributes.insert( QStringLiteral( "Y" ), str );
+    if ( QgsWkbTypes::flatType( wkbType ) == QgsWkbTypes::Point )
+    {
+      // Include the x and y coordinates of the point as a derived attribute
+      QgsPointXY pnt = mCanvas->mapSettings().layerToMapCoordinates( layer, feature->geometry().asPoint() );
+      QString str = formatXCoordinate( pnt );
+      derivedAttributes.insert( QStringLiteral( "X" ), str );
+      str = formatYCoordinate( pnt );
+      derivedAttributes.insert( QStringLiteral( "Y" ), str );
 
-    if ( QgsWkbTypes::hasZ( wkbType ) )
-    {
-      str = QLocale::system().toString( static_cast<const QgsPoint *>( feature->geometry().constGet() )->z(), 'g', 10 );
-      derivedAttributes.insert( QStringLiteral( "Z" ), str );
+      if ( QgsWkbTypes::hasZ( wkbType ) )
+      {
+        str = QLocale::system().toString( static_cast<const QgsPoint *>( feature->geometry().constGet() )->z(), 'g', 10 );
+        derivedAttributes.insert( QStringLiteral( "Z" ), str );
+      }
+      if ( QgsWkbTypes::hasM( wkbType ) )
+      {
+        str = QLocale::system().toString( static_cast<const QgsPoint *>( feature->geometry().constGet() )->m(), 'g', 10 );
+        derivedAttributes.insert( QStringLiteral( "M" ), str );
+      }
     }
-    if ( QgsWkbTypes::hasM( wkbType ) )
+    else
     {
-      str = QLocale::system().toString( static_cast<const QgsPoint *>( feature->geometry().constGet() )->m(), 'g', 10 );
-      derivedAttributes.insert( QStringLiteral( "M" ), str );
+      //multipart
+
+      //add details of closest vertex to identify point
+      const QgsAbstractGeometry *geom = feature->geometry().constGet();
+      {
+        closestVertexAttributes( *geom, vId, layer, derivedAttributes );
+      }
     }
   }
 

--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -89,12 +89,17 @@ QgsPropertyOverrideButton::QgsPropertyOverrideButton( QWidget *parent,
 
 void QgsPropertyOverrideButton::init( int propertyKey, const QgsProperty &property, const QgsPropertiesDefinition &definitions, const QgsVectorLayer *layer, bool auxiliaryStorageEnabled )
 {
+  init( propertyKey, property, definitions.value( propertyKey ), layer, auxiliaryStorageEnabled );
+}
+
+void QgsPropertyOverrideButton::init( int propertyKey, const QgsProperty &property, const QgsPropertyDefinition &definition, const QgsVectorLayer *layer, bool auxiliaryStorageEnabled )
+{
   mVectorLayer = layer;
   mAuxiliaryStorageEnabled = auxiliaryStorageEnabled;
   setToProperty( property );
   mPropertyKey = propertyKey;
 
-  mDefinition = definitions.value( propertyKey );
+  mDefinition = definition;
   mDataTypes = mDefinition.dataType();
 
   mInputDescription = mDefinition.helpText();

--- a/src/gui/qgspropertyoverridebutton.h
+++ b/src/gui/qgspropertyoverridebutton.h
@@ -80,6 +80,20 @@ class GUI_EXPORT QgsPropertyOverrideButton: public QToolButton
     /**
      * Initialize a newly constructed property button (useful if button was included in a UI layout).
      * \param propertyKey key for corresponding property
+     * \param property initial value of associated property to show in widget
+     * \param definition properties definition for button
+     * \param layer associated vector layer
+     * \param auxiliaryStorageEnabled If true, activate the button to store data defined in auxiliary storage
+     */
+    void init( int propertyKey,
+               const QgsProperty &property,
+               const QgsPropertyDefinition &definition,
+               const QgsVectorLayer *layer = nullptr,
+               bool auxiliaryStorageEnabled = false );
+
+    /**
+     * Initialize a newly constructed property button (useful if button was included in a UI layout).
+     * \param propertyKey key for corresponding property
      * \param collection associated property collection
      * \param definitions properties definitions for collection
      * \param layer associated vector layer

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1445,6 +1445,7 @@ void TestQgsProcessing::parameters()
   // test parameter utilities
 
   std::unique_ptr< QgsProcessingParameterDefinition > def;
+
   QVariantMap params;
   params.insert( QStringLiteral( "prop" ), QgsProperty::fromField( "a_field" ) );
   params.insert( QStringLiteral( "string" ), QStringLiteral( "a string" ) );
@@ -1470,6 +1471,13 @@ void TestQgsProcessing::parameters()
   QCOMPARE( QgsProcessingParameters::parameterAsString( def.get(), params, context ), QStringLiteral( "true" ) );
   def->setName( QStringLiteral( "bad" ) );
   QCOMPARE( QgsProcessingParameters::parameterAsString( def.get(), params, context ), QString() );
+
+  def->setIsDynamic( true );
+  QVERIFY( def->isDynamic() );
+  def->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "Distance" ), QObject::tr( "Buffer distance" ), QgsPropertyDefinition::Double ) );
+  QCOMPARE( def->dynamicPropertyDefinition().name(), QStringLiteral( "Distance" ) );
+  def->setDynamicLayerParameterName( "parent" );
+  QCOMPARE( def->dynamicLayerParameterName(), QStringLiteral( "parent" ) );
 
   // string with dynamic property (feature not set)
   def->setName( QStringLiteral( "prop" ) );


### PR DESCRIPTION
Exposes the previously backend-only support for dynamic (i.e. data defined) numeric properties to the processing toolbox.

When running algorithms through the toolbox, which have dynamic numeric parameters, add a data defined property override button next to the widget so that users can set the overrides for these
parameters.

Previously this was available only in the backend, but not exposed anywhere in the GUI.

Currently only the buffer distance parameter and set z value z value parameter support dynamic values, but it's relatively straightforward to upgrade algorithms to support this (without breaking api)

