### PR TITLE
mapLayerActions as members - avoiding crash on closing QGIS

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7451,8 +7451,8 @@ void QgisApp::setupLayoutManagerConnections()
 
 void QgisApp::setupDuplicateFeaturesAction()
 {
-  mDuplicateFeatureAction.reset( new QgsMapLayerAction( QString( tr( "Duplicate feature" ) ),
-                                 this, QgsMapLayerAction::AllActions,
+  mDuplicateFeatureAction.reset( new QgsMapLayerAction( tr( "Duplicate feature" ),
+                                 nullptr, QgsMapLayerAction::SingleFeature,
                                  QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeature.svg" ) ) ) );
 
   QgsGui::mapLayerActionRegistry()->addMapLayerAction( mDuplicateFeatureAction.get() );
@@ -7462,8 +7462,8 @@ void QgisApp::setupDuplicateFeaturesAction()
   }
          );
 
-  mDuplicateFeatureDigitizeAction.reset( new QgsMapLayerAction( QString( tr( "Duplicate feature and digitize" ) ),
-                                         this, QgsMapLayerAction::AllActions,
+  mDuplicateFeatureDigitizeAction.reset( new QgsMapLayerAction( tr( "Duplicate feature and digitize" ),
+                                         nullptr, QgsMapLayerAction::SingleFeature,
                                          QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeatureDigitized.svg" ) ) ) );
 
   QgsGui::mapLayerActionRegistry()->addMapLayerAction( mDuplicateFeatureDigitizeAction.get() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7451,23 +7451,23 @@ void QgisApp::setupLayoutManagerConnections()
 
 void QgisApp::setupDuplicateFeaturesAction()
 {
-  QgsMapLayerAction *action = new QgsMapLayerAction( QString( tr( "Duplicate feature" ) ),
-      this, QgsMapLayerAction::AllActions,
-      QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeature.svg" ) ) );
+  mDuplicateFeatureAction.reset( new QgsMapLayerAction( QString( tr( "Duplicate feature" ) ),
+                                 this, QgsMapLayerAction::AllActions,
+                                 QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeature.svg" ) ) ) );
 
-  QgsGui::mapLayerActionRegistry()->addMapLayerAction( action );
-  connect( action, &QgsMapLayerAction::triggeredForFeature, this, [this]( QgsMapLayer * layer, const QgsFeature & feat )
+  QgsGui::mapLayerActionRegistry()->addMapLayerAction( mDuplicateFeatureAction.get() );
+  connect( mDuplicateFeatureAction.get(), &QgsMapLayerAction::triggeredForFeature, this, [this]( QgsMapLayer * layer, const QgsFeature & feat )
   {
     duplicateFeatures( layer, feat );
   }
          );
 
-  action = new QgsMapLayerAction( QString( tr( "Duplicate feature and digitize" ) ),
-                                  this, QgsMapLayerAction::AllActions,
-                                  QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeatureDigitized.svg" ) ) );
+  mDuplicateFeatureDigitizeAction.reset( new QgsMapLayerAction( QString( tr( "Duplicate feature and digitize" ) ),
+                                         this, QgsMapLayerAction::AllActions,
+                                         QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeatureDigitized.svg" ) ) ) );
 
-  QgsGui::mapLayerActionRegistry()->addMapLayerAction( action );
-  connect( action, &QgsMapLayerAction::triggeredForFeature, this, [this]( QgsMapLayer * layer, const QgsFeature & feat )
+  QgsGui::mapLayerActionRegistry()->addMapLayerAction( mDuplicateFeatureDigitizeAction.get() );
+  connect( mDuplicateFeatureDigitizeAction.get(), &QgsMapLayerAction::triggeredForFeature, this, [this]( QgsMapLayer * layer, const QgsFeature & feat )
   {
     duplicateFeatureDigitized( layer, feat );
   }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2146,6 +2146,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QHash< QgsPrintLayout *, QgsMapLayerAction * > mAtlasFeatureActions;
 
+    std::unique_ptr<QgsMapLayerAction> mDuplicateFeatureAction;
+    std::unique_ptr<QgsMapLayerAction> mDuplicateFeatureDigitizeAction;
+
     int mProjOpen = 0;
 
     bool gestureEvent( QGestureEvent *event );


### PR DESCRIPTION
mDuplicateFeatureAction and mDuplicateFeatureDigitizeAction are smart member pointers now.
Means they are deleted when the object QgisApp is destructed (when going out of scope) and there is no crash anymore on closing QGIS.

This solves problems after issue https://github.com/qgis/QGIS/pull/5961