### PR TITLE
[need-docs] reorganize the new spatialite layer dialog

### DIFF
--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -55,13 +55,19 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/NewSpatiaLiteLayer/geometry" ) ).toByteArray() );
 
+  mGeometryTypeBox->addItem( tr( "Point" ), QStringLiteral( "POINT" ) );
+  mGeometryTypeBox->addItem( tr( "Line" ), QStringLiteral( "LINE" ) );
+  mGeometryTypeBox->addItem( tr( "Polygon" ), QStringLiteral( "POLYGON" ) );
+  mGeometryTypeBox->addItem( tr( "MultiPoint" ), QStringLiteral( "MULTIPOINT" ) );
+  mGeometryTypeBox->addItem( tr( "MultiLine" ), QStringLiteral( "MULTILINE" ) );
+  mGeometryTypeBox->addItem( tr( "MultiPolygon" ), QStringLiteral( "MULTIPOLYGON" ) );
+
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
   mTypeBox->addItem( tr( "Text data" ), "text" );
   mTypeBox->addItem( tr( "Whole number" ), "integer" );
   mTypeBox->addItem( tr( "Decimal number" ), "real" );
 
-  mPointRadioButton->setChecked( true );
   // Populate the database list from the stored connections
   settings.beginGroup( QStringLiteral( "SpatiaLite/connections" ) );
   QStringList keys = settings.childGroups();
@@ -137,33 +143,7 @@ void QgsNewSpatialiteLayerDialog::toolButtonNewDatabase_clicked()
 
 QString QgsNewSpatialiteLayerDialog::selectedType() const
 {
-  if ( mPointRadioButton->isChecked() )
-  {
-    return QStringLiteral( "POINT" );
-  }
-  else if ( mLineRadioButton->isChecked() )
-  {
-    return QStringLiteral( "LINESTRING" );
-  }
-  else if ( mPolygonRadioButton->isChecked() )
-  {
-    return QStringLiteral( "POLYGON" );
-  }
-  else if ( mMultipointRadioButton->isChecked() )
-  {
-    return QStringLiteral( "MULTIPOINT" );
-  }
-  else if ( mMultilineRadioButton->isChecked() )
-  {
-    return QStringLiteral( "MULTILINESTRING" );
-  }
-  else if ( mMultipolygonRadioButton->isChecked() )
-  {
-    return QStringLiteral( "MULTIPOLYGON" );
-  }
-
-  Q_ASSERT( !"no type selected" );
-  return QLatin1String( "" );
+  return mGeometryTypeBox->currentData( Qt::UserRole ).toString();
 }
 
 void QgsNewSpatialiteLayerDialog::checkOk()

--- a/src/ui/qgsnewspatialitelayerdialogbase.ui
+++ b/src/ui/qgsnewspatialitelayerdialogbase.ui
@@ -55,162 +55,93 @@
         <height>598</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QGroupBox" name="buttonGroup1">
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="0" column="0">
+        <widget class="QLabel" name="mFileFormatLabel">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>Database</string>
+         </property>
+         <property name="buddy">
+          <cstring>mDatabaseComboBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="mDatabaseComboBox">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
-          <string>Type</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="mPointRadioButton">
-            <property name="text">
-             <string>Point</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QRadioButton" name="mLineRadioButton">
-            <property name="text">
-             <string>Line</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QRadioButton" name="mPolygonRadioButton">
-            <property name="text">
-             <string>Polygon</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QRadioButton" name="mMultipointRadioButton">
-            <property name="text">
-             <string>MultiPoint</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QRadioButton" name="mMultilineRadioButton">
-            <property name="text">
-             <string>Multiline</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QRadioButton" name="mMultipolygonRadioButton">
-            <property name="text">
-             <string>Multipolygon</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
         </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="mFileFormatLabel">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Database</string>
-           </property>
-           <property name="buddy">
-            <cstring>mDatabaseComboBox</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="mDatabaseComboBox">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="toolButtonNewDatabase">
-           <property name="toolTip">
-            <string>Create a new SpatiaLite database</string>
-           </property>
-           <property name="text">
-            <string>…</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="0" column="2">
+        <widget class="QToolButton" name="toolButtonNewDatabase">
+         <property name="toolTip">
+          <string>Create a new SpatiaLite database</string>
+         </property>
+         <property name="text">
+          <string>…</string>
+         </property>
+        </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Layer name</string>
-           </property>
-           <property name="buddy">
-            <cstring>leLayerName</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="leLayerName">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Name for the new layer</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Layer name</string>
+         </property>
+         <property name="buddy">
+          <cstring>leLayerName</cstring>
+         </property>
+        </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Geometry column</string>
-           </property>
-           <property name="buddy">
-            <cstring>leGeometryColumn</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="leGeometryColumn">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Name for the new layer</string>
-           </property>
-           <property name="text">
-            <string>geometry</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="1" colspan="2">
+        <widget class="QLineEdit" name="leLayerName">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Name for the new layer</string>
+         </property>
+        </widget>
        </item>
-       <item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Geometry type</string>
+         </property>
+         <property name="buddy">
+          <cstring>mGeometryTypeBox</cstring>
+         </property>
+        </widget>
+      </item>
+       <item row="2" column="1" colspan="2">
+        <widget class="QComboBox" name="mGeometryTypeBox">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Geometry type&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1" colspan="2">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLineEdit" name="leSRID">
@@ -236,27 +167,15 @@
            <property name="whatsThis">
             <string>Specify the coordinate reference system of the layer's geometry.</string>
            </property>
-           <property name="text">
-            <string>Specify CRS</string>
+           <property name="icon">
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/mActionSetProjection.svg</normaloff>:/images/themes/default/mActionSetProjection.svg</iconset>
            </property>
           </widget>
          </item>
         </layout>
        </item>
-       <item>
-        <widget class="QCheckBox" name="checkBoxPrimaryKey">
-         <property name="toolTip">
-          <string>Add an integer id field as the primary key for the new layer</string>
-         </property>
-         <property name="text">
-          <string>Create an autoincrementing primary key</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
+       <item row="4" colspan="3">
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>New field</string>
@@ -265,7 +184,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="textLabel1">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -294,7 +213,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="textLabel2">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -346,7 +265,7 @@
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="5" colspan="3">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Fields list</string>
@@ -414,6 +333,57 @@
             </property>
             <property name="toolButtonStyle">
              <enum>Qt::ToolButtonTextBesideIcon</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="6" colspan="3">
+        <widget class="QgsCollapsibleGroupBox" name="groupBox">
+         <property name="title">
+          <string>Advanced options</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_6">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Geometry column</string>
+            </property>
+            <property name="buddy">
+             <cstring>leGeometryColumn</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="leGeometryColumn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Name for the new layer</string>
+            </property>
+            <property name="text">
+             <string>geometry</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkBoxPrimaryKey">
+            <property name="toolTip">
+             <string>Add an integer id field as the primary key for the new layer</string>
+            </property>
+            <property name="text">
+             <string>Create an autoincrementing primary key</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
## Description
The PR harmonizes the create spatialite layer dialog to match recent improvements done to the create geopackage layer dialog (and others).

Before vs. PR:
![screenshot from 2017-12-08 11-51-38](https://user-images.githubusercontent.com/1728657/33751593-8146f1cc-dc0e-11e7-98df-1d711353448d.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
