### PR TITLE
 Do not change property widget status if the dialog is rejected 

### DIFF
--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -634,8 +634,10 @@ void QgsPropertyOverrideButton::showAssistant()
     dlg->setWindowTitle( widget->panelTitle() );
     dlg->setLayout( new QVBoxLayout() );
     dlg->layout()->addWidget( widget );
-    QDialogButtonBox *buttonBox = new QDialogButtonBox( QDialogButtonBox::Ok );
+    QDialogButtonBox *buttonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok );
     connect( buttonBox, &QDialogButtonBox::accepted, dlg, &QDialog::accept );
+    connect( buttonBox, &QDialogButtonBox::rejected, dlg, &QDialog::reject );
+    connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPropertyOverrideButton::showHelp );
     dlg->layout()->addWidget( buttonBox );
     dlg->exec();
     settings.setValue( key, dlg->saveGeometry() );
@@ -816,4 +818,9 @@ void QgsPropertyOverrideButton::setActive( bool active )
 void QgsPropertyOverrideButton::registerExpressionContextGenerator( QgsExpressionContextGenerator *generator )
 {
   mExpressionContextGenerator = generator;
+}
+
+void QgsPropertyOverrideButton::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#data-defined" ) );
 }

--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -639,16 +639,18 @@ void QgsPropertyOverrideButton::showAssistant()
     connect( buttonBox, &QDialogButtonBox::rejected, dlg, &QDialog::reject );
     connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPropertyOverrideButton::showHelp );
     dlg->layout()->addWidget( buttonBox );
-    dlg->exec();
+
+    if ( dlg->exec() == QDialog::Accepted )
+    {
+      widget->updateProperty( mProperty );
+      mExpressionString = mProperty.asExpression();
+      mFieldName = mProperty.field();
+      widget->acceptPanel();
+      updateGui();
+
+      emit changed();
+    }
     settings.setValue( key, dlg->saveGeometry() );
-
-    widget->updateProperty( mProperty );
-    mExpressionString = mProperty.asExpression();
-    mFieldName = mProperty.field();
-    widget->acceptPanel();
-    updateGui();
-
-    emit changed();
   }
 }
 

--- a/src/gui/qgspropertyoverridebutton.h
+++ b/src/gui/qgspropertyoverridebutton.h
@@ -300,7 +300,7 @@ class GUI_EXPORT QgsPropertyOverrideButton: public QToolButton
   private slots:
     void aboutToShowMenu();
     void menuActionTriggered( QAction *action );
-
+    void showHelp();
     void updateSiblingWidgets( bool state );
 };
 


### PR DESCRIPTION
The issue is reported at https://issues.qgis.org/issues/16766: when you close the property assistant dialog, the data-defined icon status changes even if you do nothing.
This PR fixes the  issue when in dialog mode; it'd need someone else to do the panel mode part, given that I think, it will somehow impact how the (automatic) validation is processed in this mode.
Also add Cancel and Help buttons