### PR TITLE
Server exception on image overflow

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1041,7 +1041,7 @@ namespace QgsWms
       throw QgsException( QStringLiteral( "createImage: Invalid width / height parameters" ) );
     }
 
-    QImage *image = nullptr;
+    std::unique_ptr<QImage> image;
 
     // use alpha channel only if necessary because it slows down performance
     QgsWmsParameters::Format format = mWmsParameters.format();
@@ -1049,13 +1049,19 @@ namespace QgsWms
 
     if ( transparent && format != QgsWmsParameters::JPG )
     {
-      image = new QImage( width, height, QImage::Format_ARGB32_Premultiplied );
+      image = qgis::make_unique<QImage>( width, height, QImage::Format_ARGB32_Premultiplied );
       image->fill( 0 );
     }
     else
     {
-      image = new QImage( width, height, QImage::Format_RGB32 );
+      image = qgis::make_unique<QImage>( width, height, QImage::Format_RGB32 );
       image->fill( mWmsParameters.backgroundColorAsColor() );
+    }
+
+    // Check that image was correctly created
+    if ( image->isNull() )
+    {
+      throw QgsException( QStringLiteral( "createImage: image could not be created, check for out of memory conditions" ) );
     }
 
     //apply DPI parameter if present. This is an extension of Qgis Mapserver compared to WMS 1.3.
@@ -1067,7 +1073,7 @@ namespace QgsWms
 
     image->setDotsPerMeterX( dpm );
     image->setDotsPerMeterY( dpm );
-    return image;
+    return image.release();
   }
 
   void QgsRenderer::configureMapSettings( const QPaintDevice *paintDevice, QgsMapSettings &mapSettings ) const
@@ -1829,6 +1835,32 @@ namespace QgsWms
     {
       return false;
     }
+
+    // Sanity check from internal QImage checks (see qimage.cpp)
+    // this is to report a meaningful error message in case of
+    // image creation failure and to differentiate it from out
+    // of memory conditions.
+
+    // depth for now it cannot be anything other than 32, but I don't like
+    // to hardcode it: I hope we will support other depths in the future.
+    uint depth = 32;
+    switch ( mWmsParameters.format() )
+    {
+      case QgsWmsParameters::Format::JPG:
+      case QgsWmsParameters::Format::PNG:
+      default:
+        depth = 32;
+    }
+
+    const int bytes_per_line = ( ( width * depth + 31 ) >> 5 ) << 2; // bytes per scanline (must be multiple of 4)
+
+    if ( INT_MAX / depth < width
+         || bytes_per_line <= 0
+         || height <= 0
+         || INT_MAX / uint( bytes_per_line ) < height
+         || INT_MAX / sizeof( uchar * ) < uint( height ) )
+      return false;
+
 
     return true;
   }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1854,13 +1854,12 @@ namespace QgsWms
 
     const int bytes_per_line = ( ( width * depth + 31 ) >> 5 ) << 2; // bytes per scanline (must be multiple of 4)
 
-    if ( INT_MAX / depth < width
+    if ( std::numeric_limits<int>::max() / depth < ( uint )width
          || bytes_per_line <= 0
          || height <= 0
-         || INT_MAX / uint( bytes_per_line ) < height
-         || INT_MAX / sizeof( uchar * ) < uint( height ) )
+         || std::numeric_limits<int>::max() / uint( bytes_per_line ) < ( uint )height
+         || std::numeric_limits<int>::max() / sizeof( uchar * ) < uint( height ) )
       return false;
-
 
     return true;
   }

--- a/tests/src/python/qgis_wrapped_server.py
+++ b/tests/src/python/qgis_wrapped_server.py
@@ -166,6 +166,8 @@ class Handler(BaseHTTPRequestHandler):
         headers = {}
         for k, v in self.headers.items():
             headers['HTTP_%s' % k.replace(' ', '-').replace('-', '_').replace(' ', '-').upper()] = v
+        if not self.path.startswith('http'):
+            self.path = "%s://%s:%s%s" % ('https' if https else 'http', QGIS_SERVER_HOST, QGIS_SERVER_PORT, self.path)
         request = QgsBufferServerRequest(self.path, (QgsServerRequest.PostMethod if post_body is not None else QgsServerRequest.GetMethod), headers, post_body)
         response = QgsBufferServerResponse()
         qgs_server.handleRequest(request, response)


### PR DESCRIPTION
Because we don't wont a broken image in the output
when a null image is created.

This introduces an additional check for null images
and a check for image size taken verbatim from QImage
internal checks.

This fixes an unreported bug that produced a broken image
instead of a proper exception in case of size overflow
due to QImage internal checks or to out of memory conditions.