### PR TITLE
[needs-docs][processing] move providers actions into the processing panel toolbar

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -206,7 +206,6 @@ class ProcessingPlugin:
         self.modelerAction.triggered.connect(self.openModeler)
         self.iface.registerMainWindowAction(self.modelerAction, 'Ctrl+Alt+M')
         self.menu.addAction(self.modelerAction)
-        self.toolbox.processingToolbar.addAction(self.modelerAction)
 
         self.historyAction = QAction(
             QIcon(os.path.join(cmd_folder, 'images', 'history.svg')),


### PR DESCRIPTION
## Description
Now that we have a toolbar in our processing panel, it's time we (finally) move provider actions out of the algorithms tree. 

This PR moves the provider actions into dedicated toolbar buttons:
![screenshot from 2018-01-24 11-35-32](https://user-images.githubusercontent.com/1728657/35314749-c3c29f54-00fa-11e8-947a-f4c722340996.png)

IMHO, this makes a lot more sense. First, those actions were not algorithms to begin with, and second, it increases the visibility of those actions, which includes the creation of modes and scripts as well as access to online collections.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
