### PR TITLE
[spatialite provider] auto-generate auto-incrementing primary keys

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -860,11 +860,32 @@ void QgsSpatiaLiteProvider::fetchConstraints()
 
   Q_FOREACH ( int fieldIdx, mPrimaryKeyAttrs )
   {
-    //primary keys are unique, not null
     QgsFieldConstraints constraints = mAttributeFields.at( fieldIdx ).constraints();
     constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
     constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
     mAttributeFields[ fieldIdx ].setConstraints( constraints );
+
+    if ( mAttributeFields[ fieldIdx ].name() == mPrimaryKey )
+    {
+      QString sql = QStringLiteral( "SELECT COUNT(*) FROM sqlite_sequence WHERE name=%1" ).arg( quotedIdentifier( mTableName ) );
+      int ret = sqlite3_get_table( mSqliteHandle, sql.toUtf8().constData(), &results, &rows, &columns, &errMsg );
+      if ( ret != SQLITE_OK )
+      {
+        handleError( sql, errMsg );
+        return;
+      }
+
+      if ( rows >= 1 )
+      {
+        int sequential = QString::fromUtf8( results[ 1 ] ).toInt();
+        if ( sequential > 0 )
+        {
+          insertDefaultValue( fieldIdx, tr( "Autogenerate" ) );
+          mPrimaryKeyAutoIncrement = true;
+        }
+      }
+      sqlite3_free_table( results );
+    }
   }
 }
 
@@ -872,27 +893,31 @@ void QgsSpatiaLiteProvider::insertDefaultValue( int fieldIndex, QString defaultV
 {
   if ( !defaultVal.isEmpty() )
   {
-    QVariant defaultVariant;
-    switch ( mAttributeFields.at( fieldIndex ).type() )
+    QVariant defaultVariant = defaultVal;
+
+    if ( mAttributeFields.at( fieldIndex ) != mPrimaryKey && ( mAttributeFields.at( fieldIndex ) == mPrimaryKey && !mPrimaryKeyAutoIncrement ) )
     {
-      case QVariant::LongLong:
-        defaultVariant = defaultVal.toLongLong();
-        break;
-
-      case QVariant::Double:
-        defaultVariant = defaultVal.toDouble();
-        break;
-
-      default:
+      switch ( mAttributeFields.at( fieldIndex ).type() )
       {
-        if ( defaultVal.startsWith( '\'' ) )
-          defaultVal = defaultVal.remove( 0, 1 );
-        if ( defaultVal.endsWith( '\'' ) )
-          defaultVal.chop( 1 );
-        defaultVal.replace( QLatin1String( "''" ), QLatin1String( "'" ) );
+        case QVariant::LongLong:
+          defaultVariant = defaultVal.toLongLong();
+          break;
 
-        defaultVariant = defaultVal;
-        break;
+        case QVariant::Double:
+          defaultVariant = defaultVal.toDouble();
+          break;
+
+        default:
+        {
+          if ( defaultVal.startsWith( '\'' ) )
+            defaultVal = defaultVal.remove( 0, 1 );
+          if ( defaultVal.endsWith( '\'' ) )
+            defaultVal.chop( 1 );
+          defaultVal.replace( QLatin1String( "''" ), QLatin1String( "'" ) );
+
+          defaultVariant = defaultVal;
+          break;
+        }
       }
     }
     mDefaultValues.insert( fieldIndex, defaultVariant );
@@ -978,9 +1003,6 @@ void QgsSpatiaLiteProvider::loadFields()
     }
     sqlite3_free_table( results );
 
-    // check for constraints
-    fetchConstraints();
-
     // for views try to get the primary key from the meta table
     if ( mViewBased && mPrimaryKey.isEmpty() )
     {
@@ -1044,6 +1066,9 @@ void QgsSpatiaLiteProvider::loadFields()
     // setting the Primary Key column name
     mPrimaryKey = pkName;
   }
+
+  // check for constraints
+  fetchConstraints();
 
   updatePrimaryKeyCapabilities();
 }
@@ -3932,6 +3957,11 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList &flist, Flags flags )
           {
             ++ia;
           }
+          else if ( fieldname == mPrimaryKey && mPrimaryKeyAutoIncrement && v == QVariant( tr( "Autogenerate" ) ) )
+          {
+            // use auto-generated value if user hasn't specified a unique value
+            ++ia;
+          }
           else if ( v.isNull() )
           {
             // binding a NULL value
@@ -4377,6 +4407,20 @@ QgsVectorDataProvider::Capabilities QgsSpatiaLiteProvider::capabilities() const
 QVariant QgsSpatiaLiteProvider::defaultValue( int fieldId ) const
 {
   return mDefaultValues.value( fieldId, QVariant() );
+}
+
+bool QgsSpatiaLiteProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value ) const
+{
+  Q_UNUSED( constraint );
+
+  // If the field is the primary key, skip in case it's autog-enerated / auto-incrementing
+  if ( mAttributeFields.at( fieldIndex ).name() == mPrimaryKey  && mPrimaryKeyAutoIncrement )
+  {
+    const QVariant defVal = mDefaultValues.value( fieldIndex );
+    return defVal != value && defVal.isNull() != value.isNull();
+  }
+
+  return true;
 }
 
 void QgsSpatiaLiteProvider::closeDb()

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -113,6 +113,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     bool changeGeometryValues( const QgsGeometryMap &geometry_map ) override;
     QgsVectorDataProvider::Capabilities capabilities() const override;
     QVariant defaultValue( int fieldId ) const override;
+    virtual bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value = QVariant() ) const override;
     bool createAttributeIndex( int field ) override;
 
     /**
@@ -249,6 +250,9 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
 
     //! Name of the primary key column in the table
     QString mPrimaryKey;
+
+    //! Flag indicating whether the primary key is auto-generated
+    bool mPrimaryKeyAutoIncrement = false;
 
     //! List of primary key columns in the table
     QgsAttributeList mPrimaryKeyAttrs;


### PR DESCRIPTION
## Description
@m-kuhn , @elpaso , this PR fixes the spatialite provider's auto-incrementing primary key not being auto-generated when entering new features. 

Without this, it's a real pain to use the spatialite provider under master as users are required to enter a unique ID manually upon each feature addition.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
