### PR TITLE
Avoid urlencoding spaces in GeoPackage file path

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -65,7 +65,7 @@ QVector<QgsDataItem *> QgsGeoPackageRootItem::createChildren()
   for ( const QString &connName : connList )
   {
     QgsOgrDbConnection connection( connName, QStringLiteral( "GPKG" ) );
-    QgsDataItem *conn = new QgsGeoPackageConnectionItem( this, connection.name(), connection.uri().encodedUri() );
+    QgsDataItem *conn = new QgsGeoPackageConnectionItem( this, connection.name(), connection.uri().encodedUri().replace( "%20", " " ) );
 
     connections.append( conn );
   }


### PR DESCRIPTION
GeoPackages are broken in Browser->GeoPackage branch if the file path contains spaces (only in that branch; the disk branches as well as DB Manager work well). They are url-encoded into %20, so this dirty hack reverts it. Is it ok?

Note the encodedUri is a QByteArray, so I found the replace working with simple string literals. I can pack them into QByteArrays, if there is any reason (is there?).

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
