### PR TITLE
Update all attributes in a single transaction

### DIFF
--- a/python/core/qgsvectorlayer.sip.in
+++ b/python/core/qgsvectorlayer.sip.in
@@ -1504,6 +1504,50 @@ Returns true if the feature's attribute was successfully changed.
 .. seealso:: :py:func:`updateFeature`
 %End
 
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skeipDefaultValues = false );
+%Docstring
+Changes attributes' values for a feature (but does not immediately
+commit the changes).
+The ``fid`` argument specifies the ID of the feature to be changed.
+
+The new values to be assigned to the fields are given by ``newValues``.
+
+If a valid QVariant is specified for a field in ``oldValues``, it will be
+used as the field value in the case of an undo operation corresponding
+to this attribute value change. If an invalid QVariant is used (the
+default behavior), then the feature's current value will be
+automatically retrieved and used. Note that this involves a feature
+request to the underlying data provider, so it is more efficient to
+explicitly pass an oldValue if it is already available.
+
+If ``skipDefaultValue`` is set to true, default field values will not
+be updated. This can be used to override default field value
+expressions.
+
+Returns true if feature's attributes was successfully changed.
+
+.. note::
+
+   Calls to changeAttributeValues() are only valid for layers in
+   which edits have been enabled by a call to startEditing(). Changes made
+   to features using this method are not committed to the underlying data
+   provider until a commitChanges() call is made. Any uncommitted changes
+   can be discarded by calling rollBack().
+
+.. seealso:: :py:func:`startEditing`
+
+.. seealso:: :py:func:`commitChanges`
+
+.. seealso:: :py:func:`changeGeometry`
+
+.. seealso:: :py:func:`updateFeature`
+
+.. seealso:: :py:func:`changeAttributeValue`
+
+
+.. versionadded:: 3.0
+%End
+
     bool addAttribute( const QgsField &field );
 %Docstring
 Add an attribute field (but does not commit it)

--- a/python/core/qgsvectorlayer.sip.in
+++ b/python/core/qgsvectorlayer.sip.in
@@ -1483,7 +1483,7 @@ QVariant is used (the default behavior), then the feature's current value will b
 retrieved and used. Note that this involves a feature request to the underlying data provider,
 so it is more efficient to explicitly pass an ``oldValue`` if it is already available.
 
-If ``skipDefaultValue`` is set to true, default field values will not
+If ``skipDefaultValues`` is set to true, default field values will not
 be updated. This can be used to override default field value expressions.
 
 Returns true if the feature's attribute was successfully changed.
@@ -1504,7 +1504,7 @@ Returns true if the feature's attribute was successfully changed.
 .. seealso:: :py:func:`updateFeature`
 %End
 
-    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skeipDefaultValues = false );
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skipDefaultValues = false );
 %Docstring
 Changes attributes' values for a feature (but does not immediately
 commit the changes).
@@ -1520,7 +1520,7 @@ automatically retrieved and used. Note that this involves a feature
 request to the underlying data provider, so it is more efficient to
 explicitly pass an oldValue if it is already available.
 
-If ``skipDefaultValue`` is set to true, default field values will not
+If ``skipDefaultValues`` is set to true, default field values will not
 be updated. This can be used to override default field value
 expressions.
 

--- a/python/core/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/qgsvectorlayereditbuffer.sip.in
@@ -60,6 +60,15 @@ Change feature's geometry
 Changed an attribute value (but does not commit it)
 %End
 
+    virtual bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
+%Docstring
+Changes values of attributes (but does not commit it).
+
+:return: true if attributes are well updated, false otherwise
+
+.. versionadded:: 3.0
+%End
+
     virtual bool addAttribute( const QgsField &field );
 %Docstring
 Add an attribute field (but does not commit it)

--- a/python/core/qgsvectorlayereditpassthrough.sip.in
+++ b/python/core/qgsvectorlayereditpassthrough.sip.in
@@ -30,6 +30,17 @@ class QgsVectorLayerEditPassthrough : QgsVectorLayerEditBuffer
 
     virtual bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
 
+
+    virtual bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
+
+%Docstring
+Changes values of attributes (but does not commit it).
+
+:return: true if attributes are well updated, false otherwise
+
+.. versionadded:: 3.0
+%End
+
     virtual bool addAttribute( const QgsField &field );
 
     virtual bool deleteAttribute( int attr );

--- a/python/core/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/qgsvectorlayerjoinbuffer.sip.in
@@ -188,6 +188,23 @@ created if its fields are not empty.
 .. versionadded:: 3.0
 %End
 
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap() );
+%Docstring
+Changes attributes' values in joined layers. The feature id given in
+parameter is the one added in target layer. If the corresponding joined
+feature does not exist in a joined layer, then it's automatically
+created if its fields are not empty.
+
+:param fid: The feature id
+:param newValues: The new values for attributes
+:param oldValues: The old values for attributes
+
+:return: false if an error happened, true otherwise
+
+
+.. versionadded:: 3.0
+%End
+
     bool deleteFeature( QgsFeatureId fid ) const;
 %Docstring
 Deletes a feature from joined layers. The feature id given in

--- a/python/core/qgsvectorlayerundopassthroughcommand.sip.in
+++ b/python/core/qgsvectorlayerundopassthroughcommand.sip.in
@@ -202,6 +202,37 @@ Constructor for QgsVectorLayerUndoPassthroughCommandChangeAttribute
 };
 
 
+class QgsVectorLayerUndoPassthroughCommandChangeAttributes: QgsVectorLayerUndoPassthroughCommand
+{
+%Docstring
+ Undo command for changing attributes' values from a vector layer in transaction group.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsvectorlayerundopassthroughcommand.h"
+%End
+  public:
+
+    QgsVectorLayerUndoPassthroughCommandChangeAttributes( QgsVectorLayerEditBuffer *buffer /Transfer/, QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap() );
+%Docstring
+Constructor for QgsVectorLayerUndoPassthroughCommandChangeAttributes
+
+:param buffer: associated edit buffer
+:param fid: feature ID of feature
+:param newValues: New values for attributes
+:param oldValues: Old values for attributes
+%End
+
+    virtual void undo();
+
+    virtual void redo();
+
+
+};
+
+
 class QgsVectorLayerUndoPassthroughCommandAddAttribute : QgsVectorLayerUndoPassthroughCommand
 {
 %Docstring

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1396,6 +1396,43 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant(), bool skipDefaultValues = false );
 
     /**
+     * Changes attributes' values for a feature (but does not immediately
+     * commit the changes).
+     * The \a fid argument specifies the ID of the feature to be changed.
+     *
+     * The new values to be assigned to the fields are given by \a newValues.
+     *
+     * If a valid QVariant is specified for a field in \a oldValues, it will be
+     * used as the field value in the case of an undo operation corresponding
+     * to this attribute value change. If an invalid QVariant is used (the
+     * default behavior), then the feature's current value will be
+     * automatically retrieved and used. Note that this involves a feature
+     * request to the underlying data provider, so it is more efficient to
+     * explicitly pass an oldValue if it is already available.
+     *
+     * If \a skipDefaultValue is set to true, default field values will not
+     * be updated. This can be used to override default field value
+     * expressions.
+     *
+     * Returns true if feature's attributes was successfully changed.
+     *
+     * \note Calls to changeAttributeValues() are only valid for layers in
+     * which edits have been enabled by a call to startEditing(). Changes made
+     * to features using this method are not committed to the underlying data
+     * provider until a commitChanges() call is made. Any uncommitted changes
+     * can be discarded by calling rollBack().
+     *
+     * \see startEditing()
+     * \see commitChanges()
+     * \see changeGeometry()
+     * \see updateFeature()
+     * \see changeAttributeValue()
+     *
+     * \since QGIS 3.0
+     */
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skeipDefaultValues = false );
+
+    /**
      * Add an attribute field (but does not commit it)
      * returns true if the field was added
      *
@@ -2376,6 +2413,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! stores information about uncommitted changes to layer
     QgsVectorLayerEditBuffer *mEditBuffer = nullptr;
     friend class QgsVectorLayerEditBuffer;
+    friend class QgsVectorLayerEditPassthrough;
 
     //stores information about joined layers
     QgsVectorLayerJoinBuffer *mJoinBuffer = nullptr;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1378,7 +1378,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * retrieved and used. Note that this involves a feature request to the underlying data provider,
      * so it is more efficient to explicitly pass an \a oldValue if it is already available.
      *
-     * If \a skipDefaultValue is set to true, default field values will not
+     * If \a skipDefaultValues is set to true, default field values will not
      * be updated. This can be used to override default field value expressions.
      *
      * Returns true if the feature's attribute was successfully changed.
@@ -1410,7 +1410,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * request to the underlying data provider, so it is more efficient to
      * explicitly pass an oldValue if it is already available.
      *
-     * If \a skipDefaultValue is set to true, default field values will not
+     * If \a skipDefaultValues is set to true, default field values will not
      * be updated. This can be used to override default field value
      * expressions.
      *
@@ -1430,7 +1430,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \since QGIS 3.0
      */
-    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skeipDefaultValues = false );
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap(), bool skipDefaultValues = false );
 
     /**
      * Add an attribute field (but does not commit it)

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -208,6 +208,23 @@ bool QgsVectorLayerEditBuffer::changeGeometry( QgsFeatureId fid, const QgsGeomet
   return true;
 }
 
+bool QgsVectorLayerEditBuffer::changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues )
+{
+  bool success = true;
+  for ( auto it = newValues.constBegin() ; it != newValues.constEnd(); ++it )
+  {
+    const int field = it.key();
+    const QVariant newValue = it.value();
+    QVariant oldValue;
+
+    if ( oldValues.contains( field ) )
+      oldValue = oldValues[field];
+
+    success &= changeAttributeValue( fid, field, newValue, oldValue );
+  }
+
+  return success;
+}
 
 bool QgsVectorLayerEditBuffer::changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue )
 {

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -66,6 +66,13 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     virtual bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
 
     /**
+     * Changes values of attributes (but does not commit it).
+     * \returns true if attributes are well updated, false otherwise
+     * \since QGIS 3.0
+     */
+    virtual bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
+
+    /**
      * Add an attribute field (but does not commit it)
         returns true if the field was added */
     virtual bool addAttribute( const QgsField &field );
@@ -265,6 +272,7 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     friend class QgsVectorLayerUndoPassthroughCommandDeleteFeatures;
     friend class QgsVectorLayerUndoPassthroughCommandChangeGeometry;
     friend class QgsVectorLayerUndoPassthroughCommandChangeAttribute;
+    friend class QgsVectorLayerUndoPassthroughCommandChangeAttributes;
     friend class QgsVectorLayerUndoPassthroughCommandAddAttribute;
     friend class QgsVectorLayerUndoPassthroughCommandDeleteAttribute;
     friend class QgsVectorLayerUndoPassthroughCommandRenameAttribute;

--- a/src/core/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/qgsvectorlayereditpassthrough.cpp
@@ -86,6 +86,11 @@ bool QgsVectorLayerEditPassthrough::changeAttributeValue( QgsFeatureId fid, int 
   return modify( new QgsVectorLayerUndoPassthroughCommandChangeAttribute( this, fid, field, newValue ) );
 }
 
+bool QgsVectorLayerEditPassthrough::changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues )
+{
+  return modify( new QgsVectorLayerUndoPassthroughCommandChangeAttributes( this, fid, newValues, oldValues ) );
+}
+
 bool QgsVectorLayerEditPassthrough::addAttribute( const QgsField &field )
 {
   return modify( new QgsVectorLayerUndoPassthroughCommandAddAttribute( this, field ) );

--- a/src/core/qgsvectorlayereditpassthrough.h
+++ b/src/core/qgsvectorlayereditpassthrough.h
@@ -38,6 +38,14 @@ class CORE_EXPORT QgsVectorLayerEditPassthrough : public QgsVectorLayerEditBuffe
     bool deleteFeatures( const QgsFeatureIds &fids ) override;
     bool changeGeometry( QgsFeatureId fid, const QgsGeometry &geom ) override;
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() ) override;
+
+    /**
+     * Changes values of attributes (but does not commit it).
+     * \returns true if attributes are well updated, false otherwise
+     * \since QGIS 3.0
+     */
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues ) override;
+
     bool addAttribute( const QgsField &field ) override;
     bool deleteAttribute( int attr ) override;
     bool renameAttribute( int attr, const QString &newName ) override;

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -637,6 +637,25 @@ bool QgsVectorLayerJoinBuffer::changeAttributeValue( QgsFeatureId fid, int field
     return false;
 }
 
+bool QgsVectorLayerJoinBuffer::changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues )
+{
+  bool success = true;
+
+  for ( auto it = newValues.constBegin(); it != newValues.constEnd(); ++it )
+  {
+    const int field = it.key();
+    const QVariant newValue = it.value();
+    QVariant oldValue;
+
+    if ( oldValues.contains( field ) )
+      oldValue = oldValues[field];
+
+    success &= changeAttributeValue( fid, field, newValue, oldValue );
+  }
+
+  return success;
+}
+
 bool QgsVectorLayerJoinBuffer::deleteFeature( QgsFeatureId fid ) const
 {
   return deleteFeatures( QgsFeatureIds() << fid );

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -172,6 +172,22 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
 
     /**
+     * Changes attributes' values in joined layers. The feature id given in
+     * parameter is the one added in target layer. If the corresponding joined
+     * feature does not exist in a joined layer, then it's automatically
+     * created if its fields are not empty.
+     *
+     * \param fid The feature id
+     * \param newValues The new values for attributes
+     * \param oldValues The old values for attributes
+     *
+     * \returns false if an error happened, true otherwise
+     *
+     * \since QGIS 3.0
+     */
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap() );
+
+    /**
      * Deletes a feature from joined layers. The feature id given in
      * parameter is the one coming from the target layer.
      *

--- a/src/core/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/qgsvectorlayerundopassthroughcommand.h
@@ -205,6 +205,35 @@ class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandChangeAttribute: public Qg
 
 /**
  * \ingroup core
+ * \class QgsVectorLayerUndoPassthroughCommandChangeAttributes
+ * \brief Undo command for changing attributes' values from a vector layer in transaction group.
+ * \since QGIS 3.0
+ */
+
+class CORE_EXPORT QgsVectorLayerUndoPassthroughCommandChangeAttributes: public QgsVectorLayerUndoPassthroughCommand
+{
+  public:
+
+    /**
+     * Constructor for QgsVectorLayerUndoPassthroughCommandChangeAttributes
+     * \param buffer associated edit buffer
+     * \param fid feature ID of feature
+     * \param newValues New values for attributes
+     * \param oldValues Old values for attributes
+     */
+    QgsVectorLayerUndoPassthroughCommandChangeAttributes( QgsVectorLayerEditBuffer *buffer SIP_TRANSFER, QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues = QgsAttributeMap() );
+
+    void undo() override;
+    void redo() override;
+
+  private:
+    QgsFeatureId mFid;
+    const QgsAttributeMap mNewValues;
+    const QgsAttributeMap mOldValues;
+};
+
+/**
+ * \ingroup core
  * \class QgsVectorLayerUndoPassthroughCommandAddAttribute
  * \brief Undo command for adding attri to a vector layer in transaction group.
  * \since QGIS 3.0

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -330,6 +330,9 @@ bool QgsAttributeForm::saveEdits()
       {
         mLayer->beginEditCommand( mEditCommandMessage );
 
+        QgsAttributeMap newValues;
+        QgsAttributeMap oldValues;
+
         int n = 0;
         for ( int i = 0; i < dst.count(); ++i )
         {
@@ -346,9 +349,13 @@ bool QgsAttributeForm::saveEdits()
           QgsDebugMsg( QString( "src:'%1' (type:%2, isNull:%3, isValid:%4)" )
                        .arg( src.at( i ).toString(), src.at( i ).typeName() ).arg( src.at( i ).isNull() ).arg( src.at( i ).isValid() ) );
 
-          success &= mLayer->changeAttributeValue( mFeature.id(), i, dst.at( i ), src.at( i ) );
+          newValues[i] = dst.at( i );
+          oldValues[i] = src.at( i );
+
           n++;
         }
+
+        success = mLayer->changeAttributeValues( mFeature.id(), newValues, oldValues );
 
         if ( success && n > 0 )
         {

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -41,8 +41,9 @@ from qgis.core import (
     QgsWkbTypes,
     QgsGeometry
 )
-from qgis.gui import QgsGui
+from qgis.gui import QgsGui, QgsAttributeForm
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QObject
+from qgis.PyQt.QtWidgets import QLabel
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtXml import QDomDocument
 from utilities import unitTestDataPath
@@ -426,6 +427,46 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # check that the pk of the feature has been changed
         ft1 = vl.getFeatures('pk=1')
         self.assertFalse(ft1.nextFeature(f))
+
+    def testTransactionConstrains(self):
+        # create a vector layer based on postgres
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'id\' table="qgis_test"."check_constraints" sql=', 'test', 'postgres')
+        self.assertTrue(vl.isValid())
+
+        # prepare a project with transactions enabled
+        p = QgsProject()
+        p.setAutoTransaction(True)
+        p.addMapLayers([vl])
+
+        # get feature
+        f = QgsFeature()
+        self.assertTrue(vl.getFeatures('id=1').nextFeature(f))
+        self.assertEqual(f.attributes(), [1, 4, 3])
+
+        # start edition
+        vl.startEditing()
+
+        # update attribute form with a failing constraints
+        # coming from the database if attributes are updated
+        # one at a time.
+        # Current feature: a = 4 / b = 3
+        # Update feature: a = 1 / b = 0
+        # If updated one at a time, '(a = 1) < (b = 3)' => FAIL!
+        form = QgsAttributeForm(vl, f)
+        for w in form.findChildren(QLabel):
+            if w.buddy():
+                spinBox = w.buddy()
+                if w.text() == 'a':
+                    spinBox.setValue(1)
+                elif w.text() == 'b':
+                    spinBox.setValue(0)
+
+        # save
+        form.save()
+
+        # check new values
+        self.assertTrue(vl.getFeatures('id=1').nextFeature(f))
+        self.assertEqual(f.attributes(), [1, 1, 0])
 
     def testTransactionTuple(self):
         # create a vector layer based on postgres

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -510,3 +510,14 @@ CREATE UNIQUE INDEX constraints_uniq
   ON qgis_test.constraints
   USING btree
   (name COLLATE pg_catalog."default"); -- unique index
+
+CREATE TABLE qgis_test.check_constraints (
+  id integer PRIMARY KEY,
+  a integer,
+  b integer, CHECK (a > b)
+);
+INSERT INTO qgis_test.check_constraints VALUES (
+  1, -- id
+  4, -- a
+  3  -- b
+)


### PR DESCRIPTION
## Description

Update all attributes in one transaction in order to correctly check database constraints.

Fixes https://issues.qgis.org/issues/17869

## Checklist


- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
