### PR TITLE
[processing] Correctly supress CRS selector dialog when testing

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -141,7 +141,7 @@ class ProjectionSettingRestorer
     {
       QgsSettings settings;
       previousSetting = settings.value( QStringLiteral( "/Projections/defaultBehavior" ) ).toString();
-      settings.setValue( QStringLiteral( "/Projections/defaultBehavior" ), QString() );
+      settings.setValue( QStringLiteral( "/Projections/defaultBehavior" ), QStringLiteral( "useProject" ) );
     }
 
     ~ProjectionSettingRestorer()


### PR DESCRIPTION
input layer validity

TODO: we NEED a non-hacky way to supress this dialog and allow invalid CRS for layers!

Fixes #17948
