### PR TITLE
Contextmenu with individual actions

### DIFF
--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -247,6 +247,14 @@ Emitted when the form changes mode.
 :param mode: new mode
 %End
 
+    void showContextMenuExternally( QgsActionMenu *menu, const QgsFeatureId fid );
+%Docstring
+Emitted when selecting context menu on the feature list to create the context menu individually
+
+:param menu: context menu
+:param fid: feature id of the selected feature
+%End
+
   protected:
     virtual void hideEvent( QHideEvent *event );
 

--- a/python/gui/attributetable/qgsfeaturelistview.sip
+++ b/python/gui/attributetable/qgsfeaturelistview.sip
@@ -128,6 +128,14 @@ Is emitted, whenever the display expression is successfully changed
 %End
 
 
+    void willShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex );
+%Docstring
+Is emitted, when the context menu is created to add the specific actions to it
+
+:param menu: is the already created context menu
+:param atIndex: is the position of the current feature in the model
+%End
+
   public slots:
 
     void setEditSelection( const QgsFeatureIds &fids );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -105,6 +105,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   connect( mMainView, &QgsDualView::currentChanged, this, &QgsAttributeTableDialog::mMainView_currentChanged );
   connect( mActionAddFeature, &QAction::triggered, this, &QgsAttributeTableDialog::mActionAddFeature_triggered );
   connect( mActionExpressionSelect, &QAction::triggered, this, &QgsAttributeTableDialog::mActionExpressionSelect_triggered );
+  connect( mMainView, &QgsDualView::showContextMenuExternally, this, &QgsAttributeTableDialog::showContextMenu );
 
   Q_FOREACH ( const QgsField &field, mLayer->fields() )
   {
@@ -1041,6 +1042,21 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
   mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowFilteredList );
 }
 
+
+void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
+{
+  QgsDebugMsg( QString( "Delete %1" ).arg( fid ) );
+  mLayer->deleteFeature( fid );
+}
+
+void QgsAttributeTableDialog::showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid )
+{
+  if ( mLayer->isEditable() )
+  {
+    QAction *qAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteSelected.svg" ) ),  tr( "Delete feature" ) );
+    connect( qAction, &QAction::triggered, this, [this, fid]() { deleteFeature( fid ); } );
+  }
+}
 
 //
 // QgsAttributeTableDock

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -219,6 +219,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     void updateFieldFromExpressionSelected();
     void viewModeChanged( QgsAttributeForm::Mode mode );
     void formFilterSet( const QString &filter, QgsAttributeForm::FilterType type );
+    void showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid );
 
   private:
     QMenu *mMenuActions = nullptr;
@@ -236,6 +237,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     QgsAttributeEditorContext mEditorContext;
 
     void updateMultiEditButtonState();
+    void deleteFeature( const QgsFeatureId fid );
 
     friend class TestQgsAttributeTable;
 };

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -74,6 +74,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   mTableView->horizontalHeader()->setContextMenuPolicy( Qt::CustomContextMenu );
   connect( mTableView->horizontalHeader(), &QHeaderView::customContextMenuRequested, this, &QgsDualView::showViewHeaderMenu );
   connect( mTableView, &QgsAttributeTableView::columnResized, this, &QgsDualView::tableColumnResized );
+  connect( mFeatureList, &QgsFeatureListView::willShowContextMenu, this, &QgsDualView::widgetWillShowContextMenu );
 
   initLayerCache( !( request.flags() & QgsFeatureRequest::NoGeometry ) || !request.filterRect().isNull() );
   initModels( mapCanvas, request, loadFeatures );
@@ -401,7 +402,6 @@ void QgsDualView::insertRecentlyUsedDisplayExpression( const QString &expression
   mLastDisplayExpressionAction = previewAction;
 }
 
-
 void QgsDualView::mFeatureList_aboutToChangeEditSelection( bool &ok )
 {
   if ( mLayer->isEditable() && !mAttributeForm->save() )
@@ -543,7 +543,6 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &atInd
     return;
   }
 
-
   QModelIndex sourceIndex = mFilterModel->mapToSource( atIndex );
 
   QAction *copyContentAction = new QAction( tr( "Copy cell content" ), this );
@@ -607,6 +606,13 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &atInd
   menu->addAction( tr( "Open form" ), a, &QgsAttributeTableAction::featureForm );
 #endif
 }
+
+
+void QgsDualView::widgetWillShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex )
+{
+  emit showContextMenuExternally( menu, mFilterModel->rowToId( atIndex ) );
+}
+
 
 void QgsDualView::showViewHeaderMenu( QPoint point )
 {

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -269,6 +269,13 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      */
     void formModeChanged( QgsAttributeForm::Mode mode );
 
+    /**
+     * Emitted when selecting context menu on the feature list to create the context menu individually
+     * \param menu context menu
+     * \param fid feature id of the selected feature
+     */
+    void showContextMenuExternally( QgsActionMenu *menu, const QgsFeatureId fid );
+
   protected:
     void hideEvent( QHideEvent *event ) override;
 
@@ -288,6 +295,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void previewColumnChanged( QAction *previewAction, const QString &expression );
 
     void viewWillShowContextMenu( QMenu *menu, const QModelIndex &atIndex );
+
+    void widgetWillShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex );
 
     void showViewHeaderMenu( QPoint point );
 

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -19,7 +19,6 @@
 #include <QSet>
 #include <QSettings>
 
-#include "qgsactionmenu.h"
 #include "qgsattributetabledelegate.h"
 #include "qgsattributetablefiltermodel.h"
 #include "qgsattributetablemodel.h"
@@ -302,6 +301,9 @@ void QgsFeatureListView::contextMenuEvent( QContextMenuEvent *event )
     QgsFeature feature = mModel->data( index, QgsFeatureListModel::FeatureRole ).value<QgsFeature>();
 
     QgsActionMenu *menu = new QgsActionMenu( mModel->layerCache()->layer(), feature, QStringLiteral( "Feature" ), this );
+
+    emit willShowContextMenu( menu, index );
+
     menu->exec( event->globalPos() );
   }
 }

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -20,6 +20,7 @@
 #include "qgis_sip.h"
 #include "qgis.h"
 #include <qdebug.h>
+#include "qgsactionmenu.h"
 
 #include "qgsfeature.h" // For QgsFeatureIds
 #include "qgis_gui.h"
@@ -146,6 +147,13 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     //! \note not available in Python bindings
     void aboutToChangeEditSelection( bool &ok ) SIP_SKIP;
 
+    /**
+     * Is emitted, when the context menu is created to add the specific actions to it
+     * \param menu is the already created context menu
+     * \param atIndex is the position of the current feature in the model
+     */
+    void willShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex );
+
   public slots:
 
     /**
@@ -191,6 +199,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     bool mEditSelectionDrag = false; // Is set to true when the user initiated a left button click over an edit button and still keeps pressing //!< TODO
     int mRowAnchor = 0;
     QItemSelectionModel::SelectionFlags mCtrlDragSelectionFlag;
+
 };
 
 #endif

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -148,11 +148,14 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void addFeature();
     void duplicateFeature();
     void linkFeature();
-    void deleteFeature();
-    void unlinkFeature();
+    void deleteFeature( const QgsFeatureId featureid = QgsFeatureId() );
+    void deleteSelectedFeatures();
+    void unlinkFeature( const QgsFeatureId featureid = QgsFeatureId() );
+    void unlinkSelectedFeatures();
     void saveEdits();
     void toggleEditing( bool state );
     void onCollapsedStateChanged( bool collapsed );
+    void showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid );
 
   private:
     void updateUi();
@@ -179,6 +182,20 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
 
     bool mShowLabel = true;
     bool mVisible = false;
+
+    /**
+     * Deletes the features
+     * \param featureids features to delete
+     * \since QGIS 3.00
+     */
+    void deleteFeatures( const QgsFeatureIds &featureids );
+
+    /**
+     * Unlinks the features
+     * \param featureids features to unlink
+     * \since QGIS 3.00
+     */
+    void unlinkFeatures( const QgsFeatureIds &featureids );
 };
 
 #endif // QGSRELATIONEDITOR_H


### PR DESCRIPTION
Individual actions in the contextmenu of the **attributetable** and the **relationeditorwidget**.

It's **unlink feature** and **delete feature** in the **relationeditorwidget**.
It's **delete feature** in the **attributetable** (form view)

## Description
There are several action types like the maplayer actions and the user definded actions. These are actions that are specific for the GUI we are using. They do only appear there.

It's unlink and delete feature in the relationeditorwidget.
![contextmenu_relationeditorwidget](https://user-images.githubusercontent.com/28384354/34438002-9cde6384-eca3-11e7-8dc3-d1cffcd53155.gif)
(here you can see the duplicate feature maplayer actions too)
![contextmenu_attributetable](https://user-images.githubusercontent.com/28384354/34438005-a1460af8-eca3-11e7-953c-acdc120f2b90.gif)
It's delete feature in the attributetable (form view)

Unlike the maplayer actions these actions are not available when not in the edit mode. It can be discussed how it should be. 