### PR TITLE
[macos] move add button of the datasource manager dialog on the right

### DIFF
--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -39,6 +39,9 @@ void QgsAbstractDataSourceWidget::setupButtons( QDialogButtonBox *buttonBox )
 {
 
   buttonBox->setStandardButtons( QDialogButtonBox::Apply | QDialogButtonBox::Close | QDialogButtonBox::Help );
+#ifdef Q_OS_MACX
+  buttonBox->setStyleSheet( "* { button-layout: 2 }" );
+#endif
   mAddButton = buttonBox->button( QDialogButtonBox::Apply );
   mAddButton->setText( tr( "&Add" ) );
   mAddButton->setToolTip( tr( "Add selected layers to map" ) );


### PR DESCRIPTION
## Description
The current position of the add button of the datasource manager dialog is no very ergonomic on macOS, I don't know if this was already discussed before, but I think that move it on the right is better position. I guess in linux and windows OS the button is on the right.
<img width="852" alt="schermata 2018-01-23 alle 15 28 22" src="https://user-images.githubusercontent.com/1374682/35281663-bb99aeaa-0053-11e8-9b3f-e9e59e9c661f.png">



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
