### PR TITLE
Fix parameter name decoding when using POST + urlencoded

### DIFF
--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -228,10 +228,12 @@ void QgsRequestHandler::parseInput()
       typedef QPair<QString, QString> pair_t;
       QUrlQuery query( inputString );
       QList<pair_t> items = query.queryItems();
-      Q_FOREACH ( const pair_t &pair, items )
+      Q_FOREACH ( pair_t pair, items )
       {
-        const QString value = QUrl::fromPercentEncoding( pair.second.toUtf8() );
-        mRequest.setParameter( pair.first.toUpper(), value );
+        // QUrl::fromPercentEncoding doesn't replace '+' with space
+        const QString key = QUrl::fromPercentEncoding( pair.first.replace( '+', ' ' ).toUtf8() );
+        const QString value = QUrl::fromPercentEncoding( pair.second.replace( '+', ' ' ).toUtf8() );
+        mRequest.setParameter( key.toUpper(), value );
       }
       setupParameters();
     }

--- a/tests/src/python/test_qgsserver_wms_getprint.py
+++ b/tests/src/python/test_qgsserver_wms_getprint.py
@@ -33,6 +33,7 @@ import osgeo.gdal  # NOQA
 
 from test_qgsserver import QgsServerTestBase
 from qgis.core import QgsProject
+from qgis.server import QgsServerRequest
 
 # Strip path and content length because path may vary
 RE_STRIP_UNCHECKABLE = b'MAP=[^"]+|Content-Length: \d+'
@@ -302,7 +303,7 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
             "REQUEST": "GetPrint",
             "TEMPLATE": "layoutA4",
             "FORMAT": "png",
-            "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
+            "map0%3AEXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
             "CRS": "EPSG:3857",
             "SELECTION": "Country: 4",
@@ -313,14 +314,15 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetPrint_Opacity")
 
-        qs = "?" + "&".join(["%s=%s" % i for i in list({
+    def test_wms_getprint_opacity_post(self):
+        qs = "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),
             "SERVICE": "WMS",
             "VERSION": "1.1.1",
             "REQUEST": "GetPrint",
             "TEMPLATE": "layoutA4",
             "FORMAT": "png",
-            "map0:EXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
+            "map0%3AEXTENT": "-33626185.498,-13032965.185,33978427.737,16020257.031",
             "map0:LAYERS": "Country,Hello",
             "CRS": "EPSG:3857",
             "SELECTION": "Country: 4",
@@ -328,7 +330,7 @@ class TestQgsServerWMSGetPrint(QgsServerTestBase):
             "OPACITIES": "125%2C125"
         }.items())])
 
-        r, h = self._result(self._execute_request(qs))
+        r, h = self._result(self._execute_request('', QgsServerRequest.PostMethod, data=qs.encode('utf-8')))
         self._img_diff_error(r, h, "WMS_GetPrint_Opacity")
 
     def test_wms_getprint_highlight(self):


### PR DESCRIPTION
## Description
This is a followup of dfe48d13c85cbae559a7a09a1bd62140cf11848b which solved the issue for parameter values.

Fix https://issues.qgis.org/issues/17694

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
