### PR TITLE
improve sorting of field values for the query builder

### DIFF
--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -137,7 +137,8 @@ void QgsQueryBuilder::fillValues( int idx, int limit )
   mModelValues->clear();
 
   // determine the field type
-  QSet<QVariant> values = mLayer->uniqueValues( idx, limit );
+  QList<QVariant> values = mLayer->uniqueValues( idx, limit ).toList();
+  std::sort( values.begin(), values.end() );
 
   QString nullValue = QgsApplication::nullRepresentation();
 
@@ -159,7 +160,6 @@ void QgsQueryBuilder::fillValues( int idx, int limit )
     mModelValues->insertRow( mModelValues->rowCount(), myItem );
     QgsDebugMsg( QString( "Value is null: %1\nvalue: %2" ).arg( var.isNull() ).arg( var.isNull() ? nullValue : var.toString() ) );
   }
-  mModelValues->sort( 0 );
 }
 
 void QgsQueryBuilder::btnSampleValues_clicked()


### PR DESCRIPTION
## Description
Prior to this PR, the query builder field values would be sorted as string after being added to the list. This is not ideal for two reasons:
1/ For non-string fields, the sorting is broken (i.e. 1, 100, 101, 5, 60... instead of 1, 5, 60, 100, 101)
2/ NULL values were added in the middle of string lists (i.e. "Armor", "Belt", "NULL", "Zipper")

Sorting the values before transforming those to strings gives a much better result.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
