### PR TITLE
[bugfix] Do not crash when layer is destroyed while loading

### DIFF
--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -210,6 +210,12 @@ class QgsDualView : QStackedWidget
 .. versionadded:: 1.16
 %End
 
+    void cancelProgress( );
+%Docstring
+ Cancel the progress dialog (if any)
+.. versionadded:: 3.0
+%End
+
   signals:
 
     void displayExpressionChanged( const QString &expression );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -69,7 +69,7 @@ QgsExpressionContext QgsAttributeTableDialog::createExpressionContext() const
 
 void QgsAttributeTableDialog::updateMultiEditButtonState()
 {
-  if ( mLayer->editFormConfig().layout() == QgsEditFormConfig::UiFileLayout )
+  if ( ! mLayer || ( mLayer->editFormConfig().layout() == QgsEditFormConfig::UiFileLayout ) )
     return;
 
   mActionToggleMultiEdit->setEnabled( mLayer->isEditable() );
@@ -199,7 +199,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   // info from layer to table
   connect( mLayer, &QgsVectorLayer::editingStarted, this, &QgsAttributeTableDialog::editingToggled );
   connect( mLayer, &QgsVectorLayer::editingStopped, this, &QgsAttributeTableDialog::editingToggled );
-  connect( mLayer, &QObject::destroyed, this, &QWidget::close );
+  connect( mLayer, &QObject::destroyed, mMainView, &QgsDualView::cancelProgress );
   connect( mLayer, &QgsVectorLayer::selectionChanged, this, &QgsAttributeTableDialog::updateTitle );
   connect( mLayer, &QgsVectorLayer::featureAdded, this, &QgsAttributeTableDialog::updateTitle );
   connect( mLayer, &QgsVectorLayer::featuresDeleted, this, &QgsAttributeTableDialog::updateTitle );
@@ -292,59 +292,69 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
       break;
   }
 
-  mUpdateExpressionText->registerExpressionContextGenerator( this );
-  mFieldCombo->setFilters( QgsFieldProxyModel::AllTypes | QgsFieldProxyModel::HideReadOnly );
-  mFieldCombo->setLayer( mLayer );
-
-  connect( mRunFieldCalc, &QAbstractButton::clicked, this, &QgsAttributeTableDialog::updateFieldFromExpression );
-  connect( mRunFieldCalcSelected, &QAbstractButton::clicked, this, &QgsAttributeTableDialog::updateFieldFromExpressionSelected );
-  // NW TODO Fix in 2.6 - Doesn't work with field model for some reason.
-//  connect( mUpdateExpressionText, SIGNAL( returnPressed() ), this, SLOT( updateFieldFromExpression() ) );
-  connect( mUpdateExpressionText, static_cast < void ( QgsFieldExpressionWidget::* )( const QString &, bool ) > ( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsAttributeTableDialog::updateButtonStatus );
-  mUpdateExpressionText->setLayer( mLayer );
-  mUpdateExpressionText->setLeftHandButtonStyle( true );
-
-  int initialView = settings.value( QStringLiteral( "qgis/attributeTableView" ), -1 ).toInt();
-  if ( initialView < 0 )
+  // Layer might have been destroyed while loading!
+  if ( mLayer )
   {
-    initialView = settings.value( QStringLiteral( "qgis/attributeTableLastView" ), QgsDualView::AttributeTable ).toInt();
-  }
-  mMainView->setView( static_cast< QgsDualView::ViewMode >( initialView ) );
-  mMainViewButtonGroup->button( initialView )->setChecked( true );
+    mUpdateExpressionText->registerExpressionContextGenerator( this );
+    mFieldCombo->setFilters( QgsFieldProxyModel::AllTypes | QgsFieldProxyModel::HideReadOnly );
+    mFieldCombo->setLayer( mLayer );
 
-  connect( mActionToggleMultiEdit, &QAction::toggled, mMainView, &QgsDualView::setMultiEditEnabled );
-  connect( mActionSearchForm, &QAction::toggled, mMainView, &QgsDualView::toggleSearchMode );
-  updateMultiEditButtonState();
+    connect( mRunFieldCalc, &QAbstractButton::clicked, this, &QgsAttributeTableDialog::updateFieldFromExpression );
+    connect( mRunFieldCalcSelected, &QAbstractButton::clicked, this, &QgsAttributeTableDialog::updateFieldFromExpressionSelected );
+    // NW TODO Fix in 2.6 - Doesn't work with field model for some reason.
+    //  connect( mUpdateExpressionText, SIGNAL( returnPressed() ), this, SLOT( updateFieldFromExpression() ) );
+    connect( mUpdateExpressionText, static_cast < void ( QgsFieldExpressionWidget::* )( const QString &, bool ) > ( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsAttributeTableDialog::updateButtonStatus );
+    mUpdateExpressionText->setLayer( mLayer );
+    mUpdateExpressionText->setLeftHandButtonStyle( true );
 
-  if ( mLayer->editFormConfig().layout() == QgsEditFormConfig::UiFileLayout )
-  {
-    //not supported with custom UI
-    mActionToggleMultiEdit->setEnabled( false );
-    mActionToggleMultiEdit->setToolTip( tr( "Multiedit is not supported when using custom UI forms" ) );
-    mActionSearchForm->setEnabled( false );
-    mActionSearchForm->setToolTip( tr( "Search is not supported when using custom UI forms" ) );
-  }
+    int initialView = settings.value( QStringLiteral( "qgis/attributeTableView" ), -1 ).toInt();
+    if ( initialView < 0 )
+    {
+      initialView = settings.value( QStringLiteral( "qgis/attributeTableLastView" ), QgsDualView::AttributeTable ).toInt();
+    }
+    mMainView->setView( static_cast< QgsDualView::ViewMode >( initialView ) );
+    mMainViewButtonGroup->button( initialView )->setChecked( true );
 
-  QList<QgsAction> actions = mLayer->actions()->actions( QStringLiteral( "Layer" ) );
+    connect( mActionToggleMultiEdit, &QAction::toggled, mMainView, &QgsDualView::setMultiEditEnabled );
+    connect( mActionSearchForm, &QAction::toggled, mMainView, &QgsDualView::toggleSearchMode );
+    updateMultiEditButtonState();
 
-  if ( actions.isEmpty() )
-  {
-    mActionFeatureActions->setVisible( false );
+    if ( mLayer->editFormConfig().layout() == QgsEditFormConfig::UiFileLayout )
+    {
+      //not supported with custom UI
+      mActionToggleMultiEdit->setEnabled( false );
+      mActionToggleMultiEdit->setToolTip( tr( "Multiedit is not supported when using custom UI forms" ) );
+      mActionSearchForm->setEnabled( false );
+      mActionSearchForm->setToolTip( tr( "Search is not supported when using custom UI forms" ) );
+    }
+
+    QList<QgsAction> actions = mLayer->actions()->actions( QStringLiteral( "Layer" ) );
+
+    if ( actions.isEmpty() )
+    {
+      mActionFeatureActions->setVisible( false );
+    }
+    else
+    {
+      QMenu *actionMenu = new QMenu();
+      Q_FOREACH ( const QgsAction &action, actions )
+      {
+        QAction *qAction = actionMenu->addAction( action.icon(), action.shortTitle() );
+        qAction->setToolTip( action.name() );
+        qAction->setData( QVariant::fromValue<QgsAction>( action ) );
+        connect( qAction, &QAction::triggered, this, &QgsAttributeTableDialog::layerActionTriggered );
+      }
+      mActionFeatureActions->setMenu( actionMenu );
+    }
+
+    editingToggled();
+    // Close and delete if the layer has been destroyed
+    connect( mLayer, &QObject::destroyed, this, &QWidget::close );
   }
   else
   {
-    QMenu *actionMenu = new QMenu();
-    Q_FOREACH ( const QgsAction &action, actions )
-    {
-      QAction *qAction = actionMenu->addAction( action.icon(), action.shortTitle() );
-      qAction->setToolTip( action.name() );
-      qAction->setData( QVariant::fromValue<QgsAction>( action ) );
-      connect( qAction, &QAction::triggered, this, &QgsAttributeTableDialog::layerActionTriggered );
-    }
-    mActionFeatureActions->setMenu( actionMenu );
+    QWidget::close();
   }
-
-  editingToggled();
 }
 
 QgsAttributeTableDialog::~QgsAttributeTableDialog()
@@ -354,6 +364,10 @@ QgsAttributeTableDialog::~QgsAttributeTableDialog()
 
 void QgsAttributeTableDialog::updateTitle()
 {
+  if ( ! mLayer )
+  {
+    return;
+  }
   QWidget *w = mDock ? qobject_cast<QWidget *>( mDock ) : qobject_cast<QWidget *>( this );
   w->setWindowTitle( tr( " %1 :: Features Total: %2, Filtered: %3, Selected: %4" )
                      .arg( mLayer->name() )

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -230,7 +230,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     QMenu *mFilterColumnsMenu = nullptr;
     QSignalMapper *mFilterActionMapper = nullptr;
 
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer< QgsVectorLayer > mLayer = nullptr;
     QgsSearchWidgetWrapper *mCurrentSearchWidgetWrapper = nullptr;
     QStringList mVisibleFields;
     QgsAttributeEditorContext mEditorContext;

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -318,6 +318,10 @@ void QgsDualView::restoreRecentDisplayExpressions()
 
 void QgsDualView::saveRecentDisplayExpressions() const
 {
+  if ( ! mLayer )
+  {
+    return;
+  }
   QList<QAction *> actions = mFeatureListPreviewButton->actions();
 
   // Remove existing same action
@@ -396,6 +400,7 @@ void QgsDualView::insertRecentlyUsedDisplayExpression( const QString &expression
   mFeatureListPreviewButton->insertAction( mLastDisplayExpressionAction, previewAction );
   mLastDisplayExpressionAction = previewAction;
 }
+
 
 void QgsDualView::mFeatureList_aboutToChangeEditSelection( bool &ok )
 {
@@ -513,6 +518,12 @@ void QgsDualView::copyCellContent() const
     QVariant var = masterModel()->data( index, Qt::DisplayRole );
     QApplication::clipboard()->setText( var.toString() );
   }
+}
+
+void QgsDualView::cancelProgress()
+{
+  if ( mProgressDlg )
+    mProgressDlg->cancel();
 }
 
 void QgsDualView::hideEvent( QHideEvent *event )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -236,6 +236,12 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      */
     void copyCellContent() const;
 
+    /**
+     * Cancel the progress dialog (if any)
+     * \since QGIS 3.0
+     */
+    void cancelProgress( );
+
   signals:
 
     /**
@@ -360,7 +366,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     QAction *mLastDisplayExpressionAction = nullptr;
     QMenu *mHorizontalHeaderMenu = nullptr;
     QgsVectorLayerCache *mLayerCache = nullptr;
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer< QgsVectorLayer > mLayer = nullptr;
     QProgressDialog *mProgressDlg = nullptr;
     QgsIFeatureSelectionManager *mFeatureSelectionManager = nullptr;
     QgsDistanceArea mDistanceArea;


### PR DESCRIPTION
Fixes #17636 QGIS crashes when a layer is removed
while loading the attribute table
