### PR TITLE
[processing] Support non-filed based outputs (e.g. postgis, geopackage) for models, scripts

### DIFF
--- a/python/core/processing/qgsprocessingparameters.sip.in
+++ b/python/core/processing/qgsprocessingparameters.sip.in
@@ -1775,20 +1775,20 @@ Returns a new QgsProcessingOutputDefinition corresponding to the definition of t
 parameter.
 %End
 
-    bool supportsNonFileBasedOutputs() const;
+    bool supportsNonFileBasedOutput() const;
 %Docstring
 Returns true if the destination parameter supports non filed-based outputs,
 such as memory layers or direct database outputs.
 
-.. seealso:: :py:func:`setSupportsNonFileBasedOutputs`
+.. seealso:: :py:func:`setSupportsNonFileBasedOutput`
 %End
 
-    void setSupportsNonFileBasedOutputs( bool supportsNonFileBasedOutputs );
+    void setSupportsNonFileBasedOutput( bool supportsNonFileBasedOutput );
 %Docstring
 Sets whether the destination parameter supports non filed-based outputs,
 such as memory layers or direct database outputs.
 
-.. seealso:: :py:func:`supportsNonFileBasedOutputs`
+.. seealso:: :py:func:`supportsNonFileBasedOutput`
 %End
 
     virtual QString defaultFileExtension() const = 0;

--- a/python/core/processing/qgsprocessingprovider.sip.in
+++ b/python/core/processing/qgsprocessingprovider.sip.in
@@ -143,7 +143,10 @@ Otherwise the first reported supported raster format will be used.
     virtual bool supportsNonFileBasedOutput() const;
 %Docstring
 Returns true if the provider supports non-file based outputs (such as memory layers
-or direct database outputs).
+or direct database outputs). If a provider returns false for this method than it
+indicates that none of the outputs from any of the provider's algorithms have
+support for non-file based outputs. Returning true indicates that the algorithm's
+parameters will each individually declare their non-file based support.
 
 .. seealso:: :py:func:`supportedOutputVectorLayerExtensions`
 %End

--- a/python/plugins/processing/gui/DestinationSelectionPanel.py
+++ b/python/plugins/processing/gui/DestinationSelectionPanel.py
@@ -77,7 +77,7 @@ class DestinationSelectionPanel(BASE, WIDGET):
                 self.leText.setPlaceholderText(self.SKIP_OUTPUT)
                 self.use_temporary = False
             elif isinstance(self.parameter, QgsProcessingParameterFeatureSink) \
-                    and alg.provider().supportsNonFileBasedOutput():
+                    and self.parameter.supportsNonFileBasedOutput():
                 # use memory layers for temporary files if supported
                 self.leText.setPlaceholderText(self.SAVE_TO_TEMP_LAYER)
             elif not isinstance(self.parameter, QgsProcessingParameterFolderDestination):
@@ -107,7 +107,7 @@ class DestinationSelectionPanel(BASE, WIDGET):
                 popupMenu.addAction(actionSkipOutput)
 
             if isinstance(self.parameter, QgsProcessingParameterFeatureSink) \
-                    and self.alg.provider().supportsNonFileBasedOutput():
+                    and self.parameter.supportsNonFileBasedOutput():
                 # use memory layers for temporary layers if supported
                 actionSaveToTemp = QAction(
                     self.tr('Create temporary layer'), self.btnSelect)
@@ -123,7 +123,7 @@ class DestinationSelectionPanel(BASE, WIDGET):
             popupMenu.addAction(actionSaveToFile)
 
             if isinstance(self.parameter, QgsProcessingParameterFeatureSink) \
-                    and self.alg.provider().supportsNonFileBasedOutput():
+                    and self.parameter.supportsNonFileBasedOutput():
                 actionSaveToGpkg = QAction(
                     self.tr('Save to GeoPackage...'), self.btnSelect)
                 actionSaveToGpkg.triggered.connect(self.saveToGeopackage)
@@ -146,7 +146,7 @@ class DestinationSelectionPanel(BASE, WIDGET):
             popupMenu.exec_(QCursor.pos())
 
     def saveToTemporary(self):
-        if isinstance(self.parameter, QgsProcessingParameterFeatureSink) and self.alg.provider().supportsNonFileBasedOutput():
+        if isinstance(self.parameter, QgsProcessingParameterFeatureSink) and self.parameter.supportsNonFileBasedOutput():
             self.leText.setPlaceholderText(self.SAVE_TO_TEMP_LAYER)
         else:
             self.leText.setPlaceholderText(self.SAVE_TO_TEMP_FILE)
@@ -188,7 +188,7 @@ class DestinationSelectionPanel(BASE, WIDGET):
         filename, filter = QFileDialog.getSaveFileName(self, self.tr("Save to GeoPackage"), path,
                                                        file_filter, options=QFileDialog.DontConfirmOverwrite)
 
-        if filename is None:
+        if not filename:
             return
 
         layer_name, ok = QInputDialog.getText(self, self.tr('Save to GeoPackage'), self.tr('Layer name'), text=self.parameter.name().lower())

--- a/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
@@ -92,6 +92,9 @@ class ModelerAlgorithmProvider(QgsProcessingProvider):
     def svgIconPath(self):
         return QgsApplication.iconPath("processingModel.svg")
 
+    def supportsNonFileBasedOutput(self):
+        return True
+
     def loadAlgorithms(self):
         self.algs = []
         folders = ModelerUtils.modelsFolders()

--- a/python/plugins/processing/script/ScriptAlgorithmProvider.py
+++ b/python/plugins/processing/script/ScriptAlgorithmProvider.py
@@ -99,3 +99,10 @@ class ScriptAlgorithmProvider(QgsProcessingProvider):
 
     def addAlgorithmsFromFolder(self, folder):
         self.folder_algorithms.extend(ScriptUtils.loadFromFolder(folder))
+
+    def supportsNonFileBasedOutput(self):
+        # TODO - this may not be strictly true. We probably need a way for scripts
+        # to indicate whether individual outputs support non-file based outputs,
+        # but for now allow it. At best we expose nice features to users, at worst
+        # they'll get an error if they use them with incompatible outputs...
+        return True

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -107,12 +107,12 @@ void QgsProcessingAlgorithm::setProvider( QgsProcessingProvider *provider )
 {
   mProvider = provider;
 
-  if ( !mProvider->supportsNonFileBasedOutput() )
+  if ( mProvider && !mProvider->supportsNonFileBasedOutput() )
   {
     // need to update all destination parameters to turn off non file based outputs
     Q_FOREACH ( const QgsProcessingParameterDefinition *definition, mParameters )
     {
-      if ( definition->isDestination() && mProvider )
+      if ( definition->isDestination() )
       {
         const QgsProcessingDestinationParameter *destParam = static_cast< const QgsProcessingDestinationParameter *>( definition );
         const_cast< QgsProcessingDestinationParameter *>( destParam )->setSupportsNonFileBasedOutput( false );

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -107,13 +107,16 @@ void QgsProcessingAlgorithm::setProvider( QgsProcessingProvider *provider )
 {
   mProvider = provider;
 
-  // need to update all destination parameters to set whether the provider supports non file based outputs
-  Q_FOREACH ( const QgsProcessingParameterDefinition *definition, mParameters )
+  if ( !mProvider->supportsNonFileBasedOutput() )
   {
-    if ( definition->isDestination() && mProvider )
+    // need to update all destination parameters to turn off non file based outputs
+    Q_FOREACH ( const QgsProcessingParameterDefinition *definition, mParameters )
     {
-      const QgsProcessingDestinationParameter *destParam = static_cast< const QgsProcessingDestinationParameter *>( definition );
-      const_cast< QgsProcessingDestinationParameter *>( destParam )->setSupportsNonFileBasedOutputs( mProvider->supportsNonFileBasedOutput() );
+      if ( definition->isDestination() && mProvider )
+      {
+        const QgsProcessingDestinationParameter *destParam = static_cast< const QgsProcessingDestinationParameter *>( definition );
+        const_cast< QgsProcessingDestinationParameter *>( destParam )->setSupportsNonFileBasedOutput( false );
+      }
     }
   }
 }
@@ -246,7 +249,8 @@ bool QgsProcessingAlgorithm::addParameter( QgsProcessingParameterDefinition *def
   if ( definition->isDestination() && mProvider )
   {
     QgsProcessingDestinationParameter *destParam = static_cast< QgsProcessingDestinationParameter *>( definition );
-    destParam->setSupportsNonFileBasedOutputs( mProvider->supportsNonFileBasedOutput() );
+    if ( !mProvider->supportsNonFileBasedOutput() )
+      destParam->setSupportsNonFileBasedOutput( false );
   }
 
   mParameters << definition;

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -3209,7 +3209,7 @@ bool QgsProcessingParameterFeatureSink::fromVariantMap( const QVariantMap &map )
 
 QString QgsProcessingParameterFeatureSink::generateTemporaryDestination() const
 {
-  if ( supportsNonFileBasedOutputs() )
+  if ( supportsNonFileBasedOutput() )
     return QStringLiteral( "memory:%1" ).arg( description() );
   else
     return QgsProcessingDestinationParameter::generateTemporaryDestination();

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -1720,16 +1720,16 @@ class CORE_EXPORT QgsProcessingDestinationParameter : public QgsProcessingParame
     /**
      * Returns true if the destination parameter supports non filed-based outputs,
      * such as memory layers or direct database outputs.
-     * \see setSupportsNonFileBasedOutputs()
+     * \see setSupportsNonFileBasedOutput()
      */
-    bool supportsNonFileBasedOutputs() const { return mSupportsNonFileBasedOutputs; }
+    bool supportsNonFileBasedOutput() const { return mSupportsNonFileBasedOutputs; }
 
     /**
      * Sets whether the destination parameter supports non filed-based outputs,
      * such as memory layers or direct database outputs.
-     * \see supportsNonFileBasedOutputs()
+     * \see supportsNonFileBasedOutput()
      */
-    void setSupportsNonFileBasedOutputs( bool supportsNonFileBasedOutputs ) { mSupportsNonFileBasedOutputs = supportsNonFileBasedOutputs; }
+    void setSupportsNonFileBasedOutput( bool supportsNonFileBasedOutput ) { mSupportsNonFileBasedOutputs = supportsNonFileBasedOutput; }
 
     /**
      * Returns the default file extension for destination file paths

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -146,7 +146,10 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
 
     /**
      * Returns true if the provider supports non-file based outputs (such as memory layers
-     * or direct database outputs).
+     * or direct database outputs). If a provider returns false for this method than it
+     * indicates that none of the outputs from any of the provider's algorithms have
+     * support for non-file based outputs. Returning true indicates that the algorithm's
+     * parameters will each individually declare their non-file based support.
      * \see supportedOutputVectorLayerExtensions()
      */
     virtual bool supportsNonFileBasedOutput() const { return false; }

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1396,10 +1396,10 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
           break;
 
         case OFTString:
-          QgsDebugMsg( QString( "Writing string attribute %1 with %2, encoding %3" )
-                       .arg( qgisAttId )
-                       .arg( attrVal.toString(),
-                             textEncoding()->name().data() ) );
+          QgsDebugMsgLevel( QString( "Writing string attribute %1 with %2, encoding %3" )
+                            .arg( qgisAttId )
+                            .arg( attrVal.toString(),
+                                  textEncoding()->name().data() ), 3 );
           OGR_F_SetFieldString( feature.get(), ogrAttId, textEncoding()->fromUnicode( attrVal.toString() ).constData() );
           break;
 


### PR DESCRIPTION
Non-filed based outputs (e.g. postgis, geopackage) options should be available for certain model outputs and script algorithm outputs

We do this by swapping the test for non-file based output support from checking only the algorithm's provider to instead checking on a parameter-by-parameter basis.

This is done in order to support models. For models, depending on what child algorithm a model output is based off, an individual model may or may not have support for non-file based outputs. E.g a model may generate outputs from a native qgis alg (supporting these outputs) AND an output from a GDAL alg (with no support for these outputs). In this case we need to enable or disable the ui controls for non-file based outputs on an individual output basis.

For scripts (for now) we blindly just say all outputs support non-file based formats. This is going to be the case most of the time, since scripts will usually be written using PyQGIS API. For the exceptions (e.g. scripts which call other algs like GDAL algs) we probably should add some way for the script to indicate whether an individual output supports this, but for now we just say they all do.

Fixes https://issues.qgis.org/issues/17949