### PR TITLE
[processing] Add flag to indicate whether an algorithm is safe 

### DIFF
--- a/python/core/processing/qgsprocessingalgorithm.sip
+++ b/python/core/processing/qgsprocessingalgorithm.sip
@@ -44,6 +44,7 @@ Abstract base class for processing algorithms.
       FlagSupportsBatch,
       FlagCanCancel,
       FlagRequiresMatchingCrs,
+      FlagCanRunInBackground,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
+++ b/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
@@ -135,6 +135,12 @@ Sets a progress text message.
 Pushes a console info string to the dialog's log.
 %End
 
+    QDialog *createProgressDialog();
+%Docstring
+Creates a modal progress dialog showing progress and log messages
+from this dialog.
+%End
+
   protected:
 
     QPushButton *runButton();
@@ -208,6 +214,7 @@ Called when the algorithm has finished executing.
 %End
 
 };
+
 
 
 /************************************************************************

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -28,7 +28,7 @@ __revision__ = '$Format:%H$'
 from pprint import pformat
 import time
 
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, Qt
 from qgis.PyQt.QtWidgets import QMessageBox, QPushButton, QSizePolicy, QDialogButtonBox
 from qgis.PyQt.QtGui import QColor, QPalette
 
@@ -241,6 +241,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     feedback.pushInfo('')
 
                     self.cancelButton().setEnabled(False)
+
                     self.finish(ok, results, context, feedback)
 
                 if self.algorithm().flags() & QgsProcessingAlgorithm.FlagCanRunInBackground:
@@ -248,7 +249,6 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     task.executed.connect(on_complete)
                     QgsApplication.taskManager().addTask(task)
                 else:
-                    self.setWindowModality(Qt.ApplicationModal)
                     ok, results = execute(self.algorithm(), parameters, context, feedback)
                     on_complete(ok, results)
 

--- a/src/3d/processing/qgsalgorithmtessellate.cpp
+++ b/src/3d/processing/qgsalgorithmtessellate.cpp
@@ -31,6 +31,11 @@ QString QgsTessellateAlgorithm::displayName() const
   return QObject::tr( "Tessellate" );
 }
 
+QgsProcessingAlgorithm::Flags QgsTessellateAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QStringList QgsTessellateAlgorithm::tags() const
 {
   return QObject::tr( "3d,triangle" ).split( ',' );

--- a/src/3d/processing/qgsalgorithmtessellate.h
+++ b/src/3d/processing/qgsalgorithmtessellate.h
@@ -36,6 +36,7 @@ class QgsTessellateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsTessellateAlgorithm() = default;
     QString name() const override;
     QString displayName() const override;
+    Flags flags() const override;
     QStringList tags() const override;
     QString group() const override;
     QString shortHelpString() const override;

--- a/src/analysis/network/qgsgraphanalyzer.cpp
+++ b/src/analysis/network/qgsgraphanalyzer.cpp
@@ -24,6 +24,12 @@
 
 void QgsGraphAnalyzer::dijkstra( const QgsGraph *source, int startPointIdx, int criterionNum, QVector<int> *resultTree, QVector<double> *resultCost )
 {
+  if ( startPointIdx < 0 || startPointIdx >= source->vertexCount() )
+  {
+    // invalid start point
+    return;
+  }
+
   QVector< double > *result = nullptr;
   if ( resultCost )
   {

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsAddIncrementalFieldAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsAddIncrementalFieldAlgorithm::name() const
 {
   return QStringLiteral( "addautoincrementalfield" );

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.h
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.h
@@ -34,6 +34,7 @@ class QgsAddIncrementalFieldAlgorithm : public QgsProcessingFeatureBasedAlgorith
   public:
 
     QgsAddIncrementalFieldAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmassignprojection.cpp
+++ b/src/analysis/processing/qgsalgorithmassignprojection.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsAssignProjectionAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsAssignProjectionAlgorithm::name() const
 {
   return QStringLiteral( "assignprojection" );

--- a/src/analysis/processing/qgsalgorithmassignprojection.h
+++ b/src/analysis/processing/qgsalgorithmassignprojection.h
@@ -34,6 +34,7 @@ class QgsAssignProjectionAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsAssignProjectionAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmboundary.cpp
+++ b/src/analysis/processing/qgsalgorithmboundary.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsBoundaryAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsBoundaryAlgorithm::name() const
 {
   return QStringLiteral( "boundary" );

--- a/src/analysis/processing/qgsalgorithmboundary.h
+++ b/src/analysis/processing/qgsalgorithmboundary.h
@@ -34,6 +34,7 @@ class QgsBoundaryAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsBoundaryAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmboundingbox.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsBoundingBoxAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsBoundingBoxAlgorithm::name() const
 {
   return QStringLiteral( "boundingboxes" );

--- a/src/analysis/processing/qgsalgorithmboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmboundingbox.h
@@ -34,6 +34,7 @@ class QgsBoundingBoxAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsBoundingBoxAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -63,6 +63,11 @@ void QgsBufferAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Buffered" ), QgsProcessing::TypeVectorPolygon ) );
 }
 
+QgsProcessingAlgorithm::Flags QgsBufferAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsBufferAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm computes a buffer area for all the features in an input layer, using a fixed or dynamic distance.\n\n"

--- a/src/analysis/processing/qgsalgorithmbuffer.h
+++ b/src/analysis/processing/qgsalgorithmbuffer.h
@@ -35,7 +35,7 @@ class QgsBufferAlgorithm : public QgsProcessingAlgorithm
 
     QgsBufferAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
-
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmcentroid.cpp
+++ b/src/analysis/processing/qgsalgorithmcentroid.cpp
@@ -49,6 +49,11 @@ QString QgsCentroidAlgorithm::outputName() const
   return QObject::tr( "Centroids" );
 }
 
+QgsProcessingAlgorithm::Flags QgsCentroidAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsCentroidAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmcentroid.h
+++ b/src/analysis/processing/qgsalgorithmcentroid.h
@@ -34,6 +34,7 @@ class QgsCentroidAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsCentroidAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmclip.cpp
+++ b/src/analysis/processing/qgsalgorithmclip.cpp
@@ -40,6 +40,11 @@ QString QgsClipAlgorithm::group() const
   return QObject::tr( "Vector overlay" );
 }
 
+QgsProcessingAlgorithm::Flags QgsClipAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsClipAlgorithm::groupId() const
 {
   return QStringLiteral( "vectoroverlay" );

--- a/src/analysis/processing/qgsalgorithmclip.h
+++ b/src/analysis/processing/qgsalgorithmclip.h
@@ -34,6 +34,7 @@ class QgsClipAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsClipAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmconvexhull.cpp
+++ b/src/analysis/processing/qgsalgorithmconvexhull.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsConvexHullAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsConvexHullAlgorithm::name() const
 {
   return QStringLiteral( "convexhull" );

--- a/src/analysis/processing/qgsalgorithmconvexhull.h
+++ b/src/analysis/processing/qgsalgorithmconvexhull.h
@@ -35,6 +35,7 @@ class QgsConvexHullAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsConvexHullAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -23,6 +23,11 @@
 // QgsCollectorAlgorithm
 //
 
+QgsProcessingAlgorithm::Flags QgsCollectorAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback,
     const std::function<QgsGeometry( const QVector< QgsGeometry >& )> &collector, int maxQueueLength )
 {

--- a/src/analysis/processing/qgsalgorithmdissolve.h
+++ b/src/analysis/processing/qgsalgorithmdissolve.h
@@ -32,6 +32,7 @@ class QgsCollectorAlgorithm : public QgsProcessingAlgorithm
 {
   protected:
 
+    Flags flags() const override;
     QVariantMap processCollection( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback,
                                    const std::function<QgsGeometry( const QVector<QgsGeometry>& )> &collector, int maxQueueLength = 0 );
 };

--- a/src/analysis/processing/qgsalgorithmdropgeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmdropgeometry.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsDropGeometryAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsDropGeometryAlgorithm::name() const
 {
   return QStringLiteral( "dropgeometries" );

--- a/src/analysis/processing/qgsalgorithmdropgeometry.h
+++ b/src/analysis/processing/qgsalgorithmdropgeometry.h
@@ -34,6 +34,7 @@ class QgsDropGeometryAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsDropGeometryAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmdropmzvalues.cpp
+++ b/src/analysis/processing/qgsalgorithmdropmzvalues.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsDropMZValuesAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsDropMZValuesAlgorithm::name() const
 {
   return QStringLiteral( "dropmzvalues" );

--- a/src/analysis/processing/qgsalgorithmdropmzvalues.h
+++ b/src/analysis/processing/qgsalgorithmdropmzvalues.h
@@ -34,6 +34,7 @@ class QgsDropMZValuesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsDropMZValuesAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmextenttolayer.cpp
+++ b/src/analysis/processing/qgsalgorithmextenttolayer.cpp
@@ -24,6 +24,11 @@ QString QgsExtentToLayerAlgorithm::name() const
   return QStringLiteral( "extenttolayer" );
 }
 
+QgsProcessingAlgorithm::Flags QgsExtentToLayerAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsExtentToLayerAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "INPUT" ), QObject::tr( "Extent" ) ) );

--- a/src/analysis/processing/qgsalgorithmextenttolayer.h
+++ b/src/analysis/processing/qgsalgorithmextenttolayer.h
@@ -34,6 +34,7 @@ class QgsExtentToLayerAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtentToLayerAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override { return QObject::tr( "Create layer from extent" ); }

--- a/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
@@ -39,6 +39,11 @@ QString QgsExtractByAttributeAlgorithm::group() const
   return QObject::tr( "Vector selection" );
 }
 
+QgsProcessingAlgorithm::Flags QgsExtractByAttributeAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsExtractByAttributeAlgorithm::groupId() const
 {
   return QStringLiteral( "vectorselection" );

--- a/src/analysis/processing/qgsalgorithmextractbyattribute.h
+++ b/src/analysis/processing/qgsalgorithmextractbyattribute.h
@@ -49,6 +49,7 @@ class QgsExtractByAttributeAlgorithm : public QgsProcessingAlgorithm
     };
 
     QgsExtractByAttributeAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
@@ -44,6 +44,11 @@ QString QgsExtractByExpressionAlgorithm::groupId() const
   return QStringLiteral( "vectorselection" );
 }
 
+QgsProcessingAlgorithm::Flags QgsExtractByExpressionAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsExtractByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmextractbyexpression.h
+++ b/src/analysis/processing/qgsalgorithmextractbyexpression.h
@@ -34,6 +34,7 @@ class QgsExtractByExpressionAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtractByExpressionAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractbyextent.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyextent.cpp
@@ -44,6 +44,11 @@ QString QgsExtractByExtentAlgorithm::groupId() const
   return QStringLiteral( "vectoroverlay" );
 }
 
+QgsProcessingAlgorithm::Flags QgsExtractByExtentAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsExtractByExtentAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmextractbyextent.h
+++ b/src/analysis/processing/qgsalgorithmextractbyextent.h
@@ -34,6 +34,7 @@ class QgsExtractByExtentAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtractByExtentAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -286,6 +286,11 @@ QVariantMap QgsSelectByLocationAlgorithm::processAlgorithm( const QVariantMap &p
 // QgsExtractByLocationAlgorithm
 //
 
+QgsProcessingAlgorithm::Flags QgsExtractByLocationAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsExtractByLocationAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "INPUT" ), QObject::tr( "Extract features from" ),

--- a/src/analysis/processing/qgsalgorithmextractbylocation.h
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.h
@@ -87,6 +87,7 @@ class QgsExtractByLocationAlgorithm : public QgsLocationBasedAlgorithm
   public:
 
     QgsExtractByLocationAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractnodes.cpp
+++ b/src/analysis/processing/qgsalgorithmextractnodes.cpp
@@ -59,6 +59,11 @@ QgsExtractNodesAlgorithm *QgsExtractNodesAlgorithm::createInstance() const
   return new QgsExtractNodesAlgorithm();
 }
 
+QgsProcessingAlgorithm::Flags QgsExtractNodesAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsExtractNodesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmextractnodes.h
+++ b/src/analysis/processing/qgsalgorithmextractnodes.h
@@ -34,6 +34,7 @@ class QgsExtractNodesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtractNodesAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -60,6 +60,11 @@ QgsFileDownloaderAlgorithm *QgsFileDownloaderAlgorithm::createInstance() const
   return new QgsFileDownloaderAlgorithm();
 }
 
+QgsProcessingAlgorithm::Flags QgsFileDownloaderAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsFileDownloaderAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterString( QStringLiteral( "URL" ), tr( "URL" ), QVariant(), false, false ) );

--- a/src/analysis/processing/qgsalgorithmfiledownloader.h
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.h
@@ -34,6 +34,7 @@ class QgsFileDownloaderAlgorithm : public QgsProcessingAlgorithm, public QObject
 {
   public:
     QgsFileDownloaderAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmfixgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsFixGeometriesAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsFixGeometriesAlgorithm::name() const
 {
   return QStringLiteral( "fixgeometries" );

--- a/src/analysis/processing/qgsalgorithmfixgeometries.h
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.h
@@ -34,6 +34,7 @@ class QgsFixGeometriesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsFixGeometriesAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
@@ -44,6 +44,11 @@ QString QgsJoinByAttributeAlgorithm::groupId() const
   return QStringLiteral( "vectorgeneral" );
 }
 
+QgsProcessingAlgorithm::Flags QgsJoinByAttributeAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsJoinByAttributeAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.h
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.h
@@ -34,6 +34,7 @@ class QgsJoinByAttributeAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsJoinByAttributeAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
@@ -45,6 +45,11 @@ QString QgsJoinWithLinesAlgorithm::groupId() const
   return QStringLiteral( "vectoranalysis" );
 }
 
+QgsProcessingAlgorithm::Flags QgsJoinWithLinesAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsJoinWithLinesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "HUBS" ),

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.h
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.h
@@ -34,6 +34,7 @@ class QgsJoinWithLinesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsJoinWithLinesAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmlineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmlineintersection.cpp
@@ -45,6 +45,11 @@ QString QgsLineIntersectionAlgorithm::groupId() const
   return QStringLiteral( "vectoroverlay" );
 }
 
+QgsProcessingAlgorithm::Flags QgsLineIntersectionAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsLineIntersectionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmlineintersection.h
+++ b/src/analysis/processing/qgsalgorithmlineintersection.h
@@ -34,6 +34,7 @@ class QgsLineIntersectionAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsLineIntersectionAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmloadlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmloadlayer.cpp
@@ -26,7 +26,7 @@ QString QgsLoadLayerAlgorithm::name() const
 
 QgsProcessingAlgorithm::Flags QgsLoadLayerAlgorithm::flags() const
 {
-  return FlagHideFromToolbox;
+  return FlagHideFromToolbox | QgsProcessingAlgorithm::FlagCanRunInBackground;
 }
 
 QString QgsLoadLayerAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmmeancoordinates.cpp
+++ b/src/analysis/processing/qgsalgorithmmeancoordinates.cpp
@@ -44,6 +44,11 @@ QString QgsMeanCoordinatesAlgorithm::groupId() const
   return QStringLiteral( "vectoranalysis" );
 }
 
+QgsProcessingAlgorithm::Flags QgsMeanCoordinatesAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsMeanCoordinatesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmmeancoordinates.h
+++ b/src/analysis/processing/qgsalgorithmmeancoordinates.h
@@ -35,6 +35,7 @@ class QgsMeanCoordinatesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsMeanCoordinatesAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmmergelines.cpp
+++ b/src/analysis/processing/qgsalgorithmmergelines.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsMergeLinesAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsMergeLinesAlgorithm::name() const
 {
   return QStringLiteral( "mergelines" );

--- a/src/analysis/processing/qgsalgorithmmergelines.h
+++ b/src/analysis/processing/qgsalgorithmmergelines.h
@@ -38,6 +38,7 @@ class QgsMergeLinesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsMergeLinesAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmmergevector.cpp
+++ b/src/analysis/processing/qgsalgorithmmergevector.cpp
@@ -39,6 +39,11 @@ QString QgsMergeVectorAlgorithm::group() const
   return QObject::tr( "Vector general" );
 }
 
+QgsProcessingAlgorithm::Flags QgsMergeVectorAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsMergeVectorAlgorithm::groupId() const
 {
   return QStringLiteral( "vectorgeneral" );

--- a/src/analysis/processing/qgsalgorithmmergevector.h
+++ b/src/analysis/processing/qgsalgorithmmergevector.h
@@ -34,6 +34,7 @@ class QgsMergeVectorAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsMergeVectorAlgorithm() = default;
+    QgsProcessingAlgorithm::Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmminimumenclosingcircle.cpp
+++ b/src/analysis/processing/qgsalgorithmminimumenclosingcircle.cpp
@@ -54,6 +54,11 @@ QgsWkbTypes::Type QgsMinimumEnclosingCircleAlgorithm::outputWkbType( QgsWkbTypes
   return QgsWkbTypes::Polygon;
 }
 
+QgsProcessingAlgorithm::Flags QgsMinimumEnclosingCircleAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsMinimumEnclosingCircleAlgorithm::initParameters( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "SEGMENTS" ), QObject::tr( "Number of segments in circles" ), QgsProcessingParameterNumber::Integer,

--- a/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
+++ b/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
@@ -34,6 +34,7 @@ class QgsMinimumEnclosingCircleAlgorithm : public QgsProcessingFeatureBasedAlgor
   public:
 
     QgsMinimumEnclosingCircleAlgorithm() = default;
+    Flags flags() const override;
     void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmmultiparttosinglepart.cpp
+++ b/src/analysis/processing/qgsalgorithmmultiparttosinglepart.cpp
@@ -44,6 +44,11 @@ QString QgsMultipartToSinglepartAlgorithm::groupId() const
   return QStringLiteral( "vectorgeometry" );
 }
 
+QgsProcessingAlgorithm::Flags QgsMultipartToSinglepartAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsMultipartToSinglepartAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
+++ b/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
@@ -34,6 +34,7 @@ class QgsMultipartToSinglepartAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsMultipartToSinglepartAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmorderbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmorderbyexpression.cpp
@@ -47,6 +47,11 @@ QString QgsOrderByExpressionAlgorithm::groupId() const
   return QStringLiteral( "vectorgeneral" );
 }
 
+QgsProcessingAlgorithm::Flags QgsOrderByExpressionAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsOrderByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmorderbyexpression.h
+++ b/src/analysis/processing/qgsalgorithmorderbyexpression.h
@@ -34,6 +34,7 @@ class QgsOrderByExpressionAlgorithm : public QgsProcessingAlgorithm
 {
   public:
     QgsOrderByExpressionAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsOrientedMinimumBoundingBoxAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsOrientedMinimumBoundingBoxAlgorithm::name() const
 {
   return QStringLiteral( "orientedminimumboundingbox" );

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
@@ -34,6 +34,7 @@ class QgsOrientedMinimumBoundingBoxAlgorithm : public QgsProcessingFeatureBasedA
   public:
 
     QgsOrientedMinimumBoundingBoxAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -47,6 +47,11 @@ QString QgsPackageAlgorithm::groupId() const
   return QStringLiteral( "database" );
 }
 
+QgsProcessingAlgorithm::Flags QgsPackageAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsPackageAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterMultipleLayers( QStringLiteral( "LAYERS" ), QObject::tr( "Input layers" ), QgsProcessing::TypeVector ) );

--- a/src/analysis/processing/qgsalgorithmpackage.h
+++ b/src/analysis/processing/qgsalgorithmpackage.h
@@ -36,6 +36,7 @@ class QgsPackageAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsPackageAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsPromoteToMultipartAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsPromoteToMultipartAlgorithm::name() const
 {
   return QStringLiteral( "promotetomulti" );

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.h
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.h
@@ -35,6 +35,7 @@ class QgsPromoteToMultipartAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsPromoteToMultipartAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
@@ -44,6 +44,11 @@ QString QgsRasterLayerUniqueValuesReportAlgorithm::groupId() const
   return QStringLiteral( "rasteranalysis" );
 }
 
+QgsProcessingAlgorithm::Flags QgsRasterLayerUniqueValuesReportAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsRasterLayerUniqueValuesReportAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
@@ -34,6 +34,7 @@ class QgsRasterLayerUniqueValuesReportAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsRasterLayerUniqueValuesReportAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmremoveduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatenodes.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsAlgorithmRemoveDuplicateNodes::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsAlgorithmRemoveDuplicateNodes::name() const
 {
   return QStringLiteral( "removeduplicatenodes" );

--- a/src/analysis/processing/qgsalgorithmremoveduplicatenodes.h
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatenodes.h
@@ -34,6 +34,7 @@ class QgsAlgorithmRemoveDuplicateNodes : public QgsProcessingFeatureBasedAlgorit
   public:
 
     QgsAlgorithmRemoveDuplicateNodes() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmremovenullgeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmremovenullgeometry.cpp
@@ -44,6 +44,11 @@ QString QgsRemoveNullGeometryAlgorithm::groupId() const
   return QStringLiteral( "vectorgeometry" );
 }
 
+QgsProcessingAlgorithm::Flags QgsRemoveNullGeometryAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsRemoveNullGeometryAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmremovenullgeometry.h
+++ b/src/analysis/processing/qgsalgorithmremovenullgeometry.h
@@ -34,6 +34,7 @@ class QgsRemoveNullGeometryAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsRemoveNullGeometryAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmrenamelayer.cpp
+++ b/src/analysis/processing/qgsalgorithmrenamelayer.cpp
@@ -26,7 +26,7 @@ QString QgsRenameLayerAlgorithm::name() const
 
 QgsProcessingAlgorithm::Flags QgsRenameLayerAlgorithm::flags() const
 {
-  return FlagHideFromToolbox;
+  return FlagHideFromToolbox | FlagCanRunInBackground;
 }
 
 QString QgsRenameLayerAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsSaveSelectedFeatures::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsSaveSelectedFeatures::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmsaveselectedfeatures.h
+++ b/src/analysis/processing/qgsalgorithmsaveselectedfeatures.h
@@ -34,6 +34,7 @@ class QgsSaveSelectedFeatures : public QgsProcessingAlgorithm
   public:
 
     QgsSaveSelectedFeatures() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmsimplify.cpp
+++ b/src/analysis/processing/qgsalgorithmsimplify.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsSimplifyAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsSimplifyAlgorithm::name() const
 {
   return QStringLiteral( "simplifygeometries" );

--- a/src/analysis/processing/qgsalgorithmsimplify.h
+++ b/src/analysis/processing/qgsalgorithmsimplify.h
@@ -35,6 +35,7 @@ class QgsSimplifyAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSimplifyAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmsmooth.cpp
+++ b/src/analysis/processing/qgsalgorithmsmooth.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsSmoothAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsSmoothAlgorithm::name() const
 {
   return QStringLiteral( "smoothgeometry" );

--- a/src/analysis/processing/qgsalgorithmsmooth.h
+++ b/src/analysis/processing/qgsalgorithmsmooth.h
@@ -34,6 +34,7 @@ class QgsSmoothAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSmoothAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsSnapToGridAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsSnapToGridAlgorithm::name() const
 {
   return QStringLiteral( "snappointstogrid" );

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.h
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.h
@@ -34,6 +34,7 @@ class QgsSnapToGridAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSnapToGridAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -45,6 +45,11 @@ QString QgsSplitWithLinesAlgorithm::groupId() const
   return QStringLiteral( "vectoroverlay" );
 }
 
+QgsProcessingAlgorithm::Flags QgsSplitWithLinesAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsSplitWithLinesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.h
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.h
@@ -35,6 +35,7 @@ class QgsSplitWithLinesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsSplitWithLinesAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmstringconcatenation.cpp
+++ b/src/analysis/processing/qgsalgorithmstringconcatenation.cpp
@@ -26,7 +26,7 @@ QString QgsStringConcatenationAlgorithm::name() const
 
 QgsProcessingAlgorithm::Flags QgsStringConcatenationAlgorithm::flags() const
 {
-  return FlagHideFromToolbox;
+  return FlagHideFromToolbox | FlagCanRunInBackground;
 }
 
 QString QgsStringConcatenationAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -20,6 +20,11 @@
 ///@cond PRIVATE
 
 
+QgsProcessingAlgorithm::Flags QgsSubdivideAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsSubdivideAlgorithm::initParameters( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsProcessingParameterNumber::Integer,

--- a/src/analysis/processing/qgsalgorithmsubdivide.h
+++ b/src/analysis/processing/qgsalgorithmsubdivide.h
@@ -34,6 +34,7 @@ class QgsSubdivideAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSubdivideAlgorithm() = default;
+    Flags flags() const override;
     void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmtransect.cpp
+++ b/src/analysis/processing/qgsalgorithmtransect.cpp
@@ -46,6 +46,11 @@ QString QgsTransectAlgorithm::groupId() const
   return QStringLiteral( "vectorgeometry" );
 }
 
+QgsProcessingAlgorithm::Flags QgsTransectAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 void QgsTransectAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmtransect.h
+++ b/src/analysis/processing/qgsalgorithmtransect.h
@@ -43,6 +43,7 @@ class QgsTransectAlgorithm : public QgsProcessingAlgorithm
       Both
     };
     QgsTransectAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -35,6 +35,11 @@ QString QgsTransformAlgorithm::outputName() const
   return QObject::tr( "Reprojected" );
 }
 
+QgsProcessingAlgorithm::Flags QgsTransformAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsTransformAlgorithm::name() const
 {
   return QStringLiteral( "reprojectlayer" );

--- a/src/analysis/processing/qgsalgorithmtransform.h
+++ b/src/analysis/processing/qgsalgorithmtransform.h
@@ -34,6 +34,7 @@ class QgsTransformAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsTransformAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmtranslate.cpp
+++ b/src/analysis/processing/qgsalgorithmtranslate.cpp
@@ -19,6 +19,11 @@
 
 ///@cond PRIVATE
 
+QgsProcessingAlgorithm::Flags QgsTranslateAlgorithm::flags() const
+{
+  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+}
+
 QString QgsTranslateAlgorithm::name() const
 {
   return QStringLiteral( "translategeometry" );

--- a/src/analysis/processing/qgsalgorithmtranslate.h
+++ b/src/analysis/processing/qgsalgorithmtranslate.h
@@ -34,6 +34,7 @@ class QgsTranslateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsTranslateAlgorithm() = default;
+    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -72,6 +72,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagSupportsBatch = 1 << 3,  //!< Algorithm supports batch mode
       FlagCanCancel = 1 << 4, //!< Algorithm can be canceled
       FlagRequiresMatchingCrs = 1 << 5, //!< Algorithm requires that all input layers have matching coordinate reference systems
+      FlagCanRunInBackground = 1 << 6, //!< Algorithm is safe to run in a background thread
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -130,6 +130,9 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
     textShortHelp->setHtml( algHelp );
     connect( textShortHelp, &QTextBrowser::anchorClicked, this, &QgsProcessingAlgorithmDialogBase::linkClicked );
   }
+
+  if ( algorithm->flags() & QgsProcessingAlgorithm::FlagCanRunInBackground )
+    mButtonRun->setText( tr( "Run in Background" ) );
 }
 
 QgsProcessingAlgorithm *QgsProcessingAlgorithmDialogBase::algorithm()

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -306,6 +306,23 @@ void QgsProcessingAlgorithmDialogBase::pushConsoleInfo( const QString &info )
   processEvents();
 }
 
+QDialog *QgsProcessingAlgorithmDialogBase::createProgressDialog()
+{
+  QgsProcessingAlgorithmProgressDialog *dialog = new QgsProcessingAlgorithmProgressDialog( this );
+  dialog->setWindowModality( Qt::ApplicationModal );
+  dialog->setWindowTitle( windowTitle() );
+  connect( progressBar, &QProgressBar::valueChanged, dialog->progressBar(), &QProgressBar::setValue );
+  connect( dialog->cancelButton(), &QPushButton::clicked, buttonCancel, &QPushButton::click );
+  dialog->logTextEdit()->setHtml( txtLog->toHtml() );
+  connect( txtLog, &QTextEdit::textChanged, dialog, [this, dialog]()
+  {
+    dialog->logTextEdit()->setHtml( txtLog->toHtml() );
+    QScrollBar *sb = dialog->logTextEdit()->verticalScrollBar();
+    sb->setValue( sb->maximum() );
+  } );
+  return dialog;
+}
+
 void QgsProcessingAlgorithmDialogBase::setPercentage( double percent )
 {
   // delay setting maximum progress value until we know algorithm reports progress
@@ -392,5 +409,38 @@ void QgsProcessingAlgorithmDialogBase::setInfo( const QString &message, bool isE
   scrollToBottomOfLog();
   processEvents();
 }
+
+//
+// QgsProcessingAlgorithmProgressDialog
+//
+
+QgsProcessingAlgorithmProgressDialog::QgsProcessingAlgorithmProgressDialog( QWidget *parent )
+  : QDialog( parent )
+{
+  setWindowFlags( Qt::Dialog ); // hide close button
+  setupUi( this );
+}
+
+QProgressBar *QgsProcessingAlgorithmProgressDialog::progressBar()
+{
+  return mProgressBar;
+}
+
+QPushButton *QgsProcessingAlgorithmProgressDialog::cancelButton()
+{
+  return mButtonBox->button( QDialogButtonBox::Cancel );
+}
+
+QTextEdit *QgsProcessingAlgorithmProgressDialog::logTextEdit()
+{
+  return mTxtLog;
+}
+
+void QgsProcessingAlgorithmProgressDialog::reject()
+{
+
+}
+
+
 
 ///@endcond

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -271,6 +271,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     bool mHelpCollapsed = false;
 
     QString formatHelp( QgsProcessingAlgorithm *algorithm );
+    void processEvents();
+    void scrollToBottomOfLog();
 
 };
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -19,6 +19,7 @@
 #include "qgis.h"
 #include "qgis_gui.h"
 #include "ui_qgsprocessingalgorithmdialogbase.h"
+#include "ui_qgsprocessingalgorithmprogressdialogbase.h"
 #include "processing/qgsprocessingcontext.h"
 #include "processing/qgsprocessingfeedback.h"
 
@@ -180,6 +181,12 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      */
     void pushConsoleInfo( const QString &info );
 
+    /**
+     * Creates a modal progress dialog showing progress and log messages
+     * from this dialog.
+     */
+    QDialog *createProgressDialog();
+
   protected:
 
     /**
@@ -271,10 +278,52 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     bool mHelpCollapsed = false;
 
     QString formatHelp( QgsProcessingAlgorithm *algorithm );
-    void processEvents();
     void scrollToBottomOfLog();
+    void processEvents();
 
 };
+
+#ifndef SIP_RUN
+
+/**
+ * \ingroup gui
+ * \brief A modal dialog for showing algorithm progress and log messages.
+ * \note This is not considered stable API and may change in future QGIS versions.
+ * \since QGIS 3.0
+ */
+class QgsProcessingAlgorithmProgressDialog : public QDialog, private Ui::QgsProcessingProgressDialogBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProcessingAlgorithmProgressDialog.
+     */
+    QgsProcessingAlgorithmProgressDialog( QWidget *parent = nullptr );
+
+    /**
+     * Returns the dialog's progress bar.
+     */
+    QProgressBar *progressBar();
+
+    /**
+     * Returns the dialog's cancel button.
+     */
+    QPushButton *cancelButton();
+
+    /**
+     * Returns the dialog's text log.
+     */
+    QTextEdit *logTextEdit();
+
+  public slots:
+
+    void reject() override;
+
+};
+
+#endif
 
 ///@endcond
 

--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -45,11 +45,14 @@ QgsTaskManagerWidget::QgsTaskManagerWidget( QgsTaskManager *manager, QWidget *pa
   mTreeView->setHeaderHidden( true );
   mTreeView->setRootIsDecorated( false );
   mTreeView->setSelectionBehavior( QAbstractItemView::SelectRows );
-  mTreeView->setColumnWidth( 2, 28 );
+  int progressColWidth = fontMetrics().width( "X" ) * 10 * Qgis::UI_SCALE_FACTOR;
+  mTreeView->setColumnWidth( QgsTaskManagerModel::Progress, progressColWidth );
+  int statusColWidth = fontMetrics().width( "X" ) * 2 * Qgis::UI_SCALE_FACTOR;
+  mTreeView->setColumnWidth( QgsTaskManagerModel::Status, statusColWidth );
   mTreeView->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
   mTreeView->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOn );
   mTreeView->header()->setStretchLastSection( false );
-  mTreeView->header()->setSectionResizeMode( 0, QHeaderView::Stretch );
+  mTreeView->header()->setSectionResizeMode( QgsTaskManagerModel::Description, QHeaderView::Stretch );
 
   vLayout->addWidget( mTreeView );
 
@@ -469,7 +472,9 @@ QgsTaskManagerFloatingWidget::QgsTaskManagerFloatingWidget( QgsTaskManager *mana
 {
   setLayout( new QVBoxLayout() );
   QgsTaskManagerWidget *w = new QgsTaskManagerWidget( manager );
-  setMinimumSize( 350, 270 );
+  int minWidth = fontMetrics().width( 'X' ) * 60 * Qgis::UI_SCALE_FACTOR;
+  int minHeight = fontMetrics().height() * 15 * Qgis::UI_SCALE_FACTOR;
+  setMinimumSize( minWidth, minHeight );
   layout()->addWidget( w );
   setStyleSheet( ".QgsTaskManagerFloatingWidget { border-top-left-radius: 8px;"
                  "border-top-right-radius: 8px; background-color: rgb(0, 0, 0, 70%); }" );
@@ -506,7 +511,7 @@ QgsTaskManagerStatusBarWidget::QgsTaskManagerStatusBarWidget( QgsTaskManager *ma
 
 QSize QgsTaskManagerStatusBarWidget::sizeHint() const
 {
-  int width = 100;
+  int width = fontMetrics().width( 'X' ) * 10 * Qgis::UI_SCALE_FACTOR;
   int height = QToolButton::sizeHint().height();
   return QSize( width, height );
 }

--- a/src/ui/processing/qgsprocessingalgorithmprogressdialogbase.ui
+++ b/src/ui/processing/qgsprocessingalgorithmprogressdialogbase.ui
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsProcessingProgressDialogBase</class>
+ <widget class="QDialog" name="QgsProcessingProgressDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1603</width>
+    <height>1239</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTextEdit" name="mTxtLog">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QProgressBar" name="mProgressBar">
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="mButtonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
...and only run algorithms with this flag as background tasks.

Avoids issues with the Python GIL locking up the UI thread, by only allowing those algorithms which specifically flag that they can run in the background (i.e. the native c++ algorithms) to run as tasks.

It's possible other python based algs may NOT incur the GIL lock, and can also report this flag - but that will need to be done on an algorithm-by-algorithm basis.

TODO: for algorithms which can't be run in the background, we need to make sure the algorithm dialog is modal and prevents interaction with the QGIS window. I've needed to add processEvents calls to the dialog whenever the progress is changed in order to get the UI to refresh and detect cancellation requests, but we don't want this to allow interaction with the main qgis window.