### PR TITLE
Fix displayed extent for US National Atlas CRS (and others) on projection map

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1072,7 +1072,11 @@ QgsRectangle QgsCoordinateReferenceSystem::bounds() const
       double north = statement.columnAsDouble( 1 );
       double east = statement.columnAsDouble( 2 );
       double south = statement.columnAsDouble( 3 );
-      rect = QgsRectangle( west, north, east, south );
+
+      rect.setXMinimum( west );
+      rect.setYMinimum( south );
+      rect.setXMaximum( east );
+      rect.setYMaximum( north );
     }
   }
 

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -1028,14 +1028,32 @@ void QgsProjectionSelectionTreeWidget::updateBoundsPreview()
     return;
 
   QgsRectangle rect = currentCrs.bounds();
-  if ( !rect.isEmpty() )
+  if ( !qgsDoubleNear( rect.area(), 0.0 ) )
   {
-    mPreviewBand->setToGeometry( QgsGeometry::fromRect( rect ), nullptr );
+    QgsGeometry geom;
+    if ( rect.xMinimum() > rect.xMaximum() )
+    {
+      QgsRectangle rect1 = QgsRectangle( -180, rect.yMinimum(), rect.xMaximum(), rect.yMaximum() );
+      QgsRectangle rect2 = QgsRectangle( rect.xMinimum(), rect.yMinimum(), 180, rect.yMaximum() );
+      geom = QgsGeometry::fromRect( rect1 );
+      geom.addPart( QgsGeometry::fromRect( rect2 ) );
+    }
+    else
+    {
+      geom = QgsGeometry::fromRect( rect );
+    }
+    mPreviewBand->setToGeometry( geom, nullptr );
     mPreviewBand->setColor( QColor( 255, 0, 0, 65 ) );
-    mAreaCanvas->setExtent( rect );
+    QgsRectangle extent = geom.boundingBox();
+    extent.scale( 1.1 );
+    mAreaCanvas->setExtent( extent );
+    mAreaCanvas->refresh();
     mPreviewBand->show();
-    mAreaCanvas->zoomOut();
-    QString extentString = tr( "Extent: %1" ).arg( rect.toString( 2 ) );
+    QString extentString = tr( "Extent: %1, %2, %3, %4" )
+                           .arg( rect.xMinimum(), 0, 'f', 2 )
+                           .arg( rect.yMinimum(), 0, 'f', 2 )
+                           .arg( rect.xMaximum(), 0, 'f', 2 )
+                           .arg( rect.yMaximum(), 0, 'f', 2 );
     QString proj4String = tr( "Proj4: %1" ).arg( selectedProj4String() );
     teProjection->setText( extentString + "\n" + proj4String );
   }

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -812,6 +812,13 @@ void TestQgsCoordinateReferenceSystem::bounds()
   QGSCOMPARENEAR( bounds.xMaximum(), 180.000000, 0.0001 );
   QGSCOMPARENEAR( bounds.yMinimum(), -90.00000, 0.0001 );
   QGSCOMPARENEAR( bounds.yMaximum(), 90.00000, 0.0001 );
+
+  QgsCoordinateReferenceSystem crs2163( "EPSG:2163" );
+  bounds = crs2163.bounds();
+  QGSCOMPARENEAR( bounds.xMinimum(), 167.65000, 0.0001 );
+  QGSCOMPARENEAR( bounds.xMaximum(), -65.69000, 0.0001 );
+  QGSCOMPARENEAR( bounds.yMinimum(), 15.56000, 0.0001 );
+  QGSCOMPARENEAR( bounds.yMaximum(), 74.71000, 0.0001 );
 }
 
 void TestQgsCoordinateReferenceSystem::saveAsUserCrs()


### PR DESCRIPTION
## Description
A number of projections (79 in our srs.db) display a wrong extent on the projection map widget due to the projection bound crossing across the +180/-180 longitude coordinate. The most important of such projection is EPSG: 2163 (US National Atlas).

Currently, the extent for the US National Atlas' EPSG is:
![screenshot from 2017-11-27 15-38-30](https://user-images.githubusercontent.com/1728657/33259333-2054364a-d38f-11e7-939a-6a6c8c40284c.png)

It's clearly wrong. I initially thought it was the QgsRectangle who couldn't transform properly into a QgsGeometry, but trying a properly ordered WKT polygon for the extent also fails on QGIS.

One way to work around the issue is tried in this PR. It results in a proper extent shown on the projection map widget:
![screenshot from 2017-11-27 16-10-50](https://user-images.githubusercontent.com/1728657/33259449-85faaed4-d38f-11e7-837a-ee84b571094f.png)

That said, I have no idea whether this is acceptable. @NathanW2 , @nyalldawson , opinion?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
