### PR TITLE
Ensure member QObjects for QgsMapLayer (and subclasses) are correctly parented to their owner QgsMapLayer

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1751,10 +1751,10 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /**
      * Paste features from clipboard into a new memory layer.
-     *  If no features are in clipboard an empty layer is returned.
-     *  \returns pointer to a new layer or 0 if failed
+     * If no features are in clipboard an empty layer is returned.
+     * Returns a new memory layer or a nullptr if the operation failed.
      */
-    QgsVectorLayer *pasteToNewMemoryVector();
+    std::unique_ptr< QgsVectorLayer > pasteToNewMemoryVector();
 
     //! Returns all annotation items in the canvas
     QList<QgsMapCanvasAnnotationItem *> annotationItems();

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1909,7 +1909,10 @@ void QgsMapLayer::setLegend( QgsMapLayerLegend *legend )
   mLegend = legend;
 
   if ( mLegend )
+  {
+    mLegend->setParent( this );
     connect( mLegend, &QgsMapLayerLegend::itemsChanged, this, &QgsMapLayer::legendChanged );
+  }
 
   emit legendChanged();
 }

--- a/src/core/qgsmaplayerstylemanager.h
+++ b/src/core/qgsmaplayerstylemanager.h
@@ -25,6 +25,7 @@ class QgsMapLayer;
 #include <QObject>
 
 #include "qgis_core.h"
+#include "qgis_sip.h"
 
 class QDomElement;
 
@@ -96,8 +97,12 @@ class CORE_EXPORT QgsMapLayerStyleManager : public QObject
 {
     Q_OBJECT
   public:
-    //! Construct a style manager associated with a map layer (must not be null)
-    QgsMapLayerStyleManager( QgsMapLayer *layer );
+
+    /**
+     * Construct a style manager associated with a map layer (must not be null).
+     * The style manager will be parented to \a layer.
+     */
+    QgsMapLayerStyleManager( QgsMapLayer *layer SIP_TRANSFERTHIS );
 
     //! Get pointer to the associated map layer
     QgsMapLayer *layer() const { return mLayer; }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -147,6 +147,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   mConditionalStyles = new QgsConditionalLayerStyles();
 
   mJoinBuffer = new QgsVectorLayerJoinBuffer( this );
+  mJoinBuffer->setParent( this );
   connect( mJoinBuffer, &QgsVectorLayerJoinBuffer::joinedFieldsChanged, this, &QgsVectorLayer::onJoinedFieldsChanged );
 
   mExpressionFieldBuffer = new QgsExpressionFieldBuffer();
@@ -1553,6 +1554,7 @@ bool QgsVectorLayer::setDataProvider( QString const &provider )
     return false;
   }
 
+  mDataProvider->setParent( this );
   connect( mDataProvider, &QgsVectorDataProvider::raiseError, this, &QgsVectorLayer::raiseError );
 
   QgsDebugMsgLevel( QStringLiteral( "Instantiated the data provider plugin" ), 2 );
@@ -4405,6 +4407,7 @@ void QgsVectorLayer::setAuxiliaryLayer( QgsAuxiliaryLayer *alayer )
   }
 
   mAuxiliaryLayer.reset( alayer );
+  mAuxiliaryLayer->setParent( this );
   updateFields();
 }
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -614,6 +614,7 @@ void QgsRasterLayer::setDataProvider( QString const &provider )
     return;
   }
   QgsDebugMsgLevel( "Data provider created", 4 );
+  mDataProvider->setParent( this );
 
   // Set data provider into pipe even if not valid so that it is deleted with pipe (with layer)
   mPipe.set( mDataProvider );


### PR DESCRIPTION
This ensures that if the layer is moved to a different thread with QObject::moveToThread(), then those children are also considered by QObject::moveToThread() and correctly also moved to the new target thread. This fixes broken connections (and likely other issues) caused when moving layers between threads (such as is done when a background processing algorithm completes).

Fixes #18005