### PR TITLE
Fix #17510 - Better scoping of QgsProjectionSelectionDialog inside Qg…

### DIFF
--- a/python/gui/qgsprojectionselectionwidget.sip
+++ b/python/gui/qgsprojectionselectionwidget.sip
@@ -35,14 +35,6 @@ class QgsProjectionSelectionWidget : QWidget
 
     explicit QgsProjectionSelectionWidget( QWidget *parent /TransferThis/ = 0 );
 
-    QgsProjectionSelectionDialog *dialog();
-%Docstring
- Returns a pointer to the projection selector dialog used by the widget.
- Can be used to modify how the projection selector dialog behaves.
- :return: projection selector dialog
- :rtype: QgsProjectionSelectionDialog
-%End
-
     QgsCoordinateReferenceSystem crs() const;
 %Docstring
  Returns the currently selected CRS for the widget
@@ -70,6 +62,14 @@ class QgsProjectionSelectionWidget : QWidget
 %Docstring
  Sets the text to show for the not set option. Note that this option is not shown
  by default and must be set visible by calling setOptionVisible().
+.. versionadded:: 3.0
+%End
+
+    void setMessage( const QString &text );
+%Docstring
+ Sets a ``message`` to show in the dialog. If an empty string is
+ passed, the message will be a generic
+ 'define the CRS for this layer'.
 .. versionadded:: 3.0
 %End
 

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -90,8 +90,8 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
   QgsCoordinateReferenceSystem crs( crsid, QgsCoordinateReferenceSystem::InternalCrsId );
   mCrsSelector->setCrs( crs );
   mCrsSelector->setLayerCrs( crs );
-  mCrsSelector->dialog()->setMessage( tr( "Select the coordinate reference system for the dxf file. "
-                                          "The data points will be transformed from the layer coordinate reference system." ) );
+  mCrsSelector->setMessage( tr( "Select the coordinate reference system for the dxf file. "
+                                "The data points will be transformed from the layer coordinate reference system." ) );
 
   pbLoadDatabase_clicked();
   updateUI();

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -474,8 +474,8 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mCRS = QgsCoordinateReferenceSystem::fromSrsId( crsid );
   mCrsSelector->setCrs( mCRS );
   mCrsSelector->setLayerCrs( mCRS );
-  mCrsSelector->dialog()->setMessage( tr( "Select the coordinate reference system for the dxf file. "
-                                          "The data points will be transformed from the layer coordinate reference system." ) );
+  mCrsSelector->setMessage( tr( "Select the coordinate reference system for the dxf file. "
+                                "The data points will be transformed from the layer coordinate reference system." ) );
 
   mEncoding->addItems( QgsDxfExport::encodings() );
   mEncoding->setCurrentIndex( mEncoding->findText( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), s.value( QStringLiteral( "qgis/lastDxfEncoding" ), "CP1252" ).toString() ) ) );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -120,8 +120,8 @@ void QgsVectorLayerSaveAsDialog::setup()
   QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem::fromSrsId( mCRS );
   mCrsSelector->setCrs( srs );
   mCrsSelector->setLayerCrs( srs );
-  mCrsSelector->dialog()->setMessage( tr( "Select the coordinate reference system for the vector file. "
-                                          "The data points will be transformed from the layer coordinate reference system." ) );
+  mCrsSelector->setMessage( tr( "Select the coordinate reference system for the vector file. "
+                                "The data points will be transformed from the layer coordinate reference system." ) );
 
   mEncodingComboBox->setCurrentIndex( idx );
   mFormatComboBox_currentIndexChanged( mFormatComboBox->currentIndex() );

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -24,7 +24,6 @@
 QgsProjectionSelectionWidget::QgsProjectionSelectionWidget( QWidget *parent )
   : QWidget( parent )
 {
-  mDialog = new QgsProjectionSelectionDialog( this );
 
 
   QHBoxLayout *layout = new QHBoxLayout();
@@ -157,6 +156,11 @@ void QgsProjectionSelectionWidget::setNotSetText( const QString &text )
   }
 }
 
+void QgsProjectionSelectionWidget::setMessage( const QString &text )
+{
+  mMessage = text;
+}
+
 bool QgsProjectionSelectionWidget::optionVisible( QgsProjectionSelectionWidget::CrsOption option ) const
 {
   int optionIndex = mCrsComboBox->findData( option );
@@ -166,17 +170,19 @@ bool QgsProjectionSelectionWidget::optionVisible( QgsProjectionSelectionWidget::
 void QgsProjectionSelectionWidget::selectCrs()
 {
   //find out crs id of current proj4 string
+  QgsProjectionSelectionDialog dlg( this );
+  dlg.setMessage( mMessage );
   if ( mCrs.isValid() )
   {
-    mDialog->setCrs( mCrs );
+    dlg.setCrs( mCrs );
   }
 
-  if ( mDialog->exec() )
+  if ( dlg.exec() )
   {
     mCrsComboBox->blockSignals( true );
     mCrsComboBox->setCurrentIndex( mCrsComboBox->findData( QgsProjectionSelectionWidget::CurrentCrs ) );
     mCrsComboBox->blockSignals( false );
-    QgsCoordinateReferenceSystem crs = mDialog->crs();
+    QgsCoordinateReferenceSystem crs = dlg.crs();
     setCrs( crs );
     emit crsChanged( crs );
   }

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -55,13 +55,6 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     explicit QgsProjectionSelectionWidget( QWidget *parent SIP_TRANSFERTHIS = 0 );
 
     /**
-     * Returns a pointer to the projection selector dialog used by the widget.
-     * Can be used to modify how the projection selector dialog behaves.
-     * \returns projection selector dialog
-     */
-    QgsProjectionSelectionDialog *dialog() { return mDialog; }
-
-    /**
      * Returns the currently selected CRS for the widget
      * \returns current CRS
      */
@@ -88,6 +81,14 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
      * \since QGIS 3.0
      */
     void setNotSetText( const QString &text );
+
+    /**
+     * Sets a \a message to show in the dialog. If an empty string is
+     * passed, the message will be a generic
+     * 'define the CRS for this layer'.
+     * \since QGIS 3.0
+     */
+    void setMessage( const QString &text );
 
   signals:
 
@@ -132,6 +133,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     QToolButton *mButton = nullptr;
     QgsProjectionSelectionDialog *mDialog = nullptr;
     QString mNotSetText;
+    QString mMessage;
 
     void addNotSetOption();
     void addProjectCrsOption();


### PR DESCRIPTION
Removes the API exposing QgsProjectionSelectionDialog via the widget and stops a crash on QGIS close. Also should help speed up things a little as QgsProjectionSelectionDialog now contains the world map for the projection data so we don't create that until asked.