### PR TITLE
[ui] fix status bar's message item resizing window on long string

### DIFF
--- a/src/gui/qgsstatusbar.cpp
+++ b/src/gui/qgsstatusbar.cpp
@@ -17,7 +17,8 @@
 
 #include "qgsstatusbar.h"
 #include <QLayout>
-#include <QLabel>
+#include <QLineEdit>
+#include <QPalette>
 #include <QTimer>
 
 QgsStatusBar::QgsStatusBar( QWidget *parent )
@@ -28,8 +29,15 @@ QgsStatusBar::QgsStatusBar( QWidget *parent )
   mLayout->setContentsMargins( 2, 0, 2, 0 );
   mLayout->setSpacing( 6 );
 
-  mLabel = new QLabel( QString() );
-  mLayout->addWidget( mLabel, 1 );
+  mLineEdit = new QLineEdit( QString() );
+  mLineEdit->setDisabled( true );
+  mLineEdit->setFrame( false );
+  mLineEdit->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum );
+  QPalette palette;
+  palette.setColor( QPalette::Disabled, QPalette::Text, QPalette::WindowText );
+  mLineEdit->setPalette( palette );
+  mLineEdit->setStyleSheet( QStringLiteral( "* { background-color: rgba(0, 0, 0, 0); }" ) );
+  mLayout->addWidget( mLineEdit, 10 );
   setLayout( mLayout );
 }
 
@@ -54,12 +62,13 @@ void QgsStatusBar::removeWidget( QWidget *widget )
 
 QString QgsStatusBar::currentMessage() const
 {
-  return mLabel->text();
+  return mLineEdit->text();
 }
 
 void QgsStatusBar::showMessage( const QString &text, int timeout )
 {
-  mLabel->setText( text );
+  mLineEdit->setText( text );
+  mLineEdit->setCursorPosition( 0 );
   if ( timeout > 0 )
   {
     if ( !mTempMessageTimer )
@@ -78,5 +87,5 @@ void QgsStatusBar::showMessage( const QString &text, int timeout )
 
 void QgsStatusBar::clearMessage()
 {
-  mLabel->setText( QString() );
+  mLineEdit->setText( QString() );
 }

--- a/src/gui/qgsstatusbar.h
+++ b/src/gui/qgsstatusbar.h
@@ -23,7 +23,7 @@
 #include <QWidget>
 
 class QHBoxLayout;
-class QLabel;
+class QLineEdit;
 
 /**
  * \class QgsStatusBar
@@ -103,7 +103,7 @@ class GUI_EXPORT QgsStatusBar : public QWidget
   private:
 
     QHBoxLayout *mLayout = nullptr;
-    QLabel *mLabel = nullptr;
+    QLineEdit *mLineEdit = nullptr;
     QTimer *mTempMessageTimer = nullptr;
 
 };


### PR DESCRIPTION
## Description
This PR axes a long-standing UX issue on small screens: the (infamous) status bar message resizing the main window on long strings.

The nightmare is demonstrated in this short youtube video: https://www.youtube.com/watch?v=72k-hYxg4Yw&feature=youtu.be . To anyone who ever had to do QGIS presentations using projectors with low-resolution, this'll make your week 😄 

The solution offered here is to move away from a QLabel to use a read-only QLineEdit instead.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
