### PR TITLE
[debian package] include world_map shapefile

### DIFF
--- a/debian/qgis-common.install
+++ b/debian/qgis-common.install
@@ -18,4 +18,5 @@ usr/share/qgis/i18n/*
 usr/share/qgis/images/*
 usr/share/qgis/resources/spatialite.db
 usr/share/qgis/resources/themes/*
+usr/share/qgis/resources/data/*
 usr/share/qgis/qgis_global_settings.ini


### PR DESCRIPTION
## Description
@jef-n , while dissecting a QGIS crasher, I noticed the QGIS nightlies .debs were not adding the world_map shapefile (in qgis-common's deb) used in the projection selection tree widget. 

I have _no_ idea whether this is the right way to fix the missing files from the .deb 😄 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
