### PR TITLE
Add geometry type and field icons to dialogs

### DIFF
--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -56,15 +56,13 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/NewSpatiaLiteLayer/geometry" ) ).toByteArray() );
 
-  QString path = QgsApplication::defaultThemePath();
-
-  mGeometryTypeBox->addItem( tr( "Non spatial" ), QStringLiteral( "" ) );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QStringLiteral( "POINT" ) );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QStringLiteral( "LINESTRING" ) );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QStringLiteral( "POLYGON" ) );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "MultiPoint" ), QStringLiteral( "MULTIPOINT" ) );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiLine" ), QStringLiteral( "MULTILINESTRING" ) );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiPolygon" ), QStringLiteral( "MULTIPOLYGON" ) );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) ), tr( "No geometry" ), QStringLiteral( "" ) );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "Point" ), QStringLiteral( "POINT" ) );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "Line" ), QStringLiteral( "LINESTRING" ) );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "Polygon" ), QStringLiteral( "POLYGON" ) );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "MultiPoint" ), QStringLiteral( "MULTIPOINT" ) );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "MultiLine" ), QStringLiteral( "MULTILINESTRING" ) );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "MultiPolygon" ), QStringLiteral( "MULTIPOLYGON" ) );
 
   pbnFindSRID->setEnabled( false );
   mGeometryWithZCheckBox->setEnabled( false );
@@ -73,9 +71,9 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
 
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
-  mTypeBox->addItem( QIcon( path + "/mIconFieldText.svg" ), tr( "Text data" ), "text" );
-  mTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number" ), "integer" );
-  mTypeBox->addItem( QIcon( path + "/mIconFieldFloat.svg" ), tr( "Decimal number" ), "real" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text data" ), "text" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole number" ), "integer" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), tr( "Decimal number" ), "real" );
 
   // Populate the database list from the stored connections
   settings.beginGroup( QStringLiteral( "SpatiaLite/connections" ) );

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -56,13 +56,15 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/NewSpatiaLiteLayer/geometry" ) ).toByteArray() );
 
+  QString path = QgsApplication::defaultThemePath();
+
   mGeometryTypeBox->addItem( tr( "Non spatial" ), QStringLiteral( "" ) );
-  mGeometryTypeBox->addItem( tr( "Point" ), QStringLiteral( "POINT" ) );
-  mGeometryTypeBox->addItem( tr( "Line" ), QStringLiteral( "LINESTRING" ) );
-  mGeometryTypeBox->addItem( tr( "Polygon" ), QStringLiteral( "POLYGON" ) );
-  mGeometryTypeBox->addItem( tr( "MultiPoint" ), QStringLiteral( "MULTIPOINT" ) );
-  mGeometryTypeBox->addItem( tr( "MultiLine" ), QStringLiteral( "MULTILINESTRING" ) );
-  mGeometryTypeBox->addItem( tr( "MultiPolygon" ), QStringLiteral( "MULTIPOLYGON" ) );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QStringLiteral( "POINT" ) );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QStringLiteral( "LINESTRING" ) );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QStringLiteral( "POLYGON" ) );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "MultiPoint" ), QStringLiteral( "MULTIPOINT" ) );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiLine" ), QStringLiteral( "MULTILINESTRING" ) );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiPolygon" ), QStringLiteral( "MULTIPOLYGON" ) );
 
   pbnFindSRID->setEnabled( false );
   mGeometryWithZCheckBox->setEnabled( false );

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -71,9 +71,9 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
 
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
-  mTypeBox->addItem( tr( "Text data" ), "text" );
-  mTypeBox->addItem( tr( "Whole number" ), "integer" );
-  mTypeBox->addItem( tr( "Decimal number" ), "real" );
+  mTypeBox->addItem( QIcon( path + "/mIconFieldText.svg" ), tr( "Text data" ), "text" );
+  mTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number" ), "integer" );
+  mTypeBox->addItem( QIcon( path + "/mIconFieldFloat.svg" ), tr( "Decimal number" ), "real" );
 
   // Populate the database list from the stored connections
   settings.beginGroup( QStringLiteral( "SpatiaLite/connections" ) );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -98,13 +98,12 @@ void QgsVectorLayerSaveAsDialog::setup()
   mFormatComboBox->blockSignals( false );
 
   //add geometry types to combobox
-  QString path = QgsApplication::defaultThemePath();
   mGeometryTypeComboBox->addItem( tr( "Automatic" ), -1 );
-  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::Point ), QgsWkbTypes::Point );
-  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::LineString ), QgsWkbTypes::LineString );
-  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::Polygon ), QgsWkbTypes::Polygon );
+  mGeometryTypeComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), QgsWkbTypes::displayString( QgsWkbTypes::Point ), QgsWkbTypes::Point );
+  mGeometryTypeComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), QgsWkbTypes::displayString( QgsWkbTypes::LineString ), QgsWkbTypes::LineString );
+  mGeometryTypeComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), QgsWkbTypes::displayString( QgsWkbTypes::Polygon ), QgsWkbTypes::Polygon );
   mGeometryTypeComboBox->addItem( QgsWkbTypes::displayString( QgsWkbTypes::GeometryCollection ), QgsWkbTypes::GeometryCollection );
-  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
+  mGeometryTypeComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
   mGeometryTypeComboBox->setCurrentIndex( mGeometryTypeComboBox->findData( -1 ) );
 
   mEncodingComboBox->addItems( QgsVectorDataProvider::availableEncodings() );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -98,12 +98,13 @@ void QgsVectorLayerSaveAsDialog::setup()
   mFormatComboBox->blockSignals( false );
 
   //add geometry types to combobox
+  QString path = QgsApplication::defaultThemePath();
   mGeometryTypeComboBox->addItem( tr( "Automatic" ), -1 );
-  mGeometryTypeComboBox->addItem( QgsWkbTypes::displayString( QgsWkbTypes::Point ), QgsWkbTypes::Point );
-  mGeometryTypeComboBox->addItem( QgsWkbTypes::displayString( QgsWkbTypes::LineString ), QgsWkbTypes::LineString );
-  mGeometryTypeComboBox->addItem( QgsWkbTypes::displayString( QgsWkbTypes::Polygon ), QgsWkbTypes::Polygon );
+  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::Point ), QgsWkbTypes::Point );
+  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::LineString ), QgsWkbTypes::LineString );
+  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::Polygon ), QgsWkbTypes::Polygon );
   mGeometryTypeComboBox->addItem( QgsWkbTypes::displayString( QgsWkbTypes::GeometryCollection ), QgsWkbTypes::GeometryCollection );
-  mGeometryTypeComboBox->addItem( tr( "No geometry" ), QgsWkbTypes::NoGeometry );
+  mGeometryTypeComboBox->addItem( QIcon( path + "/mActionOpenTable.svg" ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
   mGeometryTypeComboBox->setCurrentIndex( mGeometryTypeComboBox->findData( -1 ) );
 
   mEncodingComboBox->addItems( QgsVectorDataProvider::availableEncodings() );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -104,7 +104,7 @@ void QgsVectorLayerSaveAsDialog::setup()
   mGeometryTypeComboBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::LineString ), QgsWkbTypes::LineString );
   mGeometryTypeComboBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), QgsWkbTypes::displayString( QgsWkbTypes::Polygon ), QgsWkbTypes::Polygon );
   mGeometryTypeComboBox->addItem( QgsWkbTypes::displayString( QgsWkbTypes::GeometryCollection ), QgsWkbTypes::GeometryCollection );
-  mGeometryTypeComboBox->addItem( QIcon( path + "/mActionOpenTable.svg" ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
+  mGeometryTypeComboBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
   mGeometryTypeComboBox->setCurrentIndex( mGeometryTypeComboBox->findData( -1 ) );
 
   mEncodingComboBox->addItems( QgsVectorDataProvider::availableEncodings() );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -64,22 +64,23 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
 
-  mGeometryTypeBox->addItem( tr( "Non spatial" ), wkbNone );
-  mGeometryTypeBox->addItem( tr( "Point" ), wkbPoint );
-  mGeometryTypeBox->addItem( tr( "Line" ), wkbLineString );
-  mGeometryTypeBox->addItem( tr( "Polygon" ), wkbPolygon );
-  mGeometryTypeBox->addItem( tr( "MultiPoint" ), wkbMultiPoint );
-  mGeometryTypeBox->addItem( tr( "MultiLine" ), wkbMultiLineString );
-  mGeometryTypeBox->addItem( tr( "MultiPolygon" ), wkbMultiPolygon );
+  QString path = QgsApplication::defaultThemePath();
+  mGeometryTypeBox->addItem( QIcon( path + "/mActionOpenTable.svg" ), tr( "Non spatial" ), wkbNone );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), wkbPoint );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), wkbLineString );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), wkbPolygon );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "MultiPoint" ), wkbMultiPoint );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiLine" ), wkbMultiLineString );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiPolygon" ), wkbMultiPolygon );
 
 #if 0
   // QGIS always create CompoundCurve and there's no real interest of having just CircularString. CompoundCurve are more useful
-  mGeometryTypeBox->addItem( tr( "CircularString" ), wkbCircularString );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "CircularString" ), wkbCircularString );
 #endif
-  mGeometryTypeBox->addItem( tr( "CompoundCurve" ), wkbCompoundCurve );
-  mGeometryTypeBox->addItem( tr( "CurvePolygon" ), wkbCurvePolygon );
-  mGeometryTypeBox->addItem( tr( "MultiCurve" ), wkbMultiCurve );
-  mGeometryTypeBox->addItem( tr( "MultiSurface" ), wkbMultiSurface );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "CompoundCurve" ), wkbCompoundCurve );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "CurvePolygon" ), wkbCurvePolygon );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiCurve" ), wkbMultiCurve );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiSurface" ), wkbMultiSurface );
 
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -65,7 +65,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
 
   QString path = QgsApplication::defaultThemePath();
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "Non spatial" ), wkbNone );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "No geometry" ), wkbNone );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), wkbPoint );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), wkbLineString );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), wkbPolygon );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -64,23 +64,22 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
 
-  QString path = QgsApplication::defaultThemePath();
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "No geometry" ), wkbNone );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), wkbPoint );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), wkbLineString );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), wkbPolygon );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "MultiPoint" ), wkbMultiPoint );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiLine" ), wkbMultiLineString );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiPolygon" ), wkbMultiPolygon );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) ), tr( "No geometry" ), wkbNone );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "Point" ), wkbPoint );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "Line" ), wkbLineString );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "Polygon" ), wkbPolygon );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "MultiPoint" ), wkbMultiPoint );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "MultiLine" ), wkbMultiLineString );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "MultiPolygon" ), wkbMultiPolygon );
 
 #if 0
   // QGIS always create CompoundCurve and there's no real interest of having just CircularString. CompoundCurve are more useful
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "CircularString" ), wkbCircularString );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "CircularString" ), wkbCircularString );
 #endif
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "CompoundCurve" ), wkbCompoundCurve );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "CurvePolygon" ), wkbCurvePolygon );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiCurve" ), wkbMultiCurve );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiSurface" ), wkbMultiSurface );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "CompoundCurve" ), wkbCompoundCurve );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "CurvePolygon" ), wkbCurvePolygon );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "MultiCurve" ), wkbMultiCurve );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "MultiSurface" ), wkbMultiSurface );
 
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
@@ -88,12 +87,12 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
 
-  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldText.svg" ), tr( "Text data" ), "text" );
-  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number (integer)" ), "integer" );
-  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number (integer 64 bit)" ), "integer64" );
-  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldFloat.svg" ), tr( "Decimal number (real)" ), "real" );
-  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldDate.svg" ), tr( "Date" ), "date" );
-  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldDateTime.svg" ), tr( "Date&time" ), "datetime" );
+  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text data" ), "text" );
+  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole number (integer)" ), "integer" );
+  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole number (integer 64 bit)" ), "integer64" );
+  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), tr( "Decimal number (real)" ), "real" );
+  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), tr( "Date" ), "date" );
+  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) ), tr( "Date&time" ), "datetime" );
 
   mOkButton = buttonBox->button( QDialogButtonBox::Ok );
   mOkButton->setEnabled( false );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -88,12 +88,12 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
 
-  mFieldTypeBox->addItem( tr( "Text data" ), "text" );
-  mFieldTypeBox->addItem( tr( "Whole number (integer)" ), "integer" );
-  mFieldTypeBox->addItem( tr( "Whole number (integer 64 bit)" ), "integer64" );
-  mFieldTypeBox->addItem( tr( "Decimal number (real)" ), "real" );
-  mFieldTypeBox->addItem( tr( "Date" ), "date" );
-  mFieldTypeBox->addItem( tr( "Date&time" ), "datetime" );
+  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldText.svg" ), tr( "Text data" ), "text" );
+  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number (integer)" ), "integer" );
+  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number (integer 64 bit)" ), "integer64" );
+  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldFloat.svg" ), tr( "Decimal number (real)" ), "real" );
+  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldDate.svg" ), tr( "Date" ), "date" );
+  mFieldTypeBox->addItem( QIcon( path + "/mIconFieldDateTime.svg" ), tr( "Date&time" ), "datetime" );
 
   mOkButton = buttonBox->button( QDialogButtonBox::Ok );
   mOkButton->setEnabled( false );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -65,7 +65,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
 
   QString path = QgsApplication::defaultThemePath();
-  mGeometryTypeBox->addItem( QIcon( path + "/mActionOpenTable.svg" ), tr( "Non spatial" ), wkbNone );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "Non spatial" ), wkbNone );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), wkbPoint );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), wkbLineString );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), wkbPolygon );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -54,14 +54,13 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/NewMemoryLayer/geometry" ) ).toByteArray() );
 
-  QString path = QgsApplication::defaultThemePath();
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QgsWkbTypes::Point );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QgsWkbTypes::LineString );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QgsWkbTypes::Polygon );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "MultiPoint" ), QgsWkbTypes::MultiPoint );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiLine" ), QgsWkbTypes::MultiLineString );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiPolygon" ), QgsWkbTypes::MultiPolygon );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "Point" ), QgsWkbTypes::Point );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "Line" ), QgsWkbTypes::LineString );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "Polygon" ), QgsWkbTypes::Polygon );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "MultiPoint" ), QgsWkbTypes::MultiPoint );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "MultiLine" ), QgsWkbTypes::MultiLineString );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "MultiPolygon" ), QgsWkbTypes::MultiPolygon );
 
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -55,7 +55,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   restoreGeometry( settings.value( QStringLiteral( "Windows/NewMemoryLayer/geometry" ) ).toByteArray() );
 
   QString path = QgsApplication::defaultThemePath();
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "Non spatial" ), QgsWkbTypes::NoGeometry );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "No geometry" ), QgsWkbTypes::NoGeometry );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QgsWkbTypes::Point );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QgsWkbTypes::LineString );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QgsWkbTypes::Polygon );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -55,7 +55,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   restoreGeometry( settings.value( QStringLiteral( "Windows/NewMemoryLayer/geometry" ) ).toByteArray() );
 
   QString path = QgsApplication::defaultThemePath();
-  mGeometryTypeBox->addItem( QIcon( path + "/mActionOpenTable.svg" ), tr( "Non spatial" ), QgsWkbTypes::NoGeometry );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconTableLayer.svg" ), tr( "Non spatial" ), QgsWkbTypes::NoGeometry );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QgsWkbTypes::Point );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QgsWkbTypes::LineString );
   mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QgsWkbTypes::Polygon );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -54,13 +54,14 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/NewMemoryLayer/geometry" ) ).toByteArray() );
 
-  mGeometryTypeBox->addItem( tr( "Non spatial" ), QgsWkbTypes::NoGeometry );
-  mGeometryTypeBox->addItem( tr( "Point" ), QgsWkbTypes::Point );
-  mGeometryTypeBox->addItem( tr( "Line" ), QgsWkbTypes::LineString );
-  mGeometryTypeBox->addItem( tr( "Polygon" ), QgsWkbTypes::Polygon );
-  mGeometryTypeBox->addItem( tr( "MultiPoint" ), QgsWkbTypes::MultiPoint );
-  mGeometryTypeBox->addItem( tr( "MultiLine" ), QgsWkbTypes::MultiLineString );
-  mGeometryTypeBox->addItem( tr( "MultiPolygon" ), QgsWkbTypes::MultiPolygon );
+  QString path = QgsApplication::defaultThemePath();
+  mGeometryTypeBox->addItem( QIcon( path + "/mActionOpenTable.svg" ), tr( "Non spatial" ), QgsWkbTypes::NoGeometry );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QgsWkbTypes::Point );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QgsWkbTypes::LineString );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QgsWkbTypes::Polygon );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "MultiPoint" ), QgsWkbTypes::MultiPoint );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "MultiLine" ), QgsWkbTypes::MultiLineString );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "MultiPolygon" ), QgsWkbTypes::MultiPolygon );
 
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -56,9 +56,9 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
   mPrecision->setValidator( new QIntValidator( 0, 15, this ) );
 
-  mGeometryTypeBox->addItem( tr( "Point" ), QgsWkbTypes::Point );
-  mGeometryTypeBox->addItem( tr( "Line" ), QgsWkbTypes::LineString );
-  mGeometryTypeBox->addItem( tr( "Polygon" ), QgsWkbTypes::Polygon );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QgsWkbTypes::Point );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QgsWkbTypes::LineString );
+  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QgsWkbTypes::Polygon );
 
   mOkButton = buttonBox->button( QDialogButtonBox::Ok );
   mOkButton->setEnabled( false );

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -48,10 +48,11 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
 
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
-  mTypeBox->addItem( tr( "Text data" ), "String" );
-  mTypeBox->addItem( tr( "Whole number" ), "Integer" );
-  mTypeBox->addItem( tr( "Decimal number" ), "Real" );
-  mTypeBox->addItem( tr( "Date" ), "Date" );
+  QString path = QgsApplication::defaultThemePath();
+  mTypeBox->addItem( QIcon( path + "/mIconFieldText.svg" ), tr( "Text data" ), "String" );
+  mTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number" ), "Integer" );
+  mTypeBox->addItem( QIcon( path + "/mIconFieldFloat.svg" ), tr( "Decimal number" ), "Real" );
+  mTypeBox->addItem( QIcon( path + "/mIconFieldDate.svg" ), tr( "Date" ), "Date" );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
   mPrecision->setValidator( new QIntValidator( 0, 15, this ) );

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -48,18 +48,18 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
 
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
-  QString path = QgsApplication::defaultThemePath();
-  mTypeBox->addItem( QIcon( path + "/mIconFieldText.svg" ), tr( "Text data" ), "String" );
-  mTypeBox->addItem( QIcon( path + "/mIconFieldInteger.svg" ), tr( "Whole number" ), "Integer" );
-  mTypeBox->addItem( QIcon( path + "/mIconFieldFloat.svg" ), tr( "Decimal number" ), "Real" );
-  mTypeBox->addItem( QIcon( path + "/mIconFieldDate.svg" ), tr( "Date" ), "Date" );
+
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text data" ), "String" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole number" ), "Integer" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), tr( "Decimal number" ), "Real" );
+  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), tr( "Date" ), "Date" );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
   mPrecision->setValidator( new QIntValidator( 0, 15, this ) );
 
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPointLayer.svg" ), tr( "Point" ), QgsWkbTypes::Point );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconLineLayer.svg" ), tr( "Line" ), QgsWkbTypes::LineString );
-  mGeometryTypeBox->addItem( QIcon( path + "/mIconPolygonLayer.svg" ), tr( "Polygon" ), QgsWkbTypes::Polygon );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "Point" ), QgsWkbTypes::Point );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "Line" ), QgsWkbTypes::LineString );
+  mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "Polygon" ), QgsWkbTypes::Polygon );
 
   mOkButton = buttonBox->button( QDialogButtonBox::Ok );
   mOkButton->setEnabled( false );


### PR DESCRIPTION
follow-up https://github.com/qgis/QGIS/pull/5803#issuecomment-349254287 - Add icon in the combobox for the geometry type and field options in "new xxx dialog" and save vector as...(btw, looking for an icon for geometry collection)

![image](https://user-images.githubusercontent.com/7983394/33790231-a4429404-dc7e-11e7-9840-17952f5ee165.png)

![image](https://user-images.githubusercontent.com/7983394/33790541-50536924-dc81-11e7-8c75-d72604ab75b4.png)

![image](https://user-images.githubusercontent.com/7983394/33790586-ac3e992a-dc81-11e7-8bb1-2bd2e983be22.png)
