### PR TITLE
[bugfix] Allow precision config for doubles in range widget

### DIFF
--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -92,7 +92,7 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     double stepval = step.isValid() ? step.toDouble() : 1.0;
     double minval = min.isValid() ? min.toDouble() : std::numeric_limits<double>::lowest();
     double maxval  = max.isValid() ? max.toDouble() : std::numeric_limits<double>::max();
-    int precisionval = precision.isValid() ? precision.toInt() : 4;
+    int precisionval = precision.isValid() ? precision.toInt() : layer()->fields().at( fieldIdx() ).precision();
 
     mDoubleSpinBox->setDecimals( precisionval );
 

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -85,21 +85,19 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
   QVariant min( config( QStringLiteral( "Min" ) ) );
   QVariant max( config( QStringLiteral( "Max" ) ) );
   QVariant step( config( QStringLiteral( "Step" ) ) );
+  QVariant precision( config( QStringLiteral( "Precision" ) ) );
 
   if ( mDoubleSpinBox )
   {
-    // set the precision if field is integer
-    int precision = layer()->fields().at( fieldIdx() ).precision();
-    if ( precision > 0 )
-    {
-      mDoubleSpinBox->setDecimals( layer()->fields().at( fieldIdx() ).precision() );
-    }
-
-    QgsDoubleSpinBox *qgsWidget = dynamic_cast<QgsDoubleSpinBox *>( mDoubleSpinBox );
-
     double stepval = step.isValid() ? step.toDouble() : 1.0;
     double minval = min.isValid() ? min.toDouble() : std::numeric_limits<double>::lowest();
     double maxval  = max.isValid() ? max.toDouble() : std::numeric_limits<double>::max();
+    int precisionval = precision.isValid() ? precision.toInt() : 4;
+
+    mDoubleSpinBox->setDecimals( precisionval );
+
+    QgsDoubleSpinBox *qgsWidget = dynamic_cast<QgsDoubleSpinBox *>( mDoubleSpinBox );
+
 
     if ( qgsWidget )
       qgsWidget->setShowClearButton( allowNull );
@@ -107,9 +105,9 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     if ( allowNull )
     {
       double decr;
-      if ( precision > 0 )
+      if ( precisionval > 0 )
       {
-        decr = std::pow( 10, -precision );
+        decr = std::pow( 10, -precisionval );
       }
       else
       {

--- a/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
@@ -44,6 +44,23 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="precisionLabel">
+        <property name="text">
+         <string>Precision</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="precisionSpinBox">
+        <property name="toolTip">
+         <string>Number of decimal places</string>
+        </property>
+        <property name="value">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/tests/src/gui/testqgsrangewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsrangewidgetwrapper.cpp
@@ -74,11 +74,11 @@ void TestQgsRangeWidgetWrapper::init()
   // add fields
   QList<QgsField> fields;
   fields.append( QgsField( "id", QVariant::Int ) );
-  // 9 precision
+  // precision = 9
   QgsField dfield( "number",  QVariant::Double );
   dfield.setPrecision( 9 );
   fields.append( dfield );
-  // default precision
+  // default precision = 0
   QgsField dfield2( "number_def",  QVariant::Double );
   fields.append( dfield2 );
   vl->dataProvider()->addAttributes( fields );
@@ -137,17 +137,15 @@ void TestQgsRangeWidgetWrapper::test_setDoubleRange()
   widget2->setFeature( vl->getFeature( 1 ) );
   QCOMPARE( vl->fields().at( 1 ).precision(), 9 );
   // Default is 0 !!! for double, really ?
-  // btw if it is 0 the decimals property in the spinbox is left to the default value of 2
   QCOMPARE( vl->fields().at( 2 ).precision(), 0 );
   QCOMPARE( editor->decimals(), vl->fields().at( 1 ).precision() );
   QCOMPARE( editor->decimals(), 9 );
-  // This fails: QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
-  QCOMPARE( editor2->decimals(), 2 ); // Default spinbox decimals is 2
+  QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
   QCOMPARE( editor->valueFromText( feat.attribute( 1 ).toString() ),  123.123456789 );
   QCOMPARE( feat.attribute( 1 ).toString(), QStringLiteral( "123.123456789" ) );
   QCOMPARE( editor2->valueFromText( feat.attribute( 1 ).toString() ), 123.123456789 );
   QCOMPARE( editor->value( ), 123.123456789 );
-  QCOMPARE( editor2->value( ), 123.12 );
+  QCOMPARE( editor2->value( ), 123.0 );
   QCOMPARE( editor->minimum( ), std::numeric_limits<double>::lowest() );
   QCOMPARE( editor2->minimum( ), std::numeric_limits<double>::lowest() );
   QCOMPARE( editor->maximum( ), std::numeric_limits<double>::max() );
@@ -161,7 +159,7 @@ void TestQgsRangeWidgetWrapper::test_setDoubleRange()
   widget->setFeature( vl->getFeature( 3 ) );
   widget2->setFeature( vl->getFeature( 3 ) );
   QCOMPARE( editor->value( ), -123.123456789 );
-  QCOMPARE( editor2->value( ), -123.12 );
+  QCOMPARE( editor2->value( ), -123.0 );
 }
 
 void TestQgsRangeWidgetWrapper::test_setDoubleSmallerRange()
@@ -189,11 +187,9 @@ void TestQgsRangeWidgetWrapper::test_setDoubleSmallerRange()
 
   QCOMPARE( vl->fields().at( 1 ).precision(), 9 );
   // Default is 0 !!! for double, really ?
-  // btw if it is 0 the decimals property in the spinbox is left to the default value of 2
   QCOMPARE( vl->fields().at( 2 ).precision(), 0 );
   QCOMPARE( editor->decimals(), vl->fields().at( 1 ).precision() );
-  // This fails: QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
-  QCOMPARE( editor2->decimals(), 2 ); // Default spinbox decimals is 2
+  QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
   // value was changed to the maximum (not NULL) accepted value
   QCOMPARE( editor->value( ), 100.0 );
   // value was changed to the maximum (not NULL) accepted value
@@ -250,13 +246,11 @@ void TestQgsRangeWidgetWrapper::test_setDoubleLimits()
 
   QCOMPARE( vl->fields().at( 1 ).precision(), 9 );
   // Default is 0 !!! for double, really ?
-  // btw if it is 0 the decimals property in the spinbox is left to the default value of 2
   QCOMPARE( vl->fields().at( 2 ).precision(), 0 );
   QCOMPARE( editor->decimals(), vl->fields().at( 1 ).precision() );
-  // This fails: QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
-  QCOMPARE( editor2->decimals(), 2 ); // Default spinbox decimals is 2
+  QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
   QCOMPARE( editor->value( ), 123.123456789 );
-  QCOMPARE( editor2->value( ), 123.12 );
+  QCOMPARE( editor2->value( ), 123.0 );
 
   // NULL, NULL
   widget->setFeature( vl->getFeature( 2 ) );
@@ -269,7 +263,7 @@ void TestQgsRangeWidgetWrapper::test_setDoubleLimits()
   widget2->setFeature( vl->getFeature( 3 ) );
   // value was changed to the minimum
   QCOMPARE( editor->value( ), -123.123456789 );
-  QCOMPARE( editor2->value( ), -123.12 );
+  QCOMPARE( editor2->value( ), -123.0 );
 
 }
 


### PR DESCRIPTION
Fixes #17878 followup for PR https://github.com/qgis/QGIS/pull/6185

This commit adds a configuration option for precision to
double field types in range widget.

![qgis-double-config](https://user-images.githubusercontent.com/142164/35525328-79a7f490-0524-11e8-9794-48aab464224c.png)
