### PR TITLE
switch select by radius map tool to click-click

### DIFF
--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -50,6 +50,6 @@ void QgsMapToolSelect::canvasReleaseEvent( QgsMapMouseEvent *e )
   QgsMapToolSelectUtils::expandSelectRectangle( selectRect, vlayer, e->pos() );
   QgsMapToolSelectUtils::setRubberBand( mCanvas, selectRect, &rubberBand );
   QgsGeometry selectGeom( rubberBand.asGeometry() );
-  QgsMapToolSelectUtils::selectSingleFeature( mCanvas, selectGeom, e );
+  QgsMapToolSelectUtils::selectSingleFeature( mCanvas, selectGeom, e->modifiers() );
   rubberBand.reset( QgsWkbTypes::PolygonGeometry );
 }

--- a/src/app/qgsmaptoolselectfreehand.cpp
+++ b/src/app/qgsmaptoolselectfreehand.cpp
@@ -86,9 +86,9 @@ void QgsMapToolSelectFreehand::canvasReleaseEvent( QgsMapMouseEvent *e )
   {
     QgsGeometry shapeGeom = mRubberBand->asGeometry();
     if ( singleSelect )
-      QgsMapToolSelectUtils::selectSingleFeature( mCanvas, shapeGeom, e );
+      QgsMapToolSelectUtils::selectSingleFeature( mCanvas, shapeGeom, e->modifiers() );
     else
-      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, shapeGeom, e );
+      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, shapeGeom, e->modifiers() );
   }
 
   mRubberBand->reset( QgsWkbTypes::PolygonGeometry );

--- a/src/app/qgsmaptoolselectpolygon.cpp
+++ b/src/app/qgsmaptoolselectpolygon.cpp
@@ -54,7 +54,7 @@ void QgsMapToolSelectPolygon::canvasPressEvent( QgsMapMouseEvent *e )
     if ( mRubberBand->numberOfVertices() > 2 )
     {
       QgsGeometry polygonGeom = mRubberBand->asGeometry();
-      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, polygonGeom, e );
+      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, polygonGeom, e->modifiers() );
     }
     mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
     delete mRubberBand;

--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -83,7 +83,7 @@ bool QgsDistanceWidget::eventFilter( QObject *obj, QEvent *ev )
     QKeyEvent *event = static_cast<QKeyEvent *>( ev );
     if ( event->key() == Qt::Key_Escape )
     {
-      emit distanceEditingCancelled();
+      emit distanceEditingCanceled();
       return true;
     }
     if ( event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return )
@@ -258,7 +258,7 @@ void QgsMapToolSelectRadius::createRotationWidget()
 
   connect( mDistanceWidget, &QgsDistanceWidget::distanceChanged, this, &QgsMapToolSelectRadius::updateRubberband );
   connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingFinished, this, &QgsMapToolSelectRadius::radiusValueEntered );
-  connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingCancelled, this, &QgsMapToolSelectRadius::cancel );
+  connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingCanceled, this, &QgsMapToolSelectRadius::cancel );
 }
 
 void QgsMapToolSelectRadius::deleteRotationWidget()
@@ -267,6 +267,7 @@ void QgsMapToolSelectRadius::deleteRotationWidget()
   {
     disconnect( mDistanceWidget, &QgsDistanceWidget::distanceChanged, this, &QgsMapToolSelectRadius::updateRubberband );
     disconnect( mDistanceWidget, &QgsDistanceWidget::distanceEditingFinished, this, &QgsMapToolSelectRadius::radiusValueEntered );
+    disconnect( mDistanceWidget, &QgsDistanceWidget::distanceEditingCanceled, this, &QgsMapToolSelectRadius::cancel );
     mDistanceWidget->releaseKeyboard();
     mDistanceWidget->deleteLater();
   }

--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -81,6 +81,11 @@ bool QgsDistanceWidget::eventFilter( QObject *obj, QEvent *ev )
   if ( obj == mDistanceSpinBox && ev->type() == QEvent::KeyPress )
   {
     QKeyEvent *event = static_cast<QKeyEvent *>( ev );
+    if ( event->key() == Qt::Key_Escape )
+    {
+      emit distanceEditingCancelled();
+      return true;
+    }
     if ( event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return )
     {
       emit distanceEditingFinished( distance(), event->modifiers() );
@@ -185,6 +190,16 @@ void QgsMapToolSelectRadius::deactivate()
   QgsMapTool::deactivate();
 }
 
+void QgsMapToolSelectRadius::keyReleaseEvent( QKeyEvent *e )
+{
+  if ( mActive && e->key() == Qt::Key_Escape )
+  {
+    cancel();
+    return;
+  }
+  QgsMapTool::keyReleaseEvent( e );
+}
+
 void QgsMapToolSelectRadius::updateRubberband( const double &radius )
 {
   mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
@@ -214,6 +229,13 @@ void QgsMapToolSelectRadius::radiusValueEntered( const double &radius, const Qt:
   selectFromRubberband( modifiers );
 }
 
+void QgsMapToolSelectRadius::cancel()
+{
+  deleteRotationWidget();
+  deleteRubberband();
+  mActive = false;
+}
+
 void QgsMapToolSelectRadius::deleteRubberband()
 {
   delete mRubberBand;
@@ -236,6 +258,7 @@ void QgsMapToolSelectRadius::createRotationWidget()
 
   connect( mDistanceWidget, &QgsDistanceWidget::distanceChanged, this, &QgsMapToolSelectRadius::updateRubberband );
   connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingFinished, this, &QgsMapToolSelectRadius::radiusValueEntered );
+  connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingCancelled, this, &QgsMapToolSelectRadius::cancel );
 }
 
 void QgsMapToolSelectRadius::deleteRotationWidget()

--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -13,6 +13,14 @@ email                : jpalmer at linz dot govt dot nz
 *                                                                         *
 ***************************************************************************/
 
+
+#include <cmath>
+#include <QMouseEvent>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+
+#include "qgisapp.h"
 #include "qgsmaptoolselectradius.h"
 #include "qgsmaptoolselectutils.h"
 #include "qgsgeometry.h"
@@ -20,15 +28,76 @@ email                : jpalmer at linz dot govt dot nz
 #include "qgsmapcanvas.h"
 #include "qgis.h"
 #include "qgslogger.h"
+#include "qgsdoublespinbox.h"
 
-#include <cmath>
-#include <QMouseEvent>
+
 
 const int RADIUS_SEGMENTS = 40;
 
+QgsDistanceWidget::QgsDistanceWidget( const QString &label, QWidget *parent )
+  : QWidget( parent )
+{
+  mLayout = new QHBoxLayout( this );
+  mLayout->setContentsMargins( 0, 0, 0, 0 );
+  //mLayout->setAlignment( Qt::AlignLeft );
+  setLayout( mLayout );
+
+  if ( !label.isEmpty() )
+  {
+    QLabel *lbl = new QLabel( label, this );
+    lbl->setAlignment( Qt::AlignRight | Qt::AlignCenter );
+    mLayout->addWidget( lbl );
+  }
+
+  mDistanceSpinBox = new QgsDoubleSpinBox( this );
+  mDistanceSpinBox->setSingleStep( 1 );
+  mDistanceSpinBox->setValue( 0 );
+  mDistanceSpinBox->setMinimum( 0 );
+  mDistanceSpinBox->setMaximum( 1000000000 );
+  mDistanceSpinBox->setShowClearButton( false );
+  mDistanceSpinBox->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Preferred );
+  mLayout->addWidget( mDistanceSpinBox );
+
+  // connect signals
+  mDistanceSpinBox->installEventFilter( this );
+  connect( mDistanceSpinBox, static_cast < void ( QgsDoubleSpinBox::* )( double ) > ( &QgsDoubleSpinBox::valueChanged ), this, &QgsDistanceWidget::distanceSpinBoxValueChanged );
+
+  // config focus
+  setFocusProxy( mDistanceSpinBox );
+}
+
+void QgsDistanceWidget::setDistance( double distance )
+{
+  mDistanceSpinBox->setValue( distance );
+}
+
+double QgsDistanceWidget::distance()
+{
+  return mDistanceSpinBox->value();
+}
+
+bool QgsDistanceWidget::eventFilter( QObject *obj, QEvent *ev )
+{
+  if ( obj == mDistanceSpinBox && ev->type() == QEvent::KeyPress )
+  {
+    QKeyEvent *event = static_cast<QKeyEvent *>( ev );
+    if ( event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return )
+    {
+      emit distanceEditingFinished( distance(), event->modifiers() );
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void QgsDistanceWidget::distanceSpinBoxValueChanged( double distance )
+{
+  emit distanceChanged( distance );
+}
+
 QgsMapToolSelectRadius::QgsMapToolSelectRadius( QgsMapCanvas *canvas )
   : QgsMapTool( canvas )
-  , mDragging( false )
 {
   mRubberBand = nullptr;
   mCursor = Qt::ArrowCursor;
@@ -38,44 +107,47 @@ QgsMapToolSelectRadius::QgsMapToolSelectRadius( QgsMapCanvas *canvas )
 
 QgsMapToolSelectRadius::~QgsMapToolSelectRadius()
 {
-  delete mRubberBand;
+  deleteRotationWidget();
+  deleteRubberband();
 }
-
-void QgsMapToolSelectRadius::canvasPressEvent( QgsMapMouseEvent *e )
-{
-  if ( e->button() != Qt::LeftButton )
-    return;
-
-  mRadiusCenter = toMapCoordinates( e->pos() );
-}
-
 
 void QgsMapToolSelectRadius::canvasMoveEvent( QgsMapMouseEvent *e )
 {
-  if ( e->buttons() != Qt::LeftButton )
+  if ( !mActive )
     return;
 
-  if ( !mDragging )
+  if ( !mRubberBand )
   {
-    if ( !mRubberBand )
-    {
-      mRubberBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
-      mRubberBand->setFillColor( mFillColor );
-      mRubberBand->setStrokeColor( mStrokeColor );
-    }
-    mDragging = true;
+    mRubberBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PolygonGeometry );
+    mRubberBand->setFillColor( mFillColor );
+    mRubberBand->setStrokeColor( mStrokeColor );
   }
+
   QgsPointXY radiusEdge = toMapCoordinates( e->pos() );
-  setRadiusRubberBand( radiusEdge );
+  updateRadiusFromEdge( radiusEdge );
 }
 
 
 void QgsMapToolSelectRadius::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
+  if ( e->button() == Qt::RightButton )
+  {
+    deleteRotationWidget();
+    deleteRubberband();
+    mActive = false;
+    return;
+  }
+
   if ( e->button() != Qt::LeftButton )
     return;
 
-  if ( !mDragging )
+  if ( !mActive )
+  {
+    mActive = true;
+    mRadiusCenter = toMapCoordinates( e->pos() );
+    createRotationWidget();
+  }
+  else
   {
     if ( !mRubberBand )
     {
@@ -83,29 +155,97 @@ void QgsMapToolSelectRadius::canvasReleaseEvent( QgsMapMouseEvent *e )
       mRubberBand->setFillColor( mFillColor );
       mRubberBand->setStrokeColor( mStrokeColor );
     }
-    mRadiusCenter = toMapCoordinates( e->pos() );
     QgsPointXY radiusEdge = toMapCoordinates( QPoint( e->pos().x() + 1, e->pos().y() + 1 ) );
-    setRadiusRubberBand( radiusEdge );
+    updateRadiusFromEdge( radiusEdge );
+    selectFromRubberband( e->modifiers() );
   }
-  QgsGeometry radiusGeometry = mRubberBand->asGeometry();
-  QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, radiusGeometry, e );
-  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
-  delete mRubberBand;
-  mRubberBand = nullptr;
-  mDragging = false;
 }
 
 
-void QgsMapToolSelectRadius::setRadiusRubberBand( QgsPointXY &radiusEdge )
+void QgsMapToolSelectRadius::updateRadiusFromEdge( QgsPointXY &radiusEdge )
 {
-  double r = std::sqrt( mRadiusCenter.sqrDist( radiusEdge ) );
+  double radius = std::sqrt( mRadiusCenter.sqrDist( radiusEdge ) );
+  if ( mDistanceWidget )
+  {
+    mDistanceWidget->setDistance( radius );
+    mDistanceWidget->setFocus( Qt::TabFocusReason );
+    mDistanceWidget->editor()->selectAll();
+  }
+  else
+  {
+    updateRubberband( radius );
+  }
+}
+
+void QgsMapToolSelectRadius::deactivate()
+{
+  deleteRotationWidget();
+  deleteRubberband();
+  mActive = false;
+  QgsMapTool::deactivate();
+}
+
+void QgsMapToolSelectRadius::updateRubberband( const double &radius )
+{
   mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
   for ( int i = 0; i <= RADIUS_SEGMENTS; ++i )
   {
     double theta = i * ( 2.0 * M_PI / RADIUS_SEGMENTS );
-    QgsPointXY radiusPoint( mRadiusCenter.x() + r * std::cos( theta ),
-                            mRadiusCenter.y() + r * std::sin( theta ) );
+    QgsPointXY radiusPoint( mRadiusCenter.x() + radius * std::cos( theta ),
+                            mRadiusCenter.y() + radius * std::sin( theta ) );
     mRubberBand->addPoint( radiusPoint, false );
   }
   mRubberBand->closePoints( true );
+}
+
+void QgsMapToolSelectRadius::selectFromRubberband( const Qt::KeyboardModifiers &modifiers )
+{
+  QgsGeometry radiusGeometry = mRubberBand->asGeometry();
+  QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, radiusGeometry, modifiers );
+  mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
+  deleteRotationWidget();
+  deleteRubberband();
+  mActive = false;
+}
+
+void QgsMapToolSelectRadius::radiusValueEntered( const double &radius, const Qt::KeyboardModifiers &modifiers )
+{
+  updateRubberband( radius );
+  selectFromRubberband( modifiers );
+}
+
+void QgsMapToolSelectRadius::deleteRubberband()
+{
+  delete mRubberBand;
+  mRubberBand = nullptr;
+}
+
+
+void QgsMapToolSelectRadius::createRotationWidget()
+{
+  if ( !mCanvas )
+  {
+    return;
+  }
+
+  deleteRotationWidget();
+
+  mDistanceWidget = new QgsDistanceWidget( QStringLiteral( "Selection radius:" ) );
+  QgisApp::instance()->addUserInputWidget( mDistanceWidget );
+  mDistanceWidget->setFocus( Qt::TabFocusReason );
+
+  connect( mDistanceWidget, &QgsDistanceWidget::distanceChanged, this, &QgsMapToolSelectRadius::updateRubberband );
+  connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingFinished, this, &QgsMapToolSelectRadius::radiusValueEntered );
+}
+
+void QgsMapToolSelectRadius::deleteRotationWidget()
+{
+  if ( mDistanceWidget )
+  {
+    disconnect( mDistanceWidget, &QgsDistanceWidget::distanceChanged, this, &QgsMapToolSelectRadius::updateRubberband );
+    disconnect( mDistanceWidget, &QgsDistanceWidget::distanceEditingFinished, this, &QgsMapToolSelectRadius::radiusValueEntered );
+    mDistanceWidget->releaseKeyboard();
+    mDistanceWidget->deleteLater();
+  }
+  mDistanceWidget = nullptr;
 }

--- a/src/app/qgsmaptoolselectradius.h
+++ b/src/app/qgsmaptoolselectradius.h
@@ -44,7 +44,7 @@ class APP_EXPORT QgsDistanceWidget : public QWidget
   signals:
     void distanceChanged( double distance );
     void distanceEditingFinished( double distance, const Qt::KeyboardModifiers &modifiers );
-    void distanceEditingCancelled();
+    void distanceEditingCanceled();
 
   protected:
     bool eventFilter( QObject *obj, QEvent *ev ) override;

--- a/src/app/qgsmaptoolselectradius.h
+++ b/src/app/qgsmaptoolselectradius.h
@@ -21,8 +21,40 @@ email                : jpalmer at linz dot govt dot nz
 #include "qgspointxy.h"
 #include "qgis_app.h"
 
+class QHBoxLayout;
+
+class QgsDoubleSpinBox;
 class QgsMapCanvas;
 class QgsRubberBand;
+
+class APP_EXPORT QgsDistanceWidget : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    explicit QgsDistanceWidget( const QString &label = QString(), QWidget *parent = nullptr );
+
+    void setDistance( double distance );
+
+    double distance();
+
+    QgsDoubleSpinBox *editor() {return mDistanceSpinBox;}
+
+  signals:
+    void distanceChanged( double distance );
+    void distanceEditingFinished( double distance, const Qt::KeyboardModifiers &modifiers );
+
+  protected:
+    bool eventFilter( QObject *obj, QEvent *ev ) override;
+
+  private slots:
+    void distanceSpinBoxValueChanged( double distance );
+
+  private:
+    QHBoxLayout *mLayout = nullptr;
+    QgsDoubleSpinBox *mDistanceSpinBox = nullptr;
+};
 
 
 class APP_EXPORT QgsMapToolSelectRadius : public QgsMapTool
@@ -36,17 +68,32 @@ class APP_EXPORT QgsMapToolSelectRadius : public QgsMapTool
     //! Overridden mouse move event
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
 
-    //! Overridden mouse press event
-    void canvasPressEvent( QgsMapMouseEvent *e ) override;
-
     //! Overridden mouse release event
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
 
-  private:
+    //! called when map tool is being deactivated
+    void deactivate() override;
 
-    //! sets the rubber band to a circle approximated using 40 segments.
-    // The radius center point is defined in the canvasPressEvent event.
-    void setRadiusRubberBand( QgsPointXY &radiusEdge );
+  private slots:
+    //! update the rubber band from the input widget
+    void updateRubberband( const double &radius );
+
+    /**
+     * triggered when the user input widget has a new value
+     * either programmatically (from the mouse event) or entered by the user
+     */
+    void radiusValueEntered( const double &radius, const Qt::KeyboardModifiers &modifiers );
+
+  private:
+    //! perform selection using radius from rubberband
+    void selectFromRubberband( const Qt::KeyboardModifiers &modifiers );
+
+    //! on mouse events update the rubber band using the mouse position
+    void updateRadiusFromEdge( QgsPointXY &radiusEdge );
+
+    void deleteRubberband();
+    void deleteRotationWidget();
+    void createRotationWidget();
 
     //! used for storing all of the maps point for the polygon
     QgsRubberBand *mRubberBand = nullptr;
@@ -54,11 +101,13 @@ class APP_EXPORT QgsMapToolSelectRadius : public QgsMapTool
     //! Center point for the radius
     QgsPointXY mRadiusCenter;
 
-    bool mDragging;
+    bool mActive = false;
 
     QColor mFillColor;
-
     QColor mStrokeColor;
+
+    //! Shows current angle value and allows numerical editing
+    QgsDistanceWidget *mDistanceWidget = nullptr;
 };
 
 #endif

--- a/src/app/qgsmaptoolselectradius.h
+++ b/src/app/qgsmaptoolselectradius.h
@@ -44,6 +44,7 @@ class APP_EXPORT QgsDistanceWidget : public QWidget
   signals:
     void distanceChanged( double distance );
     void distanceEditingFinished( double distance, const Qt::KeyboardModifiers &modifiers );
+    void distanceEditingCancelled();
 
   protected:
     bool eventFilter( QObject *obj, QEvent *ev ) override;
@@ -74,6 +75,9 @@ class APP_EXPORT QgsMapToolSelectRadius : public QgsMapTool
     //! called when map tool is being deactivated
     void deactivate() override;
 
+    //! catch escape when active to cancel selection
+    void keyReleaseEvent( QKeyEvent *e ) override;
+
   private slots:
     //! update the rubber band from the input widget
     void updateRubberband( const double &radius );
@@ -83,6 +87,9 @@ class APP_EXPORT QgsMapToolSelectRadius : public QgsMapTool
      * either programmatically (from the mouse event) or entered by the user
      */
     void radiusValueEntered( const double &radius, const Qt::KeyboardModifiers &modifiers );
+
+    //! cancel selecting (between two click events)
+    void cancel();
 
   private:
     //! perform selection using radius from rubberband

--- a/src/app/qgsmaptoolselectrectangle.cpp
+++ b/src/app/qgsmaptoolselectrectangle.cpp
@@ -104,10 +104,10 @@ void QgsMapToolSelectFeatures::canvasReleaseEvent( QgsMapMouseEvent *e )
     QgsGeometry selectGeom = mRubberBand->asGeometry();
     if ( !mDragging )
     {
-      QgsMapToolSelectUtils::selectSingleFeature( mCanvas, selectGeom, e );
+      QgsMapToolSelectUtils::selectSingleFeature( mCanvas, selectGeom, e->modifiers() );
     }
     else
-      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, selectGeom, e );
+      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, selectGeom, e->modifiers() );
 
     delete mRubberBand;
     mRubberBand = nullptr;

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -87,21 +87,21 @@ void QgsMapToolSelectUtils::expandSelectRectangle( QRect &selectRect,
   selectRect.setBottom( point.y() + boxSize );
 }
 
-void QgsMapToolSelectUtils::selectMultipleFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, QMouseEvent *e )
+void QgsMapToolSelectUtils::selectMultipleFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, const Qt::KeyboardModifiers &modifiers )
 {
   QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection;
-  if ( e->modifiers() & Qt::ShiftModifier && e->modifiers() & Qt::ControlModifier )
+  if ( modifiers & Qt::ShiftModifier && modifiers & Qt::ControlModifier )
     behavior = QgsVectorLayer::IntersectSelection;
-  else if ( e->modifiers() & Qt::ShiftModifier )
+  else if ( modifiers & Qt::ShiftModifier )
     behavior = QgsVectorLayer::AddToSelection;
-  else if ( e->modifiers() & Qt::ControlModifier )
+  else if ( modifiers & Qt::ControlModifier )
     behavior = QgsVectorLayer::RemoveFromSelection;
 
-  bool doContains = e->modifiers() & Qt::AltModifier;
+  bool doContains = modifiers & Qt::AltModifier;
   setSelectedFeatures( canvas, selectGeometry, behavior, doContains );
 }
 
-void QgsMapToolSelectUtils::selectSingleFeature( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, QMouseEvent *e )
+void QgsMapToolSelectUtils::selectSingleFeature( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, const Qt::KeyboardModifiers &modifiers )
 {
   QgsVectorLayer *vlayer = QgsMapToolSelectUtils::getCurrentVectorLayer( canvas );
   if ( !vlayer )
@@ -112,7 +112,7 @@ void QgsMapToolSelectUtils::selectSingleFeature( QgsMapCanvas *canvas, const Qgs
   QgsFeatureIds selectedFeatures = getMatchingFeatures( canvas, selectGeometry, false, true );
   if ( selectedFeatures.isEmpty() )
   {
-    if ( !( e->modifiers() & Qt::ShiftModifier || e->modifiers() & Qt::ControlModifier ) )
+    if ( !( modifiers & Qt::ShiftModifier || modifiers & Qt::ControlModifier ) )
     {
       // if no modifiers then clicking outside features clears the selection
       // but if there's a shift or ctrl modifier, then it's likely the user was trying
@@ -127,7 +127,7 @@ void QgsMapToolSelectUtils::selectSingleFeature( QgsMapCanvas *canvas, const Qgs
   QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection;
 
   //either shift or control modifier switches to "toggle" selection mode
-  if ( e->modifiers() & Qt::ShiftModifier || e->modifiers() & Qt::ControlModifier )
+  if ( modifiers & Qt::ShiftModifier || modifiers & Qt::ControlModifier )
   {
     QgsFeatureId selectId = *selectedFeatures.constBegin();
     QgsFeatureIds layerSelectedFeatures = vlayer->selectedFeatureIds();

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -71,12 +71,12 @@ namespace QgsMapToolSelectUtils
     for any required geometry transformations
     \param selectGeometry the geometry to select the layers features. This geometry
     must be in terms of the canvas coordinate system.
-    \param e MouseEvents are used to determine the current selection
+    \param modifiers Keyboard modifiers are used to determine the current selection
     operations (add, subtract, contains)
     \since QGIS 2.16
     \see selectSingleFeature()
   */
-  void selectMultipleFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, QMouseEvent *e );
+  void selectMultipleFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, const Qt::KeyboardModifiers &modifiers );
 
   /**
     Selects a single feature from within currently selected layer.
@@ -84,11 +84,11 @@ namespace QgsMapToolSelectUtils
     for any required geometry transformations
     \param selectGeometry the geometry to select the layers features. This geometry
     must be in terms of the canvas coordinate system.
-    \param e MouseEvents are used to determine the current selection
+    \param modifiers Keyboard modifiers are used to determine the current selection
     operations (add, subtract, contains)
     \see selectMultipleFeatures()
   */
-  void selectSingleFeature( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, QMouseEvent *e );
+  void selectSingleFeature( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, const Qt::KeyboardModifiers &modifiers );
 
   /**
     Get the current selected canvas map layer. Returns nullptr if it is not a vector layer


### PR DESCRIPTION
fix #17868

this is seen as a bugfix and will be merged in 3.0 to have coherent map tools changes
also add a user input (also features keyboard modifiers)

![https://media.giphy.com/media/3o751SIqkQeowDttkI/giphy.gif](https://media.giphy.com/media/3o751SIqkQeowDttkI/giphy.gif)

