### PR TITLE
Fix crashes rendering temporary layers with spatial index

### DIFF
--- a/python/core/qgsspatialindex.sip.in
+++ b/python/core/qgsspatialindex.sip.in
@@ -60,6 +60,20 @@ Copy constructor
     ~QgsSpatialIndex();
 
 
+    void detach();
+%Docstring
+Detaches the index, forcing a deep copy of the underlying
+spatial index data.
+
+Since the underlying libspatialindex is not thread safe on some platforms (e.g. Windows),
+manual calls to detach() must be made if a QgsSpatialIndex is to be accessed across multiple threads.
+
+Note that for platforms on which libspatialindex is thread safe, calling
+detach() has no effect and does not force the deep copy.
+
+.. versionadded:: 3.0
+%End
+
 
     bool insertFeature( const QgsFeature &f );
 %Docstring

--- a/python/core/qgsspatialindex.sip.in
+++ b/python/core/qgsspatialindex.sip.in
@@ -16,6 +16,18 @@
 
 class QgsSpatialIndex
 {
+%Docstring
+
+A spatial index for QgsFeature objects.
+
+QgsSpatialIndex objects are implicitly shared and can be inexpensively copied.
+
+.. note::
+
+   While the underlying libspatialindex is not thread safe on some platforms, the QgsSpatialIndex
+   class implements its own locks and accordingly, a single QgsSpatialIndex object can safely
+   be used across multiple threads.
+%End
 
 %TypeHeaderCode
 #include "qgsspatialindex.h"
@@ -25,7 +37,7 @@ class QgsSpatialIndex
 
     QgsSpatialIndex();
 %Docstring
-Constructor - creates R-tree
+Constructor for QgsSpatialIndex. Creates an empty R-tree index.
 %End
 
     explicit QgsSpatialIndex( const QgsFeatureIterator &fi, QgsFeedback *feedback = 0 );
@@ -60,24 +72,10 @@ Copy constructor
     ~QgsSpatialIndex();
 
 
-    void detach();
+
+    bool insertFeature( const QgsFeature &feature );
 %Docstring
-Detaches the index, forcing a deep copy of the underlying
-spatial index data.
-
-Since the underlying libspatialindex is not thread safe on some platforms (e.g. Windows),
-manual calls to detach() must be made if a QgsSpatialIndex is to be accessed across multiple threads.
-
-Note that for platforms on which libspatialindex is thread safe, calling
-detach() has no effect and does not force the deep copy.
-
-.. versionadded:: 3.0
-%End
-
-
-    bool insertFeature( const QgsFeature &f );
-%Docstring
-Add feature to index
+Adds a ``feature`` to the index.
 %End
 
     bool insertFeature( QgsFeatureId id, const QgsRectangle &bounds );
@@ -89,21 +87,33 @@ Add a feature ``id`` to the index with a specified bounding box.
 .. versionadded:: 3.0
 %End
 
-    bool deleteFeature( const QgsFeature &f );
+    bool deleteFeature( const QgsFeature &feature );
 %Docstring
-Remove feature from index
+Removes a ``feature`` from the index.
 %End
 
 
 
-    QList<QgsFeatureId> intersects( const QgsRectangle &rect ) const;
+    QList<QgsFeatureId> intersects( const QgsRectangle &rectangle ) const;
 %Docstring
-Returns features that intersect the specified rectangle
+Returns a list of features with a bounding box which intersects the specified ``rectangle``.
+
+.. note::
+
+   The intersection test is performed based on the feature bounding boxes only, so for non-point
+   geometry features it is necessary to manually test the returned features for exact geometry intersection
+   when required.
 %End
 
     QList<QgsFeatureId> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;
 %Docstring
-Returns nearest neighbors (their count is specified by second parameter)
+Returns nearest neighbors to a ``point``. The number of neighbours returned is specified
+by the ``neighbours`` argument.
+
+.. note::
+
+   The nearest neighbour test is performed based on the feature bounding boxes only, so for non-point
+   geometry features this method is not guaranteed to return the actual closest neighbours.
 %End
 
 

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -240,7 +240,7 @@ QgsMemoryFeatureSource::QgsMemoryFeatureSource( const QgsMemoryProvider *p )
   mExpressionContext.setFields( mFields );
 
   // QgsSpatialIndex is not thread safe - so make spatial index safe to use across threads by forcing a full deep copy
-  if ( mSpatialIndex )
+  if ( mSpatialIndex && p->thread() != QThread::currentThread() )
     mSpatialIndex->detach();
 }
 

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -231,17 +231,13 @@ bool QgsMemoryFeatureIterator::close()
 QgsMemoryFeatureSource::QgsMemoryFeatureSource( const QgsMemoryProvider *p )
   : mFields( p->mFields )
   , mFeatures( p->mFeatures )
-  , mSpatialIndex( p->mSpatialIndex ? qgis::make_unique< QgsSpatialIndex >( *p->mSpatialIndex ) : nullptr ) // this is just a shallow copy, but see below...
+  , mSpatialIndex( p->mSpatialIndex ? qgis::make_unique< QgsSpatialIndex >( *p->mSpatialIndex ) : nullptr ) // just shallow copy
   , mSubsetString( p->mSubsetString )
   , mCrs( p->mCrs )
 {
   mExpressionContext << QgsExpressionContextUtils::globalScope()
                      << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
   mExpressionContext.setFields( mFields );
-
-  // QgsSpatialIndex is not thread safe - so make spatial index safe to use across threads by forcing a full deep copy
-  if ( mSpatialIndex && p->thread() != QThread::currentThread() )
-    mSpatialIndex->detach();
 }
 
 QgsFeatureIterator QgsMemoryFeatureSource::getFeatures( const QgsFeatureRequest &request )

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -264,7 +264,7 @@ void QgsMapRendererCustomPainterJob::doRender()
 
       job.renderer->render();
 
-      job.renderingTime = layerTime.elapsed();
+      job.renderingTime += layerTime.elapsed();
     }
 
     if ( job.img )

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -343,7 +343,10 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     if ( hasStyleOverride )
       ml->styleManager()->setOverrideStyle( mSettings.layerStyleOverrides().value( ml->id() ) );
 
+    QTime layerTime;
+    layerTime.start();
     job.renderer = ml->createMapRenderer( job.context );
+    job.renderingTime = layerTime.elapsed(); // include job preparation time in layer rendering time
 
     if ( hasStyleOverride )
       ml->styleManager()->restoreOverrideStyle();

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -269,7 +269,7 @@ void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
   {
     QgsDebugMsg( "Caught unhandled unknown exception" );
   }
-  job.renderingTime = t.elapsed();
+  job.renderingTime += t.elapsed();
   QgsDebugMsgLevel( QString( "job %1 end [%2 ms] (layer %3)" ).arg( reinterpret_cast< quint64 >( &job ), 0, 16 ).arg( job.renderingTime ).arg( job.layer ? job.layer->id() : QString() ), 2 );
 }
 

--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -266,6 +266,14 @@ QgsSpatialIndex &QgsSpatialIndex::operator=( const QgsSpatialIndex &other )
   return *this;
 }
 
+void QgsSpatialIndex::detach()
+{
+  // libspatialindex is not thread safe on windows - so force the deep copy
+#if defined(Q_OS_WIN)
+  d.detach();
+#endif
+}
+
 SpatialIndex::Region QgsSpatialIndex::rectToRegion( const QgsRectangle &rect )
 {
   double pt1[2] = { rect.xMinimum(), rect.yMinimum() },

--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -186,8 +186,8 @@ class QgsSpatialIndexData : public QSharedData
       initTree();
 
       // copy R-tree data one by one (is there a faster way??)
-      double low[]  = { DBL_MIN, DBL_MIN };
-      double high[] = { DBL_MAX, DBL_MAX };
+      double low[]  = { std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest() };
+      double high[] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max() };
       SpatialIndex::Region query( low, high, 2 );
       QgsSpatialIndexCopyVisitor visitor( mRTree );
       other.mRTree->intersectsWithQuery( query, visitor );

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -97,6 +97,20 @@ class CORE_EXPORT QgsSpatialIndex
     //! Implement assignment operator
     QgsSpatialIndex &operator=( const QgsSpatialIndex &other );
 
+    /**
+     * Detaches the index, forcing a deep copy of the underlying
+     * spatial index data.
+     *
+     * Since the underlying libspatialindex is not thread safe on some platforms (e.g. Windows),
+     * manual calls to detach() must be made if a QgsSpatialIndex is to be accessed across multiple threads.
+     *
+     * Note that for platforms on which libspatialindex is thread safe, calling
+     * detach() has no effect and does not force the deep copy.
+     *
+     * \since QGIS 3.0
+     */
+    void detach();
+
     /* operations */
 
     //! Add feature to index

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -52,6 +52,14 @@ class QgsFeatureSource;
 /**
  * \ingroup core
  * \class QgsSpatialIndex
+ *
+ * A spatial index for QgsFeature objects.
+ *
+ * QgsSpatialIndex objects are implicitly shared and can be inexpensively copied.
+ *
+ * \note While the underlying libspatialindex is not thread safe on some platforms, the QgsSpatialIndex
+ * class implements its own locks and accordingly, a single QgsSpatialIndex object can safely
+ * be used across multiple threads.
  */
 class CORE_EXPORT QgsSpatialIndex
 {
@@ -60,7 +68,9 @@ class CORE_EXPORT QgsSpatialIndex
 
     /* creation of spatial index */
 
-    //! Constructor - creates R-tree
+    /**
+     * Constructor for QgsSpatialIndex. Creates an empty R-tree index.
+     */
     QgsSpatialIndex();
 
     /**
@@ -97,24 +107,12 @@ class CORE_EXPORT QgsSpatialIndex
     //! Implement assignment operator
     QgsSpatialIndex &operator=( const QgsSpatialIndex &other );
 
-    /**
-     * Detaches the index, forcing a deep copy of the underlying
-     * spatial index data.
-     *
-     * Since the underlying libspatialindex is not thread safe on some platforms (e.g. Windows),
-     * manual calls to detach() must be made if a QgsSpatialIndex is to be accessed across multiple threads.
-     *
-     * Note that for platforms on which libspatialindex is thread safe, calling
-     * detach() has no effect and does not force the deep copy.
-     *
-     * \since QGIS 3.0
-     */
-    void detach();
-
     /* operations */
 
-    //! Add feature to index
-    bool insertFeature( const QgsFeature &f );
+    /**
+     * Adds a \a feature to the index.
+     */
+    bool insertFeature( const QgsFeature &feature );
 
     /**
      * Add a feature \a id to the index with a specified bounding box.
@@ -123,16 +121,30 @@ class CORE_EXPORT QgsSpatialIndex
     */
     bool insertFeature( QgsFeatureId id, const QgsRectangle &bounds );
 
-    //! Remove feature from index
-    bool deleteFeature( const QgsFeature &f );
+    /**
+     * Removes a \a feature from the index.
+     */
+    bool deleteFeature( const QgsFeature &feature );
 
 
     /* queries */
 
-    //! Returns features that intersect the specified rectangle
-    QList<QgsFeatureId> intersects( const QgsRectangle &rect ) const;
+    /**
+     * Returns a list of features with a bounding box which intersects the specified \a rectangle.
+     *
+     * \note The intersection test is performed based on the feature bounding boxes only, so for non-point
+     * geometry features it is necessary to manually test the returned features for exact geometry intersection
+     * when required.
+     */
+    QList<QgsFeatureId> intersects( const QgsRectangle &rectangle ) const;
 
-    //! Returns nearest neighbors (their count is specified by second parameter)
+    /**
+     * Returns nearest neighbors to a \a point. The number of neighbours returned is specified
+     * by the \a neighbours argument.
+     *
+     * \note The nearest neighbour test is performed based on the feature bounding boxes only, so for non-point
+     * geometry features this method is not guaranteed to return the actual closest neighbours.
+     */
     QList<QgsFeatureId> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;
 
     /* debugging */


### PR DESCRIPTION
Since the underlying libspatialindex is not thread safe on some platforms (e.g. Windows), we have to deep copy the spatial index data if a QgsSpatialIndex is to be accessed across multiple threads (such as when rendering a memory layer with a spatial index attached).

Fixes https://issues.qgis.org/issues/17705 (at the cost of slow feature iterator creation for memory layers with large spatial indexes on Windows - but we don't have an alternative here)