### PR TITLE
Revert QVERIFY change

### DIFF
--- a/tests/src/providers/grass/testqgsgrassprovider.cpp
+++ b/tests/src/providers/grass/testqgsgrassprovider.cpp
@@ -1577,7 +1577,7 @@ bool TestQgsGrassProvider::compare( QMap<QString, QgsVectorLayer *> layers, bool
   Q_FOREACH ( const QString &grassUri, layers.keys() )
   {
     QgsVectorLayer *layer = layers.value( grassUri );
-    QVERIFY( layer );
+    Q_ASSERT( layer );
     if ( !compare( grassUri, layer, ok ) )
     {
       reportRow( "comparison failed: " + grassUri );


### PR DESCRIPTION
Fix the build error
```
In file included from /usr/include/i386-linux-gnu/qt5/QtTest/qtest.h:38:0,
                 from /usr/include/i386-linux-gnu/qt5/QtTest/QtTest:7,
                 from ../src/test/qgstest.h:19,
                 from ../tests/src/providers/grass/testqgsgrassprovider.cpp:23:
../tests/src/providers/grass/testqgsgrassprovider.cpp: In member function ‘bool TestQgsGrassProvider::compare(QMap<QString, QgsVectorLayer*>, bool&)’:
../tests/src/providers/grass/testqgsgrassprovider.cpp:1580:5: error: return-statement with no value, in function returning ‘bool’ [-fpermissive]
     QVERIFY( layer );
     ^
```
@m-kuhn ?