### PR TITLE
Avoid translated name for fields when creating a new gpkg layer

### DIFF
--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -30,6 +30,7 @@
 #include "qgssettings.h"
 #include "qgshelp.h"
 #include "qgsogrutils.h"
+#include "qgsgui.h"
 
 #include <QPushButton>
 #include <QLineEdit>
@@ -47,6 +48,8 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   : QDialog( parent, fl )
 {
   setupUi( this );
+  QgsGui::instance()->enableAutoGeometryRestore( this );
+
   connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewGeoPackageLayerDialog::mAddAttributeButton_clicked );
   connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewGeoPackageLayerDialog::mRemoveAttributeButton_clicked );
   connect( mFieldTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewGeoPackageLayerDialog::mFieldTypeBox_currentIndexChanged );
@@ -57,9 +60,6 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsNewGeoPackageLayerDialog::buttonBox_accepted );
   connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsNewGeoPackageLayerDialog::buttonBox_rejected );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsNewGeoPackageLayerDialog::showHelp );
-
-  QgsSettings settings;
-  restoreGeometry( settings.value( QStringLiteral( "Windows/NewGeoPackageLayer/geometry" ) ).toByteArray() );
 
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
@@ -84,6 +84,8 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
   mGeometryColumnEdit->setEnabled( false );
+  mGeometryColumnEdit->setText( "geometry" );
+  mFeatureIdColumnEdit->setText( "fid" );
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
 
@@ -106,6 +108,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
 
   mCheckBoxCreateSpatialIndex->setChecked( true );
 
+  QgsSettings settings;
   mDatabase->setStorageMode( QgsFileWidget::SaveFile );
   mDatabase->setFilter( tr( "GeoPackage" ) + " (*.gpkg)" );
   mDatabase->setDialogTitle( tr( "Select Existing or Create a New GeoPackage Database File..." ) );
@@ -127,8 +130,6 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
 
 QgsNewGeoPackageLayerDialog::~QgsNewGeoPackageLayerDialog()
 {
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "Windows/NewGeoPackageLayer/geometry" ), saveGeometry() );
 }
 
 void QgsNewGeoPackageLayerDialog::setCrs( const QgsCoordinateReferenceSystem &crs )

--- a/src/ui/qgsnewgeopackagelayerdialogbase.ui
+++ b/src/ui/qgsnewgeopackagelayerdialogbase.ui
@@ -66,10 +66,7 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_51">
-       <item row="0" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_6"/>
-       </item>
-       <item row="4" column="0">
+       <item row="3" column="0">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
           <string>New field</string>
@@ -83,6 +80,12 @@
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="mFieldLengthLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Maximum length</string>
             </property>
@@ -144,9 +147,9 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="0" column="0">
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="1" column="2">
+         <item row="0" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout">
            <item>
             <widget class="QgsFileWidget" name="mDatabase">
@@ -163,7 +166,7 @@
            </item>
           </layout>
          </item>
-         <item row="3" column="0">
+         <item row="2" column="0">
           <widget class="QLabel" name="mGeometryTypeLabel">
            <property name="enabled">
             <bool>true</bool>
@@ -173,7 +176,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
+         <item row="1" column="1">
           <widget class="QLineEdit" name="mTableNameEdit">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -186,7 +189,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="0" column="0">
           <widget class="QLabel" name="mDatabaseLabel">
            <property name="enabled">
             <bool>true</bool>
@@ -196,7 +199,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="1" column="0">
           <widget class="QLabel" name="mTableNameLabel">
            <property name="text">
             <string>Table name</string>
@@ -206,7 +209,7 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="2">
+         <item row="2" column="1">
           <widget class="QComboBox" name="mGeometryTypeBox">
            <property name="enabled">
             <bool>true</bool>
@@ -222,7 +225,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
+         <item row="3" column="1">
           <layout class="QHBoxLayout" name="horizontalZMLayout">
            <item>
             <widget class="QCheckBox" name="mGeometryWithZCheckBox">
@@ -238,9 +241,22 @@
              </property>
             </widget>
            </item>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
          </item>
-         <item row="5" column="2">
+         <item row="4" column="1">
           <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
            <property name="focusPolicy">
             <enum>Qt::StrongFocus</enum>
@@ -249,7 +265,7 @@
          </item>
         </layout>
        </item>
-       <item row="5" column="0">
+       <item row="4" column="0">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Fields list</string>
@@ -328,7 +344,7 @@
          </layout>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="5" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupBox" native="true">
          <property name="title" stdset="0">
           <string>Advanced options</string>
@@ -363,7 +379,7 @@
           <item row="2" column="0">
            <widget class="QLabel" name="mLayerDescriptionLabel">
             <property name="text">
-            <string>Layer description</string>
+             <string>Layer description</string>
             </property>
             <property name="buddy">
              <cstring>mLayerIdentifierEdit</cstring>
@@ -471,21 +487,22 @@
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
-  <tabstop>mDatabase</tabstop>
   <tabstop>mTableNameEdit</tabstop>
-  <tabstop>mLayerIdentifierEdit</tabstop>
-  <tabstop>mLayerDescriptionEdit</tabstop>
-  <tabstop>mFeatureIdColumnEdit</tabstop>
   <tabstop>mGeometryTypeBox</tabstop>
-  <tabstop>mGeometryColumnEdit</tabstop>
+  <tabstop>mGeometryWithZCheckBox</tabstop>
+  <tabstop>mGeometryWithMCheckBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
-  <tabstop>mCheckBoxCreateSpatialIndex</tabstop>
   <tabstop>mFieldNameEdit</tabstop>
   <tabstop>mFieldTypeBox</tabstop>
   <tabstop>mFieldLengthEdit</tabstop>
   <tabstop>mAddAttributeButton</tabstop>
   <tabstop>mAttributeView</tabstop>
   <tabstop>mRemoveAttributeButton</tabstop>
+  <tabstop>mLayerIdentifierEdit</tabstop>
+  <tabstop>mLayerDescriptionEdit</tabstop>
+  <tabstop>mFeatureIdColumnEdit</tabstop>
+  <tabstop>mGeometryColumnEdit</tabstop>
+  <tabstop>mCheckBoxCreateSpatialIndex</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsnewgeopackagelayerdialogbase.ui
+++ b/src/ui/qgsnewgeopackagelayerdialogbase.ui
@@ -404,9 +404,6 @@
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Name of the feature id column&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
-            <property name="text">
-             <string>fid</string>
-            </property>
            </widget>
           </item>
           <item row="4" column="0">
@@ -429,9 +426,6 @@
             </property>
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Name of the geometry column&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>geometry</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This avoids some fields to appear translated by default (geometry ->géométrie eg)
Also make some dialog cleanup 
![image](https://user-images.githubusercontent.com/7983394/34914182-924dfcd8-f90d-11e7-855a-4d0522bceabf.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
