### PR TITLE
[needs-docs] Allow adding and remove nodes from node tool selection

### DIFF
--- a/src/app/nodetool/qgsnodetool.h
+++ b/src/app/nodetool/qgsnodetool.h
@@ -165,7 +165,15 @@ class APP_EXPORT QgsNodeTool : public QgsMapToolAdvancedDigitizing
 
     void applyEditsToLayers( NodeEdits &edits );
 
-    void setHighlightedNodes( QList<Vertex> listNodes );
+
+    enum HighlightMode
+    {
+      ModeReset, //!< Reset any current selection
+      ModeAdd, //!< Add to current selection
+      ModeSubtract, //!< Remove from current selection
+    };
+
+    void setHighlightedNodes( const QList<Vertex> &listNodes, HighlightMode mode = ModeReset );
 
     void setHighlightedNodesVisible( bool visible );
 


### PR DESCRIPTION
Holding shift while clicking and dragging adds nodes to selection, holding ctrl removes nodes from selection.

Additionally, this commit:
- fixes the current 'select node but don't start moving' shortcut, but changes it from ctrl-click on a node to shift-click on a node (since it's 'adding' to the selection)
- makes ctrl-click on a single node remove just that node from the selection

Fixes #17259
