### PR TITLE
[needs-docs][Gui] Reorganize Interface customization dialog

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -50,11 +50,11 @@ QgsCustomizationDialog::QgsCustomizationDialog( QWidget * parent, QSettings * se
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
 
-  connect( actionSave, &QAction::triggered, this, &QgsCustomizationDialog::actionSave_triggered );
-  connect( actionLoad, &QAction::triggered, this, &QgsCustomizationDialog::actionLoad_triggered );
-  connect( actionExpandAll, &QAction::triggered, this, &QgsCustomizationDialog::actionExpandAll_triggered );
-  connect( actionCollapseAll, &QAction::triggered, this, &QgsCustomizationDialog::actionCollapseAll_triggered );
-  connect( actionSelectAll, &QAction::triggered, this, &QgsCustomizationDialog::actionSelectAll_triggered );
+  connect( btnSave, &QAbstractButton::clicked, this, &QgsCustomizationDialog::actionSave_triggered );
+  connect( btnLoad, &QAbstractButton::clicked, this, &QgsCustomizationDialog::actionLoad_triggered );
+  connect( btnExpandAll, &QAbstractButton::clicked, this, &QgsCustomizationDialog::actionExpandAll_triggered );
+  connect( btnCollapseAll, &QAbstractButton::clicked, this, &QgsCustomizationDialog::actionCollapseAll_triggered );
+  connect( btnSelectAll, &QAbstractButton::clicked, this, &QgsCustomizationDialog::actionSelectAll_triggered );
   connect( mCustomizationEnabledCheckBox, &QCheckBox::toggled, this, &QgsCustomizationDialog::mCustomizationEnabledCheckBox_toggled );
 
   init();
@@ -198,7 +198,12 @@ void QgsCustomizationDialog::reset()
   bool enabled = settings.value( QStringLiteral( "UI/Customization/enabled" ), "false" ).toString() == QLatin1String( "true" );
   mCustomizationEnabledCheckBox->setChecked( enabled );
   treeWidget->setEnabled( enabled );
-  toolBar->setEnabled( enabled );
+  btnCatch->setEnabled( enabled );
+  btnSave->setEnabled( enabled );
+  btnLoad->setEnabled( enabled );
+  btnCollapseAll->setEnabled( enabled );
+  btnExpandAll->setEnabled( enabled );
+  btnSelectAll->setEnabled( enabled );
 }
 
 void QgsCustomizationDialog::ok()
@@ -229,7 +234,7 @@ void QgsCustomizationDialog::actionSave_triggered( bool checked )
   QString lastDir = mySettings.value( mLastDirSettingsName, QDir::homePath() ).toString();
 
   QString fileName = QFileDialog::getSaveFileName( this,
-                     tr( "Choose a customization INI file" ),
+                     tr( "Save a Customization INI File" ),
                      lastDir, tr( "Customization files (*.ini)" ) );
 
   if ( fileName.isEmpty() )
@@ -256,7 +261,7 @@ void QgsCustomizationDialog::actionLoad_triggered( bool checked )
   QString lastDir = mySettings.value( mLastDirSettingsName, QDir::homePath() ).toString();
 
   QString fileName = QFileDialog::getOpenFileName( this,
-                     tr( "Choose a customization INI file" ),
+                     tr( "Choose a Customization INI File" ),
                      lastDir, tr( "Customization files (*.ini)" ) );
 
   if ( fileName.isEmpty() )
@@ -292,7 +297,12 @@ void QgsCustomizationDialog::actionSelectAll_triggered( bool checked )
 void QgsCustomizationDialog::mCustomizationEnabledCheckBox_toggled( bool checked )
 {
   treeWidget->setEnabled( checked );
-  toolBar->setEnabled( checked );
+  btnCatch->setEnabled( checked );
+  btnSave->setEnabled( checked );
+  btnLoad->setEnabled( checked );
+  btnCollapseAll->setEnabled( checked );
+  btnExpandAll->setEnabled( checked );
+  btnSelectAll->setEnabled( checked );
 }
 
 void QgsCustomizationDialog::init()
@@ -384,7 +394,7 @@ QTreeWidgetItem *QgsCustomizationDialog::readWidgetsXmlNode( const QDomNode &nod
 bool QgsCustomizationDialog::switchWidget( QWidget *widget, QMouseEvent *e )
 {
   Q_UNUSED( e );
-  if ( !actionCatch->isChecked() )
+  if ( !btnCatch->isChecked() )
     return false;
 
   QString path = widgetPath( widget );
@@ -480,11 +490,11 @@ QString QgsCustomizationDialog::widgetPath( QWidget *widget, const QString &path
 
 void QgsCustomizationDialog::setCatch( bool on )
 {
-  actionCatch->setChecked( on );
+  btnCatch->setChecked( on );
 }
 bool QgsCustomizationDialog::catchOn()
 {
-  return actionCatch->isChecked();
+  return btnCatch->isChecked();
 }
 
 void QgsCustomizationDialog::showHelp()

--- a/src/ui/qgscustomizationdialogbase.ui
+++ b/src/ui/qgscustomizationdialogbase.ui
@@ -23,6 +23,110 @@
      </widget>
     </item>
     <item>
+     <layout class="QHBoxLayout" name="btnGroup">
+      <item>
+       <widget class="QToolButton" name="btnCatch">
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Switch to catching widgets in main application</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionSelect.svg</normaloff>:/images/themes/default/mActionSelect.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnSave">
+        <property name="toolTip">
+         <string>Save to file</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnLoad">
+        <property name="toolTip">
+         <string>Load from file</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnExpandAll">
+        <property name="toolTip">
+         <string>Expand All</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionExpandTree.svg</normaloff>:/images/themes/default/mActionExpandTree.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnCollapseAll">
+        <property name="toolTip">
+         <string>Collapse All</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionCollapseTree.svg</normaloff>:/images/themes/default/mActionCollapseTree.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnSelectAll">
+        <property name="toolTip">
+         <string>Check All</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionSelectAllTree.svg</normaloff>:/images/themes/default/mActionSelectAllTree.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
      <widget class="QTreeWidget" name="treeWidget">
       <property name="selectionBehavior">
        <enum>QAbstractItemView::SelectItems</enum>
@@ -57,98 +161,6 @@
     </item>
    </layout>
   </widget>
-  <widget class="QToolBar" name="toolBar">
-   <property name="windowTitle">
-    <string>toolBar</string>
-   </property>
-   <property name="movable">
-    <bool>false</bool>
-   </property>
-   <property name="iconSize">
-    <size>
-     <width>24</width>
-     <height>24</height>
-    </size>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-   <addaction name="actionCatch"/>
-   <addaction name="actionSave"/>
-   <addaction name="actionLoad"/>
-   <addaction name="actionExpandAll"/>
-   <addaction name="actionCollapseAll"/>
-   <addaction name="actionSelectAll"/>
-  </widget>
-  <action name="actionCatch">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionSelect.svg</normaloff>:/images/themes/default/mActionSelect.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Catch</string>
-   </property>
-   <property name="toolTip">
-    <string>Switch to catching widgets in main application</string>
-   </property>
-  </action>
-  <action name="actionSave">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Save</string>
-   </property>
-   <property name="toolTip">
-    <string>Save to file</string>
-   </property>
-  </action>
-  <action name="actionLoad">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Load</string>
-   </property>
-   <property name="toolTip">
-    <string>Load from file</string>
-   </property>
-  </action>
-  <action name="actionExpandAll">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionExpandTree.svg</normaloff>:/images/themes/default/mActionExpandTree.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Expand All</string>
-   </property>
-  </action>
-  <action name="actionCollapseAll">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionCollapseTree.svg</normaloff>:/images/themes/default/mActionCollapseTree.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Collapse All</string>
-   </property>
-  </action>
-  <action name="actionSelectAll">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionSelectAllTree.svg</normaloff>:/images/themes/default/mActionSelectAllTree.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Check All</string>
-   </property>
-  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
Because you first need to check the "Enable customization" box to interact with the whole dialog, it should the first item proposed (otherwise, it's not really obvious/smooth).
I also think that with this configuration a search box could also find its place (...one day...)
![image](https://user-images.githubusercontent.com/7983394/35606882-b3148f9e-0651-11e8-8c34-7b588497b528.png)
