### PR TITLE
find redirected/301 doc url

### DIFF
--- a/src/gui/qgshelp.cpp
+++ b/src/gui/qgshelp.cpp
@@ -160,7 +160,7 @@ bool QgsHelp::urlExists( const QString &url )
     if ( socket.waitForReadyRead() )
     {
       QByteArray bytes = socket.readAll();
-      if ( bytes.contains( "200 OK" ) ||  bytes.contains( "302 Found" ) )
+      if ( bytes.contains( "200 OK" ) ||  bytes.contains( "302 Found" ) ||  bytes.contains( "301 Moved" ) )
       {
         return true;
       }


### PR DESCRIPTION
## Description

Currently when you click a help button (for example in the datasource manager dialog in the WMS tab), you get a 'No Help Found' page...
It appears that even if you have all settings ok, there is some check which tries to do a HEAD request , and then checks if it is a '200 OK' or a '302 Found'.

BUT our doc website will redirect most url's using a 301 Moved redirection, so current test will always fail.

Adding this patch the test will also succeed when it is a 301.
Maybe better would be to test if it si NOT a 404

Given we do 100% https now, it would maybe even be better to fix:

https://github.com/qgis/QGIS/blob/master/src/gui/qgshelp.cpp#L155
which always tries port 80 (=http) instead of 443 (https)

and 

https://github.com/qgis/QGIS/blob/master/src/app/qgsoptions.cpp#L302
which poinst to 
http://docs.qgis.org/$qgis_short_version/$qgis_locale/docs/user_manual/
(non https)

These default options is a problem anyway, as starting a fresh profile, the help/helpSearchPath will show up anyway, but will never show up in the settings (so the test in QgsHelp will never have a setting 'help/helpSearchPath' setting).. Will create an issue for that one.

