### PR TITLE
Don't crash the projection selection widget when world_map.shp fails to load

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -149,6 +149,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   mJoinBuffer = new QgsVectorLayerJoinBuffer( this );
   connect( mJoinBuffer, &QgsVectorLayerJoinBuffer::joinedFieldsChanged, this, &QgsVectorLayer::onJoinedFieldsChanged );
 
+  mExpressionFieldBuffer = new QgsExpressionFieldBuffer();
   // if we're given a provider type, try to create and bind one to this layer
   if ( !vectorLayerPath.isEmpty() && !mProviderKey.isEmpty() )
   {
@@ -1555,7 +1556,6 @@ bool QgsVectorLayer::setDataProvider( QString const &provider )
   // get and store the feature type
   mWkbType = mDataProvider->wkbType();
 
-  mExpressionFieldBuffer = new QgsExpressionFieldBuffer();
   updateFields();
 
   if ( mProviderKey == QLatin1String( "postgres" ) )

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -39,10 +39,7 @@ QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( const QgsVectorLayer *
 
   mJoinBuffer = layer->mJoinBuffer->clone();
 
-  if ( layer->mExpressionFieldBuffer )
-  {
-    mExpressionFieldBuffer = new QgsExpressionFieldBuffer( *layer->mExpressionFieldBuffer );
-  }
+  mExpressionFieldBuffer = new QgsExpressionFieldBuffer( *layer->mExpressionFieldBuffer );
   mCrs = layer->crs();
 
   mHasEditBuffer = layer->editBuffer();

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -39,7 +39,10 @@ QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( const QgsVectorLayer *
 
   mJoinBuffer = layer->mJoinBuffer->clone();
 
-  mExpressionFieldBuffer = new QgsExpressionFieldBuffer( *layer->mExpressionFieldBuffer );
+  if ( layer->mExpressionFieldBuffer )
+  {
+    mExpressionFieldBuffer = new QgsExpressionFieldBuffer( *layer->mExpressionFieldBuffer );
+  }
   mCrs = layer->crs();
 
   mHasEditBuffer = layer->editBuffer();


### PR DESCRIPTION
## Description
I believe this PR fixes a number of duplicate crashers reported recently (#17711, #17662, #17610, #17589, possibly more I haven't spotted).

QGIS was crashing while loading our projection selection tree widget when world_map.shp failed to load (missing from the system or no read access). The vector layer, invalid due to failure to load world_map.shp, would be added to the canvas and trigger an underlying issue when creating a QgsVectorLayerFeatureSource.

@nyalldawson , sounds good to you? The reason why the layer's mExpressionFieldBuffer is null is because the QgsVectorMap::setDataProvider(...) function would return due to its invalid status before the variable is init'ed to on qgsvectorlayer.cpp line 1558 (`mExpressionFieldBuffer = new QgsExpressionFieldBuffer();`). I wasn't sure whether we should also fix that or not by moving that line up the code so its init'ed prior to the early return.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
