### PR TITLE
[ogr] Advertise boolean field support for GPKG layers

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -467,6 +467,13 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri )
         << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), QStringLiteral( "datetime" ), QVariant::DateTime );
   }
 
+  bool supportsBoolean = false;
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
+  const char *pszDataTypes = GDALGetMetadataItem( mOgrOrigLayer->driver(), GDAL_DMD_CREATIONFIELDDATASUBTYPES, nullptr );
+  if ( pszDataTypes && strstr( pszDataTypes, "Boolean" ) )
+    supportsBoolean = true;
+#else
   if ( mGDALDriverName == QLatin1String( "GeoJSON" ) ||
        mGDALDriverName == QLatin1String( "GML" ) ||
        mGDALDriverName == QLatin1String( "CSV" ) ||
@@ -475,11 +482,16 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri )
        mGDALDriverName == QLatin1String( "SQLite" ) ||
        mGDALDriverName == QLatin1String( "GPKG" ) )
   {
+    supportsBoolean = true;
+  }
+#endif
+
+  if ( supportsBoolean )
+  {
     // boolean data type
     nativeTypes
         << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool, -1, -1, -1, -1 );
   }
-
 
   setNativeTypes( nativeTypes );
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -467,9 +467,15 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri )
         << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), QStringLiteral( "datetime" ), QVariant::DateTime );
   }
 
-  if ( mGDALDriverName == QLatin1String( "GPKG" ) )
+  if ( mGDALDriverName == QLatin1String( "GeoJSON" ) ||
+       mGDALDriverName == QLatin1String( "GML" ) ||
+       mGDALDriverName == QLatin1String( "CSV" ) ||
+       mGDALDriverName == QLatin1String( "PostgreSQL" ) ||
+       mGDALDriverName == QLatin1String( "PGDump" ) ||
+       mGDALDriverName == QLatin1String( "SQLite" ) ||
+       mGDALDriverName == QLatin1String( "GPKG" ) )
   {
-    // boolean data type - likely other drivers also support this
+    // boolean data type
     nativeTypes
         << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool, -1, -1, -1, -1 );
   }

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -467,6 +467,14 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri )
         << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), QStringLiteral( "datetime" ), QVariant::DateTime );
   }
 
+  if ( mGDALDriverName == QLatin1String( "GPKG" ) )
+  {
+    // boolean data type - likely other drivers also support this
+    nativeTypes
+        << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool, -1, -1, -1, -1 );
+  }
+
+
   setNativeTypes( nativeTypes );
 
   QgsOgrConnPool::instance()->ref( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ) ) );


### PR DESCRIPTION
Likely other drivers also support this, so the list should be extended for these...

@rouault are you aware off-hand of other drivers which support boolean field types?