### PR TITLE
[needs-docs][attribute table] UX improvements to cut/copy/paste actions

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -87,6 +87,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
 {
   setObjectName( QStringLiteral( "QgsAttributeTableDialog/" ) + layer->id() );
   setupUi( this );
+  connect( mActionCutSelectedRows, &QAction::triggered, this, &QgsAttributeTableDialog::mActionCutSelectedRows_triggered );
   connect( mActionCopySelectedRows, &QAction::triggered, this, &QgsAttributeTableDialog::mActionCopySelectedRows_triggered );
   connect( mActionPasteFeatures, &QAction::triggered, this, &QgsAttributeTableDialog::mActionPasteFeatures_triggered );
   connect( mActionToggleEditing, &QAction::toggled, this, &QgsAttributeTableDialog::mActionToggleEditing_toggled );
@@ -264,15 +265,18 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   mActionReload->setEnabled( ! mLayer->isEditable() );
   mActionAddAttribute->setEnabled( ( canChangeAttributes || canAddAttributes ) && mLayer->isEditable() );
   mActionRemoveAttribute->setEnabled( canDeleteAttributes && mLayer->isEditable() );
-  mActionDeleteSelected->setEnabled( canDeleteFeatures && mLayer->isEditable() );
   if ( !canDeleteFeatures )
+  {
     mToolbar->removeAction( mActionDeleteSelected );
+    mToolbar->removeAction( mActionCutSelectedRows );
+  }
   mActionAddFeature->setEnabled( canAddFeatures && mLayer->isEditable() );
+  mActionPasteFeatures->setEnabled( canAddFeatures && mLayer->isEditable() );
   if ( !canAddFeatures )
+  {
     mToolbar->removeAction( mActionAddFeature );
-
-  if ( canDeleteFeatures || canAddFeatures )
-    mToolbar->insertSeparator( mActionExpressionSelect );
+    mToolbar->removeAction( mActionPasteFeatures );
+  }
 
   mMainViewButtonGroup->setId( mTableViewButton, QgsDualView::AttributeTable );
   mMainViewButtonGroup->setId( mAttributeViewButton, QgsDualView::AttributeEditor );
@@ -382,8 +386,12 @@ void QgsAttributeTableDialog::updateTitle()
   else
     mRunFieldCalc->setText( tr( "Update Filtered" ) );
 
+  bool canDeleteFeatures = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::DeleteFeatures;
   bool enabled = mLayer->selectedFeatureCount() > 0;
   mRunFieldCalcSelected->setEnabled( enabled );
+  mActionDeleteSelected->setEnabled( canDeleteFeatures && mLayer->isEditable() && enabled );
+  mActionCutSelectedRows->setEnabled( canDeleteFeatures && mLayer->isEditable() && enabled );
+  mActionCopySelectedRows->setEnabled( enabled );
 }
 
 void QgsAttributeTableDialog::updateButtonStatus( const QString &fieldName, bool isValid )
@@ -739,6 +747,11 @@ void QgsAttributeTableDialog::mActionExpressionSelect_triggered()
   dlg->show();
 }
 
+void QgsAttributeTableDialog::mActionCutSelectedRows_triggered()
+{
+  QgisApp::instance()->cutSelectionToClipboard( mLayer );
+}
+
 void QgsAttributeTableDialog::mActionCopySelectedRows_triggered()
 {
   QgisApp::instance()->copySelectionToClipboard( mLayer );
@@ -823,8 +836,10 @@ void QgsAttributeTableDialog::editingToggled()
   bool canAddFeatures = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::AddFeatures;
   mActionAddAttribute->setEnabled( ( canChangeAttributes || canAddAttributes ) && mLayer->isEditable() );
   mActionRemoveAttribute->setEnabled( canDeleteAttributes && mLayer->isEditable() );
-  mActionDeleteSelected->setEnabled( canDeleteFeatures && mLayer->isEditable() );
+  mActionDeleteSelected->setEnabled( canDeleteFeatures && mLayer->isEditable() && mLayer->selectedFeatureCount() > 0 );
+  mActionCutSelectedRows->setEnabled( canDeleteFeatures && mLayer->isEditable() && mLayer->selectedFeatureCount() > 0 );
   mActionAddFeature->setEnabled( canAddFeatures && mLayer->isEditable() );
+  mActionPasteFeatures->setEnabled( canAddFeatures && mLayer->isEditable() );
   mActionToggleEditing->setEnabled( ( canChangeAttributes || canDeleteFeatures || canAddAttributes || canDeleteAttributes || canAddFeatures ) && !mLayer->readOnly() );
 
   mUpdateExpressionBox->setVisible( mLayer->isEditable() );

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -75,6 +75,11 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
   private slots:
 
     /**
+     * Cut selected rows to the clipboard
+     */
+    void mActionCutSelectedRows_triggered();
+
+    /**
      * Copies selected rows to the clipboard
      */
     void mActionCopySelectedRows_triggered();

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -170,6 +170,10 @@
      <addaction name="separator"/>
      <addaction name="mActionAddFeature"/>
      <addaction name="mActionDeleteSelected"/>
+     <addaction name="mActionCutSelectedRows"/>
+     <addaction name="mActionCopySelectedRows"/>
+     <addaction name="mActionPasteFeatures"/>
+     <addaction name="separator"/>
      <addaction name="mActionExpressionSelect"/>
      <addaction name="mActionSelectAll"/>
      <addaction name="mActionInvertSelection"/>
@@ -178,9 +182,6 @@
      <addaction name="mActionSelectedToTop"/>
      <addaction name="mActionPanMapToSelectedRows"/>
      <addaction name="mActionZoomMapToSelectedRows"/>
-     <addaction name="separator"/>
-     <addaction name="mActionCopySelectedRows"/>
-     <addaction name="mActionPasteFeatures"/>
      <addaction name="separator"/>
      <addaction name="mActionAddAttribute"/>
      <addaction name="mActionRemoveAttribute"/>
@@ -528,13 +529,28 @@
     <string>Ctrl+J</string>
    </property>
   </action>
+  <action name="mActionCutSelectedRows">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditCut.svg</normaloff>:/images/themes/default/mActionEditCut.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Cut selected rows to clipboard</string>
+   </property>
+   <property name="toolTip">
+    <string>Cut selected rows to clipboard (Ctrl+X)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+X</string>
+   </property>
+  </action>
   <action name="mActionCopySelectedRows">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
      <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
    </property>
    <property name="text">
-    <string>Copy selected rows to clipboard (Ctrl+C)</string>
+    <string>Copy selected rows to clipboard</string>
    </property>
    <property name="toolTip">
     <string>Copy selected rows to clipboard (Ctrl+C)</string>


### PR DESCRIPTION
## Description
This PR fixes a couple of UX issues identified while conducting a QGIS training to new users with regards to cut/copy/paste actions within the attribute table dialog.

The UX improvements are as follow:
- addition of a missing cut action
- relocating the cut / copy / paste actions to be sitting next to the delete button (harmonize position with QGIS' main window)
- only enable delete / cut / paste actions if the layer is in edit mode (harmonize behavior with QGIS' main window)
- only enable copy action if the layer has selected feature(s) (harmonize behavior with QGIS' main window)

Screenshot of changes:
![screenshot from 2018-01-31 09-38-02](https://user-images.githubusercontent.com/1728657/35602524-4193b18c-066b-11e8-9436-665f21cca825.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
