### PR TITLE
Widget size handling in status bar

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9113,12 +9113,6 @@ void QgisApp::saveLastMousePosition( const QgsPointXY &p )
 void QgisApp::showScale( double scale )
 {
   mScaleWidget->setScale( scale );
-
-  // Not sure if the lines below do anything meaningful /Homann
-  if ( mScaleWidget->width() > mScaleWidget->minimumWidth() )
-  {
-    mScaleWidget->setMinimumWidth( mScaleWidget->width() );
-  }
 }
 
 

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -226,8 +226,12 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPointXY &p )
                       mMousePrecisionDecimalPlaces ) );
 
   //ensure the label is big (and small) enough
-  mLineEdit->setMinimumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
-  mLineEdit->setMaximumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
+  int width = mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10;
+  if( mLineEdit->minimumWidth()+4 < width || mLineEdit->minimumWidth()-4 > width )
+  {
+    mLineEdit->setMinimumWidth( width );
+    mLineEdit->setMaximumWidth( width );
+  }
 }
 
 
@@ -242,7 +246,12 @@ void QgsStatusBarCoordinatesWidget::showExtent()
   QgsRectangle myExtents = mMapCanvas->extent();
   mLabel->setText( tr( "Extents:" ) );
   mLineEdit->setText( myExtents.toString( true ) );
+
   //ensure the label is big (and small) enough
-  mLineEdit->setMinimumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
-  mLineEdit->setMaximumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
+  int width = mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10;
+  if( mLineEdit->minimumWidth()+4 < width || mLineEdit->minimumWidth()-4 > width )
+  {
+    mLineEdit->setMinimumWidth( width );
+    mLineEdit->setMaximumWidth( width );
+  }
 }

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -46,7 +46,6 @@ QgsStatusBarCoordinatesWidget::QgsStatusBarCoordinatesWidget( QWidget *parent )
 
   mLineEdit = new QLineEdit( this );
   mLineEdit->setMinimumWidth( 10 );
-  mLineEdit->setMaximumWidth( 300 );
   //mLineEdit->setMaximumHeight( 20 );
   mLineEdit->setContentsMargins( 0, 0, 0, 0 );
   mLineEdit->setAlignment( Qt::AlignCenter );
@@ -226,10 +225,9 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPointXY &p )
   mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( p, mMapCanvas->mapSettings().destinationCrs(),
                       mMousePrecisionDecimalPlaces ) );
 
-  if ( mLineEdit->width() > mLineEdit->minimumWidth() )
-  {
-    mLineEdit->setMinimumWidth( mLineEdit->width() );
-  }
+  //ensure the label is big (and small) enough
+  mLineEdit->setMinimumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
+  mLineEdit->setMaximumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
 }
 
 
@@ -244,9 +242,7 @@ void QgsStatusBarCoordinatesWidget::showExtent()
   QgsRectangle myExtents = mMapCanvas->extent();
   mLabel->setText( tr( "Extents:" ) );
   mLineEdit->setText( myExtents.toString( true ) );
-  //ensure the label is big enough
-  if ( mLineEdit->width() > mLineEdit->minimumWidth() )
-  {
-    mLineEdit->setMinimumWidth( mLineEdit->width() );
-  }
+  //ensure the label is big (and small) enough
+  mLineEdit->setMinimumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
+  mLineEdit->setMaximumWidth( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10 );
 }

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -225,13 +225,7 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPointXY &p )
   mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( p, mMapCanvas->mapSettings().destinationCrs(),
                       mMousePrecisionDecimalPlaces ) );
 
-  //ensure the label is big (and small) enough
-  int width = mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10;
-  if ( mLineEdit->minimumWidth() + 4 < width || mLineEdit->minimumWidth() - 4 > width )
-  {
-    mLineEdit->setMinimumWidth( width );
-    mLineEdit->setMaximumWidth( width );
-  }
+  ensureCoordinatesVisible();
 }
 
 
@@ -247,11 +241,17 @@ void QgsStatusBarCoordinatesWidget::showExtent()
   mLabel->setText( tr( "Extents:" ) );
   mLineEdit->setText( myExtents.toString( true ) );
 
+  ensureCoordinatesVisible();
+}
+
+void QgsStatusBarCoordinatesWidget::ensureCoordinatesVisible(){
+
   //ensure the label is big (and small) enough
   int width = mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10;
-  if ( mLineEdit->minimumWidth() + 4 < width || mLineEdit->minimumWidth() - 4 > width )
+  if ( mLineEdit->minimumWidth() < width || ( mLineEdit->minimumWidth() - width ) > fontMetrics().width( QStringLiteral( "OO" ) ) )
   {
     mLineEdit->setMinimumWidth( width );
     mLineEdit->setMaximumWidth( width );
   }
 }
+

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -33,6 +33,9 @@ QgsStatusBarCoordinatesWidget::QgsStatusBarCoordinatesWidget( QWidget *parent )
   : QWidget( parent )
   , mMousePrecisionDecimalPlaces( 0 )
 {
+  // calculate the size of two chars
+  mTwoCharSize = fontMetrics().width( QStringLiteral( "OO" ) );
+
   // add a label to show current position
   mLabel = new QLabel( QString(), this );
   mLabel->setObjectName( QStringLiteral( "mCoordsLabel" ) );
@@ -244,11 +247,12 @@ void QgsStatusBarCoordinatesWidget::showExtent()
   ensureCoordinatesVisible();
 }
 
-void QgsStatusBarCoordinatesWidget::ensureCoordinatesVisible(){
+void QgsStatusBarCoordinatesWidget::ensureCoordinatesVisible()
+{
 
   //ensure the label is big (and small) enough
   int width = mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10;
-  if ( mLineEdit->minimumWidth() < width || ( mLineEdit->minimumWidth() - width ) > fontMetrics().width( QStringLiteral( "OO" ) ) )
+  if ( mLineEdit->minimumWidth() < width || ( mLineEdit->minimumWidth() - width ) > mTwoCharSize )
   {
     mLineEdit->setMinimumWidth( width );
     mLineEdit->setMaximumWidth( width );

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -227,7 +227,7 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPointXY &p )
 
   //ensure the label is big (and small) enough
   int width = mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10;
-  if( mLineEdit->minimumWidth()+4 < width || mLineEdit->minimumWidth()-4 > width )
+  if ( mLineEdit->minimumWidth() + 4 < width || mLineEdit->minimumWidth() - 4 > width )
   {
     mLineEdit->setMinimumWidth( width );
     mLineEdit->setMaximumWidth( width );
@@ -249,7 +249,7 @@ void QgsStatusBarCoordinatesWidget::showExtent()
 
   //ensure the label is big (and small) enough
   int width = mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10;
-  if( mLineEdit->minimumWidth()+4 < width || mLineEdit->minimumWidth()-4 > width )
+  if ( mLineEdit->minimumWidth() + 4 < width || mLineEdit->minimumWidth() - 4 > width )
   {
     mLineEdit->setMinimumWidth( width );
     mLineEdit->setMaximumWidth( width );

--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -72,6 +72,7 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     QValidator *mCoordsEditValidator = nullptr;
     QTimer *mDizzyTimer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
+    int mTwoCharSize;
 
     //! The number of decimal places to use if not automatic
     unsigned int mMousePrecisionDecimalPlaces;

--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -59,6 +59,7 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     void validateCoordinates();
     void dizzy();
     void showExtent();
+    void ensureCoordinatesVisible();
 
   private:
     void refreshMapCanvas();

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -78,6 +78,11 @@ void QgsStatusBarScaleWidget::setScale( double scale )
   mScale->blockSignals( true );
   mScale->setScale( scale );
   mScale->blockSignals( false );
+
+  if ( mScale->width() > mScale->minimumWidth() )
+  {
+    mScale->setMinimumWidth( mScale->width() );
+  }
 }
 
 bool QgsStatusBarScaleWidget::isLocked() const


### PR DESCRIPTION
## Description
**Fix: Only the scale line edit has the minimum size instead of the whole scale widget.**
When minimizing the window there was only the scale label not minimized before.
![image](https://user-images.githubusercontent.com/28384354/33978041-1d29edf4-e09e-11e7-8583-0d8e1144bf19.png)
Now the lable scale is minimized like the other lables:
![image](https://user-images.githubusercontent.com/28384354/33944775-6165e4f4-e01d-11e7-83e4-e8fedc4c4017.png)

**Improvement: Coordinates line edit size is now dynamic depending on the coordinate value**
Since having more widgets in the statusbar than in the 2.18 the coordinate-lineedit is mostly much smaller than before. I thought about minimum size but then I decided to make it dynamic according to the content.
Before it was mostly too small:
![image](https://user-images.githubusercontent.com/28384354/33978078-3c3571be-e09e-11e7-93cd-d48b295a084a.png)
Now it's dynamic:
![image](https://user-images.githubusercontent.com/28384354/33945149-76053b7a-e01e-11e7-822d-a1d398c34406.png)
![image](https://user-images.githubusercontent.com/28384354/33945088-520132b0-e01e-11e7-8ffe-af218fa2a634.png)
![image](https://user-images.githubusercontent.com/28384354/33945116-61cfd692-e01e-11e7-8890-50e5c34003d7.png)

