### PR TITLE
[FEATURE][locator] Add quick calculator (expression evaluator) to locator bar

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -288,6 +288,11 @@ QgsExpressionCalculatorLocatorFilter::QgsExpressionCalculatorLocatorFilter( QObj
   setUseWithoutPrefix( false );
 }
 
+QgsExpressionCalculatorLocatorFilter *QgsExpressionCalculatorLocatorFilter::clone() const
+{
+  return new QgsExpressionCalculatorLocatorFilter();
+}
+
 void QgsExpressionCalculatorLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback * )
 {
   QgsExpressionContext context;

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -26,6 +26,7 @@
 #include "qgslayoutmanager.h"
 #include "qgsmapcanvas.h"
 #include <QToolButton>
+#include <QClipboard>
 
 QgsLayerTreeLocatorFilter::QgsLayerTreeLocatorFilter( QObject *parent )
   : QgsLocatorFilter( parent )
@@ -276,4 +277,41 @@ void QgsActiveLayerFeaturesLocatorFilter::triggerResult( const QgsLocatorResult 
     return;
 
   QgisApp::instance()->mapCanvas()->zoomToFeatureIds( layer, QgsFeatureIds() << id );
+}
+
+//
+// QgsExpressionCalculatorLocatorFilter
+//
+QgsExpressionCalculatorLocatorFilter::QgsExpressionCalculatorLocatorFilter( QObject *parent )
+  : QgsLocatorFilter( parent )
+{
+  setUseWithoutPrefix( false );
+}
+
+void QgsExpressionCalculatorLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback * )
+{
+  QgsExpressionContext context;
+  context << QgsExpressionContextUtils::globalScope()
+          << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+
+  QString error;
+  if ( QgsExpression::checkExpression( string, &context, error ) )
+  {
+    QgsExpression exp( string );
+    QString resultString = exp.evaluate( &context ).toString();
+    if ( !resultString.isEmpty() )
+    {
+      QgsLocatorResult result;
+      result.filter = this;
+      result.displayString = tr( "Copy “%1” to clipboard" ).arg( resultString );
+      result.userData = resultString;
+      result.score = 1;
+      emit resultFetched( result );
+    }
+  }
+}
+
+void QgsExpressionCalculatorLocatorFilter::triggerResult( const QgsLocatorResult &result )
+{
+  QApplication::clipboard()->setText( result.userData.toString() );
 }

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -112,6 +112,22 @@ class QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     QIcon mLayerIcon;
 };
 
+class QgsExpressionCalculatorLocatorFilter : public QgsLocatorFilter
+{
+    Q_OBJECT
+
+  public:
+
+    QgsExpressionCalculatorLocatorFilter( QObject *parent = nullptr );
+    QString name() const override { return QStringLiteral( "calculator" ); }
+    QString displayName() const override { return tr( "Calculator" ); }
+    Priority priority() const override { return Highest; }
+    QString prefix() const override { return QStringLiteral( "=" ); }
+
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+};
+
 
 #endif // QGSINBUILTLOCATORFILTERS_H
 

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -18,13 +18,14 @@
 #ifndef QGSINBUILTLOCATORFILTERS_H
 #define QGSINBUILTLOCATORFILTERS_H
 
+#include "qgisapp.h"
 #include "qgslocatorfilter.h"
 #include "qgsexpressioncontext.h"
 #include "qgsfeatureiterator.h"
 
 class QAction;
 
-class QgsLayerTreeLocatorFilter : public QgsLocatorFilter
+class APP_EXPORT QgsLayerTreeLocatorFilter : public QgsLocatorFilter
 {
     Q_OBJECT
 
@@ -43,7 +44,7 @@ class QgsLayerTreeLocatorFilter : public QgsLocatorFilter
 
 };
 
-class QgsLayoutLocatorFilter : public QgsLocatorFilter
+class APP_EXPORT QgsLayoutLocatorFilter : public QgsLocatorFilter
 {
     Q_OBJECT
 
@@ -112,17 +113,19 @@ class QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     QIcon mLayerIcon;
 };
 
-class QgsExpressionCalculatorLocatorFilter : public QgsLocatorFilter
+class APP_EXPORT QgsExpressionCalculatorLocatorFilter : public QgsLocatorFilter
 {
     Q_OBJECT
 
   public:
 
     QgsExpressionCalculatorLocatorFilter( QObject *parent = nullptr );
+    QgsExpressionCalculatorLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "calculator" ); }
     QString displayName() const override { return tr( "Calculator" ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "=" ); }
+    QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
 
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2936,6 +2936,7 @@ void QgisApp::createStatusBar()
 
   mLocatorWidget->locator()->registerFilter( new QgsActionLocatorFilter( actionObjects ) );
   mLocatorWidget->locator()->registerFilter( new QgsActiveLayerFeaturesLocatorFilter() );
+  mLocatorWidget->locator()->registerFilter( new QgsExpressionCalculatorLocatorFilter() );
 }
 
 void QgisApp::setIconSizes( int size )

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -61,7 +61,7 @@ void QgsLocator::registerFilter( QgsLocatorFilter *filter )
   {
     if ( filter->name() == QStringLiteral( "actions" ) || filter->name() == QStringLiteral( "processing_alg" )
          || filter->name() == QStringLiteral( "layertree" ) || filter->name() == QStringLiteral( "layouts" )
-         || filter->name() == QStringLiteral( "features" ) )
+         || filter->name() == QStringLiteral( "features" ) || filter->name() == QStringLiteral( "calculator" ) )
     {
       //inbuilt filter, no prefix check
       mPrefixedFilters.insert( filter->prefix(), filter );

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/layout
+  ${CMAKE_SOURCE_DIR}/src/core/locator
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/symbology
@@ -94,6 +95,7 @@ ADD_QGIS_TEST(apppythontest testqgisapppython.cpp)
 ENDIF ()
 ADD_QGIS_TEST(qgisappclipboard testqgisappclipboard.cpp)
 ADD_QGIS_TEST(attributetabletest testqgsattributetable.cpp)
+ADD_QGIS_TEST(applocatorfilters testqgsapplocatorfilters.cpp)
 ADD_QGIS_TEST(fieldcalculatortest testqgsfieldcalculator.cpp)
 ADD_QGIS_TEST(maptooladdfeature testqgsmaptooladdfeature.cpp)
 ADD_QGIS_TEST(maptoolidentifyaction testqgsmaptoolidentifyaction.cpp)

--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+     testqgsapplocatorfilters.cpp
+     --------------------------
+    Date                 : 2018-02-24
+    Copyright            : (C) 2018 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include "qgisapp.h"
+#include "qgslocatorfilter.h"
+#include "qgslocator.h"
+#include "locator/qgsinbuiltlocatorfilters.h"
+#include <QSignalSpy>
+#include <QClipboard>
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the field calculator
+ */
+class TestQgsAppLocatorFilters : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void testCalculator();
+
+  private:
+    QgisApp *mQgisApp = nullptr;
+
+    QList< QgsLocatorResult > gatherResults( QgsLocatorFilter *filter, const QString &string, const QgsLocatorContext &context );
+};
+
+//runs before all tests
+void TestQgsAppLocatorFilters::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  mQgisApp = new QgisApp();
+}
+
+//runs after all tests
+void TestQgsAppLocatorFilters::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsAppLocatorFilters::testCalculator()
+{
+  QgsExpressionCalculatorLocatorFilter filter;
+
+  // valid expression
+  QList< QgsLocatorResult > results = gatherResults( &filter, QStringLiteral( "1+2" ), QgsLocatorContext() );
+  QCOMPARE( results.count(), 1 );
+  QCOMPARE( results.at( 0 ).userData.toInt(), 3 );
+
+  // trigger result
+  filter.triggerResult( results.at( 0 ) );
+  QCOMPARE( QApplication::clipboard()->text(), QStringLiteral( "3" ) );
+
+  // invalid expression
+  results = gatherResults( &filter, QStringLiteral( "1+" ), QgsLocatorContext() );
+  QVERIFY( results.empty() );
+
+}
+
+QList<QgsLocatorResult> TestQgsAppLocatorFilters::gatherResults( QgsLocatorFilter *filter, const QString &string, const QgsLocatorContext &context )
+{
+  QSignalSpy spy( filter, &QgsLocatorFilter::resultFetched );
+  QgsFeedback f;
+  filter->fetchResults( string, context, &f );
+
+  QList< QgsLocatorResult > results;
+  for ( int i = 0; i < spy.count(); ++ i )
+  {
+    QVariant v = spy.at( i ).at( i );
+    QgsLocatorResult result = v.value<QgsLocatorResult>();
+    results.append( result );
+  }
+  return results;
+}
+
+QGSTEST_MAIN( TestQgsAppLocatorFilters )
+#include "testqgsapplocatorfilters.moc"


### PR DESCRIPTION
Allows evaluation of simple expressions (well, actually ANY QGIS expression... so you could use aggregates and the like if you wanted!) by entering "= " followed by an expression into the
locator bar. If a valid expression is entered, the user is given an option to copy the result to the clipboard

E.g. entering

"= 10/3" gives an entry "Copy '3.3333333' to clipboard".

Inspired by the same feature in Qt Creator 4.6 - see http://blog.qt.io/blog/2018/02/07/qt-creator-4-6-beta-released/

I'm always using the Python console to calculate simple math expressions like this, but that's like using a sledgehammer to open an egg....

![2018-02-07](https://user-images.githubusercontent.com/1829991/35948902-98dae168-0cba-11e8-82ea-96a5d3b120bc.png)

