### PR TITLE
Store relation cardinality correct

### DIFF
--- a/src/app/qgsattributerelationedit.cpp
+++ b/src/app/qgsattributerelationedit.cpp
@@ -6,6 +6,7 @@ QgsAttributeRelationEdit::QgsAttributeRelationEdit( const QString &relationid, Q
   mRelationId( relationid )
 {
   setupUi( this );
+  coCardinality->setToolTip( QStringLiteral( "For many to many relation, the direct link has to be selected. In-between table will be hidden." ) );
 }
 
 void QgsAttributeRelationEdit::setCardinalityCombo( const QString &cardinalityComboItem, const QVariant &auserData )

--- a/src/app/qgsattributerelationedit.cpp
+++ b/src/app/qgsattributerelationedit.cpp
@@ -13,15 +13,15 @@ void QgsAttributeRelationEdit::setCardinalityCombo( const QString &cardinalityCo
   coCardinality->addItem( cardinalityComboItem, auserData );
 }
 
-void QgsAttributeRelationEdit::setCardinality( const QString &cardinality )
+void QgsAttributeRelationEdit::setCardinality( const QVariant &auserData )
 {
-  int idx = coCardinality->findText( cardinality );
+  int idx = coCardinality->findData( auserData );
 
   if ( idx != -1 )
     coCardinality->setCurrentIndex( idx );
 }
 
-QString QgsAttributeRelationEdit::cardinality()
+QVariant  QgsAttributeRelationEdit::cardinality()
 {
-  return coCardinality->currentText();
+  return coCardinality->currentData();
 }

--- a/src/app/qgsattributerelationedit.cpp
+++ b/src/app/qgsattributerelationedit.cpp
@@ -6,7 +6,7 @@ QgsAttributeRelationEdit::QgsAttributeRelationEdit( const QString &relationid, Q
   mRelationId( relationid )
 {
   setupUi( this );
-  coCardinality->setToolTip( QStringLiteral( "For many to many relation, the direct link has to be selected. In-between table will be hidden." ) );
+  coCardinality->setToolTip( tr( "For a many to many (N:M) relation, the direct link has to be selected. The in-between table will be hidden." ) );
 }
 
 void QgsAttributeRelationEdit::setCardinalityCombo( const QString &cardinalityComboItem, const QVariant &auserData )

--- a/src/app/qgsattributerelationedit.h
+++ b/src/app/qgsattributerelationedit.h
@@ -40,12 +40,12 @@ class APP_EXPORT QgsAttributeRelationEdit: public QWidget, private Ui::QgsAttrib
     /**
      * Setter for combo cardinality
      */
-    void setCardinality( const QString &cardinality );
+    void setCardinality( const QVariant &auserData = QVariant() );
 
     /**
      * Getter for combo cardinality
      */
-    QString cardinality();
+    QVariant cardinality();
 
     QString mRelationId;
   private:

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -707,7 +707,7 @@ void QgsAttributesFormProperties::apply()
     RelationConfig relCfg = configForRelation( itemData.name() );
 
     QVariantMap cfg;
-    cfg[QStringLiteral( "nm-rel" )] = relCfg.mCardinality;
+    cfg[QStringLiteral( "nm-rel" )] = relCfg.mCardinality.toString();
 
     editFormConfig.setWidgetConfig( itemData.name(), cfg );
   }
@@ -749,7 +749,7 @@ QgsAttributesFormProperties::FieldConfig::operator QVariant()
  * RelationConfig implementation
  */
 QgsAttributesFormProperties::RelationConfig::RelationConfig()
-  : mCardinality( QString() )
+  : mCardinality( QVariant() )
 {
 }
 
@@ -757,7 +757,7 @@ QgsAttributesFormProperties::RelationConfig::RelationConfig( QgsVectorLayer *lay
 {
   const QVariant nmrelcfg = layer->editFormConfig().widgetConfig( relationId ).value( QStringLiteral( "nm-rel" ) );
 
-  mCardinality = nmrelcfg.toString();
+  mCardinality = nmrelcfg;
 }
 
 QgsAttributesFormProperties::RelationConfig::operator QVariant()

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -749,7 +749,6 @@ QgsAttributesFormProperties::FieldConfig::operator QVariant()
  * RelationConfig implementation
  */
 QgsAttributesFormProperties::RelationConfig::RelationConfig()
-  : mCardinality( QVariant() )
 {
 }
 

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -159,7 +159,7 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
       RelationConfig();
       RelationConfig( QgsVectorLayer *layer, const QString &relationId );
 
-      QString mCardinality;
+      QVariant mCardinality;
 
       operator QVariant();
     };


### PR DESCRIPTION
The relation cardinality set over relation edit in the attributes form properties is handled with it's value as QVariant instead of it's name QString, because this leaded to problems in the attribute form. 

Additionally there is a tooltip on the cardinality combobox for better understanding.

Fix #17805