### PR TITLE
[FEATURE] Duplicate child feature in releationwidget of attributeform

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -66,6 +66,13 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget *parent )
   mAddFeatureButton->setToolTip( tr( "Add child feature" ) );
   mAddFeatureButton->setObjectName( QStringLiteral( "mAddFeatureButton" ) );
   buttonLayout->addWidget( mAddFeatureButton );
+  // duplicate feature
+  mDuplicateFeatureButton = new QToolButton( this );
+  mDuplicateFeatureButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeature.svg" ) ) );
+  mDuplicateFeatureButton->setText( tr( "Duplicate child feature" ) );
+  mDuplicateFeatureButton->setToolTip( tr( "Duplicate child feature" ) );
+  mDuplicateFeatureButton->setObjectName( QStringLiteral( "mDuplicateFeatureButton" ) );
+  buttonLayout->addWidget( mDuplicateFeatureButton );
   // delete feature
   mDeleteFeatureButton = new QToolButton( this );
   mDeleteFeatureButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteSelected.svg" ) ) );
@@ -130,6 +137,7 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget *parent )
   connect( mToggleEditingButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::toggleEditing );
   connect( mSaveEditsButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::saveEdits );
   connect( mAddFeatureButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::addFeature );
+  connect( mDuplicateFeatureButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::duplicateFeature );
   connect( mDeleteFeatureButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::deleteFeature );
   connect( mLinkFeatureButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::linkFeature );
   connect( mUnlinkFeatureButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::unlinkFeature );
@@ -286,6 +294,7 @@ void QgsRelationEditorWidget::updateButtons()
   }
 
   mAddFeatureButton->setEnabled( editable );
+  mDuplicateFeatureButton->setEnabled( editable && selectionNotEmpty );
   mLinkFeatureButton->setEnabled( linkable );
   mDeleteFeatureButton->setEnabled( editable && selectionNotEmpty );
   mUnlinkFeatureButton->setEnabled( linkable && selectionNotEmpty );
@@ -423,6 +432,10 @@ void QgsRelationEditorWidget::linkFeature()
       }
     }
   }
+}
+
+void QgsRelationEditorWidget::duplicateFeature()
+{
 }
 
 void QgsRelationEditorWidget::deleteFeature()

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -436,6 +436,21 @@ void QgsRelationEditorWidget::linkFeature()
 
 void QgsRelationEditorWidget::duplicateFeature()
 {
+  QgsVectorLayer *layer = nullptr;
+
+  layer = mNmRelation.referencingLayer();
+
+  const QgsFeatureIds fids = mFeatureSelectionMgr->selectedFeatureIds();
+
+  for ( const QgsFeatureId &fid : fids )
+  {
+    QgsVectorLayerUtils::QgsDuplicateFeatureContext duplicatedFeatureContext;
+    QgsFeature feature; //= layer->getFeature( fid );
+    QgsFeatureRequest freq;
+    freq.setFilterFid( fid );
+    layer->getFeatures( freq ).nextFeature( feature );
+    QgsVectorLayerUtils::duplicateFeature( layer, feature, QgsProject::instance(), 1, duplicatedFeatureContext );
+  }
 }
 
 void QgsRelationEditorWidget::deleteFeature()

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -436,20 +436,14 @@ void QgsRelationEditorWidget::linkFeature()
 
 void QgsRelationEditorWidget::duplicateFeature()
 {
-  QgsVectorLayer *layer = nullptr;
+  QgsVectorLayer *layer = mRelation.referencingLayer();
 
-  layer = mNmRelation.referencingLayer();
-
-  const QgsFeatureIds fids = mFeatureSelectionMgr->selectedFeatureIds();
-
-  for ( const QgsFeatureId &fid : fids )
+  QgsFeatureIterator fit = layer->getFeatures( QgsFeatureRequest().setFilterFids( mFeatureSelectionMgr->selectedFeatureIds() ) );
+  QgsFeature f;
+  while ( fit.nextFeature( f ) )
   {
     QgsVectorLayerUtils::QgsDuplicateFeatureContext duplicatedFeatureContext;
-    QgsFeature feature; //= layer->getFeature( fid );
-    QgsFeatureRequest freq;
-    freq.setFilterFid( fid );
-    layer->getFeatures( freq ).nextFeature( feature );
-    QgsVectorLayerUtils::duplicateFeature( layer, feature, QgsProject::instance(), 1, duplicatedFeatureContext );
+    QgsVectorLayerUtils::duplicateFeature( layer, f, QgsProject::instance(), 0, duplicatedFeatureContext );
   }
 }
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -146,6 +146,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void updateButtons();
 
     void addFeature();
+    void duplicateFeature();
     void linkFeature();
     void deleteFeature();
     void unlinkFeature();
@@ -167,6 +168,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QToolButton *mToggleEditingButton = nullptr;
     QToolButton *mSaveEditsButton = nullptr;
     QToolButton *mAddFeatureButton = nullptr;
+    QToolButton *mDuplicateFeatureButton = nullptr;
     QToolButton *mDeleteFeatureButton = nullptr;
     QToolButton *mLinkFeatureButton = nullptr;
     QToolButton *mUnlinkFeatureButton = nullptr;


### PR DESCRIPTION
## Description
Beside add and delete feature in the relationwidget of an attributeform, there is the new functionality "duplicate feature". It duplicates the selected child features and (if available) the grand child features. 
![duplchilds](https://user-images.githubusercontent.com/28384354/34214018-6db10a34-e5a1-11e7-8e5b-c103de5e536f.gif)

The depth of child duplication is one. So there are no recursion issues.