### PR TITLE
add missing metadata fields about contacts and extent

### DIFF
--- a/src/gui/qgsmetadatawidget.h
+++ b/src/gui/qgsmetadatawidget.h
@@ -101,13 +101,13 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
     void removeSelectedRight() const;
     void addConstraint() const;
     void removeSelectedConstraint() const;
-    void addContact() const;
-    void removeSelectedContact() const;
+    void toggleExtentSelector() const;
+    void addAddress() const;
+    void removeSelectedAddress() const;
     void addLink() const;
     void removeSelectedLink() const;
     void addHistory();
     void removeSelectedHistory() const;
-    void updateContactDetails() const;
     void fillComboBox() const;
     void setPropertiesFromLayer() const;
     void syncFromCategoriesTabToKeywordsTab() const;

--- a/src/ui/qgsmetadatawidget.ui
+++ b/src/ui/qgsmetadatawidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>797</width>
-    <height>568</height>
+    <width>804</width>
+    <height>697</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -35,7 +35,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="tabIdentificationDialog">
       <attribute name="title">
@@ -67,8 +67,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>777</width>
-            <height>596</height>
+            <width>798</width>
+            <height>668</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_15">
@@ -222,7 +222,7 @@
            <item>
             <widget class="QFrame" name="encodingFrame">
              <property name="enabled">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -571,8 +571,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>767</width>
-            <height>521</height>
+            <width>798</width>
+            <height>668</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -802,7 +802,7 @@
        <item>
         <widget class="QLabel" name="label_9">
          <property name="text">
-          <string>Coordinate Reference System, spatial and temporal extent(s) for this dataset.</string>
+          <string>Coordinate Reference System and spatial extent for this dataset.</string>
          </property>
         </widget>
        </item>
@@ -839,6 +839,76 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsExtentGroupBox" name="spatialExtentSelector">
+         <property name="title">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_14">
+         <item>
+          <widget class="QLabel" name="label_32">
+           <property name="text">
+            <string>Z Maximum</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsSpinBox" name="spinBoxZMaximum"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_13">
+         <item>
+          <widget class="QLabel" name="label_31">
+           <property name="text">
+            <string>Z Minimum</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsSpinBox" name="spinBoxZMinimum"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_35">
+         <property name="text">
+          <string>Temporal extent for this dataset.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
+         <item>
+          <widget class="QLabel" name="label_33">
+           <property name="text">
+            <string>From</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsDateTimeEdit" name="dateTimeFrom"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <item>
+          <widget class="QLabel" name="label_34">
+           <property name="text">
+            <string>To</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsDateTimeEdit" name="dateTimeTo"/>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -854,93 +924,19 @@
       </layout>
      </widget>
      <widget class="QWidget" name="tabContactsDialog">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
       <attribute name="title">
-       <string>Contacts</string>
+       <string>Contact</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_10">
        <item>
         <widget class="QLabel" name="label_16">
          <property name="text">
-          <string>Contacts, HELP TEXT</string>
+          <string>Contact describe the owner of the dataset.</string>
          </property>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
-         <item>
-          <spacer name="horizontalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="btnAddContact">
-           <property name="toolTip">
-            <string>Add class</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="btnRemoveContact">
-           <property name="toolTip">
-            <string>Delete</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QTableWidget" name="tabContacts">
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="editTriggers">
-            <set>QAbstractItemView::NoEditTriggers</set>
-           </property>
-           <property name="selectionMode">
-            <enum>QAbstractItemView::SingleSelection</enum>
-           </property>
-           <property name="selectionBehavior">
-            <enum>QAbstractItemView::SelectRows</enum>
-           </property>
-           <attribute name="horizontalHeaderStretchLastSection">
-            <bool>true</bool>
-           </attribute>
-           <column>
-            <property name="text">
-             <string>Name</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Organization</string>
-            </property>
-           </column>
-          </widget>
-         </item>
          <item>
           <widget class="QScrollArea" name="panelDetails">
            <property name="sizePolicy">
@@ -957,80 +953,142 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>513</width>
-              <height>419</height>
+              <width>754</width>
+              <height>608</height>
              </rect>
             </property>
             <layout class="QGridLayout" name="gridLayout_2">
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_10">
-               <property name="text">
-                <string>Name</string>
+             <item row="3" column="2" colspan="2">
+              <widget class="QLineEdit" name="lineEditContactPosition">
+               <property name="toolTip">
+                <string>Position/title of contact</string>
                </property>
               </widget>
              </item>
-             <item row="0" column="1" colspan="2">
-              <widget class="QLineEdit" name="lineEditContactName"/>
+             <item row="0" column="2" colspan="2">
+              <widget class="QLineEdit" name="lineEditContactName">
+               <property name="toolTip">
+                <string>Name of contact</string>
+               </property>
+              </widget>
              </item>
              <item row="1" column="0">
               <widget class="QLabel" name="label_15">
+               <property name="toolTip">
+                <string>Role of contact</string>
+               </property>
                <property name="text">
                 <string>Role</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="1" colspan="2">
-              <widget class="QComboBox" name="comboContactRole"/>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_12">
-               <property name="text">
-                <string>Organization</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1" colspan="2">
-              <widget class="QLineEdit" name="lineEditContactOrganization"/>
-             </item>
              <item row="3" column="0">
               <widget class="QLabel" name="label_14">
+               <property name="toolTip">
+                <string>Position/title of contact</string>
+               </property>
                <property name="text">
                 <string>Position</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="1" colspan="2">
-              <widget class="QLineEdit" name="lineEditContactPosition"/>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="label_18">
-               <property name="text">
-                <string>Email</string>
+             <item row="2" column="2" colspan="2">
+              <widget class="QLineEdit" name="lineEditContactOrganization">
+               <property name="toolTip">
+                <string>Organization contact belongs to/represents</string>
                </property>
               </widget>
              </item>
-             <item row="4" column="1" colspan="2">
-              <widget class="QLineEdit" name="lineEditContactEmail"/>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="label_19">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_10">
+               <property name="toolTip">
+                <string>Name of contact</string>
+               </property>
                <property name="text">
-                <string>Voice</string>
+                <string>Name</string>
                </property>
               </widget>
              </item>
-             <item row="5" column="1" colspan="2">
-              <widget class="QLineEdit" name="lineEditContactVoice"/>
+             <item row="5" column="2" colspan="2">
+              <widget class="QLineEdit" name="lineEditContactVoice">
+               <property name="toolTip">
+                <string>Phone number</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="2" colspan="2">
+              <widget class="QLineEdit" name="lineEditContactFax">
+               <property name="toolTip">
+                <string>Fax number</string>
+               </property>
+              </widget>
              </item>
              <item row="6" column="0">
               <widget class="QLabel" name="label_20">
+               <property name="toolTip">
+                <string>Fax number</string>
+               </property>
                <property name="text">
                 <string>Fax</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="1" colspan="2">
-              <widget class="QLineEdit" name="lineEditContactFax"/>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="toolTip">
+                <string>Organization contact belongs to/represents</string>
+               </property>
+               <property name="text">
+                <string>Organization</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2" colspan="2">
+              <widget class="QComboBox" name="comboContactRole">
+               <property name="toolTip">
+                <string>Role of contact</string>
+               </property>
+               <property name="editable">
+                <bool>true</bool>
+               </property>
+               <item>
+                <property name="text">
+                 <string/>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>custodian</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>distributor</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>owner</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="4" column="2" colspan="2">
+              <widget class="QLineEdit" name="lineEditContactEmail">
+               <property name="toolTip">
+                <string>Electronic mail address</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="label_19">
+               <property name="toolTip">
+                <string>Phone number</string>
+               </property>
+               <property name="text">
+                <string>Voice</string>
+               </property>
+              </widget>
              </item>
              <item row="7" column="0">
               <widget class="QLabel" name="label_21">
@@ -1039,30 +1097,14 @@
                </property>
               </widget>
              </item>
-             <item row="7" column="1">
-              <widget class="QPushButton" name="btnAddAddress">
-               <property name="toolTip">
-                <string>Add class</string>
-               </property>
-               <property name="icon">
-                <iconset resource="../../images/images.qrc">
-                 <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="2">
-              <widget class="QPushButton" name="btnRemoveAddress">
-               <property name="toolTip">
-                <string>Delete</string>
-               </property>
-               <property name="icon">
-                <iconset resource="../../images/images.qrc">
-                 <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="0" colspan="3">
+             <item row="8" column="0" colspan="4">
               <widget class="QTableWidget" name="tabAddresses">
+               <property name="selectionMode">
+                <enum>QAbstractItemView::SingleSelection</enum>
+               </property>
+               <property name="selectionBehavior">
+                <enum>QAbstractItemView::SelectRows</enum>
+               </property>
                <attribute name="horizontalHeaderStretchLastSection">
                 <bool>true</bool>
                </attribute>
@@ -1070,33 +1112,87 @@
                 <property name="text">
                  <string>Type</string>
                 </property>
+                <property name="toolTip">
+                 <string>Type of address, e.g 'postal'</string>
+                </property>
                </column>
                <column>
                 <property name="text">
                  <string>Address</string>
+                </property>
+                <property name="toolTip">
+                 <string>Free-form physical address component</string>
                 </property>
                </column>
                <column>
                 <property name="text">
                  <string>Postal Code</string>
                 </property>
+                <property name="toolTip">
+                 <string>Postal (or ZIP) code</string>
+                </property>
                </column>
                <column>
                 <property name="text">
                  <string>City</string>
+                </property>
+                <property name="toolTip">
+                 <string>City or locality name</string>
                 </property>
                </column>
                <column>
                 <property name="text">
                  <string>Administrative Area</string>
                 </property>
+                <property name="toolTip">
+                 <string>Administrative area (state, provice/territory, etc.)</string>
+                </property>
                </column>
                <column>
                 <property name="text">
                  <string>Country</string>
                 </property>
+                <property name="toolTip">
+                 <string>Free-form country</string>
+                </property>
                </column>
               </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="label_18">
+               <property name="toolTip">
+                <string>Electronic mail address</string>
+               </property>
+               <property name="text">
+                <string>Email</string>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="3">
+              <layout class="QHBoxLayout" name="horizontalLayout_10">
+               <item>
+                <widget class="QPushButton" name="btnAddAddress">
+                 <property name="toolTip">
+                  <string>Add address</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="../../images/images.qrc">
+                   <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="btnRemoveAddress">
+                 <property name="toolTip">
+                  <string>Remove Address</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="../../images/images.qrc">
+                   <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
            </widget>
@@ -1279,6 +1375,22 @@
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsExtentGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgsextentgroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
## Description

Some fields were missing in the metadata editor such as contact, spatial and temporal extents.

According to a discussion on Gitter between @timlinux @tomkralidis and I, it seems we will support only one extent (with only one CRS) in the QGIS internal metadata schema. The API should be updated so if it's confirmed by @tomkralidis @kalxas 
https://gitter.im/qgis/metadata?at=5a318548cc1d527f6b2a4ff1

The only limitation I've set in this PR is one contact is displayed/edited.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit