### PR TITLE
Adds missing tooltips

### DIFF
--- a/src/ui/auth/qgsauthconfigeditor.ui
+++ b/src/ui/auth/qgsauthconfigeditor.ui
@@ -44,6 +44,9 @@
        </property>
        <item>
         <widget class="QToolButton" name="btnAddConfig">
+         <property name="toolTip">
+          <string>Add new authentication configuration</string>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -55,6 +58,9 @@
        </item>
        <item>
         <widget class="QToolButton" name="btnRemoveConfig">
+         <property name="toolTip">
+          <string>Remove selected authentication configuration</string>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -66,6 +72,9 @@
        </item>
        <item>
         <widget class="QToolButton" name="btnEditConfig">
+         <property name="toolTip">
+          <string>Edit selected authentication configuration</string>
+         </property>
          <property name="text">
           <string/>
          </property>

--- a/src/ui/auth/qgsauthserverseditor.ui
+++ b/src/ui/auth/qgsauthserverseditor.ui
@@ -54,6 +54,9 @@
        </property>
        <item>
         <widget class="QToolButton" name="btnAddServer">
+         <property name="toolTip">
+          <string>Add new server certificate configuration</string>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -65,6 +68,9 @@
        </item>
        <item>
         <widget class="QToolButton" name="btnRemoveServer">
+         <property name="toolTip">
+          <string>Remove selected server certificate configuration</string>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -76,6 +82,9 @@
        </item>
        <item>
         <widget class="QToolButton" name="btnEditServer">
+         <property name="toolTip">
+          <string>Edit selected server certificate configuration</string>
+         </property>
          <property name="text">
           <string/>
          </property>

--- a/src/ui/auth/qgsauthsslconfigwidget.ui
+++ b/src/ui/auth/qgsauthsslconfigwidget.ui
@@ -64,6 +64,9 @@
       </item>
       <item row="1" column="2">
        <widget class="QToolButton" name="btnCertInfo">
+        <property name="toolTip">
+         <string>Show information for certificate</string>
+        </property>
         <property name="text">
          <string>?</string>
         </property>

--- a/src/ui/qgscompoundcolorwidget.ui
+++ b/src/ui/qgscompoundcolorwidget.ui
@@ -134,6 +134,9 @@
            </item>
            <item>
             <widget class="QPushButton" name="mAddColorToSchemeButton">
+             <property name="toolTip">
+              <string>Add current color</string>
+             </property>
              <property name="text">
               <string/>
              </property>
@@ -145,6 +148,9 @@
            </item>
            <item>
             <widget class="QPushButton" name="mRemoveColorsFromSchemeButton">
+             <property name="toolTip">
+              <string>Remove selected color</string>
+             </property>
              <property name="text">
               <string/>
              </property>
@@ -492,6 +498,9 @@
             <width>28</width>
             <height>16777215</height>
            </size>
+          </property>
+          <property name="toolTip">
+           <string>Add color to swatch</string>
           </property>
           <property name="text">
            <string/>

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -395,6 +395,9 @@
                         <verstretch>0</verstretch>
                        </sizepolicy>
                       </property>
+                      <property name="toolTip">
+                       <string>Add selected attributes</string>
+                      </property>
                       <property name="text">
                        <string/>
                       </property>
@@ -411,6 +414,9 @@
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
+                      </property>
+                      <property name="toolTip">
+                       <string>Remove selected attributes</string>
                       </property>
                       <property name="text">
                        <string/>

--- a/src/ui/qgslayertreeembeddedconfigwidgetbase.ui
+++ b/src/ui/qgslayertreeembeddedconfigwidgetbase.ui
@@ -48,6 +48,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="mBtnAdd">
+       <property name="toolTip">
+        <string>Add  selected widgets</string>
+       </property>
        <property name="text">
         <string>-&gt;</string>
        </property>
@@ -59,6 +62,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="mBtnRemove">
+       <property name="toolTip">
+        <string>Remove selected widgets</string>
+       </property>
        <property name="text">
         <string>&lt;-</string>
        </property>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1179,6 +1179,9 @@
                  <layout class="QGridLayout" name="_4">
                   <item row="0" column="5">
                    <widget class="QToolButton" name="mBtnMoveHelpDown">
+                    <property name="toolTip">
+                     <string>Lower selected path priority</string>
+                    </property>
                     <property name="text">
                      <string>…</string>
                     </property>
@@ -1256,6 +1259,9 @@
                   </item>
                   <item row="0" column="4">
                    <widget class="QToolButton" name="mBtnMoveHelpUp">
+                    <property name="toolTip">
+                     <string>Raise selected path priority</string>
+                    </property>
                     <property name="text">
                      <string>…</string>
                     </property>
@@ -3416,7 +3422,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     <item>
                      <widget class="QToolButton" name="pbnRemoveScale">
                       <property name="toolTip">
-                       <string>Remove selected</string>
+                       <string>Remove selected scale</string>
                       </property>
                       <property name="text">
                        <string>…</string>
@@ -4551,6 +4557,9 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    <layout class="QHBoxLayout" name="horizontalLayout_38">
                     <item>
                      <widget class="QToolButton" name="mAddDefaultTransformButton">
+                      <property name="toolTip">
+                       <string>Add datum transformation</string>
+                      </property>
                       <property name="text">
                        <string/>
                       </property>
@@ -4562,6 +4571,9 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </item>
                     <item>
                      <widget class="QToolButton" name="mRemoveDefaultTransformButton">
+                      <property name="toolTip">
+                       <string>Remove datum transformation</string>
+                      </property>
                       <property name="text">
                        <string/>
                       </property>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -645,7 +645,7 @@
                   </sizepolicy>
                  </property>
                  <property name="title">
-                  <string>Project scales</string>
+                  <string>Project predefined scales</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -664,6 +664,9 @@
                    <layout class="QVBoxLayout" name="verticalLayout_4">
                     <item>
                      <widget class="QToolButton" name="pbnAddScale">
+                      <property name="toolTip">
+                       <string>Add predefined scale</string>
+                      </property>
                       <property name="text">
                        <string>…</string>
                       </property>
@@ -675,6 +678,9 @@
                     </item>
                     <item>
                      <widget class="QToolButton" name="pbnRemoveScale">
+                      <property name="toolTip">
+                       <string>Remove selected scale</string>
+                      </property>
                       <property name="text">
                        <string>…</string>
                       </property>
@@ -686,6 +692,9 @@
                     </item>
                     <item>
                      <widget class="QToolButton" name="pbnImportScales">
+                      <property name="toolTip">
+                       <string>Import from file</string>
+                      </property>
                       <property name="text">
                        <string>…</string>
                       </property>
@@ -697,6 +706,9 @@
                     </item>
                     <item>
                      <widget class="QToolButton" name="pbnExportScales">
+                      <property name="toolTip">
+                       <string>Save to file</string>
+                      </property>
                       <property name="text">
                        <string>…</string>
                       </property>
@@ -934,6 +946,9 @@
                   </property>
                   <item row="0" column="5">
                    <widget class="QToolButton" name="pbtnStyleMarker">
+                    <property name="toolTip">
+                     <string>Edit symbol</string>
+                    </property>
                     <property name="text">
                      <string>…</string>
                     </property>
@@ -987,6 +1002,9 @@
                   </item>
                   <item row="1" column="5">
                    <widget class="QToolButton" name="pbtnStyleLine">
+                    <property name="toolTip">
+                     <string>Edit symbol</string>
+                    </property>
                     <property name="text">
                      <string>…</string>
                     </property>
@@ -1076,6 +1094,9 @@
                   </item>
                   <item row="2" column="5">
                    <widget class="QToolButton" name="pbtnStyleFill">
+                    <property name="toolTip">
+                     <string>Edit symbol</string>
+                    </property>
                     <property name="text">
                      <string>…</string>
                     </property>
@@ -1123,6 +1144,9 @@
                   </item>
                   <item row="3" column="5">
                    <widget class="QToolButton" name="pbtnStyleColorRamp">
+                    <property name="toolTip">
+                     <string>Edit symbol</string>
+                    </property>
                     <property name="text">
                      <string>…</string>
                     </property>
@@ -1276,8 +1300,11 @@
                   </item>
                   <item row="4" column="1">
                    <widget class="QToolButton" name="mButtonImportColors">
-                    <property name="statusTip">
+                    <property name="toolTip">
                      <string>Import colors</string>
+                    </property>
+                    <property name="statusTip">
+                     <string/>
                     </property>
                     <property name="text">
                      <string/>
@@ -1739,6 +1766,9 @@
                      </item>
                      <item row="1" column="0">
                       <widget class="QToolButton" name="mAddWMSComposerButton">
+                       <property name="toolTip">
+                        <string>Add composer to exclude</string>
+                       </property>
                        <property name="text">
                         <string/>
                        </property>
@@ -1750,6 +1780,9 @@
                      </item>
                      <item row="1" column="1">
                       <widget class="QToolButton" name="mRemoveWMSComposerButton">
+                       <property name="toolTip">
+                        <string>Remove selected composer</string>
+                       </property>
                        <property name="text">
                         <string/>
                        </property>
@@ -1798,6 +1831,9 @@
                      </item>
                      <item row="1" column="0">
                       <widget class="QToolButton" name="mAddLayerRestrictionButton">
+                       <property name="toolTip">
+                        <string>Add layer to exclude</string>
+                       </property>
                        <property name="text">
                         <string/>
                        </property>
@@ -1809,6 +1845,9 @@
                      </item>
                      <item row="1" column="1">
                       <widget class="QToolButton" name="mRemoveLayerRestrictionButton">
+                       <property name="toolTip">
+                        <string>Remove selected layer</string>
+                       </property>
                        <property name="text">
                         <string/>
                        </property>
@@ -1854,6 +1893,9 @@
                     <layout class="QGridLayout" name="gridLayout_5">
                      <item row="1" column="0">
                       <widget class="QToolButton" name="pbnWMSAddSRS">
+                       <property name="toolTip">
+                        <string>Add new CRS</string>
+                       </property>
                        <property name="icon">
                         <iconset resource="../../images/images.qrc">
                          <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
@@ -1865,6 +1907,9 @@
                      </item>
                      <item row="1" column="2">
                       <widget class="QPushButton" name="pbnWMSSetUsedSRS">
+                       <property name="toolTip">
+                        <string>Fetch all CRS's from layers</string>
+                       </property>
                        <property name="text">
                         <string>Used</string>
                        </property>
@@ -1872,6 +1917,9 @@
                      </item>
                      <item row="1" column="1">
                       <widget class="QToolButton" name="pbnWMSRemoveSRS">
+                       <property name="toolTip">
+                        <string>Remove selected CRS</string>
+                       </property>
                        <property name="icon">
                         <iconset resource="../../images/images.qrc">
                          <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1397,6 +1397,9 @@ border-radius: 2px;</string>
                 <layout class="QHBoxLayout" name="horizontalLayout">
                  <item>
                   <widget class="QPushButton" name="mButtonAddJoin">
+                   <property name="toolTip">
+                    <string>Add new join</string>
+                   </property>
                    <property name="text">
                     <string/>
                    </property>
@@ -1408,6 +1411,9 @@ border-radius: 2px;</string>
                  </item>
                  <item>
                   <widget class="QPushButton" name="mButtonRemoveJoin">
+                   <property name="toolTip">
+                    <string>Remove selected join</string>
+                   </property>
                    <property name="text">
                     <string/>
                    </property>
@@ -1419,6 +1425,9 @@ border-radius: 2px;</string>
                  </item>
                  <item>
                   <widget class="QPushButton" name="mButtonEditJoin">
+                   <property name="toolTip">
+                    <string>Edit selected join</string>
+                   </property>
                    <property name="text">
                     <string/>
                    </property>
@@ -2182,6 +2191,9 @@ border-radius: 2px;</string>
                    </item>
                    <item>
                     <widget class="QPushButton" name="mAuxiliaryStorageFieldsAddBtn">
+                     <property name="toolTip">
+                      <string>Add new field</string>
+                     </property>
                      <property name="text">
                       <string/>
                      </property>
@@ -2193,6 +2205,9 @@ border-radius: 2px;</string>
                    </item>
                    <item>
                     <widget class="QPushButton" name="mAuxiliaryStorageFieldsDeleteBtn">
+                     <property name="toolTip">
+                      <string>Remove selected field</string>
+                     </property>
                      <property name="text">
                       <string/>
                      </property>

--- a/src/ui/styledock/qgsrenderercontainerbase.ui
+++ b/src/ui/styledock/qgsrenderercontainerbase.ui
@@ -27,6 +27,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="toolTip">
+        <string>Go back</string>
+       </property>
        <property name="text">
         <string/>
        </property>


### PR DESCRIPTION
## Description
This PR adds some missing toolTips in some dialog's buttons.

Tooltips are useful for users to understand what the button will do, but also for documentation. It's easier to expalin the user to "click the Add color button" than "click the button with the plus sign".

I have also found some wrong tool tips in the metadata widget, but I will try to address that in a different PR.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
