### PR TITLE
[processing] Some toolbox improvements, shortcut manager fixes

### DIFF
--- a/python/gui/qgisinterface.sip.in
+++ b/python/gui/qgisinterface.sip.in
@@ -342,6 +342,14 @@ Get access to the native Add ArcGIS MapServer action.
     virtual QAction *actionPasteLayerStyle() = 0;
     virtual QAction *actionOpenTable() = 0;
     virtual QAction *actionOpenFieldCalculator() = 0;
+
+    virtual QAction *actionOpenStatisticalSummary() = 0;
+%Docstring
+Statistical summary action.
+
+.. versionadded:: 3.0
+%End
+
     virtual QAction *actionToggleEditing() = 0;
     virtual QAction *actionSaveActiveLayerEdits() = 0;
     virtual QAction *actionAllEdits() = 0;

--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -177,6 +177,7 @@ class ProcessingPlugin:
         self.toolbox = ProcessingToolbox()
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.toolbox)
         self.toolbox.hide()
+        self.toolbox.visibilityChanged.connect(self.toolboxVisibilityChanged)
 
         self.resultsDock = ResultsDock()
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.resultsDock)
@@ -188,12 +189,13 @@ class ProcessingPlugin:
         self.menu.setObjectName('processing')
         self.menu.setTitle(self.tr('Pro&cessing'))
 
-        self.toolboxAction = self.toolbox.toggleViewAction()
+        self.toolboxAction = QAction(self.tr('&Toolbox'), self.iface.mainWindow())
+        self.toolboxAction.setCheckable(True)
         self.toolboxAction.setObjectName('toolboxAction')
         self.toolboxAction.setIcon(
             QgsApplication.getThemeIcon("/processingAlgorithm.svg"))
-        self.toolboxAction.setText(self.tr('&Toolbox'))
         self.iface.registerMainWindowAction(self.toolboxAction, 'Ctrl+Alt+T')
+        self.toolboxAction.toggled.connect(self.openToolbox)
         self.menu.addAction(self.toolboxAction)
 
         self.modelerAction = QAction(
@@ -261,11 +263,11 @@ class ProcessingPlugin:
         removeMenus()
         Processing.deinitialize()
 
-    def openToolbox(self):
-        if self.toolbox.isVisible():
-            self.toolbox.hide()
-        else:
-            self.toolbox.show()
+    def openToolbox(self, show):
+        self.toolbox.setUserVisible(show)
+
+    def toolboxVisibilityChanged(self, visible):
+        self.toolboxAction.setChecked(visible)
 
     def openModeler(self):
         dlg = ModelerDialog()

--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -196,6 +196,7 @@ class ProcessingPlugin:
             QgsApplication.getThemeIcon("/processingAlgorithm.svg"))
         self.iface.registerMainWindowAction(self.toolboxAction, 'Ctrl+Alt+T')
         self.toolboxAction.toggled.connect(self.openToolbox)
+        self.iface.attributesToolBar().insertAction(self.iface.actionOpenStatisticalSummary(), self.toolboxAction)
         self.menu.addAction(self.toolboxAction)
 
         self.modelerAction = QAction(
@@ -234,6 +235,7 @@ class ProcessingPlugin:
     def unload(self):
         self.toolbox.setVisible(False)
         self.iface.removeDockWidget(self.toolbox)
+        self.iface.attributesToolBar().removeAction(self.toolboxAction)
 
         self.resultsDock.setVisible(False)
         self.iface.removeDockWidget(self.resultsDock)

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -34,6 +34,7 @@ from qgis.PyQt.QtWidgets import QMenu, QAction, QTreeWidgetItem, QLabel, QMessag
 from qgis.utils import iface
 from qgis.core import (QgsApplication,
                        QgsProcessingAlgorithm)
+from qgis.gui import QgsDockWidget
 
 from processing.gui.Postprocessing import handleAlgorithmResults
 from processing.core.Processing import Processing
@@ -55,7 +56,7 @@ WIDGET, BASE = uic.loadUiType(
     os.path.join(pluginPath, 'ui', 'ProcessingToolbox.ui'))
 
 
-class ProcessingToolbox(BASE, WIDGET):
+class ProcessingToolbox(QgsDockWidget, WIDGET):
     ALG_ITEM = 'ALG_ITEM'
     PROVIDER_ITEM = 'PROVIDER_ITEM'
     GROUP_ITEM = 'GROUP_ITEM'

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -492,6 +492,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionPasteLayerStyle() { return mActionPasteStyle; }
     QAction *actionOpenTable() { return mActionOpenTable; }
     QAction *actionOpenFieldCalculator() { return mActionOpenFieldCalc; }
+    QAction *actionStatisticalSummary() { return mActionStatisticalSummary; }
     QAction *actionToggleEditing() { return mActionToggleEditing; }
     QAction *actionSaveActiveLayerEdits() { return mActionSaveLayerEdits; }
     QAction *actionAllEdits() { return mActionAllEdits; }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -641,6 +641,7 @@ QAction *QgisAppInterface::actionCopyLayerStyle() { return qgis->actionCopyLayer
 QAction *QgisAppInterface::actionPasteLayerStyle() { return qgis->actionPasteLayerStyle(); }
 QAction *QgisAppInterface::actionOpenTable() { return qgis->actionOpenTable(); }
 QAction *QgisAppInterface::actionOpenFieldCalculator() { return qgis->actionOpenFieldCalculator(); }
+QAction *QgisAppInterface::actionOpenStatisticalSummary() { return qgis->actionStatisticalSummary(); }
 QAction *QgisAppInterface::actionToggleEditing() { return qgis->actionToggleEditing(); }
 QAction *QgisAppInterface::actionSaveActiveLayerEdits() { return qgis->actionSaveActiveLayerEdits(); }
 QAction *QgisAppInterface::actionAllEdits() { return qgis->actionAllEdits(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -445,6 +445,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionPasteLayerStyle() override;
     QAction *actionOpenTable() override;
     QAction *actionOpenFieldCalculator() override;
+    QAction *actionOpenStatisticalSummary() override;
     QAction *actionToggleEditing() override;
     QAction *actionSaveActiveLayerEdits() override;
     QAction *actionAllEdits() override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -314,6 +314,13 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual QAction *actionPasteLayerStyle() = 0;
     virtual QAction *actionOpenTable() = 0;
     virtual QAction *actionOpenFieldCalculator() = 0;
+
+    /**
+     * Statistical summary action.
+     * \since QGIS 3.0
+     */
+    virtual QAction *actionOpenStatisticalSummary() = 0;
+
     virtual QAction *actionToggleEditing() = 0;
     virtual QAction *actionSaveActiveLayerEdits() = 0;
     virtual QAction *actionAllEdits() = 0;

--- a/src/gui/qgsshortcutsmanager.cpp
+++ b/src/gui/qgsshortcutsmanager.cpp
@@ -77,6 +77,9 @@ void QgsShortcutsManager::registerAllChildShortcuts( QObject *object, bool recur
 
 bool QgsShortcutsManager::registerAction( QAction *action, const QString &defaultSequence )
 {
+  if ( mActions.contains( action ) )
+    return false; // already registered
+
 #ifdef QGISDEBUG
   // if using a debug build, warn on duplicate actions
   if ( actionByName( action->text() ) || shortcutByName( action->text() ) )

--- a/tests/src/python/test_qgsshortcutsmanager.py
+++ b/tests/src/python/test_qgsshortcutsmanager.py
@@ -90,6 +90,11 @@ class TestQgsShortcutsManager(unittest.TestCase):
         action2 = QAction('action2', None)
         action2.setShortcut('y')
         self.assertTrue(s.registerAction(action2, 'B'))
+        self.assertCountEqual(s.listActions(), [action1, action2])
+
+        # try re-registering an existing action - should fail, but leave action registered
+        self.assertFalse(s.registerAction(action2, 'B'))
+        self.assertCountEqual(s.listActions(), [action1, action2])
 
         # actions should have been set to default sequences
         self.assertEqual(action1.shortcut().toString(), 'A')


### PR DESCRIPTION
This PR does two things:

1. Improves the interaction with the Processing toolbox, by standardising the show/hide behaviour of the toolbox with how the style dock works. This makes the Toolbox action checkable and checked only when the toolbox is open AND user visible (i.e. not hidden behind another tab). If the toolbox is open but hidden, then hitting the Toolbox action brings it to the front tab.

Otherwise it's often necessary to hit to Toolbox shortcut twice - once to close a hidden toolbox tab, and a second time to open and raise it.

I've also added the Toolbox action to the main window toolbar, since it's a very commonly used QGIS feature.


2. Fixes a debug warning thrown for the Processing action shortcuts ("Duplicate shortcut registered") on QGIS startup.