### PR TITLE
fix NULL constraint on date/time widget with allow NULL

### DIFF
--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -65,6 +65,9 @@ Resets the widget to show no value (ie, an "unknown" state).
 .. versionadded:: 2.16
 %End
 
+  signals:
+    void dateTimeChanged( const QDateTime &date );
+
   protected:
     virtual void mousePressEvent( QMouseEvent *event );
 

--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -12,6 +12,13 @@ class QgsDateTimeEdit : QDateTimeEdit
 {
 %Docstring
  The QgsDateTimeEdit class is a QDateTimeEdit with the capability of setting/reading null date/times.
+
+.. warning::
+
+   You should use the signal dateTimeChanged of this subclass QgsDateTimeEdit
+rather than parent's one (QDateTimeEdit). If you consequently connect parent's
+dateTimeChanged signal and call dateTime() afterwards there is no warranty to
+have a proper NULL value handling.
 %End
 
 %TypeHeaderCode
@@ -66,7 +73,13 @@ Resets the widget to show no value (ie, an "unknown" state).
 %End
 
   signals:
+
     void dateTimeChanged( const QDateTime &date );
+%Docstring
+reimplements QDateTimeEdit.dateTimeChanged signal
+to properly handles NULL values.
+@param date the new date/time value.
+%End
 
   protected:
     virtual void mousePressEvent( QMouseEvent *event );

--- a/python/gui/editorwidgets/qgsdatetimeedit.sip
+++ b/python/gui/editorwidgets/qgsdatetimeedit.sip
@@ -15,8 +15,8 @@ class QgsDateTimeEdit : QDateTimeEdit
 
 .. warning::
 
-   You should use the signal dateTimeChanged of this subclass QgsDateTimeEdit
-rather than parent's one (QDateTimeEdit). If you consequently connect parent's
+   You should use the signal valueChanged of this subclass
+rather than QDateTimeEdit.dateTimeChanged. If you consequently connect parent's
 dateTimeChanged signal and call dateTime() afterwards there is no warranty to
 have a proper NULL value handling.
 %End
@@ -74,10 +74,9 @@ Resets the widget to show no value (ie, an "unknown" state).
 
   signals:
 
-    void dateTimeChanged( const QDateTime &date );
+    void valueChanged( const QDateTime &date );
 %Docstring
-reimplements QDateTimeEdit.dateTimeChanged signal
-to properly handles NULL values.
+signal emitted whenever the value changes.
 @param date the new date/time value.
 %End
 

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -61,11 +61,6 @@ void QgsDateTimeEdit::clear()
     displayNull();
 
     changed( QDateTime() );
-
-    // avoid slot double activation
-    disconnect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
-    emit dateTimeChanged( QDateTime() );
-    connect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
   }
 }
 
@@ -174,6 +169,8 @@ void QgsDateTimeEdit::changed( const QDateTime &dateTime )
   }
 
   mClearAction->setVisible( mAllowNull && !mIsNull );
+
+  emit QgsDateTimeEdit::dateTimeChanged( dateTime );
 }
 
 void QgsDateTimeEdit::displayNull( bool updateCalendar )

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -61,6 +61,15 @@ void QgsDateTimeEdit::clear()
     displayNull();
 
     changed( QDateTime() );
+
+    // emit signal of QDateTime::dateTimeChanged with an invalid date
+    // anyway, using parent's signal should be avoided
+    // If you consequently connect parent's dateTimeChanged signal
+    // and call dateTime() afterwards there is no warranty to
+    // have a proper NULL value handling
+    disconnect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
+    emit dateTimeChanged( QDateTime() );
+    connect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
   }
 }
 
@@ -170,7 +179,7 @@ void QgsDateTimeEdit::changed( const QDateTime &dateTime )
 
   mClearAction->setVisible( mAllowNull && !mIsNull );
 
-  emit QgsDateTimeEdit::dateTimeChanged( dateTime );
+  emit QgsDateTimeEdit::valueChanged( dateTime );
 }
 
 void QgsDateTimeEdit::displayNull( bool updateCalendar )

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -23,6 +23,11 @@
 /**
  * \ingroup gui
  * \brief The QgsDateTimeEdit class is a QDateTimeEdit with the capability of setting/reading null date/times.
+ *
+ * \warning You should use the signal dateTimeChanged of this subclass QgsDateTimeEdit
+ * rather than parent's one (QDateTimeEdit). If you consequently connect parent's
+ * dateTimeChanged signal and call dateTime() afterwards there is no warranty to
+ * have a proper NULL value handling.
  */
 class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
 {
@@ -63,6 +68,12 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     void setEmpty();
 
   signals:
+
+    /**
+     * reimplements QDateTimeEdit::dateTimeChanged signal
+     * to properly handles NULL values.
+     * @param date the new date/time value.
+     */
     void dateTimeChanged( const QDateTime &date );
 
   protected:

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -24,8 +24,8 @@
  * \ingroup gui
  * \brief The QgsDateTimeEdit class is a QDateTimeEdit with the capability of setting/reading null date/times.
  *
- * \warning You should use the signal dateTimeChanged of this subclass QgsDateTimeEdit
- * rather than parent's one (QDateTimeEdit). If you consequently connect parent's
+ * \warning You should use the signal valueChanged of this subclass
+ * rather than QDateTimeEdit::dateTimeChanged. If you consequently connect parent's
  * dateTimeChanged signal and call dateTime() afterwards there is no warranty to
  * have a proper NULL value handling.
  */
@@ -70,11 +70,10 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
   signals:
 
     /**
-     * reimplements QDateTimeEdit::dateTimeChanged signal
-     * to properly handles NULL values.
+     * signal emitted whenever the value changes.
      * @param date the new date/time value.
      */
-    void dateTimeChanged( const QDateTime &date );
+    void valueChanged( const QDateTime &date );
 
   protected:
     void mousePressEvent( QMouseEvent *event ) override;

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -62,6 +62,9 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
      */
     void setEmpty();
 
+  signals:
+    void dateTimeChanged( const QDateTime &date );
+
   protected:
     void mousePressEvent( QMouseEvent *event ) override;
     void focusOutEvent( QFocusEvent *event ) override;

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -93,7 +93,7 @@ void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
 
   if ( mQgsDateTimeEdit )
   {
-    connect( mQgsDateTimeEdit, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEditWrapper::dateTimeChanged );
+    connect( mQgsDateTimeEdit, &QgsDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEditWrapper::dateTimeChanged );
   }
   else
   {

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -93,7 +93,7 @@ void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
 
   if ( mQgsDateTimeEdit )
   {
-    connect( mQgsDateTimeEdit, &QgsDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEditWrapper::dateTimeChanged );
+    connect( mQgsDateTimeEdit, &QgsDateTimeEdit::valueChanged, this, &QgsDateTimeEditWrapper::dateTimeChanged );
   }
   else
   {


### PR DESCRIPTION
the issue was that the widget wrapper was using parent `QDateTimeEdit::dateTimeChanged` signal. It was connected both internally to slot `QgsDateTimeEdit::changed` but also in the form to detect changes. When QgsAttributeForm is recreating the updated feature it was calling `QgsDateTimeEdit::value()` before `changed()` could update the value (i.e. setting `mIsNull` to false).

This reimplements the parent signal in the subclass (i.e. `QgsDateTimeEdit::dateTimeChanged`).
This is working as expected but I'm not sure it's a correct way of fixing this (i.e. reimplementing signal).

The other approach I see would be to rename the signal to better distinguish them. But at the end, it'll remains the same: one has to connect the signal to correctly know about NULL values.
