### PR TITLE
[3d] Disable 3D view for unprojected (lat/lon) CRS

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10241,6 +10241,12 @@ void QgisApp::new3DMapCanvas()
     return;
   }
 
+  if ( mMapCanvas->mapSettings().destinationCrs().isGeographic() )
+  {
+    QMessageBox::warning( this, tr( "Error" ), tr( "3D view currently does not support unprojected coordinate reference systems (CRS).\nPlease switch project's CRS to a projected CRS." ) );
+    return;
+  }
+
   int i = 1;
 
   bool existing = true;


### PR DESCRIPTION
The fact that the map units are in degrees instead of meters means that various bits of the code
(e.g. tolerances) are not behaving correctly due to changes in coordinate values being several
orders of magnitude lower. So for the time being it is safer to disable 3D view for unprojected
CRS and just let the user choose a projected CRS for the project.
