### PR TITLE
Fix WMS layers in print composer

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -615,16 +615,13 @@ static void _drawDebugRect( QPainter& p, const QRectF& rect, const QColor& color
 
 QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, int pixelHeight, QgsRasterBlockFeedback* feedback )
 {
+  QgsDebugMsg( "Entering." );
+
+  // compose the URL query string for the WMS server.
+
   QImage* image = new QImage( pixelWidth, pixelHeight, QImage::Format_ARGB32 );
   image->fill( 0 );
 
-  if ( QgsApplication::instance()->thread() == QThread::currentThread() )
-  {
-    QgsDebugMsg( "Trying to draw a WMS image on the main thread. Stop it!" );
-    return image;
-  }
-
-  // compose the URL query string for the WMS server.
   if ( !mSettings.mTiled && mSettings.mMaxWidth == 0 && mSettings.mMaxHeight == 0 )
   {
     QUrl url = createRequestUrlWMS( viewExtent, pixelWidth, pixelHeight );


### PR DESCRIPTION
This reverts https://github.com/qgis/QGIS/commit/fde624099552816f1c5133edc7b3576adf8d2257, a previous attempt to fix crashers.

The most regular source for these crashes was a preview icon which has been fixed by https://github.com/qgis/QGIS/commit/b3ea17f3e2e8d430775d545bc624650ef3654766.

This fix here has the bad side-effect of preventing usage in print composer (and other places which render on the main thread).

Fix #17379