### PR TITLE
QgsGeometryUtils: rename 2 methods

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1251,6 +1251,9 @@ QgsGeometryUtils         {#qgis_api_break_3_0_QgsGeometryUtils}
 - adjacentVertices was removed - use QgsAbstractGeometry.adjacentVertices instead.
 - segmentIntersection takes an optional boolean parameter "acceptImproperIntersection" returning true even if the intersection is improper.
 Takes another boolean argument "isIntersection" returning if there is an intersection or not. The "inter" parameter has been renamed "intersectionPoint".
+- projPointOnSegment has been renamed to projectPointOnSegment
+- getSelfIntersections has been renamed to selfIntersections
+
 
 QgsGPSConnectionRegistry        {#qgis_api_break_3_0_QgsGPSConnectionRegistry}
 ------------------------

--- a/python/core/geometry/qgsgeometryutils.sip.in
+++ b/python/core/geometry/qgsgeometryutils.sip.in
@@ -151,7 +151,7 @@ Returns the squared distance between a point and a line.
 @return true if an intersection has been found
 %End
 
-    static QgsPoint projPointOnSegment( const QgsPoint &p, const QgsPoint &s1, const QgsPoint &s2 );
+    static QgsPoint projectPointOnSegment( const QgsPoint &p, const QgsPoint &s1, const QgsPoint &s2 );
 %Docstring
  Project the point on a segment
 

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
@@ -62,7 +62,7 @@ void QgsGeometrySelfContactCheck::collectErrors( QList<QgsGeometryCheckError *> 
             }
             const QgsPoint &si = ring[i];
             const QgsPoint &sj = ring[j];
-            QgsPoint q = QgsGeometryUtils::projPointOnSegment( p, si, sj );
+            QgsPoint q = QgsGeometryUtils::projectPointOnSegment( p, si, sj );
             if ( QgsGeometryUtils::sqrDistance2D( p, q ) < mContext->tolerance * mContext->tolerance )
             {
               errors.append( new QgsGeometryCheckError( this, layerFeature, p, QgsVertexId( iPart, iRing, vtxMap[iVert] ) ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
@@ -71,7 +71,7 @@ void QgsGeometrySelfIntersectionCheck::collectErrors( QList<QgsGeometryCheckErro
     {
       for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )
       {
-        for ( const QgsGeometryUtils::SelfIntersection &inter : QgsGeometryUtils::getSelfIntersections( geom, iPart, iRing, mContext->tolerance ) )
+        for ( const QgsGeometryUtils::SelfIntersection &inter : QgsGeometryUtils::selfIntersections( geom, iPart, iRing, mContext->tolerance ) )
         {
           errors.append( new QgsGeometrySelfIntersectionCheckError( this, layerFeature, inter.point, QgsVertexId( iPart, iRing ), inter ) );
         }

--- a/src/analysis/vector/qgsgeometrysnapper.cpp
+++ b/src/analysis/vector/qgsgeometrysnapper.cpp
@@ -45,7 +45,7 @@ QgsSnapIndex::SegmentSnapItem::SegmentSnapItem( const QgsSnapIndex::CoordIdx *_i
 
 QgsPoint QgsSnapIndex::SegmentSnapItem::getSnapPoint( const QgsPoint &p ) const
 {
-  return QgsGeometryUtils::projPointOnSegment( p, idxFrom->point(), idxTo->point() );
+  return QgsGeometryUtils::projectPointOnSegment( p, idxFrom->point(), idxTo->point() );
 }
 
 bool QgsSnapIndex::SegmentSnapItem::getIntersection( const QgsPoint &p1, const QgsPoint &p2, QgsPoint &inter ) const
@@ -690,7 +690,7 @@ QgsGeometry QgsGeometrySnapper::snapGeometry( const QgsGeometry &geometry, doubl
         if ( subjPointFlags[iPart][iRing][iVert] == SnappedToRefSegment &&
              subjPointFlags[iPart][iRing][iPrev] != Unsnapped &&
              subjPointFlags[iPart][iRing][iNext] != Unsnapped &&
-             QgsGeometryUtils::sqrDistance2D( QgsGeometryUtils::projPointOnSegment( pMid, pPrev, pNext ), pMid ) < 1E-12 )
+             QgsGeometryUtils::sqrDistance2D( QgsGeometryUtils::projectPointOnSegment( pMid, pPrev, pNext ), pMid ) < 1E-12 )
         {
           if ( ( ringIsClosed && nVerts > 3 ) || ( !ringIsClosed && nVerts > 2 ) )
           {

--- a/src/core/geometry/qgsellipse.cpp
+++ b/src/core/geometry/qgsellipse.cpp
@@ -84,7 +84,7 @@ QgsEllipse QgsEllipse::fromCenter2Points( const QgsPoint &center, const QgsPoint
   double azimuth = 180.0 / M_PI * QgsGeometryUtils::lineAngle( center.x(), center.y(), pt1.x(), pt1.y() );
   double axis_a = center.distance( pt1 );
 
-  double length = pt2.distance( QgsGeometryUtils::projPointOnSegment( pt2, center, pt1 ) );
+  double length = pt2.distance( QgsGeometryUtils::projectPointOnSegment( pt2, center, pt1 ) );
   QgsPoint pp = center.project( length, 90 + azimuth );
   double axis_b = center.distance( pp );
 

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -360,7 +360,7 @@ bool QgsGeometryUtils::lineCircleIntersection( const QgsPointXY &center, const d
   }
 }
 
-QVector<QgsGeometryUtils::SelfIntersection> QgsGeometryUtils::getSelfIntersections( const QgsAbstractGeometry *geom, int part, int ring, double tolerance )
+QVector<QgsGeometryUtils::SelfIntersection> QgsGeometryUtils::selfIntersections( const QgsAbstractGeometry *geom, int part, int ring, double tolerance )
 {
   QVector<SelfIntersection> intersections;
 

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -156,7 +156,7 @@ class CORE_EXPORT QgsGeometryUtils
      * \param s2 The segment end point
      * \returns The projection of the point on the segment
      */
-    static QgsPoint projPointOnSegment( const QgsPoint &p, const QgsPoint &s1, const QgsPoint &s2 )
+    static QgsPoint projectPointOnSegment( const QgsPoint &p, const QgsPoint &s1, const QgsPoint &s2 )
     {
       double nx = s2.y() - s1.y();
       double ny = -( s2.x() - s1.x() );
@@ -182,7 +182,7 @@ class CORE_EXPORT QgsGeometryUtils
      * \note not available in Python bindings
      * \since QGIS 2.12
      */
-    static QVector<SelfIntersection> getSelfIntersections( const QgsAbstractGeometry *geom, int part, int ring, double tolerance ) SIP_SKIP;
+    static QVector<SelfIntersection> selfIntersections( const QgsAbstractGeometry *geom, int part, int ring, double tolerance ) SIP_SKIP;
 
     /**
      * Returns a value < 0 if the point (\a x, \a y) is left of the line from (\a x1, \a y1) -> ( \a x2, \a y2).


### PR DESCRIPTION
- projPointOnSegment has been renamed to projectPointOnSegment
- getSelfIntersections has been renamed to selfIntersections
