### PR TITLE
Show unknown feature count instead of misleading 0 in sublayer dialog

### DIFF
--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -136,7 +136,7 @@ void QgsSublayersDialog::populateLayerTable( const QgsSublayersDialog::LayerDefi
     QStringList elements;
     elements << QString::number( item.layerId ) << item.layerName;
     if ( mShowCount )
-      elements << QString::number( item.count );
+      elements << ( item.count == -1 ? tr( "Unknown" ) : QString::number( item.count ) );
     if ( mShowType )
       elements << item.type;
     layersTable->addTopLevelItem( new SubLayerItem( elements ) );

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -749,10 +749,11 @@ void QgsOgrProvider::addSubLayerDetailsToSubLayerList( int i, QgsOgrLayer *layer
 
     QString geom = ogrWkbGeometryTypeName( layerGeomType );
 
+    // For feature count, -1 indicates an unknown count state
     QStringList parts = QStringList()
                         << QString::number( i )
                         << layerName
-                        << ( layerFeatureCount == -1 ? tr( "Unknown" ) : QString::number( layerFeatureCount ) )
+                        << QString::number( layerFeatureCount )
                         << geom
                         << geometryColumnName;
 


### PR DESCRIPTION
## Description
The OGR provider returns -1 for sub layers with an unknown feature count. When compiling the QStringList of sublayers, the -1 value is transformed into tr( "Unknown" ) (https://github.com/qgis/QGIS/blob/master/src/providers/ogr/qgsogrprovider.cpp#L755), which is a problem as that sring values is then converted into 0 when parsed through a toInt() prior to being sent to the sublayer dialog (https://github.com/qgis/QGIS/blob/master/src/app/qgisapp.cpp#L4607).

This PR keeps -1 as a feature count value, and parse it as tr( "Unknown" ) _within_ the sublayer dialog itself. Because unknown != zero 😉 

Before vs. healed feature count:
![screenshot from 2017-11-28 12-37-16](https://user-images.githubusercontent.com/1728657/33304151-cab99c38-d439-11e7-992c-d04c28cc4343.png)

@nyalldawson , review appreciated.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
