### PR TITLE
[Win] Extra environment variable to stop override of .env file when running osgeo4w shell and exe.

### DIFF
--- a/ms-windows/osgeo4w/postinstall-desktop.bat
+++ b/ms-windows/osgeo4w/postinstall-desktop.bat
@@ -6,6 +6,7 @@ REM get short path without blanks
 for %%i in ("%OSGEO4W_ROOT%") do set O4W_ROOT=%%~fsi
 if "%OSGEO4W_DESKTOP%"=="" set OSGEO4W_DESKTOP=~$folder.common_desktop$
 
+SET OSGEO4W_INSTALL=YES
 "%OSGEO4W_ROOT%\bin\@package@.bat" --exit
 
 if not %OSGEO4W_MENU_LINKS%==0 mkdir "%OSGEO4W_STARTMENU%"

--- a/ms-windows/osgeo4w/postinstall-dev.bat
+++ b/ms-windows/osgeo4w/postinstall-dev.bat
@@ -6,6 +6,7 @@ if "%OSGEO4W_DESKTOP%"=="" set OSGEO4W_DESKTOP=~$folder.common_desktop$
 if not %OSGEO4W_MENU_LINKS%==0 mkdir "%OSGEO4W_STARTMENU%"
 if not %OSGEO4W_DESKTOP_LINKS%==0 mkdir "%OSGEO4W_DESKTOP%"
 
+SET OSGEO4W_INSTALL=YES
 for %%g in (@grassversions@) do (
 	copy "%OSGEO4W_ROOT%\bin\@package@-bin.exe" "%OSGEO4W_ROOT%\bin\@package@-bin-g%%g.exe"
 	copy "%OSGEO4W_ROOT%\bin\@package@-bin.vars" "%OSGEO4W_ROOT%\bin\@package@-bin-g%%g.vars"

--- a/ms-windows/osgeo4w/postinstall-grass.bat
+++ b/ms-windows/osgeo4w/postinstall-grass.bat
@@ -4,6 +4,7 @@ if "%OSGEO4W_DESKTOP%"=="" set OSGEO4W_DESKTOP=~$folder.common_desktop$
 
 copy bin\@package@-bin.exe bin\@package@-bin-grass@grassmajor@.exe
 copy bin\@package@-bin.vars bin\@package@-bin-grass@grassmajor@.vars
+SET OSGEO4W_INSTALL=YES
 "%OSGEO4W_ROOT%\bin\@package@-grass@grassmajor@.bat" --exit
 
 if not %OSGEO4W_MENU_LINKS%==0 mkdir "%OSGEO4W_STARTMENU%"

--- a/src/app/mainwin.cpp
+++ b/src/app/mainwin.cpp
@@ -42,7 +42,7 @@ int CALLBACK WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
 {
   std::string basename( moduleExeBaseName() );
 
-  if ( getenv( "OSGEO4W_ROOT" ) )
+  if ( getenv( "OSGEO4W_ROOT" ) && getenv( "OSGEO4W_INSTALL" ) )
   {
     std::string envfile( basename + ".env" );
 


### PR DESCRIPTION
@jef-n at the moment because the only check is on OSGEO4W_ROOT it is possible bust the exe by running osgeo4w shell on windows, load the exe, which sets the env file again, busting the runtime environments for each exe you try to load.  I have just added error handling for this case but I think it's better that we have another flag to know if we are doing the install and leave the .env file alone for all other cases.

 
