### PR TITLE
Fixes a typo in syncDb() that improperly set "Imported from GDAL" as name for all geogcs imported from GDAL/PROJ

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1807,7 +1807,7 @@ int QgsCoordinateReferenceSystem::syncDb()
         ellps = ellipseRegExp.cap( 1 );
       }
 
-      QString name( OSRIsGeographic( crs ) ? OSRGetAttrValue( crs, "GEOCS", 0 ) : OSRGetAttrValue( crs, "PROJCS", 0 ) );
+      QString name( OSRIsGeographic( crs ) ? OSRGetAttrValue( crs, "GEOGCS", 0 ) : OSRGetAttrValue( crs, "PROJCS", 0 ) );
       if ( name.isEmpty() )
         name = QObject::tr( "Imported from GDAL" );
 


### PR DESCRIPTION
## Description
Fixes a typo in QgsCoordinateReferenceSystem::syncDb() that improperly set "Imported from GDAL" as name for all geographical coordinate systems imported from GDAL/PROJ definitions during postintall CRS database sync through crssync.

Fixes https://issues.qgis.org/issues/17941

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
