### PR TITLE
A simpler way to Fix broken Geopackage paths with spaces

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -65,7 +65,7 @@ QVector<QgsDataItem *> QgsGeoPackageRootItem::createChildren()
   for ( const QString &connName : connList )
   {
     QgsOgrDbConnection connection( connName, QStringLiteral( "GPKG" ) );
-    QgsDataItem *conn = new QgsGeoPackageConnectionItem( this, connection.name(), connection.uri().encodedUri() );
+    QgsDataItem *conn = new QgsGeoPackageConnectionItem( this, connection.name(), connection.path() );
 
     connections.append( conn );
   }


### PR DESCRIPTION
This PR supersedes #6044. See discussion there first.