### PR TITLE
[attribute table] fix crash when adding creating a field on field-less layers

### DIFF
--- a/src/core/qgsvectorlayerundocommand.cpp
+++ b/src/core/qgsvectorlayerundocommand.cpp
@@ -313,8 +313,8 @@ void QgsVectorLayerUndoCommandAddAttribute::undo()
 void QgsVectorLayerUndoCommandAddAttribute::redo()
 {
   mBuffer->mAddedAttributes.append( mField );
-  mBuffer->updateLayerFields();
   mBuffer->handleAttributeAdded( mFieldIndex );
+  mBuffer->updateLayerFields();
 
   emit mBuffer->attributeAdded( mFieldIndex );
 }


### PR DESCRIPTION
## Description
This fixes another crash I've been victim of over the last few months.

Steps to reproduce:
- Create a new project
- Add a new temporary scratch layer
- Add a feature to the layer, keep editing mode on
- Open the attribute table
- Create a new field via the new field toolbar button
- *boom* QGIS dies

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
