### PR TITLE
[reports] allow header and footer sections to always be included

### DIFF
--- a/python/core/layout/qgsreportsectionfieldgroup.sip.in
+++ b/python/core/layout/qgsreportsectionfieldgroup.sip.in
@@ -28,6 +28,12 @@ class QgsReportSectionFieldGroup : QgsAbstractReportSection
 %End
   public:
 
+    enum SectionVisibility
+    {
+      IncludeWhenFeaturesFound,
+      AlwaysInclude
+    };
+
     QgsReportSectionFieldGroup( QgsAbstractReportSection *parentSection = 0 );
 %Docstring
 Constructor for QgsReportSectionFieldGroup, attached to the specified ``parent`` section.
@@ -128,6 +134,34 @@ Sets whether the field values should be sorted ascending. Set to true to sort
 ascending, or false for descending sort.
 
 .. seealso:: :py:func:`sortAscending`
+%End
+
+    SectionVisibility headerVisibility() const;
+%Docstring
+Returns the header visibility mode.
+
+.. seealso:: :py:func:`setHeaderVisibility`
+%End
+
+    void setHeaderVisibility( SectionVisibility visibility );
+%Docstring
+Sets the visibility mode for the header.
+
+.. seealso:: :py:func:`headerVisibility`
+%End
+
+    SectionVisibility footerVisibility() const;
+%Docstring
+Returns the footer visibility mode.
+
+.. seealso:: :py:func:`setFooterVisibility`
+%End
+
+    void setFooterVisibility( SectionVisibility visibility );
+%Docstring
+Sets the visibility mode for the footer.
+
+.. seealso:: :py:func:`footerVisibility`
 %End
 
     virtual QgsReportSectionFieldGroup *clone() const /Factory/;

--- a/src/app/layout/qgsreportfieldgroupsectionwidget.cpp
+++ b/src/app/layout/qgsreportfieldgroupsectionwidget.cpp
@@ -39,25 +39,43 @@ QgsReportSectionFieldGroupWidget::QgsReportSectionFieldGroupWidget( QgsReportOrg
   mSortAscendingCheckBox->setChecked( section->sortAscending() );
 
   mCheckShowHeader->setChecked( section->headerEnabled() );
+  mCheckHeaderAlwaysVisible->setChecked( section->headerVisibility() == QgsReportSectionFieldGroup::AlwaysInclude );
+  mCheckHeaderAlwaysVisible->setEnabled( section->headerEnabled() );
   mCheckShowFooter->setChecked( section->footerEnabled() );
+  mCheckFooterAlwaysVisible->setChecked( section->headerVisibility() == QgsReportSectionFieldGroup::AlwaysInclude );
+  mCheckFooterAlwaysVisible->setEnabled( section->footerEnabled() );
   mCheckShowBody->setChecked( section->bodyEnabled() );
 
   connect( mSortAscendingCheckBox, &QCheckBox::toggled, this, &QgsReportSectionFieldGroupWidget::sortAscendingToggled );
   connect( mLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsReportSectionFieldGroupWidget::setLayer );
   connect( mFieldComboBox, &QgsFieldComboBox::fieldChanged, this, &QgsReportSectionFieldGroupWidget::setField );
   connect( mCheckShowHeader, &QCheckBox::toggled, this, &QgsReportSectionFieldGroupWidget::toggleHeader );
+  connect( mCheckHeaderAlwaysVisible, &QCheckBox::toggled, this, &QgsReportSectionFieldGroupWidget::toggleHeaderAlwaysVisible );
   connect( mCheckShowFooter, &QCheckBox::toggled, this, &QgsReportSectionFieldGroupWidget::toggleFooter );
+  connect( mCheckFooterAlwaysVisible, &QCheckBox::toggled, this, &QgsReportSectionFieldGroupWidget::toggleFooterAlwaysVisible );
   connect( mCheckShowBody, &QCheckBox::toggled, this, &QgsReportSectionFieldGroupWidget::toggleBody );
 }
 
 void QgsReportSectionFieldGroupWidget::toggleHeader( bool enabled )
 {
   mSection->setHeaderEnabled( enabled );
+  mCheckHeaderAlwaysVisible->setEnabled( enabled );
+}
+
+void QgsReportSectionFieldGroupWidget::toggleHeaderAlwaysVisible( bool enabled )
+{
+  mSection->setHeaderVisibility( enabled ? QgsReportSectionFieldGroup::AlwaysInclude : QgsReportSectionFieldGroup::IncludeWhenFeaturesFound );
 }
 
 void QgsReportSectionFieldGroupWidget::toggleFooter( bool enabled )
 {
   mSection->setFooterEnabled( enabled );
+  mCheckFooterAlwaysVisible->setEnabled( enabled );
+}
+
+void QgsReportSectionFieldGroupWidget::toggleFooterAlwaysVisible( bool enabled )
+{
+  mSection->setFooterVisibility( enabled ? QgsReportSectionFieldGroup::AlwaysInclude : QgsReportSectionFieldGroup::IncludeWhenFeaturesFound );
 }
 
 void QgsReportSectionFieldGroupWidget::editHeader()

--- a/src/app/layout/qgsreportfieldgroupsectionwidget.h
+++ b/src/app/layout/qgsreportfieldgroupsectionwidget.h
@@ -32,7 +32,9 @@ class QgsReportSectionFieldGroupWidget: public QWidget, private Ui::QgsReportWid
   private slots:
 
     void toggleHeader( bool enabled );
+    void toggleHeaderAlwaysVisible( bool enabled );
     void toggleFooter( bool enabled );
+    void toggleFooterAlwaysVisible( bool enabled );
     void editHeader();
     void editFooter();
     void toggleBody( bool enabled );

--- a/src/core/layout/qgsreportsectionfieldgroup.cpp
+++ b/src/core/layout/qgsreportsectionfieldgroup.cpp
@@ -94,12 +94,12 @@ bool QgsReportSectionFieldGroup::prepareHeader()
   header()->reportContext().setFeature( mHeaderFeature );
   mSkipNextRequest = true;
   mNoFeatures = !mHeaderFeature.isValid();
-  return !mNoFeatures;
+  return mHeaderVisibility == AlwaysInclude || !mNoFeatures;
 }
 
 bool QgsReportSectionFieldGroup::prepareFooter()
 {
-  return !mNoFeatures;
+  return mFooterVisibility == AlwaysInclude || !mNoFeatures;
 }
 
 QgsLayout *QgsReportSectionFieldGroup::nextBody( bool &ok )
@@ -179,6 +179,8 @@ void QgsReportSectionFieldGroup::reloadSettings()
 
 bool QgsReportSectionFieldGroup::writePropertiesToElement( QDomElement &element, QDomDocument &doc, const QgsReadWriteContext &context ) const
 {
+  element.setAttribute( QStringLiteral( "headerVisibility" ), static_cast< int >( mHeaderVisibility ) );
+  element.setAttribute( QStringLiteral( "footerVisibility" ), static_cast< int >( mFooterVisibility ) );
   element.setAttribute( QStringLiteral( "field" ), mField );
   element.setAttribute( QStringLiteral( "ascending" ), mSortAscending ? "1" : "0" );
   element.setAttribute( QStringLiteral( "bodyEnabled" ), mBodyEnabled ? "1" : "0" );
@@ -201,6 +203,8 @@ bool QgsReportSectionFieldGroup::writePropertiesToElement( QDomElement &element,
 
 bool QgsReportSectionFieldGroup::readPropertiesFromElement( const QDomElement &element, const QDomDocument &doc, const QgsReadWriteContext &context )
 {
+  mHeaderVisibility = static_cast< SectionVisibility >( element.attribute( QStringLiteral( "headerVisibility" ) ).toInt() );
+  mFooterVisibility = static_cast< SectionVisibility >( element.attribute( QStringLiteral( "footerVisibility" ) ).toInt() );
   mField = element.attribute( QStringLiteral( "field" ) );
   mSortAscending = element.attribute( QStringLiteral( "ascending" ) ).toInt();
   mBodyEnabled = element.attribute( QStringLiteral( "bodyEnabled" ) ).toInt();

--- a/src/core/layout/qgsreportsectionfieldgroup.h
+++ b/src/core/layout/qgsreportsectionfieldgroup.h
@@ -39,6 +39,15 @@ class CORE_EXPORT QgsReportSectionFieldGroup : public QgsAbstractReportSection
   public:
 
     /**
+     * Visibility modes for header and footer sections
+     */
+    enum SectionVisibility
+    {
+      IncludeWhenFeaturesFound,      //!< The section will be included when features are found
+      AlwaysInclude                  //!< The section will always be included
+    };
+
+    /**
      * Constructor for QgsReportSectionFieldGroup, attached to the specified \a parent section.
      * Note that ownership is not transferred to \a parent.
      */
@@ -120,6 +129,30 @@ class CORE_EXPORT QgsReportSectionFieldGroup : public QgsAbstractReportSection
      */
     void setSortAscending( bool sortAscending );
 
+    /**
+     * Returns the header visibility mode.
+     * \see setHeaderVisibility()
+     */
+    SectionVisibility headerVisibility() const { return mHeaderVisibility; }
+
+    /**
+     * Sets the visibility mode for the header.
+     * \see headerVisibility()
+     */
+    void setHeaderVisibility( SectionVisibility visibility ) { mHeaderVisibility = visibility; }
+
+    /**
+     * Returns the footer visibility mode.
+     * \see setFooterVisibility()
+     */
+    SectionVisibility footerVisibility() const { return mFooterVisibility; }
+
+    /**
+     * Sets the visibility mode for the footer.
+     * \see footerVisibility()
+     */
+    void setFooterVisibility( SectionVisibility visibility ) { mFooterVisibility = visibility; }
+
     QgsReportSectionFieldGroup *clone() const override SIP_FACTORY;
     bool beginRender() override;
     bool prepareHeader() override;
@@ -143,6 +176,8 @@ class CORE_EXPORT QgsReportSectionFieldGroup : public QgsAbstractReportSection
     QgsFeatureIterator mFeatures;
     bool mSkipNextRequest = false;
     bool mNoFeatures = false;
+    SectionVisibility mHeaderVisibility = IncludeWhenFeaturesFound;
+    SectionVisibility mFooterVisibility = IncludeWhenFeaturesFound;
     QgsFeature mHeaderFeature;
     QgsFeature mLastFeature;
     QSet< QVariant > mEncounteredValues;

--- a/src/ui/layout/qgsreportwidgetfieldgroupsectionbase.ui
+++ b/src/ui/layout/qgsreportwidgetfieldgroupsectionbase.ui
@@ -16,14 +16,14 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QPushButton" name="mButtonEditFooter">
        <property name="text">
         <string>Edit</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="2">
+     <item row="5" column="2">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -36,44 +36,52 @@
        </property>
       </spacer>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Field</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1" colspan="2">
+     <item row="4" column="1" colspan="2">
       <widget class="QCheckBox" name="mSortAscendingCheckBox">
        <property name="text">
         <string>Sort ascending</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Layer</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1" colspan="2">
+     <item row="2" column="1" colspan="2">
       <widget class="QgsMapLayerComboBox" name="mLayerComboBox"/>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QPushButton" name="mButtonEditBody">
        <property name="text">
         <string>Edit</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1" colspan="2">
+     <item row="3" column="1" colspan="2">
       <widget class="QgsFieldComboBox" name="mFieldComboBox"/>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QCheckBox" name="mCheckShowFooter">
        <property name="text">
         <string>Include footer</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0" colspan="2">
+      <widget class="QCheckBox" name="mCheckFooterAlwaysVisible">
+       <property name="text">
+        <string>Show footer when no matching
+features are found</string>
        </property>
       </widget>
      </item>
@@ -91,7 +99,15 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="1" column="0" colspan="2">
+      <widget class="QCheckBox" name="mCheckHeaderAlwaysVisible">
+       <property name="text">
+        <string>Show header when no matching
+features are found</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
       <widget class="QCheckBox" name="mCheckShowBody">
        <property name="text">
         <string>Include body</string>

--- a/tests/src/python/test_qgsreport.py
+++ b/tests/src/python/test_qgsreport.py
@@ -725,6 +725,38 @@ class TestQgsReport(unittest.TestCase):
         self.assertEqual(r.layout(), report_footer)
         self.assertFalse(r.next())
 
+    def testFieldGroupSectionVisibility(self):
+        states = QgsVectorLayer("Point?crs=epsg:4326&field=country:string(20)&field=state:string(20)", "points", "memory")
+
+        p = QgsProject()
+        r = QgsReport(p)
+
+        # add a child
+        child1 = QgsReportSectionFieldGroup()
+        child1.setLayer(states)
+        child1.setField('country')
+        child1_header = QgsLayout(p)
+        child1.setHeader(child1_header)
+        child1.setHeaderEnabled(True)
+        child1_footer = QgsLayout(p)
+        child1.setFooter(child1_footer)
+        child1.setFooterEnabled(True)
+        r.appendChild(child1)
+
+        # check that no header was rendered when no features are found
+        self.assertTrue(r.beginRender())
+        self.assertFalse(r.next())
+
+        child1.setHeaderVisibility(QgsReportSectionFieldGroup.AlwaysInclude)
+        child1.setFooterVisibility(QgsReportSectionFieldGroup.AlwaysInclude)
+
+        # check that the header is included when no features are found
+        self.assertTrue(r.beginRender())
+        self.assertTrue(r.next())
+        self.assertEqual(r.layout(), child1_header)
+        self.assertTrue(r.next())
+        self.assertEqual(r.layout(), child1_footer)
+
     def testFieldGroupMultiLayer(self):
         # create a layer
         states = QgsVectorLayer("Point?crs=epsg:4326&field=country:string(20)&field=state:string(20)", "points", "memory")


### PR DESCRIPTION
## Description
@nyalldawson , small follow up to your field group section tweak from earlier today.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
