### PR TITLE
Put search icon on left of QgsFilterLineEdit

### DIFF
--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -43,7 +43,7 @@ QgsFilterLineEdit::QgsFilterLineEdit( QWidget *parent, const QString &nullValue 
   QIcon searchIcon = QgsApplication::getThemeIcon( "/search.svg" );
   mSearchAction = new QAction( searchIcon, QString(), this );
   mSearchAction->setCheckable( false );
-  addAction( mSearchAction, QLineEdit::TrailingPosition );
+  addAction( mSearchAction, QLineEdit::LeadingPosition );
   mSearchAction->setVisible( false );
 
   connect( this, &QLineEdit::textChanged, this,


### PR DESCRIPTION
I think the original approach of placing this icon on the left looks much nicer - especially because it means it doesn't jump around when text is entered and cleared and the "clear" button appears and disappears.