### PR TITLE
Unify behavior of stats, bookmarks and console docks with other dock panels

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -23,7 +23,7 @@ from builtins import range
 import os
 
 from qgis.PyQt.QtCore import Qt, QTimer, QCoreApplication, QSize, QByteArray, QFileInfo, QUrl, QDir
-from qgis.PyQt.QtWidgets import QDockWidget, QToolBar, QToolButton, QWidget, QSplitter, QTreeWidget, QAction, QFileDialog, QCheckBox, QSizePolicy, QMenu, QGridLayout, QApplication, QShortcut
+from qgis.PyQt.QtWidgets import QToolBar, QToolButton, QWidget, QSplitter, QTreeWidget, QAction, QFileDialog, QCheckBox, QSizePolicy, QMenu, QGridLayout, QApplication, QShortcut
 from qgis.PyQt.QtGui import QDesktopServices, QKeySequence
 from qgis.PyQt.QtWidgets import QVBoxLayout
 from qgis.utils import iface
@@ -32,7 +32,7 @@ from .console_output import ShellOutputScintilla
 from .console_editor import EditorTabWidget
 from .console_settings import optionsDialog
 from qgis.core import QgsApplication, QgsSettings
-from qgis.gui import QgsFilterLineEdit, QgsHelp
+from qgis.gui import QgsFilterLineEdit, QgsHelp, QgsDockWidget
 from functools import partial
 
 import sys
@@ -46,14 +46,17 @@ def show_console():
     if _console is None:
         parent = iface.mainWindow() if iface else None
         _console = PythonConsole(parent)
+        if iface:
+            _console.visibilityChanged.connect(iface.actionShowPythonDialog().setChecked)
+
         _console.show()  # force show even if it was restored as hidden
         # set focus to the console so the user can start typing
         # defer the set focus event so it works also whether the console not visible yet
         QTimer.singleShot(0, _console.activate)
     else:
-        _console.setVisible(not _console.isVisible())
+        _console.setUserVisible(not _console.isUserVisible())
         # set focus to the console so the user can start typing
-        if _console.isVisible():
+        if _console.isUserVisible():
             _console.activate()
 
     return _console
@@ -70,10 +73,10 @@ def console_displayhook(obj):
     _console_output = obj
 
 
-class PythonConsole(QDockWidget):
+class PythonConsole(QgsDockWidget):
 
     def __init__(self, parent=None):
-        QDockWidget.__init__(self, parent)
+        super().__init__(parent)
         self.setObjectName("PythonConsole")
         self.setWindowTitle(QCoreApplication.translate("PythonConsole", "Python Console"))
         # self.setAllowedAreas(Qt.BottomDockWidgetArea)
@@ -89,7 +92,7 @@ class PythonConsole(QDockWidget):
     def activate(self):
         self.activateWindow()
         self.raise_()
-        QDockWidget.setFocus(self)
+        QgsDockWidget.setFocus(self)
 
     def closeEvent(self, event):
         self.console.saveSettingsConsole()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -823,12 +823,14 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   startProfile( QStringLiteral( "Stats dock" ) );
   mStatisticalSummaryDockWidget = new QgsStatisticalSummaryDockWidget( this );
   mStatisticalSummaryDockWidget->setObjectName( QStringLiteral( "StatistalSummaryDockWidget" ) );
+  connect( mStatisticalSummaryDockWidget, &QDockWidget::visibilityChanged, mActionStatisticalSummary, &QAction::setChecked );
   endProfile();
 
   // Bookmarks dock
   startProfile( QStringLiteral( "Bookmarks widget" ) );
   mBookMarksDockWidget = new QgsBookmarks( this );
   mBookMarksDockWidget->setObjectName( QStringLiteral( "BookmarksDockWidget" ) );
+  connect( mBookMarksDockWidget, &QDockWidget::visibilityChanged, mActionShowBookmarks, &QAction::setChecked );
   endProfile();
 
   startProfile( QStringLiteral( "Snapping utils" ) );
@@ -1935,7 +1937,7 @@ void QgisApp::createActions()
   connect( mActionZoomActualSize, &QAction::triggered, this, &QgisApp::zoomActualSize );
   connect( mActionMapTips, &QAction::toggled, this, &QgisApp::toggleMapTips );
   connect( mActionNewBookmark, &QAction::triggered, this, &QgisApp::newBookmark );
-  connect( mActionShowBookmarks, &QAction::triggered, this, &QgisApp::showBookmarks );
+  connect( mActionShowBookmarks, &QAction::toggled, this, &QgisApp::showBookmarks );
   connect( mActionDraw, &QAction::triggered, this, &QgisApp::refreshMapCanvas );
   connect( mActionTextAnnotation, &QAction::triggered, this, &QgisApp::addTextAnnotation );
   connect( mActionFormAnnotation, &QAction::triggered, this, &QgisApp::addFormAnnotation );
@@ -1943,7 +1945,7 @@ void QgisApp::createActions()
   connect( mActionSvgAnnotation, &QAction::triggered, this, &QgisApp::addSvgAnnotation );
   connect( mActionAnnotation, &QAction::triggered, this, &QgisApp::modifyAnnotation );
   connect( mActionLabeling, &QAction::triggered, this, &QgisApp::labeling );
-  connect( mActionStatisticalSummary, &QAction::triggered, this, &QgisApp::showStatisticsDockWidget );
+  connect( mActionStatisticalSummary, &QAction::toggled, this, &QgisApp::showStatisticsDockWidget );
 
   // Layer Menu Items
 
@@ -12281,14 +12283,13 @@ void QgisApp::customProjection()
 
 void QgisApp::newBookmark()
 {
-  showBookmarks();
+  showBookmarks( true );
   mBookMarksDockWidget->addClicked();
 }
 
-void QgisApp::showBookmarks()
+void QgisApp::showBookmarks( bool show )
 {
-  mBookMarksDockWidget->show();
-  mBookMarksDockWidget->raise();
+  mBookMarksDockWidget->setUserVisible( show );
 }
 
 // Slot that gets called when the project file was saved with an older
@@ -13114,10 +13115,9 @@ void QgisApp::showSystemNotification( const QString &title, const QString &messa
   mTray->hide();
 }
 
-void QgisApp::showStatisticsDockWidget()
+void QgisApp::showStatisticsDockWidget( bool show )
 {
-  mStatisticalSummaryDockWidget->show();
-  mStatisticalSummaryDockWidget->raise();
+  mStatisticalSummaryDockWidget->setUserVisible( show );
 }
 
 void QgisApp::onLayerError( const QString &msg )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1307,7 +1307,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void projectPropertiesProjections();
     /*  void urlData(); */
     //! Show the spatial bookmarks dialog
-    void showBookmarks();
+    void showBookmarks( bool show );
     //! Create a new spatial bookmark
     void newBookmark();
     //! activates the add feature tool
@@ -1587,7 +1587,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     /**
      * Shows the statistical summary dock widget and brings it to the foreground
      */
-    void showStatisticsDockWidget();
+    void showStatisticsDockWidget( bool show );
 
     //! Pushes a layer error to the message bar
     void onLayerError( const QString &msg );

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1815,6 +1815,9 @@ Ctrl (Cmd) increments by 15 deg.</string>
    </property>
   </action>
   <action name="mActionShowPythonDialog">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset resource="../../images/images.qrc">
      <normaloff>:/images/themes/default/console/mIconRunConsole.svg</normaloff>:/images/themes/default/console/mIconRunConsole.svg</iconset>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1288,6 +1288,9 @@
    </property>
   </action>
   <action name="mActionShowBookmarks">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset resource="../../images/images.qrc">
      <normaloff>:/images/themes/default/mActionShowBookmarks.svg</normaloff>:/images/themes/default/mActionShowBookmarks.svg</iconset>
@@ -2511,7 +2514,7 @@ Acts on currently active editable layer</string>
   </action>
   <action name="mActionStatisticalSummary">
    <property name="checkable">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="icon">
     <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
Brings these docks into line with other docks like the Toolbox and Layer Style dock, where the linked action is checkable, and checked only if that dock is open and user-visible (i.e. not hidden behind another tab). Checking the action will both show the dock AND bring it to the foreground (vs just showing it hidden behind another tab)
