### PR TITLE
Fix QgsRasterFileWriter::driverForExtension and extensionsForFormat

### DIFF
--- a/python/core/raster/qgsrasterfilewriter.sip.in
+++ b/python/core/raster/qgsrasterfilewriter.sip.in
@@ -175,6 +175,9 @@ Returns the GDAL driver name for a specified file ``extension``. E.g. the
 driver name for the ".tif" extension is "GTiff".
 If no suitable drivers are found then an empty string is returned.
 
+Note that this method works for all GDAL drivers, including those without create support
+(and which are not supported by QgsRasterFileWriter).
+
 .. versionadded:: 3.0
 %End
 
@@ -184,6 +187,9 @@ Returns a list of known file extensions for the given GDAL driver ``format``.
 E.g. returns "tif", "tiff" for the format "GTiff".
 
 If no matching format driver is found an empty list will be returned.
+
+Note that this method works for all GDAL drivers, including those without create support
+(and which are not supported by QgsRasterFileWriter).
 
 .. versionadded:: 3.0
 %End

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -996,7 +996,7 @@ QString QgsRasterFileWriter::driverForExtension( const QString &extension )
     if ( drv )
     {
       char **driverMetadata = GDALGetMetadata( drv, nullptr );
-      if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_CREATE, false ) && CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false ) )
+      if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false ) )
       {
         QString drvName = GDALGetDriverShortName( drv );
         QStringList driverExtensions = QString( GDALGetMetadataItem( drv, GDAL_DMD_EXTENSIONS, nullptr ) ).split( ' ' );
@@ -1018,7 +1018,7 @@ QStringList QgsRasterFileWriter::extensionsForFormat( const QString &format )
   if ( drv )
   {
     char **driverMetadata = GDALGetMetadata( drv, nullptr );
-    if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_CREATE, false ) && CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false ) )
+    if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false ) )
     {
       return QString( GDALGetMetadataItem( drv, GDAL_DMD_EXTENSIONS, nullptr ) ).split( ' ' );
     }

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -186,6 +186,10 @@ class CORE_EXPORT QgsRasterFileWriter
      * Returns the GDAL driver name for a specified file \a extension. E.g. the
      * driver name for the ".tif" extension is "GTiff".
      * If no suitable drivers are found then an empty string is returned.
+     *
+     * Note that this method works for all GDAL drivers, including those without create support
+     * (and which are not supported by QgsRasterFileWriter).
+     *
      * \since QGIS 3.0
      */
     static QString driverForExtension( const QString &extension );
@@ -195,6 +199,9 @@ class CORE_EXPORT QgsRasterFileWriter
      * E.g. returns "tif", "tiff" for the format "GTiff".
      *
      * If no matching format driver is found an empty list will be returned.
+     *
+     * Note that this method works for all GDAL drivers, including those without create support
+     * (and which are not supported by QgsRasterFileWriter).
      *
      * \since QGIS 3.0
      */

--- a/tests/src/python/test_qgsrasterfilewriter.py
+++ b/tests/src/python/test_qgsrasterfilewriter.py
@@ -106,6 +106,8 @@ class TestQgsRasterFileWriter(unittest.TestCase):
         self.assertEqual(QgsRasterFileWriter.driverForExtension('.tif'), 'GTiff')
         self.assertEqual(QgsRasterFileWriter.driverForExtension('img'), 'HFA')
         self.assertEqual(QgsRasterFileWriter.driverForExtension('.vrt'), 'VRT')
+        self.assertEqual(QgsRasterFileWriter.driverForExtension('.jpg'), 'JPEG')
+        self.assertEqual(QgsRasterFileWriter.driverForExtension('asc'), 'AAIGrid')
         self.assertEqual(QgsRasterFileWriter.driverForExtension('not a format'), '')
         self.assertEqual(QgsRasterFileWriter.driverForExtension(''), '')
 
@@ -113,6 +115,8 @@ class TestQgsRasterFileWriter(unittest.TestCase):
         self.assertCountEqual(QgsRasterFileWriter.extensionsForFormat('not format'), [])
         self.assertCountEqual(QgsRasterFileWriter.extensionsForFormat('GTiff'), ['tiff', 'tif'])
         self.assertCountEqual(QgsRasterFileWriter.extensionsForFormat('GPKG'), ['gpkg'])
+        self.assertCountEqual(QgsRasterFileWriter.extensionsForFormat('JPEG'), ['jpg', 'jpeg'])
+        self.assertCountEqual(QgsRasterFileWriter.extensionsForFormat('AAIGrid'), ['asc'])
 
     def testSupportedFiltersAndFormat(self):
         # test with formats in recommended order


### PR DESCRIPTION
were skipping non-creatable datasets

And indicate in the docs that read-only datasets are also considered

Fixes GDAL processing algorithms are unable to generate outputs for non-creatable gdal drivers (yep!)
