### PR TITLE
Fix crash on exit caused by snapping widget

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -78,6 +78,10 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   {
     model->resetLayerTreeModel();
   } );
+  connect( mProject, &QObject::destroyed, this, [ = ]
+  {
+    mLayerTreeView->setModel( nullptr );
+  } );
   // model->setFlags( 0 );
   mLayerTreeView->setModel( model );
   mLayerTreeView->resizeColumnToContents( 0 );


### PR DESCRIPTION
Since the snapping widget is destroyed *after* the project instance, we need to avoid referring to the project after it's deleted.

I'm not super happy with this fix... but the alternative is to ensure that QgsLayerTreeModel correctly handles the linked project destruction... and that's a lot of work for something which usually never occurs