### PR TITLE
add trandform context to QgsBearingUtils::bearingTrueNorth

### DIFF
--- a/python/core/qgsbearingutils.sip.in
+++ b/python/core/qgsbearingutils.sip.in
@@ -24,6 +24,7 @@ Utilities for calculating bearings and directions.
   public:
 
     static double bearingTrueNorth( const QgsCoordinateReferenceSystem &crs,
+                                    const QgsCoordinateTransformContext  &transformContext,
                                     const QgsPointXY &point );
 %Docstring
 Returns the direction to true north from a specified point and for a specified

--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -125,7 +125,7 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
       {
         try
         {
-          mRotationInt = QgsBearingUtils:: bearingTrueNorth( mapSettings.destinationCrs(), context.extent().center() );
+          mRotationInt = QgsBearingUtils:: bearingTrueNorth( mapSettings.destinationCrs(), mapSettings.transformContext(), context.extent().center() );
         }
         catch ( QgsException & )
         {

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -463,10 +463,11 @@ void QgsLayoutItemPicture::updateMapRotation()
     {
       QgsPointXY center = mRotationMap->extent().center();
       QgsCoordinateReferenceSystem crs = mRotationMap->crs();
+      QgsCoordinateTransformContext transformContext = mLayout->project()->transformContext();
 
       try
       {
-        double bearing = QgsBearingUtils::bearingTrueNorth( crs, center );
+        double bearing = QgsBearingUtils::bearingTrueNorth( crs, transformContext, center );
         rotation += bearing;
       }
       catch ( QgsException &e )

--- a/src/core/qgsbearingutils.cpp
+++ b/src/core/qgsbearingutils.cpp
@@ -17,16 +17,15 @@
 
 #include "qgsbearingutils.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 #include "qgspointxy.h"
 #include "qgscoordinatetransform.h"
 #include "qgsexception.h"
 
-double QgsBearingUtils::bearingTrueNorth( const QgsCoordinateReferenceSystem &crs, const QgsPointXY &point )
+double QgsBearingUtils::bearingTrueNorth( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext  &transformContext, const QgsPointXY &point )
 {
   // step 1 - transform point into WGS84 geographic crs
-  Q_NOWARN_DEPRECATED_PUSH
-  QgsCoordinateTransform transform( crs, QgsCoordinateReferenceSystem::fromEpsgId( 4326 ) );
-  Q_NOWARN_DEPRECATED_POP
+  QgsCoordinateTransform transform( crs, QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), transformContext );
 
   if ( !transform.isValid() )
   {

--- a/src/core/qgsbearingutils.h
+++ b/src/core/qgsbearingutils.h
@@ -19,6 +19,7 @@
 #define QGSBEARINGUTILS_H
 
 class QgsCoordinateReferenceSystem;
+class QgsCoordinateTransformContext;
 class QgsPointXY;
 
 #include "qgis_core.h"
@@ -39,6 +40,7 @@ class CORE_EXPORT QgsBearingUtils
      * vertical. An exception will be thrown if the bearing could not be calculated.
      */
     static double bearingTrueNorth( const QgsCoordinateReferenceSystem &crs,
+                                    const QgsCoordinateTransformContext  &transformContext,
                                     const QgsPointXY &point );
 
 };

--- a/tests/src/python/test_qgsbearingutils.py
+++ b/tests/src/python/test_qgsbearingutils.py
@@ -16,6 +16,7 @@ import qgis  # NOQA switch sip api
 
 from qgis.core import (QgsBearingUtils,
                        QgsCoordinateReferenceSystem,
+                       QgsCoordinateTransformContext,
                        QgsPointXY
                        )
 
@@ -32,26 +33,28 @@ class TestQgsBearingUtils(unittest.TestCase):
 
         # short circuit - already a geographic crs
         crs = QgsCoordinateReferenceSystem.fromEpsgId(4326)
-        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(0, 0)), 0)
-        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(44, 0)), 0)
-        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(44, -43)), 0)
-        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(44, 43)), 0)
+        transformContext = QgsCoordinateTransformContext()
 
-        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(44, 200)), 0)
-        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(44, -200)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(0, 0)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(44, 0)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(44, -43)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(44, 43)), 0)
+
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(44, 200)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(44, -200)), 0)
 
         # no short circuit
         crs = QgsCoordinateReferenceSystem.fromEpsgId(3111)
-        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(2508807, 2423425)), 0.06, 2)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(2508807, 2423425)), 0.06, 2)
 
         # try a south-up crs
         crs = QgsCoordinateReferenceSystem.fromEpsgId(2053)
-        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(29, -27.55)), -180.0, 1)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(29, -27.55)), -180.0, 1)
 
         # try a north pole crs
         crs = QgsCoordinateReferenceSystem.fromEpsgId(3575)
-        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(-780770, 652329)), 129.9, 1)
-        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPointXY(513480, 873173)), -149.5, 1)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(-780770, 652329)), 129.9, 1)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, transformContext, QgsPointXY(513480, 873173)), -149.5, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
@nyalldawson , this takes care of one more context warning linked to canvas rendering.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
