### PR TITLE
Fix slow layout designer when map item uses a preset theme setting

### DIFF
--- a/python/core/layout/qgslayoutitemmap.sip.in
+++ b/python/core/layout/qgslayoutitemmap.sip.in
@@ -458,9 +458,13 @@ This is calculated using the width of the map item and the width of the
 current visible map extent.
 %End
 
-    QgsMapSettings mapSettings( const QgsRectangle &extent, QSizeF size, double dpi ) const;
+    QgsMapSettings mapSettings( const QgsRectangle &extent, QSizeF size, double dpi, bool includeLayerSettings ) const;
 %Docstring
 Return map settings that will be used for drawing of the map.
+
+If ``includeLayerSettings`` is true, than settings specifically relating to map layers and map layer styles
+will be calculated. This can be expensive to calculate, so if they are not required in the map settings
+(e.g. for map settings which are used for scale related calculations only) then ``includeLayerSettings`` should be false.
 %End
 
     virtual void finalizeRestoreFromXml();

--- a/src/app/layout/qgslayoutmapwidget.cpp
+++ b/src/app/layout/qgslayoutmapwidget.cpp
@@ -824,7 +824,7 @@ void QgsLayoutMapWidget::mUpdatePreviewButton_clicked()
   {
     return;
   }
-  mMapItem->invalidateCache();
+  mMapItem->refresh();
 }
 
 void QgsLayoutMapWidget::mFollowVisibilityPresetCheckBox_stateChanged( int state )

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -89,7 +89,7 @@ void QgsLayoutItemLegend::paint( QPainter *painter, const QStyleOptionGraphicsIt
     QSizeF mapSizePixels = QSizeF( mMap->rect().width() * dotsPerMM, mMap->rect().height() * dotsPerMM );
     QgsRectangle mapExtent = mMap->extent();
 
-    QgsMapSettings ms = mMap->mapSettings( mapExtent, mapSizePixels, dpi );
+    QgsMapSettings ms = mMap->mapSettings( mapExtent, mapSizePixels, dpi, false );
     mSettings.setMapScale( ms.scale() );
   }
   mInitialMapScaleCalculated = true;
@@ -761,7 +761,7 @@ void QgsLayoutItemLegend::doUpdateFilterByMap()
     QSizeF size( requestRectangle.width(), requestRectangle.height() );
     size *= mLayout->convertFromLayoutUnits( mMap->mapUnitsToLayoutUnits(), QgsUnitTypes::LayoutMillimeters ).length() * dpi / 25.4;
 
-    QgsMapSettings ms = mMap->mapSettings( requestRectangle, size, dpi );
+    QgsMapSettings ms = mMap->mapSettings( requestRectangle, size, dpi, true );
 
     QgsGeometry filterPolygon;
     if ( mInAtlas )

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -408,8 +408,12 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
 
     /**
      * Return map settings that will be used for drawing of the map.
+     *
+     * If \a includeLayerSettings is true, than settings specifically relating to map layers and map layer styles
+     * will be calculated. This can be expensive to calculate, so if they are not required in the map settings
+     * (e.g. for map settings which are used for scale related calculations only) then \a includeLayerSettings should be false.
      */
-    QgsMapSettings mapSettings( const QgsRectangle &extent, QSizeF size, double dpi ) const;
+    QgsMapSettings mapSettings( const QgsRectangle &extent, QSizeF size, double dpi, bool includeLayerSettings ) const;
 
     void finalizeRestoreFromXml() override;
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -483,6 +483,8 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
 
     void shapeChanged();
 
+    void mapThemeChanged( const QString &theme );
+
   private:
 
 
@@ -550,6 +552,11 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
     bool mKeepLayerStyles = false;
     //! Stored style names (value) to be used with particular layer IDs (key) instead of default style
     QMap<QString, QString> mLayerStyleOverrides;
+
+    //! Empty if no cached style overrides stored
+    mutable QString mCachedLayerStyleOverridesPresetName;
+    //! Cached style overrides, used to avoid frequent expensive lookups of the preset style override
+    mutable QMap<QString, QString> mCachedPresetLayerStyleOverrides;
 
     /**
      * Whether layers and styles should be used from a preset (preset name is stored

--- a/src/core/layout/qgslayoututils.cpp
+++ b/src/core/layout/qgslayoututils.cpp
@@ -123,7 +123,7 @@ QgsRenderContext QgsLayoutUtils::createRenderContextForMap( QgsLayoutItemMap *ma
     QgsRectangle extent = map->extent();
     QSizeF mapSizeLayoutUnits = map->rect().size();
     QSizeF mapSizeMM = map->layout()->convertFromLayoutUnits( mapSizeLayoutUnits, QgsUnitTypes::LayoutMillimeters ).toQSizeF();
-    QgsMapSettings ms = map->mapSettings( extent, mapSizeMM * dotsPerMM, dpi );
+    QgsMapSettings ms = map->mapSettings( extent, mapSizeMM * dotsPerMM, dpi, false );
     QgsRenderContext context = QgsRenderContext::fromMapSettings( ms );
     if ( painter )
       context.setPainter( painter );


### PR DESCRIPTION
Because looking up the theme style overrides is very expensive to do, we do everything possible to avoid it whenever we can...