### PR TITLE
Throw warnings for use of deprecated Qt API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,12 @@ SET(CMAKE_CXX_STANDARD 11)
 #############################################################
 # enable warnings
 
+# Block compilation when using API deprecated in Qt <= 4.8
+# TODO - bump to min Qt version we support!
+ADD_DEFINITIONS(-DQT_DISABLE_DEPRECATED_BEFORE=0x040800)
+# Warn on ALL use of deprecated Qt API, so we make porting to future Qt releases easier
+ADD_DEFINITIONS(-DQT_DEPRECATED_WARNINGS)
+
 IF (PEDANTIC)
   MESSAGE (STATUS "Pedantic compiler settings enabled")
   IF(MSVC)

--- a/cmake/modules/ECMQt4To5Porting.cmake
+++ b/cmake/modules/ECMQt4To5Porting.cmake
@@ -35,10 +35,6 @@
 
 include(MacroAddFileDependencies)
 
-# Portability helpers.
-
-add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0)
-
 # get the Qt plugins directory
 GET_TARGET_PROPERTY(QMAKE_EXECUTABLE Qt5::qmake LOCATION)
 EXEC_PROGRAM(${QMAKE_EXECUTABLE} ARGS "-query QT_INSTALL_PLUGINS" RETURN_VALUE return_code OUTPUT_VARIABLE QT_PLUGINS_DIR )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -698,46 +698,6 @@ long QgsVectorLayer::featureCount( const QString &legendKey ) const
   return mSymbolFeatureCountMap.value( legendKey );
 }
 
-/**
- * \ingroup core
- * Used by QgsVectorLayer::countSymbolFeatures() to provide an interruption checker
- * \note not available in Python bindings
- */
-class QgsVectorLayerInterruptionCheckerDuringCountSymbolFeatures: public QgsInterruptionChecker
-{
-  public:
-
-    //! Constructor
-    explicit QgsVectorLayerInterruptionCheckerDuringCountSymbolFeatures( QProgressDialog *dialog )
-      : mDialog( dialog )
-    {
-    }
-
-    bool mustStop() const override
-    {
-      if ( mDialog->isVisible() )
-      {
-        // So that we get a chance of hitting the Abort button
-#ifdef Q_OS_LINUX
-        // For some reason on Windows hasPendingEvents() always return true,
-        // but one iteration is actually enough on Windows to get good interactivity
-        // whereas on Linux we must allow for far more iterations.
-        // For safety limit the number of iterations
-        int nIters = 0;
-        while ( QCoreApplication::hasPendingEvents() && ++nIters < 100 )
-#endif
-        {
-          QCoreApplication::processEvents();
-        }
-        return mDialog->wasCanceled();
-      }
-      return false;
-    }
-
-  private:
-    QProgressDialog *mDialog = nullptr;
-};
-
 QgsVectorLayerFeatureCounter *QgsVectorLayer::countSymbolFeatures()
 {
   if ( mSymbolFeatureCounted || mFeatureCounter )


### PR DESCRIPTION
Unfortunately, master still has quite a lot of use of API which was deprecated in Qt5. The biggest culprits are:

- QUrl -> needs to be ported to QUrlQuery
- QObject::trUtf8. It's deprecated, but in the past we've had to use this for translating strings with unicode. I don't know what the alternative is here, since I'm basically clueless when it comes to translation. @jef-n any ideas?
- Lots of use of deprecated Qt SSL and certificate related APIs

Sure, this causes a lot of warnings on master (about 200). But we really SHOULD be warned about these, since we're going to need to address them sometime. And I'd rather not see any more use of deprecated API introduced.

When we fix this, we can bump   QT_DISABLE_DEPRECATED_BEFORE to 5.5 and block compilation on use of deprecated API.