### PR TITLE
[date widget] fix current date can't be picked (2.18)

### DIFF
--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -66,6 +66,7 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
   private slots:
     void changed( const QDateTime & dateTime );
 
+    void calendarSelectionChanged();
 
   private:
     int spinButtonWidth() const;
@@ -77,6 +78,7 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
 
     QLineEdit* mNullLabel;
     QToolButton* mClearButton;
+    QString mOriginalStyleSheet = QString();
 
 };
 

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -65,7 +65,11 @@ void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
   mQDateTimeEdit->setDisplayFormat( displayFormat );
 
   const bool calendar = config( "calendar_popup", false ).toBool();
-  mQDateTimeEdit->setCalendarPopup( calendar );
+
+  if ( calendar != mQDateTimeEdit->calendarPopup() )
+  {
+    mQDateTimeEdit->setCalendarPopup( calendar );
+  }
   if ( calendar && mQDateTimeEdit->calendarWidget() )
   {
     // highlight today's date


### PR DESCRIPTION
better solution has been found for Qt5 but can't be used in Qt4
see #16579 (issue)
and #5956 (PR)

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
