### PR TITLE
Improve CRS management in extent panel

### DIFF
--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -50,6 +50,9 @@ using QgsNativeMetadataValidator.
       QgsCoordinateReferenceSystem extentCrs;
 %Docstring
 Coordinate reference system for spatial extent.
+The CRS should match the CRS defined in the QgsLayerMetadata CRS property.
+
+.. seealso:: :py:func:`QgsLayerMetadata.crs()`
 
 .. seealso:: :py:func:`spatial`
 %End
@@ -505,6 +508,11 @@ CRS which is actually used to display and manipulate the layer within QGIS.
 This may be the case when a layer has an incorrect CRS within its metadata
 and a user has manually overridden the layer's CRS within QGIS.
 
+The CRS described here should either match the CRS from the layer QgsMapLayer.crs()
+or the CRS from the data provider.
+
+This property should also match the CRS property used in the spatial extent.
+
 .. seealso:: :py:func:`setCrs()`
 %End
 
@@ -522,6 +530,11 @@ with a different CRS described by it's accompanying metadata versus the
 CRS which is actually used to display and manipulate the layer within QGIS.
 This may be the case when a layer has an incorrect CRS within its metadata
 and a user has manually overridden the layer's CRS within QGIS.
+
+The CRS described here should either match the CRS from the layer QgsMapLayer.crs()
+or the CRS from the data provider.
+
+This property should also match the CRS property used in the spatial extent.
 
 .. seealso:: :py:func:`crs()`
 %End

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -69,6 +69,8 @@ class CORE_EXPORT QgsLayerMetadata
 
       /**
        * Coordinate reference system for spatial extent.
+       * The CRS should match the CRS defined in the QgsLayerMetadata CRS property.
+       * \see QgsLayerMetadata::crs()
        * \see spatial
        */
       QgsCoordinateReferenceSystem extentCrs;
@@ -535,6 +537,12 @@ class CORE_EXPORT QgsLayerMetadata
      * CRS which is actually used to display and manipulate the layer within QGIS.
      * This may be the case when a layer has an incorrect CRS within its metadata
      * and a user has manually overridden the layer's CRS within QGIS.
+     *
+     * The CRS described here should either match the CRS from the layer QgsMapLayer::crs()
+     * or the CRS from the data provider.
+     *
+     * This property should also match the CRS property used in the spatial extent.
+     *
      * \see setCrs()
      */
     QgsCoordinateReferenceSystem crs() const;
@@ -552,6 +560,12 @@ class CORE_EXPORT QgsLayerMetadata
      * CRS which is actually used to display and manipulate the layer within QGIS.
      * This may be the case when a layer has an incorrect CRS within its metadata
      * and a user has manually overridden the layer's CRS within QGIS.
+     *
+     * The CRS described here should either match the CRS from the layer QgsMapLayer::crs()
+     * or the CRS from the data provider.
+     *
+     * This property should also match the CRS property used in the spatial extent.
+     *
      * \see crs()
      */
     void setCrs( const QgsCoordinateReferenceSystem &crs );

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -66,7 +66,6 @@ QgsMetadataWidget::QgsMetadataWidget( QWidget *parent, QgsMapLayer *layer )
   tabConstraints->setItemDelegate( new ConstraintItemDelegate( this ) );
 
   // Extent
-  selectionCrs->setOptionVisible( QgsProjectionSelectionWidget::CrsNotSet, true );
   dateTimeFrom->setAllowNull( true );
   dateTimeTo->setAllowNull( true );
 
@@ -94,8 +93,8 @@ QgsMetadataWidget::QgsMetadataWidget( QWidget *parent, QgsMapLayer *layer )
   connect( btnRemoveLicence, &QPushButton::clicked, this, &QgsMetadataWidget::removeSelectedLicence );
   connect( btnAddConstraint, &QPushButton::clicked, this, &QgsMetadataWidget::addConstraint );
   connect( btnRemoveConstraint, &QPushButton::clicked, this, &QgsMetadataWidget::removeSelectedConstraint );
-  connect( btnAutoCrs, &QPushButton::clicked, this, &QgsMetadataWidget::fillCrsFromLayer );
-  connect( selectionCrs, &QgsProjectionSelectionWidget::crsChanged, this, &QgsMetadataWidget::toggleExtentSelector );
+  connect( btnSetCrsFromLayer, &QPushButton::clicked, this, &QgsMetadataWidget::fillCrsFromLayer );
+  connect( btnSetCrsFromProvider, &QPushButton::clicked, this, &QgsMetadataWidget::fillCrsFromProvider );
   connect( btnAddAddress, &QPushButton::clicked, this, &QgsMetadataWidget::addAddress );
   connect( btnRemoveAddress, &QPushButton::clicked, this, &QgsMetadataWidget::removeSelectedAddress );
   connect( btnAddLink, &QPushButton::clicked, this, &QgsMetadataWidget::addLink );
@@ -202,8 +201,33 @@ void QgsMetadataWidget::removeSelectedConstraint() const
 
 void QgsMetadataWidget::toggleExtentSelector() const
 {
-  spatialExtentSelector->setEnabled( selectionCrs->crs().isValid() );
-  spatialExtentSelector->setOutputCrs( selectionCrs->crs() );
+  if ( mCrs->isValid() )
+  {
+    lblCurrentCrs->setText( tr( "CRS: %1 - %2" ).arg( mCrs->authid(), mCrs->description() ) );
+    spatialExtentSelector->setEnabled( true );
+    spatialExtentSelector->setOutputCrs( *mCrs );
+  }
+  else
+  {
+    lblCurrentCrs->setText( tr( "CRS: Not set." ).arg( mCrs->authid(), mCrs->description() ) );
+    spatialExtentSelector->setEnabled( false );
+  }
+  if ( *mCrs == mLayer->crs() && mCrs == mLayer->dataProvider()->crs() )
+  {
+    lblCurrentCrsStatus->setText( tr( "Same as layer properties and provider." ) );
+  }
+  else if ( *mCrs == mLayer->crs() && mCrs != mLayer->dataProvider()->crs() )
+  {
+    lblCurrentCrsStatus->setText( tr( "Same as layer properties but different than the provider." ) );
+  }
+  else if ( *mCrs != mLayer->crs() && mCrs == mLayer->dataProvider()->crs() )
+  {
+    lblCurrentCrsStatus->setText( tr( "Same as the provider but different than the layer properties." ) );
+  }
+  else
+  {
+    lblCurrentCrsStatus->setText( tr( "Does not match either layer properties or the provider." ) );
+  }
 }
 
 void QgsMetadataWidget::addAddress() const
@@ -242,9 +266,16 @@ void QgsMetadataWidget::removeSelectedAddress() const
   }
 }
 
-void QgsMetadataWidget::fillCrsFromLayer() const
+void QgsMetadataWidget::fillCrsFromLayer()
 {
-  selectionCrs->setCrs( mLayer->crs() );
+  mCrs = new QgsCoordinateReferenceSystem( mLayer->crs() );
+  toggleExtentSelector();
+}
+
+void QgsMetadataWidget::fillCrsFromProvider()
+{
+  mCrs = new QgsCoordinateReferenceSystem( mLayer->dataProvider()->crs() );
+  toggleExtentSelector();
 }
 
 void QgsMetadataWidget::addLink() const
@@ -322,7 +353,7 @@ void QgsMetadataWidget::fillComboBox() const
   }
 }
 
-void QgsMetadataWidget::setPropertiesFromLayer() const
+void QgsMetadataWidget::setPropertiesFromLayer()
 {
   // Parent ID
   lineEditParentId->setText( mMetadata.parentIdentifier() );
@@ -409,11 +440,9 @@ void QgsMetadataWidget::setPropertiesFromLayer() const
   }
 
   // CRS
+  mCrs = new QgsCoordinateReferenceSystem( mMetadata.crs() );
   if ( mMetadata.crs().isValid() )
-  {
-    selectionCrs->setCrs( mMetadata.crs() );
-  }
-  toggleExtentSelector();
+    toggleExtentSelector();
 
   // Spatial extent
   const QList<QgsLayerMetadata::SpatialExtent> &spatialExtents = mMetadata.extent().spatialExtents();
@@ -534,7 +563,10 @@ void QgsMetadataWidget::saveMetadata( QgsLayerMetadata &layerMetadata ) const
   layerMetadata.setConstraints( constraints );
 
   // CRS
-  layerMetadata.setCrs( selectionCrs->crs() );
+  if ( mCrs->isValid() )
+  {
+    layerMetadata.setCrs( *mCrs );
+  }
 
   // Extent
   struct QgsLayerMetadata::SpatialExtent spatialExtent = QgsLayerMetadata::SpatialExtent();

--- a/src/gui/qgsmetadatawidget.h
+++ b/src/gui/qgsmetadatawidget.h
@@ -21,6 +21,7 @@
 #include "QStyledItemDelegate"
 
 #include "qgis_gui.h"
+#include "qgscoordinatereferencesystem.h"
 #include "qgsmaplayer.h"
 #include "qgslayermetadata.h"
 #include "ui_qgsmetadatawidget.h"
@@ -89,7 +90,8 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
   private:
     void updatePanel() const;
     void fillSourceFromLayer() const;
-    void fillCrsFromLayer() const;
+    void fillCrsFromLayer();
+    void fillCrsFromProvider();
     void addDefaultCategory() const;
     void addNewCategory();
     void removeSelectedCategory() const;
@@ -109,10 +111,11 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
     void addHistory();
     void removeSelectedHistory() const;
     void fillComboBox() const;
-    void setPropertiesFromLayer() const;
+    void setPropertiesFromLayer();
     void syncFromCategoriesTabToKeywordsTab() const;
     QStringList mDefaultCategories;
     QgsMapLayer *mLayer = nullptr;
+    QgsCoordinateReferenceSystem *mCrs = nullptr;
     QgsLayerMetadata mMetadata;
     QStandardItemModel *mConstraintsModel = nullptr;
     QStandardItemModel *mLinksModel = nullptr;

--- a/src/ui/qgsmetadatawidget.ui
+++ b/src/ui/qgsmetadatawidget.ui
@@ -818,10 +818,14 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
-             <widget class="QgsProjectionSelectionWidget" name="selectionCrs" native="true"/>
+             <widget class="QLabel" name="lblCurrentCrs">
+              <property name="text">
+               <string notr="true">CRS label set in cpp code</string>
+              </property>
+             </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="btnAutoCrs">
+             <widget class="QPushButton" name="btnSetCrsFromLayer">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -833,7 +837,27 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QPushButton" name="btnSetCrsFromProvider">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Set CRS from provider</string>
+              </property>
+             </widget>
+            </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblCurrentCrsStatus">
+            <property name="text">
+             <string notr="true">CRS status set in cpp code</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -1368,12 +1392,6 @@
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
## Description

Ok, sorry this not ready. It's not compiling but I can't fix this issue:

```
/Users/etienne/dev/cpp/QGIS/src/gui/qgsmetadatawidget.cpp:278:65: error: member access into incomplete type 'QgsDataProvider'
  mCrs = new QgsCoordinateReferenceSystem(mLayer->dataProvider()->crs());
                                                                ^
/Users/etienne/dev/cpp/QGIS/src/core/qgsmaplayer.h:40:7: note: forward declaration of 'QgsDataProvider'
class QgsDataProvider;
      ^
```

So I'm coming to ask some help.
I tried some forward declaration but without any success. I was looking for some similar line of codes. Any hint?

I will explain this PR when it's at least compiling ;-)
Thanks

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit