### PR TITLE
 Add method to 'trigger' QgsTasks

### DIFF
--- a/python/core/qgstaskmanager.sip
+++ b/python/core/qgstaskmanager.sip
@@ -421,6 +421,15 @@ Returns the number of active (queued or running) tasks.
 .. seealso:: :py:func:`countActiveTasksChanged`
 %End
 
+  public slots:
+
+    void trigger( QgsTask *task );
+%Docstring
+Triggers a task, e.g. as a result of a GUI interaction.
+
+.. seealso:: :py:func:`triggered()`
+%End
+
   signals:
 
     void progressChanged( long taskId, double progress );
@@ -473,6 +482,15 @@ Emitted when all tasks are complete
 Emitted when the number of active tasks changes
 
 .. seealso:: :py:func:`countActiveTasks`
+%End
+
+    void triggered( QgsTask *task );
+%Docstring
+Emitted when a ``task`` is triggered. This occurs when a user clicks on
+the task from the QGIS GUI, and can be used to show detailed progress
+reports or re-open a related dialog.
+
+.. seealso:: :py:func:`trigger()`
 %End
 
 };

--- a/python/core/qgstaskmanager.sip
+++ b/python/core/qgstaskmanager.sip
@@ -423,11 +423,11 @@ Returns the number of active (queued or running) tasks.
 
   public slots:
 
-    void trigger( QgsTask *task );
+    void triggerTask( QgsTask *task );
 %Docstring
 Triggers a task, e.g. as a result of a GUI interaction.
 
-.. seealso:: :py:func:`triggered()`
+.. seealso:: :py:func:`taskTriggered`
 %End
 
   signals:
@@ -484,13 +484,13 @@ Emitted when the number of active tasks changes
 .. seealso:: :py:func:`countActiveTasks`
 %End
 
-    void triggered( QgsTask *task );
+    void taskTriggered( QgsTask *task );
 %Docstring
 Emitted when a ``task`` is triggered. This occurs when a user clicks on
 the task from the QGIS GUI, and can be used to show detailed progress
 reports or re-open a related dialog.
 
-.. seealso:: :py:func:`trigger()`
+.. seealso:: :py:func:`triggerTask`
 %End
 
 };

--- a/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
+++ b/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
@@ -32,6 +32,7 @@ class QgsProcessingAlgorithmDialogBase : QDialog
 %Docstring
 Constructor for QgsProcessingAlgorithmDialogBase.
 %End
+    ~QgsProcessingAlgorithmDialogBase();
 
     void setAlgorithm( QgsProcessingAlgorithm *algorithm );
 %Docstring
@@ -143,6 +144,9 @@ from this dialog.
 
   protected:
 
+    virtual void closeEvent( QCloseEvent *e );
+
+
     QPushButton *runButton();
 %Docstring
 Returns the dialog's run button.
@@ -204,6 +208,12 @@ Returns the dialog's message bar.
     void hideShortHelp();
 %Docstring
 Hides the short help panel.
+%End
+
+    void setCurrentTask( QgsProcessingAlgRunnerTask *task /Transfer/ );
+%Docstring
+Sets the current ``task`` running in the dialog. The task will automatically be started
+by the dialog. Ownership of ``task`` is transferred to the dialog.
 %End
 
   protected slots:

--- a/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
+++ b/python/gui/processing/qgsprocessingalgorithmdialogbase.sip
@@ -32,7 +32,6 @@ class QgsProcessingAlgorithmDialogBase : QDialog
 %Docstring
 Constructor for QgsProcessingAlgorithmDialogBase.
 %End
-    ~QgsProcessingAlgorithmDialogBase();
 
     void setAlgorithm( QgsProcessingAlgorithm *algorithm );
 %Docstring

--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -87,7 +87,6 @@ class ProcessingDropHandler(QgsCustomDropHandler):
 
         alg.setProvider(QgsApplication.processingRegistry().providerById('model'))
         dlg = AlgorithmDialog(alg)
-        dlg.setAttribute(Qt.WA_DeleteOnClose)
         dlg.show()
         return True
 

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -72,7 +72,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         self.runAsBatchButton = QPushButton(QCoreApplication.translate("AlgorithmDialog", "Run as Batch Process…"))
         self.runAsBatchButton.clicked.connect(self.runAsBatch)
         self.buttonBox().addButton(self.runAsBatchButton, QDialogButtonBox.ResetRole) # reset role to ensure left alignment
-        QgsApplication.taskManager().triggered.connect(self.taskTriggered)
+        QgsApplication.taskManager().taskTriggered.connect(self.taskTriggered)
 
     def getParametersPanel(self, alg, parent):
         return ParametersPanel(parent, alg)

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -64,6 +64,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
     def __init__(self, alg):
         super().__init__()
         self.feedback_dialog = None
+        self.task = None
 
         self.setAlgorithm(alg)
         self.setMainWidget(self.getParametersPanel(alg, self))
@@ -71,6 +72,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         self.runAsBatchButton = QPushButton(QCoreApplication.translate("AlgorithmDialog", "Run as Batch Process…"))
         self.runAsBatchButton.clicked.connect(self.runAsBatch)
         self.buttonBox().addButton(self.runAsBatchButton, QDialogButtonBox.ResetRole) # reset role to ensure left alignment
+        QgsApplication.taskManager().triggered.connect(self.taskTriggered)
 
     def getParametersPanel(self, alg, parent):
         return ParametersPanel(parent, alg)
@@ -233,6 +235,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 self.cancelButton().setEnabled(self.algorithm().flags() & QgsProcessingAlgorithm.FlagCanCancel)
 
                 def on_complete(ok, results):
+                    self.task = None
                     if ok:
                         feedback.pushInfo(self.tr('Execution completed in {0:0.2f} seconds'.format(time.time() - start_time)))
                         feedback.pushInfo(self.tr('Results:'))
@@ -255,9 +258,9 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     # Make sure the Log tab is visible before executing the algorithm
                     self.showLog()
 
-                    task = QgsProcessingAlgRunnerTask(self.algorithm(), parameters, context, feedback)
-                    task.executed.connect(on_complete)
-                    QgsApplication.taskManager().addTask(task)
+                    self.task = QgsProcessingAlgRunnerTask(self.algorithm(), parameters, context, feedback)
+                    self.task.executed.connect(on_complete)
+                    QgsApplication.taskManager().addTask(self.task)
                 else:
                     self.feedback_dialog = self.createProgressDialog()
                     self.feedback_dialog.show()
@@ -276,6 +279,13 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.messageBar().clearWidgets()
             self.messageBar().pushMessage("", self.tr("Wrong or missing parameter value: {0}").format(e.parameter.description()),
                                           level=QgsMessageBar.WARNING, duration=5)
+
+    def taskTriggered(self, task):
+        if task == self.task:
+            self.show()
+            self.raise_()
+            self.setWindowState(self.windowState() & ~Qt.WindowMinimized | Qt.WindowActive)
+            self.activateWindow()
 
     def finish(self, successful, result, context, feedback):
         keepOpen = not successful or ProcessingConfig.getSetting(ProcessingConfig.KEEP_DIALOG_OPEN)

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -88,9 +88,6 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
             prevMapTool = canvas.mapTool()
             dlg.show()
             dlg.exec_()
-            # have to manually delete the dialog - otherwise it's owned by the
-            # iface mainWindow and never deleted
-            dlg.deleteLater()
             if canvas.mapTool() != prevMapTool:
                 try:
                     canvas.mapTool().reset()

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -300,7 +300,7 @@ class ProcessingToolbox(BASE, WIDGET):
                         self.addRecentAlgorithms(True)
                 # have to manually delete the dialog - otherwise it's owned by the
                 # iface mainWindow and never deleted
-                dlg.deleteLater()
+                # dlg.deleteLater()
             else:
                 feedback = MessageBarProgress()
                 context = dataobjects.createContext(feedback)

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -257,9 +257,6 @@ class ProcessingToolbox(BASE, WIDGET):
                 dlg = BatchAlgorithmDialog(alg)
                 dlg.show()
                 dlg.exec_()
-                # have to manually delete the dialog - otherwise it's owned by the
-                # iface mainWindow and never deleted
-                dlg.deleteLater()
 
     def executeAlgorithm(self):
         item = self.algorithmTree.currentItem()
@@ -298,9 +295,6 @@ class ProcessingToolbox(BASE, WIDGET):
                         ProcessingConfig.SHOW_RECENT_ALGORITHMS)
                     if showRecent:
                         self.addRecentAlgorithms(True)
-                # have to manually delete the dialog - otherwise it's owned by the
-                # iface mainWindow and never deleted
-                # dlg.deleteLater()
             else:
                 feedback = MessageBarProgress()
                 context = dataobjects.createContext(feedback)

--- a/python/plugins/processing/gui/ScriptEditorDialog.py
+++ b/python/plugins/processing/gui/ScriptEditorDialog.py
@@ -284,11 +284,6 @@ class ScriptEditorDialog(BASE, WIDGET):
         prevMapTool = canvas.mapTool()
 
         dlg.show()
-        dlg.exec_()
-
-        # have to manually delete the dialog - otherwise it's owned by the
-        # iface mainWindow and never deleted
-        dlg.deleteLater()
 
         if canvas.mapTool() != prevMapTool:
             try:

--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -211,9 +211,6 @@ def _executeAlgorithm(alg):
         prevMapTool = canvas.mapTool()
         dlg.show()
         dlg.exec_()
-        # have to manually delete the dialog - otherwise it's owned by the
-        # iface mainWindow and never deleted
-        del dlg
         if canvas.mapTool() != prevMapTool:
             try:
                 canvas.mapTool().reset()

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -323,9 +323,6 @@ class ModelerDialog(BASE, WIDGET):
 
         dlg = AlgorithmDialog(self.model)
         dlg.exec_()
-        # have to manually delete the dialog - otherwise it's owned by the
-        # iface mainWindow and never deleted
-        dlg.deleteLater()
 
     def save(self):
         self.saveModel(False)

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -154,7 +154,4 @@ def execAlgorithmDialog(algOrName, parameters={}):
         canvas.setMapTool(prevMapTool)
 
     results = dlg.results()
-    # have to manually delete the dialog - otherwise it's owned by the
-    # iface mainWindow and never deleted
-    dlg.deleteLater()
     return results

--- a/src/core/processing/qgsprocessingalgrunnertask.cpp
+++ b/src/core/processing/qgsprocessingalgrunnertask.cpp
@@ -23,7 +23,7 @@
 #include "qgsvectorlayer.h"
 
 QgsProcessingAlgRunnerTask::QgsProcessingAlgRunnerTask( const QgsProcessingAlgorithm *algorithm, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
-  : QgsTask( tr( "Running %1" ).arg( algorithm->name() ), QgsTask::CanCancel )
+  : QgsTask( tr( "Executing “%1”" ).arg( algorithm->displayName() ), QgsTask::CanCancel )
   , mParameters( parameters )
   , mContext( context )
   , mFeedback( feedback )

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -607,6 +607,12 @@ int QgsTaskManager::countActiveTasks() const
   return tasks.intersect( mParentTasks ).count();
 }
 
+void QgsTaskManager::trigger( QgsTask *task )
+{
+  if ( task )
+    emit triggered( task );
+}
+
 void QgsTaskManager::taskProgressChanged( double progress )
 {
   QgsTask *task = qobject_cast< QgsTask * >( sender() );

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -607,10 +607,10 @@ int QgsTaskManager::countActiveTasks() const
   return tasks.intersect( mParentTasks ).count();
 }
 
-void QgsTaskManager::trigger( QgsTask *task )
+void QgsTaskManager::triggerTask( QgsTask *task )
 {
   if ( task )
-    emit triggered( task );
+    emit taskTriggered( task );
 }
 
 void QgsTaskManager::taskProgressChanged( double progress )

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -489,9 +489,9 @@ class CORE_EXPORT QgsTaskManager : public QObject
 
     /**
      * Triggers a task, e.g. as a result of a GUI interaction.
-     * \see triggered()
+     * \see taskTriggered()
      */
-    void trigger( QgsTask *task );
+    void triggerTask( QgsTask *task );
 
   signals:
 
@@ -544,9 +544,9 @@ class CORE_EXPORT QgsTaskManager : public QObject
      * Emitted when a \a task is triggered. This occurs when a user clicks on
      * the task from the QGIS GUI, and can be used to show detailed progress
      * reports or re-open a related dialog.
-     * \see trigger()
+     * \see triggerTask()
      */
-    void triggered( QgsTask *task );
+    void taskTriggered( QgsTask *task );
 
   private slots:
 

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -485,6 +485,14 @@ class CORE_EXPORT QgsTaskManager : public QObject
      */
     int countActiveTasks() const;
 
+  public slots:
+
+    /**
+     * Triggers a task, e.g. as a result of a GUI interaction.
+     * \see triggered()
+     */
+    void trigger( QgsTask *task );
+
   signals:
 
     /**
@@ -531,6 +539,14 @@ class CORE_EXPORT QgsTaskManager : public QObject
      * \see countActiveTasks()
      */
     void countActiveTasksChanged( int count );
+
+    /**
+     * Emitted when a \a task is triggered. This occurs when a user clicks on
+     * the task from the QGIS GUI, and can be used to show detailed progress
+     * reports or re-open a related dialog.
+     * \see trigger()
+     */
+    void triggered( QgsTask *task );
 
   private slots:
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -89,7 +89,6 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      * Constructor for QgsProcessingAlgorithmDialogBase.
      */
     QgsProcessingAlgorithmDialogBase( QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr );
-    ~QgsProcessingAlgorithmDialogBase();
 
     /**
      * Sets the \a algorithm to run in the dialog.

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -29,6 +29,8 @@ class QgsProcessingAlgorithm;
 class QToolButton;
 class QgsProcessingAlgorithmDialogBase;
 class QgsMessageBar;
+class QgsProcessingAlgRunnerTask;
+class QgsTask;
 
 #ifndef SIP_RUN
 
@@ -87,6 +89,7 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      * Constructor for QgsProcessingAlgorithmDialogBase.
      */
     QgsProcessingAlgorithmDialogBase( QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr );
+    ~QgsProcessingAlgorithmDialogBase();
 
     /**
      * Sets the \a algorithm to run in the dialog.
@@ -189,6 +192,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
 
   protected:
 
+    void closeEvent( QCloseEvent *e ) override;
+
     /**
      * Returns the dialog's run button.
      */
@@ -248,6 +253,12 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      */
     void hideShortHelp();
 
+    /**
+     * Sets the current \a task running in the dialog. The task will automatically be started
+     * by the dialog. Ownership of \a task is transferred to the dialog.
+     */
+    void setCurrentTask( QgsProcessingAlgRunnerTask *task SIP_TRANSFER );
+
   protected slots:
 
     /**
@@ -262,6 +273,9 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
 
     void splitterChanged( int pos, int index );
     void linkClicked( const QUrl &url );
+    void algExecuted( bool successful, const QVariantMap &results );
+    void taskTriggered( QgsTask *task );
+    void closeClicked();
 
   private:
 
@@ -275,6 +289,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     QVariantMap mResults;
     QWidget *mMainWidget = nullptr;
     QgsProcessingAlgorithm *mAlgorithm = nullptr;
+    QgsProcessingAlgRunnerTask *mAlgorithmTask = nullptr;
+
     bool mHelpCollapsed = false;
 
     QString formatHelp( QgsProcessingAlgorithm *algorithm );

--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -106,7 +106,7 @@ void QgsTaskManagerWidget::clicked( const QModelIndex &index )
   if ( !task )
     return;
 
-  mManager->trigger( task );
+  mManager->triggerTask( task );
 }
 
 ///@cond PRIVATE

--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -33,6 +33,7 @@
 
 QgsTaskManagerWidget::QgsTaskManagerWidget( QgsTaskManager *manager, QWidget *parent )
   : QWidget( parent )
+  , mManager( manager )
 {
   Q_ASSERT( manager );
 
@@ -53,6 +54,8 @@ QgsTaskManagerWidget::QgsTaskManagerWidget( QgsTaskManager *manager, QWidget *pa
   mTreeView->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOn );
   mTreeView->header()->setStretchLastSection( false );
   mTreeView->header()->setSectionResizeMode( QgsTaskManagerModel::Description, QHeaderView::Stretch );
+
+  connect( mTreeView, &QTreeView::clicked, this, &QgsTaskManagerWidget::clicked );
 
   vLayout->addWidget( mTreeView );
 
@@ -95,6 +98,15 @@ void QgsTaskManagerWidget::modelRowsInserted( const QModelIndex &, int start, in
     connect( statusWidget, &QgsTaskStatusWidget::cancelClicked, task, &QgsTask::cancel );
     mTreeView->setIndexWidget( mModel->index( row, QgsTaskManagerModel::Status ), statusWidget );
   }
+}
+
+void QgsTaskManagerWidget::clicked( const QModelIndex &index )
+{
+  QgsTask *task = mModel->indexToTask( index );
+  if ( !task )
+    return;
+
+  mManager->trigger( task );
 }
 
 ///@cond PRIVATE

--- a/src/gui/qgstaskmanagerwidget.h
+++ b/src/gui/qgstaskmanagerwidget.h
@@ -55,9 +55,11 @@ class GUI_EXPORT QgsTaskManagerWidget : public QWidget
   private slots:
 
     void modelRowsInserted( const QModelIndex &index, int start, int end );
+    void clicked( const QModelIndex &index );
 
   private:
 
+    QgsTaskManager *mManager = nullptr;
     QTreeView *mTreeView = nullptr;
     QgsTaskManagerModel *mModel = nullptr;
 };


### PR DESCRIPTION
Triggering occurs when a task is clicked in the task manager widget, and this can be used to e.g. open a dialog showing detailed task progress (or reopen a closed dialog which started the task)