### PR TITLE
Improvement to algorithm's default extension & file picker filter

### DIFF
--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -123,17 +123,6 @@ class buildvrt(GdalAlgorithm):
         arguments.append(listFile)
 
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
-        # Ideally the file extensions should be limited to just .vrt but I'm not sure how
-        # to do it simply so instead a check is performed.
-        _, ext = os.path.splitext(out)
-        if not ext.lower() == '.vrt':
-            out = out[:-len(ext)] + '.vrt'
-            if isinstance(parameters[self.OUTPUT], QgsProcessingOutputLayerDefinition):
-                output_def = QgsProcessingOutputLayerDefinition(parameters[self.OUTPUT])
-                output_def.sink = QgsProperty.fromValue(out)
-                self.setOutputValue(self.OUTPUT, output_def)
-            else:
-                self.setOutputValue(self.OUTPUT, out)
         arguments.append(out)
 
         return ['gdalbuildvrt', GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/gui/ParameterGuiUtils.py
+++ b/python/plugins/processing/gui/ParameterGuiUtils.py
@@ -90,4 +90,7 @@ def getFileFilter(param):
     elif param.type() == 'fileDestination':
         return param.fileFilter() + ';;' + tr('All files (*.*)')
 
-    return ''
+    if param.defaultFileExtension():
+        return tr('Default extension') + ' (*.' + param.defaultFileExtension() + ')'
+    else:
+        return ''


### PR DESCRIPTION
## Description
During a training last week, I've noticed an UX issue whereas the build virtual raster alg. would not automatically append .vrt to a saved (i.e. non temporary) file output. In fact, the file selection dialog only offered "All files (*.*)" as the filter, even though the algorithm was expecting a .vrt (and in fact enforced it upon executing the algorithm).

The first commit in this PR addresses this scenario, whereas the ParameterGuiUtils.getFileFilter() function will return the default extension for the parameter if present instead of returning a blank filter list.

The PR also fixes the virtual raster algorithm for extension-less file names (or other extensions given). It's bad practice to change the file extension during the algorithm as the output's file name is still passed on in models as the original file name. Now that the UI properly enforces the .VRT through the file picker, we can get rid of that. Note that the algorithm will successfully write a virtual raster file even without the proper extension.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
