### PR TITLE
message bar styling improvements

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -1538,7 +1538,7 @@ void QgsLayoutDesignerDialog::exportToRaster()
     case QgsLayoutExporter::Success:
       mMessageBar->pushMessage( tr( "Export layout" ),
                                 tr( "Successfully exported layout to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fi.path() ).toString(), fileNExt.first ),
-                                QgsMessageBar::INFO, 0 );
+                                QgsMessageBar::SUCCESS, 0 );
       break;
 
     case QgsLayoutExporter::PrintError:
@@ -1644,7 +1644,7 @@ void QgsLayoutDesignerDialog::exportToPdf()
     {
       mMessageBar->pushMessage( tr( "Export layout" ),
                                 tr( "Successfully exported layout to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fi.path() ).toString(), outputFileName ),
-                                QgsMessageBar::INFO, 0 );
+                                QgsMessageBar::SUCCESS, 0 );
       break;
     }
 
@@ -1794,7 +1794,7 @@ void QgsLayoutDesignerDialog::exportToSvg()
     {
       mMessageBar->pushMessage( tr( "Export layout" ),
                                 tr( "Successfully exported layout to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fi.path() ).toString(), outputFileName ),
-                                QgsMessageBar::INFO, 0 );
+                                QgsMessageBar::SUCCESS, 0 );
       break;
     }
 

--- a/src/gui/qgsmessagebaritem.cpp
+++ b/src/gui/qgsmessagebaritem.cpp
@@ -100,7 +100,7 @@ void QgsMessageBarItem::writeContent()
         msgIcon = QStringLiteral( "/mIconWarning.svg" );
         break;
       case QgsMessageBar::SUCCESS:
-        msgIcon = QStringLiteral( "/mIconSuccess.png" );
+        msgIcon = QStringLiteral( "/mIconSuccess.svg" );
         break;
       default:
         break;

--- a/src/gui/qgsmessagebaritem.cpp
+++ b/src/gui/qgsmessagebaritem.cpp
@@ -109,6 +109,35 @@ void QgsMessageBarItem::writeContent()
   }
   mLblIcon->setPixmap( icon.pixmap( 24 ) );
 
+
+  // STYLESHEETS
+  QString contentStyleSheet;
+  if ( mLevel == QgsMessageBar::SUCCESS )
+  {
+    mStyleSheet = "QgsMessageBar { background-color: #dff0d8; border: 1px solid #8e998a; } "
+                  "QLabel,QTextEdit { color: black; } ";
+    contentStyleSheet = "<style> a, a:visited, a:hover { color:#268300; } </style>";
+  }
+  else if ( mLevel == QgsMessageBar::CRITICAL )
+  {
+    mStyleSheet = "QgsMessageBar { background-color: #d65253; border: 1px solid #9b3d3d; } "
+                  "QLabel,QTextEdit { color: white; } ";
+    contentStyleSheet = "<style>a, a:visited, a:hover { color:#4e0001; }</style>";
+  }
+  else if ( mLevel == QgsMessageBar::WARNING )
+  {
+    mStyleSheet = "QgsMessageBar { background-color: #ffc800; border: 1px solid #e0aa00; } "
+                  "QLabel,QTextEdit { color: black; } ";
+    contentStyleSheet = "<style>a, a:visited, a:hover { color:#945a00; }</style>";
+  }
+  else if ( mLevel == QgsMessageBar::INFO )
+  {
+    mStyleSheet = "QgsMessageBar { background-color: #e7f5fe; border: 1px solid #b9cfe4; } "
+                  "QLabel,QTextEdit { color: #2554a1; } ";
+    contentStyleSheet = "<style>a, a:visited, a:hover { color:#3bb2fe; }</style>";
+  }
+  mStyleSheet += QLatin1String( "QLabel#mItemCount { font-style: italic; }" );
+
   // TITLE AND TEXT
   if ( mTitle.isEmpty() && mText.isEmpty() )
   {
@@ -147,6 +176,7 @@ void QgsMessageBarItem::writeContent()
         t += QLatin1String( ": " );
       content.prepend( QStringLiteral( "<b>" ) + t + " </b>" );
     }
+    content.prepend( contentStyleSheet );
     mTextBrowser->setText( content );
   }
 
@@ -159,29 +189,6 @@ void QgsMessageBarItem::writeContent()
       mLayout->addWidget( mWidget );
     }
   }
-
-  // STYLESHEET
-  if ( mLevel == QgsMessageBar::SUCCESS )
-  {
-    mStyleSheet = "QgsMessageBar { background-color: #dff0d8; border: 1px solid #8e998a; } "
-                  "QLabel,QTextEdit { color: black; } ";
-  }
-  else if ( mLevel == QgsMessageBar::CRITICAL )
-  {
-    mStyleSheet = "QgsMessageBar { background-color: #d65253; border: 1px solid #9b3d3d; } "
-                  "QLabel,QTextEdit { color: white; } ";
-  }
-  else if ( mLevel == QgsMessageBar::WARNING )
-  {
-    mStyleSheet = "QgsMessageBar { background-color: #ffc800; border: 1px solid #e0aa00; } "
-                  "QLabel,QTextEdit { color: black; } ";
-  }
-  else if ( mLevel == QgsMessageBar::INFO )
-  {
-    mStyleSheet = "QgsMessageBar { background-color: #e7f5fe; border: 1px solid #b9cfe4; } "
-                  "QLabel,QTextEdit { color: #2554a1; } ";
-  }
-  mStyleSheet += QLatin1String( "QLabel#mItemCount { font-style: italic; }" );
 }
 
 QgsMessageBarItem *QgsMessageBarItem::setText( const QString &text )


### PR DESCRIPTION
## Description
This PR improve the styling of recently added hyperlinks in the message bar by adjusting the hyperlink's color according to the message bar item type.

For e.g., this is a "success" item, before (top) vs. proposed (bottom):
![screenshot from 2017-12-22 20-24-33](https://user-images.githubusercontent.com/1728657/34299915-26bf934e-e758-11e7-851b-da7187dcde5b.png)

@nyalldawson , this PR also changes the item type for successful layout exports to... success 😉 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
