### PR TITLE
[cad] Fix precision issues with angle constraint (fixes #17685)

### DIFF
--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -202,7 +202,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   // 1. "hard" lock defined by the user
   // 2. "soft" lock from common angle (e.g. 45 degrees)
   bool angleLocked = false, angleRelative = false;
-  int angleValueDeg = 0;
+  double angleValueDeg = 0;
   if ( ctx.angleConstraint.locked )
   {
     angleLocked = true;


### PR DESCRIPTION
The angle was getting truncated and the alignment did not work well:

![image](https://user-images.githubusercontent.com/193367/35155924-7d9f24c6-fd2f-11e7-9384-c42b3d6d15e4.png)
