### PR TITLE
Fix metadata address element doubles with each project write

### DIFF
--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -440,7 +440,7 @@ bool QgsLayerMetadata::readMetadataXml( const QDomElement &metadataElement )
     oneContact.role = mne.namedItem( QStringLiteral( "role" ) ).toElement().text();
 
     QList< QgsLayerMetadata::Address > addresses;
-    QDomNodeList addressList = mne.elementsByTagName( QStringLiteral( "address" ) );
+    QDomNodeList addressList = mne.elementsByTagName( QStringLiteral( "contactAddress" ) );
     for ( int j = 0; j < addressList.size(); j++ )
     {
       QDomElement addressElement = addressList.at( j ).toElement();
@@ -663,7 +663,7 @@ bool QgsLayerMetadata::writeMetadataXml( QDomElement &metadataElement, QDomDocum
 
     for ( const QgsLayerMetadata::Address &oneAddress : contact.addresses )
     {
-      QDomElement addressElement = document.createElement( QStringLiteral( "address" ) );
+      QDomElement addressElement = document.createElement( QStringLiteral( "contactAddress" ) );
       QDomElement typeElement = document.createElement( QStringLiteral( "type" ) );
       QDomElement addressDetailedElement = document.createElement( QStringLiteral( "address" ) );
       QDomElement cityElement = document.createElement( QStringLiteral( "city" ) );


### PR DESCRIPTION
elementsByTagName can be dangerous, because it returns children
recursively. In this case the contact "address" element contained
a child element for the street address, also named "address".

So when restoring a project with contact addresses in the metadata,
each address was created twice...

Fixes #17940
