### PR TITLE
Fix multiple right-clicks in main window to get context menu (panels/toolbars) Fixes #17453

### DIFF
--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -83,8 +83,6 @@ Intercept key events like Esc or Del to delete the last point
 :param e: key event
 %End
 
-    virtual bool eventFilter( QObject *obj, QEvent *e );
-
     void deleteTempRubberBand();
 %Docstring
 Clean a temporary rubberband

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -41,9 +41,6 @@
 QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode )
   : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
   , mCaptureMode( mode )
-#ifdef Q_OS_WIN
-  , mSkipNextContextMenuEvent( 0 )
-#endif
 {
   mCaptureModeFromLayer = mode == CaptureNone;
   mCapturing = false;
@@ -639,18 +636,6 @@ void QgsMapToolCapture::stopCapturing()
 
   mTracingStartPoint = QgsPointXY();
 
-#ifdef Q_OS_WIN
-  Q_FOREACH ( QWidget *w, qApp->topLevelWidgets() )
-  {
-    if ( w->objectName() == "QgisApp" )
-    {
-      if ( mSkipNextContextMenuEvent++ == 0 )
-        w->installEventFilter( this );
-      break;
-    }
-  }
-#endif
-
   mCapturing = false;
   mCaptureCurve.clear();
   mSnappingMatches.clear();
@@ -782,15 +767,3 @@ void QgsMapToolCapture::setPoints( const QVector<QgsPointXY> &pointList )
     mSnappingMatches.append( QgsPointLocator::Match() );
 }
 
-#ifdef Q_OS_WIN
-bool QgsMapToolCapture::eventFilter( QObject *obj, QEvent *event )
-{
-  if ( event->type() != QEvent::ContextMenu )
-    return false;
-
-  if ( --mSkipNextContextMenuEvent == 0 )
-    obj->removeEventFilter( this );
-
-  return mSkipNextContextMenuEvent >= 0;
-}
-#endif

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -97,10 +97,6 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      */
     void keyPressEvent( QKeyEvent *e ) override;
 
-#ifdef Q_OS_WIN
-    virtual bool eventFilter( QObject *obj, QEvent *e ) override;
-#endif
-
     /**
      * Clean a temporary rubberband
      */
@@ -261,9 +257,6 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
     friend class TestQgsMapToolReshape;
 
-#ifdef Q_OS_WIN
-    int mSkipNextContextMenuEvent;
-#endif
 };
 
 #endif


### PR DESCRIPTION
This PR removes an event filter that absorbs context menu events from QgisApp. The filter is installed in Windows builds apparently to fix a problem that caused the panels/toolbars context menu to appear on ending a map tool capturing operation in earlier versions of QGIS. see https://issues.qgis.org/issues/2239

The event filter is being installed by map tools that derive from QgsMapToolCapture in response to the newProject and projectRead signals from QgisApp.

More information: https://issues.qgis.org/issues/17453

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
