### PR TITLE
[options] Hide non-matching items in tree widgets when searching children

### DIFF
--- a/src/gui/qgsoptionsdialoghighlightwidgetsimpl.h
+++ b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.h
@@ -140,5 +140,6 @@ class GUI_EXPORT QgsOptionsDialogHighlightTree : public QgsOptionsDialogHighligh
     // a map to save the tree state (backouground, font, expanded) before highlighting items
     QMap<QTreeWidgetItem *, QPair<QBrush, QBrush>> mTreeInitialStyle = QMap<QTreeWidgetItem *, QPair<QBrush, QBrush>>();
     QMap<QTreeWidgetItem *, bool> mTreeInitialExpand = QMap<QTreeWidgetItem *, bool>();
+    QMap<QTreeWidgetItem *, bool> mTreeInitialVisible = QMap<QTreeWidgetItem *, bool>();
 };
 #endif // QGSOPTIONSDIALOGHIGHLIGHTWIDGETSIMPL_H


### PR DESCRIPTION
Makes the search more useful for the advanced panel
