### PR TITLE
fix an options dialog crasher

### DIFF
--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -35,7 +35,7 @@
 #include <QAbstractItemModel>
 
 #include "qgsfilterlineedit.h"
-
+#include "qgsmessagebaritem.h"
 #include "qgslogger.h"
 
 QgsOptionsDialogBase::QgsOptionsDialogBase( const QString &settingsKey, QWidget *parent, Qt::WindowFlags fl, QgsSettings *settings )
@@ -265,6 +265,10 @@ void QgsOptionsDialogBase::registerTextSearchWidgets()
   {
     Q_FOREACH ( QWidget *w, mOptStackedWidget->widget( i )->findChildren<QWidget *>() )
     {
+      // do not register message bar content, items disappear and causes QGIS to crash
+      if ( dynamic_cast< QgsMessageBarItem * >( w ) || dynamic_cast< QgsMessageBarItem * >( w->parentWidget() ) )
+        continue;
+
       QgsSearchHighlightOptionWidget *shw = new QgsSearchHighlightOptionWidget( w );
       if ( shw->isValid() )
       {

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -266,7 +266,7 @@ void QgsOptionsDialogBase::registerTextSearchWidgets()
     Q_FOREACH ( QWidget *w, mOptStackedWidget->widget( i )->findChildren<QWidget *>() )
     {
       // do not register message bar content, items disappear and causes QGIS to crash
-      if ( dynamic_cast< QgsMessageBarItem * >( w ) || dynamic_cast< QgsMessageBarItem * >( w->parentWidget() ) )
+      if ( qobject_cast< QgsMessageBarItem * >( w ) || qobject_cast< QgsMessageBarItem * >( w->parentWidget() ) )
         continue;
 
       QgsSearchHighlightOptionWidget *shw = new QgsSearchHighlightOptionWidget( w );
@@ -475,7 +475,7 @@ bool QgsSearchHighlightOptionWidget::searchHighlight( const QString &searchText 
 
 void QgsSearchHighlightOptionWidget::reset()
 {
-  if ( mValid && mChangedStyle )
+  if ( mWidget && mValid && mChangedStyle )
   {
     QString ss = mWidget->styleSheet();
     ss.remove( mStyleSheet );
@@ -486,5 +486,6 @@ void QgsSearchHighlightOptionWidget::reset()
 
 void QgsSearchHighlightOptionWidget::widgetDestroyed()
 {
+  mWidget = nullptr;
   mValid = false;
 }

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -62,7 +62,7 @@ class GUI_EXPORT QgsSearchHighlightOptionWidget : public QObject
     /**
      * Returns if it valid: if the widget type is handled and if the widget is not still available
      */
-    bool isValid() {return mValid;}
+    bool isValid() { return mWidget && mValid; }
 
     /**
      * search for a text pattern and highlight the widget if the text is found
@@ -78,13 +78,13 @@ class GUI_EXPORT QgsSearchHighlightOptionWidget : public QObject
     /**
      * return the widget
      */
-    QWidget *widget() {return mWidget;}
+    QWidget *widget() { return mWidget; }
 
   private slots:
     void widgetDestroyed();
 
   private:
-    QWidget *mWidget = nullptr;
+    QPointer< QWidget > mWidget;
     QString mStyleSheet;
     bool mValid = true;
     bool mChangedStyle = false;


### PR DESCRIPTION
## Description
Using the options dialog's search box may lead to a crasher due to the authentification panel's use of message bar items. 

Under a number of circumstances (for e.g., here, when I run a master build from the output directory and then from the install directory), the authentification code throws a "auth db query exec () failed", which results in three message bar item, that disappear after a short while.

Once disappeared, using the search box will access a message bar item that's gone, leading to a crash. 

This PR offers the following solution: don't registered message bar items as searchable content.

I'm pretty sure this fixes issue #/17663.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
