### PR TITLE
[raster] don't auto-classify upon customizing values tree (fixes #17102)

### DIFF
--- a/python/gui/raster/qgssinglebandpseudocolorrendererwidget.sip.in
+++ b/python/gui/raster/qgssinglebandpseudocolorrendererwidget.sip.in
@@ -41,6 +41,10 @@ Executes the single band pseudo raster classficiation
 %Docstring
 called when new min/max values are loaded
 %End
+    void loadMinMaxFromTree();
+%Docstring
+called when the color ramp tree has changed
+%End
 
 };
 

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -41,12 +41,12 @@
 
 QgsSingleBandPseudoColorRendererWidget::QgsSingleBandPseudoColorRendererWidget( QgsRasterLayer *layer, const QgsRectangle &extent )
   : QgsRasterRendererWidget( layer, extent )
-  , mDisableMinMaxWidgetRefresh( false )
   , mMinMaxOrigin( 0 )
 {
   QgsSettings settings;
 
   setupUi( this );
+
   connect( mAddEntryButton, &QPushButton::clicked, this, &QgsSingleBandPseudoColorRendererWidget::mAddEntryButton_clicked );
   connect( mDeleteEntryButton, &QPushButton::clicked, this, &QgsSingleBandPseudoColorRendererWidget::mDeleteEntryButton_clicked );
   connect( mLoadFromBandButton, &QPushButton::clicked, this, &QgsSingleBandPseudoColorRendererWidget::mLoadFromBandButton_clicked );
@@ -98,9 +98,6 @@ QgsSingleBandPseudoColorRendererWidget::QgsSingleBandPseudoColorRendererWidget( 
   mMinMaxContainerWidget->setLayout( layout );
   layout->addWidget( mMinMaxWidget );
 
-  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::widgetChanged, this, &QgsSingleBandPseudoColorRendererWidget::widgetChanged );
-  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::load, this, &QgsSingleBandPseudoColorRendererWidget::loadMinMax );
-
   mBandComboBox->setLayer( mRasterLayer );
 
   mColorInterpolationComboBox->addItem( tr( "Discrete" ), QgsColorRampShader::Discrete );
@@ -116,6 +113,9 @@ QgsSingleBandPseudoColorRendererWidget::QgsSingleBandPseudoColorRendererWidget( 
   mNumberOfEntriesSpinBox->setValue( 5 ); // some default
 
   setFromRenderer( layer->renderer() );
+
+  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::widgetChanged, this, &QgsSingleBandPseudoColorRendererWidget::widgetChanged );
+  connect( mMinMaxWidget, &QgsRasterMinMaxWidget::load, this, &QgsSingleBandPseudoColorRendererWidget::loadMinMax );
 
   // If there is currently no min/max, load default with user current default options
   if ( mMinLineEdit->text().isEmpty() || mMaxLineEdit->text().isEmpty() )
@@ -189,8 +189,6 @@ QgsRasterRenderer *QgsSingleBandPseudoColorRendererWidget::renderer()
 void QgsSingleBandPseudoColorRendererWidget::doComputations()
 {
   mMinMaxWidget->doComputations();
-  if ( mColormapTreeWidget->topLevelItemCount() == 0 )
-    applyColorRamp();
 }
 
 void QgsSingleBandPseudoColorRendererWidget::setMapCanvas( QgsMapCanvas *canvas )
@@ -319,6 +317,8 @@ void QgsSingleBandPseudoColorRendererWidget::mAddEntryButton_clicked()
            this, &QgsSingleBandPseudoColorRendererWidget::mColormapTreeWidget_itemEdited );
   mColormapTreeWidget->sortItems( ValueColumn, Qt::AscendingOrder );
   autoLabel();
+
+  loadMinMaxFromTree();
   emit widgetChanged();
 }
 
@@ -335,6 +335,8 @@ void QgsSingleBandPseudoColorRendererWidget::mDeleteEntryButton_clicked()
   {
     delete item;
   }
+
+  loadMinMaxFromTree();
   emit widgetChanged();
 }
 
@@ -449,6 +451,8 @@ void QgsSingleBandPseudoColorRendererWidget::mLoadFromBandButton_clicked()
   {
     QMessageBox::warning( this, tr( "Load Color Map" ), tr( "The color map for band %1 has no entries" ).arg( bandIndex ) );
   }
+
+  loadMinMaxFromTree();
   emit widgetChanged();
 }
 
@@ -539,6 +543,8 @@ void QgsSingleBandPseudoColorRendererWidget::mLoadFromFileButton_clicked()
   {
     QMessageBox::warning( this, tr( "Read access denied" ), tr( "Read access denied. Adjust the file permissions and try again.\n\n" ) );
   }
+
+  loadMinMaxFromTree();
   emit widgetChanged();
 }
 
@@ -645,6 +651,9 @@ void QgsSingleBandPseudoColorRendererWidget::mColormapTreeWidget_itemEdited( QTr
   {
     mColormapTreeWidget->sortItems( ValueColumn, Qt::AscendingOrder );
     autoLabel();
+
+    loadMinMaxFromTree();
+
     emit widgetChanged();
   }
   else if ( column == LabelColumn )
@@ -756,26 +765,48 @@ void QgsSingleBandPseudoColorRendererWidget::loadMinMax( int bandNo, double min,
   Q_UNUSED( bandNo );
   QgsDebugMsg( QString( "theBandNo = %1 min = %2 max = %3" ).arg( bandNo ).arg( min ).arg( max ) );
 
-  mDisableMinMaxWidgetRefresh = true;
+  double oldMin = lineEditValue( mMinLineEdit );
+  double oldMax = lineEditValue( mMaxLineEdit );
+
   if ( std::isnan( min ) )
   {
-    mMinLineEdit->clear();
+    whileBlocking( mMinLineEdit )->clear();
   }
   else
   {
-    mMinLineEdit->setText( QString::number( min ) );
+    whileBlocking( mMinLineEdit )->setText( QString::number( min ) );
   }
 
   if ( std::isnan( max ) )
   {
-    mMaxLineEdit->clear();
+    whileBlocking( mMaxLineEdit )->clear();
   }
   else
   {
-    mMaxLineEdit->setText( QString::number( max ) );
+    whileBlocking( mMaxLineEdit )->setText( QString::number( max ) );
   }
-  mDisableMinMaxWidgetRefresh = false;
-  classify();
+
+  if ( oldMin != min || oldMax != max )
+  {
+    classify();
+  }
+}
+
+void QgsSingleBandPseudoColorRendererWidget::loadMinMaxFromTree()
+{
+  QTreeWidgetItem *item = mColormapTreeWidget->topLevelItem( 0 );
+  if ( !item )
+  {
+    return;
+  }
+
+  double min = item->text( ValueColumn ).toDouble();
+  item = mColormapTreeWidget->topLevelItem( mColormapTreeWidget->topLevelItemCount() - 1 );
+  double max = item->text( ValueColumn ).toDouble();
+
+  whileBlocking( mMinLineEdit )->setText( QString::number( min ) );
+  whileBlocking( mMaxLineEdit )->setText( QString::number( max ) );
+  minMaxModified();
 }
 
 void QgsSingleBandPseudoColorRendererWidget::setLineEditValue( QLineEdit *lineEdit, double value )
@@ -871,8 +902,5 @@ void QgsSingleBandPseudoColorRendererWidget::mMaxLineEdit_textEdited( const QStr
 
 void QgsSingleBandPseudoColorRendererWidget::minMaxModified()
 {
-  if ( !mDisableMinMaxWidgetRefresh )
-  {
-    mMinMaxWidget->userHasSetManualMinMaxValues();
-  }
+  mMinMaxWidget->userHasSetManualMinMaxValues();
 }

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -56,6 +56,8 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void classify();
     //! called when new min/max values are loaded
     void loadMinMax( int bandNo, double min, double max );
+    //! called when the color ramp tree has changed
+    void loadMinMaxFromTree();
 
   private:
 
@@ -107,7 +109,6 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     double lineEditValue( const QLineEdit *lineEdit ) const;
     void resetClassifyButton();
     QgsRasterMinMaxWidget *mMinMaxWidget = nullptr;
-    bool mDisableMinMaxWidgetRefresh;
     int mMinMaxOrigin;
 
     void minMaxModified();


### PR DESCRIPTION
## Description
This PR fixes an UX regression under master whereas customization of a raster singleband pseudocolor renderer via its widget's values tree resulted in an unwarranted re-classification, overwriting any customization made by the user (value change/addition/removal).


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
