### PR TITLE
Drop fields in correct position in drag and drop designer

### DIFF
--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -788,7 +788,7 @@ DnDTree::DnDTree( QgsVectorLayer *layer, QWidget *parent )
   connect( this, &QTreeWidget::itemDoubleClicked, this, &DnDTree::onItemDoubleClicked );
 }
 
-QTreeWidgetItem *DnDTree::addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data )
+QTreeWidgetItem *DnDTree::addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data, int index )
 {
   QTreeWidgetItem *newItem = new QTreeWidgetItem( QStringList() << data.name() );
   newItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled );
@@ -813,7 +813,10 @@ QTreeWidgetItem *DnDTree::addItem( QTreeWidgetItem *parent, QgsAttributesFormPro
     }
   }
   newItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, data );
-  parent->addChild( newItem );
+  if ( index < 0 )
+    parent->addChild( newItem );
+  else
+    parent->insertChild( index, newItem );
 
   return newItem;
 }
@@ -852,7 +855,6 @@ void DnDTree::dragMoveEvent( QDragMoveEvent *event )
 
 bool DnDTree::dropMimeData( QTreeWidgetItem *parent, int index, const QMimeData *data, Qt::DropAction action )
 {
-  Q_UNUSED( index )
   bool bDropSuccessful = false;
 
   if ( action == Qt::IgnoreAction )
@@ -871,12 +873,12 @@ bool DnDTree::dropMimeData( QTreeWidgetItem *parent, int index, const QMimeData 
 
       if ( parent )
       {
-        addItem( parent, itemElement );
+        addItem( parent, itemElement, index );
         bDropSuccessful = true;
       }
       else
       {
-        addItem( invisibleRootItem(), itemElement );
+        addItem( invisibleRootItem(), itemElement, index );
         bDropSuccessful = true;
       }
     }

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -238,7 +238,12 @@ class DnDTree : public QTreeWidget
 
   public:
     explicit DnDTree( QgsVectorLayer *layer, QWidget *parent = nullptr );
-    QTreeWidgetItem *addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data );
+
+    /**
+     * Adds a new item to a \a parent. If \a index is -1, the item is added to the end of the parent's existing children.
+     * Otherwise it is inserted at the specified \a index.
+     */
+    QTreeWidgetItem *addItem( QTreeWidgetItem *parent, QgsAttributesFormProperties::DnDTreeItemData data, int index = -1 );
     QTreeWidgetItem *addContainer( QTreeWidgetItem *parent, const QString &title, int columnCount );
 
     enum Type


### PR DESCRIPTION
Instead of always dropping fields at the end of the container, insert them at the dropped location. Otherwise the drop indicator line is misleading.
