### PR TITLE
[layouts] Fix rotated items move when refreshing layout

### DIFF
--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -487,7 +487,7 @@ int QgsLayoutItem::page() const
 
 QPointF QgsLayoutItem::pagePos() const
 {
-  QPointF p = pos();
+  QPointF p = positionAtReferencePoint( mReferencePoint );
 
   if ( !mLayout )
     return p;

--- a/src/core/layout/qgslayoutpagecollection.cpp
+++ b/src/core/layout/qgslayoutpagecollection.cpp
@@ -77,7 +77,7 @@ void QgsLayoutPageCollection::endPageSizeChange()
     {
       if ( !mBlockUndoCommands )
         item->beginCommand( QString() );
-      item->attemptMove( it.value().second, false, false, it.value().first );
+      item->attemptMove( it.value().second, true, false, it.value().first );
       if ( !mBlockUndoCommands )
         item->endCommand();
     }

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -1386,6 +1386,16 @@ void TestQgsLayoutItem::page()
   QCOMPARE( item->page(), 2 );
   QCOMPARE( item->pagePositionWithUnits(), QgsLayoutPoint( 5, 6, QgsUnitTypes::LayoutCentimeters ) );
   QCOMPARE( item->positionWithUnits(), QgsLayoutPoint( 5, 38, QgsUnitTypes::LayoutCentimeters ) );
+
+  // non-top-left reference
+  item->setReferencePoint( QgsLayoutItem::Middle );
+  item->attemptMove( QgsLayoutPoint( 5, 6 ), true, false, 0 );
+  QCOMPARE( item->pagePos(), QPointF( 5, 6 ) );
+  QCOMPARE( item->pagePositionWithUnits(), QgsLayoutPoint( 5, 6 ) );
+  item->attemptMove( QgsLayoutPoint( 5, 6 ), true, false, 1 );
+  QCOMPARE( item->page(), 1 );
+  QCOMPARE( item->pagePos(), QPointF( 5, 6 ) );
+  QCOMPARE( item->pagePositionWithUnits(), QgsLayoutPoint( 5, 6, QgsUnitTypes::LayoutMillimeters ) );
 }
 
 void TestQgsLayoutItem::itemVariablesFunction()
@@ -1524,6 +1534,24 @@ void TestQgsLayoutItem::rotation()
   QCOMPARE( item2->positionWithUnits().y(), 16.0 );
   QCOMPARE( item2->pos().x(), 7.0 );
   QCOMPARE( item2->pos().y(), 16.0 );
+
+  // test that refresh rotation doesn't move item (#18037)
+  item2 = qgis::make_unique< TestItem >( &l );
+  item2->setReferencePoint( QgsLayoutItem::Middle );
+  item2->attemptMove( QgsLayoutPoint( 5.0, 8.0 ) );
+  item2->attemptResize( QgsLayoutSize( 10.0, 6.0 ) );
+  item2->setItemRotation( 45 );
+  QCOMPARE( item2->positionWithUnits().x(), 5.0 );
+  QCOMPARE( item2->positionWithUnits().y(), 8.0 );
+  QGSCOMPARENEAR( item2->pos().x(), 3.58, 0.01 );
+  QGSCOMPARENEAR( item2->pos().y(), 2.343146, 0.01 );
+  QCOMPARE( item2->rotation(), 45.0 );
+  item2->refresh();
+  QCOMPARE( item2->positionWithUnits().x(), 5.0 );
+  QCOMPARE( item2->positionWithUnits().y(), 8.0 );
+  QGSCOMPARENEAR( item2->pos().x(), 3.58, 0.01 );
+  QGSCOMPARENEAR( item2->pos().y(), 2.343146, 0.01 );
+  QCOMPARE( item2->rotation(), 45.0 );
 
 
   //TODO also changing size?


### PR DESCRIPTION
Fixes #18037
