### PR TITLE
Fix possible GIL deadlock when iterating features in python and an exception is thrown

### DIFF
--- a/python/core/qgsfeatureiterator.sip.in
+++ b/python/core/qgsfeatureiterator.sip.in
@@ -201,12 +201,15 @@ Wrapper for iterator of features from vector data provider or vector layer
 
     SIP_PYOBJECT __next__();
 %MethodCode
-    QgsFeature *f = new QgsFeature;
-    if ( sipCpp->nextFeature( *f ) )
-      sipRes = sipConvertFromType( f, sipType_QgsFeature, Py_None );
+    std::unique_ptr< QgsFeature > f = qgis::make_unique< QgsFeature >();
+    bool result = false;
+    Py_BEGIN_ALLOW_THREADS
+    result = ( sipCpp->nextFeature( *f ) );
+    Py_END_ALLOW_THREADS
+    if ( result )
+      sipRes = sipConvertFromType( f.release(), sipType_QgsFeature, Py_None );
     else
     {
-      delete f;
       PyErr_SetString( PyExc_StopIteration, "" );
     }
 %End

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -276,12 +276,15 @@ class CORE_EXPORT QgsFeatureIterator
 
     SIP_PYOBJECT __next__();
     % MethodCode
-    QgsFeature *f = new QgsFeature;
-    if ( sipCpp->nextFeature( *f ) )
-      sipRes = sipConvertFromType( f, sipType_QgsFeature, Py_None );
+    std::unique_ptr< QgsFeature > f = qgis::make_unique< QgsFeature >();
+    bool result = false;
+    Py_BEGIN_ALLOW_THREADS
+    result = ( sipCpp->nextFeature( *f ) );
+    Py_END_ALLOW_THREADS
+    if ( result )
+      sipRes = sipConvertFromType( f.release(), sipType_QgsFeature, Py_None );
     else
     {
-      delete f;
       PyErr_SetString( PyExc_StopIteration, "" );
     }
     % End


### PR DESCRIPTION
This bug has been my nemesis for the past 6 months. It caused an issue where iterating over features in python would cause a deadlock in the GIL if an exception is thrown. This occurs in processing when the "halt when encountering a feature with invalid geometry" option is enabled.

It's the last blocker from allowing python algs to execute in background threads.

Whooo!