### PR TITLE
fix unknown mQgis variable on macos

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -1484,7 +1484,7 @@ void QgsLayoutDesignerDialog::exportToRaster()
 #endif
 
 #ifdef Q_OS_MAC
-  mQgis->activateWindow();
+  QgisApp::instance()->activateWindow();
   this->raise();
 #endif
   QPair<QString, QString> fileNExt = QgsGuiUtils::getSaveAsImageName( this, tr( "Save layout as" ), outputFileName );
@@ -1600,7 +1600,7 @@ void QgsLayoutDesignerDialog::exportToPdf()
 #endif
 
 #ifdef Q_OS_MAC
-  mQgis->activateWindow();
+  QgisApp::instance()->activateWindow();
   this->raise();
 #endif
   outputFileName = QFileDialog::getSaveFileName(


### PR DESCRIPTION
## Description

The build on MacOS is broken. I'm only fixing the build. I hope it's the correct behavior.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
