### PR TITLE
[processing] Default to allowing background execution of algorithms

### DIFF
--- a/python/core/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -47,6 +47,8 @@ Constructor for QgsProcessingModelAlgorithm.
 
     virtual QString helpUrl() const;
 
+    virtual Flags flags() const;
+
 
     virtual bool canExecute( QString *errorMessage /Out/ = 0 ) const;
 

--- a/python/core/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/processing/qgsprocessingalgorithm.sip.in
@@ -44,7 +44,7 @@ Abstract base class for processing algorithms.
       FlagSupportsBatch,
       FlagCanCancel,
       FlagRequiresMatchingCrs,
-      FlagCanRunInBackground,
+      FlagNoThreading,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -151,6 +151,10 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
     def svgIconPath(self):
         return QgsApplication.iconPath("providerGrass.svg")
 
+    def flags(self):
+        # TODO - maybe it's safe to background thread this?
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+
     def tr(self, string, context=''):
         if context == '':
             context = self.__class__.__name__

--- a/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
+++ b/python/plugins/processing/algs/qgis/CreateAttributeIndex.py
@@ -27,6 +27,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsVectorDataProvider,
                        QgsFields,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterField,
                        QgsProcessingOutputVectorLayer)
@@ -55,6 +56,9 @@ class CreateAttributeIndex(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterField(self.FIELD,
                                                       self.tr('Attribute to index'), None, self.INPUT))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Indexed layer')))
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def name(self):
         return 'createattributeindex'

--- a/python/plugins/processing/algs/qgis/DefineProjection.py
+++ b/python/plugins/processing/algs/qgis/DefineProjection.py
@@ -29,6 +29,7 @@ import os
 import re
 
 from qgis.core import (QgsProcessing,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterCrs,
                        QgsProcessingOutputVectorLayer)
@@ -64,6 +65,9 @@ class DefineProjection(QgisAlgorithm):
 
     def displayName(self):
         return self.tr('Define current projection')
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def processAlgorithm(self, parameters, context, feedback):
         layer = self.parameterAsVectorLayer(parameters, self.INPUT, context)

--- a/python/plugins/processing/algs/qgis/EliminateSelection.py
+++ b/python/plugins/processing/algs/qgis/EliminateSelection.py
@@ -33,6 +33,7 @@ from qgis.core import (QgsFeatureRequest,
                        QgsFeature,
                        QgsFeatureSink,
                        QgsGeometry,
+                       QgsProcessingAlgorithm,
                        QgsProcessingException,
                        QgsProcessingUtils,
                        QgsProcessingParameterVectorLayer,
@@ -66,6 +67,9 @@ class EliminateSelection(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def initAlgorithm(self, config=None):
         self.modes = [self.tr('Largest Area'),

--- a/python/plugins/processing/algs/qgis/ExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/ExecuteSQL.py
@@ -28,6 +28,7 @@ __revision__ = '$Format:%H$'
 from qgis.core import (QgsVirtualLayerDefinition,
                        QgsVectorLayer,
                        QgsWkbTypes,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterMultipleLayers,
                        QgsProcessingParameterString,
                        QgsProcessingParameterEnum,
@@ -61,6 +62,9 @@ class ExecuteSQL(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterMultipleLayers(name=self.INPUT_DATASOURCES,

--- a/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
@@ -27,6 +27,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsDataSourceUri,
                        QgsFeatureSink,
+                       QgsProcessingAlgorithm,
                        QgsVectorLayerExporter,
                        QgsProcessingException,
                        QgsProcessingParameterFeatureSource,
@@ -75,6 +76,9 @@ class ImportIntoSpatialite(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterBoolean(self.LOWERCASE_NAMES, self.tr('Convert field names to lowercase'), True))
         self.addParameter(QgsProcessingParameterBoolean(self.DROP_STRING_LENGTH, self.tr('Drop length constraints on character fields'), False))
         self.addParameter(QgsProcessingParameterBoolean(self.FORCE_SINGLEPART, self.tr('Create single-part geometries instead of multi-part'), False))
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def name(self):
         return 'importintospatialite'

--- a/python/plugins/processing/algs/qgis/RandomSelection.py
+++ b/python/plugins/processing/algs/qgis/RandomSelection.py
@@ -32,6 +32,7 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.core import (QgsFeatureSink,
                        QgsProcessingException,
                        QgsProcessingUtils,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterNumber,
@@ -58,6 +59,9 @@ class RandomSelection(QgisAlgorithm):
 
     def groupId(self):
         return 'vectorselection'
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def __init__(self):
         super().__init__()

--- a/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
@@ -33,6 +33,7 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.core import (QgsFeatureRequest,
                        QgsProcessingException,
                        QgsProcessingUtils,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterField,
@@ -64,6 +65,9 @@ class RandomSelectionWithinSubsets(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def initAlgorithm(self, config=None):
         self.methods = [self.tr('Number of selected features'),

--- a/python/plugins/processing/algs/qgis/SelectByAttribute.py
+++ b/python/plugins/processing/algs/qgis/SelectByAttribute.py
@@ -28,6 +28,7 @@ __revision__ = '$Format:%H$'
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import (QgsExpression,
                        QgsProcessingException,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterField,
                        QgsProcessingParameterEnum,
@@ -70,6 +71,9 @@ class SelectByAttribute(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def initAlgorithm(self, config=None):
         self.i18n_operators = ['=',

--- a/python/plugins/processing/algs/qgis/SelectByExpression.py
+++ b/python/plugins/processing/algs/qgis/SelectByExpression.py
@@ -26,6 +26,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsExpression,
                        QgsVectorLayer,
+                       QgsProcessingAlgorithm,
                        QgsProcessingException,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterExpression,
@@ -49,6 +50,9 @@ class SelectByExpression(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def initAlgorithm(self, config=None):
         self.methods = [self.tr('creating new selection'),

--- a/python/plugins/processing/algs/qgis/SetRasterStyle.py
+++ b/python/plugins/processing/algs/qgis/SetRasterStyle.py
@@ -29,7 +29,8 @@ import os
 
 from qgis.PyQt.QtXml import QDomDocument
 
-from qgis.core import (QgsProcessingParameterRasterLayer,
+from qgis.core import (QgsProcessingAlgorithm,
+                       QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterFile,
                        QgsProcessingOutputRasterLayer)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
@@ -49,6 +50,9 @@ class SetRasterStyle(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT,

--- a/python/plugins/processing/algs/qgis/SetVectorStyle.py
+++ b/python/plugins/processing/algs/qgis/SetVectorStyle.py
@@ -25,7 +25,8 @@ __copyright__ = '(C) 2012, Victor Olaya'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsProcessingParameterFile,
+from qgis.core import (QgsProcessingAlgorithm,
+                       QgsProcessingParameterFile,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingOutputVectorLayer)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
@@ -45,6 +46,9 @@ class SetVectorStyle(QgisAlgorithm):
 
     def __init__(self):
         super().__init__()
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT,

--- a/python/plugins/processing/algs/qgis/SpatialIndex.py
+++ b/python/plugins/processing/algs/qgis/SpatialIndex.py
@@ -28,6 +28,7 @@ __revision__ = '$Format:%H$'
 import os
 
 from qgis.core import (QgsVectorDataProvider,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingOutputVectorLayer,
                        QgsProcessing)
@@ -56,6 +57,9 @@ class SpatialIndex(QgisAlgorithm):
                                                             self.tr('Input Layer'),
                                                             [QgsProcessing.TypeVectorPolygon, QgsProcessing.TypeVectorPoint, QgsProcessing.TypeVectorLine]))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Indexed layer')))
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def name(self):
         return 'createspatialindex'

--- a/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
@@ -26,6 +26,7 @@ __copyright__ = '(C) 2016, Mathieu Pellerin'
 __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsDataSourceUri,
+                       QgsProcessingAlgorithm,
                        QgsProcessingException,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterString)
@@ -57,6 +58,9 @@ class SpatialiteExecuteSQL(QgisAlgorithm):
 
     def displayName(self):
         return self.tr('SpatiaLite execute SQL')
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def processAlgorithm(self, parameters, context, feedback):
         database = self.parameterAsVectorLayer(parameters, self.DATABASE, context)

--- a/python/plugins/processing/algs/qgis/TruncateTable.py
+++ b/python/plugins/processing/algs/qgis/TruncateTable.py
@@ -25,7 +25,8 @@ __copyright__ = '(C) 2017, Nyall Dawson'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsProcessingParameterVectorLayer,
+from qgis.core import (QgsProcessingAlgorithm,
+                       QgsProcessingParameterVectorLayer,
                        QgsProcessingOutputVectorLayer,
                        QgsProcessingException)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
@@ -52,6 +53,9 @@ class TruncateTable(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT,
                                                             self.tr('Input Layer')))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Truncated layer')))
+
+    def flags(self):
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def name(self):
         return 'truncatetable'

--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -33,6 +33,7 @@ from qgis.core import (QgsProcessingUtils,
                        QgsProcessingException,
                        QgsMessageLog,
                        QgsProcessing,
+                       QgsProcessingAlgorithm,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterBoolean,
@@ -98,6 +99,10 @@ class SagaAlgorithm(SagaAlgorithmBase):
 
     def shortHelpString(self):
         return shortHelp.get(self.id(), None)
+
+    def flags(self):
+        # TODO - maybe it's safe to background thread this?
+        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 
     def defineCharacteristicsFromFile(self):
         with open(self.description_file) as lines:

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -251,7 +251,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
 
                     self.finish(ok, results, context, feedback)
 
-                if self.algorithm().flags() & QgsProcessingAlgorithm.FlagCanRunInBackground:
+                if not (self.algorithm().flags() & QgsProcessingAlgorithm.FlagNoThreading):
                     # Make sure the Log tab is visible before executing the algorithm
                     self.showLog()
 

--- a/src/3d/processing/qgsalgorithmtessellate.cpp
+++ b/src/3d/processing/qgsalgorithmtessellate.cpp
@@ -31,11 +31,6 @@ QString QgsTessellateAlgorithm::displayName() const
   return QObject::tr( "Tessellate" );
 }
 
-QgsProcessingAlgorithm::Flags QgsTessellateAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QStringList QgsTessellateAlgorithm::tags() const
 {
   return QObject::tr( "3d,triangle" ).split( ',' );

--- a/src/3d/processing/qgsalgorithmtessellate.h
+++ b/src/3d/processing/qgsalgorithmtessellate.h
@@ -36,7 +36,6 @@ class QgsTessellateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsTessellateAlgorithm() = default;
     QString name() const override;
     QString displayName() const override;
-    Flags flags() const override;
     QStringList tags() const override;
     QString group() const override;
     QString shortHelpString() const override;

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsAddIncrementalFieldAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsAddIncrementalFieldAlgorithm::name() const
 {
   return QStringLiteral( "addautoincrementalfield" );

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.h
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.h
@@ -34,7 +34,6 @@ class QgsAddIncrementalFieldAlgorithm : public QgsProcessingFeatureBasedAlgorith
   public:
 
     QgsAddIncrementalFieldAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmassignprojection.cpp
+++ b/src/analysis/processing/qgsalgorithmassignprojection.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsAssignProjectionAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsAssignProjectionAlgorithm::name() const
 {
   return QStringLiteral( "assignprojection" );

--- a/src/analysis/processing/qgsalgorithmassignprojection.h
+++ b/src/analysis/processing/qgsalgorithmassignprojection.h
@@ -34,7 +34,6 @@ class QgsAssignProjectionAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsAssignProjectionAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmboundary.cpp
+++ b/src/analysis/processing/qgsalgorithmboundary.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsBoundaryAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsBoundaryAlgorithm::name() const
 {
   return QStringLiteral( "boundary" );

--- a/src/analysis/processing/qgsalgorithmboundary.h
+++ b/src/analysis/processing/qgsalgorithmboundary.h
@@ -34,7 +34,6 @@ class QgsBoundaryAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsBoundaryAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmboundingbox.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsBoundingBoxAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsBoundingBoxAlgorithm::name() const
 {
   return QStringLiteral( "boundingboxes" );

--- a/src/analysis/processing/qgsalgorithmboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmboundingbox.h
@@ -34,7 +34,6 @@ class QgsBoundingBoxAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsBoundingBoxAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -63,11 +63,6 @@ void QgsBufferAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Buffered" ), QgsProcessing::TypeVectorPolygon ) );
 }
 
-QgsProcessingAlgorithm::Flags QgsBufferAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsBufferAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm computes a buffer area for all the features in an input layer, using a fixed or dynamic distance.\n\n"

--- a/src/analysis/processing/qgsalgorithmbuffer.h
+++ b/src/analysis/processing/qgsalgorithmbuffer.h
@@ -35,7 +35,6 @@ class QgsBufferAlgorithm : public QgsProcessingAlgorithm
 
     QgsBufferAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmcentroid.cpp
+++ b/src/analysis/processing/qgsalgorithmcentroid.cpp
@@ -49,11 +49,6 @@ QString QgsCentroidAlgorithm::outputName() const
   return QObject::tr( "Centroids" );
 }
 
-QgsProcessingAlgorithm::Flags QgsCentroidAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsCentroidAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmcentroid.h
+++ b/src/analysis/processing/qgsalgorithmcentroid.h
@@ -34,7 +34,6 @@ class QgsCentroidAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsCentroidAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmclip.cpp
+++ b/src/analysis/processing/qgsalgorithmclip.cpp
@@ -40,11 +40,6 @@ QString QgsClipAlgorithm::group() const
   return QObject::tr( "Vector overlay" );
 }
 
-QgsProcessingAlgorithm::Flags QgsClipAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsClipAlgorithm::groupId() const
 {
   return QStringLiteral( "vectoroverlay" );

--- a/src/analysis/processing/qgsalgorithmclip.h
+++ b/src/analysis/processing/qgsalgorithmclip.h
@@ -34,7 +34,6 @@ class QgsClipAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsClipAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmconvexhull.cpp
+++ b/src/analysis/processing/qgsalgorithmconvexhull.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsConvexHullAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsConvexHullAlgorithm::name() const
 {
   return QStringLiteral( "convexhull" );

--- a/src/analysis/processing/qgsalgorithmconvexhull.h
+++ b/src/analysis/processing/qgsalgorithmconvexhull.h
@@ -35,7 +35,6 @@ class QgsConvexHullAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsConvexHullAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -23,11 +23,6 @@
 // QgsCollectorAlgorithm
 //
 
-QgsProcessingAlgorithm::Flags QgsCollectorAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback,
     const std::function<QgsGeometry( const QVector< QgsGeometry >& )> &collector, int maxQueueLength )
 {

--- a/src/analysis/processing/qgsalgorithmdissolve.h
+++ b/src/analysis/processing/qgsalgorithmdissolve.h
@@ -32,7 +32,6 @@ class QgsCollectorAlgorithm : public QgsProcessingAlgorithm
 {
   protected:
 
-    Flags flags() const override;
     QVariantMap processCollection( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback,
                                    const std::function<QgsGeometry( const QVector<QgsGeometry>& )> &collector, int maxQueueLength = 0 );
 };

--- a/src/analysis/processing/qgsalgorithmdropgeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmdropgeometry.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsDropGeometryAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsDropGeometryAlgorithm::name() const
 {
   return QStringLiteral( "dropgeometries" );

--- a/src/analysis/processing/qgsalgorithmdropgeometry.h
+++ b/src/analysis/processing/qgsalgorithmdropgeometry.h
@@ -34,7 +34,6 @@ class QgsDropGeometryAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsDropGeometryAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmdropmzvalues.cpp
+++ b/src/analysis/processing/qgsalgorithmdropmzvalues.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsDropMZValuesAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsDropMZValuesAlgorithm::name() const
 {
   return QStringLiteral( "dropmzvalues" );

--- a/src/analysis/processing/qgsalgorithmdropmzvalues.h
+++ b/src/analysis/processing/qgsalgorithmdropmzvalues.h
@@ -34,7 +34,6 @@ class QgsDropMZValuesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsDropMZValuesAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmextenttolayer.cpp
+++ b/src/analysis/processing/qgsalgorithmextenttolayer.cpp
@@ -24,11 +24,6 @@ QString QgsExtentToLayerAlgorithm::name() const
   return QStringLiteral( "extenttolayer" );
 }
 
-QgsProcessingAlgorithm::Flags QgsExtentToLayerAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsExtentToLayerAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterExtent( QStringLiteral( "INPUT" ), QObject::tr( "Extent" ) ) );

--- a/src/analysis/processing/qgsalgorithmextenttolayer.h
+++ b/src/analysis/processing/qgsalgorithmextenttolayer.h
@@ -34,7 +34,6 @@ class QgsExtentToLayerAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtentToLayerAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override { return QObject::tr( "Create layer from extent" ); }

--- a/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
@@ -39,11 +39,6 @@ QString QgsExtractByAttributeAlgorithm::group() const
   return QObject::tr( "Vector selection" );
 }
 
-QgsProcessingAlgorithm::Flags QgsExtractByAttributeAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsExtractByAttributeAlgorithm::groupId() const
 {
   return QStringLiteral( "vectorselection" );

--- a/src/analysis/processing/qgsalgorithmextractbyattribute.h
+++ b/src/analysis/processing/qgsalgorithmextractbyattribute.h
@@ -49,7 +49,6 @@ class QgsExtractByAttributeAlgorithm : public QgsProcessingAlgorithm
     };
 
     QgsExtractByAttributeAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
@@ -44,11 +44,6 @@ QString QgsExtractByExpressionAlgorithm::groupId() const
   return QStringLiteral( "vectorselection" );
 }
 
-QgsProcessingAlgorithm::Flags QgsExtractByExpressionAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsExtractByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmextractbyexpression.h
+++ b/src/analysis/processing/qgsalgorithmextractbyexpression.h
@@ -34,7 +34,6 @@ class QgsExtractByExpressionAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtractByExpressionAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractbyextent.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyextent.cpp
@@ -43,12 +43,6 @@ QString QgsExtractByExtentAlgorithm::groupId() const
 {
   return QStringLiteral( "vectoroverlay" );
 }
-
-QgsProcessingAlgorithm::Flags QgsExtractByExtentAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsExtractByExtentAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmextractbyextent.h
+++ b/src/analysis/processing/qgsalgorithmextractbyextent.h
@@ -34,7 +34,6 @@ class QgsExtractByExtentAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtractByExtentAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -230,6 +230,11 @@ QString QgsSelectByLocationAlgorithm::name() const
   return QStringLiteral( "selectbylocation" );
 }
 
+QgsProcessingAlgorithm::Flags QgsSelectByLocationAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading;
+}
+
 QString QgsSelectByLocationAlgorithm::displayName() const
 {
   return QObject::tr( "Select by location" );
@@ -285,11 +290,6 @@ QVariantMap QgsSelectByLocationAlgorithm::processAlgorithm( const QVariantMap &p
 //
 // QgsExtractByLocationAlgorithm
 //
-
-QgsProcessingAlgorithm::Flags QgsExtractByLocationAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
 
 void QgsExtractByLocationAlgorithm::initAlgorithm( const QVariantMap & )
 {

--- a/src/analysis/processing/qgsalgorithmextractbylocation.h
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.h
@@ -64,6 +64,7 @@ class QgsSelectByLocationAlgorithm : public QgsLocationBasedAlgorithm
     QgsSelectByLocationAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
+    Flags flags() const override;
     QString displayName() const override;
     QStringList tags() const override;
     QString group() const override;
@@ -87,7 +88,6 @@ class QgsExtractByLocationAlgorithm : public QgsLocationBasedAlgorithm
   public:
 
     QgsExtractByLocationAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmextractnodes.cpp
+++ b/src/analysis/processing/qgsalgorithmextractnodes.cpp
@@ -59,11 +59,6 @@ QgsExtractNodesAlgorithm *QgsExtractNodesAlgorithm::createInstance() const
   return new QgsExtractNodesAlgorithm();
 }
 
-QgsProcessingAlgorithm::Flags QgsExtractNodesAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsExtractNodesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmextractnodes.h
+++ b/src/analysis/processing/qgsalgorithmextractnodes.h
@@ -34,7 +34,6 @@ class QgsExtractNodesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsExtractNodesAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -60,11 +60,6 @@ QgsFileDownloaderAlgorithm *QgsFileDownloaderAlgorithm::createInstance() const
   return new QgsFileDownloaderAlgorithm();
 }
 
-QgsProcessingAlgorithm::Flags QgsFileDownloaderAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsFileDownloaderAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterString( QStringLiteral( "URL" ), tr( "URL" ), QVariant(), false, false ) );

--- a/src/analysis/processing/qgsalgorithmfiledownloader.h
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.h
@@ -34,7 +34,6 @@ class QgsFileDownloaderAlgorithm : public QgsProcessingAlgorithm, public QObject
 {
   public:
     QgsFileDownloaderAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmfixgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsFixGeometriesAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsFixGeometriesAlgorithm::name() const
 {
   return QStringLiteral( "fixgeometries" );

--- a/src/analysis/processing/qgsalgorithmfixgeometries.h
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.h
@@ -34,7 +34,6 @@ class QgsFixGeometriesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsFixGeometriesAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
@@ -44,11 +44,6 @@ QString QgsJoinByAttributeAlgorithm::groupId() const
   return QStringLiteral( "vectorgeneral" );
 }
 
-QgsProcessingAlgorithm::Flags QgsJoinByAttributeAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsJoinByAttributeAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.h
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.h
@@ -34,7 +34,6 @@ class QgsJoinByAttributeAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsJoinByAttributeAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
@@ -45,11 +45,6 @@ QString QgsJoinWithLinesAlgorithm::groupId() const
   return QStringLiteral( "vectoranalysis" );
 }
 
-QgsProcessingAlgorithm::Flags QgsJoinWithLinesAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsJoinWithLinesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "HUBS" ),

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.h
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.h
@@ -34,7 +34,6 @@ class QgsJoinWithLinesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsJoinWithLinesAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmlineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmlineintersection.cpp
@@ -45,11 +45,6 @@ QString QgsLineIntersectionAlgorithm::groupId() const
   return QStringLiteral( "vectoroverlay" );
 }
 
-QgsProcessingAlgorithm::Flags QgsLineIntersectionAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsLineIntersectionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmlineintersection.h
+++ b/src/analysis/processing/qgsalgorithmlineintersection.h
@@ -34,7 +34,6 @@ class QgsLineIntersectionAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsLineIntersectionAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmloadlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmloadlayer.cpp
@@ -24,11 +24,6 @@ QString QgsLoadLayerAlgorithm::name() const
   return QStringLiteral( "loadlayer" );
 }
 
-QgsProcessingAlgorithm::Flags QgsLoadLayerAlgorithm::flags() const
-{
-  return FlagHideFromToolbox | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsLoadLayerAlgorithm::displayName() const
 {
   return QObject::tr( "Load layer into project" );

--- a/src/analysis/processing/qgsalgorithmloadlayer.h
+++ b/src/analysis/processing/qgsalgorithmloadlayer.h
@@ -33,7 +33,6 @@ class QgsLoadLayerAlgorithm : public QgsProcessingAlgorithm
   public:
     QgsLoadLayerAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmmeancoordinates.cpp
+++ b/src/analysis/processing/qgsalgorithmmeancoordinates.cpp
@@ -44,11 +44,6 @@ QString QgsMeanCoordinatesAlgorithm::groupId() const
   return QStringLiteral( "vectoranalysis" );
 }
 
-QgsProcessingAlgorithm::Flags QgsMeanCoordinatesAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsMeanCoordinatesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmmeancoordinates.h
+++ b/src/analysis/processing/qgsalgorithmmeancoordinates.h
@@ -35,7 +35,6 @@ class QgsMeanCoordinatesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsMeanCoordinatesAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmmergelines.cpp
+++ b/src/analysis/processing/qgsalgorithmmergelines.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsMergeLinesAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsMergeLinesAlgorithm::name() const
 {
   return QStringLiteral( "mergelines" );

--- a/src/analysis/processing/qgsalgorithmmergelines.h
+++ b/src/analysis/processing/qgsalgorithmmergelines.h
@@ -38,7 +38,6 @@ class QgsMergeLinesAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsMergeLinesAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmmergevector.cpp
+++ b/src/analysis/processing/qgsalgorithmmergevector.cpp
@@ -39,11 +39,6 @@ QString QgsMergeVectorAlgorithm::group() const
   return QObject::tr( "Vector general" );
 }
 
-QgsProcessingAlgorithm::Flags QgsMergeVectorAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsMergeVectorAlgorithm::groupId() const
 {
   return QStringLiteral( "vectorgeneral" );

--- a/src/analysis/processing/qgsalgorithmmergevector.h
+++ b/src/analysis/processing/qgsalgorithmmergevector.h
@@ -34,7 +34,6 @@ class QgsMergeVectorAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsMergeVectorAlgorithm() = default;
-    QgsProcessingAlgorithm::Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmminimumenclosingcircle.cpp
+++ b/src/analysis/processing/qgsalgorithmminimumenclosingcircle.cpp
@@ -54,11 +54,6 @@ QgsWkbTypes::Type QgsMinimumEnclosingCircleAlgorithm::outputWkbType( QgsWkbTypes
   return QgsWkbTypes::Polygon;
 }
 
-QgsProcessingAlgorithm::Flags QgsMinimumEnclosingCircleAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsMinimumEnclosingCircleAlgorithm::initParameters( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "SEGMENTS" ), QObject::tr( "Number of segments in circles" ), QgsProcessingParameterNumber::Integer,

--- a/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
+++ b/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
@@ -34,7 +34,6 @@ class QgsMinimumEnclosingCircleAlgorithm : public QgsProcessingFeatureBasedAlgor
   public:
 
     QgsMinimumEnclosingCircleAlgorithm() = default;
-    Flags flags() const override;
     void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmmultiparttosinglepart.cpp
+++ b/src/analysis/processing/qgsalgorithmmultiparttosinglepart.cpp
@@ -44,11 +44,6 @@ QString QgsMultipartToSinglepartAlgorithm::groupId() const
   return QStringLiteral( "vectorgeometry" );
 }
 
-QgsProcessingAlgorithm::Flags QgsMultipartToSinglepartAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsMultipartToSinglepartAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
+++ b/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
@@ -34,7 +34,6 @@ class QgsMultipartToSinglepartAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsMultipartToSinglepartAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmorderbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmorderbyexpression.cpp
@@ -47,11 +47,6 @@ QString QgsOrderByExpressionAlgorithm::groupId() const
   return QStringLiteral( "vectorgeneral" );
 }
 
-QgsProcessingAlgorithm::Flags QgsOrderByExpressionAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsOrderByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmorderbyexpression.h
+++ b/src/analysis/processing/qgsalgorithmorderbyexpression.h
@@ -34,7 +34,6 @@ class QgsOrderByExpressionAlgorithm : public QgsProcessingAlgorithm
 {
   public:
     QgsOrderByExpressionAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsOrientedMinimumBoundingBoxAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsOrientedMinimumBoundingBoxAlgorithm::name() const
 {
   return QStringLiteral( "orientedminimumboundingbox" );

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
@@ -34,7 +34,6 @@ class QgsOrientedMinimumBoundingBoxAlgorithm : public QgsProcessingFeatureBasedA
   public:
 
     QgsOrientedMinimumBoundingBoxAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -47,11 +47,6 @@ QString QgsPackageAlgorithm::groupId() const
   return QStringLiteral( "database" );
 }
 
-QgsProcessingAlgorithm::Flags QgsPackageAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsPackageAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterMultipleLayers( QStringLiteral( "LAYERS" ), QObject::tr( "Input layers" ), QgsProcessing::TypeVector ) );

--- a/src/analysis/processing/qgsalgorithmpackage.h
+++ b/src/analysis/processing/qgsalgorithmpackage.h
@@ -36,7 +36,6 @@ class QgsPackageAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsPackageAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsPromoteToMultipartAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsPromoteToMultipartAlgorithm::name() const
 {
   return QStringLiteral( "promotetomulti" );

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.h
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.h
@@ -35,7 +35,6 @@ class QgsPromoteToMultipartAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsPromoteToMultipartAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
@@ -44,11 +44,6 @@ QString QgsRasterLayerUniqueValuesReportAlgorithm::groupId() const
   return QStringLiteral( "rasteranalysis" );
 }
 
-QgsProcessingAlgorithm::Flags QgsRasterLayerUniqueValuesReportAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsRasterLayerUniqueValuesReportAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
@@ -34,7 +34,6 @@ class QgsRasterLayerUniqueValuesReportAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsRasterLayerUniqueValuesReportAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmremoveduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatenodes.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsAlgorithmRemoveDuplicateNodes::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsAlgorithmRemoveDuplicateNodes::name() const
 {
   return QStringLiteral( "removeduplicatenodes" );

--- a/src/analysis/processing/qgsalgorithmremoveduplicatenodes.h
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatenodes.h
@@ -34,7 +34,6 @@ class QgsAlgorithmRemoveDuplicateNodes : public QgsProcessingFeatureBasedAlgorit
   public:
 
     QgsAlgorithmRemoveDuplicateNodes() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmremovenullgeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmremovenullgeometry.cpp
@@ -44,11 +44,6 @@ QString QgsRemoveNullGeometryAlgorithm::groupId() const
   return QStringLiteral( "vectorgeometry" );
 }
 
-QgsProcessingAlgorithm::Flags QgsRemoveNullGeometryAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsRemoveNullGeometryAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );

--- a/src/analysis/processing/qgsalgorithmremovenullgeometry.h
+++ b/src/analysis/processing/qgsalgorithmremovenullgeometry.h
@@ -34,7 +34,6 @@ class QgsRemoveNullGeometryAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsRemoveNullGeometryAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmrenamelayer.cpp
+++ b/src/analysis/processing/qgsalgorithmrenamelayer.cpp
@@ -24,11 +24,6 @@ QString QgsRenameLayerAlgorithm::name() const
   return QStringLiteral( "renamelayer" );
 }
 
-QgsProcessingAlgorithm::Flags QgsRenameLayerAlgorithm::flags() const
-{
-  return FlagHideFromToolbox | FlagCanRunInBackground;
-}
-
 QString QgsRenameLayerAlgorithm::displayName() const
 {
   return QObject::tr( "Rename layer" );

--- a/src/analysis/processing/qgsalgorithmrenamelayer.h
+++ b/src/analysis/processing/qgsalgorithmrenamelayer.h
@@ -33,7 +33,6 @@ class QgsRenameLayerAlgorithm : public QgsProcessingAlgorithm
   public:
     QgsRenameLayerAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
@@ -21,7 +21,7 @@
 
 QgsProcessingAlgorithm::Flags QgsSaveSelectedFeatures::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading;
 }
 
 void QgsSaveSelectedFeatures::initAlgorithm( const QVariantMap & )

--- a/src/analysis/processing/qgsalgorithmsimplify.cpp
+++ b/src/analysis/processing/qgsalgorithmsimplify.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsSimplifyAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsSimplifyAlgorithm::name() const
 {
   return QStringLiteral( "simplifygeometries" );

--- a/src/analysis/processing/qgsalgorithmsimplify.h
+++ b/src/analysis/processing/qgsalgorithmsimplify.h
@@ -35,7 +35,6 @@ class QgsSimplifyAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSimplifyAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmsmooth.cpp
+++ b/src/analysis/processing/qgsalgorithmsmooth.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsSmoothAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsSmoothAlgorithm::name() const
 {
   return QStringLiteral( "smoothgeometry" );

--- a/src/analysis/processing/qgsalgorithmsmooth.h
+++ b/src/analysis/processing/qgsalgorithmsmooth.h
@@ -34,7 +34,6 @@ class QgsSmoothAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSmoothAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsSnapToGridAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsSnapToGridAlgorithm::name() const
 {
   return QStringLiteral( "snappointstogrid" );

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.h
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.h
@@ -34,7 +34,6 @@ class QgsSnapToGridAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSnapToGridAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -45,11 +45,6 @@ QString QgsSplitWithLinesAlgorithm::groupId() const
   return QStringLiteral( "vectoroverlay" );
 }
 
-QgsProcessingAlgorithm::Flags QgsSplitWithLinesAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsSplitWithLinesAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.h
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.h
@@ -35,7 +35,6 @@ class QgsSplitWithLinesAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsSplitWithLinesAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmstringconcatenation.cpp
+++ b/src/analysis/processing/qgsalgorithmstringconcatenation.cpp
@@ -26,7 +26,7 @@ QString QgsStringConcatenationAlgorithm::name() const
 
 QgsProcessingAlgorithm::Flags QgsStringConcatenationAlgorithm::flags() const
 {
-  return FlagHideFromToolbox | FlagCanRunInBackground;
+  return FlagHideFromToolbox;
 }
 
 QString QgsStringConcatenationAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -19,12 +19,6 @@
 
 ///@cond PRIVATE
 
-
-QgsProcessingAlgorithm::Flags QgsSubdivideAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsSubdivideAlgorithm::initParameters( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsProcessingParameterNumber::Integer,

--- a/src/analysis/processing/qgsalgorithmsubdivide.h
+++ b/src/analysis/processing/qgsalgorithmsubdivide.h
@@ -34,7 +34,6 @@ class QgsSubdivideAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsSubdivideAlgorithm() = default;
-    Flags flags() const override;
     void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmtransect.cpp
+++ b/src/analysis/processing/qgsalgorithmtransect.cpp
@@ -46,11 +46,6 @@ QString QgsTransectAlgorithm::groupId() const
   return QStringLiteral( "vectorgeometry" );
 }
 
-QgsProcessingAlgorithm::Flags QgsTransectAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 void QgsTransectAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),

--- a/src/analysis/processing/qgsalgorithmtransect.h
+++ b/src/analysis/processing/qgsalgorithmtransect.h
@@ -43,7 +43,6 @@ class QgsTransectAlgorithm : public QgsProcessingAlgorithm
       Both
     };
     QgsTransectAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -35,11 +35,6 @@ QString QgsTransformAlgorithm::outputName() const
   return QObject::tr( "Reprojected" );
 }
 
-QgsProcessingAlgorithm::Flags QgsTransformAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsTransformAlgorithm::name() const
 {
   return QStringLiteral( "reprojectlayer" );

--- a/src/analysis/processing/qgsalgorithmtransform.h
+++ b/src/analysis/processing/qgsalgorithmtransform.h
@@ -34,7 +34,6 @@ class QgsTransformAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsTransformAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmtranslate.cpp
+++ b/src/analysis/processing/qgsalgorithmtranslate.cpp
@@ -19,11 +19,6 @@
 
 ///@cond PRIVATE
 
-QgsProcessingAlgorithm::Flags QgsTranslateAlgorithm::flags() const
-{
-  return QgsProcessingFeatureBasedAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsTranslateAlgorithm::name() const
 {
   return QStringLiteral( "translategeometry" );

--- a/src/analysis/processing/qgsalgorithmtranslate.h
+++ b/src/analysis/processing/qgsalgorithmtranslate.h
@@ -34,7 +34,6 @@ class QgsTranslateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   public:
 
     QgsTranslateAlgorithm() = default;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
     QStringList tags() const override;

--- a/src/analysis/processing/qgsalgorithmuniquevalueindex.cpp
+++ b/src/analysis/processing/qgsalgorithmuniquevalueindex.cpp
@@ -19,12 +19,6 @@
 
 ///@cond PRIVATE
 
-
-QgsProcessingAlgorithm::Flags QgsAddUniqueValueIndexAlgorithm::flags() const
-{
-  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagCanRunInBackground;
-}
-
 QString QgsAddUniqueValueIndexAlgorithm::name() const
 {
   return QStringLiteral( "adduniquevalueindexfield" );

--- a/src/analysis/processing/qgsalgorithmuniquevalueindex.h
+++ b/src/analysis/processing/qgsalgorithmuniquevalueindex.h
@@ -34,7 +34,6 @@ class QgsAddUniqueValueIndexAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsAddUniqueValueIndexAlgorithm() = default;
-    QgsProcessingAlgorithm::Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -78,6 +78,12 @@ QString QgsProcessingModelAlgorithm::helpUrl() const
   return QgsProcessingUtils::formatHelpMapAsHtml( mHelpContent, this );
 }
 
+QgsProcessingAlgorithm::Flags QgsProcessingModelAlgorithm::flags() const
+{
+  // TODO - check child algorithms, if they all support threading, then the model supports threading...
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading;
+}
+
 QVariantMap QgsProcessingModelAlgorithm::parametersForChildAlgorithm( const QgsProcessingModelChildAlgorithm &child, const QVariantMap &modelParameters, const QVariantMap &results, const QgsExpressionContext &expressionContext ) const
 {
   QVariantMap childParams;

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -52,6 +52,7 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     QString svgIconPath() const override;
     QString shortHelpString() const override;
     QString helpUrl() const override;
+    Flags flags() const override;
 
     bool canExecute( QString *errorMessage SIP_OUT = nullptr ) const override;
     QString asPythonCommand( const QVariantMap &parameters, QgsProcessingContext &context ) const override;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagSupportsBatch = 1 << 3,  //!< Algorithm supports batch mode
       FlagCanCancel = 1 << 4, //!< Algorithm can be canceled
       FlagRequiresMatchingCrs = 1 << 5, //!< Algorithm requires that all input layers have matching coordinate reference systems
-      FlagCanRunInBackground = 1 << 6, //!< Algorithm is safe to run in a background thread
+      FlagNoThreading = 1 << 6, //!< Algorithm is not thread safe and cannot be run in a background thread, e.g. for algorithms which manipulate the current project, layer selections, or with external dependencies which are not thread-safe.
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -135,7 +135,7 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
     connect( textShortHelp, &QTextBrowser::anchorClicked, this, &QgsProcessingAlgorithmDialogBase::linkClicked );
   }
 
-  if ( algorithm->flags() & QgsProcessingAlgorithm::FlagCanRunInBackground )
+  if ( !( algorithm->flags() & QgsProcessingAlgorithm::FlagNoThreading ) )
     mButtonRun->setText( tr( "Run in Background" ) );
 }
 


### PR DESCRIPTION
Since the underlying issues with the Python bindings are now fixed, in most cases we can safely default to allowing an algorithm to run in a background thread!!

So now we make this the default, and require individual algorithms which are NOT thread safe to declare this. This includes algorithms which directly manipulate the current project or layers (such as setting layer styles), alter the selections in layers, or which rely on 3rd party libraries (for now, SAGA and GRASS algorithms are marked as not thread safe... TODO - someone more familiar with these libraries can investigate and remove the flag if appropriate).

Also models are marked as non-thread safe. TODO: only flag an individual model as thread-unsafe if any of its child algorithms report this flag.
