### PR TITLE
Fix 3D view if terrain DEM is in different CRS

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(QGIS_3D_SRCS
   qgstessellatedpolygongeometry.cpp
   qgstessellator.cpp
   qgstilingscheme.cpp
+  qgsvector3d.cpp
   qgsvectorlayer3drenderer.cpp
 
   chunks/qgschunkboundsentity_p.cpp
@@ -84,6 +85,7 @@ SET(QGIS_3D_HDRS
   qgstessellatedpolygongeometry.h
   qgstessellator.h
   qgstilingscheme.h
+  qgsvector3d.h
   qgsvectorlayer3drenderer.h
 
   chunks/qgschunkboundsentity_p.h

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -84,7 +84,9 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
   QString terrainGenType = elemTerrainGenerator.attribute( "type" );
   if ( terrainGenType == "dem" )
   {
-    mTerrainGenerator.reset( new QgsDemTerrainGenerator );
+    QgsDemTerrainGenerator *demTerrainGenerator = new QgsDemTerrainGenerator;
+    demTerrainGenerator->setCrs( mCrs );
+    mTerrainGenerator.reset( demTerrainGenerator );
   }
   else if ( terrainGenType == "quantized-mesh" )
   {

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -211,16 +211,12 @@ void Qgs3DMapSettings::resolveReferences( const QgsProject &project )
 
 QgsVector3D Qgs3DMapSettings::mapToWorldCoordinates( const QgsVector3D &mapCoords ) const
 {
-  return QgsVector3D( mapCoords.x() - mOrigin.x(),
-                      -( mapCoords.z() - mOrigin.z() ),
-                      mapCoords.y() - mOrigin.y() );
+  return Qgs3DUtils::mapToWorldCoordinates( mapCoords, mOrigin );
 }
 
 QgsVector3D Qgs3DMapSettings::worldToMapCoordinates( const QgsVector3D &worldCoords ) const
 {
-  return QgsVector3D( worldCoords.x() + mOrigin.x(),
-                      -( worldCoords.z() + mOrigin.z() ),
-                      worldCoords.y() + mOrigin.y() );
+  return Qgs3DUtils::worldToMapCoordinates( worldCoords, mOrigin );
 }
 
 void Qgs3DMapSettings::setCrs( const QgsCoordinateReferenceSystem &crs )

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -25,6 +25,7 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsmaplayerref.h"
 #include "qgsterraingenerator.h"
+#include "qgsvector3d.h"
 
 class QgsMapLayer;
 class QgsRasterLayer;
@@ -36,6 +37,7 @@ class QgsReadWriteContext;
 class QgsProject;
 
 class QDomElement;
+
 
 /**
  * \ingroup 3d
@@ -72,13 +74,14 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
      * Need to look into more advanced techniques like "relative to center" or "relative to eye"
      * to improve the precision.
      */
-    void setOrigin( double originX, double originY, double originZ );
-    //! Returns X coordinate in map CRS at which 3D scene has origin (zero)
-    double originX() const { return mOriginX; }
-    //! Returns Y coordinate in map CRS at which 3D scene has origin (zero)
-    double originY() const { return mOriginY; }
-    //! Returns Z coordinate in map CRS at which 3D scene has origin (zero)
-    double originZ() const { return mOriginZ; }
+    void setOrigin( const QgsVector3D &origin ) { mOrigin = origin; }
+    //! Returns coordinates in map CRS at which 3D scene has origin (0,0,0)
+    QgsVector3D origin() const { return mOrigin; }
+
+    //! Converts map coordinates to 3D world coordinates (applies offset and turns (x,y,z) into (x,-z,y))
+    QgsVector3D mapToWorldCoordinates( const QgsVector3D &mapCoords ) const;
+    //! Converts 3D world coordinates to map coordinates (applies offset and turns (x,y,z) into (x,-z,y))
+    QgsVector3D worldToMapCoordinates( const QgsVector3D &worldCoords ) const;
 
     //! Sets coordinate reference system used in the 3D scene
     void setCrs( const QgsCoordinateReferenceSystem &crs );
@@ -218,12 +221,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     void showLabelsChanged();
 
   private:
-    //! X coordinate in map CRS at which our 3D world has origin (0,0,0)
-    double mOriginX = 0;
-    //! Y coordinate in map CRS at which our 3D world has origin (0,0,0)
-    double mOriginY = 0;
-    //! Z coordinate in map CRS at which our 3D world has origin (0,0,0)
-    double mOriginZ = 0;
+    //! Offset in map CRS coordinates at which our 3D world has origin (0,0,0)
+    QgsVector3D mOrigin;
     QgsCoordinateReferenceSystem mCrs;   //!< Destination coordinate system of the world
     QColor mBackgroundColor = Qt::black;   //!< Background color of the scene
     QColor mSelectionColor; //!< Color to be used for selected map features

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -194,7 +194,7 @@ QList<QVector3D> Qgs3DUtils::positions( const Qgs3DMapSettings &map, QgsVectorLa
           h = terrainZ + geomZ;
           break;
       }
-      positions.append( QVector3D( pt.x() - map.originX(), h, -( pt.y() - map.originY() ) ) );
+      positions.append( QVector3D( pt.x() - map.origin().x(), h, -( pt.y() - map.origin().y() ) ) );
       //qDebug() << positions.last();
     }
   }

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -84,6 +84,14 @@ class _3D_EXPORT Qgs3DUtils
         This is used to perform object culling checks.
     */
     static bool isCullable( const QgsAABB &bbox, const QMatrix4x4 &viewProjectionMatrix );
+
+    //! Converts map coordinates to 3D world coordinates (applies offset and turns (x,y,z) into (x,-z,y))
+    static QgsVector3D mapToWorldCoordinates( const QgsVector3D &mapCoords, const QgsVector3D &origin );
+    //! Converts 3D world coordinates to map coordinates (applies offset and turns (x,y,z) into (x,-z,y))
+    static QgsVector3D worldToMapCoordinates( const QgsVector3D &worldCoords, const QgsVector3D &origin );
+
+    //! Transforms a world point from (origin1, crs1) to (origin2, crs2)
+    static QgsVector3D transformWorldCoordinates( const QgsVector3D &worldPoint1, const QgsVector3D &origin1, const QgsCoordinateReferenceSystem &crs1, const QgsVector3D &origin2, const QgsCoordinateReferenceSystem &crs2 );
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgscameracontroller.h"
+#include "qgsvector3d.h"
 
 #include "qgis.h"
 
@@ -295,7 +296,7 @@ void QgsCameraController::setViewFromTop( float worldX, float worldY, float dist
   emit cameraChanged();
 }
 
-void QgsCameraController::translateWorld( const QVector3D &vWorld )
+void QgsCameraController::translateWorld( const QgsVector3D &vWorld )
 {
   setCameraData( mCameraData.x - vWorld.x(), mCameraData.y + vWorld.y(), mCameraData.dist, mCameraData.pitch, mCameraData.yaw );
   emit cameraChanged();

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -296,9 +296,14 @@ void QgsCameraController::setViewFromTop( float worldX, float worldY, float dist
   emit cameraChanged();
 }
 
-void QgsCameraController::translateWorld( const QgsVector3D &vWorld )
+QgsVector3D QgsCameraController::lookingAtPoint() const
 {
-  setCameraData( mCameraData.x - vWorld.x(), mCameraData.y + vWorld.y(), mCameraData.dist, mCameraData.pitch, mCameraData.yaw );
+  return QgsVector3D( mCameraData.x, 0, mCameraData.y );
+}
+
+void QgsCameraController::setLookingAtPoint( const QgsVector3D &point )
+{
+  setCameraData( point.x(), point.z(), mCameraData.dist, mCameraData.pitch, mCameraData.yaw );
   emit cameraChanged();
 }
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -61,8 +61,10 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! Sets camera to look down towards given point in world coordinate, in given distance from plane with zero elevation
     void setViewFromTop( float worldX, float worldY, float distance, float yaw = 0 );
 
-    //! Moves the point toward which the camera is looking - this is used when world origin changes (e.g. after terrain generator changes)
-    void translateWorld( const QgsVector3D &vWorld );
+    //! Returns the point in the world coordinates towards which the camera is looking
+    QgsVector3D lookingAtPoint() const;
+    //! Sets the point toward which the camera is looking - this is used when world origin changes (e.g. after terrain generator changes)
+    void setLookingAtPoint( const QgsVector3D &point );
 
   private:
     void setCameraData( float x, float y, float dist, float pitch = 0, float yaw = 0 );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -22,6 +22,7 @@
 #include <Qt3DInput>
 #include <Qt3DRender>
 
+class QgsVector3D;
 
 /**
  * \ingroup 3d
@@ -61,7 +62,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     void setViewFromTop( float worldX, float worldY, float distance, float yaw = 0 );
 
     //! Moves the point toward which the camera is looking - this is used when world origin changes (e.g. after terrain generator changes)
-    void translateWorld( const QVector3D &vWorld );
+    void translateWorld( const QgsVector3D &vWorld );
 
   private:
     void setCameraData( float x, float y, float dist, float pitch = 0, float yaw = 0 );

--- a/src/3d/qgsvector3d.cpp
+++ b/src/3d/qgsvector3d.cpp
@@ -1,0 +1,16 @@
+/***************************************************************************
+  qgsvector3d.h
+  --------------------------------------
+  Date                 : November 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvector3d.h"

--- a/src/3d/qgsvector3d.h
+++ b/src/3d/qgsvector3d.h
@@ -52,6 +52,15 @@ class _3D_EXPORT QgsVector3D
       mZ = z;
     }
 
+    bool operator==( const QgsVector3D &other ) const
+    {
+      return mX == other.mX && mY == other.mY && mZ == other.mZ;
+    }
+    bool operator!=( const QgsVector3D &other ) const
+    {
+      return !operator==( other );
+    }
+
     //! Returns sum of two vectors
     QgsVector3D operator+( const QgsVector3D &other )
     {

--- a/src/3d/qgsvector3d.h
+++ b/src/3d/qgsvector3d.h
@@ -19,10 +19,11 @@
 #include "qgis_3d.h"
 
 /**
+ * \ingroup 3d
  * Class for storage of 3D vectors similar to QVector3D, with the difference that it uses double precision
  * instead of single precision floating point numbers.
  *
- * \note Added in QGIS 3.0
+ * \since QGIS 3.0
  */
 class _3D_EXPORT QgsVector3D
 {

--- a/src/3d/qgsvector3d.h
+++ b/src/3d/qgsvector3d.h
@@ -1,0 +1,71 @@
+/***************************************************************************
+  qgsvector3d.h
+  --------------------------------------
+  Date                 : November 2017
+  Copyright            : (C) 2017 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTOR3D_H
+#define QGSVECTOR3D_H
+
+#include "qgis_3d.h"
+
+/**
+ * Class for storage of 3D vectors similar to QVector3D, with the difference that it uses double precision
+ * instead of single precision floating point numbers.
+ *
+ * \note Added in QGIS 3.0
+ */
+class _3D_EXPORT QgsVector3D
+{
+  public:
+    //! Constructs a null vector
+    QgsVector3D() = default;
+
+    //! Constructs a vector from given coordinates
+    QgsVector3D( double x, double y, double z )
+      : mX( x ), mY( y ), mZ( z ) {}
+
+    //! Returns true if all three coordinates are zero
+    bool isNull() const { return mX == 0 && mY == 0 && mZ == 0; }
+
+    //! Returns X coordinate
+    double x() const { return mX; }
+    //! Returns Y coordinate
+    double y() const { return mY; }
+    //! Returns Z coordinate
+    double z() const { return mZ; }
+
+    //! Sets vector coordinates
+    void set( double x, double y, double z )
+    {
+      mX = x;
+      mY = y;
+      mZ = z;
+    }
+
+    //! Returns sum of two vectors
+    QgsVector3D operator+( const QgsVector3D &other )
+    {
+      return QgsVector3D( mX + other.mX, mY + other.mY, mZ + other.mZ );
+    }
+
+    //! Returns difference of two vectors
+    QgsVector3D operator-( const QgsVector3D &other )
+    {
+      return QgsVector3D( mX - other.mX, mY - other.mY, mZ - other.mZ );
+    }
+
+  private:
+    double mX = 0, mY = 0, mZ = 0;
+};
+
+#endif // QGSVECTOR3D_H

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -93,7 +93,7 @@ QgsLine3DSymbolEntityNode::QgsLine3DSymbolEntityNode( const Qgs3DMapSettings &ma
 
 Qt3DRender::QGeometryRenderer *QgsLine3DSymbolEntityNode::renderer( const Qgs3DMapSettings &map, const QgsLine3DSymbol &symbol, const QgsVectorLayer *layer, const QgsFeatureRequest &request )
 {
-  QgsPointXY origin( map.originX(), map.originY() );
+  QgsPointXY origin( map.origin().x(), map.origin().y() );
 
   // TODO: configurable
   int nSegments = 4;

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -121,7 +121,7 @@ QgsPolygon3DSymbolEntityNode::QgsPolygon3DSymbolEntityNode( const Qgs3DMapSettin
 
 Qt3DRender::QGeometryRenderer *QgsPolygon3DSymbolEntityNode::renderer( const Qgs3DMapSettings &map, const QgsPolygon3DSymbol &symbol, const QgsVectorLayer *layer, const QgsFeatureRequest &request )
 {
-  QgsPointXY origin( map.originX(), map.originY() );
+  QgsPointXY origin( map.origin().x(), map.origin().y() );
   QList<QgsPolygon *> polygons;
   QList<float> extrusionHeightPerPolygon;  // will stay empty if not needed per polygon
 

--- a/src/3d/terrain/qgsdemterraingenerator.h
+++ b/src/3d/terrain/qgsdemterraingenerator.h
@@ -45,6 +45,9 @@ class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator
     //! Returns raster layer with elevation model to be used for terrain generation
     QgsRasterLayer *layer() const;
 
+    //! Sets CRS of the terrain
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+
     //! Sets resolution of the generator (how many elevation samples on one side of a terrain tile)
     void setResolution( int resolution ) { mResolution = resolution; updateGenerator(); }
     //! Returns resolution of the generator (how many elevation samples on one side of a terrain tile)
@@ -73,6 +76,7 @@ class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator
 
     QgsDemHeightMapGenerator *mHeightMapGenerator = nullptr;
 
+    QgsCoordinateReferenceSystem mCrs;
     //! source layer for heights
     QgsMapLayerRef mLayer;
     //! how many vertices to place on one side of the tile

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -82,8 +82,8 @@ Qt3DCore::QEntity *QgsDemTerrainTileLoader::createEntity( Qt3DCore::QEntity *par
 
   const Qgs3DMapSettings &map = terrain()->map3D();
   QgsRectangle extent = map.terrainGenerator()->tilingScheme().tileToExtent( mNode->tileX(), mNode->tileY(), mNode->tileZ() ); //node->extent;
-  double x0 = extent.xMinimum() - map.originX();
-  double y0 = extent.yMinimum() - map.originY();
+  double x0 = extent.xMinimum() - map.origin().x();
+  double y0 = extent.yMinimum() - map.origin().y();
   double side = extent.width();
   double half = side / 2;
 

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -27,8 +27,8 @@ QgsAABB QgsTerrainGenerator::rootChunkBbox( const Qgs3DMapSettings &map ) const
 
   float hMin, hMax;
   rootChunkHeightRange( hMin, hMax );
-  return QgsAABB( te.xMinimum() - map.originX(), hMin * map.terrainVerticalScale(), -te.yMaximum() + map.originY(),
-                  te.xMaximum() - map.originX(), hMax * map.terrainVerticalScale(), -te.yMinimum() + map.originY() );
+  return QgsAABB( te.xMinimum() - map.origin().x(), hMin * map.terrainVerticalScale(), -te.yMaximum() + map.origin().y(),
+                  te.xMaximum() - map.origin().x(), hMax * map.terrainVerticalScale(), -te.yMinimum() + map.origin().y() );
 }
 
 float QgsTerrainGenerator::rootChunkError( const Qgs3DMapSettings &map ) const

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -85,7 +85,7 @@ void Qgs3DMapCanvas::resetView()
 
 void Qgs3DMapCanvas::setViewFromTop( const QgsPointXY &center, float distance, float rotation )
 {
-  float worldX = center.x() - mMap->originX();
-  float worldY = center.y() - mMap->originY();
+  float worldX = center.x() - mMap->origin().x();
+  float worldY = center.y() - mMap->origin().y();
   mScene->cameraController()->setViewFromTop( worldX, -worldY, distance, rotation );
 }

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -85,16 +85,16 @@ void Qgs3DMapCanvasDockWidget::configure()
   if ( !dlg.exec() )
     return;
 
-  double oldOriginX = map->originX(), oldOriginY = map->originY(), oldOriginZ = map->originZ();
+  QgsVector3D oldOrigin = map->origin();
 
   // update map
   w->apply();
 
-  double dx = map->originX() - oldOriginX, dy = map->originY() - oldOriginY, dz = map->originZ() - oldOriginZ;
-  if ( dx || dy || dz )
+  QgsVector3D d = map->origin() - oldOrigin;
+  if ( !d.isNull() )
   {
     // apply() call has moved origin of the world so let's move camera so we look still at the same place
-    mCanvas->cameraController()->translateWorld( QVector3D( dx, dy, dz ) );
+    mCanvas->cameraController()->translateWorld( d );
   }
 }
 

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -22,6 +22,7 @@
 #include "qgsmapcanvas.h"
 
 #include "qgs3dmapsettings.h"
+#include "qgs3dutils.h"
 
 #include <QBoxLayout>
 #include <QDialog>
@@ -86,15 +87,21 @@ void Qgs3DMapCanvasDockWidget::configure()
     return;
 
   QgsVector3D oldOrigin = map->origin();
+  QgsCoordinateReferenceSystem oldCrs = map->crs();
+  QgsVector3D oldLookingAt = mCanvas->cameraController()->lookingAtPoint();
 
   // update map
   w->apply();
 
-  QgsVector3D d = map->origin() - oldOrigin;
-  if ( !d.isNull() )
+  QgsVector3D p = Qgs3DUtils::transformWorldCoordinates(
+                    oldLookingAt,
+                    oldOrigin, oldCrs,
+                    map->origin(), map->crs() );
+
+  if ( p != oldLookingAt )
   {
     // apply() call has moved origin of the world so let's move camera so we look still at the same place
-    mCanvas->cameraController()->translateWorld( d );
+    mCanvas->cameraController()->setLookingAtPoint( p );
   }
 }
 

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -108,7 +108,12 @@ void Qgs3DMapConfigWidget::apply()
 
   if ( needsUpdateOrigin )
   {
-    QgsPointXY center = mMap->terrainGenerator()->extent().center();
+    // reproject terrain's extent to map CRS
+    QgsRectangle te = mMap->terrainGenerator()->extent();
+    QgsCoordinateTransform terrainToMapTransform( mMap->terrainGenerator()->crs(), mMap->crs() );
+    te = terrainToMapTransform.transformBoundingBox( te );
+
+    QgsPointXY center = te.center();
     mMap->setOrigin( QgsVector3D( center.x(), center.y(), 0 ) );
   }
 

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -109,7 +109,7 @@ void Qgs3DMapConfigWidget::apply()
   if ( needsUpdateOrigin )
   {
     QgsPointXY center = mMap->terrainGenerator()->extent().center();
-    mMap->setOrigin( center.x(), center.y(), 0 );
+    mMap->setOrigin( QgsVector3D( center.x(), center.y(), 0 ) );
   }
 
   mMap->setTerrainVerticalScale( spinTerrainScale->value() );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -90,6 +90,7 @@ void Qgs3DMapConfigWidget::apply()
     if ( tGenNeedsUpdate )
     {
       QgsDemTerrainGenerator *demTerrainGen = new QgsDemTerrainGenerator;
+      demTerrainGen->setCrs( mMap->crs() );
       demTerrainGen->setLayer( demLayer );
       demTerrainGen->setResolution( spinTerrainResolution->value() );
       demTerrainGen->setSkirtHeight( spinTerrainSkirtHeight->value() );
@@ -139,6 +140,7 @@ void Qgs3DMapConfigWidget::updateMaxZoomLevel()
   if ( demLayer )
   {
     QgsDemTerrainGenerator *demTerrainGen = new QgsDemTerrainGenerator;
+    demTerrainGen->setCrs( mMap->crs() );
     demTerrainGen->setLayer( demLayer );
     demTerrainGen->setResolution( spinTerrainResolution->value() );
     tGen.reset( demTerrainGen );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10243,7 +10243,7 @@ void QgisApp::new3DMapCanvas()
 
     Qgs3DMapSettings *map = new Qgs3DMapSettings;
     map->setCrs( prj->crs() );
-    map->setOrigin( fullExtent.center().x(), fullExtent.center().y(), 0 );
+    map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
     map->setSelectionColor( mMapCanvas->selectionColor() );
     map->setBackgroundColor( mMapCanvas->canvasColor() );
     map->setLayers( mMapCanvas->layers() );

--- a/tests/src/3d/CMakeLists.txt
+++ b/tests/src/3d/CMakeLists.txt
@@ -8,6 +8,8 @@ SET (util_SRCS)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/tests/core #for render checker class
   ${CMAKE_SOURCE_DIR}/src/3d
+  ${CMAKE_SOURCE_DIR}/src/3d/chunks
+  ${CMAKE_SOURCE_DIR}/src/3d/terrain
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/auth
@@ -68,4 +70,5 @@ MACRO (ADD_QGIS_TEST testname testsrc)
   #  INSTALL_RPATH_USE_LINK_PATH true )
 ENDMACRO (ADD_QGIS_TEST)
 
+ADD_QGIS_TEST(3dutilstest testqgs3dutils.cpp)
 ADD_QGIS_TEST(tessellatortest testqgstessellator.cpp)

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -1,0 +1,86 @@
+/***************************************************************************
+     testqgs3dutils.cpp
+     ----------------------
+    Date                 : November 2017
+    Copyright            : (C) 2017 by Martin Dobias
+    Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgs3dutils.h"
+
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the node tool
+ */
+class TestQgs3DUtils : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgs3DUtils() = default;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+
+    void testTransforms();
+
+  private:
+};
+
+//runs before all tests
+void TestQgs3DUtils::initTestCase()
+{
+}
+
+//runs after all tests
+void TestQgs3DUtils::cleanupTestCase()
+{
+}
+
+void TestQgs3DUtils::testTransforms()
+{
+  QgsVector3D map123( 1, 2, 3 );
+
+  QgsVector3D world123 = Qgs3DUtils::mapToWorldCoordinates( map123, QgsVector3D() );
+  QCOMPARE( world123, QgsVector3D( 1, 3, -2 ) );
+
+  QgsVector3D world123map = Qgs3DUtils::worldToMapCoordinates( world123, QgsVector3D() );
+  QCOMPARE( world123map, map123 );
+
+  // now with non-zero origin
+
+  QgsVector3D origin( -10, -20, -30 );
+
+  QgsVector3D world123x = Qgs3DUtils::mapToWorldCoordinates( map123, origin );
+  QCOMPARE( world123x, QgsVector3D( 11, 33, -22 ) );
+
+  QgsVector3D world123xmap = Qgs3DUtils::worldToMapCoordinates( world123x, origin );
+  QCOMPARE( world123xmap, map123 );
+
+  //
+  // transform world point from one system to another
+  //
+
+  QgsVector3D worldPoint1( 5, 7, -6 );
+  QgsVector3D origin1( 10, 20, 30 );
+  QgsVector3D origin2( 1, 2, 3 );
+  QgsVector3D worldPoint2 = Qgs3DUtils::transformWorldCoordinates( worldPoint1, origin1, QgsCoordinateReferenceSystem(), origin2, QgsCoordinateReferenceSystem() );
+  QCOMPARE( worldPoint2, QgsVector3D( 14, 34, -24 ) );
+  // verify that both are the same map point
+  QgsVector3D mapPoint1 = Qgs3DUtils::worldToMapCoordinates( worldPoint1, origin1 );
+  QgsVector3D mapPoint2 = Qgs3DUtils::worldToMapCoordinates( worldPoint2, origin2 );
+  QCOMPARE( mapPoint1, mapPoint2 );
+}
+
+QGSTEST_MAIN( TestQgs3DUtils )
+#include "testqgs3dutils.moc"


### PR DESCRIPTION
The first two commits tidy up the first fix for bug 17514 and add unit tests to check that the camera in 3D world is translated correctly when the 3D world origin changes.

The third commit fixes the second issue in bug 17514 which was triggered when terrain's DEM was in a different CRS than the map. The DEM was not being reprojected so the 3D view went blank.

https://issues.qgis.org/issues/17514