### PR TITLE
Show field type in tooltip in attribute table header

### DIFF
--- a/python/core/qgsfieldmodel.sip.in
+++ b/python/core/qgsfieldmodel.sip.in
@@ -126,6 +126,14 @@ Returns the layer associated with the model.
     virtual QVariant data( const QModelIndex &index, int role ) const;
 
 
+    static QString fieldToolTip( const QgsField &field );
+%Docstring
+Returns a HTML formatted tooltip string for a ``field``, containing details
+like the field name, alias and type.
+
+.. versionadded:: 3.0
+%End
+
   public slots:
 
     void setLayer( QgsVectorLayer *layer );

--- a/src/core/qgsfieldmodel.cpp
+++ b/src/core/qgsfieldmodel.cpp
@@ -361,6 +361,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
 
     case Qt::DisplayRole:
     case Qt::EditRole:
+    case Qt::ToolTipRole:
     {
       if ( isEmpty )
       {
@@ -373,6 +374,10 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
       else if ( role == Qt::EditRole )
       {
         return mFields.at( index.row() - fieldOffset ).name();
+      }
+      else if ( role == Qt::ToolTipRole )
+      {
+        return fieldToolTip( mFields.at( index.row() - fieldOffset ) );
       }
       else if ( mLayer )
       {
@@ -425,4 +430,35 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
     default:
       return QVariant();
   }
+}
+
+QString QgsFieldModel::fieldToolTip( const QgsField &field )
+{
+  QString toolTip;
+  if ( !field.alias().isEmpty() )
+  {
+    toolTip = QStringLiteral( "<b>%1</b> (%2)" ).arg( field.alias(), field.name() );
+  }
+  else
+  {
+    toolTip = QStringLiteral( "<b>%1</b>" ).arg( field.name() );
+  }
+  QString typeString;
+  if ( field.length() > 0 )
+  {
+    if ( field.precision() > 0 )
+    {
+      typeString = QStringLiteral( "%1 (%2, %3)" ).arg( field.typeName() ).arg( field.length() ).arg( field.precision() );
+    }
+    else
+    {
+      typeString = QStringLiteral( "%1 (%2)" ).arg( field.typeName() ).arg( field.length() );
+    }
+  }
+  else
+  {
+    typeString = field.typeName();
+  }
+  toolTip += QStringLiteral( "<p>%1</p>" ).arg( typeString );
+  return toolTip;
 }

--- a/src/core/qgsfieldmodel.h
+++ b/src/core/qgsfieldmodel.h
@@ -128,6 +128,13 @@ class CORE_EXPORT QgsFieldModel : public QAbstractItemModel
     int columnCount( const QModelIndex &parent ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
 
+    /**
+     * Returns a HTML formatted tooltip string for a \a field, containing details
+     * like the field name, alias and type.
+     * \since QGIS 3.0
+     */
+    static QString fieldToolTip( const QgsField &field );
+
   public slots:
 
     /**

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -37,6 +37,7 @@
 #include "qgsexpressionnodeimpl.h"
 #include "qgsvectorlayerjoininfo.h"
 #include "qgsvectorlayerjoinbuffer.h"
+#include "qgsfieldmodel.h"
 
 #include <QVariant>
 
@@ -583,8 +584,8 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
     }
     else
     {
-      QgsField field = layer()->fields().at( mAttributes.at( section ) );
-      return field.name();
+      const QgsField field = layer()->fields().at( mAttributes.at( section ) );
+      return QgsFieldModel::fieldToolTip( field );
     }
   }
   else

--- a/tests/src/python/test_qgsfieldmodel.py
+++ b/tests/src/python/test_qgsfieldmodel.py
@@ -14,8 +14,10 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
 
-from qgis.core import QgsFields, QgsVectorLayer
-from qgis.core import QgsFieldModel
+from qgis.core import (QgsField,
+                       QgsFields,
+                       QgsVectorLayer,
+                       QgsFieldModel)
 from qgis.PyQt.QtCore import QVariant, Qt
 
 from qgis.testing import start_app, unittest
@@ -38,7 +40,6 @@ def create_model():
 
 
 class TestQgsFieldModel(unittest.TestCase):
-
     def testGettersSetters(self):
         """ test model getters/setters """
         l = create_layer()
@@ -244,6 +245,16 @@ class TestQgsFieldModel(unittest.TestCase):
         self.assertEqual(m.data(m.indexFromName('an expression'), Qt.DisplayRole), 'an expression')
         m.setAllowEmptyFieldName(True)
         self.assertFalse(m.data(m.indexFromName(None), Qt.DisplayRole))
+
+    def testFieldTooltip(self):
+        f = QgsField('my_string', QVariant.String, 'string')
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my_string</b><p>string</p>')
+        f.setAlias('my alias')
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my alias</b> (my_string)<p>string</p>')
+        f.setLength(20)
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my alias</b> (my_string)<p>string (20)</p>')
+        f = QgsField('my_real', QVariant.Double, 'real', 8, 3)
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my_real</b><p>real (8, 3)</p>')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is handy info to have available somewhere in the attribute table dialog