### PR TITLE
[user input widget] use a floating widget rather than a dock

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -193,6 +193,7 @@ Renamed Classes        {#qgis_api_break_3_0_renamed_classes}
 <tr><td>QgsSymbolV2SelectorWidget<td>QgsSymbolSelectorWidget
 <tr><td>QgsTicksScaleBarStyle<td>QgsTicksScaleBarRenderer
 <tr><td>QgsTINInterpolator<td>QgsTinInterpolator
+<tr><td>QgsUserInputDockWidget<td>QgsUserInputWidget
 <tr><td>QgsVectorColorBrewerColorRampV2<td>QgsColorBrewerColorRamp
 <tr><td>QgsVectorColorBrewerColorRampV2Dialog<td>QgsColorBrewerColorRampDialog
 <tr><td>QgsVectorColorBrewerColorRampV2DialogBase<td>QgsColorBrewerColorRampDialogBase

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -16,7 +16,7 @@
 %Include qgsrubberband.sip
 %Include qgssnapindicator.sip
 %Include qgstablewidgetitem.sip
-%Include qgsuserinputdockwidget.sip
+%Include qgsuserinputwidget.sip
 %Include qgsbrowserdockwidget.sip
 %Include qgsvertexmarker.sip
 %Include qgsabstractdatasourcewidget.sip

--- a/python/gui/qgsuserinputwidget.sip
+++ b/python/gui/qgsuserinputwidget.sip
@@ -1,7 +1,7 @@
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/gui/qgsuserinputdockwidget.h                                     *
+ * src/gui/qgsuserinputwidget.h                                         *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/
@@ -12,24 +12,24 @@
 
 
 
-
-class QgsUserInputDockWidget : QgsDockWidget
+class QgsUserInputWidget : QgsFloatingWidget
 {
 %Docstring
- The QgsUserInputDockWidget class is a dock widget that shall be used to display widgets for user inputs.
+ The QgsUserInputWidget class is a floating widget that shall be used to display widgets for user inputs.
 It can be used by map tools, plugins, etc.
-Several widgets can be displayed at once, they will be separated by a separator. Widgets will be either layout horizontally or vertically.
-The dock is automatically hidden if it contains no widget.
+Several widgets can be displayed at once, they will be separated by a separator.
+Widgets will be either layout horizontally or vertically.
+The widget is automatically hidden if it contains no widget.
 %End
 
 %TypeHeaderCode
-#include "qgsuserinputdockwidget.h"
+#include "qgsuserinputwidget.h"
 %End
   public:
 
-    QgsUserInputDockWidget( QWidget *parent /TransferThis/ = 0 );
+    QgsUserInputWidget( QWidget *parent /TransferThis/ = 0 );
 %Docstring
-Constructor for QgsUserInputDockWidget
+Constructor for QgsUserInputWidget
 %End
 
     void addUserInputWidget( QWidget *widget );
@@ -48,7 +48,7 @@ Add a widget to be displayed in the dock.
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *
- * src/gui/qgsuserinputdockwidget.h                                     *
+ * src/gui/qgsuserinputwidget.h                                         *
  *                                                                      *
  * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
  ************************************************************************/

--- a/python/gui/qgsuserinputwidget.sip
+++ b/python/gui/qgsuserinputwidget.sip
@@ -20,6 +20,8 @@ It can be used by map tools, plugins, etc.
 Several widgets can be displayed at once, they will be separated by a separator.
 Widgets will be either layout horizontally or vertically.
 The widget is automatically hidden if it contains no widget.
+
+.. versionadded:: 2.10
 %End
 
 %TypeHeaderCode

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -283,7 +283,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgssymbolselectordialog.h"
 #include "qgstextannotation.h"
 #include "qgsundowidget.h"
-#include "qgsuserinputdockwidget.h"
+#include "qgsuserinputwidget.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsvectorlayer.h"
@@ -788,8 +788,12 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   startProfile( QStringLiteral( "User input dock" ) );
   // User Input Dock Widget
-  mUserInputDockWidget = new QgsUserInputDockWidget( this );
+  mUserInputDockWidget = new QgsUserInputWidget( mMapCanvas );
   mUserInputDockWidget->setObjectName( QStringLiteral( "UserInputDockWidget" ) );
+  mUserInputDockWidget->setAnchorWidget( mMapCanvas );
+  mUserInputDockWidget->setAnchorWidgetPoint( QgsFloatingWidget::TopRight );
+  mUserInputDockWidget->setAnchorPoint( QgsFloatingWidget::TopRight );
+
   endProfile();
 
   //set the focus to the map canvas
@@ -958,9 +962,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   addDockWidget( Qt::LeftDockWidgetArea, mBookMarksDockWidget );
   mBookMarksDockWidget->hide();
-
-  QMainWindow::addDockWidget( Qt::BottomDockWidgetArea, mUserInputDockWidget );
-  mUserInputDockWidget->setFloating( true );
 
   // create the GPS tool on starting QGIS - this is like the browser
   mpGpsWidget = new QgsGPSInformationWidget( mMapCanvas );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -94,7 +94,7 @@ class QgsStatusBarScaleWidget;
 class QgsTaskManagerStatusBarWidget;
 class QgsTransactionGroup;
 class QgsUndoWidget;
-class QgsUserInputDockWidget;
+class QgsUserInputWidget;
 class QgsVectorLayer;
 class QgsVectorLayerTools;
 class QgsWelcomePage;
@@ -2116,7 +2116,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QWidget *mMacrosWarn = nullptr;
 
     //! A tool bar for user input
-    QgsUserInputDockWidget *mUserInputDockWidget = nullptr;
+    QgsUserInputWidget *mUserInputDockWidget = nullptr;
 
     QgsVectorLayerTools *mVectorLayerTools = nullptr;
 

--- a/src/app/qgsmaptoolrotatefeature.cpp
+++ b/src/app/qgsmaptoolrotatefeature.cpp
@@ -58,6 +58,7 @@ QgsAngleMagnetWidget::QgsAngleMagnetWidget( const QString &label, QWidget *paren
   mAngleSpinBox->setSingleStep( 1 );
   mAngleSpinBox->setValue( 0 );
   mAngleSpinBox->setShowClearButton( false );
+  mAngleSpinBox->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Preferred );
   mLayout->addWidget( mAngleSpinBox );
 
   mMagnetSpinBox = new QgsSpinBox( this );
@@ -68,6 +69,7 @@ QgsAngleMagnetWidget::QgsAngleMagnetWidget( const QString &label, QWidget *paren
   mMagnetSpinBox->setSingleStep( 15 );
   mMagnetSpinBox->setValue( 0 );
   mMagnetSpinBox->setClearValue( 0, tr( "No snapping" ) );
+  mMagnetSpinBox->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Preferred );
   mLayout->addWidget( mMagnetSpinBox );
 
   // connect signals

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -356,7 +356,7 @@ SET(QGIS_GUI_SRCS
   qgstextpreview.cpp
   qgstreewidgetitem.cpp
   qgsunitselectionwidget.cpp
-  qgsuserinputdockwidget.cpp
+  qgsuserinputwidget.cpp
   qgsvariableeditorwidget.cpp
   qgsvertexmarker.cpp
   qgsfiledownloaderdialog.cpp
@@ -519,7 +519,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgstextpreview.h
   qgstreewidgetitem.h
   qgsunitselectionwidget.h
-  qgsuserinputdockwidget.h
+  qgsuserinputwidget.h
   qgsvariableeditorwidget.h
   qgsfiledownloaderdialog.h
   qgsdatasourcemanagerdialog.h
@@ -734,7 +734,7 @@ SET(QGIS_GUI_HDRS
   qgssnapindicator.h
   qgssqlcomposerdialog.h
   qgstablewidgetitem.h
-  qgsuserinputdockwidget.h
+  qgsuserinputwidget.h
   qgsbrowserdockwidget.h
   qgsbrowserdockwidget_p.h
   qgsvertexmarker.h

--- a/src/gui/qgsuserinputwidget.h
+++ b/src/gui/qgsuserinputwidget.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsuserinputdockwidget.h
+    qgsuserinputwidget.h
      --------------------------------------
     Date                 : 04.2015
     Copyright            : (C) 2015 Denis Rouzaud
@@ -14,34 +14,35 @@
  ***************************************************************************/
 
 
+#ifndef QGSUSERINPUTWIDGET_H
+#define QGSUSERINPUTWIDGET_H
 
-#ifndef QGSUSERINPUTDOCKWIDGET_H
-#define QGSUSERINPUTDOCKWIDGET_H
-
-#include "qgsdockwidget.h"
 #include "qgis.h"
-#include <QMap>
 #include "qgis_gui.h"
+#include "qgsfloatingwidget.h"
 
+#include <QMap>
+#include <QBoxLayout>
 
-class QFrame;
 class QBoxLayout;
+class QFrame;
 
 
 /**
  * \ingroup gui
- * \brief The QgsUserInputDockWidget class is a dock widget that shall be used to display widgets for user inputs.
+ * \brief The QgsUserInputWidget class is a floating widget that shall be used to display widgets for user inputs.
  * It can be used by map tools, plugins, etc.
- * Several widgets can be displayed at once, they will be separated by a separator. Widgets will be either layout horizontally or vertically.
- * The dock is automatically hidden if it contains no widget.
+ * Several widgets can be displayed at once, they will be separated by a separator.
+ * Widgets will be either layout horizontally or vertically.
+ * The widget is automatically hidden if it contains no widget.
  */
-class GUI_EXPORT QgsUserInputDockWidget : public QgsDockWidget
+class GUI_EXPORT QgsUserInputWidget : public QgsFloatingWidget
 {
     Q_OBJECT
   public:
 
-    //! Constructor for QgsUserInputDockWidget
-    QgsUserInputDockWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    //! Constructor for QgsUserInputWidget
+    QgsUserInputWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * Add a widget to be displayed in the dock.
@@ -56,13 +57,9 @@ class GUI_EXPORT QgsUserInputDockWidget : public QgsDockWidget
   private slots:
     void widgetDestroyed( QObject *obj );
 
-    //! when area change, update the layout according to the new dock location
-    void areaChanged( Qt::DockWidgetArea area );
-    void floatingChanged( bool floating );
-
   private:
-    //! change layout according to dock location
-    void updateLayoutDirection();
+    //! change layout direction
+    void setLayoutDirection( QBoxLayout::Direction direction );
 
     // list of widget with their corresponding line separator
     QMap<QWidget *, QFrame *> mWidgetList;
@@ -71,4 +68,4 @@ class GUI_EXPORT QgsUserInputDockWidget : public QgsDockWidget
     QBoxLayout *mLayout = nullptr;
 };
 
-#endif // QGSUSERINPUTDOCKWIDGET_H
+#endif // QGSUSERINPUTWIDGET_H

--- a/src/gui/qgsuserinputwidget.h
+++ b/src/gui/qgsuserinputwidget.h
@@ -35,6 +35,7 @@ class QFrame;
  * Several widgets can be displayed at once, they will be separated by a separator.
  * Widgets will be either layout horizontally or vertically.
  * The widget is automatically hidden if it contains no widget.
+ * \since QGIS 2.10
  */
 class GUI_EXPORT QgsUserInputWidget : public QgsFloatingWidget
 {


### PR DESCRIPTION
fix #15177

<img width="906" alt="screen shot 2018-01-13 at 11 42 32" src="https://user-images.githubusercontent.com/127259/34907705-07922524-f859-11e7-9179-7d83cf1c9913.png">

**TODO**
* [ ] complete api break
* [ ] expands widgets

@nirvn could you give a hand at giving more room to the comboboxes in the rotation user input widget? I tried to use minimumExpanding both for comboboxes and user input main layout without success...

@nyalldawson it seems that the widget is not always well placed on first show (before any repaint). Am I missing something?
