### PR TITLE
[processing] Don't sort field names in multi-field input dialog

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -1362,11 +1362,11 @@ class TableFieldWidgetWrapper(WidgetWrapper):
         elif self.param.dataType() == QgsProcessingParameterField.DateTime:
             fieldTypes = [QVariant.Date, QVariant.Time, QVariant.DateTime]
 
-        fieldNames = set()
+        fieldNames = []
         for field in self._layer.fields():
             if not fieldTypes or field.type() in fieldTypes:
-                fieldNames.add(str(field.name()))
-        return sorted(list(fieldNames), key=cmp_to_key(locale.strcoll))
+                fieldNames.append(str(field.name()))
+        return fieldNames
 
     def setValue(self, value):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):


### PR DESCRIPTION
Field names should always be listed in the order that the layer defines them, since they may be logically grouped in the original data set and everywhere else in the UX we show them in layer order.