### PR TITLE
fixed closestSegmentWithContext() params in Python

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -500,7 +500,7 @@ Returns true if WKB of the geometry is of WKBMulti* type
  \param minDistPoint Receives the nearest point on the segment
  \param afterVertex Receives index of the vertex after the closest segment. The vertex
  before the closest segment is always afterVertex - 1
- \param leftOf Out: Returns if the point lies on the left of right side of the segment ( < 0 means left, > 0 means right )
+ \param leftOf Out: Returns if the point lies on the left of right side of the segment ( > 0 means left, < 0 means right )
  \param epsilon epsilon for segment snapping
  :return: The squared Cartesian distance is also returned in sqrDist, negative number on error
  :rtype: float

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -493,7 +493,7 @@ Returns true if WKB of the geometry is of WKBMulti* type
  :rtype: float
 %End
 
-    double closestSegmentWithContext( const QgsPointXY &point, QgsPointXY &minDistPoint /Out/, int &afterVertex /Out/ ) const;
+    double closestSegmentWithContext( const QgsPointXY &point, QgsPointXY &minDistPoint /Out/, int &afterVertex /Out/, double *leftOf /Out/ = 0, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
 %Docstring
  Searches for the closest segment of geometry to the given point
  \param point Specifies the point for search

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -559,11 +559,7 @@ class CORE_EXPORT QgsGeometry
      * \param epsilon epsilon for segment snapping
      * \returns The squared Cartesian distance is also returned in sqrDist, negative number on error
      */
-#ifndef SIP_RUN
-    double closestSegmentWithContext( const QgsPointXY &point, QgsPointXY &minDistPoint, int &afterVertex, double *leftOf = nullptr, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
-#else
-    double closestSegmentWithContext( const QgsPointXY &point, QgsPointXY &minDistPoint SIP_OUT, int &afterVertex SIP_OUT ) const;
-#endif
+    double closestSegmentWithContext( const QgsPointXY &point, QgsPointXY &minDistPoint SIP_OUT, int &afterVertex SIP_OUT, double *leftOf SIP_OUT = nullptr, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
 
     /**
      * Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -555,7 +555,7 @@ class CORE_EXPORT QgsGeometry
      * \param minDistPoint Receives the nearest point on the segment
      * \param afterVertex Receives index of the vertex after the closest segment. The vertex
      * before the closest segment is always afterVertex - 1
-     * \param leftOf Out: Returns if the point lies on the left of right side of the segment ( < 0 means left, > 0 means right )
+     * \param leftOf Out: Returns if the point lies on the left of right side of the segment ( > 0 means left, < 0 means right )
      * \param epsilon epsilon for segment snapping
      * \returns The squared Cartesian distance is also returned in sqrDist, negative number on error
      */

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -499,10 +499,11 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(afterVertex, 5)
         self.assertEqual(dist, 1)
 
-        (dist, minDistPoint, afterVertex) = polyline.closestSegmentWithContext(QgsPointXY(6, 2))
+        (dist, minDistPoint, afterVertex, leftOf) = polyline.closestSegmentWithContext(QgsPointXY(6, 2))
         self.assertEqual(dist, 1)
         self.assertEqual(minDistPoint, QgsPointXY(5, 2))
         self.assertEqual(afterVertex, 4)
+        self.assertTrue(leftOf > 0)
 
         (point, atVertex, beforeVertex, afterVertex, dist) = polyline.closestVertex(QgsPointXY(6, 0))
         self.assertEqual(point, QgsPointXY(5, 0))
@@ -511,7 +512,7 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(afterVertex, 1)
         self.assertEqual(dist, 1)
 
-        (dist, minDistPoint, afterVertex) = polyline.closestSegmentWithContext(QgsPointXY(6, 0))
+        (dist, minDistPoint, afterVertex, leftOf) = polyline.closestSegmentWithContext(QgsPointXY(6, 0))
         self.assertEqual(dist, 1)
         self.assertEqual(minDistPoint, QgsPointXY(5, 0))
         self.assertEqual(afterVertex, 1)
@@ -523,7 +524,7 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(afterVertex, 2)
         self.assertEqual(dist, 1)
 
-        (dist, minDistPoint, afterVertex) = polyline.closestSegmentWithContext(QgsPointXY(0, 1))
+        (dist, minDistPoint, afterVertex, leftOf) = polyline.closestSegmentWithContext(QgsPointXY(0, 1))
         self.assertEqual(dist, 0)
         self.assertEqual(minDistPoint, QgsPointXY(0, 1))
         self.assertEqual(afterVertex, 2)
@@ -544,7 +545,7 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(afterVertex, 8)
         self.assertEqual(dist, 1)
 
-        (dist, minDistPoint, afterVertex) = polyline.closestSegmentWithContext(QgsPointXY(7, 0))
+        (dist, minDistPoint, afterVertex, leftOf) = polyline.closestSegmentWithContext(QgsPointXY(7, 0))
         self.assertEqual(dist, 1)
         self.assertEqual(minDistPoint, QgsPointXY(6, 0))
         self.assertEqual(afterVertex, 9)
@@ -566,11 +567,12 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(afterVertex, 3)
         assert abs(dist - 0.1) < 0.00001, "Expected: %f; Got:%f" % (dist, 0.1)
 
-        (dist, minDistPoint, afterVertex) = polygon.closestSegmentWithContext(QgsPointXY(0.7, 1.1))
+        (dist, minDistPoint, afterVertex, leftOf) = polygon.closestSegmentWithContext(QgsPointXY(0.7, 1.1))
         self.assertEqual(afterVertex, 2)
         self.assertEqual(minDistPoint, QgsPointXY(1, 1))
         exp = 0.3 ** 2 + 0.1 ** 2
         assert abs(dist - exp) < 0.00001, "Expected: %f; Got:%f" % (exp, dist)
+        self.assertTrue(leftOf > 0)
 
         # 3-+-+-2
         # |     |
@@ -592,11 +594,12 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(afterVertex, 9)
         assert abs(dist - 0.02) < 0.00001, "Expected: %f; Got:%f" % (dist, 0.02)
 
-        (dist, minDistPoint, afterVertex) = polygon.closestSegmentWithContext(QgsPointXY(1.2, 1.9))
+        (dist, minDistPoint, afterVertex, leftOf) = polygon.closestSegmentWithContext(QgsPointXY(1.2, 1.9))
         self.assertEqual(afterVertex, 8)
         self.assertEqual(minDistPoint, QgsPointXY(1.2, 2))
         exp = 0.01
         assert abs(dist - exp) < 0.00001, "Expected: %f; Got:%f" % (exp, dist)
+        self.assertTrue(leftOf > 0)
 
         # 5-+-4 0-+-9
         # |   | |   |
@@ -616,11 +619,12 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(afterVertex, 13)
         assert abs(dist - 0.02) < 0.00001, "Expected: %f; Got:%f" % (dist, 0.02)
 
-        (dist, minDistPoint, afterVertex) = polygon.closestSegmentWithContext(QgsPointXY(4.1, 1.1))
+        (dist, minDistPoint, afterVertex, leftOf) = polygon.closestSegmentWithContext(QgsPointXY(4.1, 1.1))
         self.assertEqual(afterVertex, 12)
         self.assertEqual(minDistPoint, QgsPointXY(4, 1))
         exp = 0.02
         assert abs(dist - exp) < 0.00001, "Expected: %f; Got:%f" % (exp, dist)
+        self.assertTrue(leftOf > 0)
 
     def testAdjacentVertex(self):
         # 2-+-+-+-+-3


### PR DESCRIPTION
Missing QgsGeometry.closestSegmentWithContext() in Python bindings.