### PR TITLE
[ui] add consistent spacing in the symbol list widget

### DIFF
--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -76,7 +76,7 @@
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <property name="spacing">
-      <number>3</number>
+      <number>6</number>
      </property>
      <item>
       <widget class="QLabel" name="label">
@@ -117,6 +117,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="topMargin">
       <number>2</number>
+     </property>
+     <property name="spacing">
+      <number>6</number>
      </property>
      <item>
       <widget class="QLabel" name="lblSymbolName">


### PR DESCRIPTION
## Description
This PR adds consistent spacing to the symbol list widget.

Before vs. proposed:
![screenshot from 2018-01-04 17-11-43](https://user-images.githubusercontent.com/1728657/34559067-17bb10ba-f173-11e7-8147-00cb48344f21.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
