### PR TITLE
remove CRS picker and allow only layer CRS or provider CRS in metadata editor

### DIFF
--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -50,6 +50,9 @@ using QgsNativeMetadataValidator.
       QgsCoordinateReferenceSystem extentCrs;
 %Docstring
 Coordinate reference system for spatial extent.
+The CRS should match the CRS defined in the QgsLayerMetadata CRS property.
+
+.. seealso:: :py:func:`QgsLayerMetadata.crs()`
 
 .. seealso:: :py:func:`spatial`
 %End
@@ -505,6 +508,11 @@ CRS which is actually used to display and manipulate the layer within QGIS.
 This may be the case when a layer has an incorrect CRS within its metadata
 and a user has manually overridden the layer's CRS within QGIS.
 
+The CRS described here should either match the CRS from the layer QgsMapLayer.crs()
+or the CRS from the data provider.
+
+This property should also match the CRS property used in the spatial extent.
+
 .. seealso:: :py:func:`setCrs()`
 %End
 
@@ -522,6 +530,11 @@ with a different CRS described by it's accompanying metadata versus the
 CRS which is actually used to display and manipulate the layer within QGIS.
 This may be the case when a layer has an incorrect CRS within its metadata
 and a user has manually overridden the layer's CRS within QGIS.
+
+The CRS described here should either match the CRS from the layer QgsMapLayer.crs()
+or the CRS from the data provider.
+
+This property should also match the CRS property used in the spatial extent.
 
 .. seealso:: :py:func:`crs()`
 %End

--- a/python/gui/qgsmetadatawidget.sip
+++ b/python/gui/qgsmetadatawidget.sip
@@ -38,6 +38,11 @@ Save all fields in a QgsLayerMetadata object.
 Check if values in the wizard are correct.
 %End
 
+    void crsChanged() const;
+%Docstring
+If the CRS is updated.
+%End
+
     void acceptMetadata();
 %Docstring
 Saves the metadata to the layer.

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1223,6 +1223,7 @@ void QgsRasterLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateRefer
 {
   QgisApp::instance()->askUserForDatumTransform( crs, QgsProject::instance()->crs() );
   mRasterLayer->setCrs( crs );
+  mMetadataWidget->crsChanged();
 }
 
 void QgsRasterLayerProperties::pbnDefaultValues_clicked()

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -834,6 +834,7 @@ void QgsVectorLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateRefer
   QgisApp::instance()->askUserForDatumTransform( crs, QgsProject::instance()->crs() );
   mLayer->setCrs( crs );
   mMetadataFilled = false;
+  mMetadataWidget->crsChanged();
 }
 
 void QgsVectorLayerProperties::loadDefaultStyle_clicked()

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -69,6 +69,8 @@ class CORE_EXPORT QgsLayerMetadata
 
       /**
        * Coordinate reference system for spatial extent.
+       * The CRS should match the CRS defined in the QgsLayerMetadata CRS property.
+       * \see QgsLayerMetadata::crs()
        * \see spatial
        */
       QgsCoordinateReferenceSystem extentCrs;
@@ -535,6 +537,12 @@ class CORE_EXPORT QgsLayerMetadata
      * CRS which is actually used to display and manipulate the layer within QGIS.
      * This may be the case when a layer has an incorrect CRS within its metadata
      * and a user has manually overridden the layer's CRS within QGIS.
+     *
+     * The CRS described here should either match the CRS from the layer QgsMapLayer::crs()
+     * or the CRS from the data provider.
+     *
+     * This property should also match the CRS property used in the spatial extent.
+     *
      * \see setCrs()
      */
     QgsCoordinateReferenceSystem crs() const;
@@ -552,6 +560,12 @@ class CORE_EXPORT QgsLayerMetadata
      * CRS which is actually used to display and manipulate the layer within QGIS.
      * This may be the case when a layer has an incorrect CRS within its metadata
      * and a user has manually overridden the layer's CRS within QGIS.
+     *
+     * The CRS described here should either match the CRS from the layer QgsMapLayer::crs()
+     * or the CRS from the data provider.
+     *
+     * This property should also match the CRS property used in the spatial extent.
+     *
      * \see crs()
      */
     void setCrs( const QgsCoordinateReferenceSystem &crs );

--- a/src/gui/qgsmetadatawidget.h
+++ b/src/gui/qgsmetadatawidget.h
@@ -21,6 +21,8 @@
 #include "QStyledItemDelegate"
 
 #include "qgis_gui.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgsdataprovider.h"
 #include "qgsmaplayer.h"
 #include "qgslayermetadata.h"
 #include "ui_qgsmetadatawidget.h"
@@ -53,6 +55,11 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
      * Check if values in the wizard are correct.
      */
     bool checkMetadata() const;
+
+    /**
+     * If the CRS is updated.
+     */
+    void crsChanged() const;
 
     /**
      * Saves the metadata to the layer.
@@ -89,7 +96,8 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
   private:
     void updatePanel() const;
     void fillSourceFromLayer() const;
-    void fillCrsFromLayer() const;
+    void fillCrsFromLayer();
+    void fillCrsFromProvider();
     void addDefaultCategory() const;
     void addNewCategory();
     void removeSelectedCategory() const;
@@ -101,7 +109,6 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
     void removeSelectedRight() const;
     void addConstraint() const;
     void removeSelectedConstraint() const;
-    void toggleExtentSelector() const;
     void addAddress() const;
     void removeSelectedAddress() const;
     void addLink() const;
@@ -109,10 +116,11 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
     void addHistory();
     void removeSelectedHistory() const;
     void fillComboBox() const;
-    void setPropertiesFromLayer() const;
+    void setPropertiesFromLayer();
     void syncFromCategoriesTabToKeywordsTab() const;
     QStringList mDefaultCategories;
     QgsMapLayer *mLayer = nullptr;
+    QgsCoordinateReferenceSystem mCrs;
     QgsLayerMetadata mMetadata;
     QStandardItemModel *mConstraintsModel = nullptr;
     QStandardItemModel *mLinksModel = nullptr;

--- a/src/ui/qgsmetadatawidget.ui
+++ b/src/ui/qgsmetadatawidget.ui
@@ -818,10 +818,14 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
-             <widget class="QgsProjectionSelectionWidget" name="selectionCrs" native="true"/>
+             <widget class="QLabel" name="lblCurrentCrs">
+              <property name="text">
+               <string notr="true">CRS label set in cpp code</string>
+              </property>
+             </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="btnAutoCrs">
+             <widget class="QPushButton" name="btnSetCrsFromLayer">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -833,7 +837,27 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QPushButton" name="btnSetCrsFromProvider">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Set CRS from provider</string>
+              </property>
+             </widget>
+            </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblCurrentCrsStatus">
+            <property name="text">
+             <string notr="true">CRS status set in cpp code</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -1368,12 +1392,6 @@
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
## Description

Based on the discussion with @timlinux and @tomkralidis on gitter mainly:
https://gitter.im/qgis/metadata?at=5a37bcbc232e79134d638171

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
