### PR TITLE
Replace Q_ASSERT with QVERIFY in tests

### DIFF
--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -252,7 +252,7 @@ void TestQgsAttributeTable::testRegression15974()
   QgsFeature f1( shpLayer->dataProvider()->fields(), 1 );
   QgsGeometry geom;
   geom = QgsGeometry().fromWkt( QStringLiteral( "polygon((0 0, 0 1, 1 1, 1 0, 0 0))" ) );
-  Q_ASSERT( geom.isGeosValid() );
+  QVERIFY( geom.isGeosValid() );
   f1.setGeometry( geom );
   QgsFeature f2( shpLayer->dataProvider()->fields(), 2 );
   f2.setGeometry( geom );

--- a/tests/src/core/testmaprendererjob.cpp
+++ b/tests/src/core/testmaprendererjob.cpp
@@ -50,7 +50,7 @@ class TestQgsMapRendererJob : public QObject
 static QString _loadLayer( QString path )
 {
   QgsMapLayer *layer = new QgsVectorLayer( path, "testlayer", "ogr" );
-  Q_ASSERT( layer->isValid() );
+  QVERIFY( layer->isValid() );
   QgsProject::instance()->addMapLayer( layer );
   return layer->id();
 }

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -73,15 +73,15 @@ void TestQgsDxfExport::init()
 {
   QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
   mPointLayer = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
-  Q_ASSERT( mPointLayer->isValid() );
+  QVERIFY( mPointLayer->isValid() );
   QgsProject::instance()->addMapLayer( mPointLayer );
   filename = QStringLiteral( TEST_DATA_DIR ) + "/lines.shp";
   mLineLayer = new QgsVectorLayer( filename, QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
-  Q_ASSERT( mLineLayer->isValid() );
+  QVERIFY( mLineLayer->isValid() );
   QgsProject::instance()->addMapLayer( mLineLayer );
   filename = QStringLiteral( TEST_DATA_DIR ) + "/polys.shp";
   mPolygonLayer = new QgsVectorLayer( filename, QStringLiteral( "polygons" ), QStringLiteral( "ogr" ) );
-  Q_ASSERT( mPolygonLayer->isValid() );
+  QVERIFY( mPolygonLayer->isValid() );
   QgsProject::instance()->addMapLayer( mPolygonLayer );
 }
 

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -533,13 +533,13 @@ void TestQgsExpressionContext::takeScopes()
   auto scopes = context.takeScopes();
 
   QCOMPARE( scopes.length(), 2 );
-  Q_ASSERT( scopes.at( 0 )->hasVariable( "test_global" ) );
-  Q_ASSERT( scopes.at( 1 )->hasVariable( "test_project" ) );
+  QVERIFY( scopes.at( 0 )->hasVariable( "test_global" ) );
+  QVERIFY( scopes.at( 1 )->hasVariable( "test_project" ) );
 
   qDeleteAll( scopes );
 
-  Q_ASSERT( !context.variable( "test_global" ).isValid() );
-  Q_ASSERT( !context.variable( "test_project" ).isValid() );
+  QVERIFY( !context.variable( "test_global" ).isValid() );
+  QVERIFY( !context.variable( "test_project" ).isValid() );
 }
 
 void TestQgsExpressionContext::globalScope()

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -86,7 +86,7 @@ void TestQgsLabelingEngine::init()
 {
   QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
   vl = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
-  Q_ASSERT( vl->isValid() );
+  QVERIFY( vl->isValid() );
   QgsProject::instance()->addMapLayer( vl );
 }
 
@@ -179,7 +179,7 @@ void TestQgsLabelingEngine::testDiagrams()
 
   bool res;
   vl->loadNamedStyle( QStringLiteral( TEST_DATA_DIR ) + "/points_diagrams.qml", res );
-  Q_ASSERT( res );
+  QVERIFY( res );
 
   QgsLabelingEngine engine;
   engine.setMapSettings( mapSettings );
@@ -353,7 +353,7 @@ void TestQgsLabelingEngine::zOrder()
   //add a second layer
   QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
   QgsVectorLayer *vl2 = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
-  Q_ASSERT( vl2->isValid() );
+  QVERIFY( vl2->isValid() );
   QgsProject::instance()->addMapLayer( vl2 );
 
   QgsPalLayerSettings pls2( pls1 );

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -83,7 +83,7 @@ class TestTerminationTask : public TestTask
     ~TestTerminationTask() override
     {
       //make sure task has been terminated by manager prior to deletion
-      Q_ASSERT( status() == QgsTask::Terminated );
+      QVERIFY( status() == QgsTask::Terminated );
     }
 
   protected:
@@ -167,7 +167,7 @@ class FinishTask : public QgsTask
 
     void finished( bool result ) override
     {
-      Q_ASSERT( QApplication::instance()->thread() == QThread::currentThread() );
+      QVERIFY( QApplication::instance()->thread() == QThread::currentThread() );
       *resultObtained = result;
     }
 };

--- a/tests/src/core/testqgstracer.cpp
+++ b/tests/src/core/testqgstracer.cpp
@@ -338,7 +338,7 @@ void TestQgsTracer::testCurved()
 
   QgsPolylineXY points1 = tracer.findShortestPath( QgsPointXY( 0, 0 ), QgsPointXY( 10, 10 ) );
 
-  QVERIFY( points1.count() != 0 );
+  QVERIFY( !points1.isEmpty() );
 
   QgsGeometry tmpG1 = QgsGeometry::fromPolylineXY( points1 );
   double l = tmpG1.length();

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -188,10 +188,10 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   ww3 = qobject_cast<QgsEditorWidgetWrapper *>( form.mWidgets[3] );
 
   // no constraint so we expect an empty label
-  Q_ASSERT( constraintsLabel( &form, ww0 )->text().isEmpty() );
-  Q_ASSERT( constraintsLabel( &form, ww1 )->text().isEmpty() );
-  Q_ASSERT( constraintsLabel( &form, ww2 )->text().isEmpty() );
-  Q_ASSERT( constraintsLabel( &form, ww3 )->text().isEmpty() );
+  QVERIFY( constraintsLabel( &form, ww0 )->text().isEmpty() );
+  QVERIFY( constraintsLabel( &form, ww1 )->text().isEmpty() );
+  QVERIFY( constraintsLabel( &form, ww2 )->text().isEmpty() );
+  QVERIFY( constraintsLabel( &form, ww3 )->text().isEmpty() );
 
   // update constraint
   layer->setConstraintExpression( 0, QStringLiteral( "col0 < (col1 * col2)" ) );

--- a/tests/src/gui/testqgsfeaturelistcombobox.cpp
+++ b/tests/src/gui/testqgsfeaturelistcombobox.cpp
@@ -99,7 +99,7 @@ void TestQgsFeatureListComboBox::testSetGetLayer()
 {
   std::unique_ptr<QgsFeatureListComboBox> cb( new QgsFeatureListComboBox() );
 
-  Q_ASSERT( cb->sourceLayer() == nullptr );
+  QVERIFY( cb->sourceLayer() == nullptr );
   cb->setSourceLayer( mLayer.get() );
   QCOMPARE( cb->sourceLayer(), mLayer.get() );
 }
@@ -109,17 +109,17 @@ void TestQgsFeatureListComboBox::testSetGetForeignKey()
   QgsFeatureListComboBox *cb = new QgsFeatureListComboBox();
   // std::unique_ptr<QgsFeatureListComboBox> cb( new QgsFeatureListComboBox() );
 
-  Q_ASSERT( cb->identifierValue().isNull() );
+  QVERIFY( cb->identifierValue().isNull() );
 
   cb->setSourceLayer( mLayer.get() );
   cb->setDisplayExpression( "\"material\"" );
   cb->lineEdit()->setText( "ro" );
   emit cb->lineEdit()->textChanged( "ro" );
-  Q_ASSERT( cb->identifierValue().isNull() );
+  QVERIFY( cb->identifierValue().isNull() );
 
   waitForLoaded( cb );
 
-  Q_ASSERT( cb->identifierValue().isNull() );
+  QVERIFY( cb->identifierValue().isNull() );
 
   cb->setIdentifierValue( 20 );
   QCOMPARE( cb->identifierValue(), QVariant( 20 ) );
@@ -127,7 +127,7 @@ void TestQgsFeatureListComboBox::testSetGetForeignKey()
 
 void TestQgsFeatureListComboBox::testAllowNull()
 {
-  Q_ASSERT( false );
+  QVERIFY( false );
   // Note to self: implement this!
 }
 

--- a/tests/src/gui/testqgsfiledownloader.cpp
+++ b/tests/src/gui/testqgsfiledownloader.cpp
@@ -133,7 +133,7 @@ void TestQgsFileDownloader::init()
   mCompleted = false;
   mExited = false;
   mTempFile = new QTemporaryFile();
-  Q_ASSERT( mTempFile->open() );
+  QVERIFY( mTempFile->open() );
   mTempFile->close();
 }
 

--- a/tests/src/gui/testrenderergui.cpp
+++ b/tests/src/gui/testrenderergui.cpp
@@ -55,8 +55,8 @@ void TestRendererGUI::loadLayers()
 void TestRendererGUI::setRenderer()
 {
   QgsMapLayer *layer = mMapCanvas->layer( 0 );
-  Q_ASSERT( layer );
-  Q_ASSERT( layer->type() == QgsMapLayer::VectorLayer );
+  QVERIFY( layer );
+  QVERIFY( layer->type() == QgsMapLayer::VectorLayer );
   QgsVectorLayer *vlayer = static_cast<QgsVectorLayer *>( layer );
 
   QgsRendererPropertiesDialog dlg( vlayer, QgsStyle::defaultStyle() );

--- a/tests/src/providers/grass/testqgsgrassprovider.cpp
+++ b/tests/src/providers/grass/testqgsgrassprovider.cpp
@@ -1209,7 +1209,7 @@ void TestQgsGrassProvider::edit()
         grassLayer->startEditing();
         grassProvider->startEditing( grassLayer );
 
-        Q_ASSERT( expectedLayer );
+        QVERIFY( expectedLayer );
         expectedLayer->startEditing();
       }
 
@@ -1577,7 +1577,7 @@ bool TestQgsGrassProvider::compare( QMap<QString, QgsVectorLayer *> layers, bool
   Q_FOREACH ( const QString &grassUri, layers.keys() )
   {
     QgsVectorLayer *layer = layers.value( grassUri );
-    Q_ASSERT( layer );
+    QVERIFY( layer );
     if ( !compare( grassUri, layer, ok ) )
     {
       reportRow( "comparison failed: " + grassUri );


### PR DESCRIPTION
Q_ASSERT's are only evaluated in debug mode. However, tests should trigger in debug or release mode.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
