### PR TITLE
Fix #17573 inconsistency of icons in layer trees

### DIFF
--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -31,7 +31,7 @@ QgsWCSConnectionItem::QgsWCSConnectionItem( QgsDataItem *parent, QString name, Q
   : QgsDataCollectionItem( parent, name, path )
   , mUri( uri )
 {
-  mIconName = QStringLiteral( "mIconWcs.svg" );
+  mIconName = QStringLiteral( "mIconConnect.png" );
   mCapabilities |= Collapse;
 }
 

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -48,7 +48,7 @@ QgsWfsLayerItem::QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDa
   bool useCurrentViewExtent = settings.value( QStringLiteral( "Windows/WFSSourceSelect/FeatureCurrentViewExtent" ), true ).toBool();
   mUri = QgsWFSDataSourceURI::build( uri.uri( false ), featureType, crsString, QString(), useCurrentViewExtent );
   setState( Populated );
-  mIconName = QStringLiteral( "mIconConnect.png" );
+  mIconName = QStringLiteral( "mIconWfs.svg" );
   mBaseUri = uri.param( QStringLiteral( "url" ) );
 }
 
@@ -137,7 +137,7 @@ QgsWfsConnectionItem::QgsWfsConnectionItem( QgsDataItem *parent, QString name, Q
   : QgsDataCollectionItem( parent, name, path )
   , mUri( uri )
 {
-  mIconName = QStringLiteral( "mIconWfs.svg" );
+  mIconName = QStringLiteral( "mIconConnect.png" );
   mCapabilities |= Collapse;
 }
 


### PR DESCRIPTION
## Description
This PR adds some consistency in the use of icons in the treeviews in browser and data source manager, see: http://issues.qgis.org/issues/17573

See above issue for some example service url's

Before this patch:

![treeview](https://user-images.githubusercontent.com/731673/33322149-9264d442-d448-11e7-9c12-982baaded335.png)

After this patch:

![selection_225](https://user-images.githubusercontent.com/731673/33322207-c9dafdde-d448-11e7-984c-3a86bcfa2ac6.png)
