### PR TITLE
[3d] Show feedback when loading tiles for 3D view (fixes #17565)

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -82,6 +82,9 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
     //! Returns the root node of the whole quadtree hierarchy of nodes
     QgsChunkNode *rootNode() const { return mRootNode; }
 
+    //! Returns number of jobs pending for this entity until it is fully loaded/updated in the current view
+    int pendingJobsCount() const;
+
   protected:
     //! Cancels the background job that is currently in progress
     void cancelActiveJob();
@@ -98,6 +101,10 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
 
   private slots:
     void onActiveJobFinished();
+
+  signals:
+    //! Emitted when the number of pending jobs changes (some jobs have finished or some jobs have been just created)
+    void pendingJobsCountChanged();
 
   protected:
     //! root node of the quadtree hierarchy

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -166,6 +166,11 @@ void Qgs3DMapScene::viewZoomFull()
   mCameraController->resetView( side );  // assuming FOV being 45 degrees
 }
 
+int Qgs3DMapScene::terrainPendingJobsCount() const
+{
+  return mTerrain ? mTerrain->pendingJobsCount() : 0;
+}
+
 QgsChunkedEntity::SceneState _sceneState( QgsCameraController *cameraController )
 {
   Qt3DRender::QCamera *camera = cameraController->camera();
@@ -315,6 +320,10 @@ void Qgs3DMapScene::createTerrainDeferred()
   }
 
   mTerrainUpdateScheduled = false;
+
+  connect( mTerrain, &QgsTerrainEntity::pendingJobsCountChanged, this, &Qgs3DMapScene::terrainPendingJobsCountChanged );
+
+  emit terrainEntityChanged();
 }
 
 void Qgs3DMapScene::onBackgroundColorChanged()

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -57,10 +57,19 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Returns camera controller
     QgsCameraController *cameraController() { return mCameraController; }
     //! Returns terrain entity
-    QgsTerrainEntity *terrain() { return mTerrain; }
+    QgsTerrainEntity *terrainEntity() { return mTerrain; }
 
     //! Resets camera view to show the whole scene (top view)
     void viewZoomFull();
+
+    //! Returns number of pending jobs of the terrain entity
+    int terrainPendingJobsCount() const;
+
+  signals:
+    //! Emitted when the current terrain entity is replaced by a new one
+    void terrainEntityChanged();
+    //! Emitted when the number of terrain's pending jobs changes
+    void terrainPendingJobsCountChanged();
 
   private slots:
     void onCameraChanged();

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -39,7 +39,11 @@ class Qgs3DMapCanvas : public QWidget
     //! Configure map scene being displayed. Takes ownership.
     void setMap( Qgs3DMapSettings *map );
 
+    //! Returns access to the 3D scene configuration
     Qgs3DMapSettings *map() { return mMap; }
+
+    //! Returns access to the 3D scene (root 3D entity)
+    Qgs3DMapScene *scene() { return mScene; }
 
     //! Returns access to the view's camera controller. Returns null pointer if the scene has not been initialized yet with setMap()
     QgsCameraController *cameraController();

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -18,10 +18,12 @@
 
 #include "qgsdockwidget.h"
 
-class Qgs3DMapCanvas;
-class QgsMapCanvas;
+class QLabel;
+class QProgressBar;
 
+class Qgs3DMapCanvas;
 class Qgs3DMapSettings;
+class QgsMapCanvas;
 
 
 class Qgs3DMapCanvasDockWidget : public QgsDockWidget
@@ -43,10 +45,13 @@ class Qgs3DMapCanvasDockWidget : public QgsDockWidget
 
     void onMainCanvasLayersChanged();
     void onMainCanvasColorChanged();
+    void onTerrainPendingJobsCountChanged();
 
   private:
     Qgs3DMapCanvas *mCanvas = nullptr;
     QgsMapCanvas *mMainCanvas = nullptr;
+    QProgressBar *mProgressPendingJobs = nullptr;
+    QLabel *mLabelPendingJobs = nullptr;
 };
 
 #endif // QGS3DMAPCANVASDOCKWIDGET_H


### PR DESCRIPTION
There was no indication whether something is going on behind the scenes,
leaving user to wonder whether there is something to wait for or the scene
is already loaded in full detail.

![image](https://user-images.githubusercontent.com/193367/33774641-34e4d762-dc3c-11e7-94aa-10f53d6c2a7c.png)

Any ideas how to improve the "Loading N tiles" label are welcome :-)