### PR TITLE
[Processing] Fix raster menu split in two in some locales

### DIFF
--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -72,7 +72,7 @@ defaultMenuEntries.update({'qgis:definecurrentprojection': managementToolsMenu,
                            'qgis:mergevectorlayers': managementToolsMenu,
                            'qgis:createspatialindex': managementToolsMenu})
 
-rasterMenu = Processing.tr('&Raster')
+rasterMenu = QApplication.translate('MainWindow', '&Raster')
 projectionsMenu = rasterMenu + "/" + Processing.tr('Projections')
 defaultMenuEntries.update({'gdal:warpreproject': projectionsMenu,
                            'gdal:assignprojection': projectionsMenu,


### PR DESCRIPTION
## Description
[https://issues.qgis.org/issues/17448](https://issues.qgis.org/issues/17448)

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
