### PR TITLE
return empty CRS instead of 4326 if the XML is empty

### DIFF
--- a/python/core/qgscoordinatereferencesystem.sip
+++ b/python/core/qgscoordinatereferencesystem.sip
@@ -507,7 +507,7 @@ pieces of information about CRS.
     bool readXml( const QDomNode &node );
 %Docstring
 Restores state from the given DOM node.
-If it fails or if the node is empty, a default not empty CRS will be returned.
+If it fails or if the node is empty, a default empty CRS will be returned.
 
 :param node: The node from which state will be restored
 

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1397,9 +1397,6 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
 
         //make sure the map units have been set
         setMapUnits();
-
-        //@TODO this srs needs to be validated!!!
-        d->mIsValid = true; //shamelessly hard coded for now
       }
       //TODO: createFromProj4 used to save to the user database any new CRS
       // this behavior was changed in order to separate creation and saving.
@@ -1417,8 +1414,8 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
   }
   else
   {
-    // Return default CRS if none was found in the XML.
-    createFromId( GEOCRS_ID, InternalCrsId );
+    // Return empty CRS if none was found in the XML.
+    d = new QgsCoordinateReferenceSystemPrivate();
     result = false;
   }
   return result;

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -466,7 +466,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     /**
      * Restores state from the given DOM node.
-     * If it fails or if the node is empty, a default not empty CRS will be returned.
+     * If it fails or if the node is empty, a default empty CRS will be returned.
      * \param node The node from which state will be restored
      * \returns bool True on success, False on failure
      */

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -62,8 +62,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void equality();
     void noEquality();
     void equalityInvalid();
-    void readXml();
-    void writeXml();
+    void readWriteXml();
     void setCustomSrsValidation();
     void customSrsValidation();
     void postgisSrid();
@@ -600,18 +599,38 @@ void TestQgsCoordinateReferenceSystem::equalityInvalid()
   QgsCoordinateReferenceSystem invalidCrs2;
   QVERIFY( invalidCrs1 == invalidCrs2 );
 }
-void TestQgsCoordinateReferenceSystem::readXml()
+void TestQgsCoordinateReferenceSystem::readWriteXml()
 {
-  //QgsCoordinateReferenceSystem myCrs;
-  //myCrs.createFromSrid( GEOSRID );
-  //QgsCoordinateReferenceSystem myCrs2;
-  //QVERIFY( myCrs2.readXml( QDomNode & node ) );
-}
-void TestQgsCoordinateReferenceSystem::writeXml()
-{
-  //QgsCoordinateReferenceSystem myCrs;
-  //bool writeXml( QDomNode & node, QDomDocument & doc ) const;
-  //QVERIFY( myCrs.isValid() );
+  QgsCoordinateReferenceSystem myCrs;
+  myCrs.createFromSrid( GEOSRID );
+  QVERIFY( myCrs.isValid() );
+  QDomDocument document( "test" );
+  QDomElement node = document.createElement( QStringLiteral( "crs" ) );
+  document.appendChild( node );
+  QVERIFY( myCrs.writeXml( node, document ) );
+  QgsCoordinateReferenceSystem myCrs2;
+  QVERIFY( myCrs2.readXml( node ) );
+  QVERIFY( myCrs == myCrs2 );
+
+  // Empty XML made from writeXml operation
+  QgsCoordinateReferenceSystem myCrs3;
+  QDomDocument document2( "test" );
+  QDomElement node2 = document2.createElement( QStringLiteral( "crs" ) );
+  document2.appendChild( node2 );
+  QVERIFY( ! myCrs3.isValid() );
+  QVERIFY( myCrs3.writeXml( node2, document2 ) );
+  QgsCoordinateReferenceSystem myCrs4;
+  QVERIFY( myCrs4.readXml( node2 ) );
+  QVERIFY( ! myCrs4.isValid() );
+  QVERIFY( myCrs3 == myCrs4 );
+
+  // Empty XML node
+  QDomDocument document3( "test" );
+  QDomElement node3 = document3.createElement( QStringLiteral( "crs" ) );
+  document3.appendChild( node3 );
+  QgsCoordinateReferenceSystem myCrs5;
+  QVERIFY( ! myCrs5.readXml( node3 ) );
+  QVERIFY( myCrs5 == QgsCoordinateReferenceSystem() );
 }
 void TestQgsCoordinateReferenceSystem::setCustomSrsValidation()
 {


### PR DESCRIPTION
## Description

Followup after #5908 @m-kuhn @nyalldawson @wonder-sk 

* return empty CRS instead of 4326 if the XML is empty

Should we return True or False in that case?
Waiting for travis

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit