### PR TITLE
[BUGFIX][Server] imageQuality has to be used for JPEG images not PNG

### DIFF
--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -153,7 +153,14 @@ namespace QgsWms
     if ( outputFormat != UNKN )
     {
       response.setHeader( "Content-Type", contentType );
-      result.save( response.io(), qPrintable( saveFormat ), imageQuality );
+      if ( saveFormat == "JPEG" )
+      {
+        result.save( response.io(), qPrintable( saveFormat ), imageQuality );
+      }
+      else
+      {
+        result.save( response.io(), qPrintable( saveFormat ) );
+      }
     }
     else
     {

--- a/tests/src/python/test_authmanager_password_ows.py
+++ b/tests/src/python/test_authmanager_password_ows.py
@@ -276,7 +276,7 @@ class TestAuthManager(unittest.TestCase):
 
         # Check the we've got a likely PNG image
         self.assertTrue(self.completed_was_called)
-        self.assertTrue(os.path.getsize(destination) > 700000, "Image size: %s" % os.path.getsize(destination))  # > 1MB
+        self.assertTrue(os.path.getsize(destination) > 2000, "Image size: %s" % os.path.getsize(destination))  # > 1MB
         with open(destination, 'rb') as f:
             self.assertTrue(b'PNG' in f.read())  # is a PNG
 


### PR DESCRIPTION
During the server refactoring, the imageQuality has been applied to all format even if this option has been defined only for JPEG.

This bugfix respects the initial proposition https://github.com/qgis/QGIS/pull/1403
QGIS Server - new project option imageQuality used for JPEG images #1403
## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
