### PR TITLE
Sort the values in querybuilder

### DIFF
--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -159,6 +159,7 @@ void QgsQueryBuilder::fillValues( int idx, int limit )
     mModelValues->insertRow( mModelValues->rowCount(), myItem );
     QgsDebugMsg( QString( "Value is null: %1\nvalue: %2" ).arg( var.isNull() ).arg( var.isNull() ? nullValue : var.toString() ) );
   }
+  mModelValues->sort( 0 );
 }
 
 void QgsQueryBuilder::btnSampleValues_clicked()


### PR DESCRIPTION
After filling the values into the model, they are sorted ascending:
![sorted](https://user-images.githubusercontent.com/28384354/33991487-0efc42f0-e0cf-11e7-96cf-01285d66498b.png)

Before it was very confusing:
![unsorted](https://user-images.githubusercontent.com/28384354/33991500-25e4472e-e0cf-11e7-9d9a-0253ad86aacc.jpg)

