### PR TITLE
fix saving interface customization to .ini (fixes #17979)

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -245,7 +245,7 @@ void QgsCustomizationDialog::actionSave_triggered( bool checked )
   QFileInfo fileInfo( fileName );
   mySettings.setValue( mLastDirSettingsName, fileInfo.absoluteDir().absolutePath() );
 
-  QSettings fileSettings( fileName );
+  QSettings fileSettings( fileName, QSettings::IniFormat );
   treeToSettings( &fileSettings );
 }
 
@@ -264,7 +264,7 @@ void QgsCustomizationDialog::actionLoad_triggered( bool checked )
   QFileInfo fileInfo( fileName );
   mySettings.setValue( mLastDirSettingsName, fileInfo.absoluteDir().absolutePath() );
 
-  QSettings fileSettings( fileName );
+  QSettings fileSettings( fileName, QSettings::IniFormat );
   settingsToTree( &fileSettings );
 }
 


### PR DESCRIPTION
## Description
Fixes a regression whereas interface customization can't be exported/saved to a .ini file.

@NathanW2 , is this looking OK to you?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
