### PR TITLE
Fix displaying keyboard shortcut under macos

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -40,7 +40,7 @@ from qgis.gui import (QgsOptionsWidgetFactory,
                       QgsCustomDropHandler)
 from qgis.PyQt.QtCore import Qt, QCoreApplication, QDir, QFileInfo
 from qgis.PyQt.QtWidgets import QMenu, QAction
-from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon, QKeySequence
 
 from processing.core.Processing import Processing
 from processing.gui.AlgorithmDialog import AlgorithmDialog
@@ -189,7 +189,8 @@ class ProcessingPlugin:
         self.toolboxAction.setObjectName('toolboxAction')
         self.toolboxAction.setIcon(
             QgsApplication.getThemeIcon("/processingAlgorithm.svg"))
-        self.iface.registerMainWindowAction(self.toolboxAction, 'Ctrl+Alt+T')
+        self.iface.registerMainWindowAction(self.toolboxAction,
+                                            QKeySequence('Ctrl+Alt+T').toString(QKeySequence.NativeText))
         self.toolboxAction.toggled.connect(self.openToolbox)
         self.iface.attributesToolBar().insertAction(self.iface.actionOpenStatisticalSummary(), self.toolboxAction)
         self.menu.addAction(self.toolboxAction)
@@ -199,7 +200,8 @@ class ProcessingPlugin:
             self.tr('Graphical &Modeler...'), self.iface.mainWindow())
         self.modelerAction.setObjectName('modelerAction')
         self.modelerAction.triggered.connect(self.openModeler)
-        self.iface.registerMainWindowAction(self.modelerAction, 'Ctrl+Alt+M')
+        self.iface.registerMainWindowAction(self.modelerAction,
+                                            QKeySequence('Ctrl+Alt+M').toString(QKeySequence.NativeText))
         self.menu.addAction(self.modelerAction)
 
         self.historyAction = QAction(
@@ -207,7 +209,8 @@ class ProcessingPlugin:
             self.tr('&History...'), self.iface.mainWindow())
         self.historyAction.setObjectName('historyAction')
         self.historyAction.triggered.connect(self.openHistory)
-        self.iface.registerMainWindowAction(self.historyAction, 'Ctrl+Alt+H')
+        self.iface.registerMainWindowAction(self.historyAction,
+                                            QKeySequence('Ctrl+Alt+H').toString(QKeySequence.NativeText))
         self.menu.addAction(self.historyAction)
         self.toolbox.processingToolbar.addAction(self.historyAction)
 
@@ -215,7 +218,9 @@ class ProcessingPlugin:
             QgsApplication.getThemeIcon("/processingResult.svg"),
             self.tr('&Results Viewer'), self.iface.mainWindow())
         self.resultsAction.setCheckable(True)
-        self.iface.registerMainWindowAction(self.resultsAction, 'Ctrl+Alt+R')
+        self.iface.registerMainWindowAction(self.resultsAction,
+                                            QKeySequence('Ctrl+Alt+R').toString(QKeySequence.NativeText))
+
         self.menu.addAction(self.resultsAction)
         self.toolbox.processingToolbar.addAction(self.resultsAction)
         self.resultsDock.visibilityChanged.connect(self.resultsAction.setChecked)

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -69,13 +69,13 @@ void QgsConfigureShortcutsDialog::populateActions()
     {
       actionText = action->text();
       actionText.remove( '&' ); // remove the accelerator
-      sequence = action->shortcut().toString();
+      sequence = action->shortcut().toString( QKeySequence::NativeText );
       icon = action->icon();
     }
     else if ( QShortcut *shortcut = qobject_cast< QShortcut * >( obj ) )
     {
       actionText = shortcut->whatsThis();
-      sequence = shortcut->key().toString();
+      sequence = shortcut->key().toString( QKeySequence::NativeText );
       icon = shortcut->property( "Icon" ).value<QIcon>();
     }
     else
@@ -391,7 +391,7 @@ void QgsConfigureShortcutsDialog::updateShortcutText()
 {
   // update text of the button so that user can see what has typed already
   QKeySequence s( mModifiers + mKey );
-  btnChangeShortcut->setText( tr( "Input: " ) + s.toString() );
+  btnChangeShortcut->setText( tr( "Input: " ) + s.toString( QKeySequence::NativeText ) );
 }
 
 void QgsConfigureShortcutsDialog::setGettingShortcut( bool getting )
@@ -449,10 +449,10 @@ void QgsConfigureShortcutsDialog::setCurrentActionShortcut( const QKeySequence &
   }
 
   // update manager
-  mManager->setObjectKeySequence( object, s.toString() );
+  mManager->setObjectKeySequence( object, s.toString( QKeySequence::NativeText ) );
 
   // update gui
-  treeActions->currentItem()->setText( 1, s.toString() );
+  treeActions->currentItem()->setText( 1, s.toString( QKeySequence::NativeText ) );
 
   actionChanged( treeActions->currentItem(), nullptr );
 }

--- a/src/gui/qgsshortcutsmanager.cpp
+++ b/src/gui/qgsshortcutsmanager.cpp
@@ -38,7 +38,7 @@ void QgsShortcutsManager::registerAllChildActions( QObject *object, bool recursi
     QList< QAction * > actions = object->findChildren< QAction * >();
     Q_FOREACH ( QAction *a, actions )
     {
-      registerAction( a, a->shortcut().toString() );
+      registerAction( a, a->shortcut().toString( QKeySequence::NativeText ) );
     }
   }
   else
@@ -47,7 +47,7 @@ void QgsShortcutsManager::registerAllChildActions( QObject *object, bool recursi
     {
       if ( QAction *a = qobject_cast<QAction *>( child ) )
       {
-        registerAction( a, a->shortcut().toString() );
+        registerAction( a, a->shortcut().toString( QKeySequence::NativeText ) );
       }
     }
   }
@@ -60,7 +60,7 @@ void QgsShortcutsManager::registerAllChildShortcuts( QObject *object, bool recur
     QList< QShortcut * > shortcuts = object->findChildren< QShortcut * >();
     Q_FOREACH ( QShortcut *s, shortcuts )
     {
-      registerShortcut( s, s->key().toString() );
+      registerShortcut( s, s->key().toString( QKeySequence::NativeText ) );
     }
   }
   else
@@ -69,7 +69,7 @@ void QgsShortcutsManager::registerAllChildShortcuts( QObject *object, bool recur
     {
       if ( QShortcut *s = qobject_cast<QShortcut *>( child ) )
       {
-        registerShortcut( s, s->key().toString() );
+        registerShortcut( s, s->key().toString( QKeySequence::NativeText ) );
       }
     }
   }


### PR DESCRIPTION
## Description
properly display keyboard shortcut for action and config keyboard shortcut dialog under macOS

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
