### PR TITLE
[spatialite provider] Fix ZM support

### DIFF
--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -338,7 +338,8 @@ bool QgsNewSpatialiteLayerDialog::createDb()
     settings.setValue( QStringLiteral( "SpatiaLite/connections/selected" ), fi.fileName() + tr( "@" ) + fi.canonicalFilePath() );
     settings.setValue( key, fi.canonicalFilePath() );
 
-    QMessageBox::information( nullptr, tr( "SpatiaLite Database" ), tr( "Registered new database!" ) );
+    // Reload connections to refresh browser panel
+    QgisApp::instance()->reloadConnections();
   }
 
   pbnFindSRID->setEnabled( true );
@@ -445,6 +446,9 @@ bool QgsNewSpatialiteLayerDialog::apply()
                   leGeometryColumn->text() ), leLayerName->text(), QStringLiteral( "spatialite" ) );
         if ( layer->isValid() )
         {
+          // Reload connections to refresh browser panel
+          QgisApp::instance()->reloadConnections();
+
           // register this layer with the central layers registry
           QList<QgsMapLayer *> myList;
           myList << layer;

--- a/src/app/qgsnewspatialitelayerdialog.h
+++ b/src/app/qgsnewspatialitelayerdialog.h
@@ -55,6 +55,8 @@ class APP_EXPORT QgsNewSpatialiteLayerDialog: public QDialog, private Ui::QgsNew
   private:
     //! Returns the selected geometry type
     QString selectedType() const;
+    //! Returns the selected Z dimension and/or M measurement
+    QString selectedZM() const;
 
     //! Create a new database
     bool createDb();

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -29,6 +29,8 @@ extern "C"
 #include "qgsrectangle.h"
 #include "qgsvectorlayerexporter.h"
 #include "qgsfields.h"
+#include "qgswkbtypes.h"
+
 #include <list>
 #include <queue>
 #include <fstream>
@@ -356,7 +358,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
                              unsigned char **wkb, int *geom_size,
                              int dims );
     int computeSizeFromGeosWKB3D( const unsigned char *blob, int size,
-                                  int type, int nDims, int little_endian,
+                                  QgsWkbTypes::Type type, int nDims, int little_endian,
                                   int endian_arch );
     int computeSizeFromGeosWKB2D( const unsigned char *blob, int size,
                                   int type, int nDims, int little_endian,
@@ -365,17 +367,6 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     void fetchConstraints();
 
     void insertDefaultValue( int fieldIndex, QString defaultVal );
-
-    enum GEOS_3D
-    {
-      GEOS_3D_POINT              = -2147483647,
-      GEOS_3D_LINESTRING         = -2147483646,
-      GEOS_3D_POLYGON            = -2147483645,
-      GEOS_3D_MULTIPOINT         = -2147483644,
-      GEOS_3D_MULTILINESTRING    = -2147483643,
-      GEOS_3D_MULTIPOLYGON       = -2147483642,
-      GEOS_3D_GEOMETRYCOLLECTION = -2147483641,
-    };
 
     /**
      * Handles an error encountered while executing an sql statement.

--- a/src/ui/qgsnewspatialitelayerdialogbase.ui
+++ b/src/ui/qgsnewspatialitelayerdialogbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>450</width>
+    <width>490</width>
     <height>627</height>
    </rect>
   </property>
@@ -142,6 +142,24 @@
         </widget>
        </item>
        <item row="3" column="1" colspan="2">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QCheckBox" name="mGeometryWithZCheckBox">
+           <property name="text">
+            <string>Include Z dimension</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="mGeometryWithMCheckBox">
+           <property name="text">
+            <string>Include M values</string>
+           </property>
+          </widget>
+         </item>
+        </layout>       
+       </item>       
+       <item row="4" column="1" colspan="2">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLineEdit" name="leSRID">
@@ -175,7 +193,7 @@
          </item>
         </layout>
        </item>
-       <item row="4" colspan="3">
+       <item row="5" colspan="3">
         <widget class="QGroupBox" name="groupBox1">
          <property name="title">
           <string>New field</string>
@@ -265,7 +283,7 @@
          </layout>
         </widget>
        </item>
-       <item row="5" colspan="3">
+       <item row="6" colspan="3">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Fields list</string>
@@ -339,7 +357,7 @@
          </layout>
         </widget>
        </item>
-       <item row="6" colspan="3">
+       <item row="7" colspan="3">
         <widget class="QgsCollapsibleGroupBox" name="groupBox">
          <property name="title">
           <string>Advanced options</string>


### PR DESCRIPTION
## Description
@nyalldawson , @m-kuhn , this is a small fix to properly set the wkb type for spatialite layers.

~~That said, I *think* there's a problem with our wkb convertion that messes up the wkb -> geometry convertion, ending up with XYZ points for layers you should be XYM or XYZM. Ouch.~~

After further testing, the problem was identified _within_ the spatialite provider. The PR has been updated to fix **reading** of Z/M/ZM geometries. However, the writing part of the provider is still broken, and I'm not sure I have the strength to go through that 😄 .

To test this out, here's a sample spatialite db with three layers featuring Z, M, and ZM geometries:
[test_wkb.sqlite.zip](https://github.com/qgis/QGIS/files/1541935/test_wkb.sqlite.zip)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
