### PR TITLE
[sipify] keep Docstrings for template based classes

### DIFF
--- a/python/core/expression/qgsexpressionfunction.sip
+++ b/python/core/expression/qgsexpressionfunction.sip
@@ -67,6 +67,9 @@ Returns the default value for the parameter.
     };
 
     typedef QList< QgsExpressionFunction::Parameter > ParameterList;
+%Docstring
+List of parameters, used for function definition
+%End
 
     QgsExpressionFunction( const QString &fnname,
                            int params,

--- a/python/core/geometry/qgsabstractgeometry.sip
+++ b/python/core/geometry/qgsabstractgeometry.sip
@@ -11,6 +11,22 @@
 
 
 typedef QVector< QgsPoint > QgsPointSequence;
+%Docstring
+*************************************************************************
+qgsabstractgeometry.h
+-------------------------------------------------------------------
+Date                 : 04 Sept 2014
+Copyright            : (C) 2014 by Marco Hugentobler
+email                : marco.hugentobler at sourcepole dot com
+**************************************************************************
+*
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+*
+**************************************************************************
+%End
 typedef QVector< QVector< QgsPoint > > QgsRingSequence;
 typedef QVector< QVector< QVector< QgsPoint > > > QgsCoordinateSequence;
 

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -16,16 +16,46 @@
 
 
 typedef QVector<QgsPointXY> QgsPolylineXY;
+%Docstring
+Polyline as represented as a vector of two-dimensional points.
+
+This type has no support for Z/M dimensions and use of QgsPolyline is encouraged instead.
+
+.. note::
+
+   In QGIS 2.x this type was available as QgsPolyline.
+
+.. versionadded:: 3.0
+%End
 
 typedef QVector<QgsPoint> QgsPolyline;
+%Docstring
+Polyline as represented as a vector of points.
+
+This type has full support for Z/M dimensions.
+
+.. versionadded:: 3.0
+%End
 
 typedef QVector<QVector<QgsPointXY>> QgsPolygonXY;
+%Docstring
+Polygon: first item of the list is outer ring, inner rings (if any) start from second item
+%End
 
 typedef QVector<QgsPointXY> QgsMultiPointXY;
+%Docstring
+A collection of QgsPoints that share a common collection of attributes
+%End
 
 typedef QVector<QVector<QgsPointXY>> QgsMultiPolylineXY;
+%Docstring
+A collection of QgsPolylines that share a common collection of attributes
+%End
 
 typedef QVector<QVector<QVector<QgsPointXY>>> QgsMultiPolygonXY;
+%Docstring
+A collection of QgsPolygons that share a common collection of attributes
+%End
 
 
 

--- a/python/core/layout/qgslayouttable.sip
+++ b/python/core/layout/qgslayouttable.sip
@@ -11,11 +11,28 @@
 
 
 typedef QVector< QVariant > QgsLayoutTableRow;
+%Docstring
+List of QVariants, representing a the contents of a single row in
+a QgsComposerTable
+
+.. versionadded:: 3.0
+%End
 
 typedef QVector< QVector< QVariant > > QgsLayoutTableContents;
+%Docstring
+List of QgsLayoutTableRows, representing rows and column cell contents
+for a QgsLayoutTable
+
+.. versionadded:: 3.0
+%End
 
 
 typedef QVector< QgsLayoutTableColumn * > QgsLayoutTableColumns;
+%Docstring
+List of column definitions for a QgsLayoutTable
+
+.. versionadded:: 3.0
+%End
 
 
 

--- a/python/core/metadata/qgslayermetadata.sip
+++ b/python/core/metadata/qgslayermetadata.sip
@@ -43,6 +43,9 @@ using QgsNativeMetadataValidator.
   public:
 
     typedef QMap< QString, QStringList > KeywordMap;
+%Docstring
+Map of vocabulary string to keyword list.
+%End
 
     struct SpatialExtent
     {
@@ -104,6 +107,9 @@ Constructor for Constraint.
     };
 
     typedef QList< QgsLayerMetadata::Constraint > ConstraintList;
+%Docstring
+A list of constraints.
+%End
 
 
     struct Address
@@ -153,6 +159,9 @@ Constructor for Contact.
     };
 
     typedef QList< QgsLayerMetadata::Contact > ContactList;
+%Docstring
+A list of contacts.
+%End
 
 
     struct Link
@@ -179,6 +188,9 @@ Constructor for Link.
     };
 
     typedef QList< QgsLayerMetadata::Link > LinkList;
+%Docstring
+A list of links.
+%End
 
     QgsLayerMetadata();
 %Docstring

--- a/python/core/processing/qgsprocessingoutputs.sip
+++ b/python/core/processing/qgsprocessingoutputs.sip
@@ -99,6 +99,9 @@ used to identify this output.
 };
 
 typedef QList< const QgsProcessingOutputDefinition * > QgsProcessingOutputDefinitions;
+%Docstring
+List of processing parameters
+%End
 
 class QgsProcessingOutputMapLayer : QgsProcessingOutputDefinition
 {

--- a/python/core/processing/qgsprocessingparameters.sip
+++ b/python/core/processing/qgsprocessingparameters.sip
@@ -435,6 +435,9 @@ QFlags<QgsProcessingParameterDefinition::Flag> operator|(QgsProcessingParameterD
 
 
 typedef QList< const QgsProcessingParameterDefinition * > QgsProcessingParameterDefinitions;
+%Docstring
+List of processing parameters
+%End
 
 
 class QgsProcessingParameters

--- a/python/core/qgsattributes.sip
+++ b/python/core/qgsattributes.sip
@@ -22,6 +22,13 @@ typedef QMap<int, QgsField> QgsFieldMap;
 
 
 typedef QVector<QVariant> QgsAttributes;
+%Docstring
+A vector of attributes. Mostly equal to QVector<QVariant>.
+
+.. note::
+
+   QgsAttributes is implemented as a Python list of Python objects.
+%End
 
 %MappedType QgsAttributes
 {

--- a/python/core/qgscolorramp.sip
+++ b/python/core/qgscolorramp.sip
@@ -108,6 +108,9 @@ Constructor for QgsGradientStop
 };
 
 typedef QList<QgsGradientStop> QgsGradientStopsList;
+%Docstring
+List of gradient stops
+%End
 
 
 class QgsGradientColorRamp : QgsColorRamp

--- a/python/core/qgscolorscheme.sip
+++ b/python/core/qgscolorscheme.sip
@@ -11,6 +11,11 @@
 
 
 typedef QList< QPair< QColor, QString > > QgsNamedColorList;
+%Docstring
+List of colors paired with a friendly display name identifying the color
+
+.. versionadded:: 2.5
+%End
 
 class QgsColorScheme
 {

--- a/python/core/qgsmaphittest.sip
+++ b/python/core/qgsmaphittest.sip
@@ -23,6 +23,9 @@ will be visible on the map - this is useful for content based legend.
 %End
   public:
     typedef QMap<QString, QString> LayerFilterExpression;
+%Docstring
+Maps an expression string to a layer id
+%End
 
     QgsMapHitTest( const QgsMapSettings &settings, const QgsGeometry &polygon = QgsGeometry(), const QgsMapHitTest::LayerFilterExpression &layerFilterExpression = QgsMapHitTest::LayerFilterExpression() );
 %Docstring

--- a/python/core/qgspropertycollection.sip
+++ b/python/core/qgspropertycollection.sip
@@ -9,6 +9,9 @@
 
 
 typedef QMap< int, QgsPropertyDefinition > QgsPropertiesDefinition;
+%Docstring
+Definition of available properties
+%End
 
 
 class QgsAbstractPropertyCollection

--- a/python/core/qgsrange.sip
+++ b/python/core/qgsrange.sip
@@ -121,11 +121,33 @@ Returns true if this range overlaps another range.
 
 
 typedef QgsRange< double > QgsDoubleRange;
+%Docstring
+QgsRange which stores a range of double values.
+
+.. versionadded:: 3.0
+
+.. seealso:: :py:class:`QgsIntRange`
+
+.. seealso:: :py:class:`QgsDateRange`
+
+.. seealso:: :py:class:`QgsDateTimeRange`
+%End
 
 
 
 
 typedef QgsRange< int > QgsIntRange;
+%Docstring
+QgsRange which stores a range of integer values.
+
+.. versionadded:: 3.0
+
+.. seealso:: :py:class:`QgsDoubleRange`
+
+.. seealso:: :py:class:`QgsDateRange`
+
+.. seealso:: :py:class:`QgsDateTimeRange`
+%End
 
 
 template <T>
@@ -247,8 +269,32 @@ Returns true if this range overlaps another range.
 
 
 typedef QgsTemporalRange< QDate > QgsDateRange;
+%Docstring
+QgsRange which stores a range of dates.
+
+Invalid QDates as the beginning or end are permitted. In this case,
+the bound is considered to be infinite. E.g. QgsDateRange(QDate(),QDate(2017,1,1))
+is treated as a range containing all dates before 2017-1-1.
+QgsDateRange(QDate(2017,1,1),QDate()) is treated as a range containing all dates after 2017-1-1.
+
+.. versionadded:: 3.0
+
+.. seealso:: :py:class:`QgsDateTimeRange`
+%End
 
 typedef QgsTemporalRange< QDateTime > QgsDateTimeRange;
+%Docstring
+QgsRange which stores a range of date times.
+
+Invalid QDateTimes as the beginning or end are permitted. In this case,
+the bound is considered to be infinite. E.g. QgsDateTimeRange(QDateTime(),QDateTime(2017,1,1))
+is treated as a range containing all dates before 2017-1-1.
+QgsDateTimeRange(QDateTime(2017,1,1),QDateTime()) is treated as a range containing all dates after 2017-1-1.
+
+.. versionadded:: 3.0
+
+.. seealso:: :py:class:`QgsDateRange`
+%End
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/qgstaskmanager.sip
+++ b/python/core/qgstaskmanager.sip
@@ -12,6 +12,9 @@
 
 
 typedef QList< QgsTask * > QgsTaskList;
+%Docstring
+List of QgsTask objects
+%End
 
 class QgsTask : QObject
 {

--- a/python/core/qgsunittypes.sip
+++ b/python/core/qgsunittypes.sip
@@ -118,6 +118,9 @@ class QgsUnitTypes
     };
 
     typedef QList<QgsUnitTypes::RenderUnit> RenderUnitList;
+%Docstring
+List of render units
+%End
 
 
     static DistanceUnitType unitType( QgsUnitTypes::DistanceUnit unit );

--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -213,6 +213,11 @@ Creates a clone of the FieldValueConverter.
 
     typedef QFlags<QgsVectorFileWriter::EditionCapability> EditionCapabilities;
 
+%Docstring
+Combination of CanAddNewLayer, CanAppendToExistingLayer, CanAddNewFieldsToExistingLayer or CanDeleteLayer
+
+.. versionadded:: 3.0
+%End
 
     enum ActionOnExistingFile
     {

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -14,6 +14,16 @@
 
 
 typedef QList<int> QgsAttributeList;
+%Docstring
+*************************************************************************
+*
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+*
+**************************************************************************
+%End
 typedef QSet<int> QgsAttributeIds;
 
 

--- a/python/core/qgsvectorlayerjoinbuffer.sip
+++ b/python/core/qgsvectorlayerjoinbuffer.sip
@@ -12,6 +12,16 @@
 
 
 typedef QList< QgsVectorLayerJoinInfo > QgsVectorJoinList;
+%Docstring
+*************************************************************************
+*
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+*
+**************************************************************************
+%End
 
 
 class QgsVectorLayerJoinBuffer : QObject, QgsFeatureSink

--- a/python/core/qgsvirtuallayerdefinition.sip
+++ b/python/core/qgsvirtuallayerdefinition.sip
@@ -117,6 +117,9 @@ Add a layer with a source, a provider and an encoding
 %End
 
     typedef QList<QgsVirtualLayerDefinition::SourceLayer> SourceLayers;
+%Docstring
+List of source layers
+%End
 
     const QgsVirtualLayerDefinition::SourceLayers &sourceLayers() const;
 %Docstring

--- a/python/core/raster/qgspalettedrasterrenderer.sip
+++ b/python/core/raster/qgspalettedrasterrenderer.sip
@@ -36,6 +36,9 @@ Constructor for Class
     };
 
     typedef QList< QgsPalettedRasterRenderer::Class > ClassData;
+%Docstring
+Map of value to class properties
+%End
 
     QgsPalettedRasterRenderer( QgsRasterInterface *input, int bandNumber, const ClassData &classes );
 %Docstring

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -10,6 +10,16 @@
 
 
 typedef QList < QPair< QString, QColor > > QgsLegendColorList;
+%Docstring
+*************************************************************************
+*
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+*
+**************************************************************************
+%End
 
 
 class QgsRasterLayer : QgsMapLayer

--- a/python/core/raster/qgsrasterrange.sip
+++ b/python/core/raster/qgsrasterrange.sip
@@ -11,6 +11,16 @@
 
 
 typedef QList<QgsRasterRange> QgsRasterRangeList;
+%Docstring
+*************************************************************************
+*
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+*
+**************************************************************************
+%End
 
 class QgsRasterRange
 {

--- a/python/core/symbology/qgspointdistancerenderer.sip
+++ b/python/core/symbology/qgspointdistancerenderer.sip
@@ -54,6 +54,9 @@ Base symbol for rendering feature
     };
 
     typedef QList< QgsPointDistanceRenderer::GroupedFeature > ClusteredGroup;
+%Docstring
+A group of clustered points (ie features within the distance tolerance).
+%End
 
     QgsPointDistanceRenderer( const QString &rendererName, const QString &labelAttributeName = QString() );
 %Docstring

--- a/python/core/symbology/qgsstyle.sip
+++ b/python/core/symbology/qgsstyle.sip
@@ -13,10 +13,45 @@
 
 
 typedef QMap<QString, QgsColorRamp * > QgsVectorColorRampMap;
+%Docstring
+*************************************************************************
+qgsstyle.h
+---------------------
+begin                : November 2009
+copyright            : (C) 2009 by Martin Dobias
+email                : wonder dot sk at gmail dot com
+**************************************************************************
+*
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+*
+**************************************************************************
+%End
 typedef QMap<int, QString> QgsSymbolGroupMap;
 
 
 typedef QMultiMap<QString, QString> QgsSmartConditionMap;
+%Docstring
+A multimap to hold the smart group conditions as constraint and parameter pairs.
+Both the key and the value of the map are QString. The key is the constraint of the condition and the value is the parameter which is applied for the constraint.
+
+The supported constraints are:
+tag -> symbol has the tag matching the parameter
+!tag -> symbol doesnot have the tag matching the parameter
+name -> symbol has a part of its name matching the parameter
+!name -> symbol doesn't have any part of the name matching the parameter
+
+Example Usage:
+QgsSmartConditionMap conditions;
+conditions.insert( "tag", "red" ); // adds the condition: Symbol has the tag red
+conditions.insert( "!name", "way" ); // add the condition: Symbol doesn't have any part of its name matching `way`
+
+.. note::
+
+   This is a Multimap, which means it will contain multiple values for the same key.
+%End
 
 enum SymbolTable { SymbolId, SymbolName, SymbolXML, SymbolFavoriteId };
 enum TagTable { TagId, TagName };

--- a/python/core/symbology/qgssymbollayerutils.sip
+++ b/python/core/symbology/qgssymbollayerutils.sip
@@ -11,6 +11,22 @@
 
 
 typedef QMap<QString, QString> QgsStringMap;
+%Docstring
+*************************************************************************
+qgssymbollayerutils.h
+---------------------
+begin                : November 2009
+copyright            : (C) 2009 by Martin Dobias
+email                : wonder dot sk at gmail dot com
+**************************************************************************
+*
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+*
+**************************************************************************
+%End
 typedef QMap<QString, QgsSymbol * > QgsSymbolMap;
 
 

--- a/python/gui/qgssublayersdialog.sip
+++ b/python/gui/qgssublayersdialog.sip
@@ -32,6 +32,11 @@ class QgsSublayersDialog : QDialog
     };
 
     typedef QList<QgsSublayersDialog::LayerDefinition> LayerDefinitionList;
+%Docstring
+List of layer definitions for the purpose of this dialog
+
+.. versionadded:: 2.16
+%End
 
     QgsSublayersDialog( ProviderType providerType,
                         const QString &name,

--- a/python/server/qgsaccesscontrolfilter.sip
+++ b/python/server/qgsaccesscontrolfilter.sip
@@ -110,6 +110,9 @@ Cache key to used to create the capabilities cache
 };
 
 typedef QMultiMap<int, QgsAccessControlFilter *> QgsAccessControlFilterMap;
+%Docstring
+The registry definition
+%End
 
 
 /************************************************************************

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -1017,7 +1017,7 @@ while ($LINE_IDX < $LINE_COUNT){
         next;
     }
     if ( $LINE =~ m/\/\// ||
-            $LINE =~ m/\s*typedef / ||
+            $LINE =~ m/\s*typedef\s+\w+(?!\s*<) / ||  # keep comments for templates
             $LINE =~ m/\s*struct / ||
             $LINE =~ m/operator\[\]\(/ ||
             $LINE =~ m/^\s*operator\b/ ||


### PR DESCRIPTION
this seems to be causing a syntax error on SIP. Might be a bug upstream.

TODO: Class members shall not be documented (check `$#ACCESS`)

see QgsDateRange
https://opengisch.github.io/QGISPythonAPIDocumentation/api/core/Date/QgsDateRange.html#module-QgsDateRange