### PR TITLE
[processing] Fix Frequency_analysis' parent group

### DIFF
--- a/python/plugins/processing/algs/qgis/scripts/Frequency_analysis.py
+++ b/python/plugins/processing/algs/qgis/scripts/Frequency_analysis.py
@@ -1,4 +1,4 @@
-##Table=group
+##Vector table tools=group
 ##Input=vector
 ##Fields=Field Input
 ##Frequency=output table


### PR DESCRIPTION
There is a single algorithm "Frequency analysis" in a lonely group "Table".
I believe it should join its siblings in the "Vector table tools" group, shouldn't it?