### PR TITLE
[offline] Apply attribute changes on multiple layers

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -307,10 +307,6 @@ void QgsOfflineEditing::synchronize()
             sqlExec( db, sql );
             sql = QString( "DELETE FROM 'log_geometry_updates' WHERE \"layer_id\" = %1" ).arg( layerId );
             sqlExec( db, sql );
-
-            // reset commitNo
-            QString sql = QString( "UPDATE 'log_indices' SET 'last_index' = 0 WHERE \"name\" = 'commit_no'" );
-            sqlExec( db, sql );
           }
           else
           {
@@ -346,6 +342,10 @@ void QgsOfflineEditing::synchronize()
       QgsDebugMsg( "Remote layer is not valid!" );
     }
   }
+
+  // reset commitNo
+  QString sql = QString( "UPDATE 'log_indices' SET 'last_index' = 0 WHERE \"name\" = 'commit_no'" );
+  sqlExec( db, sql );
 
   emit progressStopped();
 


### PR DESCRIPTION
Fix #17647

The previous version tagged all changes as done once the first layer was synchronized, so for all subsequent layers no changes where reported and applied.
Now we tag them only as applied, once the all layers have been synchronized.