### PR TITLE
[2.18] QgsRelationReferenceWidget slowness

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -928,7 +928,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl )
   mVariableEditor->reloadContext();
   mVariableEditor->setEditableScopeIndex( 0 );
 
-
+  const QString key = "/QgsRelationReferenceWidget/cacheSize";
+  mSettings->setValue( key, mSettings->value( key, 200000 ) );
 
   mAdvancedSettingsEditor->setSettingsObject( mSettings );
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -583,8 +583,14 @@ void QgsRelationReferenceWidget::init()
       }
     }
 
-    QVariant featId = mFeature.isValid() ? mFeature.id() : QVariant( QVariant::Int );
-    mComboBox->setCurrentIndex( mComboBox->findData( featId, QgsAttributeTableModel::FeatureIdRole ) );
+    if ( mFeature.isValid() )
+    {
+      mComboBox->setCurrentIndex( mComboBox->findData( mFeature.id(), QgsAttributeTableModel::FeatureIdRole ) );
+    }
+    else
+    {
+      mComboBox->setCurrentIndex( -1 );
+    }
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( comboReferenceChanged( int ) ) );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -479,7 +479,8 @@ void QgsRelationReferenceWidget::init()
 
     QSet<QString> requestedAttrs;
 
-    QgsVectorLayerCache* layerCache = new QgsVectorLayerCache( mReferencedLayer, 200000, this );
+    const int cacheSize = QSettings().value( "/QgsRelationReferenceWidget/cacheSize" ).toInt();
+    QgsVectorLayerCache* layerCache = new QgsVectorLayerCache( mReferencedLayer, cacheSize, this );
 
     if ( !mFilterFields.isEmpty() )
     {

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -479,7 +479,7 @@ void QgsRelationReferenceWidget::init()
 
     QSet<QString> requestedAttrs;
 
-    QgsVectorLayerCache* layerCache = new QgsVectorLayerCache( mReferencedLayer, 100000, this );
+    QgsVectorLayerCache* layerCache = new QgsVectorLayerCache( mReferencedLayer, 200000, this );
 
     if ( !mFilterFields.isEmpty() )
     {

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -71,7 +71,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget* editor )
     if ( ctx->relation().name() == relation.name() )
     {
       mWidget->setEmbedForm( false );
-      mWidget->setReadOnlySelector( false );
+      mWidget->setReadOnlySelector( true );
       mWidget->setAllowMapIdentification( false );
     }
     ctx = ctx->parentContext();


### PR DESCRIPTION
## Description

@haubourg raised an issue on 2.18 about the opening time of QgsAttributeForm when a relation reference is made on a layer with a lot of features.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
