### PR TITLE
Crs

### DIFF
--- a/python/core/qgscoordinatereferencesystem.sip
+++ b/python/core/qgscoordinatereferencesystem.sip
@@ -514,6 +514,7 @@ Returns opposite bool value to operator ==
     bool readXml( const QDomNode &node );
 %Docstring
 Restores state from the given DOM node.
+If it fails or if the node is empty, a default not empty CRS will be returned.
 
 :param node: The node from which state will be restored
 

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -366,7 +366,8 @@ bool QgsLayerMetadata::readMetadataXml( const QDomElement &metadataElement )
 
   // crs
   mnl = metadataElement.namedItem( QStringLiteral( "crs" ) );
-  mCrs.readXml( mnl );
+  if ( !mCrs.readXml( mnl ) )
+    mCrs = QgsCoordinateReferenceSystem();
 
   // extent
   mnl = metadataElement.namedItem( QStringLiteral( "extent" ) );

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -466,6 +466,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Restores state from the given DOM node.
+     * If it fails or if the node is empty, a default not empty CRS will be returned.
      * \param node The node from which state will be restored
      * \returns bool True on success, False on failure
      */

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4032,12 +4032,16 @@ QString QgsVectorLayer::htmlMetadata() const
   }
 
   // EPSG
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" ) + crs().authid() + QStringLiteral( " - " );
-  myMetadata += crs().description() + QStringLiteral( " - " );
-  if ( crs().isGeographic() )
-    myMetadata += tr( "Geographic" );
-  else
-    myMetadata += tr( "Projected" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" );
+  if ( crs().isValid() )
+  {
+    myMetadata += crs().authid() + QStringLiteral( " - " );
+    myMetadata += crs().description() + QStringLiteral( " - " );
+    if ( crs().isGeographic() )
+      myMetadata += tr( "Geographic" );
+    else
+      myMetadata += tr( "Projected" );
+  }
   myMetadata += QLatin1String( "</td></tr>\n" );
 
   // Extent

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -324,12 +324,16 @@ QString QgsRasterLayer::htmlMetadata() const
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Provider" ) + QStringLiteral( "</td><td>" ) + providerType() + QStringLiteral( "</td></tr>\n" );
 
   // EPSG
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" ) + crs().authid() + QStringLiteral( " - " );
-  myMetadata += crs().description() + QStringLiteral( " - " );
-  if ( crs().isGeographic() )
-    myMetadata += tr( "Geographic" );
-  else
-    myMetadata += tr( "Projected" );
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" );
+  if ( crs().isValid() )
+  {
+    myMetadata += crs().authid() + QStringLiteral( " - " );
+    myMetadata += crs().description() + QStringLiteral( " - " );
+    if ( crs().isGeographic() )
+      myMetadata += tr( "Geographic" );
+    else
+      myMetadata += tr( "Projected" );
+  }
   myMetadata += QLatin1String( "</td></tr>\n" );
 
   // Extent


### PR DESCRIPTION
## Description

* Fixing HTML display if the CRS is invalid
* Fixing reading CRS from XML. I just discovered that it will return a default geographic CRS even if the XML is containing an empty CRS definition. Not logical IMHO. Fix #17455

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit