### PR TITLE
Prepare expression before checking for eval errors

### DIFF
--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -433,6 +433,7 @@ class TestQgsExpression: public QObject
       if ( expression4.hasParserError() )
         qDebug() << expression4.parserErrorString();
       Q_ASSERT( !expression4.hasParserError() );
+      expression4.prepare( &context );
       Q_ASSERT( expression4.hasEvalError() );
     }
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -430,10 +430,13 @@ class TestQgsExpression: public QObject
 
 
       QgsExpression expression4( "represent_value('Class')" );
+      qDebug() << "xxx constructed: " << expression.evalErrorString();
       if ( expression4.hasParserError() )
         qDebug() << expression4.parserErrorString();
       Q_ASSERT( !expression4.hasParserError() );
+      qDebug() << "xxx after hasParserError: " << expression.evalErrorString();
       expression4.prepare( &context );
+      qDebug() << "xxx prepared: " << expression.evalErrorString();
       Q_ASSERT( expression4.hasEvalError() );
     }
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -432,15 +432,15 @@ class TestQgsExpression: public QObject
 
       QgsExpression expression4( "represent_value('Class')" );
       qDebug() << "xxx constructed: " << expression.evalErrorString();
-      std::cout << "xxx constructed: " << expression.evalErrorString() << std::endl;
+      std::cout << "xxx constructed: " << expression.evalErrorString().toUtf8().constData() << std::endl;
       if ( expression4.hasParserError() )
         qDebug() << expression4.parserErrorString();
       Q_ASSERT( !expression4.hasParserError() );
       qDebug() << "xxx after hasParserError: " << expression.evalErrorString();
-      std::cout << "xxx after hasParserError: " << expression.evalErrorString() << std::endl;
+      std::cout << "xxx after hasParserError: " << expression.evalErrorString().toUtf8().constData() << std::endl;
       expression4.prepare( &context );
       qDebug() << "xxx prepared: " << expression.evalErrorString();
-      std::cout << "xxx prepared: " << expression.evalErrorString() << std::endl;
+      std::cout << "xxx prepared: " << expression.evalErrorString().toUtf8().constData() << std::endl;
       Q_ASSERT( expression4.hasEvalError() );
       Q_ASSERT( false );
     }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -16,6 +16,7 @@
 #include <QObject>
 #include <QString>
 #include <QtConcurrentMap>
+#include <iostream>
 
 #include <qgsapplication.h>
 //header for class being tested
@@ -431,13 +432,17 @@ class TestQgsExpression: public QObject
 
       QgsExpression expression4( "represent_value('Class')" );
       qDebug() << "xxx constructed: " << expression.evalErrorString();
+      std::cout << "xxx constructed: " << expression.evalErrorString() << std::endl;
       if ( expression4.hasParserError() )
         qDebug() << expression4.parserErrorString();
       Q_ASSERT( !expression4.hasParserError() );
       qDebug() << "xxx after hasParserError: " << expression.evalErrorString();
+      std::cout << "xxx after hasParserError: " << expression.evalErrorString() << std::endl;
       expression4.prepare( &context );
       qDebug() << "xxx prepared: " << expression.evalErrorString();
+      std::cout << "xxx prepared: " << expression.evalErrorString() << std::endl;
       Q_ASSERT( expression4.hasEvalError() );
+      Q_ASSERT( false );
     }
 
     void evaluation_data()


### PR DESCRIPTION
otherwise failing with:

QFATAL : TestQgsExpression::represent_value() ASSERT: "expression4.hasEvalError()" in file
              /usr/src/qgis/qgis-master/tests/src/core/testqgsexpression.cpp, line 436

See https://issues.qgis.org/issues/17722