### PR TITLE
[layouts] fix overview map combobox filter

### DIFF
--- a/src/app/layout/qgslayoutmapwidget.cpp
+++ b/src/app/layout/qgslayoutmapwidget.cpp
@@ -109,8 +109,6 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item )
   mLayerListFromPresetButton->setToolTip( tr( "Set layer list from a map theme" ) );
   connect( menuKeepLayers, &QMenu::aboutToShow, this, &QgsLayoutMapWidget::aboutToShowKeepLayersVisibilityPresetsMenu );
 
-  mOverviewFrameMapComboBox->setItemType( QgsLayoutItemRegistry::LayoutMap );
-
   connect( item, &QgsLayoutObject::changed, this, &QgsLayoutMapWidget::updateGuiElements );
 
 #if 0 //TODO
@@ -125,6 +123,7 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item )
   }
 #endif
   mOverviewFrameMapComboBox->setCurrentLayout( item->layout() );
+  mOverviewFrameMapComboBox->setItemType( QgsLayoutItemRegistry::LayoutMap );
   mOverviewFrameStyleButton->registerExpressionContextGenerator( item );
 
   connect( mOverviewFrameMapComboBox, &QgsLayoutItemComboBox::itemChanged, this, &QgsLayoutMapWidget::overviewMapChanged );


### PR DESCRIPTION
## Description
@nyalldawson , there's currently an issue with the map item overview's (reference) map combobox whereas all layout items are showing:
![screenshot from 2017-12-22 12-35-10](https://user-images.githubusercontent.com/1728657/34286895-43fd9d1c-e716-11e7-9b96-99cf0037229b.png)

This is caused by having the item type filter set before setting the current layout. This PR fixes the issue by moving the setItemType() below setCurrentLayout(). 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
