### PR TITLE
[snapping] fix missing layers in snapping config dialog (fixes #17792)

### DIFF
--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -72,6 +72,7 @@ class APP_EXPORT QgsSnappingLayerTreeModel : public QSortFilterProxyModel
 
     QgsLayerTreeModel *layerTreeModel() const;
     void setLayerTreeModel( QgsLayerTreeModel *layerTreeModel );
+    void resetLayerTreeModel() { reset(); }
 
     QgsVectorLayer *vectorLayer( const QModelIndex &idx ) const;
 

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -217,6 +217,12 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
     connect( model, &QgsSnappingLayerTreeModel::rowsInserted, this, &QgsSnappingWidget::onSnappingTreeLayersChanged );
     connect( model, &QgsSnappingLayerTreeModel::modelReset, this, &QgsSnappingWidget::onSnappingTreeLayersChanged );
     connect( model, &QgsSnappingLayerTreeModel::rowsRemoved, this, &QgsSnappingWidget::onSnappingTreeLayersChanged );
+    connect( project, &QgsProject::readProject, this, [ = ]
+    {
+      if ( model->layerTreeModel() )
+        delete model->layerTreeModel();
+      model->setLayerTreeModel( new QgsLayerTreeModel( mProject->layerTreeRoot(), model ) );
+    } );
 
     // model->setFlags( 0 );
     mLayerTreeView->setModel( model );

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -219,9 +219,7 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
     connect( model, &QgsSnappingLayerTreeModel::rowsRemoved, this, &QgsSnappingWidget::onSnappingTreeLayersChanged );
     connect( project, &QgsProject::readProject, this, [ = ]
     {
-      if ( model->layerTreeModel() )
-        delete model->layerTreeModel();
-      model->setLayerTreeModel( new QgsLayerTreeModel( mProject->layerTreeRoot(), model ) );
+      model->resetLayerTreeModel();
     } );
 
     // model->setFlags( 0 );

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1042,7 +1042,6 @@ bool QgsProject::readProjectFile( const QString &filename )
   }
 
   mSnappingConfig.readProject( *doc );
-  emit snappingConfigChanged( mSnappingConfig );
 
   //add variables defined in project file
   QStringList variableNames = readListEntry( QStringLiteral( "Variables" ), QStringLiteral( "/variableNames" ) );
@@ -1066,6 +1065,7 @@ bool QgsProject::readProjectFile( const QString &filename )
 
   // read the project: used by map canvas and legend
   emit readProject( *doc );
+  emit snappingConfigChanged( mSnappingConfig );
 
   // if all went well, we're allegedly in pristine state
   if ( clean )


### PR DESCRIPTION
## Description
We have a regression in master whereas the snapping configuration dialog doesn't show project layers when a project has been loaded. If a layer is added / deleted subsequently to reading a project, all the layers appear.

@m-kuhn , @wonder-sk , @nyalldawson , I'm not sure if this is the right way to fix the referred issue, but it works 😉 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
