### PR TITLE
Fix tracking of imported modules (and plugin reloading)

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -664,7 +664,7 @@ def _import(name, globals={}, locals={}, fromlist=[], level=None):
     mod = _builtin_import(name, globals, locals, fromlist, level)
 
     if mod and '__file__' in mod.__dict__:
-        module_name = mod.__name__
+        module_name = mod.__name__ if fromlist else name
         package_name = module_name.split('.')[0]
         # check whether the module belongs to one of our plugins
         if package_name in available_plugins:


### PR DESCRIPTION
This PR fixes plugin reloading which was partially broken.

Details about the change:
`__import__(name, ..., fromlist, ...)` always returns the top-level package if `import x.y.z` is used (here `x`), and the module given by `name` if `from x.y.z import a` is used, here `x.y.z`. Differentiating between these two cases can be done by looking at the `fromlist` argument. By not tracking modules correctly, plugin unloading/reloading was broken if a module hierarchy within a plugin was used and `from` was not exclusively used.