### PR TITLE
[bugfix] Restore binding for QgsCoordinateTransform

### DIFF
--- a/python/core/qgscoordinatetransform.sip
+++ b/python/core/qgscoordinatetransform.sip
@@ -169,6 +169,16 @@ Default constructor, creates an invalid QgsCoordinateTransform.
  \param direction transform direction (defaults to forward transformation)
 %End
 
+    QgsRectangle transform( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform ) const;
+%Docstring
+ Transforms a rectangle to the destination CRS.
+ If the direction is ForwardTransform then coordinates are transformed from source to destination,
+ otherwise points are transformed from destination to source CRS.
+ \param rectangle rectangle to transform
+ \param direction transform direction (defaults to ForwardTransform)
+ :return: transformed rectangle
+ :rtype: QgsRectangle
+%End
 
     void transformCoords( int numPoint, double *x, double *y, double *z, TransformDirection direction = ForwardTransform ) const;
 %Docstring

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -239,7 +239,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param direction transform direction (defaults to ForwardTransform)
      * \returns transformed rectangle
      */
-    QgsRectangle transform( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform ) const SIP_SKIP;
+    QgsRectangle transform( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform ) const;
 
     /**
      * Transform an array of coordinates to the destination CRS.

--- a/tests/src/python/test_qgscoordinatetransform.py
+++ b/tests/src/python/test_qgscoordinatetransform.py
@@ -47,6 +47,30 @@ class TestQgsCoordinateTransform(unittest.TestCase):
         self.assertAlmostEqual(myExpectedValues[2], myProjectedExtent.xMaximum(), msg=myMessage)
         self.assertAlmostEqual(myExpectedValues[3], myProjectedExtent.yMaximum(), msg=myMessage)
 
+    def testTransformQgsRectangle_Regression17600(self):
+        """Test that rectangle transform is in the bindings"""
+        myExtent = QgsRectangle(-1797107, 4392148, 6025926, 6616304)
+        myGeoCrs = QgsCoordinateReferenceSystem()
+        myGeoCrs.createFromId(4326, QgsCoordinateReferenceSystem.EpsgCrsId)
+        myUtmCrs = QgsCoordinateReferenceSystem()
+        myUtmCrs.createFromId(3857, QgsCoordinateReferenceSystem.EpsgCrsId)
+        myXForm = QgsCoordinateTransform(myUtmCrs, myGeoCrs)
+        myTransformedExtent = myXForm.transform(myExtent)
+        myTransformedExtentForward = myXForm.transform(myExtent, QgsCoordinateTransform.ForwardTransform)
+        self.assertAlmostEquals(myTransformedExtentForward.xMaximum(), myTransformedExtent.xMaximum())
+        self.assertAlmostEquals(myTransformedExtentForward.xMinimum(), myTransformedExtent.xMinimum())
+        self.assertAlmostEquals(myTransformedExtentForward.yMaximum(), myTransformedExtent.yMaximum())
+        self.assertAlmostEquals(myTransformedExtentForward.yMinimum(), myTransformedExtent.yMinimum())
+        self.assertAlmostEquals(myTransformedExtentForward.xMaximum(), 54.13181426773211)
+        self.assertAlmostEquals(myTransformedExtentForward.xMinimum(), -16.14368685298181)
+        self.assertAlmostEquals(myTransformedExtentForward.yMaximum(), 50.971783118386895)
+        self.assertAlmostEquals(myTransformedExtentForward.yMinimum(), 36.66235970825241)
+        myTransformedExtentReverse = myXForm.transform(myTransformedExtent, QgsCoordinateTransform.ReverseTransform)
+        self.assertAlmostEquals(myTransformedExtentReverse.xMaximum(), myExtent.xMaximum())
+        self.assertAlmostEquals(myTransformedExtentReverse.xMinimum(), myExtent.xMinimum())
+        self.assertAlmostEquals(myTransformedExtentReverse.yMaximum(), myExtent.yMaximum())
+        self.assertAlmostEquals(myTransformedExtentReverse.yMinimum(), myExtent.yMinimum())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #17600

Binding was lost in commit 10d34ece02bb765f5d9d88bb0524c909235fb0d7

With test