### PR TITLE
fix #17562 broken legend uris

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -175,6 +175,9 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const QgsWmsCapabilities *ca
 
 QString QgsWmsProvider::prepareUri( QString uri )
 {
+  // some services provide a percent/url encoded (legend) uri string, always decode here
+  uri = QUrl::fromPercentEncoding( uri.toUtf8() );
+
   if ( uri.contains( QLatin1String( "SERVICE=WMTS" ) ) || uri.contains( QLatin1String( "/WMTSCapabilities.xml" ) ) )
   {
     return uri;


### PR DESCRIPTION
## Description

Fixes https://issues.qgis.org/issues/17562 where you can find a failing public service url.

Some WMS services (notably ArcGis) provide a percent encode legend uri string.
QGIS fails to handle those, resulting in an uri which contains several 'format' parameters then.
On which ArcGis throws an error, resulting in a  'flawed legend image' msg in QGIS.

In 2.18 this was working ok, but apparently Qt5 handles the query string of QUrl differently.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ X] Commit messages are descriptive and explain the rationale for changes
- [ X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
