### PR TITLE
Make frames expandable and cover needed space

### DIFF
--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1588,19 +1588,6 @@ border-radius: 2px;</string>
                 </property>
                </widget>
               </item>
-              <item>
-               <spacer name="verticalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
              </layout>
             </widget>
            </item>
@@ -2162,6 +2149,12 @@ border-radius: 2px;</string>
               </item>
               <item row="2" column="0">
                <widget class="QgsCollapsibleGroupBox" name="mAuxiliaryStorageFieldsGrpBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="title">
                  <string>Fields</string>
                 </property>


### PR DESCRIPTION
In some tabs of the vector layer properties, we have blank space at the bottom of the dialog  while some frames need to be scrolled to fully see their content. this PR gives those frames more height...
The before/after screenshot
![dependencies](https://user-images.githubusercontent.com/7983394/33240987-f8031e9c-d2bf-11e7-901a-5141da379550.png)
![auxiliarystorage](https://user-images.githubusercontent.com/7983394/33240989-f8448a8a-d2bf-11e7-9054-5ee4854858c3.png)
