### PR TITLE
[bugfix][server] WMS respect order of grouped layers

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2664,8 +2664,9 @@ namespace QgsWms
       }
       else if ( mLayerGroups.contains( nickname ) )
       {
-        for ( QgsMapLayer *layer : mLayerGroups[nickname] )
+        for ( auto it = mLayerGroups[nickname].rbegin(); it !=  mLayerGroups[nickname].rend(); ++it )
         {
+          QgsMapLayer *layer = *it;
           if ( !mRestrictedLayers.contains( layerNickname( *layer ) ) )
           {
             if ( !style.isEmpty() )

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2606,15 +2606,13 @@ namespace QgsWms
             }
             else if ( mLayerGroups.contains( lname ) )
             {
-              // Reverse order for group members
-              for ( auto it = mLayerGroups[lname].rbegin(); it !=  mLayerGroups[lname].rend(); ++it )
+              for ( QgsMapLayer *layer : mLayerGroups[lname] )
               {
-                QgsMapLayer *layer = *it;
                 if ( !mRestrictedLayers.contains( layerNickname( *layer ) ) )
                 {
                   layer->readSld( namedElem, err );
                   layer->setCustomProperty( "readSLD", true );
-                  layers.append( layer );
+                  layers.insert( 0, layer );
                 }
               }
             }
@@ -2666,10 +2664,8 @@ namespace QgsWms
       }
       else if ( mLayerGroups.contains( nickname ) )
       {
-        // Reverse order for group members
-        for ( auto it = mLayerGroups[nickname].rbegin(); it !=  mLayerGroups[nickname].rend(); ++it )
+        for ( QgsMapLayer *layer : mLayerGroups[nickname] )
         {
-          QgsMapLayer *layer = *it;
           if ( !mRestrictedLayers.contains( layerNickname( *layer ) ) )
           {
             if ( !style.isEmpty() )
@@ -2680,7 +2676,7 @@ namespace QgsWms
                 throw QgsMapServiceException( QStringLiteral( "StyleNotDefined" ), QStringLiteral( "Style \"%1\" does not exist for layer \"%2\"" ).arg( style, layerNickname( *layer ) ) );
               }
             }
-            layers.append( layer );
+            layers.insert( 0, layer );
           }
         }
       }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2606,8 +2606,10 @@ namespace QgsWms
             }
             else if ( mLayerGroups.contains( lname ) )
             {
-              for ( QgsMapLayer *layer : mLayerGroups[lname] )
+              // Reverse order for group members
+              for ( auto it = mLayerGroups[lname].rbegin(); it !=  mLayerGroups[lname].rend(); ++it )
               {
+                QgsMapLayer *layer = *it;
                 if ( !mRestrictedLayers.contains( layerNickname( *layer ) ) )
                 {
                   layer->readSld( namedElem, err );
@@ -2664,6 +2666,7 @@ namespace QgsWms
       }
       else if ( mLayerGroups.contains( nickname ) )
       {
+        // Reverse order for group members
         for ( auto it = mLayerGroups[nickname].rbegin(); it !=  mLayerGroups[nickname].rend(); ++it )
         {
           QgsMapLayer *layer = *it;

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -890,12 +890,15 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         self._img_diff_error(r, h, "WMS_GetMap_SLDRestored")
 
     def test_wms_getmap_group(self):
+        """A WMS shall render the requested layers by drawing the leftmost in the list 
+        bottommost, the next one over that, and so on."""
+
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectGroupsPath),
             "SERVICE": "WMS",
             "VERSION": "1.1.1",
             "REQUEST": "GetMap",
-            "LAYERS": "Country,Country_Labels,Country_Diagrams",
+            "LAYERS": "Country_Diagrams,Country_Labels,Country",
             "STYLES": "",
             "FORMAT": "image/png",
             "BBOX": "-16817707,-4710778,5696513,14587125",
@@ -921,6 +924,16 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         }.items())])
 
         r_group, _ = self._result(self._execute_request(qs))
+
+        """ Debug check:
+        f = open('grouped.png', 'wb+')
+        f.write(r_group)
+        f.close()
+        f = open('individual.png', 'wb+')
+        f.write(r_individual)
+        f.close()
+        #"""
+
         self.assertEqual(r_individual, r_group, 'Individual layers query and group layers query results should be identical')
 
         qs = "?" + "&".join(["%s=%s" % i for i in list({


### PR DESCRIPTION
Fixes #17975 - QGIS server 2.99 reverses the layer order for layer groups
