### PR TITLE
[DB Manager]Allow preset query combobox to expand

### DIFF
--- a/python/plugins/db_manager/ui/DlgQueryBuilder.ui
+++ b/python/plugins/db_manager/ui/DlgQueryBuilder.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>SQL query builder</string>
+   <string>SQL Query Builder</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_7">
    <item>

--- a/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
@@ -131,7 +131,7 @@ columns</string>
          <item>
           <widget class="QPushButton" name="presetStore">
            <property name="text">
-            <string>Store</string>
+            <string>Save</string>
            </property>
           </widget>
          </item>

--- a/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
@@ -14,41 +14,55 @@
    <string>SQL Window</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="avoidSelectById">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avoid selecting feature by id. Sometimes - especially when running expensive queries/views - fetching the data sequentially instead of fetching features by id can be much quicker.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Avoid selecting by feature id</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="updateLayerBtn">
-       <property name="text">
-        <string>Update</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="3">
+    <widget class="QPushButton" name="getColumnsBtn">
+     <property name="text">
+      <string>Retrieve
+columns</string>
+     </property>
+    </widget>
    </item>
-   <item row="0" column="0">
+   <item row="3" column="3">
+    <widget class="QPushButton" name="updateLayerBtn">
+     <property name="text">
+      <string>Update</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QPushButton" name="btnSetFilter">
+     <property name="text">
+      <string>Set filter</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="avoidSelectById">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avoid selecting feature by id. Sometimes - especially when running expensive queries/views - fetching the data sequentially instead of fetching features by id can be much quicker.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Avoid selecting by feature id</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="4">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -198,7 +212,76 @@
      </widget>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Layer name (prefix)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="layerNameEdit">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QWidget" name="layerTypeWidget" native="true">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Type</string>
+          </property>
+          <property name="indent">
+           <number>40</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="vectorRadio">
+          <property name="text">
+           <string>Vector</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rasterRadio">
+          <property name="text">
+           <string>Raster</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <item>
       <widget class="QCheckBox" name="uniqueColumnCheck">
@@ -253,116 +336,6 @@ unique values</string>
        </property>
        <property name="insertPolicy">
         <enum>QComboBox::NoInsert</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="getColumnsBtn">
-       <property name="text">
-        <string>Retrieve
-columns</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Layer name (prefix)</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="layerNameEdit">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string notr="true"/>
-       </property>
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QWidget" name="layerTypeWidget" native="true">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <property name="margin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Type</string>
-          </property>
-          <property name="indent">
-           <number>40</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="vectorRadio">
-          <property name="text">
-           <string>Vector</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="rasterRadio">
-          <property name="text">
-           <string>Raster</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_6">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnSetFilter">
-       <property name="text">
-        <string>Set filter</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>SQL window</string>
+   <string>SQL Window</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="3" column="0">
@@ -80,12 +80,19 @@
          <item>
           <widget class="QLabel" name="label">
            <property name="text">
-            <string>Saved query:</string>
+            <string>Saved query</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="presetCombo"/>
+          <widget class="QComboBox" name="presetCombo">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QLabel" name="label_2">
@@ -96,6 +103,12 @@
          </item>
          <item>
           <widget class="QLineEdit" name="presetName">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string notr="true"/>
            </property>

--- a/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
@@ -351,9 +351,26 @@ unique values</string>
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>queryBuilderBtn</tabstop>
+  <tabstop>presetCombo</tabstop>
+  <tabstop>presetName</tabstop>
+  <tabstop>presetStore</tabstop>
+  <tabstop>presetDelete</tabstop>
+  <tabstop>editSql</tabstop>
   <tabstop>btnExecute</tabstop>
   <tabstop>btnClear</tabstop>
   <tabstop>viewResult</tabstop>
+  <tabstop>uniqueColumnCheck</tabstop>
+  <tabstop>uniqueCombo</tabstop>
+  <tabstop>hasGeometryCol</tabstop>
+  <tabstop>geomCombo</tabstop>
+  <tabstop>getColumnsBtn</tabstop>
+  <tabstop>layerNameEdit</tabstop>
+  <tabstop>vectorRadio</tabstop>
+  <tabstop>rasterRadio</tabstop>
+  <tabstop>btnSetFilter</tabstop>
+  <tabstop>avoidSelectById</tabstop>
+  <tabstop>updateLayerBtn</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -6,12 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>626</width>
+    <width>679</width>
     <height>525</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
-   <string>SQL window</string>
+   <string>SQL Window</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="1" column="0">
@@ -286,12 +292,19 @@ columns</string>
          <item>
           <widget class="QLabel" name="label">
            <property name="text">
-            <string>Saved query:</string>
+            <string>Saved query</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="presetCombo"/>
+          <widget class="QComboBox" name="presetCombo">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QLabel" name="label_2">
@@ -302,6 +315,12 @@ columns</string>
          </item>
          <item>
           <widget class="QLineEdit" name="presetName">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string notr="true"/>
            </property>

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -400,9 +400,28 @@ unique values</string>
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>queryBuilderBtn</tabstop>
+  <tabstop>presetCombo</tabstop>
+  <tabstop>presetName</tabstop>
+  <tabstop>presetStore</tabstop>
+  <tabstop>presetDelete</tabstop>
+  <tabstop>editSql</tabstop>
   <tabstop>btnExecute</tabstop>
+  <tabstop>btnCreateView</tabstop>
   <tabstop>btnClear</tabstop>
   <tabstop>viewResult</tabstop>
+  <tabstop>loadAsLayerGroup</tabstop>
+  <tabstop>uniqueColumnCheck</tabstop>
+  <tabstop>uniqueCombo</tabstop>
+  <tabstop>hasGeometryCol</tabstop>
+  <tabstop>geomCombo</tabstop>
+  <tabstop>getColumnsBtn</tabstop>
+  <tabstop>layerNameEdit</tabstop>
+  <tabstop>vectorRadio</tabstop>
+  <tabstop>rasterRadio</tabstop>
+  <tabstop>btnSetFilter</tabstop>
+  <tabstop>avoidSelectById</tabstop>
+  <tabstop>loadLayerBtn</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -38,131 +38,70 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
+      <item row="0" column="0" colspan="2">
        <widget class="QWidget" name="loadAsLayerWidget" native="true">
         <layout class="QGridLayout" name="gridLayout_3">
-         <property name="margin">
+         <property name="leftMargin">
           <number>0</number>
          </property>
-         <item row="2" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QCheckBox" name="avoidSelectById">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avoid selecting feature by id. Sometimes - especially when running expensive queries/views - fetching the data sequentially instead of fetching features by id can be much quicker.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Avoid selecting by feature id</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="loadLayerBtn">
-             <property name="text">
-              <string>Load now!</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="0" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
-           <item>
-            <widget class="QCheckBox" name="uniqueColumnCheck">
-             <property name="text">
-              <string>Column(s) with 
-unique values</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="uniqueCombo">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="editable">
-              <bool>true</bool>
-             </property>
-             <property name="insertPolicy">
-              <enum>QComboBox::NoInsert</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="hasGeometryCol">
-             <property name="text">
-              <string>Geometry column</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-             <property name="tristate">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="geomCombo">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="editable">
-              <bool>true</bool>
-             </property>
-             <property name="insertPolicy">
-              <enum>QComboBox::NoInsert</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_5">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="getColumnsBtn">
-             <property name="text">
-              <string>Retrieve 
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="3">
+          <widget class="QPushButton" name="getColumnsBtn">
+           <property name="text">
+            <string>Retrieve 
 columns</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+           </property>
+          </widget>
          </item>
-         <item row="1" column="0">
+         <item row="2" column="1">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="3">
+          <widget class="QPushButton" name="btnSetFilter">
+           <property name="text">
+            <string>Set filter</string>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QPushButton" name="loadLayerBtn">
+           <property name="text">
+            <string>Load now!</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="avoidSelectById">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Avoid selecting feature by id. Sometimes - especially when running expensive queries/views - fetching the data sequentially instead of fetching features by id can be much quicker.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Avoid selecting by feature id</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
           <layout class="QHBoxLayout" name="horizontalLayout_7">
            <item>
             <widget class="QLabel" name="label_5">
@@ -223,32 +162,66 @@ columns</string>
                 </property>
                </widget>
               </item>
-              <item>
-               <spacer name="horizontalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
              </layout>
             </widget>
            </item>
+          </layout>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
            <item>
-            <widget class="QPushButton" name="btnSetFilter">
+            <widget class="QCheckBox" name="uniqueColumnCheck">
              <property name="text">
-              <string>Set filter</string>
+              <string>Column(s) with 
+unique values</string>
              </property>
-             <property name="autoDefault">
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="uniqueCombo">
+             <property name="enabled">
               <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+             <property name="insertPolicy">
+              <enum>QComboBox::NoInsert</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="hasGeometryCol">
+             <property name="text">
+              <string>Geometry column</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <property name="tristate">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="geomCombo">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+             <property name="insertPolicy">
+              <enum>QComboBox::NoInsert</enum>
              </property>
             </widget>
            </item>

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -87,7 +87,7 @@ columns</string>
          <item row="2" column="3">
           <widget class="QPushButton" name="loadLayerBtn">
            <property name="text">
-            <string>Load now!</string>
+            <string>Load</string>
            </property>
           </widget>
          </item>
@@ -302,7 +302,7 @@ unique values</string>
          <item>
           <widget class="QPushButton" name="presetStore">
            <property name="text">
-            <string>Store</string>
+            <string>Save</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Fixes #17933
Also add some window title capitalisation and better align widgets
[needs-docs] because some GUI labels have changed

Before 
![image](https://user-images.githubusercontent.com/7983394/35371739-31c1624c-0196-11e8-8032-a55551609947.png)
After
![image](https://user-images.githubusercontent.com/7983394/35371760-513177de-0196-11e8-8d86-fca9b9fc79d3.png)

Questions:
1. Could we replace the "Load now!" label by "Load"?
1. The [DlgSqlLayerWindow.ui](https://github.com/qgis/QGIS/blob/c1cdfe860dcd5eace90f13a71f47ee15182eb79e/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui/DlgSqlLayerWindow.ui) and [DlgSqlWindow.ui](https://github.com/qgis/QGIS/blob/c1cdfe860dcd5eace90f13a71f47ee15182eb79e/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui/DlgSqlWindow.ui) files are almost the same (only a group container makes the difference). Any reason to not have a single file that we can reshape according to context or, maybe "easier/cleaner", two really different files ("with group container" vs content) that we import? It's weird to have to fix dialog twice. That said i couldn't find how to trigger DlgSqlLayerWindow dialog