### PR TITLE
avoid startup warning, do not look for empty setting value

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -666,7 +666,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
 
   Q_FOREACH ( QObject *obj, menubar->children() )
   {
-    if ( obj->inherits( "QMenu" ) )
+    if ( obj->inherits( "QMenu" ) && !obj->objectName().isEmpty() )
     {
       QMenu *menu = qobject_cast<QMenu *>( obj );
       bool visible = mSettings->value( menu->objectName(), true ).toBool();
@@ -688,7 +688,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
   mSettings->beginGroup( QStringLiteral( "Customization/Toolbars" ) );
   Q_FOREACH ( QObject *obj, mw->children() )
   {
-    if ( obj->inherits( "QToolBar" ) )
+    if ( obj->inherits( "QToolBar" ) && !obj->objectName().isEmpty() )
     {
       QToolBar *tb = qobject_cast<QToolBar *>( obj );
       bool visible = mSettings->value( tb->objectName(), true ).toBool();
@@ -724,7 +724,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
   mSettings->beginGroup( QStringLiteral( "Customization/Docks" ) );
   Q_FOREACH ( QObject *obj, mw->children() )
   {
-    if ( obj->inherits( "QDockWidget" ) )
+    if ( obj->inherits( "QDockWidget" ) && !obj->objectName().isEmpty() )
     {
       bool visible = mSettings->value( obj->objectName(), true ).toBool();
       if ( !visible )
@@ -745,7 +745,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
     QgsStatusBar *sb = mw->statusBarIface();
     Q_FOREACH ( QObject *obj, sb->children() )
     {
-      if ( obj->inherits( "QWidget" ) )
+      if ( obj->inherits( "QWidget" ) && !obj->objectName().isEmpty() )
       {
         QWidget *widget = qobject_cast<QWidget *>( obj );
         if ( widget->objectName().isEmpty() )


### PR DESCRIPTION
## Description
When interface customization is enabled, qt throws a warning when starting QGIS due to the code attempting to get an empty QSetting value. This PR insures we don't do that.

The warning was harmless, but it's always nice to lower the console noise.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
