### PR TITLE
use sane number of decimals for the extent groupbox widget

### DIFF
--- a/src/gui/qgsextentgroupbox.cpp
+++ b/src/gui/qgsextentgroupbox.cpp
@@ -17,7 +17,6 @@
 
 #include "qgslogger.h"
 #include "qgscoordinatetransform.h"
-#include "qgsrasterblock.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayermodel.h"
 #include "qgsexception.h"
@@ -141,10 +140,28 @@ void QgsExtentGroupBox::setOutputExtent( const QgsRectangle &r, const QgsCoordin
     }
   }
 
-  mXMinLineEdit->setText( QgsRasterBlock::printValue( extent.xMinimum() ) );
-  mXMaxLineEdit->setText( QgsRasterBlock::printValue( extent.xMaximum() ) );
-  mYMinLineEdit->setText( QgsRasterBlock::printValue( extent.yMinimum() ) );
-  mYMaxLineEdit->setText( QgsRasterBlock::printValue( extent.yMaximum() ) );
+  int decimals;
+  switch ( mOutputCrs.mapUnits() )
+  {
+    case QgsUnitTypes::DistanceDegrees:
+    case QgsUnitTypes::DistanceUnknownUnit:
+      decimals = 9;
+      break;
+    case QgsUnitTypes::DistanceMeters:
+    case QgsUnitTypes::DistanceKilometers:
+    case QgsUnitTypes::DistanceFeet:
+    case QgsUnitTypes::DistanceNauticalMiles:
+    case QgsUnitTypes::DistanceYards:
+    case QgsUnitTypes::DistanceMiles:
+    case QgsUnitTypes::DistanceCentimeters:
+    case QgsUnitTypes::DistanceMillimeters:
+      decimals = 4;
+      break;
+  }
+  mXMinLineEdit->setText( QString::number( extent.xMinimum(), 'f', decimals ) );
+  mXMaxLineEdit->setText( QString::number( extent.xMaximum(), 'f', decimals ) );
+  mYMinLineEdit->setText( QString::number( extent.yMinimum(), 'f', decimals ) );
+  mYMaxLineEdit->setText( QString::number( extent.yMaximum(), 'f', decimals ) );
 
   mExtentState = state;
 


### PR DESCRIPTION
## Description
Our extent groupbox widget was adding way too many decimals for non-geographic CRSes. This PR add some logic which limits decimals to 4 for those. 

Before vs. proposed:
![screenshot from 2018-02-02 15-42-49](https://user-images.githubusercontent.com/1728657/35724720-57d49052-0831-11e8-9373-315752de86b3.png)
_What? I can actually read the extent coordinates!_

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
