### PR TITLE
[processing] Add api to show algorithm dialog, use dialog for history

### DIFF
--- a/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
+++ b/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
@@ -69,6 +69,19 @@ Switches the dialog to the log page.
     bool wasExecuted() const;
 %Docstring
 Returns true if an algorithm was executed in the dialog.
+
+.. seealso:: :py:func:`results()`
+
+.. seealso:: :py:func:`setExecuted()`
+%End
+
+    QVariantMap results() const;
+%Docstring
+Returns the results returned by the algorithm executed.
+
+.. seealso:: :py:func:`wasExecuted()`
+
+.. seealso:: :py:func:`setResults()`
 %End
 
     QgsProcessingFeedback *createFeedback() /Factory/;
@@ -157,6 +170,19 @@ Clears any current progress from the dialog.
     void setExecuted( bool executed );
 %Docstring
 Sets whether the algorithm was executed through the dialog.
+
+.. seealso:: :py:func:`wasExecuted()`
+
+.. seealso:: :py:func:`setResults()`
+%End
+
+    void setResults( const QVariantMap &results );
+%Docstring
+Sets the algorithm results.
+
+.. seealso:: :py:func:`results()`
+
+.. seealso:: :py:func:`setExecuted()`
 %End
 
     void setInfo( const QString &message, bool isError = false, bool escapeHtml = true );

--- a/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
+++ b/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
@@ -99,8 +99,6 @@ Returns the parameter values for the algorithm to run in the dialog.
 
     virtual void accept();
 
-    virtual void reject();
-
 
     void reportError( const QString &error );
 %Docstring
@@ -138,9 +136,6 @@ Pushes a console info string to the dialog's log.
 %End
 
   protected:
-
-    virtual void closeEvent( QCloseEvent *e );
-
 
     QPushButton *runButton();
 %Docstring

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -80,6 +80,9 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         dlg.show()
         dlg.exec_()
 
+    def setParameters(self, parameters):
+        self.mainWidget().setParameters(parameters)
+
     def getParameterValues(self):
         parameters = {}
 

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -276,6 +276,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 return
 
         self.setExecuted(True)
+        self.setResults(result)
         self.setInfo(self.tr('Algorithm \'{0}\' finished').format(self.algorithm().displayName()), escapeHtml=False)
 
         if not keepOpen:

--- a/python/plugins/processing/gui/DestinationSelectionPanel.py
+++ b/python/plugins/processing/gui/DestinationSelectionPanel.py
@@ -266,6 +266,12 @@ class DestinationSelectionPanel(BASE, WIDGET):
             self.leText.setText(QDir.toNativeSeparators(dirName))
             settings.setValue('/Processing/LastOutputPath', dirName)
 
+    def setValue(self, value):
+        if value == 'memory:':
+            self.saveToTemporary()
+        else:
+            self.leText.setText(value)
+
     def getValue(self):
         key = None
         if self.use_temporary and isinstance(self.parameter, QgsProcessingParameterFeatureSink):

--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -113,7 +113,8 @@ class HistoryDialog(BASE, WIDGET):
             if item.isAlg:
                 script = 'import processing\n'
                 script += 'from qgis.core import QgsProcessingOutputLayerDefinition, QgsProcessingFeatureSourceDefinition\n'
-                script += item.entry.text.replace('processing.run(', 'processing.runAndLoadResults(')
+                script += item.entry.text.replace('processing.run(', 'processing.execAlgorithmDialog(')
+                self.close()
                 exec(script)
 
     def changeText(self):

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -181,6 +181,21 @@ class ParametersPanel(BASE, WIDGET):
         for wrapper in list(self.wrappers.values()):
             wrapper.postInitialize(list(self.wrappers.values()))
 
+    def setParameters(self, parameters):
+        for param in self.alg.parameterDefinitions():
+            if param.flags() & QgsProcessingParameterDefinition.FlagHidden:
+                continue
+
+            if not param.name() in parameters:
+                continue
+
+            if not param.isDestination():
+                wrapper = self.wrappers[param.name()]
+                wrapper.setValue(parameters[param.name()])
+            else:
+                dest_widget = self.outputWidgets[param.name()]
+                dest_widget.setValue(parameters[param.name()])
+
     def buttonToggled(self, value):
         if value:
             sender = self.sender()

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -782,7 +782,13 @@ class MapLayerWidgetWrapper(WidgetWrapper):
 
     def setValue(self, value):
         if self.dialogType == DIALOG_STANDARD:
-            pass  # TODO
+            if self.combo.findText(value) >= 0:
+                self.combo.setCurrentIndex(self.combo.findText(value))
+            else:
+                items = self.combo.additionalItems()
+                items.append(value)
+                self.combo.setAdditionalItems(items)
+                self.combo.setCurrentIndex(self.combo.findText(value))
         elif self.dialogType == DIALOG_BATCH:
             self.widget.setText(value)
         else:
@@ -985,7 +991,13 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
 
     def setValue(self, value):
         if self.dialogType == DIALOG_STANDARD:
-            pass  # TODO
+            if self.combo.findText(value) >= 0:
+                self.combo.setCurrentIndex(self.combo.findText(value))
+            else:
+                items = self.combo.additionalItems()
+                items.append(value)
+                self.combo.setAdditionalItems(items)
+                self.combo.setCurrentIndex(self.combo.findText(value))
         elif self.dialogType == DIALOG_BATCH:
             self.widget.setValue(value)
         else:
@@ -1262,7 +1274,13 @@ class VectorLayerWidgetWrapper(WidgetWrapper):
 
     def setValue(self, value):
         if self.dialogType == DIALOG_STANDARD:
-            pass  # TODO
+            if self.combo.findText(value) >= 0:
+                self.combo.setCurrentIndex(self.combo.findText(value))
+            else:
+                items = self.combo.additionalItems()
+                items.append(value)
+                self.combo.setAdditionalItems(items)
+                self.combo.setCurrentIndex(self.combo.findText(value))
         elif self.dialogType == DIALOG_BATCH:
             return self.widget.setText(value)
         else:

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -17,6 +17,7 @@
 #include "qgssettings.h"
 #include "qgshelp.h"
 #include "qgsmessagebar.h"
+#include "qgsgui.h"
 #include "processing/qgsprocessingalgorithm.h"
 #include "processing/qgsprocessingprovider.h"
 #include <QToolButton>
@@ -83,8 +84,9 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
   handleLayout->addStretch();
   splitterHandle->setLayout( handleLayout );
 
+  QgsGui::instance()->enableAutoGeometryRestore( this );
+
   QgsSettings settings;
-  restoreGeometry( settings.value( QStringLiteral( "/Processing/dialogBase" ) ).toByteArray() );
   splitter->restoreState( settings.value( QStringLiteral( "/Processing/dialogBaseSplitter" ), QByteArray() ).toByteArray() );
   mSplitterState = splitter->saveState();
   splitterChanged( 0, 0 );
@@ -184,12 +186,6 @@ void QgsProcessingAlgorithmDialogBase::showLog()
   mTabWidget->setCurrentIndex( 1 );
 }
 
-void QgsProcessingAlgorithmDialogBase::closeEvent( QCloseEvent *e )
-{
-  saveWindowGeometry();
-  QDialog::closeEvent( e );
-}
-
 QPushButton *QgsProcessingAlgorithmDialogBase::runButton()
 {
   return mButtonRun;
@@ -222,12 +218,6 @@ void QgsProcessingAlgorithmDialogBase::finished( bool, const QVariantMap &, QgsP
 
 void QgsProcessingAlgorithmDialogBase::accept()
 {
-}
-
-void QgsProcessingAlgorithmDialogBase::reject()
-{
-  saveWindowGeometry();
-  QDialog::reject();
 }
 
 void QgsProcessingAlgorithmDialogBase::openHelp()
@@ -333,11 +323,6 @@ QString QgsProcessingAlgorithmDialogBase::formatHelp( QgsProcessingAlgorithm *al
   }
   else
     return QString();
-}
-
-void QgsProcessingAlgorithmDialogBase::saveWindowGeometry()
-{
-
 }
 
 void QgsProcessingAlgorithmDialogBase::resetGui()

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -210,6 +210,11 @@ void QgsProcessingAlgorithmDialogBase::setExecuted( bool executed )
   mExecuted = executed;
 }
 
+void QgsProcessingAlgorithmDialogBase::setResults( const QVariantMap &results )
+{
+  mResults = results;
+}
+
 void QgsProcessingAlgorithmDialogBase::finished( bool, const QVariantMap &, QgsProcessingContext &, QgsProcessingFeedback * )
 {
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -144,7 +144,6 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
   public slots:
 
     void accept() override;
-    void reject() override;
 
     /**
      * Reports an \a error string to the dialog's log.
@@ -182,8 +181,6 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     void pushConsoleInfo( const QString &info );
 
   protected:
-
-    void closeEvent( QCloseEvent *e ) override;
 
     /**
      * Returns the dialog's run button.
@@ -274,7 +271,6 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     bool mHelpCollapsed = false;
 
     QString formatHelp( QgsProcessingAlgorithm *algorithm );
-    void saveWindowGeometry();
 
 };
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -118,8 +118,17 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
 
     /**
      * Returns true if an algorithm was executed in the dialog.
+     * \see results()
+     * \see setExecuted()
      */
     bool wasExecuted() const { return mExecuted; }
+
+    /**
+     * Returns the results returned by the algorithm executed.
+     * \see wasExecuted()
+     * \see setResults()
+     */
+    QVariantMap results() const { return mResults; }
 
     /**
      * Creates a new processing feedback object, automatically connected to the appropriate
@@ -203,8 +212,17 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
 
     /**
      * Sets whether the algorithm was executed through the dialog.
+     * \see wasExecuted()
+     * \see setResults()
      */
     void setExecuted( bool executed );
+
+    /**
+     * Sets the algorithm results.
+     * \see results()
+     * \see setExecuted()
+     */
+    void setResults( const QVariantMap &results );
 
     /**
      * Displays an info \a message in the dialog's log.
@@ -250,6 +268,7 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     QgsMessageBar *mMessageBar = nullptr;
 
     bool mExecuted = false;
+    QVariantMap mResults;
     QWidget *mMainWidget = nullptr;
     QgsProcessingAlgorithm *mAlgorithm = nullptr;
     bool mHelpCollapsed = false;


### PR DESCRIPTION
Adds processing.createAlgorithmDialog and processing.execAlgorithmDialog. These methods can be used
to create and execute algorithm dialogs for a specified algorithm, optionally pre-populated with a given set of (non-default) parameter values.

Additionally, double clicking a history entry now shows the algorithm dialog instead of immediately executing same alg. This allows users to edit the parameters before re-running, which is a more common user-operation (e.g. changing the input layer, changing a parameter value "oops, that buffer was a bit too big....").