### PR TITLE
[rendering] semi-opaque rendering of preview tiles

### DIFF
--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -75,6 +75,7 @@ void QgsMapCanvasMap::paint( QPainter *painter )
   double offsetY = pt.y() - mRect.yMaximum();
 
   //draw preview images first
+  painter->setOpacity( 0.5 );
   QList< QPair< QImage, QgsRectangle > >::const_iterator imIt = mPreviewImages.constBegin();
   for ( ; imIt != mPreviewImages.constEnd(); ++imIt )
   {
@@ -83,6 +84,7 @@ void QgsMapCanvasMap::paint( QPainter *painter )
     painter->drawImage( QRectF( ul.x(), ul.y(), lr.x() - ul.x(), lr.y() - ul.y() ), imIt->first, QRect( 0, 0, imIt->first.width(), imIt->first.height() ) );
   }
 
+  painter->setOpacity( 1 );
   painter->drawImage( QRect( 0, 0, w, h ), mImage );
 
   // For debugging:


### PR DESCRIPTION
## Description
As a way to indicate that preview tiles rendered around the main canvas are not "full content" renderings*, draw those semi-opaquely.

Screencast of current 100% opacity rendering: https://www.dropbox.com/s/2cirisb4an64i2o/noopacity.mp4?dl=0
Screencast of proposed 50% opacity rendering: https://www.dropbox.com/s/hy9kxfz4a7we800/opacity.mp4?dl=0

(*) Preview tiles are missing labels, and soon vector/raster layers taking too long to render. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
