### PR TITLE
Put X field above Y field in Delimited Text dialog. Fix #11746.

### DIFF
--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -180,8 +180,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>696</width>
-        <height>742</height>
+        <width>704</width>
+        <height>694</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -950,7 +950,7 @@
               </property>
               <item>
                <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,0">
-                <item row="3" column="1">
+                <item row="4" column="1">
                  <widget class="QCheckBox" name="cbxXyDms">
                   <property name="toolTip">
                    <string>X and Y coordinates are expressed in degrees/minutes/seconds</string>
@@ -963,37 +963,6 @@
                   </property>
                   <property name="text">
                    <string>DMS coordinates</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QComboBox" name="cmbYField">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>120</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="toolTip">
-                   <string>Name of the field containing y values</string>
-                  </property>
-                  <property name="statusTip">
-                   <string>Name of the field containing y values</string>
-                  </property>
-                  <property name="whatsThis">
-                   <string>Name of the field containing y values</string>
-                  </property>
-                  <property name="editable">
-                   <bool>false</bool>
                   </property>
                  </widget>
                 </item>
@@ -1028,19 +997,34 @@
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="textLabely">
+                <item row="2" column="1">
+                 <widget class="QComboBox" name="cmbYField">
                   <property name="enabled">
                    <bool>true</bool>
                   </property>
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <property name="text">
-                   <string>&lt;p align=&quot;left&quot;&gt;Y field&lt;/p&gt;</string>
+                  <property name="minimumSize">
+                   <size>
+                    <width>120</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Name of the field containing y values</string>
+                  </property>
+                  <property name="statusTip">
+                   <string>Name of the field containing y values</string>
+                  </property>
+                  <property name="whatsThis">
+                   <string>Name of the field containing y values</string>
+                  </property>
+                  <property name="editable">
+                   <bool>false</bool>
                   </property>
                  </widget>
                 </item>
@@ -1054,6 +1038,22 @@
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="textLabely">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>&lt;p align=&quot;left&quot;&gt;Y field&lt;/p&gt;</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
## Description
Address this ticket https://issues.qgis.org/issues/17746
Before (from the ticket):
<img width="708" alt="before" src="https://issues.qgis.org/attachments/download/11873/Spectacle.K17690.png">

After:
<img width="708" alt="screen shot 2017-12-26 at 21 08 58" src="https://user-images.githubusercontent.com/1421861/34358347-7e724420-ea81-11e7-8d53-3b2ec1f9eb38.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

Funded by: Kartoza