### PR TITLE
getter for the output crs in QgsExtentGroupBox

### DIFF
--- a/python/gui/qgsextentgroupbox.sip
+++ b/python/gui/qgsextentgroupbox.sip
@@ -103,7 +103,16 @@ class QgsExtentGroupBox : QgsCollapsibleGroupBox
     QgsRectangle outputExtent() const;
 %Docstring
  Returns the extent shown in the widget - in output CRS coordinates.
+.. seealso:: :py:func:`outputCrs`
  :rtype: QgsRectangle
+%End
+
+    QgsCoordinateReferenceSystem outputCrs() const;
+%Docstring
+ Returns the current output CRS, used in the display.
+.. seealso:: :py:func:`outputExtent`
+.. versionadded:: 3.0
+ :rtype: QgsCoordinateReferenceSystem
 %End
 
     QgsExtentGroupBox::ExtentState extentState() const;

--- a/src/gui/qgsextentgroupbox.h
+++ b/src/gui/qgsextentgroupbox.h
@@ -120,8 +120,16 @@ class GUI_EXPORT QgsExtentGroupBox : public QgsCollapsibleGroupBox, private Ui::
 
     /**
      * Returns the extent shown in the widget - in output CRS coordinates.
+     * \see outputCrs
      */
     QgsRectangle outputExtent() const;
+
+    /**
+     * Returns the current output CRS, used in the display.
+     * \see outputExtent
+     * \since QGIS 3.0
+     */
+    QgsCoordinateReferenceSystem outputCrs() const { return mOutputCrs; }
 
     /**
      * Returns the currently selected state for the widget's extent.


### PR DESCRIPTION
## Description

getter for the output crs in QgsExtentGroupBox

Maybe I missed something, but I need to know the CRS used for the current extent in the widget.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit