### PR TITLE
Store ValueMap as QList instead of QMap

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -43,7 +43,7 @@ QgsValueMapConfigDlg::QgsValueMapConfigDlg( QgsVectorLayer *vl, int fieldIdx, QW
 
 QVariantMap QgsValueMapConfigDlg::config()
 {
-  QList<QPair<QString, QVariant>> valueList;
+  QList<QVariant> valueList;
 
   //store data to map
   for ( int i = 0; i < tableWidget->rowCount() - 1; i++ )
@@ -58,22 +58,21 @@ QVariantMap QgsValueMapConfigDlg::config()
     if ( ( ks == QgsApplication::nullRepresentation() ) && !( ki->flags() & Qt::ItemIsEditable ) )
       ks = QgsValueMapFieldFormatter::NULL_VALUE;
 
+    QVariantMap value;
+
     if ( !vi || vi->text().isNull() )
     {
-      valueList.append( qMakePair( ks, ks ) );
+      value.insert( ks, ks );
     }
     else
     {
-      valueList.append( qMakePair( vi->text(), ks ) );
+      value.insert( vi->text(), ks );
     }
+    valueList.append( value );
   }
 
-  QByteArray ba;
-  QDataStream data( &ba, QIODevice::WriteOnly );
-  data << valueList;
-
   QVariantMap cfg;
-  cfg.insert( QStringLiteral( "map" ), ba );
+  cfg.insert( QStringLiteral( "map" ), valueList );
   return cfg;
 }
 
@@ -85,17 +84,13 @@ void QgsValueMapConfigDlg::setConfig( const QVariantMap &config )
     tableWidget->removeRow( i );
   }
 
-  QList<QPair<QString, QVariant>> valueList;
-
-  QByteArray ba = config.value( QStringLiteral( "map" ) ).toByteArray();
-  QDataStream data( &ba, QIODevice::ReadOnly );
-  data >> valueList;
+  QList<QVariant> valueList = config.value( QStringLiteral( "map" ) ).toList();
 
   if ( valueList.count() > 0 )
   {
     for ( int i = 0, row = 0; i < valueList.count(); i++, row++ )
     {
-      setRow( row, valueList[i].second.toString(), valueList[i].first );
+      setRow( row, valueList[i].toMap().constBegin().value().toString(), valueList[i].toMap().constBegin().key() );
     }
   }
   else

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -58,14 +58,31 @@ void QgsValueMapWidgetWrapper::initWidget( QWidget *editor )
 
   if ( mComboBox )
   {
-    const QVariantMap map = config().value( QStringLiteral( "map" ) ).toMap();
-    QVariantMap::ConstIterator it = map.constBegin();
+    QList<QPair<QString, QVariant>> valueList;
 
-    while ( it != map.constEnd() )
+    QByteArray ba = config().value( QStringLiteral( "map" ) ).toByteArray();
+    QDataStream data( &ba, QIODevice::ReadOnly );
+    data >> valueList;
+
+    if ( valueList.count() > 0 )
     {
-      mComboBox->addItem( it.key(), it.value() );
-      ++it;
+      for ( int i = 0; i < valueList.count(); i++ )
+      {
+        mComboBox->addItem( valueList[i].first, valueList[i].second );
+      }
     }
+    else
+    {
+      const QVariantMap map = config().value( QStringLiteral( "map" ) ).toMap();
+      QVariantMap::ConstIterator it = map.constBegin();
+
+      while ( it != map.constEnd() )
+      {
+        mComboBox->addItem( it.key(), it.value() );
+        ++it;
+      }
+    }
+
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ),
              this, static_cast<void ( QgsEditorWidgetWrapper::* )()>( &QgsEditorWidgetWrapper::emitValueChanged ) );
   }

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -58,17 +58,13 @@ void QgsValueMapWidgetWrapper::initWidget( QWidget *editor )
 
   if ( mComboBox )
   {
-    QList<QPair<QString, QVariant>> valueList;
-
-    QByteArray ba = config().value( QStringLiteral( "map" ) ).toByteArray();
-    QDataStream data( &ba, QIODevice::ReadOnly );
-    data >> valueList;
+    QList<QVariant> valueList = config().value( QStringLiteral( "map" ) ).toList();
 
     if ( valueList.count() > 0 )
     {
-      for ( int i = 0; i < valueList.count(); i++ )
+      for ( int i = 0, row = 0; i < valueList.count(); i++, row++ )
       {
-        mComboBox->addItem( valueList[i].first, valueList[i].second );
+        mComboBox->addItem( valueList[i].toMap().constBegin().key(), valueList[i].toMap().constBegin().value() );
       }
     }
     else

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -119,7 +119,7 @@ class TestQgsValueMapEditWidget(unittest.TestCase):
         reg = QgsGui.editorWidgetRegistry()
         configWdg = reg.createConfigWidget('ValueMap', layer, 0, None)
 
-        config = {'map': [ {'two': '2'}, {'twoandhalf': '2.5'}, {'NULL text': 'NULL'}, {'nothing': self.VALUEMAP_NULL_TEXT} ] }
+        config = {'map': [{'two': '2'}, {'twoandhalf': '2.5'}, {'NULL text': 'NULL'}, {'nothing': self.VALUEMAP_NULL_TEXT}]}
 
         # Set a configuration containing values and NULL and check if it
         # is returned intact.

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -119,8 +119,7 @@ class TestQgsValueMapEditWidget(unittest.TestCase):
         reg = QgsGui.editorWidgetRegistry()
         configWdg = reg.createConfigWidget('ValueMap', layer, 0, None)
 
-        config = {'map': {'two': '2', 'twoandhalf': '2.5', 'NULL text': 'NULL',
-                          'nothing': self.VALUEMAP_NULL_TEXT}}
+        config = {'map': [ {'two': '2'}, {'twoandhalf': '2.5'}, {'NULL text': 'NULL'}, {'nothing': self.VALUEMAP_NULL_TEXT} ] }
 
         # Set a configuration containing values and NULL and check if it
         # is returned intact.


### PR DESCRIPTION
## Description
Store the valuemap in the field widget configuration as a QList (of 2D QMaps) instead of one QMap. This because with QMap it looses the order, like the user entered the data - users took that as a bug.

Means. When you entered a range before like with logical order, the combobox sorted it alphabetically:
![bad sorting](https://user-images.githubusercontent.com/28384354/35053401-49d7d2a4-fbaa-11e7-926c-722d576e1bec.png)

This because a QMap sorts the key-values alphabetically. 

Now it keeps the order, like the user entered it in the configuration. If he want's them sorted, he still can sort them by clicking the headers.
![valuemap_good-sorting2](https://user-images.githubusercontent.com/28384354/35053413-5167f0bc-fbaa-11e7-8020-4c88fce65a59.gif)

For the backwards compatibility QGIS is still able to read data stored in QMap format, and stores it after in the QList way.

Fix: 
