### PR TITLE
Server: if there is a primary key, use the pk value(s) as gml id inst…

### DIFF
--- a/python/server/qgswfserver.sip
+++ b/python/server/qgswfserver.sip
@@ -104,7 +104,8 @@ class QgsWFSServer: public QgsOWSServer
   protected:
 
     void startGetFeature( QgsRequestHandler& request, const QString& format, int prec, QgsCoordinateReferenceSystem& crs, QgsRectangle* rect );
-    void setGetFeature( QgsRequestHandler& request, const QString& format, QgsFeature* feat, int featIdx, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes );
+    void setGetFeature( QgsRequestHandler& request, const QString& format, QgsFeature* feat, int featIdx, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+                        const QgsAttributeList& pkAttributes = QgsAttributeList());
     void endGetFeature( QgsRequestHandler& request, const QString& format );
 
     //method for transaction
@@ -114,10 +115,12 @@ class QgsWFSServer: public QgsOWSServer
     QString createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/;
 
     //methods to write GML2
-    QDomElement createFeatureGML2( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/;
+    QDomElement createFeatureGML2( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+                                   const QgsAttributeList& pkAttributes = QgsAttributeList()) /*const*/;
 
     //methods to write GML3
-    QDomElement createFeatureGML3( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, QgsAttributeList attrIndexes, QSet<QString> excludedAttributes ) /*const*/;
+    QDomElement createFeatureGML3( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, QgsAttributeList attrIndexes, QSet<QString> excludedAttributes,
+                                   const QgsAttributeList& pkAttributes = QgsAttributeList() ) /*const*/;
 
     void addTransactionResult( QDomDocument& responseDoc, QDomElement& responseElem, const QString& status, const QString& locator, const QString& message );
 };

--- a/src/server/qgsowsserver.cpp
+++ b/src/server/qgsowsserver.cpp
@@ -72,16 +72,10 @@ QString QgsOWSServer::featureGmlId( const QgsFeature* f, const QgsAttributeList&
     return QString();
   }
 
-  if ( pkAttributes.isEmpty() )
+  if ( pkAttributes.size() != 1 )
   {
     return QString::number( f->id() );
   }
 
-  QString pkId;
-  QgsAttributeList::const_iterator it = pkAttributes.constBegin();
-  for ( ; it != pkAttributes.constEnd(); ++it )
-  {
-    pkId.append( f->attribute( *it ).toString() );
-  }
-  return pkId;
+  return f->attribute( pkAttributes.at( 0 ) ).toString();
 }

--- a/src/server/qgsowsserver.cpp
+++ b/src/server/qgsowsserver.cpp
@@ -64,3 +64,24 @@ void QgsOWSServer::restoreLayerFilters( const QHash<QgsMapLayer*, QString>& filt
     }
   }
 }
+
+QString QgsOWSServer::featureGmlId( const QgsFeature* f, const QgsAttributeList& pkAttributes )
+{
+  if ( !f )
+  {
+    return QString();
+  }
+
+  if ( pkAttributes.isEmpty() )
+  {
+    return QString::number( f->id() );
+  }
+
+  QString pkId;
+  QgsAttributeList::const_iterator it = pkAttributes.constBegin();
+  for ( ; it != pkAttributes.constEnd(); ++it )
+  {
+    pkId.append( f->attribute( *it ).toString() );
+  }
+  return pkId;
+}

--- a/src/server/qgsowsserver.cpp
+++ b/src/server/qgsowsserver.cpp
@@ -72,10 +72,20 @@ QString QgsOWSServer::featureGmlId( const QgsFeature* f, const QgsAttributeList&
     return QString();
   }
 
-  if ( pkAttributes.size() != 1 )
+  if ( pkAttributes.isEmpty() )
   {
     return QString::number( f->id() );
   }
 
-  return f->attribute( pkAttributes.at( 0 ) ).toString();
+  QString pkId;
+  QgsAttributeList::const_iterator it = pkAttributes.constBegin();
+  for ( ; it != pkAttributes.constEnd(); ++it )
+  {
+    if ( it != pkAttributes.constBegin() )
+    {
+      pkId.append( pkSeparator() );
+    }
+    pkId.append( f->attribute( *it ).toString() );
+  }
+  return pkId;
 }

--- a/src/server/qgsowsserver.h
+++ b/src/server/qgsowsserver.h
@@ -55,6 +55,8 @@ class QgsOWSServer
      */
     static void restoreLayerFilters( const QHash < QgsMapLayer*, QString >& filterMap );
 
+    static QString pkSeparator() { return "@@"; }
+
   private:
     QgsOWSServer() {}
 

--- a/src/server/qgsowsserver.h
+++ b/src/server/qgsowsserver.h
@@ -23,6 +23,7 @@
 #include "qgsaccesscontrol.h"
 #endif
 
+#include "qgsfield.h"
 #include <QHash>
 
 class QgsMapLayer;
@@ -72,6 +73,13 @@ class QgsOWSServer
      */
     void applyAccessControlLayerFilters( QgsMapLayer* layer, QHash<QgsMapLayer*, QString>& originalLayerFilters ) const;
 #endif
+
+    /** Creates gml id for feature. Returns primary key value or feature id in case there is no PK
+     * @param f feature
+     * @param pkAttributes list of attribute indices used as primary key
+     * @return pk as string or feature id
+    */
+    static QString featureGmlId( const QgsFeature* f, const QgsAttributeList& pkAttributes );
 
 };
 

--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -603,7 +603,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
               if ( featureCounter == 0 )
                 startGetFeature( request, format, layerPrec, layerCrs, &searchRect );
 
-              setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+              setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
 
               fid = "";
               ++featCounter;
@@ -642,7 +642,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
               if ( featureCounter >= startIndex )
               {
-                setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+                setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
                 ++featCounter;
               }
               ++featureCounter;
@@ -696,7 +696,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
                   if ( featureCounter >= startIndex )
                   {
-                    setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+                    setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
                     ++featCounter;
                   }
                   ++featureCounter;
@@ -714,7 +714,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
             if ( featureCounter >= startIndex )
             {
-              setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+              setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
               ++featCounter;
             }
             ++featureCounter;
@@ -977,7 +977,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
           if ( featureCounter == 0 )
             startGetFeature( request, format, layerPrec, layerCrs, &searchRect );
 
-          setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+          setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
           ++featCounter;
           ++featureCounter;
         }
@@ -1026,7 +1026,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
               if ( featureCounter >= startIndex )
               {
-                setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+                setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
                 ++featCounter;
               }
               ++featureCounter;
@@ -1063,7 +1063,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
             if ( featureCounter == 0 )
               startGetFeature( request, format, layerPrec, layerCrs, &searchRect );
 
-            setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+            setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
 
             fid = "";
             ++featCounter;
@@ -1102,7 +1102,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
             if ( featureCounter >= startIndex )
             {
-              setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+              setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
               ++featCounter;
             }
             ++featureCounter;
@@ -1151,7 +1151,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
                 if ( featureCounter >= startIndex )
                 {
-                  setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+                  setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
                   ++featCounter;
                 }
                 ++featureCounter;
@@ -1190,7 +1190,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
           if ( featureCounter >= startIndex )
           {
-            setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes );
+            setGetFeature( request, format, &feature, featCounter, layerPrec, layerCrs, attrIndexes, layerExcludedAttributes, provider->pkAttributeIndexes() );
             ++featCounter;
           }
           ++featureCounter;
@@ -1363,7 +1363,8 @@ void QgsWFSServer::startGetFeature( QgsRequestHandler& request, const QString& f
   fcString = "";
 }
 
-void QgsWFSServer::setGetFeature( QgsRequestHandler& request, const QString& format, QgsFeature* feat, int featIdx, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/
+void QgsWFSServer::setGetFeature( QgsRequestHandler& request, const QString& format, QgsFeature* feat, int featIdx, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+                                  const QgsAttributeList& pkAttributes ) /*const*/
 {
   if ( !feat->isValid() )
     return;
@@ -1389,12 +1390,12 @@ void QgsWFSServer::setGetFeature( QgsRequestHandler& request, const QString& for
     QDomElement featureElement;
     if ( format == "GML3" )
     {
-      featureElement = createFeatureGML3( feat, gmlDoc, prec, crs, attrIndexes, excludedAttributes );
+      featureElement = createFeatureGML3( feat, gmlDoc, prec, crs, attrIndexes, excludedAttributes, pkAttributes );
       gmlDoc.appendChild( featureElement );
     }
     else
     {
-      featureElement = createFeatureGML2( feat, gmlDoc, prec, crs, attrIndexes, excludedAttributes );
+      featureElement = createFeatureGML2( feat, gmlDoc, prec, crs, attrIndexes, excludedAttributes, pkAttributes );
       gmlDoc.appendChild( featureElement );
     }
 
@@ -1963,14 +1964,16 @@ QString QgsWFSServer::createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoord
   return exporter.exportFeature( f, QVariantMap(), id );
 }
 
-QDomElement QgsWFSServer::createFeatureGML2( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/
+QDomElement QgsWFSServer::createFeatureGML2( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+    const QgsAttributeList& pkAttributes ) /*const*/
 {
   //gml:FeatureMember
   QDomElement featureElement = doc.createElement( "gml:featureMember"/*wfs:FeatureMember*/ );
 
   //qgs:%TYPENAME%
   QDomElement typeNameElement = doc.createElement( "qgs:" + mTypeName /*qgs:%TYPENAME%*/ );
-  typeNameElement.setAttribute( "fid", mTypeName + "." + QString::number( feat->id() ) );
+  QString gmlId = featureGmlId( feat, pkAttributes );
+  typeNameElement.setAttribute( "fid", mTypeName + "." + gmlId );
   featureElement.appendChild( typeNameElement );
 
   if ( mWithGeom && mGeometryName != "NONE" )
@@ -2047,14 +2050,16 @@ QDomElement QgsWFSServer::createFeatureGML2( QgsFeature* feat, QDomDocument& doc
   return featureElement;
 }
 
-QDomElement QgsWFSServer::createFeatureGML3( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/
+QDomElement QgsWFSServer::createFeatureGML3( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+    const QgsAttributeList& pkAttributes ) /*const*/
 {
   //gml:FeatureMember
   QDomElement featureElement = doc.createElement( "gml:featureMember"/*wfs:FeatureMember*/ );
 
   //qgs:%TYPENAME%
   QDomElement typeNameElement = doc.createElement( "qgs:" + mTypeName /*qgs:%TYPENAME%*/ );
-  typeNameElement.setAttribute( "gml:id", mTypeName + "." + QString::number( feat->id() ) );
+  QString gmlId = featureGmlId( feat, pkAttributes );
+  typeNameElement.setAttribute( "gml:id", mTypeName + "." + gmlId );
   featureElement.appendChild( typeNameElement );
 
   if ( mWithGeom && mGeometryName != "NONE" )

--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -1377,7 +1377,7 @@ void QgsWFSServer::setGetFeature( QgsRequestHandler& request, const QString& for
       fcString += "  ";
     else
       fcString += " ,";
-    fcString += createFeatureGeoJSON( feat, prec, crs, attrIndexes, excludedAttributes );
+    fcString += createFeatureGeoJSON( feat, prec, crs, attrIndexes, excludedAttributes, pkAttributes );
     fcString += "\n";
 
     result = fcString.toUtf8();
@@ -1926,9 +1926,10 @@ QgsFeatureIds QgsWFSServer::getFeatureIdsFromFilter( const QDomElement& filterEl
   return fids;
 }
 
-QString QgsWFSServer::createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/
+QString QgsWFSServer::createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+    const QgsAttributeList& pkAttributes ) /*const*/
 {
-  QString id = QString( "%1.%2" ).arg( mTypeName, FID_TO_STRING( feat->id() ) );
+  QString id = QString( "%1.%2" ).arg( mTypeName, featureGmlId( feat, pkAttributes ) );
 
   QgsJSONExporter exporter;
   exporter.setSourceCrs( crs );

--- a/src/server/qgswfsserver.h
+++ b/src/server/qgswfsserver.h
@@ -120,7 +120,8 @@ class QgsWFSServer: public QgsOWSServer
     QgsFeatureIds getFeatureIdsFromFilter( const QDomElement& filter, QgsVectorLayer* layer );
 
     //methods to write GeoJSON
-    QString createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/;
+    QString createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+                                  const QgsAttributeList& pkAttributes = QgsAttributeList() ) /*const*/;
 
     //methods to write GML2
     QDomElement createFeatureGML2( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,

--- a/src/server/qgswfsserver.h
+++ b/src/server/qgswfsserver.h
@@ -112,7 +112,8 @@ class QgsWFSServer: public QgsOWSServer
   protected:
 
     void startGetFeature( QgsRequestHandler& request, const QString& format, int prec, QgsCoordinateReferenceSystem& crs, QgsRectangle* rect );
-    void setGetFeature( QgsRequestHandler& request, const QString& format, QgsFeature* feat, int featIdx, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes );
+    void setGetFeature( QgsRequestHandler& request, const QString& format, QgsFeature* feat, int featIdx, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+                        const QgsAttributeList& pkAttributes = QgsAttributeList() );
     void endGetFeature( QgsRequestHandler& request, const QString& format );
 
     //method for transaction
@@ -122,10 +123,12 @@ class QgsWFSServer: public QgsOWSServer
     QString createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/;
 
     //methods to write GML2
-    QDomElement createFeatureGML2( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/;
+    QDomElement createFeatureGML2( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+                                   const QgsAttributeList& pkAttributes = QgsAttributeList() ) /*const*/;
 
     //methods to write GML3
-    QDomElement createFeatureGML3( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes ) /*const*/;
+    QDomElement createFeatureGML3( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes, const QSet<QString>& excludedAttributes,
+                                   const QgsAttributeList& pkAttributes = QgsAttributeList() ) /*const*/;
 
     void addTransactionResult( QDomDocument& responseDoc, QDomElement& responseElem, const QString& status, const QString& locator, const QString& message );
 };

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -2426,7 +2426,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
     else
     {
       QDomElement featureElement = infoDocument.createElement( "Feature" );
-      featureElement.setAttribute( "id", FID_TO_STRING( feature.id() ) );
+      featureElement.setAttribute( "id", featureGmlId( &feature, layer->dataProvider()->pkAttributeIndexes() ) );
       layerElement.appendChild( featureElement );
 
       //read all attribute values from the feature

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -3312,7 +3312,8 @@ QDomElement QgsWMSServer::createFeatureGML(
 {
   //qgs:%TYPENAME%
   QDomElement typeNameElement = doc.createElement( "qgs:" + typeName /*qgs:%TYPENAME%*/ );
-  typeNameElement.setAttribute( "fid", typeName + "." + QString::number( feat->id() ) );
+  QString gmlId = featureGmlId( feat, layer->dataProvider()->pkAttributeIndexes() );
+  typeNameElement.setAttribute( "fid", typeName + "." + gmlId );
 
   const QgsCoordinateTransform* transform = nullptr;
   if ( layer && layer->crs() != crs )


### PR DESCRIPTION
In WFS and in WMS GetFeatureInfo (format GML), there is a 'fid' Attribute with a feature identification. Currently, we are using the QGIS feature id there. However, the postgres provider uses an id/value map for some data types (e.g. bigint in 2.18). Therefore, the feature id depends on the fetching order and might not be stable between different requests. So clients cannot use the fid for feature identification.

This PR fixes that such that primary key values are preferred for the fid. If the data provider does not report any PK columns, there is a fallback to the QGIS feature id.
