### PR TITLE
Fix layout items with non-top left reference move when exporting

### DIFF
--- a/src/core/layout/qgslayoutpagecollection.cpp
+++ b/src/core/layout/qgslayoutpagecollection.cpp
@@ -77,7 +77,7 @@ void QgsLayoutPageCollection::endPageSizeChange()
     {
       if ( !mBlockUndoCommands )
         item->beginCommand( QString() );
-      item->attemptMove( it.value().second, true, false, it.value().first );
+      item->attemptMove( it.value().second, false, false, it.value().first );
       if ( !mBlockUndoCommands )
         item->endCommand();
     }


### PR DESCRIPTION
Fixes #17910
