### PR TITLE
[3d] missing piece of the jigsaw: save 3d canvas as image

### DIFF
--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -17,6 +17,7 @@
 
 #include <QBoxLayout>
 #include <Qt3DExtras/Qt3DWindow>
+#include <Qt3DRender/QRenderCapture>
 
 #include "qgscameracontroller.h"
 #include "qgs3dmapsettings.h"
@@ -27,6 +28,11 @@ Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
   : QWidget( parent )
 {
   mWindow3D = new Qt3DExtras::Qt3DWindow;
+
+  mCapture = new Qt3DRender::QRenderCapture;
+  mWindow3D->activeFrameGraph()->setParent( mCapture );
+  mWindow3D->setActiveFrameGraph( mCapture );
+
   mContainer = QWidget::createWindowContainer( mWindow3D );
 
   QHBoxLayout *hLayout = new QHBoxLayout( this );
@@ -88,4 +94,20 @@ void Qgs3DMapCanvas::setViewFromTop( const QgsPointXY &center, float distance, f
   float worldX = center.x() - mMap->origin().x();
   float worldY = center.y() - mMap->origin().y();
   mScene->cameraController()->setViewFromTop( worldX, -worldY, distance, rotation );
+}
+
+void Qgs3DMapCanvas::saveAsImage( const QString fileName, const QString fileFormat )
+{
+  if ( !fileName.isEmpty() )
+  {
+    Qt3DRender::QRenderCaptureReply *captureReply;
+    captureReply = mCapture->requestCapture();
+    connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
+    {
+      captureReply->image().save( fileName, fileFormat.toLocal8Bit().data() );
+      emit savedAsImage( fileName );
+
+      captureReply->deleteLater();
+    } );
+  }
 }

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -17,6 +17,7 @@
 #define QGS3DMAPCANVAS_H
 
 #include <QWidget>
+#include <Qt3DRender/QRenderCapture>
 
 namespace Qt3DExtras
 {
@@ -54,12 +55,22 @@ class Qgs3DMapCanvas : public QWidget
     //! Sets camera position to look down at the given point (in map coordinates) in given distance from plane with zero elevation
     void setViewFromTop( const QgsPointXY &center, float distance, float rotation = 0 );
 
+    //! Saves the current scene as an image
+    void saveAsImage( const QString fileName, const QString fileFormat );
+
+  signals:
+    //! Emitted when the 3D map canvas was successfully saved as image
+    void savedAsImage( const QString fileName );
+
   protected:
     void resizeEvent( QResizeEvent *ev ) override;
 
   private:
     //! 3D window with all the 3D magic inside
     Qt3DExtras::Qt3DWindow *mWindow3D = nullptr;
+    //! Frame graph node for render capture
+    Qt3DRender::QRenderCapture *mCapture = nullptr;
+
     //! Container QWidget that encapsulates mWindow3D so we can use it embedded in ordinary widgets app
     QWidget *mContainer = nullptr;
     //! Description of the 3D scene

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -42,6 +42,7 @@ class Qgs3DMapCanvasDockWidget : public QgsDockWidget
   private slots:
     void resetView();
     void configure();
+    void saveAsImage();
 
     void onMainCanvasLayersChanged();
     void onMainCanvasColorChanged();


### PR DESCRIPTION
## Description
@wonder-sk , IMHO, for the 3D map canvas to go beyond "a magical toy", we need a save 3D map canvas as image. This PR does it. Again, IMHO, we need this when we first publish your amazing 3D work to the world in QGIS 3.0.

Video screencast coming in a minute.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
