### PR TITLE
Use qgsfilewidget for the delimited text prodivder source select

### DIFF
--- a/python/gui/qgsfilewidget.sip
+++ b/python/gui/qgsfilewidget.sip
@@ -98,9 +98,14 @@ returns the filters used for QDialog.getOpenFileName
 :param filter: Only files that match the given filter are shown, it may be an empty string. If you want multiple filters, separate them with ';;',
 %End
 
+    void setSelectedFilter( const QString selectedFilter );
+%Docstring
+Sets the selected filter when the file dialog opens.
+%End
+
     QString selectedFilter() const;
 %Docstring
-Returns the filter selected from the last opened file dialog.
+Returns the selected filter from the last opened file dialog.
 %End
 
     void setConfirmOverwrite( bool confirmOverwrite );

--- a/python/gui/qgsfilewidget.sip
+++ b/python/gui/qgsfilewidget.sip
@@ -98,6 +98,11 @@ returns the filters used for QDialog.getOpenFileName
 :param filter: Only files that match the given filter are shown, it may be an empty string. If you want multiple filters, separate them with ';;',
 %End
 
+    QString selectedFilter() const;
+%Docstring
+Returns the filter selected from the last opened file dialog.
+%End
+
     void setConfirmOverwrite( bool confirmOverwrite );
 %Docstring
 Sets whether a confirmation to overwrite an existing file will appear.

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -253,11 +253,11 @@ void QgsFileWidget::openFileDialog()
   {
     case GetFile:
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Select a file" );
-      fileName = QFileDialog::getOpenFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter );
+      fileName = QFileDialog::getOpenFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter );
       break;
     case GetMultipleFiles:
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Select one or more files" );
-      fileNames = QFileDialog::getOpenFileNames( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter );
+      fileNames = QFileDialog::getOpenFileNames( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter );
       break;
     case GetDirectory:
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Select a directory" );
@@ -265,20 +265,19 @@ void QgsFileWidget::openFileDialog()
       break;
     case SaveFile:
     {
-      QString filter;
       title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Create or select a file" );
       if ( !confirmOverwrite() )
       {
-        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &filter, QFileDialog::DontConfirmOverwrite );
+        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter, QFileDialog::DontConfirmOverwrite );
       }
       else
       {
-        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &filter );
+        fileName = QFileDialog::getSaveFileName( this, title, QFileInfo( oldPath ).absoluteFilePath(), mFilter, &mSelectedFilter );
       }
 
       // make sure filename ends with filter. This isn't automatically done by
       // getSaveFileName on some platforms (e.g. gnome)
-      fileName = QgsFileUtils::addExtensionFromFilter( fileName, filter );
+      fileName = QgsFileUtils::addExtensionFromFilter( fileName, mSelectedFilter );
     }
     break;
   }

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -122,6 +122,16 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     void setFilter( const QString &filter );
 
     /**
+     * Sets the selected filter when the file dialog opens.
+     */
+    void setSelectedFilter( const QString selectedFilter ) { mSelectedFilter = selectedFilter; }
+
+    /**
+     * Returns the selected filter from the last opened file dialog.
+     */
+    QString selectedFilter() const { return mSelectedFilter; }
+
+    /**
      * Sets whether a confirmation to overwrite an existing file will appear.
      * By default, a confirmation will appear.
      * \param confirmOverwrite If set to true, an overwrite confirmation will be shown
@@ -185,6 +195,7 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     bool mFullUrl = false;
     QString mDialogTitle;
     QString mFilter;
+    QString mSelectedFilter;
     QString mDefaultRoot;
     bool mConfirmOverwrite = true;
     StorageMode mStorageMode = GetFile;

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -40,7 +40,6 @@ QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget *parent, Qt:
 {
 
   setupUi( this );
-  connect( btnBrowseForFile, &QPushButton::clicked, this, &QgsDelimitedTextSourceSelect::btnBrowseForFile_clicked );
   setupButtons( buttonBox );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDelimitedTextSourceSelect::showHelp );
 
@@ -67,7 +66,6 @@ QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget *parent, Qt:
   loadSettings();
   updateFieldsAndEnable();
 
-  connect( txtFilePath, &QLineEdit::textChanged, this, &QgsDelimitedTextSourceSelect::updateFileName );
   connect( txtLayerName, &QLineEdit::textChanged, this, &QgsDelimitedTextSourceSelect::enableAccept );
   connect( cmbEncoding, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsDelimitedTextSourceSelect::updateFieldsAndEnable );
 
@@ -93,6 +91,11 @@ QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget *parent, Qt:
 
   connect( cbxPointIsComma, &QAbstractButton::toggled, this, &QgsDelimitedTextSourceSelect::updateFieldsAndEnable );
   connect( cbxXyDms, &QAbstractButton::toggled, this, &QgsDelimitedTextSourceSelect::updateFieldsAndEnable );
+
+  mFileWidget->setDialogTitle( tr( "Choose a Delimited Text File to Ppen" ) );
+  mFileWidget->setFilter( tr( "Text files" ) + " (*.txt *.csv *.dat *.wkt);;" + tr( "All files" ) + " (* *.*)" );
+  mFileWidget->setSelectedFilter( settings.value( mPluginKey + "/file_filter", "" ).toString() );
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]() { updateFileName(); } );
 }
 
 QgsDelimitedTextSourceSelect::~QgsDelimitedTextSourceSelect()
@@ -100,11 +103,6 @@ QgsDelimitedTextSourceSelect::~QgsDelimitedTextSourceSelect()
   QgsSettings settings;
   settings.setValue( mPluginKey + "/geometry", saveGeometry() );
   delete mFile;
-}
-
-void QgsDelimitedTextSourceSelect::btnBrowseForFile_clicked()
-{
-  getOpenFileName();
 }
 
 void QgsDelimitedTextSourceSelect::addButtonClicked()
@@ -187,7 +185,7 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   // store the settings
   saveSettings();
-  saveSettingsForFile( txtFilePath->text() );
+  saveSettingsForFile( mFileWidget->filePath() );
 
 
   // add the layer to the map
@@ -343,7 +341,7 @@ void QgsDelimitedTextSourceSelect::saveSettingsForFile( const QString &filename 
 
 bool QgsDelimitedTextSourceSelect::loadDelimitedFileDefinition()
 {
-  mFile->setFileName( txtFilePath->text() );
+  mFile->setFileName( mFileWidget->filePath() );
   mFile->setEncoding( cmbEncoding->currentText() );
   if ( delimiterChars->isChecked() )
   {
@@ -610,37 +608,20 @@ bool QgsDelimitedTextSourceSelect::trySetXYField( QStringList &fields, QList<boo
   return indexY >= 0;
 }
 
-void QgsDelimitedTextSourceSelect::getOpenFileName()
-{
-  // Get a file to process, starting at the current directory
-  // Set initial dir to last used
-  QgsSettings settings;
-  QString selectedFilter = settings.value( mPluginKey + "/file_filter", "" ).toString();
-
-  QString s = QFileDialog::getOpenFileName(
-                this,
-                tr( "Choose a delimited text file to open" ),
-                settings.value( mPluginKey + "/text_path", QDir::homePath() ).toString(),
-                tr( "Text files" ) + " (*.txt *.csv *.dat *.wkt);;"
-                + tr( "All files" ) + " (* *.*)",
-                &selectedFilter
-              );
-  // set path
-  if ( s.isNull() ) return;
-  settings.setValue( mPluginKey + "/file_filter", selectedFilter );
-  txtFilePath->setText( s );
-}
-
 void QgsDelimitedTextSourceSelect::updateFileName()
 {
+  QgsSettings settings;
+  settings.setValue( mPluginKey + "/file_filter", mFileWidget->selectedFilter() );
+
   // put a default layer name in the text entry
-  QString filename = txtFilePath->text();
+  QString filename = mFileWidget->filePath();
   QFileInfo finfo( filename );
   if ( finfo.exists() )
   {
     QgsSettings settings;
     settings.setValue( mPluginKey + "/text_path", finfo.path() );
   }
+
   txtLayerName->setText( finfo.completeBaseName() );
   loadSettingsForFile( filename );
   updateFieldsAndEnable();
@@ -659,13 +640,13 @@ bool QgsDelimitedTextSourceSelect::validate()
   QString message( QLatin1String( "" ) );
   bool enabled = false;
 
-  if ( txtFilePath->text().trimmed().isEmpty() )
+  if ( mFileWidget->filePath().trimmed().isEmpty() )
   {
     message = tr( "Please select an input file" );
   }
-  else if ( ! QFileInfo::exists( txtFilePath->text() ) )
+  else if ( ! QFileInfo::exists( mFileWidget->filePath() ) )
   {
-    message = tr( "File %1 does not exist" ).arg( txtFilePath->text() );
+    message = tr( "File %1 does not exist" ).arg( mFileWidget->filePath() );
   }
   else if ( txtLayerName->text().isEmpty() )
   {

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -41,7 +41,6 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
   private:
     bool loadDelimitedFileDefinition();
     void updateFieldLists();
-    void getOpenFileName();
     QString selectedChars();
     void setSelectedChars( const QString &delimiters );
     void loadSettings( const QString &subkey = QString(), bool loadGeomSettings = true );
@@ -59,9 +58,6 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     QButtonGroup *bgFileFormat = nullptr;
     QButtonGroup *bgGeomType = nullptr;
     void showHelp();
-
-  private slots:
-    void btnBrowseForFile_clicked();
 
   public slots:
     void addButtonClicked() override;

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -79,42 +79,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="txtFilePath">
-          <property name="toolTip">
-           <string>Full path to the delimited text file</string>
-          </property>
-          <property name="whatsThis">
-           <string>Full path to the delimited text file. In order to properly parse the fields in the file, the delimiter must be defined prior to entering the file name. Use the Browse button to the right of this field to choose the input file.</string>
-          </property>
-          <property name="readOnly">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="btnBrowseForFile">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Browse to find the delimited text file to be processed</string>
-          </property>
-          <property name="whatsThis">
-           <string>Use this button to browse to the location of the delimited text file. This button will not be enabled until a delimiter has been entered in the &lt;i&gt;Delimiter&lt;/i&gt; box. Once a file is chosen, the X and Y field drop-down boxes will be populated with the fields from the delimited text file.</string>
-          </property>
-          <property name="text">
-           <string>Browse...</string>
-          </property>
-          <property name="flat">
-           <bool>false</bool>
-          </property>
-         </widget>
+         <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
         </item>
        </layout>
       </item>
@@ -132,7 +97,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Layer name</string>
+           <string>Layer Name</string>
           </property>
          </widget>
         </item>
@@ -1353,6 +1318,11 @@
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
## Description
@nyalldawson , one more use of QgsFileWidget. It also harmonizes the UI by moving away from "browse..." to the "..." button label.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
