### PR TITLE
Drop color button/dialog live update option from API and UI

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -627,12 +627,14 @@ QgsColorButton     {#qgis_api_break_3_0_QgsColorButton}
 
 - Behaviour enum and its corresponding setter/getter have been renamed to Behavior <!--#spellok-->
 - setAllowAlpha() and allowAlpha() were removed. Use setAllowOpacity() and allowOpacity() instead.
+- acceptLiveUpdates() and setAcceptLiveUpdates() were removed. This functionality is no longer supported.
 
 
 QgsColorDialog     {#qgis_api_break_3_0_QgsColorDialog}
 --------------
 
 - setAllowAlpha() was removed. Use setAllowOpacity() instead.
+- getLiveColor() was removed. This functionality is no longer supported.
 
 
 QgsColorEffect        {#qgis_api_break_3_0_QgsColorEffect}

--- a/python/gui/qgscolorbutton.sip
+++ b/python/gui/qgscolorbutton.sip
@@ -100,25 +100,6 @@ Returns the title for the color chooser dialog window.
 .. seealso:: :py:func:`setColorDialogTitle`
 %End
 
-    bool acceptLiveUpdates() const;
-%Docstring
-Returns whether the button accepts live updates from QColorDialog.
-
-:return: true if the button will be accepted immediately when the dialog's color changes
-
-.. seealso:: :py:func:`setAcceptLiveUpdates`
-%End
-
-    void setAcceptLiveUpdates( const bool accept );
-%Docstring
-Sets whether the button accepts live updates from QColorDialog. Live updates may cause changes
-that are not undoable on QColorDialog cancel.
-
-:param accept: set to true to enable live updates
-
-.. seealso:: :py:func:`acceptLiveUpdates`
-%End
-
     void setShowMenu( const bool showMenu );
 %Docstring
 Sets whether the drop-down menu should be shown for the button. The default behavior is to

--- a/python/gui/qgscolordialog.sip
+++ b/python/gui/qgscolordialog.sip
@@ -58,25 +58,6 @@ for the color dialog. Defaults to true.
 .. versionadded:: 3.0
 %End
 
-    static QColor getLiveColor( const QColor &initialColor, QObject *updateObject, const char *updateSlot,
-                                QWidget *parent = 0,
-                                const QString &title = QString(),
-                                const bool allowOpacity = true );
-%Docstring
-Return a color selection from a color dialog, with live updating of interim selections.
-
-:param initialColor: the initial color of the selection dialog.
-:param updateObject: the receiver object of the live updating.
-:param updateSlot: the receiver object's slot for live updating (e.g. SLOT( setValidColor( const QColor& ) ) ).
-:param parent: parent widget
-:param title: the title of the dialog.
-:param allowOpacity: set to true to allow modification of color opacity value (transparency)
-
-:return: Selected color on accepted() or initialColor on rejected().
-
-.. seealso:: :py:func:`getColor`
-%End
-
     static QColor getColor( const QColor &initialColor, QWidget *parent, const QString &title = QString(),
                             const bool allowOpacity = false );
 %Docstring

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -563,7 +563,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   cmbUITheme->setCurrentIndex( cmbUITheme->findText( theme, Qt::MatchFixedString ) );
 
   mNativeColorDialogsChkBx->setChecked( mSettings->value( QStringLiteral( "/qgis/native_color_dialogs" ), false ).toBool() );
-  mLiveColorDialogsChkBx->setChecked( mSettings->value( QStringLiteral( "/qgis/live_color_dialogs" ), false ).toBool() );
 
   //set the state of the checkboxes
   //Changed to default to true as of QGIS 1.7
@@ -1301,7 +1300,6 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/messageTimeout" ), mMessageTimeoutSpnBx->value() );
 
   mSettings->setValue( QStringLiteral( "/qgis/native_color_dialogs" ), mNativeColorDialogsChkBx->isChecked() );
-  mSettings->setValue( QStringLiteral( "/qgis/live_color_dialogs" ), mLiveColorDialogsChkBx->isChecked() );
 
   // rasters settings
   mSettings->setValue( QStringLiteral( "/Raster/defaultRedBand" ), spnRed->value() );

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -110,32 +110,22 @@ void QgsColorButton::showColorDialog()
   QColor newColor;
   QgsSettings settings;
 
-  if ( mAcceptLiveUpdates && settings.value( QStringLiteral( "qgis/live_color_dialogs" ), false ).toBool() )
+  // first check if we need to use the limited native dialogs
+  bool useNative = settings.value( QStringLiteral( "qgis/native_color_dialogs" ), false ).toBool();
+  if ( useNative )
   {
-    // live updating dialog - QgsColorDialog will automatically use native dialog if option is set
-    newColor = QgsColorDialog::getLiveColor(
-                 color(), this, SLOT( setValidColor( const QColor & ) ),
-                 this, mColorDialogTitle, mAllowOpacity );
+    // why would anyone want this? who knows.... maybe the limited nature of native dialogs helps ease the transition for MapInfo users?
+    newColor = QColorDialog::getColor( color(), this, mColorDialogTitle, mAllowOpacity ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption )0 );
   }
   else
   {
-    // not using live updating dialog - first check if we need to use the limited native dialogs
-    bool useNative = settings.value( QStringLiteral( "qgis/native_color_dialogs" ), false ).toBool();
-    if ( useNative )
-    {
-      // why would anyone want this? who knows.... maybe the limited nature of native dialogs helps ease the transition for MapInfo users?
-      newColor = QColorDialog::getColor( color(), this, mColorDialogTitle, mAllowOpacity ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption )0 );
-    }
-    else
-    {
-      QgsColorDialog dialog( this, nullptr, color() );
-      dialog.setTitle( mColorDialogTitle );
-      dialog.setAllowOpacity( mAllowOpacity );
+    QgsColorDialog dialog( this, nullptr, color() );
+    dialog.setTitle( mColorDialogTitle );
+    dialog.setAllowOpacity( mAllowOpacity );
 
-      if ( dialog.exec() )
-      {
-        newColor = dialog.color();
-      }
+    if ( dialog.exec() )
+    {
+      newColor = dialog.color();
     }
   }
 

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -48,7 +48,6 @@ class GUI_EXPORT QgsColorButton : public QToolButton
 
     Q_OBJECT
     Q_PROPERTY( QString colorDialogTitle READ colorDialogTitle WRITE setColorDialogTitle )
-    Q_PROPERTY( bool acceptLiveUpdates READ acceptLiveUpdates WRITE setAcceptLiveUpdates )
     Q_PROPERTY( QColor color READ color WRITE setColor )
     Q_PROPERTY( bool allowOpacity READ allowOpacity WRITE setAllowOpacity )
     Q_PROPERTY( bool showMenu READ showMenu WRITE setShowMenu )
@@ -120,21 +119,6 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * \see setColorDialogTitle
      */
     QString colorDialogTitle() const;
-
-    /**
-     * Returns whether the button accepts live updates from QColorDialog.
-     * \returns true if the button will be accepted immediately when the dialog's color changes
-     * \see setAcceptLiveUpdates
-     */
-    bool acceptLiveUpdates() const { return mAcceptLiveUpdates; }
-
-    /**
-     * Sets whether the button accepts live updates from QColorDialog. Live updates may cause changes
-     * that are not undoable on QColorDialog cancel.
-     * \param accept set to true to enable live updates
-     * \see acceptLiveUpdates
-     */
-    void setAcceptLiveUpdates( const bool accept ) { mAcceptLiveUpdates = accept; }
 
     /**
      * Sets whether the drop-down menu should be shown for the button. The default behavior is to
@@ -426,7 +410,6 @@ class GUI_EXPORT QgsColorButton : public QToolButton
     QColor mDefaultColor;
     QString mContext;
     bool mAllowOpacity = false;
-    bool mAcceptLiveUpdates = true;
     bool mColorSet = false;
 
     bool mShowNoColorOption = false;

--- a/src/gui/qgscolordialog.cpp
+++ b/src/gui/qgscolordialog.cpp
@@ -77,51 +77,6 @@ void QgsColorDialog::setAllowOpacity( const bool allowOpacity )
   mColorWidget->setAllowOpacity( allowOpacity );
 }
 
-QColor QgsColorDialog::getLiveColor( const QColor &initialColor, QObject *updateObject, const char *updateSlot, QWidget *parent, const QString &title, const bool allowOpacity )
-{
-  QColor returnColor( initialColor );
-
-  QgsSettings settings;
-
-  //using native color dialogs?
-  bool useNative = settings.value( QStringLiteral( "qgis/native_color_dialogs" ), false ).toBool();
-  if ( useNative )
-  {
-    QColorDialog *liveDialog = new QColorDialog( initialColor, parent );
-    liveDialog->setWindowTitle( title.isEmpty() ? tr( "Select Color" ) : title );
-    liveDialog->setOptions( allowOpacity ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption )0 );
-
-    connect( liveDialog, SIGNAL( currentColorChanged( const QColor & ) ),
-             updateObject, updateSlot );
-
-    if ( liveDialog->exec() )
-    {
-      returnColor = liveDialog->currentColor();
-    }
-    delete liveDialog;
-  }
-  else
-  {
-    QgsColorDialog *liveDialog = new QgsColorDialog( parent, nullptr, initialColor );
-    liveDialog->setWindowTitle( title.isEmpty() ? tr( "Select Color" ) : title );
-    if ( !allowOpacity )
-    {
-      liveDialog->setAllowOpacity( false );
-    }
-
-    connect( liveDialog, SIGNAL( currentColorChanged( const QColor & ) ),
-             updateObject, updateSlot );
-
-    if ( liveDialog->exec() )
-    {
-      returnColor = liveDialog->color();
-    }
-    delete liveDialog;
-  }
-
-  return returnColor;
-}
-
 QColor QgsColorDialog::getColor( const QColor &initialColor, QWidget *parent, const QString &title, const bool allowOpacity )
 {
   QString dialogTitle = title.isEmpty() ? tr( "Select Color" ) : title;

--- a/src/gui/qgscolordialog.h
+++ b/src/gui/qgscolordialog.h
@@ -70,22 +70,6 @@ class GUI_EXPORT QgsColorDialog : public QDialog, private Ui::QgsColorDialogBase
     void setAllowOpacity( const bool allowOpacity );
 
     /**
-     * Return a color selection from a color dialog, with live updating of interim selections.
-     * \param initialColor the initial color of the selection dialog.
-     * \param updateObject the receiver object of the live updating.
-     * \param updateSlot the receiver object's slot for live updating (e.g. SLOT( setValidColor( const QColor& ) ) ).
-     * \param parent parent widget
-     * \param title the title of the dialog.
-     * \param allowOpacity set to true to allow modification of color opacity value (transparency)
-     * \returns Selected color on accepted() or initialColor on rejected().
-     * \see getColor
-     */
-    static QColor getLiveColor( const QColor &initialColor, QObject *updateObject, const char *updateSlot,
-                                QWidget *parent = nullptr,
-                                const QString &title = QString(),
-                                const bool allowOpacity = true );
-
-    /**
      * Return a color selection from a color dialog.
      * \param initialColor the initial color of the selection dialog.
      * \param parent parent widget

--- a/src/gui/symbology/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology/qgssymbolslistwidget.cpp
@@ -108,8 +108,6 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbol *symbol, QgsStyle *style, 
   connect( this, &QgsSymbolsListWidget::changed, this, &QgsSymbolsListWidget::updateAssistantSymbol );
   updateAssistantSymbol();
 
-  // Live color updates are not undoable to child symbol layers
-  btnColor->setAcceptLiveUpdates( false );
   btnColor->setAllowOpacity( true );
   btnColor->setColorDialogTitle( tr( "Select Color" ) );
   btnColor->setContext( QStringLiteral( "symbology" ) );

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -320,7 +320,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>9</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -690,13 +690,6 @@
                      <widget class="QCheckBox" name="mNativeColorDialogsChkBx">
                       <property name="text">
                        <string>Use native color chooser dialogs</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="1">
-                     <widget class="QCheckBox" name="mLiveColorDialogsChkBx">
-                      <property name="text">
-                       <string>Use live-updating color chooser dialogs</string>
                       </property>
                      </widget>
                     </item>
@@ -5354,7 +5347,6 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
   <tabstop>mDataSourceManagerNonModal</tabstop>
   <tabstop>mCustomGroupBoxChkBx</tabstop>
   <tabstop>mNativeColorDialogsChkBx</tabstop>
-  <tabstop>mLiveColorDialogsChkBx</tabstop>
   <tabstop>mProjectOnLaunchCmbBx</tabstop>
   <tabstop>mProjectOnLaunchLineEdit</tabstop>
   <tabstop>mProjectOnLaunchPushBtn</tabstop>


### PR DESCRIPTION
This options is broken in QGIS 3.0, but in any case has been
mostly made redundant by the live styling dock, and the other
non blocking color pickers which are implemented in most areas
of qgis now.

Dropping the options is a good idea because:
- it's one less user option to make the options dialog overwhelming for users
- the live styling dock does this in a safer way - a global live color setting may result in unexpected behaviour for code paths which are not expecting color updates to be sent for every incremental change, and may cause lengthy blocking operations to perform or other issues.

Better to remove it, and if a ui area needs this functionality then it should be updated to use docks and other non-blocking UI widgets.


Refs https://issues.qgis.org/issues/17841