### PR TITLE
[backport][bugfix] Do not add binding line in both side in reshape map tool 

### DIFF
--- a/src/app/qgsmaptoolreshape.h
+++ b/src/app/qgsmaptoolreshape.h
@@ -28,6 +28,11 @@ class APP_EXPORT QgsMapToolReshape: public QgsMapToolCapture
     QgsMapToolReshape( QgsMapCanvas* canvas );
     virtual ~QgsMapToolReshape();
     void cadCanvasReleaseEvent( QgsMapMouseEvent * e ) override;
+
+  private:
+    void reshape( QgsVectorLayer *vlayer );
+
+    bool isBindingLine( QgsVectorLayer *vlayer, const QgsRectangle &bbox ) const;
 };
 
 #endif

--- a/src/app/qgsmaptoolreshape.h
+++ b/src/app/qgsmaptoolreshape.h
@@ -33,6 +33,8 @@ class APP_EXPORT QgsMapToolReshape: public QgsMapToolCapture
     void reshape( QgsVectorLayer *vlayer );
 
     bool isBindingLine( QgsVectorLayer *vlayer, const QgsRectangle &bbox ) const;
+
+    friend class TestQgsMapToolReshape;
 };
 
 #endif

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -713,7 +713,7 @@ int QgsMapToolCapture::size()
   return mCaptureCurve.numPoints();
 }
 
-QList<QgsPoint> QgsMapToolCapture::points()
+QList<QgsPoint> QgsMapToolCapture::points() const
 {
   QgsPointSequenceV2 pts;
   QList<QgsPoint> points;

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -192,7 +192,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      * List of digitized points
      * @return List of points
      */
-    QList<QgsPoint> points();
+    QList<QgsPoint> points() const;
 
     /**
      * List of digitized points with z support

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -248,6 +248,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
     QgsVertexMarker* mSnappingMarker;
 
+    friend class TestQgsMapToolReshape;
+
 #ifdef Q_OS_WIN
     int mSkipNextContextMenuEvent;
 #endif

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -16,6 +16,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/gui/attributetable
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/gui/symbology-ng
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/gui/raster
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/gui/layertree
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/python
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/app
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/app/pluginmanager
@@ -108,5 +109,6 @@ ADD_QGIS_TEST(attributetabletest testqgsattributetable.cpp)
 ADD_QGIS_TEST(fieldcalculatortest testqgsfieldcalculator.cpp)
 ADD_QGIS_TEST(maptoolidentifyaction testqgsmaptoolidentifyaction.cpp)
 ADD_QGIS_TEST(maptoolselect testqgsmaptoolselect.cpp)
+ADD_QGIS_TEST(maptoolreshape testqgsmaptoolreshape.cpp)
 ADD_QGIS_TEST(measuretool testqgsmeasuretool.cpp)
 ADD_QGIS_TEST(vectorlayersaveasdialogtest testqgsvectorlayersaveasdialog.cpp)

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -1,0 +1,150 @@
+/***************************************************************************
+  testqgsmaptoolreshape.cpp
+  --------------------------------
+Date                 : 2017-12-14
+Copyright            : (C) 2017 by Paul Blottiere
+Email                : paul.blottiere@oslandia.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+#include "qgsapplication.h"
+#include "qgsmapcanvas.h"
+#include "qgsvectorlayer.h"
+#include "qgslinestringv2.h"
+#include "qgsmaptoolreshape.h"
+#include "qgsvectordataprovider.h"
+#include "qgsmaplayerregistry.h"
+#include "qgisapp.h"
+
+class TestQgsMapToolReshape : public QObject
+{
+  Q_OBJECT
+  public:
+    TestQgsMapToolReshape() = default;
+
+    private slots:
+      void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void reshapeWithBindingLine();
+
+  private:
+    QgisApp *mQgisApp = nullptr;
+};
+
+void TestQgsMapToolReshape::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  QgsApplication::showSettings();
+
+  // enforce C locale because the tests expect it
+  // (decimal separators / thousand separators)
+  QLocale::setDefault( QLocale::c() );
+
+  mQgisApp = new QgisApp();
+}
+
+void TestQgsMapToolReshape::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMapToolReshape::init()
+{
+}
+
+void TestQgsMapToolReshape::cleanup()
+{
+}
+
+void TestQgsMapToolReshape::reshapeWithBindingLine()
+{
+  // prepare vector layer
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:4326&field=name:string(20)" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+
+  QgsGeometry *g0 = QgsGeometry::fromWkt( "LineString (0 0, 1 1, 1 2)" );
+  QgsFeature f0;
+  f0.setGeometry( g0 );
+  f0.setAttribute( 0, "polyline0" );
+
+  QgsGeometry *g1 = QgsGeometry::fromWkt( "LineString (2 1, 3 2, 3 3, 2 2)" );
+  QgsFeature f1;
+  f1.setGeometry( g1 );
+  f1.setAttribute( 0, "polyline1" );
+
+  vl->dataProvider()->addFeatures( QgsFeatureList() << f0 << f1 );
+
+  std::cout << "Feature count: " << vl->featureCount() << std::endl;
+
+  // prepare canvas
+  QList<QgsMapLayer *> layers;
+  layers.append( vl );
+
+  QgsCoordinateReferenceSystem srs( 4326, QgsCoordinateReferenceSystem::EpsgCrsId );
+  QgsMapLayerRegistry::instance()->addMapLayer( vl );
+  mQgisApp->mapCanvas()->setDestinationCrs( srs );
+  mQgisApp->mapCanvas()->setCurrentLayer( vl );
+
+  // reshape to add line to polyline0
+  QgsLineStringV2 cl0;
+  cl0.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 1 ) );
+
+  QgsAbstractGeometryV2 *curveGgeom0 = cl0.toCurveType();
+  QgsCompoundCurveV2 curve0;
+  curve0.fromWkt( curveGgeom0->asWkt() );
+
+  QgsMapToolReshape tool0( mQgisApp->mapCanvas() );
+  tool0.mCaptureCurve = curve0;
+
+  vl->startEditing();
+  tool0.reshape( vl );
+
+  vl->getFeatures( QgsFeatureRequest().setFilterFid( 1 ) ).nextFeature( f0 );
+  QCOMPARE( f0.geometry()->exportToWkt(), QStringLiteral( "LineString (0 0, 1 1, 1 2, 2 1)" ) );
+
+  vl->getFeatures( QgsFeatureRequest().setFilterFid( 2 ) ).nextFeature( f1 );
+  QCOMPARE( f1.geometry()->exportToWkt(), QStringLiteral( "LineString (2 1, 3 2, 3 3, 2 2)" ) );
+
+  vl->rollBack();
+
+  // reshape to add line to polyline1
+  QgsLineStringV2 cl1;
+  cl1.setPoints( QgsPointSequenceV2() << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 2 ) );
+
+  QgsAbstractGeometryV2 *curveGeom1 = cl1.toCurveType();
+  QgsCompoundCurveV2 curve1;
+  curve1.fromWkt( curveGeom1->asWkt() );
+
+  QgsMapToolReshape tool1( mQgisApp->mapCanvas() );
+  tool1.mCaptureCurve = curve1;
+
+  vl->startEditing();
+  tool1.reshape( vl );
+
+  vl->getFeatures( QgsFeatureRequest().setFilterFid( 1 ) ).nextFeature( f0 );
+  QCOMPARE( f0.geometry()->exportToWkt(), QStringLiteral( "LineString (0 0, 1 1, 1 2)" ) );
+
+  vl->getFeatures( QgsFeatureRequest().setFilterFid( 2 ) ).nextFeature( f1 );
+  QCOMPARE( f1.geometry()->exportToWkt(), QStringLiteral( "LineString (1 2, 2 1, 3 2, 3 3, 2 2)" ) );
+
+  vl->rollBack();
+}
+
+QTEST_MAIN( TestQgsMapToolReshape )
+#include "testqgsmaptoolreshape.moc"

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -25,12 +25,12 @@ Email                : paul.blottiere@oslandia.com
 
 class TestQgsMapToolReshape : public QObject
 {
-  Q_OBJECT
+    Q_OBJECT
   public:
     TestQgsMapToolReshape() = default;
 
-    private slots:
-      void initTestCase(); // will be called before the first testfunction is executed.
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
     void cleanupTestCase(); // will be called after the last testfunction was executed.
     void init(); // will be called before each testfunction is executed.
     void cleanup(); // will be called after every testfunction.


### PR DESCRIPTION
## Description

Backport of: https://github.com/qgis/QGIS/pull/5780

When the reshape map tool is used to extend a line whereas the ending point belongs to another line, then both lines are extended. This PR fixes this issue raised here:  https://github.com/qwat/QWAT/issues/221#issuecomment-338694705

Some tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
