### PR TITLE
[offline] Apply attribute changes on multiple layers

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -297,10 +297,6 @@ void QgsOfflineEditing::synchronize()
           sqlExec( database.get(), sql );
           sql = QStringLiteral( "DELETE FROM 'log_geometry_updates' WHERE \"layer_id\" = %1" ).arg( layerId );
           sqlExec( database.get(), sql );
-
-          // reset commitNo
-          QString sql = QStringLiteral( "UPDATE 'log_indices' SET 'last_index' = 0 WHERE \"name\" = 'commit_no'" );
-          sqlExec( database.get(), sql );
         }
         else
         {
@@ -330,6 +326,10 @@ void QgsOfflineEditing::synchronize()
       QgsDebugMsg( "Remote layer is not valid!" );
     }
   }
+
+  // reset commitNo
+  QString sql = QStringLiteral( "UPDATE 'log_indices' SET 'last_index' = 0 WHERE \"name\" = 'commit_no'" );
+  sqlExec( database.get(), sql );
 
   emit progressStopped();
 }


### PR DESCRIPTION
Fix #17647

The previous version tagged all changes as done once the first layer was synchronized, so for all subsequent layers no changes where reported and applied.
Now we tag them only as applied, once the all layers have been synchronized.