### PR TITLE
Show whole symbol selector dialog (with Cancel and Help buttons) in some context

### DIFF
--- a/python/gui/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -96,17 +96,17 @@ from the XML file with a matching name.
 
     int currentCategoryRow();
 %Docstring
-return row index for the currently selected category (-1 if on no selection)
+Returns row index for the currently selected category (-1 if on no selection)
 %End
 
     QList<int> selectedCategories();
 %Docstring
-return a list of indexes for the categories unders selection
+Returns a list of indexes for the categories under selection
 %End
 
     void changeSelectedSymbols();
 %Docstring
-change the selected symbols alone for the change button, if there is a selection
+Changes the selected symbols alone for the change button, if there is a selection
 %End
 
     void changeCategorySymbol();

--- a/python/gui/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -110,6 +110,10 @@ Changes the selected symbols alone for the change button, if there is a selectio
 %End
 
     void changeCategorySymbol();
+    void applyChangeToSymbol();
+%Docstring
+Applies current symbol to selected categories, or to all categories if none is selected
+%End
 
     virtual QList<QgsSymbol *> selectedSymbols();
 

--- a/python/gui/symbology/qgsgraduatedsymbolrendererwidget.sip.in
+++ b/python/gui/symbology/qgsgraduatedsymbolrendererwidget.sip.in
@@ -70,7 +70,7 @@ Toggle the link between classes boundaries
 
     QList<int> selectedClasses();
 %Docstring
-return a list of indexes for the classes under selection
+Returns a list of indexes for the classes under selection
 %End
     QgsRangeList selectedRanges();
 

--- a/python/gui/symbology/qgsgraduatedsymbolrendererwidget.sip.in
+++ b/python/gui/symbology/qgsgraduatedsymbolrendererwidget.sip.in
@@ -78,6 +78,10 @@ Returns a list of indexes for the classes under selection
     void changeRange( int rangeIdx );
 
     void changeSelectedSymbols();
+    void applyChangeToSymbol();
+%Docstring
+Applies current symbol to selected ranges, or to all ranges if none is selected
+%End
 
     virtual QList<QgsSymbol *> selectedSymbols();
 

--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -6367,6 +6367,7 @@ skiped:skipped
 skiping:skipping
 slashs:slashes
 slaugterhouses:slaughterhouses
+slection:selection
 slighly:slightly
 sligth:slight
 sligthly:slightly

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -550,11 +550,15 @@ void QgsCategorizedSymbolRendererWidget::changeCategorizedSymbol()
 
   connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsCategorizedSymbolRendererWidget::updateSymbolsFromWidget );
   connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsCategorizedSymbolRendererWidget::cleanUpSymbolSelector );
+  connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsCategorizedSymbolRendererWidget::updateCategorizedSymbolIcon );
   openPanel( dlg );
 }
 
 void QgsCategorizedSymbolRendererWidget::updateCategorizedSymbolIcon()
 {
+  if ( !mCategorizedSymbol )
+    return;
+
   QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( mCategorizedSymbol.get(), btnChangeCategorizedSymbol->iconSize() );
   btnChangeCategorizedSymbol->setIcon( icon );
 }
@@ -950,7 +954,6 @@ void QgsCategorizedSymbolRendererWidget::updateSymbolsFromWidget()
   QgsSymbolSelectorWidget *dlg = qobject_cast<QgsSymbolSelectorWidget *>( sender() );
   mCategorizedSymbol.reset( dlg->symbol()->clone() );
 
-  updateCategorizedSymbolIcon();
   // When there is a selection, change the selected symbols only
   QItemSelectionModel *m = viewCategories->selectionModel();
   QModelIndexList i = m->selectedRows();
@@ -973,10 +976,12 @@ void QgsCategorizedSymbolRendererWidget::updateSymbolsFromWidget()
       }
       emit widgetChanged();
     }
-    return;
+  }
+  else
+  {
+    mRenderer->updateSymbols( mCategorizedSymbol.get() );
   }
 
-  mRenderer->updateSymbols( mCategorizedSymbol.get() );
   emit widgetChanged();
 }
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -951,8 +951,7 @@ void QgsCategorizedSymbolRendererWidget::updateSymbolsFromWidget()
   mCategorizedSymbol.reset( dlg->symbol()->clone() );
 
   updateCategorizedSymbolIcon();
-
-  // When there is a slection, change the selected symbols alone
+  // When there is a selection, change the selected symbols only
   QItemSelectionModel *m = viewCategories->selectionModel();
   QModelIndexList i = m->selectedRows();
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -173,6 +173,8 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void changeSelectedSymbols();
 
     void changeCategorySymbol();
+    //! Applies current symbol to selected categories, or to all categories if none is selected
+    void applyChangeToSymbol();
 
     QList<QgsSymbol *> selectedSymbols() override;
     QgsCategoryList selectedCategoryList();

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -163,13 +163,13 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     // Called by virtual refreshSymbolView()
     void populateCategories();
 
-    //! return row index for the currently selected category (-1 if on no selection)
+    //! Returns row index for the currently selected category (-1 if on no selection)
     int currentCategoryRow();
 
-    //! return a list of indexes for the categories unders selection
+    //! Returns a list of indexes for the categories under selection
     QList<int> selectedCategories();
 
-    //! change the selected symbols alone for the change button, if there is a selection
+    //! Changes the selected symbols alone for the change button, if there is a selection
     void changeSelectedSymbols();
 
     void changeCategorySymbol();

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -780,7 +780,6 @@ void QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget()
   }
   else
   {
-    updateGraduatedSymbolIcon();
     mRenderer->updateSymbols( mGraduatedSymbol.get() );
   }
 
@@ -880,6 +879,7 @@ void QgsGraduatedSymbolRendererWidget::changeGraduatedSymbol()
 
   connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget );
   connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::cleanUpSymbolSelector );
+  connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::updateGraduatedSymbolIcon );
   openPanel( dlg );
 }
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -754,6 +754,11 @@ void QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget()
   QgsSymbolSelectorWidget *dlg = qobject_cast<QgsSymbolSelectorWidget *>( sender() );
   mGraduatedSymbol.reset( dlg->symbol()->clone() );
 
+  applyChangeToSymbol();
+}
+
+void QgsGraduatedSymbolRendererWidget::applyChangeToSymbol()
+{
   mSizeUnitWidget->blockSignals( true );
   mSizeUnitWidget->setUnit( mGraduatedSymbol->outputUnit() );
   mSizeUnitWidget->setMapUnitScale( mGraduatedSymbol->mapUnitScale() );
@@ -874,13 +879,31 @@ void QgsGraduatedSymbolRendererWidget::reapplySizes()
 void QgsGraduatedSymbolRendererWidget::changeGraduatedSymbol()
 {
   QgsSymbol *newSymbol = mGraduatedSymbol->clone();
-  QgsSymbolSelectorWidget *dlg = new QgsSymbolSelectorWidget( newSymbol, mStyle, mLayer, nullptr );
-  dlg->setContext( mContext );
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsSymbolSelectorWidget *dlg = new QgsSymbolSelectorWidget( newSymbol, mStyle, mLayer, panel );
+    dlg->setContext( mContext );
 
-  connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget );
-  connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::cleanUpSymbolSelector );
-  connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::updateGraduatedSymbolIcon );
-  openPanel( dlg );
+    connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget );
+    connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::cleanUpSymbolSelector );
+    connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::updateGraduatedSymbolIcon );
+    panel->openPanel( dlg );
+  }
+  else
+  {
+    QgsSymbolSelectorDialog dlg( newSymbol, mStyle, mLayer, panel );
+    if ( !dlg.exec() || !newSymbol )
+    {
+      delete newSymbol;
+      return;
+    }
+
+    delete mGraduatedSymbol;
+    mGraduatedSymbol = newSymbol;
+    updateGraduatedSymbolIcon();
+    applyChangeToSymbol();
+  }
 }
 
 void QgsGraduatedSymbolRendererWidget::updateGraduatedSymbolIcon()
@@ -953,12 +976,29 @@ void QgsGraduatedSymbolRendererWidget::changeSelectedSymbols()
 void QgsGraduatedSymbolRendererWidget::changeRangeSymbol( int rangeIdx )
 {
   QgsSymbol *newSymbol = mRenderer->ranges()[rangeIdx].symbol()->clone();
-  QgsSymbolSelectorWidget *dlg = new QgsSymbolSelectorWidget( newSymbol, mStyle, mLayer, nullptr );
-  dlg->setContext( mContext );
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsSymbolSelectorWidget *dlg = new QgsSymbolSelectorWidget( newSymbol, mStyle, mLayer, panel );
+    dlg->setContext( mContext );
+    connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget );
+    connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::cleanUpSymbolSelector );
+    openPanel( dlg );
+  }
+  else
+  {
+    QgsSymbolSelectorDialog dlg( newSymbol, mStyle, mLayer, panel );
+    dlg.setContext( mContext );
+    if ( !dlg.exec() || !newSymbol )
+    {
+      delete newSymbol;
+      return;
+    }
 
-  connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget );
-  connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::cleanUpSymbolSelector );
-  openPanel( dlg );
+    delete mGraduatedSymbol;
+    mGraduatedSymbol = newSymbol;
+    applyChangeToSymbol();
+  }
 }
 
 void QgsGraduatedSymbolRendererWidget::changeRange( int rangeIdx )

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -146,6 +146,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     void changeRange( int rangeIdx );
 
     void changeSelectedSymbols();
+    //! Applies current symbol to selected ranges, or to all ranges if none is selected
+    void applyChangeToSymbol();
 
     QList<QgsSymbol *> selectedSymbols() override;
     QgsSymbol *findSymbolForRange( double lowerBound, double upperBound, const QgsRangeList &ranges ) const;

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -138,7 +138,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
 
     void updateGraduatedSymbolIcon();
 
-    //! return a list of indexes for the classes under selection
+    //! Returns a list of indexes for the classes under selection
     QList<int> selectedClasses();
     QgsRangeList selectedRanges();
 


### PR DESCRIPTION
Fixes [#17903](https://issues.qgis.org/issues/17903) and [#17902](https://issues.qgis.org/issues/17902)
In Layer Properties -> Symbology ->Categorized (or Graduated), clicking the [Change] button does not open the symbol selector dialog but the symbol selector widget, meaning that you miss Cancel and Help buttons. Also clicking a category symbol should not change the main button's.
Also fix an unreported crash that occurs when hitting ESC from a symbol selector widget (you may need two clicks)
  