### PR TITLE
[3d] Fix tilting of camera in docked 3D view with Shift (fixes #17337)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1291,7 +1291,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   }
 #endif
 
-  connect( qApp, &QApplication::focusChanged, this, &QgisApp::onFocusChanged );
 } // QgisApp ctor
 
 QgisApp::QgisApp()
@@ -9125,16 +9124,6 @@ void QgisApp::userRotation()
   double degrees = mRotationEdit->value();
   mMapCanvas->setRotation( degrees );
   mMapCanvas->refresh();
-}
-
-void QgisApp::onFocusChanged( QWidget *oldWidget, QWidget *newWidget )
-{
-  Q_UNUSED( oldWidget );
-  // If nothing has focus even though this window is active, ensure map canvas receives it
-  if ( !newWidget && isActiveWindow() )
-  {
-    mapCanvas()->setFocus();
-  }
 }
 
 void QgisApp::projectCrsChanged()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1616,8 +1616,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void updateCrsStatusBar();
 
-    void onFocusChanged( QWidget *oldWidget, QWidget *newWidget );
-
     //! handle project crs changes
     void projectCrsChanged();
 


### PR DESCRIPTION
This reverts a6b0c44

Map canvas was stealing keyboard focus from the docked 3D view and the key presses
of modifiers were not passed to the 3D view.
