### PR TITLE
Adjust colorramp height on HiDPI screens

### DIFF
--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -69,7 +69,8 @@ QSize QgsColorRampButton::sizeHint() const
 #ifdef Q_OS_WIN
   return QSize( 120, 22 );
 #else
-  return QSize( 120, 28 );
+  // Adjust height for HiDPI screens
+  return QSize( 120, std::max( static_cast<int>( fontMetrics().height( ) * 1.4 ), 28 ) );
 #endif
 }
 

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -67,10 +67,10 @@ QSize QgsColorRampButton::sizeHint() const
 {
   //make sure height of button looks good under different platforms
 #ifdef Q_OS_WIN
-  return QSize( 120, 22 );
+  return QSize( 120, static_cast<int>( std::max( Qgis::UI_SCALE_FACTOR * fontMetrics().height( ), 22.0 ) ) );
 #else
   // Adjust height for HiDPI screens
-  return QSize( 120, std::max( static_cast<int>( fontMetrics().height( ) * 1.4 ), 28 ) );
+  return QSize( 120, static_cast<int>( std::max( Qgis::UI_SCALE_FACTOR * fontMetrics().height( ) * 1.4, 28.0 ) ) );
 #endif
 }
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -64,9 +64,12 @@ void QgsCategorizedSymbolRendererModel::setRenderer( QgsCategorizedSymbolRendere
   }
   if ( renderer )
   {
-    beginInsertRows( QModelIndex(), 0, renderer->categories().size() - 1 );
     mRenderer = renderer;
-    endInsertRows();
+    if ( renderer->categories().size() > 0 )
+    {
+      beginInsertRows( QModelIndex(), 0, renderer->categories().size() - 1 );
+      endInsertRows();
+    }
   }
 }
 


### PR DESCRIPTION
Color Ramp button looks too short on retina and 4k screens:

![qgis-colorramp-button-hidpi](https://user-images.githubusercontent.com/142164/33707498-d39ccd70-db37-11e7-8e80-76121bae1985.png)

This PR dynamically calculate height:

![qgis-colorramp-button-hidpi1](https://user-images.githubusercontent.com/142164/33707561-145c0a38-db38-11e7-9042-58788078f10e.png)


@NathanW2  @nirvn would you be able to test this on other platforms/screens?

