### PR TITLE
remove risky qApp->processEvents() call

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11091,23 +11091,6 @@ void QgisApp::showProgress( int progress, int totalSteps )
     }
     mProgressBar->setMaximum( totalSteps );
     mProgressBar->setValue( progress );
-
-    if ( mProgressBar->maximum() == 0 )
-    {
-      // for busy indicator (when minimum equals to maximum) the oxygen Qt style (used in KDE)
-      // has some issues and does not start busy indicator animation. This is an ugly fix
-      // that forces creation of a temporary progress bar that somehow resumes the animations.
-      // Caution: looking at the code below may introduce mild pain in stomach.
-      if ( strcmp( QApplication::style()->metaObject()->className(), "Oxygen::Style" ) == 0 )
-      {
-        QProgressBar pb;
-        pb.setAttribute( Qt::WA_DontShowOnScreen ); // no visual annoyance
-        pb.setMaximum( 0 );
-        pb.show();
-        qApp->processEvents();
-      }
-    }
-
   }
 }
 


### PR DESCRIPTION
## Description
@wonder-sk , in 2014, you added this piece of code to deal with a qt4 oxygen theme issue. The "hack" involved calling the infamous qApp->processEvents(), which has been a recurring nightmare for us. 

I was wondering whether it'd be a good time to get rid of this. The issue might not be present under qt5 oxygen (I haven't tried yet, if anyone runs kubuntu, that'd be helpful), and it's probably wise to close this potential mine field anyways (now that we have progressive rendering, even if the infinite progress bar is still an issue, it's not as big of a deal).

Thoughts?
