### PR TITLE
[bugfix] Set missing expression context in some filters (fixes #17893)

### DIFF
--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -137,6 +137,8 @@ int QgsAtlasComposition::updateFeatures()
   // select all features with all attributes
   QgsFeatureRequest req;
 
+  req.setExpressionContext( expressionContext );
+
   std::unique_ptr<QgsExpression> filterExpression;
   if ( mFilterFeatures && !mFeatureFilter.isEmpty() )
   {

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -118,6 +118,8 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
   request.setSubsetOfAttributes( QgsAttributeList() << ki << vi );
   if ( !config.value( QStringLiteral( "FilterExpression" ) ).toString().isEmpty() )
   {
+    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+    request.setExpressionContext( context );
     request.setFilterExpression( config.value( QStringLiteral( "FilterExpression" ) ).toString() );
   }
 

--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -220,6 +220,8 @@ int QgsLayoutAtlas::updateFeatures()
   // select all features with all attributes
   QgsFeatureRequest req;
 
+  req.setExpressionContext( expressionContext );
+
   mFilterParserError.clear();
   if ( mFilterFeatures && !mFilterExpression.isEmpty() )
   {


### PR DESCRIPTION
## Description
In some filters the expression context was not set, so that references to variables would only work in the preview, but not when actually using them. This PR fixes that.

I have attached a sample project with test data: [example.zip](https://github.com/qgis/QGIS/files/1648980/example.zip). The point layer has two cities ("Amsterdam" and "Zaandam") and two villages. A project variable is set to show only cities.
- The symbology is configured so that only the points for cities are shown. This works correctly already.
- The line layer "verbindingen" has two value relation fields connected to the points, with corresponding filter. This does not yet work, this PR fixes this in file `src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp`
- The layout "A4" has an atlas connected to the points, with corresponding filter. This does not yet work, this PR fixes this in file `src/core/composer/qgsatlascomposition.cpp`

The file `src/core/layout/qgslayoutatlas.cpp` seems very similar to the latter of the above, so I changed it as well. However, I cannot find any actual usage of it. What is the purpose of it?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit