### PR TITLE
[processing] Default to supporting non-file based outputs for providers

### DIFF
--- a/python/core/processing/qgsprocessingprovider.sip.in
+++ b/python/core/processing/qgsprocessingprovider.sip.in
@@ -148,6 +148,10 @@ indicates that none of the outputs from any of the provider's algorithms have
 support for non-file based outputs. Returning true indicates that the algorithm's
 parameters will each individually declare their non-file based support.
 
+The default behavior for providers is to support non-file based outputs, and most
+providers which rely solely on QGIS API (and which do not depend on third-party scripts
+or external dependencies) will automatically support this.
+
 .. seealso:: :py:func:`supportedOutputVectorLayerExtensions`
 %End
 

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -199,6 +199,12 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
     def supportedOutputRasterLayerExtensions(self):
         return GdalUtils.getSupportedRasterExtensions()
 
+    def supportsNonFileBasedOutput(self):
+        """
+        GDAL Provider doesn't support non file based outputs
+        """
+        return False
+
     def tr(self, string, context=''):
         if context == '':
             context = 'GdalAlgorithmProvider'

--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -127,6 +127,12 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
     def supportedOutputTableExtensions(self):
         return ['dbf']
 
+    def supportsNonFileBasedOutput(self):
+        """
+        SAGA Provider doesn't support non file based outputs
+        """
+        return False
+
     def icon(self):
         return QIcon(os.path.join(pluginPath, 'images', 'saga.png'))
 

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -140,3 +140,8 @@ QString QgsProcessingProvider::defaultRasterFileExtension() const
     return defaultExtension;
   }
 }
+
+bool QgsProcessingProvider::supportsNonFileBasedOutput() const
+{
+  return true;
+}

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -150,9 +150,14 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * indicates that none of the outputs from any of the provider's algorithms have
      * support for non-file based outputs. Returning true indicates that the algorithm's
      * parameters will each individually declare their non-file based support.
+     *
+     * The default behavior for providers is to support non-file based outputs, and most
+     * providers which rely solely on QGIS API (and which do not depend on third-party scripts
+     * or external dependencies) will automatically support this.
+     *
      * \see supportedOutputVectorLayerExtensions()
      */
-    virtual bool supportsNonFileBasedOutput() const { return false; }
+    virtual bool supportsNonFileBasedOutput() const;
 
     /**
      * Loads the provider. This will be called when the plugin is being loaded, and any general


### PR DESCRIPTION
And make this support opt-out, since the vast majority of providers are based on QGIS API and don't have external dependencies which would restrict use of memory layers/etc.

Plus, I'd rather see non-compliant providers expose this support when they can't use non-file-based-outputs (and make this the bug which needs fixing) then have to rely on plugin providers to discover and
explicitly expose this support.
