### PR TITLE
 NULL value absorbs others in some functions

### DIFF
--- a/resources/function_help/json/max
+++ b/resources/function_help/json/max
@@ -1,12 +1,13 @@
 {
   "name": "max",
   "type": "function",
-  "description": "Returns the largest value in a set of values.",
+  "description": "Returns the largest value in a set of values. If an input value is NULL then the result will be NULL.",
   "variableLenArguments": true,
   "arguments": [
 	{"arg":"value1", "syntaxOnly": true},
 	{"arg":"value2", "syntaxOnly": true},
 	{"arg":"value", "descOnly": true, "description":"a number"}],
-  "examples": [ { "expression":"max(2,10.2,5.5)", "returns":"10.2"}
+  "examples": [ { "expression":"max(2, 10.2, 5.5)", "returns":"10.2"},
+  "examples": [ { "expression":"max(2, 10.2, NULL)", "returns":"NULL"}
   ]
 }

--- a/resources/function_help/json/max
+++ b/resources/function_help/json/max
@@ -8,6 +8,6 @@
 	{"arg":"value2", "syntaxOnly": true},
 	{"arg":"value", "descOnly": true, "description":"a number"}],
   "examples": [ { "expression":"max(2, 10.2, 5.5)", "returns":"10.2"},
-  "examples": [ { "expression":"max(2, 10.2, NULL)", "returns":"NULL"}
+                { "expression":"max(2, 10.2, NULL)", "returns":"NULL"}
   ]
 }

--- a/resources/function_help/json/min
+++ b/resources/function_help/json/min
@@ -1,11 +1,12 @@
 {
   "name": "min",
   "type": "function",
-  "description": "Returns the smallest value in a set of values.",
+  "description": "Returns the smallest value in a set of values. If an input value is NULL then the result will be NULL.",
   "variableLenArguments": true,
   "arguments": [ {"arg":"value1", "syntaxOnly": true},
                  {"arg":"value2", "syntaxOnly": true},
                  {"arg":"value", "descOnly": true, "description":"a number"}],
-  "examples": [ { "expression":"min(20.5,10,6.2)", "returns":"6.2"}
+  "examples": [ { "expression":"min(20.5, 10, 6.2)", "returns":"6.2"},
+                { "expression":"min(20.5, NULL, 6.2)", "returns":"NULL"}
   ]
 }


### PR DESCRIPTION
Because we sometimes forget that _NULL_ value can make function behave "weirdly", it could be nice to document this behavior
backport to 2.18?