### PR TITLE
Fix tracing still active when snapping is turned off

### DIFF
--- a/python/gui/qgsmapcanvastracer.sip
+++ b/python/gui/qgsmapcanvastracer.sip
@@ -45,6 +45,21 @@ Assign "enable tracing" checkable action to the tracer.
 The action is used to determine whether tracing is currently enabled by the user
 %End
 
+    QAction *actionEnableSnapping() const;
+%Docstring
+Access to action that user may use to toggle snapping on/off. May be null if no action was associated.
+
+.. versionadded:: 3.0
+%End
+
+    void setActionEnableSnapping( QAction *action );
+%Docstring
+Assign "enable snapping" checkable action to the tracer.
+The action is used to determine whether snapping is currently enabled by the user.
+
+.. versionadded:: 3.0
+%End
+
     static QgsMapCanvasTracer *tracerForCanvas( QgsMapCanvas *canvas );
 %Docstring
 Retrieve instance of this class associated with given canvas (if any).

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2415,6 +2415,7 @@ void QgisApp::createToolBars()
 
   mTracer = new QgsMapCanvasTracer( mMapCanvas, messageBar() );
   mTracer->setActionEnableTracing( mSnappingWidget->enableTracingAction() );
+  mTracer->setActionEnableSnapping( mSnappingWidget->enableSnappingAction() );
   connect( mSnappingWidget->tracingOffsetSpinBox(), static_cast< void ( QgsDoubleSpinBox::* )( double ) >( &QgsDoubleSpinBox::valueChanged ),
   this, [ = ]( double v ) { mTracer->setOffset( v ); } );
 

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -75,6 +75,11 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
      */
     QAction *enableTracingAction() { return mEnableTracingAction; }
 
+    /**
+     * Returns the enable snapping action widget.
+     */
+    QAction *enableSnappingAction() { return mEnabledAction; }
+
     //! Returns spin box used to set offset for tracing
     QgsDoubleSpinBox *tracingOffsetSpinBox() { return mTracingOffsetSpinBox; }
 

--- a/src/gui/qgsmapcanvastracer.h
+++ b/src/gui/qgsmapcanvastracer.h
@@ -56,6 +56,19 @@ class GUI_EXPORT QgsMapCanvasTracer : public QgsTracer
     void setActionEnableTracing( QAction *action ) { mActionEnableTracing = action; }
 
     /**
+     * Access to action that user may use to toggle snapping on/off. May be null if no action was associated.
+     * \since QGIS 3.0
+     */
+    QAction *actionEnableSnapping() const { return mActionEnableSnapping; }
+
+    /**
+     * Assign "enable snapping" checkable action to the tracer.
+     * The action is used to determine whether snapping is currently enabled by the user.
+     * \since QGIS 3.0
+     */
+    void setActionEnableSnapping( QAction *action ) { mActionEnableSnapping = action; }
+
+    /**
      * Retrieve instance of this class associated with given canvas (if any).
      * The class keeps a simple registry of tracers associated with map canvas
      * instances for easier access to the common tracer by various map tools
@@ -78,6 +91,7 @@ class GUI_EXPORT QgsMapCanvasTracer : public QgsTracer
     QgsMessageBarItem *mLastMessage = nullptr;
 
     QAction *mActionEnableTracing = nullptr;
+    QAction *mActionEnableSnapping = nullptr;
 
     static QHash<QgsMapCanvas *, QgsMapCanvasTracer *> sTracers;
 };

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -129,7 +129,8 @@ void QgsMapToolCapture::currentLayerChanged( QgsMapLayer *layer )
 bool QgsMapToolCapture::tracingEnabled()
 {
   QgsMapCanvasTracer *tracer = QgsMapCanvasTracer::tracerForCanvas( mCanvas );
-  return tracer && tracer->actionEnableTracing() && tracer->actionEnableTracing()->isChecked();
+  return tracer && ( !tracer->actionEnableTracing() || tracer->actionEnableTracing()->isChecked() )
+         && ( !tracer->actionEnableSnapping() || tracer->actionEnableSnapping()->isChecked() );
 }
 
 


### PR DESCRIPTION
Otherwise tracing is disabled in the snapping toolbar, yet still active on the canvas.
