### PR TITLE
Crashhandler allthreads

### DIFF
--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -91,9 +91,11 @@ int main( int argc, char *argv[] )
   dlg.show();
   app.exec();
 
-  for(HANDLE threadHandle : stackTrace->threads) {
-      ResumeThread( threadHandle );
-      CloseHandle( threadHandle);
+
+  for ( HANDLE threadHandle : stackTrace->threads )
+  {
+    ResumeThread( threadHandle );
+    CloseHandle( threadHandle );
   }
   CloseHandle( stackTrace->process );
 

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -91,8 +91,10 @@ int main( int argc, char *argv[] )
   dlg.show();
   app.exec();
 
-  ResumeThread( stackTrace->thread );
-  CloseHandle( stackTrace->thread );
+  for(HANDLE threadHandle : stackTrace->threads) {
+      ResumeThread( threadHandle );
+      CloseHandle( threadHandle);
+  }
   CloseHandle( stackTrace->process );
 
   return 0;

--- a/src/crashhandler/qgsstacktrace.cpp
+++ b/src/crashhandler/qgsstacktrace.cpp
@@ -798,8 +798,6 @@ QgsStackTrace *QgsStackTrace::trace( DWORD processId, DWORD threadId, LPEXCEPTIO
         {
           if ( te.th32OwnerProcessID == processId )
           {
-            printf( "Process 0x%04x Thread 0x%04x\n",
-                    te.th32OwnerProcessID, te.th32ThreadID );
             HANDLE threadHandle = OpenThread( THREAD_ALL_ACCESS, FALSE, te.th32ThreadID );
             trace->threads.push_back( threadHandle );
             SuspendThread( threadHandle );

--- a/src/crashhandler/qgsstacktrace.cpp
+++ b/src/crashhandler/qgsstacktrace.cpp
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <tlhelp32.h>
 
 #include <Windows.h>
 #include <DbgHelp.h>
@@ -780,9 +781,36 @@ QgsStackTrace *QgsStackTrace::trace( DWORD processId, DWORD threadId, LPEXCEPTIO
   StackTrace *stackTrace = ( StackTrace * )calloc( sizeof( *stackTrace ), 1 );
   stackTrace->process = OpenProcess( PROCESS_ALL_ACCESS, FALSE, processId );
   stackTrace->thread = OpenThread( THREAD_ALL_ACCESS, FALSE, threadId );
-  SuspendThread( stackTrace->thread );
   trace->process = stackTrace->process;
   trace->thread = stackTrace->thread;
+
+  HANDLE h = CreateToolhelp32Snapshot( TH32CS_SNAPTHREAD, 0 );
+  if ( h != INVALID_HANDLE_VALUE )
+  {
+    THREADENTRY32 te;
+    te.dwSize = sizeof( te );
+    if ( Thread32First( h, &te ) )
+    {
+      do
+      {
+        if ( te.dwSize >= FIELD_OFFSET( THREADENTRY32, th32OwnerProcessID ) +
+             sizeof( te.th32OwnerProcessID ) )
+        {
+          if ( te.th32OwnerProcessID == processId )
+          {
+            printf( "Process 0x%04x Thread 0x%04x\n",
+                    te.th32OwnerProcessID, te.th32ThreadID );
+            HANDLE threadHandle = OpenThread( THREAD_ALL_ACCESS, FALSE, te.th32ThreadID );
+            trace->threads.push_back( threadHandle );
+            SuspendThread( threadHandle );
+          }
+        }
+        te.dwSize = sizeof( te );
+      }
+      while ( Thread32Next( h, &te ) );
+    }
+    CloseHandle( h );
+  }
 
   ReadProcessMemory( stackTrace->process, exception, &remoteException, sizeof( remoteException ), NULL );
   ReadProcessMemory( stackTrace->process, remoteException.ContextRecord, &remoteContextRecord, sizeof( remoteContextRecord ), NULL );

--- a/src/crashhandler/qgsstacktrace.h
+++ b/src/crashhandler/qgsstacktrace.h
@@ -71,6 +71,7 @@ class QgsStackTrace
 #ifdef _MSC_VER
     HANDLE process;
     HANDLE thread;
+    std::vector<HANDLE> threads;
 
     /**
      * Return a demangled stack backtrace of the caller function.


### PR DESCRIPTION
So it turns out that if you only suspend the thread with the crash on it and that isn't the main thread you might end up spamming the user with crash dialogs.  Consider a crash in the threaded render logic, each time you pan, for each renderer, it might throw a dialog.  Gross.  

This now blocks all threads once we get to this point.  This is what debuggers do so I think it's only wise we do the same.