### PR TITLE
Allow clickable links in message bar text

### DIFF
--- a/python/gui/qgsmessagebaritem.sip
+++ b/python/gui/qgsmessagebaritem.sip
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsMessageBarItem : QWidget
 {
 
@@ -113,7 +114,6 @@ returns the styleSheet
 %Docstring
 emitted when the message level has changed
 %End
-
 
 };
 

--- a/src/gui/qgsmessagebaritem.cpp
+++ b/src/gui/qgsmessagebaritem.cpp
@@ -21,7 +21,8 @@
 
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QTextEdit>
+#include <QTextBrowser>
+#include <QDesktopServices>
 
 QgsMessageBarItem::QgsMessageBarItem( const QString &text, QgsMessageBar::MessageLevel level, int duration, QWidget *parent )
   : QWidget( parent )
@@ -72,7 +73,7 @@ void QgsMessageBarItem::writeContent()
   {
     mLayout = new QHBoxLayout( this );
     mLayout->setContentsMargins( 0, 0, 0, 0 );
-    mTextEdit = nullptr;
+    mTextBrowser = nullptr;
     mLblIcon = nullptr;
   }
 
@@ -111,28 +112,31 @@ void QgsMessageBarItem::writeContent()
   // TITLE AND TEXT
   if ( mTitle.isEmpty() && mText.isEmpty() )
   {
-    if ( mTextEdit )
+    if ( mTextBrowser )
     {
-      delete mTextEdit;
-      mTextEdit = nullptr;
+      delete mTextBrowser;
+      mTextBrowser = nullptr;
     }
   }
   else
   {
-    if ( !mTextEdit )
+    if ( !mTextBrowser )
     {
-      mTextEdit = new QTextEdit( this );
-      mTextEdit->setObjectName( QStringLiteral( "textEdit" ) );
-      mTextEdit->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Maximum );
-      mTextEdit->setReadOnly( true );
-      mTextEdit->setFrameShape( QFrame::NoFrame );
+      mTextBrowser = new QTextBrowser( this );
+      mTextBrowser->setObjectName( QStringLiteral( "textEdit" ) );
+      mTextBrowser->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Maximum );
+      mTextBrowser->setReadOnly( true );
+      mTextBrowser->setOpenLinks( false );
+      connect( mTextBrowser, &QTextBrowser::anchorClicked, this, &QgsMessageBarItem::urlClicked );
+
+      mTextBrowser->setFrameShape( QFrame::NoFrame );
       // stylesheet set here so Qt-style substitued scrollbar arrows can show within limited height
       // adjusts to height of font set in app options
-      mTextEdit->setStyleSheet( "QTextEdit { background-color: rgba(0,0,0,0); margin-top: 0.25em; max-height: 1.75em; min-height: 1.75em; } "
-                                "QScrollBar { background-color: rgba(0,0,0,0); } "
-                                "QScrollBar::add-page,QScrollBar::sub-page,QScrollBar::handle { background-color: rgba(0,0,0,0); color: rgba(0,0,0,0); } "
-                                "QScrollBar::up-arrow,QScrollBar::down-arrow { color: rgb(0,0,0); } " );
-      mLayout->addWidget( mTextEdit );
+      mTextBrowser->setStyleSheet( "QTextEdit { background-color: rgba(0,0,0,0); margin-top: 0.25em; max-height: 1.75em; min-height: 1.75em; } "
+                                   "QScrollBar { background-color: rgba(0,0,0,0); } "
+                                   "QScrollBar::add-page,QScrollBar::sub-page,QScrollBar::handle { background-color: rgba(0,0,0,0); color: rgba(0,0,0,0); } "
+                                   "QScrollBar::up-arrow,QScrollBar::down-arrow { color: rgb(0,0,0); } " );
+      mLayout->addWidget( mTextBrowser );
     }
     QString content = mText;
     if ( !mTitle.isEmpty() )
@@ -143,7 +147,7 @@ void QgsMessageBarItem::writeContent()
         t += QLatin1String( ": " );
       content.prepend( QStringLiteral( "<b>" ) + t + " </b>" );
     }
-    mTextEdit->setText( content );
+    mTextBrowser->setText( content );
   }
 
   // WIDGET
@@ -256,3 +260,7 @@ QgsMessageBarItem *QgsMessageBarItem::setDuration( int duration )
   return this;
 }
 
+void QgsMessageBarItem::urlClicked( const QUrl &url )
+{
+  QDesktopServices::openUrl( url );
+}

--- a/src/gui/qgsmessagebaritem.h
+++ b/src/gui/qgsmessagebaritem.h
@@ -23,9 +23,10 @@
 
 #include <QWidget>
 #include <QIcon>
-#include <QTextEdit>
 #include <QHBoxLayout>
 #include "qgis_gui.h"
+
+class QTextBrowser;
 
 /**
  * \ingroup gui
@@ -94,6 +95,9 @@ class GUI_EXPORT QgsMessageBarItem : public QWidget
     //! emitted when the message level has changed
     void styleChanged( const QString &styleSheet );
 
+  private slots:
+
+    void urlClicked( const QUrl &url );
 
   private:
     void writeContent();
@@ -107,7 +111,7 @@ class GUI_EXPORT QgsMessageBarItem : public QWidget
     QHBoxLayout *mLayout = nullptr;
     QLabel *mLblIcon = nullptr;
     QString mStyleSheet;
-    QTextEdit *mTextEdit = nullptr;
+    QTextBrowser *mTextBrowser = nullptr;
 };
 
 #endif // qgsmessagebaritem_H


### PR DESCRIPTION
Links are opened using QDesktopServices::openUrl, i.e. the default OS handler for that link type

To facilitate this I've swapped the QTextEdit used in the messagebar to the QTextBrowser subclass of QTextEdit, which seems a better choice anyway.