### PR TITLE
[processing] support show/hide parameters in providers

### DIFF
--- a/python/core/processing/qgsprocessingparameters.sip.in
+++ b/python/core/processing/qgsprocessingparameters.sip.in
@@ -185,6 +185,23 @@ Constructor for QgsProcessingParameterDefinition.
 Creates a clone of the parameter definition.
 %End
 
+    bool isVisible();
+%Docstring
+Returns the visiblity of the parameter. This flag can used to show/hide
+this parameter from AlgorithmDialog or exclude from passing to parameter
+processing algorithms.
+
+.. seealso:: :py:func:`setVisible`
+%End
+
+    bool setVisible(bool v);
+%Docstring
+Sets the ``mVisible`` of the parameter. This value is used to flag
+visiblity of parameter
+
+.. seealso:: :py:func:`isVisible`
+%End
+
     virtual QString type() const = 0;
 %Docstring
 Unique parameter type name.
@@ -418,6 +435,7 @@ the dynamic parameter.
 %End
 
   protected:
+
 
 
 

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -204,7 +204,8 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             feedback.pushInfo(self.tr('Input parameters:'))
             display_params = []
             for k, v in parameters.items():
-                display_params.append("'" + k + "' : " + self.algorithm().parameterDefinition(k).valueAsPythonString(v, context))
+                if self.algorithm().parameterDefinition(k).isVisible():
+                    display_params.append("'" + k + "' : " + self.algorithm().parameterDefinition(k).valueAsPythonString(v, context))
             feedback.pushCommandInfo('{ ' + ', '.join(display_params) + ' }')
             feedback.pushInfo('')
             start_time = time.time()

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -119,6 +119,7 @@ class ParametersPanel(BASE, WIDGET):
                 wrapper = WidgetWrapperFactory.create_wrapper(param, self.parent)
                 self.wrappers[param.name()] = wrapper
                 widget = wrapper.widget
+                widget.setVisible(param.isVisible())
 
                 if widget is not None:
                     if isinstance(param, QgsProcessingParameterFeatureSource):
@@ -147,6 +148,7 @@ class ParametersPanel(BASE, WIDGET):
                         widget.setText(desc)
                     else:
                         label = QLabel(desc)
+                        label.setVisible(param.isVisible())
                         # label.setToolTip(tooltip)
                         self.labels[param.name()] = label
 

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -133,7 +133,7 @@ class ModelerParametersDialog(QDialog):
                 self.verticalLayout.addLayout(advancedButtonHLayout)
                 break
         for param in self._alg.parameterDefinitions():
-            if param.isDestination() or param.flags() & QgsProcessingParameterDefinition.FlagHidden:
+            if not param.isVisible() or param.isDestination() or param.flags() & QgsProcessingParameterDefinition.FlagHidden:
                 continue
             desc = param.description()
             if isinstance(param, QgsProcessingParameterExtent):

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -133,7 +133,7 @@ class ModelerParametersDialog(QDialog):
                 self.verticalLayout.addLayout(advancedButtonHLayout)
                 break
         for param in self._alg.parameterDefinitions():
-            if not param.isVisible() or param.isDestination() or param.flags() & QgsProcessingParameterDefinition.FlagHidden:
+            if param.isDestination() or param.flags() & QgsProcessingParameterDefinition.FlagHidden:
                 continue
             desc = param.description()
             if isinstance(param, QgsProcessingParameterExtent):
@@ -143,6 +143,7 @@ class ModelerParametersDialog(QDialog):
             if param.flags() & QgsProcessingParameterDefinition.FlagOptional:
                 desc += self.tr(' [optional]')
             label = QLabel(desc)
+            label.setVisible(param.isVisible())
             self.labels[param.name()] = label
 
             wrapper = WidgetWrapperFactory.create_wrapper(param, self)
@@ -150,6 +151,7 @@ class ModelerParametersDialog(QDialog):
 
             widget = wrapper.widget
             if widget is not None:
+                widget.setVisible(param.isVisible())
                 self.valueItems[param.name()] = widget
                 tooltip = param.description()
                 label.setToolTip(tooltip)
@@ -303,7 +305,7 @@ class ModelerParametersDialog(QDialog):
             alg.setChildId(self.childId)
         alg.setDescription(self.descriptionBox.text())
         for param in self._alg.parameterDefinitions():
-            if param.isDestination() or param.flags() & QgsProcessingParameterDefinition.FlagHidden:
+            if not param.isVisible() or param.isDestination() or param.flags() & QgsProcessingParameterDefinition.FlagHidden:
                 continue
             try:
                 val = self.wrappers[param.name()].value()

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -264,6 +264,21 @@ class CORE_EXPORT QgsProcessingParameterDefinition
     virtual QgsProcessingParameterDefinition *clone() const = 0 SIP_FACTORY;
 
     /**
+     * Returns the visiblity of the parameter. This flag can used to show/hide
+     * this parameter from AlgorithmDialog or exclude from passing to parameter
+     * processing algorithms.
+     * \see setVisible()
+     */
+    bool isVisible() { return mVisible; }
+
+    /**
+     * Sets the \a mVisible of the parameter. This value is used to flag
+     * visiblity of parameter
+     * \see isVisible()
+     */
+    bool setVisible( bool v ) { return mVisible = v; }
+
+    /**
      * Unique parameter type name.
      */
     virtual QString type() const = 0;
@@ -494,6 +509,8 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 
     //! True for dynamic parameters, which can have data-defined (QgsProperty) based values
     bool mIsDynamic = false;
+
+    bool mVisible = true;
 
     //! Data defined property definition
     QgsPropertyDefinition mPropertyDefinition;


### PR DESCRIPTION
This commits allows one to control visiblity of parameters in
AlgorithmDialog UI. mVisible flag in QgsProcessingParameterDefinition
defines whether the parameter widget and its associate QLabel is
visible in AlgorithmDialog.

A processing provider such as OTB requires one such feature for smooth
integration of its application through gui. Rules that decide if
parameter should be visible at any point is left out for providers to
handle. OTB has a fixed scheme for this behavior and it is explained
here.
https://lists.osgeo.org/pipermail/qgis-developer/2018-February/051797.html

This flag is true by default so that existing providers will not be affected.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
