### PR TITLE
Make QgsField::type a Q_PROPERTY

### DIFF
--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -52,6 +52,7 @@ class CORE_EXPORT QgsField
     Q_PROPERTY( bool isNumeric READ isNumeric )
     Q_PROPERTY( int length READ length WRITE setLength )
     Q_PROPERTY( int precision READ precision WRITE setPrecision )
+    Q_PROPERTY( QVariant::Type type READ type WRITE setType )
     Q_PROPERTY( QString comment READ comment WRITE setComment )
     Q_PROPERTY( QString name READ name WRITE setName )
     Q_PROPERTY( QString alias READ alias WRITE setAlias )


### PR DESCRIPTION
## Description
The Q_PROPERTY of the type to use it exernally.
