### PR TITLE
Avoid 'geometry' field name being translated when creating new SpatiaLite layer

### DIFF
--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -46,7 +46,7 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
 {
   setupUi( this );
   QgsGui::instance()->enableAutoGeometryRestore( this );
-  
+
   connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mAddAttributeButton_clicked );
   connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mRemoveAttributeButton_clicked );
   connect( mGeometryTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewSpatialiteLayerDialog::mGeometryTypeBox_currentIndexChanged );

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -31,6 +31,7 @@
 #include "qgsspatialiteutils.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgsgui.h"
 
 #include <QPushButton>
 #include <QLineEdit>
@@ -44,6 +45,8 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   : QDialog( parent, fl )
 {
   setupUi( this );
+  QgsGui::instance()->enableAutoGeometryRestore( this );
+  
   connect( mAddAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mAddAttributeButton_clicked );
   connect( mRemoveAttributeButton, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::mRemoveAttributeButton_clicked );
   connect( mGeometryTypeBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewSpatialiteLayerDialog::mGeometryTypeBox_currentIndexChanged );
@@ -52,9 +55,6 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   connect( toolButtonNewDatabase, &QToolButton::clicked, this, &QgsNewSpatialiteLayerDialog::toolButtonNewDatabase_clicked );
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsNewSpatialiteLayerDialog::buttonBox_accepted );
   connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsNewSpatialiteLayerDialog::buttonBox_rejected );
-
-  QgsSettings settings;
-  restoreGeometry( settings.value( QStringLiteral( "Windows/NewSpatiaLiteLayer/geometry" ) ).toByteArray() );
 
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconTableLayer.svg" ) ), tr( "No geometry" ), QStringLiteral( "" ) );
   mGeometryTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPointLayer.svg" ) ), tr( "Point" ), QStringLiteral( "POINT" ) );
@@ -68,6 +68,7 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
   leGeometryColumn->setEnabled( false );
+  leGeometryColumn->setText( "geometry" );
 
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
@@ -76,6 +77,7 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), tr( "Decimal number" ), "real" );
 
   // Populate the database list from the stored connections
+  QgsSettings settings;
   settings.beginGroup( QStringLiteral( "SpatiaLite/connections" ) );
   QStringList keys = settings.childGroups();
   QStringList::Iterator it = keys.begin();
@@ -112,8 +114,7 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
 
 QgsNewSpatialiteLayerDialog::~QgsNewSpatialiteLayerDialog()
 {
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "Windows/NewSpatiaLiteLayer/geometry" ), saveGeometry() );
+
 }
 
 void QgsNewSpatialiteLayerDialog::mGeometryTypeBox_currentIndexChanged( int index )
@@ -502,4 +503,3 @@ void QgsNewSpatialiteLayerDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#creating-a-new-spatialite-layer" ) );
 }
-

--- a/src/ui/qgsnewspatialitelayerdialogbase.ui
+++ b/src/ui/qgsnewspatialitelayerdialogbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>490</width>
+    <width>470</width>
     <height>627</height>
    </rect>
   </property>
@@ -51,8 +51,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>419</width>
-        <height>598</height>
+        <width>450</width>
+        <height>560</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_5">
@@ -124,7 +124,7 @@
           <cstring>mGeometryTypeBox</cstring>
          </property>
         </widget>
-      </item>
+       </item>
        <item row="2" column="1" colspan="2">
         <widget class="QComboBox" name="mGeometryTypeBox">
          <property name="enabled">
@@ -157,8 +157,21 @@
            </property>
           </widget>
          </item>
-        </layout>       
-       </item>       
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>0</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
        <item row="4" column="1" colspan="2">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
@@ -193,12 +206,12 @@
          </item>
         </layout>
        </item>
-       <item row="5" colspan="3">
+       <item row="5" column="0" colspan="3">
         <widget class="QGroupBox" name="groupBox1">
          <property name="title">
           <string>New field</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
+         <layout class="QGridLayout" name="gridLayout_7">
           <item row="0" column="0">
            <widget class="QLabel" name="textLabel1">
             <property name="sizePolicy">
@@ -283,7 +296,7 @@
          </layout>
         </widget>
        </item>
-       <item row="6" colspan="3">
+       <item row="6" column="0" colspan="3">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Fields list</string>
@@ -357,9 +370,9 @@
          </layout>
         </widget>
        </item>
-       <item row="7" colspan="3">
-        <widget class="QgsCollapsibleGroupBox" name="groupBox">
-         <property name="title">
+       <item row="7" column="0" colspan="3">
+        <widget class="QgsCollapsibleGroupBox" name="groupBox" native="true">
+         <property name="title" stdset="0">
           <string>Advanced options</string>
          </property>
          <property name="collapsed" stdset="0">
@@ -385,10 +398,7 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Name for the new layer</string>
-            </property>
-            <property name="text">
-             <string>geometry</string>
+             <string>Name of the geometry column</string>
             </property>
            </widget>
           </item>
@@ -432,21 +442,30 @@
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QWidget</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>mDatabaseComboBox</tabstop>
   <tabstop>toolButtonNewDatabase</tabstop>
   <tabstop>leLayerName</tabstop>
-  <tabstop>leGeometryColumn</tabstop>
+  <tabstop>mGeometryTypeBox</tabstop>
+  <tabstop>mGeometryWithZCheckBox</tabstop>
+  <tabstop>mGeometryWithMCheckBox</tabstop>
   <tabstop>leSRID</tabstop>
   <tabstop>pbnFindSRID</tabstop>
-  <tabstop>checkBoxPrimaryKey</tabstop>
   <tabstop>mNameEdit</tabstop>
   <tabstop>mTypeBox</tabstop>
   <tabstop>mAddAttributeButton</tabstop>
   <tabstop>mAttributeView</tabstop>
   <tabstop>mRemoveAttributeButton</tabstop>
+  <tabstop>leGeometryColumn</tabstop>
+  <tabstop>checkBoxPrimaryKey</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
Add some improvements to the dialog (tab stops,avoid button expanding, missing include, indentation...)
also enable dialog geometry autorestoration