### PR TITLE
Better default snapping settings

### DIFF
--- a/python/core/qgis.sip.in
+++ b/python/core/qgis.sip.in
@@ -69,6 +69,9 @@ The Qgis class provides global constants for use throughout the application.
 
     static const double UI_SCALE_FACTOR;
 
+    static const double DEFAULT_SNAP_TOLERANCE;
+
+    static const int DEFAULT_SNAP_UNITS;
 };
 
 

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -1,6 +1,26 @@
 [qgis]
-# if formatLayerName is set to true, added layer names will be automatically capitalized and underscores replaced with spaces
+# If true, added layer names will be automatically capitalized and underscores replaced with spaces
 formatLayerName=false
+
+# Snapping enabled by default
+digitizing\default_snap_enabled=false
+
+# Default snapping tolerance (distance)
+digitizing\default_snapping_tolerance=15.0
+
+# Default snap to type
+# 1 = Vertices only
+# 2 = Vertices and segments
+# 3 = Segments only
+digitizing\default_snap_type=1
+
+# Default snapping unit
+# 0 = Layer units
+# 1 = Pixels
+# 2 = Project units
+digitizing\default_snapping_tolerance_unit=1
+
+# Default XYZ tile servers to include
 connections-xyz\OpenStreetMap\authcfg=
 connections-xyz\OpenStreetMap\password=
 connections-xyz\OpenStreetMap\referer=

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -6,7 +6,7 @@ formatLayerName=false
 digitizing\default_snap_enabled=false
 
 # Default snapping tolerance (distance)
-digitizing\default_snapping_tolerance=15.0
+digitizing\default_snapping_tolerance=12.0
 
 # Default snap to type
 # 1 = Vertices only

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -872,9 +872,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mDefaultSnapModeComboBox->addItem( tr( "Vertex and segment" ), QgsSnappingConfig::VertexAndSegment );
   mDefaultSnapModeComboBox->addItem( tr( "Segment" ), QgsSnappingConfig::Segment );
   mDefaultSnapModeComboBox->setCurrentIndex( mDefaultSnapModeComboBox->findData( mSettings->value( QStringLiteral( "/qgis/digitizing/default_snap_type" ), QgsSnappingConfig::Vertex ).toInt() ) );
-  mDefaultSnappingToleranceSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance" ), 0 ).toDouble() );
+  mDefaultSnappingToleranceSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance" ), Qgis::DEFAULT_SNAP_TOLERANCE ).toDouble() );
   mSearchRadiusVertexEditSpinBox->setValue( mSettings->value( QStringLiteral( "/qgis/digitizing/search_radius_vertex_edit" ), 10 ).toDouble() );
-  int defSnapUnits = mSettings->value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance_unit" ), QgsTolerance::ProjectUnits ).toInt();
+  int defSnapUnits = mSettings->value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance_unit" ), Qgis::DEFAULT_SNAP_UNITS ).toInt();
   if ( defSnapUnits == QgsTolerance::ProjectUnits || defSnapUnits == QgsTolerance::LayerUnits )
   {
     index = mDefaultSnappingToleranceComboBox->findText( tr( "map units" ) );

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -84,7 +84,7 @@ const double Qgis::SCALE_PRECISION = 0.9999999999;
 
 const double Qgis::DEFAULT_Z_COORDINATE = 0.0;
 
-const double Qgis::DEFAULT_SNAP_TOLERANCE = 15.0;
+const double Qgis::DEFAULT_SNAP_TOLERANCE = 12.0;
 
 const int Qgis::DEFAULT_SNAP_UNITS = 1;
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -84,6 +84,10 @@ const double Qgis::SCALE_PRECISION = 0.9999999999;
 
 const double Qgis::DEFAULT_Z_COORDINATE = 0.0;
 
+const double Qgis::DEFAULT_SNAP_TOLERANCE = 15.0;
+
+const int Qgis::DEFAULT_SNAP_UNITS = 1;
+
 #ifdef Q_OS_WIN
 const double Qgis::UI_SCALE_FACTOR = 1.5;
 #else

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -137,6 +137,17 @@ class CORE_EXPORT Qgis
     */
     static const double UI_SCALE_FACTOR;
 
+    /**
+     * Default snapping distance tolerance.
+     *  \since QGIS 3.0
+    */
+    static const double DEFAULT_SNAP_TOLERANCE;
+
+    /**
+     * Default snapping distance units.
+     *  \since QGIS 3.0
+    */
+    static const int DEFAULT_SNAP_UNITS;
 };
 
 // hack to workaround warnings when casting void pointers

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -126,8 +126,8 @@ void QgsSnappingConfig::reset()
     mode = AllLayers;
   }
   SnappingType type = static_cast<SnappingType>( QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snap_type" ), Vertex ).toInt() );
-  double tolerance = QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance" ), 0 ).toDouble();
-  QgsTolerance::UnitType units = static_cast<QgsTolerance::UnitType>( QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance_unit" ), QgsTolerance::ProjectUnits ).toInt() );
+  double tolerance = QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance" ), Qgis::DEFAULT_SNAP_TOLERANCE ).toDouble();
+  QgsTolerance::UnitType units = static_cast<QgsTolerance::UnitType>( QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance_unit" ), Qgis::DEFAULT_SNAP_UNITS ).toInt() );
 
   // assign main (standard) config
   mEnabled = enabled;
@@ -369,8 +369,8 @@ bool QgsSnappingConfig::addLayers( const QList<QgsMapLayer *> &layers )
   bool changed = false;
   bool enabled = QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snap_enabled" ), true ).toBool();
   SnappingType type = ( SnappingType )QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snap_type" ), Vertex ).toInt();
-  double tolerance = QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance" ), 0 ).toDouble();
-  QgsTolerance::UnitType units = ( QgsTolerance::UnitType )QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance_unit" ), QgsTolerance::ProjectUnits ).toInt();
+  double tolerance = QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance" ), Qgis::DEFAULT_SNAP_TOLERANCE ).toDouble();
+  QgsTolerance::UnitType units = ( QgsTolerance::UnitType )QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_snapping_tolerance_unit" ), Qgis::DEFAULT_SNAP_UNITS ).toInt();
 
   Q_FOREACH ( QgsMapLayer *ml, layers )
   {

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -135,7 +135,7 @@ void QgsSnappingConfig::reset()
   mType = type;
   mTolerance = tolerance;
   // do not allow unit to be "layer" if not in advanced configuration
-  if ( mMode != AdvancedConfiguration )
+  if ( mUnits == QgsTolerance::LayerUnits && mMode != AdvancedConfiguration )
   {
     mUnits = QgsTolerance::ProjectUnits;
   }

--- a/src/core/qgstolerance.cpp
+++ b/src/core/qgstolerance.cpp
@@ -90,8 +90,8 @@ double QgsTolerance::vertexSearchRadius( QgsMapLayer *layer, const QgsMapSetting
 double QgsTolerance::defaultTolerance( QgsMapLayer *layer, const QgsMapSettings &mapSettings )
 {
   QgsSettings settings;
-  double tolerance = settings.value( QStringLiteral( "qgis/digitizing/default_snapping_tolerance" ), 0 ).toDouble();
-  UnitType units = static_cast< QgsTolerance::UnitType >( settings.value( QStringLiteral( "qgis/digitizing/default_snapping_tolerance_unit" ), ProjectUnits ).toInt() );
+  double tolerance = settings.value( QStringLiteral( "qgis/digitizing/default_snapping_tolerance" ), Qgis::DEFAULT_SNAP_TOLERANCE ).toDouble();
+  UnitType units = static_cast< QgsTolerance::UnitType >( settings.value( QStringLiteral( "qgis/digitizing/default_snapping_tolerance_unit" ), Qgis::DEFAULT_SNAP_UNITS ).toInt() );
   return toleranceInMapUnits( tolerance, layer, mapSettings, units );
 }
 


### PR DESCRIPTION
Set default snapping tolerance to 15 pixels, because 0 meter default is bad UX.

Also update global_settings ini with snapping settings.
