### PR TITLE
[date widget] fix current date can't be picked

### DIFF
--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -67,9 +67,6 @@ Resets the widget to show no value (ie, an "unknown" state).
 %End
 
   protected:
-    virtual void resizeEvent( QResizeEvent *event );
-
-
     virtual void mousePressEvent( QMouseEvent *event );
 
 

--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -73,7 +73,6 @@ Resets the widget to show no value (ie, an "unknown" state).
     virtual void mousePressEvent( QMouseEvent *event );
 
 
-
 };
 
 /************************************************************************

--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -8,7 +8,6 @@
 
 
 
-
 class QgsDateTimeEdit : QDateTimeEdit
 {
 %Docstring

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -17,9 +17,7 @@
 #include <QCalendarWidget>
 #include <QLineEdit>
 #include <QMouseEvent>
-#include <QSettings>
 #include <QStyle>
-#include <QToolButton>
 #include <QStyleOptionSpinBox>
 
 

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -20,9 +20,6 @@
 #include "qgis.h"
 #include "qgis_gui.h"
 
-class QToolButton;
-class QLineEdit;
-
 /**
  * \ingroup gui
  * \brief The QgsDateTimeEdit class is a QDateTimeEdit with the capability of setting/reading null date/times.

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -66,8 +66,6 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     void setEmpty();
 
   protected:
-    void resizeEvent( QResizeEvent *event ) override;
-
     void mousePressEvent( QMouseEvent *event ) override;
 
   private slots:
@@ -76,15 +74,12 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     void calendarSelectionChanged();
 
   private:
-    int spinButtonWidth() const;
-    int frameWidth() const;
-
     bool mAllowNull = true;
     bool mIsNull = true;
     bool mIsEmpty = false;
 
-    QToolButton *mClearButton = nullptr;
     QString mOriginalStyleSheet = QString();
+    QAction *mClearAction;
 
     /**
      * Set the lowest Date that can be displayed with the Qt::ISODate format

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -74,6 +74,8 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
   private slots:
     void changed( const QDateTime &dateTime );
 
+    void calendarSelectionChanged();
+
 
   private:
     int spinButtonWidth() const;
@@ -101,7 +103,6 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     {
       setMinimumDateTime( QDateTime::fromString( QStringLiteral( "0100-01-01" ), Qt::ISODate ) );
     }
-
 };
 
 #endif // QGSDATETIMEEDIT_H

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -70,12 +70,10 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
 
     void mousePressEvent( QMouseEvent *event ) override;
 
-
   private slots:
     void changed( const QDateTime &dateTime );
 
     void calendarSelectionChanged();
-
 
   private:
     int spinButtonWidth() const;
@@ -85,8 +83,8 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     bool mIsNull = true;
     bool mIsEmpty = false;
 
-    QLineEdit *mNullLabel = nullptr;
     QToolButton *mClearButton = nullptr;
+    QString mOriginalStyleSheet = QString();
 
     /**
      * Set the lowest Date that can be displayed with the Qt::ISODate format

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -67,7 +67,10 @@ void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
   mQDateTimeEdit->setDisplayFormat( displayFormat );
 
   const bool calendar = config( QStringLiteral( "calendar_popup" ), true ).toBool();
-  mQDateTimeEdit->setCalendarPopup( calendar );
+  if ( calendar != mQDateTimeEdit->calendarPopup() )
+  {
+    mQDateTimeEdit->setCalendarPopup( calendar );
+  }
   if ( calendar && mQDateTimeEdit->calendarWidget() )
   {
     // highlight today's date


### PR DESCRIPTION
fix #16579

Current date couldn't be picked up when allowing NULL date in the calendar widget because it was actually the already selected date in the subsequent QDateTimeEdit.

So now, when clearing the `QgsDateTimeEdit` (setting to NULL), the date of `QDateTimeEdit` is set to `mimimumDate()` (but only when in `calendarPopup()`is true).

To display the calendar at the current date page, it detects `QCalendarWidget::selectionChanged` signal, and if the date is the `mimimumDate()` the page is changed to current date.

There is two (very) small drawbacks:
* if one needs to use the `mimimunDate()` value and widget accepts NIULL values, the calendar will show up at today's page and not at the value's page (minimum date)
* turning off then on again the calendar popup will lead to not showing the current page properly (as the calendar widget object will be deleted and thus disconnected).

I think these are fairly acceptable...

I tried a few other ways, and that's the only one I got working properly.

One of the other approach was to subclass QCalendarWidget and implement showEvent but this is useless as the setDate happens afterwards.
I also tried to setCurrentPage of the calendar when clearing the date time edit, but it's the same issue.