### PR TITLE
use a QMimeData clipboard object to paste features as HTML table

### DIFF
--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -161,20 +161,32 @@ void QgsClipboard::setSystemClipboard()
   QMimeData *m = new QMimeData();
   m->setText( textCopy );
 
-  QgsSettings settings;
-  CopyFormat format = AttributesWithWKT;
-  if ( settings.contains( QStringLiteral( "/qgis/copyFeatureFormat" ) ) )
+  if ( mFeatureClipboard.count() < 1000 )
   {
-    format = static_cast< CopyFormat >( settings.value( QStringLiteral( "qgis/copyFeatureFormat" ), true ).toInt() );
-  }
+    QgsSettings settings;
+    CopyFormat format = AttributesWithWKT;
+    if ( settings.contains( QStringLiteral( "/qgis/copyFeatureFormat" ) ) )
+    {
+      format = static_cast< CopyFormat >( settings.value( QStringLiteral( "qgis/copyFeatureFormat" ), true ).toInt() );
+    }
 
-  if ( format == AttributesWithWKT && mFeatureClipboard.count() < 1000 )
-  {
-    QString htmlCopy = textCopy;
-    htmlCopy.replace( QRegExp( "\n" ), QStringLiteral( "</td></tr><tr><td>" ) );
-    htmlCopy.replace( QRegExp( "\t" ), QStringLiteral( "</td><td>" ) );
-    htmlCopy = QStringLiteral( "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\"><html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"/></head><body><table border=\"1\"><tr><td>" ) + htmlCopy + QStringLiteral( "</td></tr></table></body></html>" );
-    m->setHtml( htmlCopy );
+    QString htmlCopy;
+    switch ( format )
+    {
+      case AttributesOnly:
+      case AttributesWithWKT:
+        htmlCopy = textCopy;
+        htmlCopy.replace( '\n', QStringLiteral( "</td></tr><tr><td>" ) );
+        htmlCopy.replace( '\t', QStringLiteral( "</td><td>" ) );
+        htmlCopy = QStringLiteral( "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\"><html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"/></head><body><table border=\"1\"><tr><td>" ) + htmlCopy + QStringLiteral( "</td></tr></table></body></html>" );
+        break;
+      case GeoJSON:
+        break;
+    }
+    if ( !htmlCopy.isEmpty() )
+    {
+      m->setHtml( htmlCopy );
+    }
   }
 
   // With qgis running under Linux, but with a Windows based X

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -154,22 +154,38 @@ void QgsClipboard::setSystemClipboard()
   // that just the next call to systemClipboardChanged() should be ignored
   mIgnoreNextSystemClipboardChange = true;
 
-  QString textCopy = generateClipboardText();
-
   QClipboard *cb = QApplication::clipboard();
 
   // Copy text into the clipboard
+  QString textCopy = generateClipboardText();
+  QMimeData *m = new QMimeData();
+  m->setText( textCopy );
+
+  QgsSettings settings;
+  CopyFormat format = AttributesWithWKT;
+  if ( settings.contains( QStringLiteral( "/qgis/copyFeatureFormat" ) ) )
+  {
+    format = static_cast< CopyFormat >( settings.value( QStringLiteral( "qgis/copyFeatureFormat" ), true ).toInt() );
+  }
+
+  if ( format == AttributesWithWKT && mFeatureClipboard.count() < 1000 )
+  {
+    QString htmlCopy = textCopy;
+    htmlCopy.replace( QRegExp( "\n" ), QStringLiteral( "</td></tr><tr><td>" ) );
+    htmlCopy.replace( QRegExp( "\t" ), QStringLiteral( "</td><td>" ) );
+    htmlCopy = QStringLiteral( "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\"><html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"/></head><body><table border=\"1\"><tr><td>" ) + htmlCopy + QStringLiteral( "</td></tr></table></body></html>" );
+    m->setHtml( htmlCopy );
+  }
 
   // With qgis running under Linux, but with a Windows based X
   // server (Xwin32), ::Selection was necessary to get the data into
   // the Windows clipboard (which seems contrary to the Qt
   // docs). With a Linux X server, ::Clipboard was required.
   // The simple solution was to put the text into both clipboards.
-
 #ifdef Q_OS_LINUX
-  cb->setText( textCopy, QClipboard::Selection );
+  cb->setMimeData( m, QClipboard::Selection );
 #endif
-  cb->setText( textCopy, QClipboard::Clipboard );
+  cb->setMimeData( m, QClipboard::Clipboard );
 
   QgsDebugMsgLevel( QString( "replaced system clipboard with: %1." ).arg( textCopy ), 4 );
 }

--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -149,6 +149,11 @@ void TestQgisAppClipboard::copyToText()
   result = mQgisApp->clipboard()->generateClipboardText();
   QCOMPARE( result, QString( "wkt_geom\tint_field\tstring_field\nPoint (5 6)\t9\tval\nPoint (7 8)\t19\tval2" ) );
 
+  // HTML test
+  mQgisApp->clipboard()->replaceWithCopyOf( feats );
+  result = mQgisApp->clipboard()->data( "text/html" );
+  QCOMPARE( result, QString( "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\"><html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"/></head><body><table border=\"1\"><tr><td>wkt_geom</td><td>int_field</td><td>string_field</td></tr><tr><td>Point (5 6)</td><td>9</td><td>val</td></tr><tr><td>Point (7 8)</td><td>19</td><td>val2</td></tr></table></body></html>" ) );
+
   // GeoJSON
   settings.setValue( QStringLiteral( "/qgis/copyFeatureFormat" ), QgsClipboard::GeoJSON );
   result = mQgisApp->clipboard()->generateClipboardText();


### PR DESCRIPTION
## Description
Until now, when pasting copied features into a word processor or a browser's rich text area, the result is a series of non-formatted text lines. It can be frustrating when copying from the attribute table and expecting a table when pasting. The user is left with opening a spreadsheet program, pasting the clipboard content into a sheet first.

This PR fixes that gab by using a QMimeData object and passing in both text as well as HTML content.

Increased productivity ensues:
![giphy](https://user-images.githubusercontent.com/1728657/35661895-afda0d80-0747-11e8-9ccb-f377408b4348.gif)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
