### PR TITLE
Use correct open form icon in identify results toolbar

### DIFF
--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -63,10 +63,13 @@
           <bool>false</bool>
          </property>
          <addaction name="mOpenFormAction"/>
+         <addaction name="separator"/>
          <addaction name="mExpandAction"/>
          <addaction name="mCollapseAction"/>
          <addaction name="mExpandNewAction"/>
+         <addaction name="separator"/>
          <addaction name="mClearResultsAction"/>
+         <addaction name="separator"/>
          <addaction name="mActionCopy"/>
          <addaction name="mActionPrint"/>
         </widget>

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -288,7 +288,7 @@
     <string>Expand New Results</string>
    </property>
    <property name="toolTip">
-    <string>New results will be expanded by default.</string>
+    <string>Expand New Results by Default</string>
    </property>
   </action>
   <action name="mOpenFormAction">
@@ -324,7 +324,7 @@
     <string>Copy Feature</string>
    </property>
    <property name="toolTip">
-    <string>Copy selected feature to clipboard.</string>
+    <string>Copy Selected Feature to Clipboard </string>
    </property>
   </action>
   <action name="mActionPrint">
@@ -336,7 +336,7 @@
     <string>Print Response</string>
    </property>
    <property name="toolTip">
-    <string>Print selected HTML response.</string>
+    <string>Print Selected HTML Response</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -62,10 +62,10 @@
          <property name="floatable">
           <bool>false</bool>
          </property>
+         <addaction name="mOpenFormAction"/>
          <addaction name="mExpandAction"/>
          <addaction name="mCollapseAction"/>
          <addaction name="mExpandNewAction"/>
-         <addaction name="mOpenFormAction"/>
          <addaction name="mClearResultsAction"/>
          <addaction name="mActionCopy"/>
          <addaction name="mActionPrint"/>
@@ -291,7 +291,7 @@
   <action name="mOpenFormAction">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionPropertyItem.svg</normaloff>:/images/themes/default/mActionPropertyItem.svg</iconset>
+     <normaloff>:/images/themes/default/mActionFormView.svg</normaloff>:/images/themes/default/mActionFormView.svg</iconset>
    </property>
    <property name="text">
     <string>Open Form</string>


### PR DESCRIPTION
Before we used a different (non obvious) icon for "open form" in the toolbar. This changes the toolbar icon to reuse the same (clearer) icon which is used when expanding out the tree and finding the "view feature form" action.

I've also moved the Open Form action to be first in the toolbar, since it's the most frequently used action.

Before:

![2018-02-07 2](https://user-images.githubusercontent.com/1829991/35952142-57427e72-0cca-11e8-9e0e-a239bbca0676.png)


After:
![2018-02-07 1](https://user-images.githubusercontent.com/1829991/35952119-396ed6de-0cca-11e8-86c3-ea8d853bbaae.png)
