### PR TITLE
Clean some map theme related debug messages

### DIFF
--- a/src/core/qgsmaplayerstylemanager.cpp
+++ b/src/core/qgsmaplayerstylemanager.cpp
@@ -270,6 +270,11 @@ void QgsMapLayerStyle::readFromLayer( QgsMapLayer *layer )
 
 void QgsMapLayerStyle::writeToLayer( QgsMapLayer *layer ) const
 {
+  if ( !isValid() )
+  {
+    return;
+  }
+
   QDomDocument doc( QStringLiteral( "qgis" ) );
   if ( !doc.setContent( mXmlData ) )
   {

--- a/src/core/qgsprojectversion.cpp
+++ b/src/core/qgsprojectversion.cpp
@@ -49,8 +49,7 @@ QgsProjectVersion::QgsProjectVersion( const QString &string )
   }
   mName  = string.section( '-', 1 );
 
-  QgsDebugMsg( QString( "Version is set to " ) + text() );
-
+  QgsDebugMsgLevel( QString( "Version is set to " ) + text(), 4 );
 }
 
 bool QgsProjectVersion::operator==( const QgsProjectVersion &other ) const


### PR DESCRIPTION
## Description
While debug an issue related to map theme, I noticed way too many debug messages are thrown at the console. This PR removes unwarranted messages (i.e. write an empty style onto a layer) and tweaks another message (the project version) so it doesn't show up on the default debug level.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
