### PR TITLE
[ui] use the expression icon for the rule-based renderer's rule panel

### DIFF
--- a/src/ui/qgsrendererrulepropsdialogbase.ui
+++ b/src/ui/qgsrendererrulepropsdialogbase.ui
@@ -64,8 +64,9 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="text">
-              <string>…</string>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
## Description
This PR updates the  rule-based renderer's rule dialog to make use of the expression (E) icon instead of "...". This offers a clearer meaning, and harmonizes the UI to match what's used in the rule-based label's rule dialog.

Before (left) vs proposed (right):
![screenshot from 2018-01-30 11-19-51](https://user-images.githubusercontent.com/1728657/35548144-18d90906-05b0-11e8-88bc-14592cabb363.png)

Bonus: this leaves more horizontal space for the rule's text box.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
