### PR TITLE
[3d] Respect no-data values from DEMs in terrain generator (fixes #17558)

### DIFF
--- a/src/3d/chunks/qgschunknode_p.cpp
+++ b/src/3d/chunks/qgschunknode_p.cpp
@@ -60,7 +60,7 @@ bool QgsChunkNode::allChildChunksResident( const QTime &currentTime ) const
   {
     if ( !mChildren[i] )
       return false;  // not even a skeleton
-    if ( !mChildren[i]->mEntity )
+    if ( mChildren[i]->mHasData && !mChildren[i]->mEntity )
       return false;  // no there yet
     Q_UNUSED( currentTime ); // seems we do not need this extra time (it just brings extra problems)
     //if (children[i]->entityCreatedTime.msecsTo(currentTime) < 100)

--- a/src/3d/chunks/qgschunknode_p.h
+++ b/src/3d/chunks/qgschunknode_p.h
@@ -172,6 +172,11 @@ class QgsChunkNode
     //! called when bounding box
     void setExactBbox( const QgsAABB &box );
 
+    //! Sets whether the node has any data to be displayed. Can be used to set to false after load returned no data
+    void setHasData( bool hasData ) { mHasData = hasData; }
+    //! Returns whether the node has any data to be displayed. If not, it will be kept as a skeleton node and will not get loaded anymore
+    bool hasData() const { return mHasData; }
+
   private:
     QgsAABB mBbox;      //!< Bounding box in world coordinates
     float mError;    //!< Error of the node in world coordinates
@@ -193,6 +198,7 @@ class QgsChunkNode
     QgsChunkQueueJob *mUpdater;                //!< Object that does update of the chunk (not null <=> Updating state)
 
     QTime mEntityCreatedTime;
+    bool mHasData = true;   //!< Whether there are (will be) any data in this node (or any descentants) and so whether it makes sense to load this node
 };
 
 /// @endcond


### PR DESCRIPTION
No-data values from rasters are now interpreted correctly: in terrain tiles the quads where at least one corner has no-data value will be skipped (forming two collapsed triangles).

Tiles with no input height data will not be split further as that supposedly would not generate any data.