### PR TITLE
[FEATURE][processing] Add 'Project points (cartesian)' algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/projected_multipoints.gml
+++ b/python/plugins/processing/tests/testdata/expected/projected_multipoints.gml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ projected_multipoints.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-0.5</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>7.5</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                          
+  <gml:featureMember>
+    <ogr:projected_multipoints fid="points.9">
+      <ogr:d>5</ogr:d>
+    </ogr:projected_multipoints>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_multipoints fid="points.0">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>0.5,1.0</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>1.5,2.0</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>2.5,3.0</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>1</ogr:d>
+    </ogr:projected_multipoints>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_multipoints fid="points.3">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>4.5,2.0</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>3.5,1.0</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>2</ogr:d>
+    </ogr:projected_multipoints>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_multipoints fid="points.5">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>-0.5,-5.0</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>7.5,-1.0</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>3</ogr:d>
+    </ogr:projected_multipoints>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_multipoints fid="points.7">
+      <ogr:geometryProperty><gml:MultiPoint srsName="EPSG:4326"><gml:pointMember><gml:Point><gml:coordinates>6.5,-1.0</gml:coordinates></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:coordinates>-0.5,-1.0</gml:coordinates></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:d>4</ogr:d>
+    </ogr:projected_multipoints>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/projected_multipoints.xsd
+++ b/python/plugins/processing/tests/testdata/expected/projected_multipoints.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="projected_multipoints" type="ogr:projected_multipoints_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="projected_multipoints_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:MultiPointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="d" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/projected_points.gml
+++ b/python/plugins/processing/tests/testdata/expected/projected_points.gml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ projected_points.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>1</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>9</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:projected_points fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>6,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>9.0,-1.0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8.0,-1.0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:projected_points fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.0,-1.0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:projected_points>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/projected_points.xsd
+++ b/python/plugins/processing/tests/testdata/expected/projected_points.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="projected_points" type="ogr:projected_points_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="projected_points_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -4664,6 +4664,32 @@ tests:
         name: expected/difference.gml
         type: vector
 
+  - algorithm: native:projectpointcartesian
+    name: Project points cartesian
+    params:
+      BEARING: 90.0
+      DISTANCE: 1.0
+      INPUT:
+        name: points.gml
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/projected_points.gml
+        type: vector
+
+  - algorithm: native:projectpointcartesian
+    name: Project multipoints cartesian
+    params:
+      BEARING: -90.0
+      DISTANCE: 0.5
+      INPUT:
+        name: multipoints.gml
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/projected_multipoints.gml
+        type: vector
+
   - algorithm: native:removeduplicatevertices
     name: Remove duplicate vertices from lines
     params:

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -50,6 +50,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmorderbyexpression.cpp
   processing/qgsalgorithmorientedminimumboundingbox.cpp
   processing/qgsalgorithmpackage.cpp
+  processing/qgsalgorithmprojectpointcartesian.cpp
   processing/qgsalgorithmpromotetomultipart.cpp
   processing/qgsalgorithmrasterlayeruniquevalues.cpp
   processing/qgsalgorithmremoveduplicatevertices.cpp

--- a/src/analysis/processing/qgsalgorithmprojectpointcartesian.cpp
+++ b/src/analysis/processing/qgsalgorithmprojectpointcartesian.cpp
@@ -1,0 +1,140 @@
+/***************************************************************************
+                         qgsalgorithmprojectpointcartesian.cpp
+                         ---------------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmprojectpointcartesian.h"
+#include "qgsmultipoint.h"
+
+///@cond PRIVATE
+
+QString QgsProjectPointCartesianAlgorithm::name() const
+{
+  return QStringLiteral( "projectpointcartesian" );
+}
+
+QString QgsProjectPointCartesianAlgorithm::displayName() const
+{
+  return QObject::tr( "Project points (Cartesian)" );
+}
+
+QStringList QgsProjectPointCartesianAlgorithm::tags() const
+{
+  return QObject::tr( "bearing,azimuth,distance,angle" ).split( ',' );
+}
+
+QString QgsProjectPointCartesianAlgorithm::group() const
+{
+  return QObject::tr( "Vector geometry" );
+}
+
+QString QgsProjectPointCartesianAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorgeometry" );
+}
+
+QString QgsProjectPointCartesianAlgorithm::outputName() const
+{
+  return QObject::tr( "Projected" );
+}
+
+QString QgsProjectPointCartesianAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm projects point geometries by a specified distance and bearing (azimuth), creating a new point layer with the projected points.\n\n"
+                      "The distance is specified in layer units, and the bearing in degrees clockwise from North." );
+}
+
+QList<int> QgsProjectPointCartesianAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << QgsProcessing::TypeVectorPoint;
+}
+
+QgsProcessing::SourceType QgsProjectPointCartesianAlgorithm::outputLayerType() const
+{
+  return QgsProcessing::TypeVectorPoint;
+}
+
+QgsProjectPointCartesianAlgorithm *QgsProjectPointCartesianAlgorithm::createInstance() const
+{
+  return new QgsProjectPointCartesianAlgorithm();
+}
+
+void QgsProjectPointCartesianAlgorithm::initParameters( const QVariantMap & )
+{
+  std::unique_ptr< QgsProcessingParameterNumber > bearing = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "BEARING" ), QObject::tr( "Bearing (degrees from North)" ), QgsProcessingParameterNumber::Double, false );
+  bearing->setIsDynamic( true );
+  bearing->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "Bearing" ), QObject::tr( "Bearing (degrees from North)" ), QgsPropertyDefinition::Double ) );
+  bearing->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( bearing.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > distance = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DISTANCE" ), QObject::tr( "Distance" ), QgsProcessingParameterNumber::Double, false );
+  distance->setIsDynamic( true );
+  distance->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "Distance" ), QObject::tr( "Projection distance" ), QgsPropertyDefinition::Double ) );
+  distance->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( distance.release() );
+}
+
+bool QgsProjectPointCartesianAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  mBearing = parameterAsDouble( parameters, QStringLiteral( "BEARING" ), context );
+  mDynamicBearing = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "BEARING" ) );
+  if ( mDynamicBearing )
+    mBearingProperty = parameters.value( QStringLiteral( "BEARING" ) ).value< QgsProperty >();
+
+  mDistance = parameterAsDouble( parameters, QStringLiteral( "DISTANCE" ), context );
+  mDynamicDistance = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DISTANCE" ) );
+  if ( mDynamicDistance )
+    mDistanceProperty = parameters.value( QStringLiteral( "DISTANCE" ) ).value< QgsProperty >();
+
+  return true;
+}
+
+QgsFeatureList QgsProjectPointCartesianAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsFeature f = feature;
+  if ( f.hasGeometry() && QgsWkbTypes::geometryType( f.geometry().wkbType() ) == QgsWkbTypes::PointGeometry )
+  {
+    double distance = mDistance;
+    if ( mDynamicDistance )
+      distance = mDistanceProperty.valueAsDouble( context.expressionContext(), distance );
+    double bearing = mBearing;
+    if ( mDynamicBearing )
+      bearing = mBearingProperty.valueAsDouble( context.expressionContext(), bearing );
+
+    QgsGeometry g = f.geometry();
+    if ( QgsWkbTypes::isMultiType( g.wkbType() ) )
+    {
+      const QgsMultiPoint *mp = static_cast< const QgsMultiPoint * >( g.constGet() );
+      std::unique_ptr< QgsMultiPoint > result = qgis::make_unique< QgsMultiPoint >();
+      for ( int i = 0; i < mp->numGeometries(); ++i )
+      {
+        const QgsPoint *p = static_cast< const QgsPoint * >( mp->geometryN( i ) );
+        result->addGeometry( p->project( distance, bearing ).clone() );
+      }
+      f.setGeometry( QgsGeometry( std::move( result ) ) );
+    }
+    else
+    {
+      const QgsPoint *p = static_cast< const QgsPoint * >( g.constGet() );
+      QgsPoint result = p->project( distance, bearing );
+      f.setGeometry( QgsGeometry( result.clone() ) );
+    }
+  }
+
+  return QgsFeatureList() << f;
+}
+
+///@endcond
+

--- a/src/analysis/processing/qgsalgorithmprojectpointcartesian.h
+++ b/src/analysis/processing/qgsalgorithmprojectpointcartesian.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+                         qgsalgorithmprojectpointcartesian.h
+                         ---------------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMPROJECTPOINTCARTESIAN_H
+#define QGSALGORITHMPROJECTPOINTCARTESIAN_H
+
+#define SIP_NO_FILE
+
+#include "qgis.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native Cartesian project points algorithm.
+ */
+class QgsProjectPointCartesianAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsProjectPointCartesianAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QList<int> inputLayerTypes() const override;
+    QgsProcessing::SourceType outputLayerType() const override;
+    QgsProjectPointCartesianAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    QString outputName() const override;
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+
+    double mBearing = 0.0;
+    bool mDynamicBearing = false;
+    QgsProperty mBearingProperty;
+    double mDistance = 0.0;
+    bool mDynamicDistance = false;
+    QgsProperty mDistanceProperty;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMPROJECTPOINTCARTESIAN_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -47,6 +47,7 @@
 #include "qgsalgorithmorderbyexpression.h"
 #include "qgsalgorithmorientedminimumboundingbox.h"
 #include "qgsalgorithmpackage.h"
+#include "qgsalgorithmprojectpointcartesian.h"
 #include "qgsalgorithmpromotetomultipart.h"
 #include "qgsalgorithmrasterlayeruniquevalues.h"
 #include "qgsalgorithmremoveduplicatevertices.h"
@@ -136,6 +137,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsOrderByExpressionAlgorithm() );
   addAlgorithm( new QgsOrientedMinimumBoundingBoxAlgorithm() );
   addAlgorithm( new QgsPackageAlgorithm() );
+  addAlgorithm( new QgsProjectPointCartesianAlgorithm() );
   addAlgorithm( new QgsPromoteToMultipartAlgorithm() );
   addAlgorithm( new QgsRasterLayerUniqueValuesReportAlgorithm() );
   addAlgorithm( new QgsAlgorithmRemoveDuplicateVertices() );


### PR DESCRIPTION
Projects points from an input point layer by a specified distance and bearing (azimuth). Supports dynamic parameters for the distance and bearing so that they can use field values or expressions.
