### PR TITLE
[ui] prevent infinite canvas redraw due to progress bar changing status bar height when shown/hidden.

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2783,10 +2783,8 @@ void QgisApp::createStatusBar()
   // And also rendering suppression checkbox
   mProgressBar = new QProgressBar( mStatusBar );
   mProgressBar->setObjectName( QStringLiteral( "mProgressBar" ) );
-  mProgressBar->setMaximumWidth( 100 );
-  mProgressBar->hide();
-  mProgressBar->setWhatsThis( tr( "Progress bar that displays the status "
-                                  "of rendering layers and other time-intensive operations" ) );
+  mProgressBar->setMaximumWidth( 0 );
+  mProgressBar->setMaximumHeight( 18 );
   mStatusBar->addPermanentWidget( mProgressBar, 1 );
 
   connect( mMapCanvas, &QgsMapCanvas::renderStarting, this, &QgisApp::canvasRefreshStarted );
@@ -11083,14 +11081,14 @@ void QgisApp::showProgress( int progress, int totalSteps )
   if ( progress == totalSteps )
   {
     mProgressBar->reset();
-    mProgressBar->hide();
+    mProgressBar->setMaximumWidth( 0 );
   }
   else
   {
     //only call show if not already hidden to reduce flicker
-    if ( !mProgressBar->isVisible() )
+    if ( mProgressBar->maximumWidth() == 0 )
     {
-      mProgressBar->show();
+      mProgressBar->setMaximumWidth( 100 );
     }
     mProgressBar->setMaximum( totalSteps );
     mProgressBar->setValue( progress );


### PR DESCRIPTION
## Description
During a training session to a dozen windows GIS users today, I witnessed a very serious problem: on half of the machines (that's six!), the status bar would expand of a few pixels when the progress bar appears, resulting in the following infinite cycle of canvas redraw:
1/ canvas starts redrawing
2/ progress bar appears, expanding the status bar height & changing the canvas size
3/ canvas redraws
3/ progress bar disappears after redraw is over, shrinking the status bar height & changing the canvas size
4/ canvas redraws
5/ progress bar appears,
etc. etc. etc. 

Yes, it's as bad as it reads.

This PR prevents this infinite cycle of madness by doing two things: i/ it doesn't hide the widget, instead just shrinks its width to 0, ii/ it limits the height too (it looks nicer, and its an additional safeguard to avoid increasing height of status bar.

Lesson learned: we shouldn't toggle visibility of elements in the status bar.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
