### PR TITLE
fix width in coordinate widget

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -202,8 +202,10 @@ void QgsStatusBarCoordinatesWidget::extentsViewToggled( bool flag )
     mToggleExtentsViewButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "tracking.svg" ) ) );
     mLineEdit->setToolTip( tr( "Map coordinates at mouse cursor position" ) );
     mLineEdit->setReadOnly( false );
+    mLineEdit->clear();
     mLabel->setText( tr( "Coordinate:" ) );
   }
+  resizeLineEdit();
 }
 
 void QgsStatusBarCoordinatesWidget::refreshMapCanvas()
@@ -232,7 +234,6 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPointXY &p )
   }
 }
 
-
 void QgsStatusBarCoordinatesWidget::showExtent()
 {
   if ( !mToggleExtentsViewButton->isChecked() )
@@ -244,9 +245,16 @@ void QgsStatusBarCoordinatesWidget::showExtent()
   QgsRectangle myExtents = mMapCanvas->extent();
   mLabel->setText( tr( "Extents:" ) );
   mLineEdit->setText( myExtents.toString( true ) );
-  //ensure the label is big enough
-  if ( mLineEdit->width() > mLineEdit->minimumWidth() )
-  {
-    mLineEdit->setMinimumWidth( mLineEdit->width() );
-  }
 }
+
+void QgsStatusBarCoordinatesWidget::resizeLineEdit()
+{
+  // margin is set because of this QT bug:
+  // https://bugreports.qt.io/browse/QTBUG-15974
+  int margin = 30;
+  QString text = mLineEdit->text();
+  QFontMetrics fm = mLineEdit->fontMetrics();
+  int w = fm.boundingRect( text ).width() + margin;
+  mLineEdit->setMinimumWidth( w );
+}
+

--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -59,6 +59,7 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     void validateCoordinates();
     void dizzy();
     void showExtent();
+    void resizeLineEdit();
 
   private:
     void refreshMapCanvas();


### PR DESCRIPTION
## Description
The coordinate/extent text in the status bar widget is cut off when toggle extent and mouse position display. This PR fixes issue #16740

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
