### PR TITLE
[georeferencer] improve ui layout, use qgsfilewidget

### DIFF
--- a/src/plugins/georeferencer/qgstransformsettingsdialog.cpp
+++ b/src/plugins/georeferencer/qgstransformsettingsdialog.cpp
@@ -20,6 +20,7 @@
 #include "qgssettings.h"
 #include "qgsprojectionselectiontreewidget.h"
 #include "qgsapplication.h"
+#include "qgsfilewidget.h"
 #include "qgsrasterlayer.h"
 #include "qgstransformsettingsdialog.h"
 #include "qgscoordinatereferencesystem.h"
@@ -31,14 +32,53 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
   , mCountGCPpoints( countGCPpoints )
 {
   setupUi( this );
-  connect( tbnOutputRaster, &QToolButton::clicked, this, &QgsTransformSettingsDialog::tbnOutputRaster_clicked );
-  connect( tbnMapFile, &QToolButton::clicked, this, &QgsTransformSettingsDialog::tbnMapFile_clicked );
-  connect( tbnReportFile, &QToolButton::clicked, this, &QgsTransformSettingsDialog::tbnReportFile_clicked );
+
+  QgsSettings settings;
+  restoreGeometry( settings.value( QStringLiteral( "/Plugin-GeoReferencer/TransformSettingsWindow/geometry" ) ).toByteArray() );
+
+  mOutputRaster->setStorageMode( QgsFileWidget::SaveFile );
+  if ( output.isEmpty() )
+  {
+    mOutputRaster->setFilePath( generateModifiedRasterFileName( mSourceRasterFile ) );
+  }
+  else
+  {
+    mOutputRaster->setFilePath( output );
+  }
+  mOutputRaster->setFilter( tr( "TIF files" ) + " (*.tif *.tiff *.TIF *.TIFF)" );
+  mOutputRaster->setDialogTitle( tr( "Destination Raster" ) );
+  mOutputRaster->setDefaultRoot( settings.value( QStringLiteral( "UI/lastRasterFileFilterDir" ), QDir::homePath() ).toString() );
+  connect( mOutputRaster, &QgsFileWidget::fileChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    QFileInfo tmplFileInfo( mOutputRaster->filePath() );
+    settings.setValue( QStringLiteral( "UI/lastRasterFileFilterDir" ), tmplFileInfo.absolutePath() );
+  } );
+
+  mPdfMap->setStorageMode( QgsFileWidget::SaveFile );
+  mPdfMap->setFilter( tr( "PDF files" ) + " (*.pdf *.PDF)" );
+  mPdfMap->setDialogTitle( tr( "Save Map File as" ) );
+  mPdfMap->setDefaultRoot( settings.value( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() ).toString() );
+  connect( mPdfMap, &QgsFileWidget::fileChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    QFileInfo tmplFileInfo( mPdfMap->filePath() );
+    settings.setValue( QStringLiteral( "Plugin-GeoReferencer/lastPDFReportDir" ), tmplFileInfo.absolutePath() );
+  } );
+
+  mPdfReport->setStorageMode( QgsFileWidget::SaveFile );
+  mPdfReport->setFilter( tr( "PDF files" ) + " (*.pdf *.PDF)" );
+  mPdfReport->setDialogTitle( tr( "Save Report File as" ) );
+  mPdfReport->setDefaultRoot( settings.value( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() ).toString() );
+  connect( mPdfReport, &QgsFileWidget::fileChanged, this, [ = ]
+  {
+    QgsSettings settings;
+    QFileInfo tmplFileInfo( mPdfReport->filePath() );
+    settings.setValue( QStringLiteral( "Plugin-GeoReferencer/lastPDFReportDir" ), tmplFileInfo.absolutePath() );
+  } );
+
   connect( cmbTransformType, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentIndexChanged ), this, &QgsTransformSettingsDialog::cmbTransformType_currentIndexChanged );
   connect( mWorldFileCheckBox, &QCheckBox::stateChanged, this, &QgsTransformSettingsDialog::mWorldFileCheckBox_stateChanged );
-
-  QgsSettings s;
-  restoreGeometry( s.value( QStringLiteral( "/Plugin-GeoReferencer/TransformSettingsWindow/geometry" ) ).toByteArray() );
 
   cmbTransformType->addItem( tr( "Linear" ), ( int )QgsGeorefTransform::Linear );
   cmbTransformType->addItem( tr( "Helmert" ), ( int )QgsGeorefTransform::Helmert );
@@ -47,8 +87,6 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
   cmbTransformType->addItem( tr( "Polynomial 3" ), ( int )QgsGeorefTransform::PolynomialOrder3 );
   cmbTransformType->addItem( tr( "Thin Plate Spline" ), ( int )QgsGeorefTransform::ThinPlateSpline );
   cmbTransformType->addItem( tr( "Projective" ), ( int )QgsGeorefTransform::Projective );
-
-  leOutputRaster->setText( output );
 
   // Populate CompressionComboBox
   mListCompression.append( QStringLiteral( "None" ) );
@@ -62,27 +100,27 @@ QgsTransformSettingsDialog::QgsTransformSettingsDialog( const QString &raster, c
   }
   cmbCompressionComboBox->addItems( listCompressionTr );
 
-  cmbTransformType->setCurrentIndex( s.value( QStringLiteral( "/Plugin-GeoReferencer/lasttransformation" ), -1 ).toInt() );
-  cmbResampling->setCurrentIndex( s.value( QStringLiteral( "/Plugin-GeoReferencer/lastresampling" ), 0 ).toInt() );
-  cmbCompressionComboBox->setCurrentIndex( s.value( QStringLiteral( "/Plugin-GeoReferencer/lastcompression" ), 0 ).toInt() );
+  cmbTransformType->setCurrentIndex( settings.value( QStringLiteral( "/Plugin-GeoReferencer/lasttransformation" ), -1 ).toInt() );
+  cmbResampling->setCurrentIndex( settings.value( QStringLiteral( "/Plugin-GeoReferencer/lastresampling" ), 0 ).toInt() );
+  cmbCompressionComboBox->setCurrentIndex( settings.value( QStringLiteral( "/Plugin-GeoReferencer/lastcompression" ), 0 ).toInt() );
 
-  QString targetCRSString = s.value( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ) ).toString();
+  QString targetCRSString = settings.value( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ) ).toString();
   QgsCoordinateReferenceSystem targetCRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( targetCRSString );
   mCrsSelector->setCrs( targetCRS );
 
-  mWorldFileCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-Georeferencer/word_file_checkbox" ), false ).toBool() );
+  mWorldFileCheckBox->setChecked( settings.value( QStringLiteral( "/Plugin-Georeferencer/word_file_checkbox" ), false ).toBool() );
 
-  cbxUserResolution->setChecked( s.value( QStringLiteral( "/Plugin-Georeferencer/user_specified_resolution" ), false ).toBool() );
+  cbxUserResolution->setChecked( settings.value( QStringLiteral( "/Plugin-Georeferencer/user_specified_resolution" ), false ).toBool() );
   bool ok;
-  dsbHorizRes->setValue( s.value( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resx" ),     1.0 ).toDouble( &ok ) );
+  dsbHorizRes->setValue( settings.value( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resx" ), .0 ).toDouble( &ok ) );
   if ( !ok )
     dsbHorizRes->setValue( 1.0 );
-  dsbVerticalRes->setValue( s.value( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resy" ), -1.0 ).toDouble( &ok ) );
+  dsbVerticalRes->setValue( settings.value( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resy" ), -1.0 ).toDouble( &ok ) );
   if ( !ok )
     dsbHorizRes->setValue( -1.0 );
 
-  cbxZeroAsTrans->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/zeroastrans" ), false ).toBool() );
-  cbxLoadInQgisWhenDone->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), false ).toBool() );
+  cbxZeroAsTrans->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/zeroastrans" ), false ).toBool() );
+  cbxLoadInQgisWhenDone->setChecked( settings.value( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), false ).toBool() );
 }
 
 QgsTransformSettingsDialog::~QgsTransformSettingsDialog()
@@ -110,11 +148,11 @@ void QgsTransformSettingsDialog::getTransformSettings( QgsGeorefTransform::Trans
   }
   else
   {
-    raster = leOutputRaster->text();
+    raster = mOutputRaster->filePath();
   }
   proj = mCrsSelector->crs();
-  pdfMapFile = mMapFileLineEdit->text();
-  pdfReportFile = mReportFileLineEdit->text();
+  pdfMapFile = mPdfMap->filePath();
+  pdfReportFile = mPdfReport->filePath();
   zt = cbxZeroAsTrans->isChecked();
   loadInQgis = cbxLoadInQgisWhenDone->isChecked();
   resX = 0.0;
@@ -157,96 +195,40 @@ void QgsTransformSettingsDialog::changeEvent( QEvent *e )
 
 void QgsTransformSettingsDialog::accept()
 {
-  if ( !leOutputRaster->text().isEmpty() )
+  if ( !mOutputRaster->filePath().isEmpty() )
   {
     //if the file path is relative, make it relative to the raster file directory
-    QString outputRasterName = leOutputRaster->text();
+    QString outputRasterName = mOutputRaster->filePath();
     QFileInfo rasterFileInfo( mSourceRasterFile );
     QFileInfo outputFileInfo( rasterFileInfo.absoluteDir(), outputRasterName );
 
     if ( outputFileInfo.fileName().isEmpty() || !outputFileInfo.dir().exists() )
     {
       QMessageBox::warning( this, tr( "Destination Raster" ), tr( "Invalid output file name." ) );
-      leOutputRaster->setFocus();
       return;
     }
     if ( outputFileInfo.filePath() == mSourceRasterFile )
     {
       //can't overwrite input file
       QMessageBox::warning( this, tr( "Destination Raster" ), tr( "Input raster can not be overwritten." ) );
-      leOutputRaster->setFocus();
       return;
     }
-    leOutputRaster->setText( outputFileInfo.absoluteFilePath() );
+    mOutputRaster->setFilePath( outputFileInfo.absoluteFilePath() );
   }
 
-  QgsSettings s;
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lasttransformation" ), cmbTransformType->currentIndex() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastresampling" ), cmbResampling->currentIndex() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastcompression" ), cmbCompressionComboBox->currentIndex() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ), mCrsSelector->crs().authid() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/zeroastrans" ), cbxZeroAsTrans->isChecked() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), cbxLoadInQgisWhenDone->isChecked() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resolution" ), cbxUserResolution->isChecked() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resx" ), dsbHorizRes->value() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resy" ), dsbVerticalRes->value() );
-  s.setValue( QStringLiteral( "/Plugin-GeoReferencer/word_file_checkbox" ), mWorldFileCheckBox->isChecked() );
-  QString pdfReportFileName = mReportFileLineEdit->text();
-  if ( !pdfReportFileName.isEmpty() )
-  {
-    QFileInfo fi( pdfReportFileName );
-    s.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), fi.absolutePath() );
-  }
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/lasttransformation" ), cmbTransformType->currentIndex() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastresampling" ), cmbResampling->currentIndex() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/lastcompression" ), cmbCompressionComboBox->currentIndex() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ), mCrsSelector->crs().authid() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/zeroastrans" ), cbxZeroAsTrans->isChecked() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/loadinqgis" ), cbxLoadInQgisWhenDone->isChecked() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resolution" ), cbxUserResolution->isChecked() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resx" ), dsbHorizRes->value() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/user_specified_resy" ), dsbVerticalRes->value() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/word_file_checkbox" ), mWorldFileCheckBox->isChecked() );
+
   QDialog::accept();
-}
-
-void QgsTransformSettingsDialog::tbnOutputRaster_clicked()
-{
-  QString selectedFile = leOutputRaster->text();
-  if ( selectedFile.isEmpty() )
-  {
-    selectedFile = generateModifiedRasterFileName( mSourceRasterFile );
-  }
-
-  QString rasterFileName = QFileDialog::getSaveFileName( this, tr( "Destination Raster" ),
-                           selectedFile, QStringLiteral( "GeoTIFF (*.tif *.tiff *.TIF *.TIFF)" ) );
-  if ( rasterFileName.isEmpty() )
-    return;
-
-  leOutputRaster->setText( rasterFileName );
-  leOutputRaster->setToolTip( rasterFileName );
-}
-
-void QgsTransformSettingsDialog::tbnMapFile_clicked()
-{
-  QgsSettings s;
-  QString myLastUsedDir = s.value( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() ).toString();
-  QString initialFile = !mMapFileLineEdit->text().isEmpty() ? mMapFileLineEdit->text() : myLastUsedDir;
-  QString outputFileName = QFileDialog::getSaveFileName( this, tr( "Save Map File as" ), initialFile, tr( "PDF Format" ) + " (*.pdf *PDF)" );
-  if ( !outputFileName.isNull() )
-  {
-    if ( !outputFileName.endsWith( QLatin1String( ".pdf" ), Qt::CaseInsensitive ) )
-    {
-      outputFileName.append( ".pdf" );
-    }
-    mMapFileLineEdit->setText( outputFileName );
-  }
-}
-
-void QgsTransformSettingsDialog::tbnReportFile_clicked()
-{
-  QgsSettings s;
-  QString myLastUsedDir = s.value( QStringLiteral( "/Plugin-GeoReferencer/lastPDFReportDir" ), QDir::homePath() ).toString();
-  QString initialFile = !mReportFileLineEdit->text().isEmpty() ? mReportFileLineEdit->text() : myLastUsedDir;
-  QString outputFileName = QFileDialog::getSaveFileName( this, tr( "Save Report File as" ), initialFile, tr( "PDF Format" ) + " (*.pdf *PDF)" );
-  if ( !outputFileName.isNull() )
-  {
-    if ( !outputFileName.endsWith( QLatin1String( ".pdf" ), Qt::CaseInsensitive ) )
-    {
-      outputFileName.append( ".pdf" );
-    }
-    mReportFileLineEdit->setText( outputFileName );
-  }
 }
 
 void QgsTransformSettingsDialog::cmbTransformType_currentIndexChanged( const QString &text )
@@ -271,8 +253,7 @@ void QgsTransformSettingsDialog::mWorldFileCheckBox_stateChanged( int state )
     enableOutputRaster = false;
   }
   label_2->setEnabled( enableOutputRaster );
-  leOutputRaster->setEnabled( enableOutputRaster );
-  tbnOutputRaster->setEnabled( enableOutputRaster );
+  mOutputRaster->setEnabled( enableOutputRaster );
 }
 
 bool QgsTransformSettingsDialog::checkGCPpoints( int count, int &minGCPpoints )

--- a/src/plugins/georeferencer/qgstransformsettingsdialog.h
+++ b/src/plugins/georeferencer/qgstransformsettingsdialog.h
@@ -42,9 +42,6 @@ class QgsTransformSettingsDialog : public QDialog, private Ui::QgsTransformSetti
     void accept() override;
 
   private slots:
-    void tbnOutputRaster_clicked();
-    void tbnMapFile_clicked();
-    void tbnReportFile_clicked();
     void cmbTransformType_currentIndexChanged( const QString &text );
     void mWorldFileCheckBox_stateChanged( int state );
     QIcon getThemeIcon( const QString &name );

--- a/src/plugins/georeferencer/qgstransformsettingsdialogbase.ui
+++ b/src/plugins/georeferencer/qgstransformsettingsdialogbase.ui
@@ -22,6 +22,12 @@
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
        <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Transformation type</string>
         </property>
@@ -71,6 +77,12 @@
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="textLabel1">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Resampling method</string>
         </property>
@@ -88,6 +100,12 @@
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Target SRS</string>
         </property>
@@ -104,27 +122,20 @@
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Output raster</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLineEdit" name="leOutputRaster"/>
-        </item>
-        <item>
-         <widget class="QToolButton" name="tbnOutputRaster">
-          <property name="text">
-           <string>…</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QgsFileWidget" name="mOutputRaster">
+       </widget>
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="cmbCompressionComboBox">
@@ -205,6 +216,12 @@
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="mCompressionLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Compression</string>
         </property>
@@ -277,21 +294,8 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <property name="spacing">
-         <number>1</number>
-        </property>
-        <item>
-         <widget class="QLineEdit" name="mMapFileLineEdit"/>
-        </item>
-        <item>
-         <widget class="QToolButton" name="tbnMapFile">
-          <property name="text">
-           <string>…</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QgsFileWidget" name="mPdfMap">
+       </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_6">
@@ -301,21 +305,8 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <property name="spacing">
-         <number>1</number>
-        </property>
-        <item>
-         <widget class="QLineEdit" name="mReportFileLineEdit"/>
-        </item>
-        <item>
-         <widget class="QToolButton" name="tbnReportFile">
-          <property name="text">
-           <string>…</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QgsFileWidget" name="mPdfReport">
+       </widget>
       </item>
      </layout>
     </widget>
@@ -334,23 +325,26 @@
    <header location="global">qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>cmbTransformType</tabstop>
   <tabstop>cmbResampling</tabstop>
   <tabstop>mCrsSelector</tabstop>
-  <tabstop>leOutputRaster</tabstop>
-  <tabstop>tbnOutputRaster</tabstop>
+  <tabstop>mOutputRaster</tabstop>
   <tabstop>cmbCompressionComboBox</tabstop>
   <tabstop>mWorldFileCheckBox</tabstop>
   <tabstop>cbxZeroAsTrans</tabstop>
   <tabstop>cbxUserResolution</tabstop>
   <tabstop>dsbHorizRes</tabstop>
   <tabstop>dsbVerticalRes</tabstop>
-  <tabstop>mMapFileLineEdit</tabstop>
-  <tabstop>tbnMapFile</tabstop>
-  <tabstop>mReportFileLineEdit</tabstop>
-  <tabstop>tbnReportFile</tabstop>
+  <tabstop>mPdfMap</tabstop>
+  <tabstop>mPdfReport</tabstop>
   <tabstop>cbxLoadInQgisWhenDone</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
## Description
This PR imporves the georeferencer's transformation settings UI by avoiding labels expanding horizontally to provide more space for the projection selector widget. It also upgrade the code to make use of our QgsFileWidget.

Before (left) vs. proposed (right):
![screenshot from 2017-12-26 12-06-33](https://user-images.githubusercontent.com/1728657/34347467-0c119df4-ea36-11e7-81b4-0db6de185903.png)
_Notice the widget spacing improvements all around, using an harmonized value for projection selector & file widgets_

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
