### PR TITLE
add constructor to QgsBox3d with a QgsRectangle

### DIFF
--- a/python/core/geometry/qgsbox3d.sip
+++ b/python/core/geometry/qgsbox3d.sip
@@ -37,6 +37,12 @@ class QgsBox3d
  The box is normalized after construction.
 %End
 
+    QgsBox3d( const QgsRectangle &rect );
+%Docstring
+ Constructs a QgsBox3D from a rectangle.
+ Z Minimum and Z Maximum are set to 0.0.
+%End
+
     void setXMinimum( double x );
 %Docstring
  Sets the minimum ``x`` value.

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -32,6 +32,10 @@ QgsBox3d::QgsBox3d( const QgsPoint &p1, const QgsPoint &p2 )
   mBounds2d.normalize();
 }
 
+QgsBox3d::QgsBox3d( const QgsRectangle &rect )
+  : mBounds2d( rect )
+{}
+
 void QgsBox3d::setXMinimum( double x )
 {
   mBounds2d.setXMinimum( x );

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -48,6 +48,12 @@ class CORE_EXPORT QgsBox3d
     QgsBox3d( const QgsPoint &p1, const QgsPoint &p2 );
 
     /**
+     * Constructs a QgsBox3D from a rectangle.
+     * Z Minimum and Z Maximum are set to 0.0.
+     */
+    QgsBox3d( const QgsRectangle &rect );
+
+    /**
      * Sets the minimum \a x value.
      * \see xMinimum()
      * \see setXMaximum()

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -52,6 +52,14 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertEqual(box.yMaximum(), 11.0)
         self.assertEqual(box.zMaximum(), 12.0)
 
+        box = QgsBox3d(QgsRectangle(5, 6, 11, 13))
+        self.assertEqual(box.xMinimum(), 5.0)
+        self.assertEqual(box.yMinimum(), 6.0)
+        self.assertEqual(box.zMinimum(), 0.0)
+        self.assertEqual(box.xMaximum(), 11.0)
+        self.assertEqual(box.yMaximum(), 13.0)
+        self.assertEqual(box.zMaximum(), 0.0)
+
     def testSetters(self):
         box = QgsBox3d(5.0, 6.0, 7.0, 10.0, 11.0, 12.0)
 


### PR DESCRIPTION
## Description

We can already export the QgsBox3d to a QgsRectangle, but not the reverse

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit