### PR TITLE
[bugfix] Range formatter for doubles and ints

### DIFF
--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -287,6 +287,7 @@
 %Include geometry/qgswkbtypes.sip
 %Include ./3d/qgs3drendererregistry.sip
 %Include ./3d/qgsabstract3drenderer.sip
+%Include fieldformatter/qgsrangefieldformatter.sip
 %Include fieldformatter/qgsdatetimefieldformatter.sip
 %Include fieldformatter/qgsfallbackfieldformatter.sip
 %Include fieldformatter/qgskeyvaluefieldformatter.sip

--- a/python/core/fieldformatter/qgsrangefieldformatter.sip.in
+++ b/python/core/fieldformatter/qgsrangefieldformatter.sip.in
@@ -1,0 +1,42 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/fieldformatter/qgsrangefieldformatter.h                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+class QgsRangeFieldFormatter : QgsFieldFormatter
+{
+%Docstring
+Field formatter for a range (double) field with precision and locale
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsrangefieldformatter.h"
+%End
+  public:
+
+    QgsRangeFieldFormatter();
+%Docstring
+Default constructor of field formatter for a range (double)field.
+%End
+
+    virtual QString id() const;
+
+
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/fieldformatter/qgsrangefieldformatter.h                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/editorwidgets/qgsdoublespinbox.sip.in
+++ b/python/gui/editorwidgets/qgsdoublespinbox.sip.in
@@ -119,6 +119,13 @@ Returns the value used when clear() is called.
 .. seealso:: :py:func:`setClearValue`
 %End
 
+    void setLineEditAlignment( Qt::Alignment alignment );
+%Docstring
+Set alignment in the embedded line edit widget
+
+:param alignment:
+%End
+
     virtual double valueFromText( const QString &text ) const;
 
     virtual QValidator::State validate( QString &input, int &pos ) const;

--- a/python/gui/editorwidgets/qgsspinbox.sip.in
+++ b/python/gui/editorwidgets/qgsspinbox.sip.in
@@ -119,6 +119,13 @@ Returns the value used when clear() is called.
 .. seealso:: :py:func:`setClearValue`
 %End
 
+    void setLineEditAlignment( Qt::Alignment alignment );
+%Docstring
+Set alignment in the embedded line edit widget
+
+:param alignment:
+%End
+
     virtual int valueFromText( const QString &text ) const;
 
     virtual QValidator::State validate( QString &input, int &pos ) const;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -473,6 +473,7 @@ SET(QGIS_CORE_SRCS
   3d/qgs3drendererregistry.cpp
   3d/qgsabstract3drenderer.cpp
 
+  fieldformatter/qgsrangefieldformatter.cpp
   fieldformatter/qgsdatetimefieldformatter.cpp
   fieldformatter/qgsfallbackfieldformatter.cpp
   fieldformatter/qgskeyvaluefieldformatter.cpp
@@ -1110,6 +1111,7 @@ SET(QGIS_CORE_HDRS
   3d/qgs3drendererregistry.h
   3d/qgsabstract3drenderer.h
 
+  fieldformatter/qgsrangefieldformatter.h
   fieldformatter/qgsdatetimefieldformatter.h
   fieldformatter/qgsfallbackfieldformatter.h
   fieldformatter/qgskeyvaluefieldformatter.h

--- a/src/core/fieldformatter/qgsrangefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrangefieldformatter.cpp
@@ -53,14 +53,14 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
   const QgsField field = layer->fields().at( fieldIndex );
 
   if ( field.type() == QVariant::Double &&
-       field.editorWidgetSetup().config().contains( QStringLiteral( "Precision" ) ) &&
+       config.contains( QStringLiteral( "Precision" ) ) &&
        value.isValid( ) )
   {
     bool ok;
     double val( value.toDouble( &ok ) );
     if ( ok )
     {
-      int precision( field.editorWidgetSetup().config()[ QStringLiteral( "Precision" ) ].toInt( &ok ) );
+      int precision( config[ QStringLiteral( "Precision" ) ].toInt( &ok ) );
       if ( ok )
       {
         // TODO: make the format configurable!

--- a/src/core/fieldformatter/qgsrangefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrangefieldformatter.cpp
@@ -1,0 +1,84 @@
+/***************************************************************************
+  qgsrangefieldformatter.cpp - QgsRangeFieldFormatter
+
+ ---------------------
+ begin                : 01/02/2018
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QLocale>
+
+#include "qgsrangefieldformatter.h"
+
+#include "qgssettings.h"
+#include "qgsfield.h"
+#include "qgsvectorlayer.h"
+
+
+QString QgsRangeFieldFormatter::id() const
+{
+  return QStringLiteral( "Range" );
+}
+
+QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const
+{
+  Q_UNUSED( cache )
+  Q_UNUSED( config )
+
+  if ( value.isNull() )
+  {
+    return QgsApplication::nullRepresentation();
+  }
+
+  QString result;
+
+  const QgsField field = layer->fields().at( fieldIndex );
+
+  if ( field.type() == QVariant::Double &&
+       field.editorWidgetSetup().config().contains( QStringLiteral( "Precision" ) ) &&
+       value.isValid( ) )
+  {
+    bool ok;
+    double val( value.toDouble( &ok ) );
+    if ( ok )
+    {
+      int precision( field.editorWidgetSetup().config()[ QStringLiteral( "Precision" ) ].toInt( &ok ) );
+      if ( ok )
+      {
+        // TODO: make the format configurable!
+        QLocale locale( QgsApplication::instance()->locale() );
+        QLocale::NumberOptions options( locale.numberOptions() );
+        options |= QLocale::NumberOption::OmitGroupSeparator;
+        locale.setNumberOptions( options );
+        result = locale.toString( val, 'f', precision );
+      }
+    }
+  }
+  else if ( field.type() == QVariant::Int &&
+            value.isValid( ) )
+  {
+    bool ok;
+    double val( value.toInt( &ok ) );
+    if ( ok )
+    {
+      QLocale locale( QgsApplication::instance()->locale() );
+      QLocale::NumberOptions options( locale.numberOptions() );
+      options |= QLocale::NumberOption::OmitGroupSeparator;
+      locale.setNumberOptions( options );
+      result = locale.toString( val );
+    }
+  }
+  else
+  {
+    result = value.toString();
+  }
+  return result;
+}

--- a/src/core/fieldformatter/qgsrangefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrangefieldformatter.cpp
@@ -40,6 +40,16 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
 
   QString result;
 
+  // Prepare locale
+  std::function<QLocale()> f_locale = [ ]
+  {
+    QLocale locale( QgsApplication::instance()->locale() );
+    QLocale::NumberOptions options( locale.numberOptions() );
+    options |= QLocale::NumberOption::OmitGroupSeparator;
+    locale.setNumberOptions( options );
+    return locale;
+  };
+
   const QgsField field = layer->fields().at( fieldIndex );
 
   if ( field.type() == QVariant::Double &&
@@ -54,11 +64,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
       if ( ok )
       {
         // TODO: make the format configurable!
-        QLocale locale( QgsApplication::instance()->locale() );
-        QLocale::NumberOptions options( locale.numberOptions() );
-        options |= QLocale::NumberOption::OmitGroupSeparator;
-        locale.setNumberOptions( options );
-        result = locale.toString( val, 'f', precision );
+        result = f_locale().toString( val, 'f', precision );
       }
     }
   }
@@ -69,11 +75,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
     double val( value.toInt( &ok ) );
     if ( ok )
     {
-      QLocale locale( QgsApplication::instance()->locale() );
-      QLocale::NumberOptions options( locale.numberOptions() );
-      options |= QLocale::NumberOption::OmitGroupSeparator;
-      locale.setNumberOptions( options );
-      result = locale.toString( val );
+      result =  f_locale().toString( val );
     }
   }
   else

--- a/src/core/fieldformatter/qgsrangefieldformatter.h
+++ b/src/core/fieldformatter/qgsrangefieldformatter.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+  qgsrangefieldformatter.h - QgsRangeFieldFormatter
+
+ ---------------------
+ begin                : 01/02/2018
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSRANGEFIELDFORMATTER_H
+#define QGSRANGEFIELDFORMATTER_H
+
+#include "qgis_core.h"
+#include "qgsfieldformatter.h"
+
+/**
+ * \ingroup core
+ * Field formatter for a range (double) field with precision and locale
+ *
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsRangeFieldFormatter : public QgsFieldFormatter
+{
+  public:
+
+    /**
+      * Default constructor of field formatter for a range (double)field.
+      */
+    QgsRangeFieldFormatter() = default;
+
+    QString id() const override;
+
+    QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const override;
+
+};
+
+#endif // QGSRANGEFIELDFORMATTER_H

--- a/src/core/qgsfieldformatterregistry.cpp
+++ b/src/core/qgsfieldformatterregistry.cpp
@@ -22,6 +22,7 @@
 #include "qgsrelationreferencefieldformatter.h"
 #include "qgskeyvaluefieldformatter.h"
 #include "qgslistfieldformatter.h"
+#include "qgsrangefieldformatter.h"
 #include "qgsfallbackfieldformatter.h"
 
 
@@ -34,6 +35,7 @@ QgsFieldFormatterRegistry::QgsFieldFormatterRegistry( QObject *parent )
   addFieldFormatter( new QgsKeyValueFieldFormatter() );
   addFieldFormatter( new QgsListFieldFormatter() );
   addFieldFormatter( new QgsDateTimeFieldFormatter() );
+  addFieldFormatter( new QgsRangeFieldFormatter() );
 
   mFallbackFieldFormatter = new QgsFallbackFieldFormatter();
 }

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -34,7 +34,6 @@ QgsDoubleSpinBox::QgsDoubleSpinBox( QWidget *parent )
   // By default, group separator is off
   setLocale( QLocale( QgsApplication::locale( ) ) );
   setLineEdit( mLineEdit );
-  mLineEdit->setAlignment( Qt::AlignRight );
 
   QSize msz = minimumSizeHint();
   setMinimumSize( msz.width() + CLEAR_ICON_SIZE + 9 + frameWidth() * 2 + 2,
@@ -135,6 +134,11 @@ double QgsDoubleSpinBox::clearValue() const
     return maximum();
   else
     return mCustomClearValue;
+}
+
+void QgsDoubleSpinBox::setLineEditAlignment( Qt::Alignment alignment )
+{
+  mLineEdit->setAlignment( alignment );
 }
 
 QString QgsDoubleSpinBox::stripped( const QString &originalText ) const

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -31,7 +31,10 @@ QgsDoubleSpinBox::QgsDoubleSpinBox( QWidget *parent )
 {
   mLineEdit = new QgsSpinBoxLineEdit();
 
+  // By default, group separator is off
+  setLocale( QLocale( QgsApplication::locale( ) ) );
   setLineEdit( mLineEdit );
+  mLineEdit->setAlignment( Qt::AlignRight );
 
   QSize msz = minimumSizeHint();
   setMinimumSize( msz.width() + CLEAR_ICON_SIZE + 9 + frameWidth() * 2 + 2,

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -126,6 +126,12 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
      */
     double clearValue() const;
 
+    /**
+     * Set alignment in the embedded line edit widget
+     * \param alignment
+     */
+    void setLineEditAlignment( Qt::Alignment alignment );
+
     double valueFromText( const QString &text ) const override;
     QValidator::State validate( QString &input, int &pos ) const override;
     void paintEvent( QPaintEvent *e ) override;

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -47,12 +47,14 @@ QWidget *QgsRangeWidgetWrapper::createWidget( QWidget *parent )
       case QVariant::Double:
       {
         editor = new QgsDoubleSpinBox( parent );
+        static_cast<QgsDoubleSpinBox *>( editor )->setLineEditAlignment( Qt::AlignRight );
         break;
       }
       case QVariant::Int:
       case QVariant::LongLong:
       default:
         editor = new QgsSpinBox( parent );
+        static_cast<QgsSpinBox *>( editor )->setLineEditAlignment( Qt::AlignRight );
         break;
     }
   }

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -30,7 +30,6 @@ QgsSpinBox::QgsSpinBox( QWidget *parent )
   : QSpinBox( parent )
 {
   mLineEdit = new QgsSpinBoxLineEdit();
-  mLineEdit->setAlignment( Qt::AlignRight );
   setLineEdit( mLineEdit );
 
   QSize msz = minimumSizeHint();
@@ -131,6 +130,11 @@ int QgsSpinBox::clearValue() const
     return maximum();
   else
     return mCustomClearValue;
+}
+
+void QgsSpinBox::setLineEditAlignment( Qt::Alignment alignment )
+{
+  mLineEdit->setAlignment( alignment );
 }
 
 int QgsSpinBox::valueFromText( const QString &text ) const

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -30,7 +30,7 @@ QgsSpinBox::QgsSpinBox( QWidget *parent )
   : QSpinBox( parent )
 {
   mLineEdit = new QgsSpinBoxLineEdit();
-
+  mLineEdit->setAlignment( Qt::AlignRight );
   setLineEdit( mLineEdit );
 
   QSize msz = minimumSizeHint();

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -126,6 +126,12 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
      */
     int clearValue() const;
 
+    /**
+     * Set alignment in the embedded line edit widget
+     * \param alignment
+     */
+    void setLineEditAlignment( Qt::Alignment alignment );
+
     int valueFromText( const QString &text ) const override;
     QValidator::State validate( QString &input, int &pos ) const override;
 


### PR DESCRIPTION
Double and ints are now formatted according
to chosen locale (in user settings) and precision
(from the widget field config)

Numbers are also right aligned in the form
and not only in the table.

IMHO a bugfix since the numbers looked very
different in the form and the table
when the system locale used decimal
separator and group separator which were not
the same than system locale.


![out20180201194059](https://user-images.githubusercontent.com/142164/35702004-25b8ab24-0798-11e8-8d60-57b1b894a194.gif)
