### PR TITLE
Fix drag and drop for qgz files. List in browser

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5962,7 +5962,7 @@ void QgisApp::openFile( const QString &fileName )
 {
   // check to see if we are opening a project file
   QFileInfo fi( fileName );
-  if ( fi.completeSuffix() == QLatin1String( "qgs" ) )
+  if ( fi.completeSuffix() == QLatin1String( "qgs" ) || fi.completeSuffix() == QLatin1String( "qgz" ) )
   {
     QgsDebugMsg( "Opening project " + fileName );
     openProject( fileName );

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -795,7 +795,7 @@ QVector<QgsDataItem *> QgsDirectoryItem::createChildren()
     QString path = dir.absoluteFilePath( name );
     QFileInfo fileInfo( path );
 
-    if ( fileInfo.suffix() == QLatin1String( "qgs" ) )
+    if ( fileInfo.suffix() == QLatin1String( "qgs" ) || fileInfo.suffix() == QLatin1String( "qgz" ) )
     {
       QgsDataItem *item = new QgsProjectItem( this, fileInfo.baseName(), path );
       children.append( item );


### PR DESCRIPTION
## Description
Fixes drag and drop for qgz files and lists them in the browser panel.  At the moment they use the same icon as normal projects.

![image](https://user-images.githubusercontent.com/381660/34085807-19ff0bdc-e3e1-11e7-8d85-b566dc5cf5c9.png)

