### PR TITLE
[ui] toggle bool value in advanced settings tree

### DIFF
--- a/src/app/qgssettingstree.cpp
+++ b/src/app/qgssettingstree.cpp
@@ -58,7 +58,7 @@ QgsSettingsTree::QgsSettingsTree( QWidget *parent )
   // header()->setResizeMode( 2, QHeaderView::Stretch );
   header()->resizeSection( 0, 250 );
   header()->resizeSection( 1, 100 );
-  header()->resizeSection( 2, 100 );
+  header()->resizeSection( 2, 250 );
 
   settings = nullptr;
   refreshTimer.setInterval( 2000 );
@@ -69,6 +69,8 @@ QgsSettingsTree::QgsSettingsTree( QWidget *parent )
   groupIcon.addPixmap( style()->standardPixmap( QStyle::SP_DirOpenIcon ),
                        QIcon::Normal, QIcon::On );
   keyIcon.addPixmap( style()->standardPixmap( QStyle::SP_FileIcon ) );
+
+  setEditTriggers( QAbstractItemView::AllEditTriggers );
 
   connect( &refreshTimer, &QTimer::timeout, this, &QgsSettingsTree::maybeRefresh );
 }


### PR DESCRIPTION
## Description
While giving a class to non-native English language QGIS users yesterday, I noticed one user needlessly struggling with the advanced settings when trying to switch a bool value from/to false<->true. The fellow was (out of pure instinct) trying to type true in French.

This PR improves the UX here by simply toggling the bool value on double-click.

@nyalldawson , @NathanW2 , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
