### PR TITLE
[ogr] Fix ExactIntersection flag should be ignored if filter rect is not set

### DIFF
--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -363,7 +363,7 @@ bool QgsOgrFeatureIterator::readFeature( gdal::ogr_feature_unique_ptr fet, QgsFe
   feature.initAttributes( mSource->mFields.count() );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups
 
-  bool useIntersect = mRequest.flags() & QgsFeatureRequest::ExactIntersect;
+  bool useIntersect = !mRequest.filterRect().isNull() && mRequest.flags() & QgsFeatureRequest::ExactIntersect;
   bool geometryTypeFilter = mSource->mOgrGeometryTypeFilter != wkbUnknown;
   if ( mFetchGeometry || useIntersect || geometryTypeFilter )
   {

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -485,6 +485,14 @@ class FeatureSourceTestCase(object):
         assert set(features) == set([1, 2, 3, 4, 5]), 'Got {} instead'.format(features)
         self.assertTrue(all_valid)
 
+        # ExactIntersection flag set, but no filter rect set. Should be ignored.
+        request = QgsFeatureRequest()
+        request.setFlags(QgsFeatureRequest.ExactIntersect)
+        features = [f['pk'] for f in self.source.getFeatures(request)]
+        all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
+        assert set(features) == set([1, 2, 3, 4, 5]), 'Got {} instead'.format(features)
+        self.assertTrue(all_valid)
+
     def testRectAndExpression(self):
         extent = QgsRectangle(-70, 67, -60, 80)
         request = QgsFeatureRequest().setFilterExpression('"cnt">200').setFilterRect(extent)


### PR DESCRIPTION
Otherwise iterator churns through every feature in the layer and eventually returns none

And add provider test case to ensure no other providers have this issue
