### PR TITLE
Fix tab order in XYZ connect dialog. Fixes #17983.

### DIFF
--- a/src/ui/qgsxyzconnectiondialog.ui
+++ b/src/ui/qgsxyzconnectiondialog.ui
@@ -172,10 +172,13 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mEditName</tabstop>
   <tabstop>mEditUrl</tabstop>
   <tabstop>mCheckBoxZMin</tabstop>
+  <tabstop>mSpinZMin</tabstop>
   <tabstop>mCheckBoxZMax</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>mSpinZMax</tabstop>
+  <tabstop>mEditReferer</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
## Description
The issue is https://issues.qgis.org/issues/17983, change the order of the tab to:

<img width="670" alt="screen shot 2018-01-29 at 15 01 06" src="https://user-images.githubusercontent.com/1421861/35499533-4b442962-0505-11e8-9462-cb2c3fd293c4.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit