### PR TITLE
[bugfix] Constraints are updated even if the key is deleted from the keyboard

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -164,7 +164,7 @@ QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget* parent )
   connect( mMapIdentificationButton, SIGNAL( clicked() ), this, SLOT( mapIdentification() ) );
   connect( mRemoveFKButton, SIGNAL( clicked() ), this, SLOT( deleteForeignKey() ) );
   connect( mAddEntryButton, SIGNAL( clicked( bool ) ), this, SLOT( addEntry() ) );
-  connect( mComboBox, SIGNAL( editTextChanged( QString ) ), this, SLOT( updateAddEntryButton() ) );
+  connect( mComboBox, SIGNAL( editTextChanged( QString ) ), this, SLOT( editTextUpdated( const QString & ) ) );
 }
 
 QgsRelationReferenceWidget::~QgsRelationReferenceWidget()
@@ -989,4 +989,14 @@ void QgsRelationReferenceWidget::disableChainedComboBoxes( const QComboBox *scb 
 
     ccb = cb;
   }
+}
+
+void QgsRelationReferenceWidget::editTextUpdated( const QString &text )
+{
+  updateAddEntryButton();
+
+  // allow to raise an invalid constraint on NULL values if necessary
+  // and when the combobox is updated manually from the keyboard
+  if ( text.isEmpty() && mAllowNull )
+    mComboBox->setCurrentIndex( 0 );
 }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -157,12 +157,13 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     void mapToolDeactivated();
     void filterChanged();
     void addEntry();
-    void updateAddEntryButton();
+    void editTextUpdated( const QString &text );
 
   private:
     void highlightFeature( QgsFeature f = QgsFeature(), CanvasExtent canvasExtent = Fixed );
     void updateAttributeEditorFrame( const QgsFeature& feature );
     void disableChainedComboBoxes( const QComboBox *scb );
+    void updateAddEntryButton();
 
     // initialized
     QgsAttributeEditorContext mEditorContext;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -259,7 +259,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void onConstraintStatusChanged( const QString& constraint,
                                     const QString& description, const QString& err, bool ok );
     void preventFeatureRefresh();
-    void synchronizeEnabledState();
+    void synchronizeEnabledState( bool synchronizeWidgetWrapper = true );
     void layerSelectionChanged();
 
     //! Save multi edit changes


### PR DESCRIPTION
## Description

PR for the 2.18 branch.

The aim is to raise a constraint error from the *QgsRelationReferenceWidget* when:
- the *Constraints not null* option is activated  
- the *Allow NULL value* option is activated
- the key is manually deleted from the keyboard in the combobox line edit (and not only when *NULL* is selected in the filtered list of features).

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
