### PR TITLE
Hide Aggregate search button for non-relation widget fields

### DIFF
--- a/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgssearchwidgetwrapper.sip
@@ -86,6 +86,7 @@ class QgsSearchWidgetWrapper : QgsWidgetWrapper
       IsNotNull,
       StartsWith,
       EndsWith,
+      Aggregates,
     };
     typedef QFlags<QgsSearchWidgetWrapper::FilterFlag> FilterFlags;
 

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
@@ -79,6 +79,8 @@ QString QgsSearchWidgetWrapper::toString( QgsSearchWidgetWrapper::FilterFlag fla
       return QObject::tr( "Starts with" );
     case EndsWith:
       return QObject::tr( "Ends with" );
+    case Aggregates:
+      return QObject::tr( "Aggregates" );
   }
   return QString();
 }

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
@@ -108,6 +108,7 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
       IsNotNull = 1 << 13, //!< Supports searching for non-null values
       StartsWith = 1 << 14, //!< Supports searching for strings that start with
       EndsWith = 1 << 15, //!< Supports searching for strings that end with
+      Aggregates = 1 << 16, //!< Supports searching by aggregate values
     };
     Q_DECLARE_FLAGS( FilterFlags, FilterFlag )
 

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -53,7 +53,7 @@ QVariant QgsRelationReferenceSearchWidgetWrapper::value() const
 
 QgsSearchWidgetWrapper::FilterFlags QgsRelationReferenceSearchWidgetWrapper::supportedFlags() const
 {
-  return EqualTo | NotEqualTo | IsNull | IsNotNull;
+  return EqualTo | NotEqualTo | IsNull | IsNotNull | Aggregates;
 }
 
 QgsSearchWidgetWrapper::FilterFlags QgsRelationReferenceSearchWidgetWrapper::defaultFlags() const

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -44,6 +44,7 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
 
   mMultiEditButton->setField( mWidget->field() );
   mAggregateButton = new QgsAggregateToolButton();
+  mAggregateButton->hide();
   mAggregateButton->setType( editorWidget->field().type() );
   connect( mAggregateButton, &QgsAggregateToolButton::aggregateChanged, this, &QgsAttributeFormEditorWidget::onAggregateChanged );
 
@@ -66,6 +67,7 @@ QgsAttributeFormEditorWidget::~QgsAttributeFormEditorWidget()
 {
   //there's a chance these widgets are not currently added to the layout, so have no parent set
   delete mMultiEditButton;
+  delete mAggregateButton;
 }
 
 void QgsAttributeFormEditorWidget::createSearchWidgetWrappers( const QgsAttributeEditorContext &context )
@@ -77,7 +79,11 @@ void QgsAttributeFormEditorWidget::createSearchWidgetWrappers( const QgsAttribut
   QgsSearchWidgetWrapper *sww = QgsGui::editorWidgetRegistry()->createSearchWidget( mWidgetType, layer(), fieldIdx, config,
                                 searchWidgetFrame(), context );
   setSearchWidgetWrapper( sww );
-  searchWidgetFrame()->layout()->addWidget( mAggregateButton );
+  if ( sww->supportedFlags() & QgsSearchWidgetWrapper::Aggregates )
+  {
+    mAggregateButton->show();
+    searchWidgetFrame()->layout()->addWidget( mAggregateButton );
+  }
   if ( sww->supportedFlags() & QgsSearchWidgetWrapper::Between ||
        sww->supportedFlags() & QgsSearchWidgetWrapper::IsNotBetween )
   {
@@ -86,6 +92,8 @@ void QgsAttributeFormEditorWidget::createSearchWidgetWrappers( const QgsAttribut
                                    searchWidgetFrame(), context );
     addAdditionalSearchWidgetWrapper( sww2 );
   }
+
+
 }
 
 void QgsAttributeFormEditorWidget::setConstraintStatus( const QString &constraint, const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result )
@@ -253,7 +261,6 @@ void QgsAttributeFormEditorWidget::updateWidgets()
 
     case SearchMode:
     {
-      mAggregateButton->setVisible( true );
       stack()->setCurrentWidget( searchPage() );
       break;
     }


### PR DESCRIPTION
@m-kuhn 

I noticed that the new "aggregate" search widget is shown for all fields in the F3 "select by value" dialog. I'm not sure exactly how this new search is supposed to work, but I don't think it should be shown here.

In this PR i've hidden it for all widget types except relation reference widgets. But alternatively should it be shown for all widgets types, but only when the form is in AggregateSearchMode? 