### PR TITLE
Fix offset curve tool offsets curves in opposite direction to mouse

### DIFF
--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -42,6 +42,19 @@ QgsMapToolOffsetCurve::~QgsMapToolOffsetCurve()
   delete mSnapVertexMarker;
 }
 
+void QgsMapToolOffsetCurve::keyPressEvent( QKeyEvent *e )
+{
+  if ( e && e->key() == Qt::Key_Escape && !e->isAutoRepeat() )
+  {
+    deleteRubberBandAndGeometry();
+    deleteDistanceWidget();
+  }
+  else
+  {
+    QgsMapToolEdit::keyPressEvent( e );
+  }
+}
+
 
 void QgsMapToolOffsetCurve::canvasReleaseEvent( QgsMapMouseEvent *e )
 {

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -33,10 +33,6 @@
 
 QgsMapToolOffsetCurve::QgsMapToolOffsetCurve( QgsMapCanvas *canvas )
   : QgsMapToolEdit( canvas )
-  , mModifiedFeature( -1 )
-  , mGeometryModified( false )
-  , mForceCopy( false )
-  , mMultiPartGeometry( false )
 {
 }
 
@@ -75,11 +71,6 @@ void QgsMapToolOffsetCurve::canvasReleaseEvent( QgsMapMouseEvent *e )
     deleteRubberBandAndGeometry();
     mGeometryModified = false;
     mForceCopy = false;
-
-    if ( e->button() == Qt::RightButton )
-    {
-      return;
-    }
 
     QgsSnappingUtils *snapping = mCanvas->snappingUtils();
 
@@ -122,10 +113,11 @@ void QgsMapToolOffsetCurve::canvasReleaseEvent( QgsMapMouseEvent *e )
     {
       emit messageEmitted( tr( "Could not find a nearby feature in any vector layer." ) );
     }
-    return;
   }
-
-  applyOffset();
+  else
+  {
+    applyOffset();
+  }
 }
 
 void QgsMapToolOffsetCurve::applyOffset()

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -248,13 +248,13 @@ void QgsMapToolOffsetCurve::canvasMoveEvent( QgsMapMouseEvent *e )
   if ( mDistanceWidget )
   {
     // this will also set the rubber band
-    mDistanceWidget->setValue( leftOf < 0 ? offset : -offset );
+    mDistanceWidget->setValue( leftOf < 0 ? -offset : offset );
     mDistanceWidget->setFocus( Qt::TabFocusReason );
   }
   else
   {
     //create offset geometry using geos
-    setOffsetForRubberBand( leftOf < 0 ? offset : -offset );
+    setOffsetForRubberBand( leftOf < 0 ? -offset : offset );
   }
 }
 

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -39,7 +39,7 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
     void placeOffsetCurveToValue();
 
     //! Apply the offset either from the spin box or from the mouse event
-    void applyOffset();
+    void applyOffset( bool forceCopy = false );
 
   private:
     //! Rubberband that shows the position of the offset curve
@@ -59,7 +59,7 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
     //! Marker to show the cursor was snapped to another location
     QgsVertexMarker *mSnapVertexMarker = nullptr;
     //! Forces geometry copy (no modification of geometry in current layer)
-    bool mForceCopy = false;
+    bool mCtrlWasHeldOnFeatureSelection = false;
     bool mMultiPartGeometry = false;
 
 

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -49,18 +49,18 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
     //! Geometry after manipulation
     QgsGeometry mModifiedGeometry;
     //! ID of manipulated feature
-    QgsFeatureId mModifiedFeature;
+    QgsFeatureId mModifiedFeature = -1;
     //! Layer ID of source layer
     QString mSourceLayerId;
     //! Internal flag to distinguish move from click
-    bool mGeometryModified;
+    bool mGeometryModified = false;
     //! Shows current distance value and allows numerical editing
     QgsDoubleSpinBox *mDistanceWidget = nullptr;
     //! Marker to show the cursor was snapped to another location
     QgsVertexMarker *mSnapVertexMarker = nullptr;
     //! Forces geometry copy (no modification of geometry in current layer)
-    bool mForceCopy;
-    bool mMultiPartGeometry;
+    bool mForceCopy = false;
+    bool mMultiPartGeometry = false;
 
 
     void deleteRubberBandAndGeometry();

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -31,6 +31,7 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
     QgsMapToolOffsetCurve( QgsMapCanvas *canvas );
     ~QgsMapToolOffsetCurve();
 
+    void keyPressEvent( QKeyEvent *e ) override;
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
 


### PR DESCRIPTION
...but I'm not sure... is this intentional behavior? It seems strange to me that there's no open bug about the tool being so fundamentally broken.

(and if it's intentional - i don't think it's correct!)