### PR TITLE
[bugfix]  Fixes auto select foreign key when filters are updated in QgsRelationReferenceWidget

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -941,6 +941,18 @@ void QgsRelationReferenceWidget::filterChanged()
   }
 
   mFilterModel->setFilteredFeatures( featureIds );
+
+  if ( mChainFilters && mComboBox->count() > 0 )
+  {
+    if ( scb->currentIndex() == 0 )
+    {
+      mComboBox->setCurrentIndex( 0 );
+    }
+    else if ( mComboBox->count() > 1 )
+    {
+      mComboBox->setCurrentIndex( 1 );
+    }
+  }
 }
 
 void QgsRelationReferenceWidget::addEntry()

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -174,8 +174,20 @@ void TestQgsRelationReferenceWidget::testChainFilter()
 
   // set the filter for "raccord" and then reset filter for "diameter". As
   // chain filter is activated, the filter on "raccord" field should be reset
+  cbs[0]->setCurrentIndex( 0 );
+  QCOMPARE( w.mComboBox->currentIndex(), 0 );
+
+  cbs[0]->setCurrentIndex( cbs[0]->findText( "iron" ) );
+  QCOMPARE( w.mComboBox->currentIndex(), 1 );
+
+  cbs[1]->setCurrentIndex( cbs[1]->findText( "120" ) );
+  QCOMPARE( w.mComboBox->currentIndex(), 1 );
+
   cbs[2]->setCurrentIndex( cbs[2]->findText( "brides" ) );
+  QCOMPARE( w.mComboBox->currentIndex(), 1 );
+
   cbs[1]->setCurrentIndex( cbs[1]->findText( "diameter" ) );
+  QCOMPARE( w.mComboBox->currentIndex(), 0 );
 
   // combobox should propose NULL, 10 and 11 because the filter is now:
   // "material" == 'iron'


### PR DESCRIPTION
## Description

When a filtering combobox is updated, the first valid foreign key should be selected when the option `Chain filters` is activated.

Some tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
