### PR TITLE
Refine geometry equals checks

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1354,6 +1354,8 @@ maintains Z or M dimensions from the input points and is more efficient.
 - exportToWkt() was renamed to asWkt()
 - exportToGeoJSON() was renamed to asJson()
 - closestSegmentWithContext() now returns an extra value, indicating whether the point is to the left of the geometry
+- equals() now performs a fast, strict equality check, where geometries are considered equal only if they have the
+exact same type, vertices and order. The slower topological test can be performed by calling isGeosEqual instead.
 
 
 QgsGeometryAnalyzer        {#qgis_api_break_3_0_QgsGeometryAnalyzer}

--- a/python/core/geometry/qgsabstractgeometry.sip
+++ b/python/core/geometry/qgsabstractgeometry.sip
@@ -72,6 +72,9 @@ Constructor for QgsAbstractGeometry.
     virtual ~QgsAbstractGeometry();
     QgsAbstractGeometry( const QgsAbstractGeometry &geom );
 
+    virtual bool operator==( const QgsAbstractGeometry &other ) const = 0;
+    virtual bool operator!=( const QgsAbstractGeometry &other ) const = 0;
+
     virtual QgsAbstractGeometry *clone() const = 0 /Factory/;
 %Docstring
 Clones the geometry by performing a deep copy

--- a/python/core/geometry/qgscircularstring.sip
+++ b/python/core/geometry/qgscircularstring.sip
@@ -25,9 +25,7 @@ class QgsCircularString: QgsCurve
   public:
     QgsCircularString();
 
-    virtual bool operator==( const QgsCurve &other ) const;
-
-    virtual bool operator!=( const QgsCurve &other ) const;
+    virtual bool equals( const QgsCurve &other ) const;
 
 
     virtual QString geometryType() const;

--- a/python/core/geometry/qgscompoundcurve.sip
+++ b/python/core/geometry/qgscompoundcurve.sip
@@ -25,9 +25,7 @@ class QgsCompoundCurve: QgsCurve
     QgsCompoundCurve( const QgsCompoundCurve &curve );
     ~QgsCompoundCurve();
 
-    virtual bool operator==( const QgsCurve &other ) const;
-
-    virtual bool operator!=( const QgsCurve &other ) const;
+    virtual bool equals( const QgsCurve &other ) const;
 
 
     virtual QString geometryType() const;

--- a/python/core/geometry/qgscurve.sip
+++ b/python/core/geometry/qgscurve.sip
@@ -29,6 +29,11 @@ Constructor for QgsCurve.
 %End
 
     virtual bool equals( const QgsCurve &other ) const = 0;
+%Docstring
+Checks whether this curve exactly equals another curve.
+
+.. versionadded:: 3.0
+%End
 
     virtual bool operator==( const QgsAbstractGeometry &other ) const;
 

--- a/python/core/geometry/qgscurve.sip
+++ b/python/core/geometry/qgscurve.sip
@@ -28,8 +28,12 @@ class QgsCurve: QgsAbstractGeometry
 Constructor for QgsCurve.
 %End
 
-    virtual bool operator==( const QgsCurve &other ) const = 0;
-    virtual bool operator!=( const QgsCurve &other ) const = 0;
+    virtual bool equals( const QgsCurve &other ) const = 0;
+
+    virtual bool operator==( const QgsAbstractGeometry &other ) const;
+
+    virtual bool operator!=( const QgsAbstractGeometry &other ) const;
+
 
     virtual QgsCurve *clone() const = 0 /Factory/;
 

--- a/python/core/geometry/qgscurvepolygon.sip
+++ b/python/core/geometry/qgscurvepolygon.sip
@@ -25,8 +25,10 @@ class QgsCurvePolygon: QgsSurface
     QgsCurvePolygon();
     QgsCurvePolygon( const QgsCurvePolygon &p );
 
-    bool operator==( const QgsCurvePolygon &other ) const;
-    bool operator!=( const QgsCurvePolygon &other ) const;
+    virtual bool operator==( const QgsAbstractGeometry &other ) const;
+
+    virtual bool operator!=( const QgsAbstractGeometry &other ) const;
+
 
     ~QgsCurvePolygon();
 

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -249,11 +249,44 @@ return true for isEmpty().
 Returns true if WKB of the geometry is of WKBMulti* type
 %End
 
-    bool isGeosEqual( const QgsGeometry & ) const;
+    bool equals( const QgsGeometry &geometry ) const;
 %Docstring
-Compares the geometry with another geometry using GEOS
+Test if this geometry is exactly equal to another ``geometry``.
+
+This is a strict equality check, where the underlying geometries must
+have exactly the same type, component vertices and vertex order.
+
+Calling this method is dramatically faster than the topological
+equality test performed by isGeosEqual().
+
+.. note::
+
+   Comparing two null geometries will return false.
 
 .. versionadded:: 1.5
+
+.. seealso:: :py:func:`isGeosEqual()`
+%End
+
+    bool isGeosEqual( const QgsGeometry & ) const;
+%Docstring
+Compares the geometry with another geometry using GEOS.
+
+This method performs a slow, topological check, where geometries
+are considered equal if all of the their component edges overlap. E.g.
+lines with the same vertex locations but opposite direction will be
+considered equal by this method.
+
+Consider using the much faster, stricter equality test performed
+by equals() instead.
+
+.. note::
+
+   Comparing two null geometries will return false.
+
+.. versionadded:: 1.5
+
+.. seealso:: :py:func:`equals()`
 %End
 
     bool isGeosValid() const;
@@ -748,13 +781,6 @@ Tests for if geometry is contained in another (uses GEOS)
     bool disjoint( const QgsGeometry &geometry ) const;
 %Docstring
 Tests for if geometry is disjoint of another (uses GEOS)
-
-.. versionadded:: 1.5
-%End
-
-    bool equals( const QgsGeometry &geometry ) const;
-%Docstring
-Test for if geometry equals another (uses GEOS)
 
 .. versionadded:: 1.5
 %End

--- a/python/core/geometry/qgsgeometrycollection.sip
+++ b/python/core/geometry/qgsgeometrycollection.sip
@@ -27,6 +27,11 @@ class QgsGeometryCollection: QgsAbstractGeometry
     QgsGeometryCollection( const QgsGeometryCollection &c );
     ~QgsGeometryCollection();
 
+    virtual bool operator==( const QgsAbstractGeometry &other ) const;
+
+    virtual bool operator!=( const QgsAbstractGeometry &other ) const;
+
+
     virtual QgsGeometryCollection *clone() const /Factory/;
 
 

--- a/python/core/geometry/qgslinestring.sip
+++ b/python/core/geometry/qgslinestring.sip
@@ -57,9 +57,7 @@ or repeatedly calling addVertex()
 .. versionadded:: 3.0
 %End
 
-    virtual bool operator==( const QgsCurve &other ) const;
-
-    virtual bool operator!=( const QgsCurve &other ) const;
+    virtual bool equals( const QgsCurve &other ) const;
 
 
     QgsPoint pointN( int i ) const;

--- a/python/core/geometry/qgspoint.sip
+++ b/python/core/geometry/qgspoint.sip
@@ -85,8 +85,10 @@ Construct a QgsPoint from a QPointF
 %End
 
 
-    bool operator==( const QgsPoint &pt ) const;
-    bool operator!=( const QgsPoint &pt ) const;
+    virtual bool operator==( const QgsAbstractGeometry &other ) const;
+
+    virtual bool operator!=( const QgsAbstractGeometry &other ) const;
+
 
     double x() const;
 %Docstring

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -202,7 +202,7 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
               // between geometry and splitLine, only the first one is considered.
               if ( result == QgsGeometry::Success ) // split occurred
               {
-                if ( inGeom.equals( before ) )
+                if ( inGeom.isGeosEqual( before ) )
                 {
                   // bug in splitGeometry: sometimes it returns 0 but
                   // the geometry is unchanged

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -110,6 +110,9 @@ class CORE_EXPORT QgsAbstractGeometry
     QgsAbstractGeometry( const QgsAbstractGeometry &geom );
     QgsAbstractGeometry &operator=( const QgsAbstractGeometry &geom );
 
+    virtual bool operator==( const QgsAbstractGeometry &other ) const = 0;
+    virtual bool operator!=( const QgsAbstractGeometry &other ) const = 0;
+
     /**
      * Clones the geometry by performing a deep copy
      */

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -33,7 +33,7 @@ QgsCircularString::QgsCircularString()
   mWkbType = QgsWkbTypes::CircularString;
 }
 
-bool QgsCircularString::operator==( const QgsCurve &other ) const
+bool QgsCircularString::equals( const QgsCurve &other ) const
 {
   const QgsCircularString *otherLine = dynamic_cast< const QgsCircularString * >( &other );
   if ( !otherLine )
@@ -59,11 +59,6 @@ bool QgsCircularString::operator==( const QgsCurve &other ) const
   }
 
   return true;
-}
-
-bool QgsCircularString::operator!=( const QgsCurve &other ) const
-{
-  return !operator==( other );
 }
 
 QgsCircularString *QgsCircularString::createEmptyWithSameType() const

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -36,8 +36,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
   public:
     QgsCircularString();
 
-    bool operator==( const QgsCurve &other ) const override;
-    bool operator!=( const QgsCurve &other ) const override;
+    bool equals( const QgsCurve &other ) const override;
 
     QString geometryType() const override;
     int dimension() const override;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -35,7 +35,7 @@ QgsCompoundCurve::~QgsCompoundCurve()
   clear();
 }
 
-bool QgsCompoundCurve::operator==( const QgsCurve &other ) const
+bool QgsCompoundCurve::equals( const QgsCurve &other ) const
 {
   const QgsCompoundCurve *otherCurve = qgsgeometry_cast< const QgsCompoundCurve * >( &other );
   if ( !otherCurve )
@@ -54,11 +54,6 @@ bool QgsCompoundCurve::operator==( const QgsCurve &other ) const
   }
 
   return true;
-}
-
-bool QgsCompoundCurve::operator!=( const QgsCurve &other ) const
-{
-  return !operator==( other );
 }
 
 QgsCompoundCurve *QgsCompoundCurve::createEmptyWithSameType() const

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -36,8 +36,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     QgsCompoundCurve &operator=( const QgsCompoundCurve &curve );
     ~QgsCompoundCurve() override;
 
-    bool operator==( const QgsCurve &other ) const override;
-    bool operator!=( const QgsCurve &other ) const override;
+    bool equals( const QgsCurve &other ) const override;
 
     QString geometryType() const override;
     int dimension() const override;

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -22,6 +22,20 @@
 #include "qgspoint.h"
 #include "qgsmultipoint.h"
 
+bool QgsCurve::operator==( const QgsAbstractGeometry &other ) const
+{
+  const QgsCurve *otherCurve = qgsgeometry_cast< const QgsCurve * >( &other );
+  if ( !otherCurve )
+    return false;
+
+  return equals( *otherCurve );
+}
+
+bool QgsCurve::operator!=( const QgsAbstractGeometry &other ) const
+{
+  return !operator==( other );
+}
+
 bool QgsCurve::isClosed() const
 {
   if ( numPoints() == 0 )

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -41,8 +41,10 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry
      */
     QgsCurve() = default;
 
-    virtual bool operator==( const QgsCurve &other ) const = 0;
-    virtual bool operator!=( const QgsCurve &other ) const = 0;
+    virtual bool equals( const QgsCurve &other ) const = 0;
+
+    bool operator==( const QgsAbstractGeometry &other ) const override;
+    bool operator!=( const QgsAbstractGeometry &other ) const override;
 
     QgsCurve *clone() const override = 0 SIP_FACTORY;
 

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -41,6 +41,10 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry
      */
     QgsCurve() = default;
 
+    /**
+     * Checks whether this curve exactly equals another curve.
+     * \since QGIS 3.0
+     */
     virtual bool equals( const QgsCurve &other ) const = 0;
 
     bool operator==( const QgsAbstractGeometry &other ) const override;

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -90,40 +90,44 @@ QgsCurvePolygon &QgsCurvePolygon::operator=( const QgsCurvePolygon &p )
   return *this;
 }
 
-bool QgsCurvePolygon::operator==( const QgsCurvePolygon &other ) const
+bool QgsCurvePolygon::operator==( const QgsAbstractGeometry &other ) const
 {
+  const QgsCurvePolygon *otherPolygon = qgsgeometry_cast< const QgsCurvePolygon * >( &other );
+  if ( !otherPolygon )
+    return false;
+
   //run cheap checks first
-  if ( mWkbType != other.mWkbType )
+  if ( mWkbType != otherPolygon->mWkbType )
     return false;
 
-  if ( ( !mExteriorRing && other.mExteriorRing ) || ( mExteriorRing && !other.mExteriorRing ) )
+  if ( ( !mExteriorRing && otherPolygon->mExteriorRing ) || ( mExteriorRing && !otherPolygon->mExteriorRing ) )
     return false;
 
-  if ( mInteriorRings.count() != other.mInteriorRings.count() )
+  if ( mInteriorRings.count() != otherPolygon->mInteriorRings.count() )
     return false;
 
   // compare rings
-  if ( mExteriorRing && other.mExteriorRing )
+  if ( mExteriorRing && otherPolygon->mExteriorRing )
   {
-    if ( *mExteriorRing != *other.mExteriorRing )
+    if ( *mExteriorRing != *otherPolygon->mExteriorRing )
       return false;
   }
 
   for ( int i = 0; i < mInteriorRings.count(); ++i )
   {
-    if ( ( !mInteriorRings.at( i ) && other.mInteriorRings.at( i ) ) ||
-         ( mInteriorRings.at( i ) && !other.mInteriorRings.at( i ) ) )
+    if ( ( !mInteriorRings.at( i ) && otherPolygon->mInteriorRings.at( i ) ) ||
+         ( mInteriorRings.at( i ) && !otherPolygon->mInteriorRings.at( i ) ) )
       return false;
 
-    if ( mInteriorRings.at( i ) && other.mInteriorRings.at( i ) &&
-         *mInteriorRings.at( i ) != *other.mInteriorRings.at( i ) )
+    if ( mInteriorRings.at( i ) && otherPolygon->mInteriorRings.at( i ) &&
+         *mInteriorRings.at( i ) != *otherPolygon->mInteriorRings.at( i ) )
       return false;
   }
 
   return true;
 }
 
-bool QgsCurvePolygon::operator!=( const QgsCurvePolygon &other ) const
+bool QgsCurvePolygon::operator!=( const QgsAbstractGeometry &other ) const
 {
   return !operator==( other );
 }

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -38,8 +38,8 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     QgsCurvePolygon( const QgsCurvePolygon &p );
     QgsCurvePolygon &operator=( const QgsCurvePolygon &p );
 
-    bool operator==( const QgsCurvePolygon &other ) const;
-    bool operator!=( const QgsCurvePolygon &other ) const;
+    bool operator==( const QgsAbstractGeometry &other ) const override;
+    bool operator!=( const QgsAbstractGeometry &other ) const override;
 
     ~QgsCurvePolygon() override;
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1147,9 +1147,12 @@ bool QgsGeometry::equals( const QgsGeometry &geometry ) const
     return false;
   }
 
-  QgsGeos geos( d->geometry.get() );
-  mLastError.clear();
-  return geos.isEqual( geometry.d->geometry.get(), &mLastError );
+  // fast check - are they shared copies of the same underlying geometry?
+  if ( d == geometry.d )
+    return true;
+
+  // slower check - actually test the geometries
+  return *d->geometry.get() == *geometry.d->geometry.get();
 }
 
 bool QgsGeometry::touches( const QgsGeometry &geometry ) const

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -307,8 +307,36 @@ class CORE_EXPORT QgsGeometry
     bool isMultipart() const;
 
     /**
-     * Compares the geometry with another geometry using GEOS
+     * Test if this geometry is exactly equal to another \a geometry.
+     *
+     * This is a strict equality check, where the underlying geometries must
+     * have exactly the same type, component vertices and vertex order.
+     *
+     * Calling this method is dramatically faster than the topological
+     * equality test performed by isGeosEqual().
+     *
+     * \note Comparing two null geometries will return false.
+     *
      * \since QGIS 1.5
+     * \see isGeosEqual()
+     */
+    bool equals( const QgsGeometry &geometry ) const;
+
+    /**
+     * Compares the geometry with another geometry using GEOS.
+     *
+     * This method performs a slow, topological check, where geometries
+     * are considered equal if all of the their component edges overlap. E.g.
+     * lines with the same vertex locations but opposite direction will be
+     * considered equal by this method.
+     *
+     * Consider using the much faster, stricter equality test performed
+     * by equals() instead.
+     *
+     * \note Comparing two null geometries will return false.
+     *
+     * \since QGIS 1.5
+     * \see equals()
      */
     bool isGeosEqual( const QgsGeometry & ) const;
 
@@ -789,12 +817,6 @@ class CORE_EXPORT QgsGeometry
      *  \since QGIS 1.5
      */
     bool disjoint( const QgsGeometry &geometry ) const;
-
-    /**
-     * Test for if geometry equals another (uses GEOS)
-     *  \since QGIS 1.5
-     */
-    bool equals( const QgsGeometry &geometry ) const;
 
     /**
      * Test for if geometry touch another (uses GEOS)

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -64,6 +64,32 @@ QgsGeometryCollection::~QgsGeometryCollection()
   clear();
 }
 
+bool QgsGeometryCollection::operator==( const QgsAbstractGeometry &other ) const
+{
+  const QgsGeometryCollection *otherCollection = qgsgeometry_cast< const QgsGeometryCollection * >( &other );
+  if ( !otherCollection )
+    return false;
+
+  if ( mWkbType != otherCollection->mWkbType )
+    return false;
+
+  if ( mGeometries.count() != otherCollection->mGeometries.count() )
+    return false;
+
+  for ( int i = 0; i < mGeometries.count(); ++i )
+  {
+    if ( mGeometries.at( i ) != otherCollection->mGeometries.at( i ) )
+      return false;
+  }
+
+  return true;
+}
+
+bool QgsGeometryCollection::operator!=( const QgsAbstractGeometry &other ) const
+{
+  return !operator==( other );
+}
+
 QgsGeometryCollection *QgsGeometryCollection::createEmptyWithSameType() const
 {
   auto result = qgis::make_unique< QgsGeometryCollection >();

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -39,6 +39,9 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     QgsGeometryCollection &operator=( const QgsGeometryCollection &c );
     ~QgsGeometryCollection() override;
 
+    bool operator==( const QgsAbstractGeometry &other ) const override;
+    bool operator!=( const QgsAbstractGeometry &other ) const override;
+
     QgsGeometryCollection *clone() const override SIP_FACTORY;
 
     /**

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -136,7 +136,7 @@ QgsLineString::QgsLineString( const QVector<QgsPointXY> &points )
   }
 }
 
-bool QgsLineString::operator==( const QgsCurve &other ) const
+bool QgsLineString::equals( const QgsCurve &other ) const
 {
   const QgsLineString *otherLine = qgsgeometry_cast< const QgsLineString * >( &other );
   if ( !otherLine )
@@ -162,11 +162,6 @@ bool QgsLineString::operator==( const QgsCurve &other ) const
   }
 
   return true;
-}
-
-bool QgsLineString::operator!=( const QgsCurve &other ) const
-{
-  return !operator==( other );
 }
 
 QgsLineString *QgsLineString::clone() const

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -71,8 +71,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      */
     QgsLineString( const QVector<QgsPointXY> &points );
 
-    bool operator==( const QgsCurve &other ) const override;
-    bool operator!=( const QgsCurve &other ) const override;
+    bool equals( const QgsCurve &other ) const override;
 
     /**
      * Returns the specified point from inside the line string.

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -91,22 +91,26 @@ QgsPoint::QgsPoint( QgsWkbTypes::Type wkbType, double x, double y, double z, dou
  * See details in QEP #17
  ****************************************************************************/
 
-bool QgsPoint::operator==( const QgsPoint &pt ) const
+bool QgsPoint::operator==( const QgsAbstractGeometry &other ) const
 {
+  const QgsPoint *pt = qgsgeometry_cast< const QgsPoint * >( &other );
+  if ( !pt )
+    return false;
+
   const QgsWkbTypes::Type type = wkbType();
 
-  bool equal = pt.wkbType() == type;
-  equal &= qgsDoubleNear( pt.x(), mX, 1E-8 );
-  equal &= qgsDoubleNear( pt.y(), mY, 1E-8 );
+  bool equal = pt->wkbType() == type;
+  equal &= qgsDoubleNear( pt->x(), mX, 1E-8 );
+  equal &= qgsDoubleNear( pt->y(), mY, 1E-8 );
   if ( QgsWkbTypes::hasZ( type ) )
-    equal &= qgsDoubleNear( pt.z(), mZ, 1E-8 ) || ( std::isnan( pt.z() ) && std::isnan( mZ ) );
+    equal &= qgsDoubleNear( pt->z(), mZ, 1E-8 ) || ( std::isnan( pt->z() ) && std::isnan( mZ ) );
   if ( QgsWkbTypes::hasM( type ) )
-    equal &= qgsDoubleNear( pt.m(), mM, 1E-8 ) || ( std::isnan( pt.m() ) && std::isnan( mM ) );
+    equal &= qgsDoubleNear( pt->m(), mM, 1E-8 ) || ( std::isnan( pt->m() ) && std::isnan( mM ) );
 
   return equal;
 }
 
-bool QgsPoint::operator!=( const QgsPoint &pt ) const
+bool QgsPoint::operator!=( const QgsAbstractGeometry &pt ) const
 {
   return !operator==( pt );
 }

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -117,8 +117,8 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
      */
     explicit QgsPoint( QgsWkbTypes::Type wkbType, double x = 0.0, double y = 0.0, double z = std::numeric_limits<double>::quiet_NaN(), double m = std::numeric_limits<double>::quiet_NaN() ) SIP_SKIP;
 
-    bool operator==( const QgsPoint &pt ) const;
-    bool operator!=( const QgsPoint &pt ) const;
+    bool operator==( const QgsAbstractGeometry &other ) const override;
+    bool operator!=( const QgsAbstractGeometry &other ) const override;
 
     /**
      * Returns the point's x-coordinate.

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -985,7 +985,7 @@ bool QgsVectorLayer::updateFeature( const QgsFeature &updatedFeature, bool skipD
     bool hasChanged = false;
     bool hasError = false;
 
-    if ( ( updatedFeature.hasGeometry() || currentFeature.hasGeometry() ) && !updatedFeature.geometry().isGeosEqual( currentFeature.geometry() ) )
+    if ( ( updatedFeature.hasGeometry() || currentFeature.hasGeometry() ) && !updatedFeature.geometry().equals( currentFeature.geometry() ) )
     {
       if ( changeGeometry( updatedFeature.id(), updatedFeature.geometry(), true ) )
       {

--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -412,7 +412,7 @@ ErrorList topolTest::checkDuplicates( double tolerance, QgsVectorLayer *layer1, 
         continue;
       }
 
-      if ( g1.equals( g2 ) )
+      if ( g1.isGeosEqual( g2 ) )
       {
         duplicate = true;
         duplicateIds.append( mFeatureMap2[*cit].feature.id() );

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -579,6 +579,10 @@ void TestQgsGeometry::point()
   QVERIFY( !( QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 1 / 3.0 ) != QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 1 / 3.0 ) ) );
   QVERIFY( QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 1 / 3.0 ) != QgsPoint( QgsWkbTypes::PointZ, 2 / 3.0, 1 / 3.0 ) );
 
+  QgsLineString nonPoint;
+  QVERIFY( p8 != nonPoint );
+  QVERIFY( !( p8 == nonPoint ) );
+
   //test setters and getters
   //x
   QgsPoint p10( QgsWkbTypes::PointZM );
@@ -3044,6 +3048,10 @@ void TestQgsGeometry::lineString()
   QVERIFY( e5 != e6 );
 
   QVERIFY( e6 != QgsCircularString() );
+  QgsPoint p1;
+  QVERIFY( !( e6 == p1 ) );
+  QVERIFY( e6 != p1 );
+  QVERIFY( e6 == e6 );
 
   //close/isClosed
   QgsLineString l11;
@@ -4242,7 +4250,6 @@ void TestQgsGeometry::lineString()
                       << QgsPoint( 11, 12, 4 ) << QgsPoint( 111, 12, 5 ) << QgsPoint( 111.01, 11.99, 6 ) );
   QVERIFY( !nodeLine.removeDuplicateNodes( 0.02, true ) );
   QCOMPARE( nodeLine.asWkt( 2 ), QStringLiteral( "LineStringZ (11 2 1, 11.01 1.99 2, 11.02 2.01 3, 11 12 4, 111 12 5, 111.01 11.99 6)" ) );
-
 }
 
 void TestQgsGeometry::polygon()
@@ -4743,6 +4750,10 @@ void TestQgsGeometry::polygon()
   p10b.addInteriorRing( p10.interiorRing( 0 )->clone() );
   QVERIFY( p10 == p10b );
   QVERIFY( !( p10 != p10b ) );
+
+  QgsLineString nonPolygon;
+  QVERIFY( p10 != nonPolygon );
+  QVERIFY( !( p10 == nonPolygon ) );
 
   //clone
 
@@ -13936,6 +13947,28 @@ void TestQgsGeometry::geometryCollection()
   QCOMPARE( c15.numGeometries(), 2 );
   QCOMPARE( *static_cast< const QgsLineString * >( c15.geometryN( 0 ) ), part );
   QCOMPARE( *static_cast< const QgsLineString * >( c15.geometryN( 1 ) ), part2 );
+
+  //equality
+  QgsGeometryCollection emptyCollection;
+  QVERIFY( !( emptyCollection == c15 ) );
+  QVERIFY( emptyCollection != c15 );
+  QgsPoint notCollection;
+  QVERIFY( !( emptyCollection == notCollection ) );
+  QVERIFY( emptyCollection != notCollection );
+  QgsMultiPoint mp;
+  QgsMultiLineString ml;
+  QVERIFY( mp != ml );
+  QgsMultiLineString ml2;
+  part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  ml.addGeometry( part.clone() );
+  QVERIFY( ml != ml2 );
+  part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  ml2.addGeometry( part.clone() );
+  QVERIFY( ml != ml2 );
 
   //toCurveType
   std::unique_ptr< QgsGeometryCollection > curveType( c12.toCurveType() );

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -80,7 +80,9 @@ class TestQgsGeometry : public QObject
     void asVariant(); //test conversion to and from a QVariant
     void isEmpty();
     void operatorBool();
+    void equality();
     void vertexIterator();
+
 
     // geometry types
     void point(); //test QgsPointV2
@@ -429,6 +431,43 @@ void TestQgsGeometry::operatorBool()
 
   geom.set( 0 );
   QVERIFY( !geom );
+}
+
+void TestQgsGeometry::equality()
+{
+  // null geometries
+  QVERIFY( !QgsGeometry().equals( QgsGeometry() ) );
+
+  // compare to null
+  QgsGeometry g1( qgis::make_unique< QgsPoint >( 1.0, 2.0 ) );
+  QVERIFY( !g1.equals( QgsGeometry() ) );
+  QVERIFY( !QgsGeometry().equals( g1 ) );
+
+  // compare implicitly shared copies
+  QgsGeometry g2( g1 );
+  QVERIFY( g2.equals( g1 ) );
+  QVERIFY( g1.equals( g2 ) );
+  QVERIFY( g1.equals( g1 ) );
+
+  // equal geometry, but different internal data
+  g2 = QgsGeometry::fromWkt( "Point( 1.0 2.0 )" );
+  QVERIFY( g2.equals( g1 ) );
+  QVERIFY( g1.equals( g2 ) );
+
+  // different dimensionality
+  g2 = QgsGeometry::fromWkt( "PointM( 1.0 2.0 3.0)" );
+  QVERIFY( !g2.equals( g1 ) );
+  QVERIFY( !g1.equals( g2 ) );
+
+  // different type
+  g2 = QgsGeometry::fromWkt( "LineString( 1.0 2.0, 3.0 4.0 )" );
+  QVERIFY( !g2.equals( g1 ) );
+  QVERIFY( !g1.equals( g2 ) );
+
+  // different direction
+  g1 = QgsGeometry::fromWkt( "LineString( 3.0 4.0, 1.0 2.0 )" );
+  QVERIFY( !g2.equals( g1 ) );
+  QVERIFY( !g1.equals( g2 ) );
 }
 
 void TestQgsGeometry::vertexIterator()


### PR DESCRIPTION
Before we had two checks - equals() and isGeosEqual() which performed the exact same check (since equals() called the geos equality test)

Since the geos equality test is a slow, topological test, which considers two geometries equal if their component edges overlap, but disregards ordering of vertices this is not always what we want. There's also the issue that geos cannot consider m values when testing the geometries, so two geometries with different m values would be reported equal.

So, now calling QgsGeometry::equals performs a very fast, strict equality test where geometries are only equal if the have exactly the same vertices, type, and order.

And swap most code which was calling the slow geos test to instead use the fast strict native test. Note that the slow method was being used by QgsFeature == operator, so maybe there's some big performance boosts to certain code paths here.