### PR TITLE
[processing] Add missing resampling methods to GDAL warp.

### DIFF
--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -50,7 +50,8 @@ class warp(GdalAlgorithm):
     SOURCE_SRS = 'SOURCE_SRS'
     DEST_SRS = 'DEST_SRS'
     METHOD = 'METHOD'
-    METHOD_OPTIONS = ['near', 'bilinear', 'cubic', 'cubicspline', 'lanczos']
+    METHOD_OPTIONS = ['near', 'bilinear', 'cubic', 'cubicspline', 'lanczos',
+                      'average', 'mode', 'max', 'min', 'med', 'q1', 'q3']
     TR = 'TR'
     NO_DATA = 'NO_DATA'
     EXTRA = 'EXTRA'


### PR DESCRIPTION
## Description
Add missing resampling methods to GDAL warp. They are all available since at least GDAL 2.0.0.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
