### PR TITLE
[bugfix] Add dirty bit to attribute form

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -565,7 +565,7 @@ bool QgsAttributeForm::saveMultiEdits()
 
 bool QgsAttributeForm::save()
 {
-  if ( mIsSaving )
+  if ( mIsSaving || !mDirty )
     return true;
 
   mIsSaving = true;
@@ -594,16 +594,20 @@ bool QgsAttributeForm::save()
 
   mIsSaving = false;
   mUnsavedMultiEditChanges = false;
+  mDirty = false;
 
   return success;
 }
 
 void QgsAttributeForm::resetValues()
 {
+  mValuesInitialized = false;
   Q_FOREACH ( QgsWidgetWrapper *ww, mWidgets )
   {
     ww->setFeature( mFeature );
   }
+  mValuesInitialized = true;
+  mDirty = false;
 }
 
 void QgsAttributeForm::resetSearch()
@@ -657,6 +661,9 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value )
   // Safety check, if we receive the same value again, no reason to do anything
   if ( oldValue == value && oldValue.isNull() == value.isNull() )
     return;
+
+  if ( mValuesInitialized )
+    mDirty = true;
 
   switch ( mMode )
   {

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -364,6 +364,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QList< QgsAttributeFormWidget *> mFormWidgets;
     QgsExpressionContext mExpressionContext;
     QMap<const QgsVectorLayerJoinInfo *, QgsFeature> mJoinedFeatures;
+    bool mValuesInitialized = false;
+    bool mDirty = false;
 
     struct ContainerInformation
     {


### PR DESCRIPTION
## Description
In some cases it is difficult to prevent that an edit widget doesn't return the original value, even if the user didn't change anything. So rather than just comparing values to check if they have been modified, this PR adds a dirty bit which is set whenever the user actually edits the data in an edit widget. This is part of the fix for #17878. See also PR #6185.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
