### PR TITLE
Follow up #17673 Spatial Bookmarks fixes backport to 2.18

### DIFF
--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -202,16 +202,17 @@ void QgsBookmarks::addClicked()
 
 void QgsBookmarks::deleteClicked()
 {
-  QList<int> rows;
-  Q_FOREACH ( const QModelIndex &idx, lstBookmarks->selectionModel()->selectedIndexes() )
+  QItemSelection selection( mProxyModel->mapSelectionToSource( lstBookmarks->selectionModel()->selection() ) );
+  std::vector<int> rows;
+  Q_FOREACH ( const QModelIndex &idx, selection.indexes() )
   {
     if ( idx.column() == 1 )
     {
-      rows << idx.row();
+      rows.push_back( idx.row() );
     }
   }
 
-  if ( rows.isEmpty() )
+  if ( rows.size() == 0 )
     return;
 
   // make sure the user really wants to delete these bookmarks
@@ -220,12 +221,14 @@ void QgsBookmarks::deleteClicked()
        QMessageBox::Ok | QMessageBox::Cancel ) )
     return;
 
-  int i = 0;
+  // Remove in reverse order to keep the merged model indexes
+  std::sort( rows.begin(), rows.end(), std::greater<int>() );
+
   Q_FOREACH ( int row, rows )
   {
-    mMergedModel->removeRow( row - i );
-    i++;
+    mMergedModel->removeRow( row );
   }
+  mProxyModel->_resetModel();
 }
 
 void QgsBookmarks::lstBookmarks_doubleClicked( const QModelIndex &index )

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -387,8 +387,17 @@ void QgsBookmarks::exportToXml()
       if ( idx.isValid() )
       {
         QString value = idx.data( Qt::DisplayRole ).toString();
-        QDomText idText = doc.createTextNode( value );
         QString header = headerList.at( j );
+        // If it's the EPSG code, convert it to internal srid
+        if ( header == QStringLiteral( "sr_id" ) )
+        {
+          QgsCoordinateReferenceSystem crs;
+          if ( crs.createFromOgcWmsCrs( value ) )
+            value = QString::number( crs.srsid( ) );
+          else
+            value = QString();
+        }
+        QDomText idText = doc.createTextNode( value );
         QDomElement id = doc.createElement( header );
         id.appendChild( idText );
         bookmark.appendChild( id );

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -395,7 +395,7 @@ void QgsBookmarks::exportToXml()
         QString value = idx.data( Qt::DisplayRole ).toString();
         QString header = headerList.at( j );
         // If it's the EPSG code, convert it to internal srid
-        if ( header == QStringLiteral( "sr_id" ) )
+        if ( header == "sr_id" )
         {
           QgsCoordinateReferenceSystem crs = QgsCRSCache::instance()->crsByOgcWmsCrs( value );
           if ( crs.isValid() )
@@ -524,9 +524,9 @@ bool QgsProjectBookmarksTableModel::insertRows( int row, int count, const QModel
   Q_UNUSED( parent );
   Q_UNUSED( row );
   // append
-  int oldCount = QgsProject::instance()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ) );
+  int oldCount = QgsProject::instance()->readNumEntry( "Bookmarks", "/count" );
   beginInsertRows( parent, oldCount, oldCount + count );
-  bool result = QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ), oldCount + count );
+  bool result = QgsProject::instance()->writeEntry( "Bookmarks", "/count", oldCount + count );
   endInsertRows();
   return result;
 }

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -397,9 +397,9 @@ void QgsBookmarks::exportToXml()
         // If it's the EPSG code, convert it to internal srid
         if ( header == QStringLiteral( "sr_id" ) )
         {
-          QgsCoordinateReferenceSystem crs;
-          if ( crs.createFromOgcWmsCrs( value ) )
-            value = QString::number( crs.srsid( ) );
+          QgsCoordinateReferenceSystem crs = QgsCRSCache::instance()->crsByOgcWmsCrs( value );
+          if ( crs.isValid() )
+            value = QString::number( crs.srsid() );
           else
             value = QString();
         }

--- a/src/app/qgsbookmarks.h
+++ b/src/app/qgsbookmarks.h
@@ -105,6 +105,10 @@ class QgsMergedBookmarksTableModel: public QAbstractTableModel
     bool projectAvailable() const;
     void moveBookmark( QAbstractTableModel& modelFrom, QAbstractTableModel& modelTo, int row );
 
+  signals:
+
+    void selectItem( const QModelIndex &index );
+
   private slots:
     void allLayoutChanged()
     {
@@ -154,6 +158,8 @@ class APP_EXPORT QgsBookmarks : public QgsDockWidget, private Ui::QgsBookmarksBa
     void importFromXml();
 
     void lstBookmarks_doubleClicked( const QModelIndex & );
+
+    void scrollToIndex( const QModelIndex & );
 
   private:
     QSqlTableModel *mQgisModel;

--- a/src/app/qgsbookmarks.h
+++ b/src/app/qgsbookmarks.h
@@ -158,7 +158,7 @@ class APP_EXPORT QgsBookmarks : public QgsDockWidget, private Ui::QgsBookmarksBa
   private:
     QSqlTableModel *mQgisModel;
     QgsProjectBookmarksTableModel *mProjectModel;
-    QgsMergedBookmarksTableModel *mModel;
+    QgsMergedBookmarksTableModel *mMergedModel;
     QgsBookmarksProxyModel *mProxyModel;
 
     void saveWindowLocation();


### PR DESCRIPTION
This PR apples several fixes to Spatial Bookmarks from master to the 2.18 branch.
These include:
- Proper deletion of objects in the destructor to prevent crash on closing QGIS
- Bookmark deletion in reverse order of the underlying list
- Refreshing the list after importing or changing the In Project status
- Minor member name change to reflect its use: mModel to mMergedModel

see  https://issues.qgis.org/issues/17386

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
