### PR TITLE
[browser] Allow renaming favorite items

### DIFF
--- a/python/core/qgsbrowsermodel.sip
+++ b/python/core/qgsbrowsermodel.sip
@@ -165,9 +165,13 @@ Reload the whole model
     void itemDataChanged( QgsDataItem *item );
     void itemStateChanged( QgsDataItem *item, QgsDataItem::State oldState );
 
-    void addFavoriteDirectory( const QString &directory );
+    void addFavoriteDirectory( const QString &directory, const QString &name = QString() );
 %Docstring
- Adds a directory to the favorites group.
+ Adds a ``directory`` to the favorites group.
+
+ If ``name`` is specified, it will be used as the favorite's name. Otherwise
+ the name will be set to match ``directory``.
+
 .. versionadded:: 3.0
 .. seealso:: :py:func:`removeFavorite()`
 %End

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -673,9 +673,13 @@ class QgsFavoritesItem : QgsDataCollectionItem
     virtual QVector<QgsDataItem *> createChildren();
 
 
-    void addDirectory( const QString &directory );
+    void addDirectory( const QString &directory, const QString &name = QString() );
 %Docstring
- Adds a new directory to the favorites group.
+ Adds a new ``directory`` to the favorites group.
+
+ If ``name`` is specified, it will be used as the favorite's name. Otherwise
+ the name will be set to match ``directory``.
+
 .. seealso:: :py:func:`removeDirectory()`
 %End
 
@@ -683,6 +687,11 @@ class QgsFavoritesItem : QgsDataCollectionItem
 %Docstring
  Removes an existing directory from the favorites group.
 .. seealso:: :py:func:`addDirectory()`
+%End
+
+    void renameFavorite( const QString &path, const QString &name );
+%Docstring
+ Renames the stored favorite with corresponding ``path`` a new ``name``.
 %End
 
     static QIcon iconFavorites();

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -255,11 +255,22 @@ Create new data item.
 %Docstring
  :rtype: QIcon
 %End
+
     QString name() const;
 %Docstring
+ Returns the name of the item (the displayed text for the item).
+
+.. seealso:: :py:func:`setName()`
  :rtype: str
 %End
+
     void setName( const QString &name );
+%Docstring
+ Sets the ``name`` of the item (the displayed text for the item).
+
+.. seealso:: :py:func:`name()`
+%End
+
     QString path() const;
 %Docstring
  :rtype: str

--- a/python/gui/qgsbrowserdockwidget.sip
+++ b/python/gui/qgsbrowserdockwidget.sip
@@ -29,7 +29,7 @@ class QgsBrowserDockWidget : QgsDockWidget
  \param parent parent widget
 %End
     ~QgsBrowserDockWidget();
-    void addFavoriteDirectory( const QString &favDir );
+    void addFavoriteDirectory( const QString &favDir, const QString &name = QString() );
 %Docstring
 Add directory to favorites
 %End

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -546,10 +546,10 @@ void QgsBrowserModel::refresh( const QModelIndex &index )
   item->refresh();
 }
 
-void QgsBrowserModel::addFavoriteDirectory( const QString &directory )
+void QgsBrowserModel::addFavoriteDirectory( const QString &directory, const QString &name )
 {
   Q_ASSERT( mFavorites );
-  mFavorites->addDirectory( directory );
+  mFavorites->addDirectory( directory, name );
 }
 
 void QgsBrowserModel::removeFavorite( const QModelIndex &index )

--- a/src/core/qgsbrowsermodel.h
+++ b/src/core/qgsbrowsermodel.h
@@ -164,11 +164,15 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
     void itemStateChanged( QgsDataItem *item, QgsDataItem::State oldState );
 
     /**
-     * Adds a directory to the favorites group.
+     * Adds a \a directory to the favorites group.
+     *
+     * If \a name is specified, it will be used as the favorite's name. Otherwise
+     * the name will be set to match \a directory.
+     *
      * \since QGIS 3.0
      * \see removeFavorite()
      */
-    void addFavoriteDirectory( const QString &directory );
+    void addFavoriteDirectory( const QString &directory, const QString &name = QString() );
 
     /**
      * Removes a favorite directory from its corresponding model index.

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -229,6 +229,12 @@ QIcon QgsDataItem::icon()
   return mIconMap.value( mIconName );
 }
 
+void QgsDataItem::setName( const QString &name )
+{
+  mName = name;
+  emit dataChanged( this );
+}
+
 QVector<QgsDataItem *> QgsDataItem::createChildren()
 {
   return QVector<QgsDataItem *>();

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -640,10 +640,14 @@ class CORE_EXPORT QgsFavoritesItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
 
     /**
-     * Adds a new directory to the favorites group.
+     * Adds a new \a directory to the favorites group.
+     *
+     * If \a name is specified, it will be used as the favorite's name. Otherwise
+     * the name will be set to match \a directory.
+     *
      * \see removeDirectory()
      */
-    void addDirectory( const QString &directory );
+    void addDirectory( const QString &directory, const QString &name = QString() );
 
     /**
      * Removes an existing directory from the favorites group.
@@ -651,13 +655,18 @@ class CORE_EXPORT QgsFavoritesItem : public QgsDataCollectionItem
      */
     void removeDirectory( QgsDirectoryItem *item );
 
+    /**
+     * Renames the stored favorite with corresponding \a path a new \a name.
+     */
+    void renameFavorite( const QString &path, const QString &name );
+
     //! Icon for favorites group
     static QIcon iconFavorites();
 
     QVariant sortKey() const override;
 
   private:
-    QVector<QgsDataItem *> createChildren( const QString &favDir );
+    QVector<QgsDataItem *> createChildren( const QString &favDir, const QString &name );
 };
 
 /**
@@ -714,6 +723,8 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
 */
 class CORE_EXPORT QgsProjectHomeItem : public QgsDirectoryItem
 {
+    Q_OBJECT
+
   public:
 
     QgsProjectHomeItem( QgsDataItem *parent, const QString &name, const QString &dirPath, const QString &path );
@@ -722,6 +733,30 @@ class CORE_EXPORT QgsProjectHomeItem : public QgsDirectoryItem
     QVariant sortKey() const override;
 
 };
+
+/**
+ * \ingroup core
+ * A directory item showing the a single favorite directory.
+ * \since QGIS 3.0
+*/
+class CORE_EXPORT QgsFavoriteItem : public QgsDirectoryItem
+{
+    Q_OBJECT
+
+  public:
+
+    QgsFavoriteItem( QgsFavoritesItem *parent, const QString &name, const QString &dirPath, const QString &path );
+
+    /**
+     * Sets a new \a name for the favorite, storing the new name permanently for the favorite.
+     */
+    void rename( const QString &name );
+
+  private:
+
+    QgsFavoritesItem *mFavorites = nullptr;
+};
+
 #endif
 ///@endcond
 

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -248,8 +248,21 @@ class CORE_EXPORT QgsDataItem : public QObject
     void setParent( QgsDataItem *parent );
     QVector<QgsDataItem *> children() const { return mChildren; }
     virtual QIcon icon();
+
+    /**
+     * Returns the name of the item (the displayed text for the item).
+     *
+     * \see setName()
+     */
     QString name() const { return mName; }
-    void setName( const QString &name ) { mName = name; }
+
+    /**
+     * Sets the \a name of the item (the displayed text for the item).
+     *
+     * \see name()
+     */
+    void setName( const QString &name );
+
     QString path() const { return mPath; }
     void setPath( const QString &path ) { mPath = path; }
     //! Create path component replacing path separators

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -31,6 +31,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgsnewnamedialog.h"
 
 // browser layer properties dialog
 #include "qgsapplication.h"
@@ -168,6 +169,24 @@ void QgsBrowserDockWidget::itemDoubleClicked( const QModelIndex &index )
     addLayerAtIndex( index ); // default double-click handler
 }
 
+void QgsBrowserDockWidget::renameFavorite()
+{
+  QgsDataItem *dataItem = mModel->dataItem( mProxyModel->mapToSource( mBrowserView->currentIndex() ) );
+  if ( !dataItem )
+    return;
+
+  QgsFavoriteItem *favorite = qobject_cast< QgsFavoriteItem * >( dataItem );
+  if ( !favorite )
+    return;
+
+  QgsNewNameDialog dlg( tr( "favorite “%1”" ).arg( favorite->name() ), favorite->name() );
+  dlg.setWindowTitle( tr( "Rename Favorite" ) );
+  if ( dlg.exec() != QDialog::Accepted || dlg.name() == favorite->name() )
+    return;
+
+  favorite->rename( dlg.name() );
+}
+
 void QgsBrowserDockWidget::showContextMenu( QPoint pt )
 {
   QModelIndex index = mProxyModel->mapToSource( mBrowserView->indexAt( pt ) );
@@ -180,9 +199,8 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
   if ( item->type() == QgsDataItem::Directory )
   {
     QgsSettings settings;
-    QStringList favDirs = settings.value( QStringLiteral( "browser/favourites" ) ).toStringList();
-    bool inFavDirs = item->parent() && item->parent()->type() == QgsDataItem::Favorites;
 
+    bool inFavDirs = item->parent() && item->parent()->type() == QgsDataItem::Favorites;
     if ( item->parent() && !inFavDirs )
     {
       // only non-root directories can be added as favorites
@@ -190,8 +208,11 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
     }
     else if ( inFavDirs )
     {
-      // only favorites can be removed
+      QAction *actionRename = new QAction( tr( "Rename Favorite..." ), this );
+      connect( actionRename, &QAction::triggered, this, &QgsBrowserDockWidget::renameFavorite );
+      menu->addAction( actionRename );
       menu->addAction( tr( "Remove Favorite" ), this, SLOT( removeFavorite() ) );
+      menu->addSeparator();
     }
     menu->addAction( tr( "Properties..." ), this, SLOT( showProperties() ) );
     menu->addAction( tr( "Hide from Browser" ), this, SLOT( hideItem() ) );
@@ -261,9 +282,9 @@ void QgsBrowserDockWidget::addFavoriteDirectory()
   }
 }
 
-void QgsBrowserDockWidget::addFavoriteDirectory( const QString &favDir )
+void QgsBrowserDockWidget::addFavoriteDirectory( const QString &favDir, const QString &name )
 {
-  mModel->addFavoriteDirectory( favDir );
+  mModel->addFavoriteDirectory( favDir, name );
 }
 
 void QgsBrowserDockWidget::removeFavorite()

--- a/src/gui/qgsbrowserdockwidget.h
+++ b/src/gui/qgsbrowserdockwidget.h
@@ -53,7 +53,7 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
     explicit QgsBrowserDockWidget( const QString &name, QgsBrowserModel *browserModel, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsBrowserDockWidget();
     //! Add directory to favorites
-    void addFavoriteDirectory( const QString &favDir );
+    void addFavoriteDirectory( const QString &favDir, const QString &name = QString() );
 
   public slots:
     //! Add layer at index
@@ -112,6 +112,7 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
 
   private slots:
     void itemDoubleClicked( const QModelIndex &index );
+    void renameFavorite();
 
   private:
     //! Refresh the model


### PR DESCRIPTION
Without this ability favorites can be of limited use, because favoriting any path which is more than 2 or 3 folders deep leads to a very long unreadable title for the favorite.