### PR TITLE
Use GDAL metadata to determine format support

### DIFF
--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -506,6 +506,16 @@ Filter string for file picker dialogs
  :rtype: list of str
 %End
 
+    static bool supportsFeatureStyles( const QString &driverName );
+%Docstring
+ Returns true if the specified ``driverName`` supports feature styles.
+
+ The ``driverName`` argument must be a valid GDAL driver name.
+
+.. versionadded:: 3.0
+ :rtype: bool
+%End
+
     struct DriverDetails
     {
       QString longName;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -112,6 +112,23 @@ QgsVectorFileWriter::QgsVectorFileWriter( const QString &vectorFileName,
         layerName, action );
 }
 
+bool QgsVectorFileWriter::supportsFeatureStyles( const QString &driverName )
+{
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
+  GDALDriverH gdalDriver = GDALGetDriverByName( driverName.toLocal8Bit().constData() );
+  if ( !gdalDriver )
+    return false;
+
+  char **driverMetadata = GDALGetMetadata( gdalDriver, nullptr );
+  if ( !driverMetadata )
+    return false;
+
+  return CSLFetchBoolean( driverMetadata, GDAL_DCAP_FEATURE_STYLES, false );
+#else
+  return driverName == QLatin1String( "DXF" ) || driverName == QLatin1String( "KML" ) || driverName == QLatin1String( "MapInfo File" ) || driverName == QLatin1String( "MapInfo MIF" );
+#endif
+}
+
 void QgsVectorFileWriter::init( QString vectorFileName,
                                 QString fileEncoding,
                                 const QgsFields &fields,
@@ -2724,7 +2741,7 @@ QList< QgsVectorFileWriter::FilterFormatDetails > QgsVectorFileWriter::supported
         driverMetadata = GDALGetMetadata( gdalDriver, nullptr );
       }
 
-      bool nonSpatialFormat = nonSpatialFormat = CSLFetchBoolean( driverMetadata, GDAL_DCAP_NONSPATIAL, false );
+      bool nonSpatialFormat = CSLFetchBoolean( driverMetadata, GDAL_DCAP_NONSPATIAL, false );
 #else
       bool nonSpatialFormat = ( drvName == QLatin1String( "ODS" ) || drvName == QLatin1String( "XLSX" ) || drvName == QLatin1String( "XLS" ) );
 #endif

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -539,6 +539,15 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     static QStringList supportedFormatExtensions( VectorFormatOptions options = SortRecommended );
 
     /**
+     * Returns true if the specified \a driverName supports feature styles.
+     *
+     * The \a driverName argument must be a valid GDAL driver name.
+     *
+     * \since QGIS 3.0
+     */
+    static bool supportsFeatureStyles( const QString &driverName );
+
+    /**
      * Details of available driver formats.
      * \since QGIS 3.0
      */

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -388,7 +388,7 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
   }
 
   // Show symbology options only for some formats
-  if ( sFormat == QLatin1String( "DXF" ) || sFormat == QLatin1String( "KML" ) || sFormat == QLatin1String( "MapInfo File" ) || sFormat == QLatin1String( "MapInfo MIF" ) )
+  if ( QgsVectorFileWriter::supportsFeatureStyles( sFormat ) )
   {
     mSymbologyExportLabel->setVisible( true );
     mSymbologyExportComboBox->setVisible( true );

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -842,6 +842,14 @@ class TestQgsVectorFileWriter(unittest.TestCase):
         self.assertEqual(QgsVectorFileWriter.driverForExtension('not a format'), '')
         self.assertEqual(QgsVectorFileWriter.driverForExtension(''), '')
 
+    def testSupportsFeatureStyles(self):
+        self.assertFalse(QgsVectorFileWriter.supportsFeatureStyles('ESRI Shapefile'))
+        self.assertFalse(QgsVectorFileWriter.supportsFeatureStyles('not a driver'))
+        self.assertTrue(QgsVectorFileWriter.supportsFeatureStyles('DXF'))
+        self.assertTrue(QgsVectorFileWriter.supportsFeatureStyles('KML'))
+        self.assertTrue(QgsVectorFileWriter.supportsFeatureStyles('MapInfo File'))
+        self.assertTrue(QgsVectorFileWriter.supportsFeatureStyles('MapInfo MIF'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Replaces some hardcoded format list detections with use of GDAL driver metadata (GDAL >= 2.3 only)