### PR TITLE
Fix crash when executing background threadable processing algorithms on Windows

### DIFF
--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -417,6 +417,16 @@ QString QgsProcessingAlgorithmDialogBase::formatHelp( QgsProcessingAlgorithm *al
 
 void QgsProcessingAlgorithmDialogBase::processEvents()
 {
+  if ( mAlgorithmTask )
+  {
+    // no need to call this - the algorithm is running in a thread.
+    // in fact, calling it causes a crash on Windows when the algorithm
+    // is running in a background thread... unfortunately we need something
+    // like this for non-threadable algorithms, otherwise there's no chance
+    // for users to hit cancel or see progress updates...
+    return;
+  }
+
   // So that we get a chance of hitting the Abort button
 #ifdef Q_OS_LINUX
   // For some reason on Windows hasPendingEvents() always return true,


### PR DESCRIPTION
Yet again processEvents() comes around to bite us in the butt.

unfortunately we need the processEvents call for non-threadable algorithms, otherwise there's no chance for users to hit cancel or see progress updates...