### PR TITLE
[bugfix] Lower priority of range widget for doubles

### DIFF
--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -37,7 +37,8 @@ QgsEditorConfigWidget *QgsRangeWidgetFactory::configWidget( QgsVectorLayer *vl, 
 unsigned int QgsRangeWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const
 {
   const QgsField field = vl->fields().at( fieldIdx );
-  if ( field.type() == QVariant::Int || field.type() == QVariant::Double ) return 20;
+  if ( field.type() == QVariant::Int ) return 20;
+  if ( field.type() == QVariant::Double ) return 5; // low priority because the fixed number of decimal places may alter the original data
   if ( field.isNumeric() ) return 5; // widgets used support only signed 32bits (int) and double
   return 0;
 }

--- a/tests/src/gui/testqgseditorwidgetregistry.cpp
+++ b/tests/src/gui/testqgseditorwidgetregistry.cpp
@@ -77,7 +77,7 @@ class TestQgsEditorWidgetRegistry: public QObject
 
     void doubleType()
     {
-      checkSimple( QStringLiteral( "double" ), QStringLiteral( "Range" ) );
+      checkSimple( QStringLiteral( "double" ), QStringLiteral( "TextEdit" ) );
     }
 
     void arrayType()


### PR DESCRIPTION
This was the root cause of several critical bugs with
data corruption in the attribute table and forms:
SpinBox has a fixed number of decimal places, which
makes it not ideal for floating points because most
of the times it rounds the number changing it when
in edit mode even if the user has not really modified
the value by writing in the spin box or using the
controls.

So, the default is now back to the line edit (which has
bugs in the validator, but that's another less
critical and separate issue).

Partially fixes #17861
Partially fixes #18007
Partially fixes #17878

