### PR TITLE
[layouts] avoid adding too much bleeding pixels for page items

### DIFF
--- a/src/core/layout/qgslayoutitempage.cpp
+++ b/src/core/layout/qgslayoutitempage.cpp
@@ -228,7 +228,10 @@ void QgsLayoutItemPage::draw( QgsRenderContext &context, const QStyleOptionGraph
   //Now subtract 1 pixel to prevent semi-transparent borders at edge of solid page caused by
   //anti-aliased painting. This may cause a pixel to be cropped from certain edge lines/symbols,
   //but that can be counteracted by adding a dummy transparent line symbol layer with a wider line width
-  maxBleedPixels = std::floor( maxBleedPixels - 2 );
+  if ( !mLayout->context().isPreviewRender() || !qgsDoubleNear( maxBleedPixels, 0.0 ) )
+  {
+    maxBleedPixels = std::floor( maxBleedPixels - 2 );
+  }
 
   // round up
   QPolygonF pagePolygon = QPolygonF( QRectF( maxBleedPixels, maxBleedPixels,


### PR DESCRIPTION
## Description
@nyalldawson , as per our chat discussion, this improves the layout page item rendering when previewed in the layout window/.

Current (top) vs. PR (bottom):
![screenshot from 2017-12-19 14-55-02](https://user-images.githubusercontent.com/1728657/34148615-96e5a39c-e4d4-11e7-8c68-c5ad22426843.png)

Per your suggestion, if the page isn't being previewed but rather exported, we can "safely" overbleed  (to avoid a semi-transparent bottom row) since the image ends up cropped.



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
