### PR TITLE
Hide aggregate button in non-aggregate context

### DIFF
--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -253,7 +253,7 @@ void QgsAttributeFormEditorWidget::updateWidgets()
 
     case SearchMode:
     {
-      mAggregateButton->setVisible( true );
+      mAggregateButton->setVisible( false );
       stack()->setCurrentWidget( searchPage() );
       break;
     }

--- a/src/gui/qgsguiutils.h
+++ b/src/gui/qgsguiutils.h
@@ -156,7 +156,7 @@ namespace QgsGuiUtils
 
   /**
    * Creates a key for the given widget that can be used to store related data in settings.
-   * Will use objectName() or class name if objectName() is not set. Can be overridden using \param keyName.
+   * Will use objectName() or class name if objectName() is not set. Can be overridden using \a keyName.
    * \param widget The widget to make the key from.
    * \param keyName Override for objectName() if needed. If not set will use objectName()
    * \return A key name that can be used for the widget in settings.


### PR DESCRIPTION
The aggregate button was shown for all search contexts and not only for the ones in which aggregate is actually supported.

Supersedes https://github.com/qgis/QGIS/pull/5788