### PR TITLE
[need-docs] reduce width of the meters (at map scale) unit label

### DIFF
--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -1761,7 +1761,7 @@ QString QgsUnitTypes::toString( QgsUnitTypes::RenderUnit unit )
       return QObject::tr( "millimeters", "render" );
 
     case RenderMetersInMapUnits:
-      return QObject::tr( "meters (at map scale)", "render" );
+      return QObject::tr( "meters at scale", "render" );
 
     case RenderMapUnits:
       return QObject::tr( "map units", "render" );

--- a/src/gui/qgsunitselectionwidget.cpp
+++ b/src/gui/qgsunitselectionwidget.cpp
@@ -171,7 +171,7 @@ void QgsUnitSelectionWidget::setUnits( const QgsUnitTypes::RenderUnitList &units
   }
   if ( units.contains( QgsUnitTypes::RenderMetersInMapUnits ) )
   {
-    mUnitCombo->addItem( tr( "Meters (at Map Scale)" ), QgsUnitTypes::RenderMetersInMapUnits );
+    mUnitCombo->addItem( tr( "Meters at Scale" ), QgsUnitTypes::RenderMetersInMapUnits );
   }
   if ( units.contains( QgsUnitTypes::RenderMapUnits ) )
   {


### PR DESCRIPTION
## Description
Under master, we have a bit of an UI issue when it comes to our unit selection widget & the style dock, whereas the widget takes too much horizontal space due to the "Meters (at map scale)" string.

This PR reduces the string to "Meters (at scale)".

Before vs proposed:
![screenshot from 2018-01-11 13-52-15](https://user-images.githubusercontent.com/1728657/34812210-4e4c2880-f6d7-11e7-92cb-64c29960f233.png)


@nyalldawson , take 2, hope this time it'll be satisfactory :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
