### PR TITLE
[FEATURE][processing] Alpha channel for rasterize algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -110,7 +110,7 @@ class RasterizeAlgorithm(QgisAlgorithm):
                 self.MAKE_BACKGROUND_TRANSPARENT,
                 self.tr('Make background transparent'),
                 defaultValue=False))
-        
+
         map_theme_param = QgsProcessingParameterString(
             self.MAP_THEME,
             description=self.tr(
@@ -136,7 +136,6 @@ class RasterizeAlgorithm(QgisAlgorithm):
             self.tr(
                 'Output layer')))
 
-                
     def name(self):
         # Unique (non-user visible) name of algorithm
         return 'rasterize'
@@ -184,7 +183,7 @@ class RasterizeAlgorithm(QgisAlgorithm):
             parameters,
             self.MAKE_BACKGROUND_TRANSPARENT,
             context)
-            
+
         mupp = self.parameterAsDouble(
             parameters,
             self.MAP_UNITS_PER_PIXEL,
@@ -244,12 +243,12 @@ class TileSet():
             no_bands = 4
         else:
             no_bands = 3
-        
+
         self.dataset = driver.Create(output, xsize, ysize, no_bands)
         self.dataset.SetProjection(str(crs.toWkt()))
         self.dataset.SetGeoTransform(
             [extent.xMinimum(), mupp, 0, extent.yMaximum(), 0, -mupp])
-            
+
         self.image = QImage(QSize(tile_size, tile_size), QImage.Format_ARGB32)
 
         self.settings = QgsMapSettings()
@@ -265,7 +264,7 @@ class TileSet():
             self.settings.setBackgroundColor(QColor(255, 255, 255, 0))
         else:
             self.settings.setBackgroundColor(QColor(255, 255, 255))
-        
+
         if QgsProject.instance().mapThemeCollection().hasMapTheme(map_theme):
             self.settings.setLayers(
                 QgsProject.instance().mapThemeCollection(
@@ -318,7 +317,7 @@ class TileSet():
         job = QgsMapRendererCustomPainterJob(self.settings, painter)
         job.renderSynchronously()
         painter.end()
-        
+
         # Needs not to be deleted or Windows will kill it too early...
         tmpfile = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
         try:

--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -21,7 +21,7 @@
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
-from qgis.PyQt.QtGui import QImage, QPainter
+from qgis.PyQt.QtGui import QImage, QPainter, QColor
 from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsMapSettings,
@@ -228,7 +228,7 @@ class TileSet():
         xsize = self.x_tile_count * tile_size
         ysize = self.y_tile_count * tile_size
 
-        self.dataset = driver.Create(output, xsize, ysize, 3)  # 3 bands
+        self.dataset = driver.Create(output, xsize, ysize, 4)  # 4 bands
         self.dataset.SetProjection(str(crs.toWkt()))
         self.dataset.SetGeoTransform(
             [extent.xMinimum(), mupp, 0, extent.yMaximum(), 0, -mupp])
@@ -240,6 +240,7 @@ class TileSet():
         self.settings.setOutputImageFormat(QImage.Format_ARGB32)
         self.settings.setDestinationCrs(crs)
         self.settings.setOutputSize(self.image.size())
+        self.settings.setBackgroundColor(QColor(255,255,255,0))
         self.settings.setFlag(QgsMapSettings.Antialiasing, True)
         self.settings.setFlag(QgsMapSettings.RenderMapTile, True)
 
@@ -277,6 +278,10 @@ class TileSet():
         :param x: The x index of the current tile
         :param y: The y index of the current tile
         """
+
+        background_colour = QColor(255,255,255,0)
+        self.image.fill(background_colour.rgba())
+        
         painter = QPainter(self.image)
 
         self.settings.setExtent(QgsRectangle(


### PR DESCRIPTION
Originally the background colour defaulted to white with no transparency for areas without vector data. I have added an alpha channel to the geotiff and set it zero (full transparency) for areas with no vector data. This could be optional, in case the user wants a solid background.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
