### PR TITLE
[authentification manager] fix auth error

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -703,6 +703,13 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mSplash->showMessage( tr( "Setting up the GUI" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();
 
+  QgsApplication::initQgis();
+  if ( !QgsApplication::authManager()->isDisabled() )
+  {
+    // Most of the auth initialization is now done inside initQgis, no need to profile here
+    masterPasswordSetup();
+  }
+
   QgsSettings settings;
 
   startProfile( QStringLiteral( "Building style sheet" ) );
@@ -1032,13 +1039,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   // load providers
   mSplash->showMessage( tr( "Checking provider plugins" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();
-  QgsApplication::initQgis();
-
-  if ( !QgsApplication::authManager()->isDisabled() )
-  {
-    // Most of the auth initialization is now done inside initQgis, no need to profile here
-    masterPasswordSetup();
-  }
 
   // Setup QgsNetworkAccessManager (this needs to happen after authentication, for proxy settings)
   namSetup();


### PR DESCRIPTION
## Description
Yay, the source of the authentication manager's infamous "auth exec() FAILED!" error has been diagnosed. This PR fixes it, as reported @ https://issues.qgis.org/issues/17386.

Long story short, we were using the manager prior to initializing it. 

The longer story: when QGIS is run from a non build directory, the welcome page widget triggers a QgsVersionInfo::checkVersion(), which in turn sends a query through QgsNetworkAccessManager relying on QgsAuthManager. 

It resulted in a messy situation, and ended up messing reading / access to qgis-auth.db.

The solution offered in this PR is to move the call to QgsApplication::initQgis() (which initiates the authentication manager & the network access manager) up the chain so it happens _prior to_ creating the welcome page and triggering the version check.

@nyalldawson , @elpaso , how do you feel about this? Alternative solutions: remove the welcome page version check altogether (na!), or create a QgsWelcomePage::checkVersion() function and trigger it after QgsApplication::initQgis() if we don't want the latter to move.

It's probably more future-proof to move QgsApplication::initQgis() up.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

  