### PR TITLE
Use standard buttons for unified add layer dialog

### DIFF
--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -38,16 +38,16 @@ const QgsMapCanvas *QgsAbstractDataSourceWidget::mapCanvas() const
 void QgsAbstractDataSourceWidget::setupButtons( QDialogButtonBox *buttonBox )
 {
 
-  mAddButton = new QPushButton( tr( "&Add" ) );
+  buttonBox->setStandardButtons( QDialogButtonBox::Apply | QDialogButtonBox::Close | QDialogButtonBox::Help );
+  mAddButton = buttonBox->button( QDialogButtonBox::Apply );
+  mAddButton->setText( tr( "&Add" ) );
   mAddButton->setToolTip( tr( "Add selected layers to map" ) );
   mAddButton->setEnabled( false );
-  buttonBox->addButton( mAddButton, QDialogButtonBox::ApplyRole );
   connect( mAddButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::addButtonClicked );
   connect( this, &QgsAbstractDataSourceWidget::enableButtons, mAddButton, &QPushButton::setEnabled );
 
-  QPushButton *closeButton = new QPushButton( tr( "&Close" ) );
+  QPushButton *closeButton = buttonBox->button( QDialogButtonBox::Close );
   closeButton->setToolTip( tr( "Close this dialog without adding any layer" ) );
-  buttonBox->addButton( closeButton, QDialogButtonBox::RejectRole );
   connect( closeButton, &QPushButton::clicked, this, &QgsAbstractDataSourceWidget::reject );
 
 }


### PR DESCRIPTION
Fixes #17728 by setting the standard buttons in the
button box instead of manually adding them by code.

This way the buttons should honour the platform-specific
position and look&feel.

![qgis-unified-dialog-std-buttons](https://user-images.githubusercontent.com/142164/34264620-c4d70516-e673-11e7-968d-1eda9f5e1085.png)
