### PR TITLE
[processing] properly size toolbar button for provider actions

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -232,8 +232,6 @@ class ProcessingPlugin:
         self.optionsAction.triggered.connect(self.openProcessingOptions)
         self.toolbox.processingToolbar.addAction(self.optionsAction)
 
-        self.toolbox.processingToolbar.setIconSize(self.iface.iconSize(True))
-
         menuBar = self.iface.mainWindow().menuBar()
         menuBar.insertMenu(
             self.iface.firstRightStandardMenu().menuAction(), self.menu)

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -70,6 +70,7 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
         self.tipWasClosed = False
         self.setupUi(self)
         self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.processingToolbar.setIconSize(iface.iconSize(True))
 
         self.searchBox.textChanged.connect(self.textChanged)
         self.algorithmTree.customContextMenuRequested.connect(


### PR DESCRIPTION
## Description
@nyalldawson , this fixes the toolbar button size for provider actions when QGIS launches. 

For some reason, the toolbar button size won't dynamically change if you tweak the size in the options dialog until / unless you restart QGIS. That's however a different issue, which we can address later if we, well, ever figure out what's wrong with pyqt5 😉 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
