### PR TITLE
Attempt to fix #17783, window not activated on OSX after font dialog displayed

### DIFF
--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -105,6 +105,7 @@ void QgsFontButton::showSettingsDialog()
 
   // reactivate button's window
   activateWindow();
+  raise();
 }
 
 QgsMapCanvas *QgsFontButton::mapCanvas() const


### PR DESCRIPTION
@timlinux can you test this? I'm unsure it'll fix the issue, but can't see any difference between this and the color button dialog (does that correctly refocus the window?)