### PR TITLE
Value relation widget: respect readonly state

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     QgsValueRelationFieldFormatter::ValueRelationCache mCache;
     QgsVectorLayer *mLayer = nullptr;
 
-    bool mEnabled = false;
+    bool mEnabled = true;
 
     friend class QgsValueRelationWidgetFactory;
     friend class TestQgsValueRelationWidgetWrapper;

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -67,11 +67,13 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
   QgsProject::instance()->addMapLayer( &vl1, false, false );
 
   // build a value relation widget wrapper
-  QListWidget lw;
-  QWidget editor;
-  QgsValueRelationWidgetWrapper w( &vl1, 0, &editor, nullptr );
+  QgsValueRelationWidgetWrapper w( &vl1, 0, nullptr, nullptr );
+
+  QVariantMap config;
+  config.insert( QStringLiteral( "AllowMulti" ), true );
+  w.setConfig( config );
+  w.widget();
   w.setEnabled( true );
-  w.initWidget( &lw );
 
   // add an item virtually
   QListWidgetItem item;

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -26,8 +26,6 @@ start_app()
 
 class TestQgsTextEditWidget(unittest.TestCase):
 
-    VALUEMAP_NULL_TEXT = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"
-
     @classmethod
     def setUpClass(cls):
         QgsGui.editorWidgetRegistry().initEditors()
@@ -39,8 +37,8 @@ class TestQgsTextEditWidget(unittest.TestCase):
         f = QgsFeature()
         f.setAttributes(["test", 123])
         f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(100, 200)))
-        assert pr.addFeatures([f])
-        assert self.layer.pendingFeatureCount() == 1
+        self.assertTrue(pr.addFeatures([f]))
+        self.assertEqual(self.layer.pendingFeatureCount(), 1)
         return self.layer
 
     def doAttributeTest(self, idx, expected):
@@ -50,16 +48,16 @@ class TestQgsTextEditWidget(unittest.TestCase):
         editwidget = reg.create('TextEdit', self.layer, idx, config, None, None)
 
         editwidget.setValue('value')
-        assert editwidget.value() == expected[0]
+        self.assertEqual(editwidget.value(), expected[0])
 
         editwidget.setValue(123)
-        assert editwidget.value() == expected[1]
+        self.assertEqual(editwidget.value(), expected[1])
 
         editwidget.setValue(None)
-        assert editwidget.value() == expected[2]
+        self.assertEqual(editwidget.value(), expected[2])
 
         editwidget.setValue(NULL)
-        assert editwidget.value() == expected[3]
+        self.assertEqual(editwidget.value(), expected[3])
 
     def test_SetValue(self):
         self.createLayerWithOnePoint()
@@ -70,7 +68,7 @@ class TestQgsTextEditWidget(unittest.TestCase):
     def testStringWithMaxLen(self):
         """ tests that text edit wrappers correctly handle string fields with a maximum length """
         layer = QgsVectorLayer("none?field=fldint:integer", "layer", "memory")
-        assert layer.isValid()
+        self.assertTrue(layer.isValid())
         layer.dataProvider().addAttributes([QgsField('max', QVariant.String, 'string', 10),
                                             QgsField('nomax', QVariant.String, 'string', 0)])
         layer.updateFields()
@@ -94,9 +92,29 @@ class TestQgsTextEditWidget(unittest.TestCase):
 
         QgsProject.instance().removeAllMapLayers()
 
+
+class TestQgsValueRelationWidget(unittest.TestCase):
+
+    def test_enableDisable(self):
+        reg = QgsGui.editorWidgetRegistry()
+        layer = QgsVectorLayer("none?field=number:integer", "layer", "memory")
+        wrapper = reg.create('ValueRelation', layer, 0, {}, None, None)
+
+        widget = wrapper.widget()
+
+        self.assertTrue(widget.isEnabled())
+        wrapper.setEnabled(False)
+        self.assertFalse(widget.isEnabled())
+        wrapper.setEnabled(True)
+        self.assertTrue(widget.isEnabled())
+
+
+class TestQgsValueMapEditWidget(unittest.TestCase):
+    VALUEMAP_NULL_TEXT = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"
+
     def test_ValueMap_set_get(self):
         layer = QgsVectorLayer("none?field=number:integer", "layer", "memory")
-        assert layer.isValid()
+        self.assertTrue(layer.isValid())
         QgsProject.instance().addMapLayer(layer)
         reg = QgsGui.editorWidgetRegistry()
         configWdg = reg.createConfigWidget('ValueMap', layer, 0, None)
@@ -110,4 +128,6 @@ class TestQgsTextEditWidget(unittest.TestCase):
         self.assertEqual(configWdg.config(), config)
 
         QgsProject.instance().removeAllMapLayers()
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -129,5 +129,6 @@ class TestQgsValueMapEditWidget(unittest.TestCase):
 
         QgsProject.instance().removeAllMapLayers()
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The value relation widget was shown editable despite the form being read only.