### PR TITLE
Python console top level window

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -22,7 +22,7 @@ from builtins import str
 from builtins import range
 import os
 
-from qgis.PyQt.QtCore import Qt, QTimer, QCoreApplication, QSize, QByteArray, QFileInfo, QUrl, QDir
+from qgis.PyQt.QtCore import Qt, QTimer, QCoreApplication, QSize, QByteArray, QFileInfo, QUrl, QDir, QVariant
 from qgis.PyQt.QtWidgets import QDockWidget, QToolBar, QToolButton, QWidget, QSplitter, QTreeWidget, QAction, QFileDialog, QCheckBox, QSizePolicy, QMenu, QGridLayout, QApplication, QShortcut
 from qgis.PyQt.QtGui import QDesktopServices, QKeySequence
 from qgis.PyQt.QtWidgets import QVBoxLayout
@@ -38,23 +38,66 @@ from functools import partial
 import sys
 
 _console = None
+_consoleEditor = None
+_consoleAsDock = None
 
 
 def show_console():
     """ called from QGIS to open the console """
-    global _console
-    if _console is None:
-        parent = iface.mainWindow() if iface else None
-        _console = PythonConsole(parent)
+    global _console         # current console widget
+    global _consoleEditor   # actual console object
+    global _consoleAsDock
+
+    s = QgsSettings()
+
+    # get the setting as a bool value (for "true"/"false" values QgsSettings returns a string to Python)
+    dockValue = QVariant(s.value("qgis/dockPythonConsole","true"))
+    # defense against other than "true" or "false"
+    if dockValue.convert(QVariant.Bool):
+      tempConsoleAsDock = dockValue.value()
+    else:
+      tempConsoleAsDock = True
+
+    # switch widget type
+    if _consoleAsDock != tempConsoleAsDock:
+        # be sure we have actual console
+        if _consoleEditor is None:
+            _consoleEditor = PythonConsoleWidget()
+
+        # prepare to switch
+        if _console is not None:
+            if _consoleAsDock:
+                iface.mainWindow().removeDockWidget(_console)
+            else:
+                _console.hide()
+
+        # make the switch
+        if tempConsoleAsDock:
+            newConsole = PythonConsole(_consoleEditor)  # QgisApp takes ownership of dockwidget when added
+        else:
+            newConsole = PythonConsoleW(_consoleEditor)
+
+        # delete old console window; store current console window, status
+        _console = None
+        _console = newConsole
+        _consoleAsDock = tempConsoleAsDock
+
         _console.show()  # force show even if it was restored as hidden
         # set focus to the console so the user can start typing
         # defer the set focus event so it works also whether the console not visible yet
         QTimer.singleShot(0, _console.activate)
+
     else:
-        _console.setVisible(not _console.isVisible())
-        # set focus to the console so the user can start typing
+        # show/hide dockwidget console or always show top-level console and make it foreground
+        if _consoleAsDock:
+            _console.setVisible(not _console.isVisible())
+        else:
+            _console.show()
+            _console.raise_()
+            _console.setWindowState(_console.windowState() & ~Qt.WindowMinimized)
+
         if _console.isVisible():
-            _console.activate()
+            QTimer.singleShot(0, _console.activate)
 
     return _console
 
@@ -72,19 +115,21 @@ def console_displayhook(obj):
 
 class PythonConsole(QDockWidget):
 
-    def __init__(self, parent=None):
+    def __init__(self, editor, parent=None):
         QDockWidget.__init__(self, parent)
         self.setObjectName("PythonConsole")
         self.setWindowTitle(QCoreApplication.translate("PythonConsole", "Python Console"))
         # self.setAllowedAreas(Qt.BottomDockWidgetArea)
 
-        self.console = PythonConsoleWidget(self)
+        self.console = editor
         self.setWidget(self.console)
         self.setFocusProxy(self.console)
 
         # try to restore position from stored main window state
         if iface and not iface.mainWindow().restoreDockWidget(self):
             iface.mainWindow().addDockWidget(Qt.BottomDockWidgetArea, self)
+
+        self.hide()
 
     def activate(self):
         self.activateWindow()
@@ -93,6 +138,33 @@ class PythonConsole(QDockWidget):
 
     def closeEvent(self, event):
         self.console.saveSettingsConsole()
+        QWidget.closeEvent(self, event)
+
+
+class PythonConsoleW(QWidget):
+    """ as a QWidget """
+    def __init__(self, editor, parent=None):
+        QWidget.__init__(self, parent)
+        self.setObjectName("PythonConsoleW")
+        self.setWindowTitle(QCoreApplication.translate("PythonConsole", "Python Console"))
+
+        self.console = editor
+        self.setLayout(QVBoxLayout())
+        self.layout().setContentsMargins(0,0,0,0)
+        self.layout().addWidget(self.console)
+        self.setFocusProxy(self.console)
+
+        self.settings = QgsSettings()
+        self.restoreGeometry(self.settings.value("pythonConsole/geometry",QByteArray()))
+
+    def activate(self):
+        self.activateWindow()
+        self.raise_()
+        QWidget.setFocus(self)
+
+    def closeEvent(self, event):
+        self.console.saveSettingsConsole()
+        self.settings.setValue("pythonConsole/geometry", self.saveGeometry())
         QWidget.closeEvent(self, event)
 
 

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -51,7 +51,7 @@ def show_console():
     s = QgsSettings()
 
     # get the setting as a bool value (for "true"/"false" values QgsSettings returns a string to Python)
-    dockValue = QVariant(s.value("qgis/dockPythonConsole","true"))
+    dockValue = QVariant(s.value("qgis/dockPythonConsole", "true"))
     # defense against other than "true" or "false"
     if dockValue.convert(QVariant.Bool):
         tempConsoleAsDock = dockValue.value()
@@ -141,7 +141,7 @@ class PythonConsole(QDockWidget):
 
 
 class PythonConsoleW(QWidget):
-    """ as a QWidget """
+
     def __init__(self, editor, parent=None):
         QWidget.__init__(self, parent)
         self.setObjectName("PythonConsoleW")

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -37,15 +37,15 @@ from functools import partial
 
 import sys
 
-_console = None
-_consoleEditor = None
-_consoleAsDock = None
+_console = None         # current console widget container
+_consoleEditor = None   # console widget
+_consoleAsDock = None   # status: True=dockwidget, False=top-level window
 
 
 def show_console():
     """ called from QGIS to open the console """
-    global _console         # current console widget
-    global _consoleEditor   # actual console object
+    global _console
+    global _consoleEditor
     global _consoleAsDock
 
     s = QgsSettings()
@@ -54,13 +54,13 @@ def show_console():
     dockValue = QVariant(s.value("qgis/dockPythonConsole","true"))
     # defense against other than "true" or "false"
     if dockValue.convert(QVariant.Bool):
-      tempConsoleAsDock = dockValue.value()
+        tempConsoleAsDock = dockValue.value()
     else:
-      tempConsoleAsDock = True
+        tempConsoleAsDock = True
 
     # switch widget type
     if _consoleAsDock != tempConsoleAsDock:
-        # be sure we have actual console
+        # be sure we have the console widget
         if _consoleEditor is None:
             _consoleEditor = PythonConsoleWidget()
 
@@ -77,7 +77,7 @@ def show_console():
         else:
             newConsole = PythonConsoleW(_consoleEditor)
 
-        # delete old console window; store current console window, status
+        # delete old console window; store current console container, status
         _console = None
         _console = newConsole
         _consoleAsDock = tempConsoleAsDock
@@ -93,11 +93,10 @@ def show_console():
             _console.setVisible(not _console.isVisible())
         else:
             _console.show()
-            _console.raise_()
             _console.setWindowState(_console.windowState() & ~Qt.WindowMinimized)
 
         if _console.isVisible():
-            QTimer.singleShot(0, _console.activate)
+            _console.activate()
 
     return _console
 
@@ -150,12 +149,12 @@ class PythonConsoleW(QWidget):
 
         self.console = editor
         self.setLayout(QVBoxLayout())
-        self.layout().setContentsMargins(0,0,0,0)
+        self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().addWidget(self.console)
         self.setFocusProxy(self.console)
 
         self.settings = QgsSettings()
-        self.restoreGeometry(self.settings.value("pythonConsole/geometry",QByteArray()))
+        self.restoreGeometry(self.settings.value("pythonConsole/geometry", QByteArray()))
 
     def activate(self):
         self.activateWindow()

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -88,13 +88,8 @@ def show_console():
         QTimer.singleShot(0, _console.activate)
 
     else:
-        # show/hide dockwidget console or always show top-level console and make it foreground
-        if _consoleAsDock:
-            _console.setVisible(not _console.isVisible())
-        else:
-            _console.show()
-            _console.setWindowState(_console.windowState() & ~Qt.WindowMinimized)
-
+        # show/hide console
+        _console.setVisible(not _console.isVisible())
         if _console.isVisible():
             _console.activate()
 


### PR DESCRIPTION
This PR provides a way to use Python Console as either a dock widget or a top-level window. It can be switched on the fly - no need to restart QGIS.

see Feature Request https://issues.qgis.org/issues/4019

Please assign this PR to Borys Jurgiel. 

The basics to switch from one type to the other:
on change of type - determined by the current state not being the same as the state stored previously
1. construct a new widget of the other type
2. re-parent the console widget by setting it to the new widget
3. remove/delete the existing window object that contained the console
4. if the new widget is a dockwidget add it to the main window
5. save the new state

Changing Python Console's window type takes effect the next time Plugins, Python Console is chosen, even if the console is visible. As the editor is retained, nothing done in the console will be lost.

I have chosen to use the setting qgis/dockPythonConsole with true for dockwidget (also the default without the setting being present), false for top-level window.

When it is a dock window it is alternately shown/hidden each time the Plugins, Python Console menu item is chosen; and it will appear in the main window's context menu and can be toggled on and off there (no change from present behavior).

As a top-level window it will be shown each time the Plugins, Python Console menu item is chosen; the window may be minimized or closed using the buttons on its title bar. And you can navigate to the console window using Alt+Tab.
It is possible to make the window be hidden/shown on alternate operation of the Python Console menu item, but I felt it better to always show the console as it may be behind other windows or minimized. If hide() is called on the console window the window won't be listed as a window of the application on the task bar and you can't navigate to it using Alt+Tab. This may differ depending on the operating system.

The top-level window geometry is saved when the window is closed and restored when the window is constructed.

I'm not sure whether or where to put an option toggle (checkbox) in QGIS Settings|Options as there are no longer such settings for windows.

I have considered putting the setting for top-level vs. dockwidget somewhere in Python Console itself. This would make this feature totally contained in the console code, rather than have some part in the main QGIS application.

Please provide some guidance on this. 

Some sample Python code (use in the console):

<pre># create the setting for dockwidget or top-level window
s=QgsSettings()

s.setValue('qgis/dockPythonConsole','true')	# dockwidget
# or
s.setValue('qgis/dockPythonConsole','false')	# top-level

# demonstrate hiding window, especially as a top-level window
import console
c=console.show_console()

c.hide()
</pre>

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
