### PR TITLE
[bugfix]  Fixes a crash in QgsRelationReferenceWidgetWrapper

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -64,9 +64,12 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   mWidget->setAllowAddFeatures( config( QStringLiteral( "AllowAddFeatures" ), false ).toBool() );
 
   const QVariant relationName = config( QStringLiteral( "Relation" ) );
-  QgsRelation relation = relationName.isValid() ?
-                         QgsProject::instance()->relationManager()->relation( relationName.toString() ) :
-                         layer()->referencingRelations( fieldIdx() )[0];
+
+  QgsRelation relation; // invalid relation by default
+  if ( relationName.isValid() )
+    relation = QgsProject::instance()->relationManager()->relation( relationName.toString() );
+  else if ( ! layer()->referencingRelations( fieldIdx() ).isEmpty() )
+    relation = layer()->referencingRelations( fieldIdx() )[0];
 
   // If this widget is already embedded by the same relation, reduce functionality
   const QgsAttributeEditorContext *ctx = &context();

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -20,6 +20,7 @@
 #include <qgsapplication.h>
 #include "qgseditorwidgetwrapper.h"
 #include <editorwidgets/qgsrelationreferencewidget.h>
+#include <editorwidgets/qgsrelationreferencewidgetwrapper.h>
 #include <qgsproject.h>
 #include <qgsattributeform.h>
 #include <qgsrelationmanager.h>
@@ -27,6 +28,7 @@
 #include "qgsfeaturelistcombobox.h"
 #include "qgsfeaturefiltermodel.h"
 #include "qgsgui.h"
+#include "qgsmapcanvas.h"
 
 class TestQgsRelationReferenceWidget : public QObject
 {
@@ -43,6 +45,7 @@ class TestQgsRelationReferenceWidget : public QObject
     void testChainFilter();
     void testChainFilterRefreshed();
     void testChainFilterDeleteForeignKey();
+    void testInvalidRelation();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer1;
@@ -271,6 +274,17 @@ void TestQgsRelationReferenceWidget::testChainFilterDeleteForeignKey()
 
   QCOMPARE( cbs[2]->currentText(), QString( "raccord" ) );
   QCOMPARE( cbs[2]->isEnabled(), false );
+}
+
+void TestQgsRelationReferenceWidget::testInvalidRelation()
+{
+  QgsVectorLayer vl( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=fk:int" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+  QgsMapCanvas canvas;
+  QgsRelationReferenceWidget editor( new QWidget() );
+
+  // initWidget with an invalid relation
+  QgsRelationReferenceWidgetWrapper ww( &vl, 10, &editor, &canvas, nullptr, nullptr );
+  ww.initWidget( nullptr );
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
## Description

Fixes a crash in QgsRelationReferenceWidgetWrapper when there's no relation.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
