### PR TITLE
fix disabled map unit  widgets when opening project prop. dialog

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -152,7 +152,8 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   // Properties stored in map canvas's QgsMapRenderer
   // these ones are propagated to QgsProject by a signal
 
-  updateGuiForMapUnits( QgsProject::instance()->crs().mapUnits() );
+  mCrs = QgsProject::instance()->crs();
+  updateGuiForMapUnits();
   projectionSelector->setCrs( QgsProject::instance()->crs() );
 
   // Datum transforms
@@ -235,11 +236,24 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   // selection of the ellipsoid from settings is defferred to a later point, because it would
   // be overridden in the meanwhile by the projection selector
   populateEllipsoidList();
-
   if ( !QgsProject::instance()->crs().isValid() )
   {
     cmbEllipsoid->setCurrentIndex( 0 );
     cmbEllipsoid->setEnabled( false );
+  }
+  else
+  {
+    // attempt to reset the projection ellipsoid according to the srs
+    int index = 0;
+    for ( int i = 0; i < mEllipsoidList.length(); i++ )
+    {
+      if ( mEllipsoidList[ i ].acronym == QgsProject::instance()->crs().ellipsoidAcronym() )
+      {
+        index = i;
+        break;
+      }
+    }
+    updateEllipsoidUI( index );
   }
 
   QString format = QgsProject::instance()->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DegreeFormat" ), QStringLiteral( "MU" ) );
@@ -1260,9 +1274,9 @@ void QgsProjectProperties::cbxWCSPubliedStateChanged( int aIdx )
   }
 }
 
-void QgsProjectProperties::updateGuiForMapUnits( QgsUnitTypes::DistanceUnit units )
+void QgsProjectProperties::updateGuiForMapUnits()
 {
-  if ( !projectionSelector->crs().isValid() )
+  if ( !mCrs.isValid() )
   {
     // no projection set - disable everything!
     int idx = mDistanceUnitsCombo->findData( QgsUnitTypes::DistanceUnknownUnit );
@@ -1289,6 +1303,8 @@ void QgsProjectProperties::updateGuiForMapUnits( QgsUnitTypes::DistanceUnit unit
   }
   else
   {
+    QgsUnitTypes::DistanceUnit units = mCrs.mapUnits();
+
     mDistanceUnitsCombo->setEnabled( true );
     mAreaUnitsCombo->setEnabled( true );
     mCoordinateDisplayComboBox->setEnabled( true );
@@ -1319,27 +1335,23 @@ void QgsProjectProperties::srIdUpdated()
   if ( !projectionSelector->hasValidSelection() )
     return;
 
-  QgsCoordinateReferenceSystem srs = projectionSelector->crs();
+  mCrs = projectionSelector->crs();
+  updateGuiForMapUnits();
 
-  //set radio button to crs map unit type
-  QgsUnitTypes::DistanceUnit units = srs.mapUnits();
-
-  updateGuiForMapUnits( units );
-
-  if ( srs.isValid() )
+  if ( mCrs.isValid() )
   {
     cmbEllipsoid->setEnabled( true );
     // attempt to reset the projection ellipsoid according to the srs
-    int myIndex = 0;
+    int index = 0;
     for ( int i = 0; i < mEllipsoidList.length(); i++ )
     {
-      if ( mEllipsoidList[ i ].acronym == srs.ellipsoidAcronym() )
+      if ( mEllipsoidList[ i ].acronym == mCrs.ellipsoidAcronym() )
       {
-        myIndex = i;
+        index = i;
         break;
       }
     }
-    updateEllipsoidUI( myIndex );
+    updateEllipsoidUI( index );
   }
   else
   {
@@ -1410,10 +1422,8 @@ void QgsProjectProperties::pbnWMSSetUsedSRS_clicked()
   }
 
   QSet<QString> crsList;
-
-  QgsCoordinateReferenceSystem srs = projectionSelector->crs();
-  if ( srs.isValid() )
-    crsList << srs.authid();
+  if ( mCrs.isValid() )
+    crsList << mCrs.authid();
 
   const QMap<QString, QgsMapLayer *> &mapLayers = QgsProject::instance()->mapLayers();
   for ( QMap<QString, QgsMapLayer *>::const_iterator it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
@@ -1927,7 +1937,7 @@ void QgsProjectProperties::updateEllipsoidUI( int newIndex )
   leSemiMajor->clear();
   leSemiMinor->clear();
 
-  cmbEllipsoid->setEnabled( projectionSelector->crs().isValid() );
+  cmbEllipsoid->setEnabled( mCrs.isValid() );
   cmbEllipsoid->setToolTip( QLatin1String( "" ) );
   if ( mEllipsoidList.at( mEllipsoidIndex ).acronym.startsWith( QLatin1String( "PARAMETER:" ) ) )
   {
@@ -1945,7 +1955,7 @@ void QgsProjectProperties::updateEllipsoidUI( int newIndex )
     leSemiMinor->setText( QLocale::system().toString( myMinor, 'f', 3 ) );
   }
 
-  if ( projectionSelector->crs().isValid() )
+  if ( mCrs.isValid() )
     cmbEllipsoid->setCurrentIndex( mEllipsoidIndex ); // Not always necessary
 }
 
@@ -1956,12 +1966,12 @@ void QgsProjectProperties::projectionSelectorInitialized()
   // Reading ellipsoid from settings
   QStringList mySplitEllipsoid = QgsProject::instance()->ellipsoid().split( ':' );
 
-  int myIndex = 0;
+  int index = 0;
   for ( int i = 0; i < mEllipsoidList.length(); i++ )
   {
     if ( mEllipsoidList.at( i ).acronym.startsWith( mySplitEllipsoid[ 0 ] ) )
     {
-      myIndex = i;
+      index = i;
       break;
     }
   }
@@ -1969,11 +1979,11 @@ void QgsProjectProperties::projectionSelectorInitialized()
   // Update parameters if present.
   if ( mySplitEllipsoid.length() >= 3 )
   {
-    mEllipsoidList[ myIndex ].semiMajor = mySplitEllipsoid[ 1 ].toDouble();
-    mEllipsoidList[ myIndex ].semiMinor = mySplitEllipsoid[ 2 ].toDouble();
+    mEllipsoidList[ index ].semiMajor = mySplitEllipsoid[ 1 ].toDouble();
+    mEllipsoidList[ index ].semiMinor = mySplitEllipsoid[ 2 ].toDouble();
   }
 
-  updateEllipsoidUI( myIndex );
+  updateEllipsoidUI( index );
 }
 
 void QgsProjectProperties::mButtonAddColor_clicked()

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -174,6 +174,8 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsStyle *mStyle = nullptr;
 
+    QgsCoordinateReferenceSystem mCrs;
+
     void populateStyles();
     void editSymbol( QComboBox *cbo );
 
@@ -217,7 +219,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
     static const char *GEO_NONE_DESC;
 
-    void updateGuiForMapUnits( QgsUnitTypes::DistanceUnit units );
+    void updateGuiForMapUnits();
 
     void showHelp();
 };


### PR DESCRIPTION
## Description
This PR fixes a regression which slipped into QGIS master, whereas map unit related widgets (in the general tab) are disabled upon dialog opening. We need to set the projectionSelector's CRS prior to updating the GUI so the CRS validity check doesn't disable those widgets.

(Fixes reported issue #17208)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
