### PR TITLE
[bugfix] Bookmarks: fix a crash and show 6 digits

### DIFF
--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -30,8 +30,12 @@
 #include <QSqlQuery>
 #include <QSqlRecord>
 #include <QModelIndex>
+#include <QDoubleSpinBox>
 #include <QAbstractTableModel>
 #include <QToolButton>
+
+
+const int QgsDoubleSpinBoxBookmarksDelegate::DECIMAL_PLACES = 6;
 
 QgsBookmarks::QgsBookmarks( QWidget *parent )
   : QgsDockWidget( parent )
@@ -105,6 +109,7 @@ QgsBookmarks::QgsBookmarks( QWidget *parent )
   mProxyModel->setSourceModel( mModel );
 
   lstBookmarks->setModel( mProxyModel );
+  lstBookmarks->setItemDelegate( new QgsDoubleSpinBoxBookmarksDelegate );
 
   connect( mModel, &QgsMergedBookmarksTableModel::layoutChanged, mProxyModel, &QgsBookmarksProxyModel::_resetModel );
 
@@ -755,3 +760,23 @@ QVariant QgsBookmarksProxyModel::headerData( int section, Qt::Orientation orient
   return sourceModel()->headerData( section, orientation, role );
 }
 
+QString QgsDoubleSpinBoxBookmarksDelegate::displayText( const QVariant &value, const QLocale &locale ) const
+{
+  if ( value.userType() == QVariant::Double )
+  {
+    return locale.toString( value.toDouble(), 'f', QgsDoubleSpinBoxBookmarksDelegate::DECIMAL_PLACES );
+  }
+  else
+  {
+    return QStyledItemDelegate::displayText( value, locale );
+  }
+}
+
+QWidget *QgsDoubleSpinBoxBookmarksDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+{
+  QWidget *widget = QStyledItemDelegate::createEditor( parent, option, index );
+  QDoubleSpinBox *spinbox = qobject_cast<QDoubleSpinBox *>( widget );
+  if ( spinbox )
+    spinbox->setDecimals( QgsDoubleSpinBoxBookmarksDelegate::DECIMAL_PLACES );
+  return widget;
+}

--- a/src/app/qgsbookmarks.h
+++ b/src/app/qgsbookmarks.h
@@ -19,7 +19,7 @@
 
 #include <QSqlTableModel>
 #include <QSortFilterProxyModel>
-#include <memory>
+#include <QStyledItemDelegate>
 
 #include "ui_qgsbookmarksbase.h"
 #include "qgsdockwidget.h"
@@ -70,6 +70,27 @@ class QgsBookmarksProxyModel: public QSortFilterProxyModel
     {
       reset();
     }
+};
+
+
+/**
+ * \brief QgsDoubleSpinBoxBookmarksDelegate class shows 6 digits when value is a double
+ */
+class QgsDoubleSpinBoxBookmarksDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+
+    QString displayText( const QVariant &value, const QLocale &locale ) const override;
+
+    QWidget *createEditor( QWidget *parent,
+                           const QStyleOptionViewItem &option,
+                           const QModelIndex &index ) const override;
+  private:
+
+    static const int  DECIMAL_PLACES;
+
 };
 
 /*

--- a/src/ui/qgsbookmarksbase.ui
+++ b/src/ui/qgsbookmarksbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Spatial Bookmarks Panel</string>
+   <string>Sp&amp;atial Bookmarks Panel</string>
   </property>
   <widget class="QWidget" name="bookmarksDockContents">
    <layout class="QGridLayout" name="gridLayout">
@@ -54,8 +54,14 @@
       <property name="rootIsDecorated">
        <bool>false</bool>
       </property>
-      <property name="sortingEnabled">
-       <bool>true</bool>
+      <property name="itemsExpandable">
+       <bool>false</bool>
+      </property>
+      <property name="animated">
+       <bool>false</bool>
+      </property>
+      <property name="expandsOnDoubleClick">
+       <bool>false</bool>
       </property>
      </widget>
     </item>
@@ -103,8 +109,9 @@
    <class>QgsDockWidget</class>
    <extends>QDockWidget</extends>
    <header>qgsdockwidget.h</header>
+   <container>1</container>
   </customwidget>
-</customwidgets>
+ </customwidgets>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>


### PR DESCRIPTION
Fixes #17003 Spatial bookmarks keyboard navigation:
right-arrow causes a row to appear below the current
one and looks like a tree expansion (actually crashes
master)

Fixes #16350 Spatial Bookmark Panel: precision gets
trimmed
